### PR TITLE
Pin operator image version to v0.1.0

### DIFF
--- a/ray-operator/config/default/kustomization.yaml
+++ b/ray-operator/config/default/kustomization.yaml
@@ -22,5 +22,5 @@ bases:
 images:
 - name: kuberay/operator
   newName: kuberay/operator
-  newTag: nightly
+  newTag: v0.1.0
 


### PR DESCRIPTION
## Why are these changes needed?

Pin image version to v0.1.0 and this would be the stable version

## Related issue number

#47 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [x] This PR is not tested :(


I manually test fetching images.
