### PR TITLE
Rename go module to kuberay

### DIFF
--- a/ray-operator/controllers/common/pod.go
+++ b/ray-operator/controllers/common/pod.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	rayiov1alpha1 "github.com/ray-project/ray-contrib/ray-operator/api/v1alpha1"
-	"github.com/ray-project/ray-contrib/ray-operator/controllers/utils"
+	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/api/v1alpha1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/utils"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 

--- a/ray-operator/controllers/common/pod_test.go
+++ b/ray-operator/controllers/common/pod_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	rayiov1alpha1 "github.com/ray-project/ray-contrib/ray-operator/api/v1alpha1"
-	"github.com/ray-project/ray-contrib/ray-operator/controllers/utils"
+	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/api/v1alpha1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/utils"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/ray-operator/controllers/common/service.go
+++ b/ray-operator/controllers/common/service.go
@@ -1,8 +1,8 @@
 package common
 
 import (
-	rayiov1alpha1 "github.com/ray-project/ray-contrib/ray-operator/api/v1alpha1"
-	"github.com/ray-project/ray-contrib/ray-operator/controllers/utils"
+	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/api/v1alpha1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/ray-operator/controllers/common/service_test.go
+++ b/ray-operator/controllers/common/service_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	rayiov1alpha1 "github.com/ray-project/ray-contrib/ray-operator/api/v1alpha1"
+	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/api/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
 

--- a/ray-operator/controllers/raycluster_controller.go
+++ b/ray-operator/controllers/raycluster_controller.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"time"
 
-	rayiov1alpha1 "github.com/ray-project/ray-contrib/ray-operator/api/v1alpha1"
-	"github.com/ray-project/ray-contrib/ray-operator/controllers/common"
-	_ "github.com/ray-project/ray-contrib/ray-operator/controllers/common"
-	"github.com/ray-project/ray-contrib/ray-operator/controllers/utils"
+	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/api/v1alpha1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/common"
+	_ "github.com/ray-project/kuberay/ray-operator/controllers/common"
+	"github.com/ray-project/kuberay/ray-operator/controllers/utils"
 
 	"k8s.io/client-go/tools/record"
 

--- a/ray-operator/controllers/raycluster_controller_test.go
+++ b/ray-operator/controllers/raycluster_controller_test.go
@@ -21,9 +21,9 @@ import (
 	"reflect"
 	"time"
 
-	rayiov1alpha1 "github.com/ray-project/ray-contrib/ray-operator/api/v1alpha1"
-	"github.com/ray-project/ray-contrib/ray-operator/controllers/common"
-	"github.com/ray-project/ray-contrib/ray-operator/controllers/utils"
+	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/api/v1alpha1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/common"
+	"github.com/ray-project/kuberay/ray-operator/controllers/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/ray-operator/controllers/suite_test.go
+++ b/ray-operator/controllers/suite_test.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	rayiov1alpha1 "github.com/ray-project/ray-contrib/ray-operator/api/v1alpha1"
+	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
 	. "github.com/onsi/ginkgo"

--- a/ray-operator/controllers/utils/util.go
+++ b/ray-operator/controllers/utils/util.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"unicode"
 
-	rayiov1alpha1 "github.com/ray-project/ray-contrib/ray-operator/api/v1alpha1"
+	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/api/v1alpha1"
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -1,4 +1,4 @@
-module github.com/ray-project/ray-contrib/ray-operator
+module github.com/ray-project/kuberay/ray-operator
 
 go 1.15
 

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
-	"github.com/ray-project/ray-contrib/ray-operator/controllers"
+	"github.com/ray-project/kuberay/ray-operator/controllers"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -13,7 +13,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	rayiov1alpha1 "github.com/ray-project/ray-contrib/ray-operator/api/v1alpha1"
+	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`ray-contrib` has been rename to `kuberay`. code references need corresponding modification

## Related issue number

Closes #https://github.com/ray-project/kuberay/issues/39

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
