### PR TITLE
Fix flaky tests by retrying 409 conflict error

### DIFF
--- a/ray-operator/controllers/raycluster_controller_test.go
+++ b/ray-operator/controllers/raycluster_controller_test.go
@@ -32,9 +32,15 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	// +kubebuilder:scaffold:imports
+)
+
+const (
+	DefaultAttempts               = 4
+	DefaultSleepDurationInSeconds = 2
 )
 
 var _ = Context("Inside the default namespace", func() {
@@ -193,7 +199,13 @@ var _ = Context("Inside the default namespace", func() {
 			*rep = 2
 			myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = rep
 
-			Expect(k8sClient.Update(ctx, myRayCluster)).Should(Succeed(), "failed to update test RayCluster resource")
+			// Operator may update revision after we get cluster earlier. Update may result in 409 conflict error.
+			// We need to handle conflict error and retry the update.
+			err := retryOnOldRevision(DefaultAttempts, DefaultSleepDurationInSeconds, func() error {
+				return k8sClient.Update(ctx, myRayCluster)
+			})
+
+			Expect(err).NotTo(HaveOccurred(), "failed to update test RayCluster resource")
 		})
 
 		It("should have only 2 running worker", func() {
@@ -248,4 +260,24 @@ func listResourceFunc(ctx context.Context, workerPods *corev1.PodList, opt ...cl
 
 		return count, nil
 	}
+}
+
+func retryOnOldRevision(attempts int, sleep time.Duration, f func() error) error {
+	var err error
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			fmt.Printf("retrying after error: %v", err)
+			time.Sleep(sleep)
+			sleep *= 2
+		}
+		err = f()
+		if err == nil {
+			return nil
+		}
+
+		if !errors.IsConflict(err) {
+			return nil
+		}
+	}
+	return fmt.Errorf("after %d attempts, last error: %s", attempts, err)
 }


### PR DESCRIPTION
Failure is because of error "Operation cannot be fulfilled on rayclusters.ray.io: the object has been modified; please apply your changes to the latest version and try again". This is pretty common and because test code may not use latest revision to update the object since operator updates the object in the middle. Retry on this kind of issues will work.

## Why are these changes needed?

This helps resolve flaky test and we can save efforts to rerun failed GitHub workflow. :D

## Related issue number

https://github.com/ray-project/kuberay/issues/35

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
