### PR TITLE
Ignore reconcile cluster being deleted

### DIFF
--- a/ray-operator/controllers/raycluster_controller.go
+++ b/ray-operator/controllers/raycluster_controller.go
@@ -80,6 +80,11 @@ func (r *RayClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	if instance.DeletionTimestamp != nil && !instance.DeletionTimestamp.IsZero() {
+		log.Info("RayCluser is being deleted, just ignore", "cluster name", request.Name)
+		return ctrl.Result{}, nil
+	}
+
 	if err := r.reconcileServices(instance); err != nil {
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ignore reconcile ray cluster object when it is being deleted

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
