### PR TITLE
fix missing template objectmeta

### DIFF
--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:maxDescLen=100,trivialVersions=true,preserveUnknownFields=false"
+CRD_OPTIONS ?= "crd:maxDescLen=100,trivialVersions=true,preserveUnknownFields=false,generateEmbeddedObjectMeta=true"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -87,7 +87,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.5.0)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: rayclusters.ray.io
 spec:
@@ -22,10 +22,12 @@ spec:
         description: RayCluster is the Schema for the RayClusters API
         properties:
           apiVersion:
-            description: APIVersion defines the versioned schema of this representation of an object.
+            description: APIVersion defines the versioned schema of this representation
+              of an object.
             type: string
           kind:
-            description: Kind is a string value representing the REST resource this object represents.
+            description: Kind is a string value representing the REST resource this
+              object represents.
             type: string
           metadata:
             type: object
@@ -33,66 +35,106 @@ spec:
             description: Specification of the desired behavior of the RayCluster.
             properties:
               enableInTreeAutoscaling:
-                description: EnableInTreeAutoscaling indicates whether operator should create in tree autoscaling configs
+                description: EnableInTreeAutoscaling indicates whether operator should
+                  create in tree autoscaling configs
                 type: boolean
               headGroupSpec:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code af'
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code af'
                 properties:
                   enableIngress:
-                    description: EnableIngress indicates whether operator should create ingress object for head service or not.
+                    description: EnableIngress indicates whether operator should create
+                      ingress object for head service or not.
                     type: boolean
                   rayStartParams:
                     additionalProperties:
                       type: string
-                    description: 'RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...'
+                    description: 'RayStartParams are the params of the start command:
+                      node-manager-port, object-store-memory, ...'
                     type: object
                   replicas:
                     description: Number of desired pods in this pod group.
                     format: int32
                     type: integer
                   serviceType:
-                    description: ServiceType is Kubernetes service type of the head service.
+                    description: ServiceType is Kubernetes service type of the head
+                      service.
                     type: string
                   template:
-                    description: Template is the eaxct pod template used in K8s depoyments, statefulsets, etc.
+                    description: Template is the eaxct pod template used in K8s depoyments,
+                      statefulsets, etc.
                     properties:
                       metadata:
                         description: 'Standard object''s metadata. More info: https://git.k8s.'
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
                         type: object
                       spec:
-                        description: 'Specification of the desired behavior of the pod. More info: https://git.k8s.'
+                        description: 'Specification of the desired behavior of the
+                          pod. More info: https://git.k8s.'
                         properties:
                           activeDeadlineSeconds:
-                            description: Optional duration in seconds the pod may be active on the node relative to StartTime before the syst
+                            description: Optional duration in seconds the pod may
+                              be active on the node relative to StartTime before the
+                              syst
                             format: int64
                             type: integer
                           affinity:
                             description: If specified, the pod's scheduling constraints
                             properties:
                               nodeAffinity:
-                                description: Describes node affinity scheduling rules for the pod.
+                                description: Describes node affinity scheduling rules
+                                  for the pod.
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
+                                    description: 'The scheduler will prefer to schedule
+                                      pods to nodes that satisfy the affinity expressions
+                                      specified '
                                     items:
-                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
+                                      description: An empty preferred scheduling term
+                                        matches all objects with implicit weight 0
+                                        (i.e. it's a no-op).
                                       properties:
                                         preference:
-                                          description: A node selector term, associated with the corresponding weight.
+                                          description: A node selector term, associated
+                                            with the corresponding weight.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector requirements by node's labels.
+                                              description: A list of node selector
+                                                requirements by node's labels.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
+                                                description: 'A node selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
+                                                    description: The label key that
+                                                      the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
+                                                    description: Represents a key's
+                                                      relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
+                                                    description: An array of string
+                                                      values. If the operator is In
+                                                      or NotIn, the values array must
+                                                      be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -102,18 +144,26 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector requirements by node's fields.
+                                              description: A list of node selector
+                                                requirements by node's fields.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
+                                                description: 'A node selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
+                                                    description: The label key that
+                                                      the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
+                                                    description: Represents a key's
+                                                      relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
+                                                    description: An array of string
+                                                      values. If the operator is In
+                                                      or NotIn, the values array must
+                                                      be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -124,7 +174,9 @@ spec:
                                               type: array
                                           type: object
                                         weight:
-                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                          description: Weight associated with matching
+                                            the corresponding nodeSelectorTerm, in
+                                            the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -133,26 +185,39 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
+                                    description: If the affinity requirements specified
+                                      by this field are not met at scheduling time,
+                                      the pod will no
                                     properties:
                                       nodeSelectorTerms:
-                                        description: Required. A list of node selector terms. The terms are ORed.
+                                        description: Required. A list of node selector
+                                          terms. The terms are ORed.
                                         items:
-                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
+                                          description: A null or empty node selector
+                                            term matches no objects. The requirements
+                                            of them are ANDed.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector requirements by node's labels.
+                                              description: A list of node selector
+                                                requirements by node's labels.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
+                                                description: 'A node selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
+                                                    description: The label key that
+                                                      the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
+                                                    description: Represents a key's
+                                                      relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
+                                                    description: An array of string
+                                                      values. If the operator is In
+                                                      or NotIn, the values array must
+                                                      be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -162,18 +227,26 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector requirements by node's fields.
+                                              description: A list of node selector
+                                                requirements by node's fields.
                                               items:
-                                                description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
+                                                description: 'A node selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates '
                                                 properties:
                                                   key:
-                                                    description: The label key that the selector applies to.
+                                                    description: The label key that
+                                                      the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: Represents a key's relationship to a set of values.
+                                                    description: Represents a key's
+                                                      relationship to a set of values.
                                                     type: string
                                                   values:
-                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
+                                                    description: An array of string
+                                                      values. If the operator is In
+                                                      or NotIn, the values array must
+                                                      be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -189,32 +262,50 @@ spec:
                                     type: object
                                 type: object
                               podAffinity:
-                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc.
+                                description: Describes pod affinity scheduling rules
+                                  (e.g. co-locate this pod in the same node, zone,
+                                  etc.
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
+                                    description: 'The scheduler will prefer to schedule
+                                      pods to nodes that satisfy the affinity expressions
+                                      specified '
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
+                                      description: The weights of all of the matched
+                                        WeightedPodAffinityTerm fields are added per-node
+                                        to find the most
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                          description: Required. A pod affinity term,
+                                            associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set of resources, in this case pods.
+                                              description: A label query over a set
+                                                of resources, in this case pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
+                                                        description: values is an
+                                                          array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -226,22 +317,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs.
                                                   type: object
                                               type: object
                                             namespaces:
-                                              description: 'namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty '
+                                              description: 'namespaces specifies which
+                                                namespaces the labelSelector applies
+                                                to (matches against); null or empty '
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching th
                                               type: string
                                           required:
                                           - topologyKey
                                           type: object
                                         weight:
-                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                          description: weight associated with matching
+                                            the corresponding podAffinityTerm, in
+                                            the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -250,26 +348,40 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
+                                    description: If the affinity requirements specified
+                                      by this field are not met at scheduling time,
+                                      the pod will no
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
+                                      description: Defines a set of pods (namely those
+                                        matching the labelSelector relative to the
+                                        given namespace(s)) t
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of resources, in this case pods.
+                                          description: A label query over a set of
+                                            resources, in this case pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
+                                                    description: values is an array
+                                                      of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -281,16 +393,21 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: 'namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty '
+                                          description: 'namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty '
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching th
                                           type: string
                                       required:
                                       - topologyKey
@@ -298,32 +415,49 @@ spec:
                                     type: array
                                 type: object
                               podAntiAffinity:
-                                description: Describes pod anti-affinity scheduling rules (e.g.
+                                description: Describes pod anti-affinity scheduling
+                                  rules (e.g.
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
+                                    description: The scheduler will prefer to schedule
+                                      pods to nodes that satisfy the anti-affinity
+                                      expressions speci
                                     items:
-                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
+                                      description: The weights of all of the matched
+                                        WeightedPodAffinityTerm fields are added per-node
+                                        to find the most
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                          description: Required. A pod affinity term,
+                                            associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set of resources, in this case pods.
+                                              description: A label query over a set
+                                                of resources, in this case pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
+                                                        description: values is an
+                                                          array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -335,22 +469,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs.
                                                   type: object
                                               type: object
                                             namespaces:
-                                              description: 'namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty '
+                                              description: 'namespaces specifies which
+                                                namespaces the labelSelector applies
+                                                to (matches against); null or empty '
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching th
                                               type: string
                                           required:
                                           - topologyKey
                                           type: object
                                         weight:
-                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                          description: weight associated with matching
+                                            the corresponding podAffinityTerm, in
+                                            the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -359,26 +500,40 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
+                                    description: If the anti-affinity requirements
+                                      specified by this field are not met at scheduling
+                                      time, the pod wi
                                     items:
-                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
+                                      description: Defines a set of pods (namely those
+                                        matching the labelSelector relative to the
+                                        given namespace(s)) t
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of resources, in this case pods.
+                                          description: A label query over a set of
+                                            resources, in this case pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values.
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values.
+                                                    description: values is an array
+                                                      of string values.
                                                     items:
                                                       type: string
                                                     type: array
@@ -390,16 +545,21 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs.
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: 'namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty '
+                                          description: 'namespaces specifies which
+                                            namespaces the labelSelector applies to
+                                            (matches against); null or empty '
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching th
                                           type: string
                                       required:
                                       - topologyKey
@@ -408,36 +568,47 @@ spec:
                                 type: object
                             type: object
                           automountServiceAccountToken:
-                            description: AutomountServiceAccountToken indicates whether a service account token should be automatically mount
+                            description: AutomountServiceAccountToken indicates whether
+                              a service account token should be automatically mount
                             type: boolean
                           containers:
-                            description: List of containers belonging to the pod. Containers cannot currently be added or removed.
+                            description: List of containers belonging to the pod.
+                              Containers cannot currently be added or removed.
                             items:
-                              description: A single application container that you want to run within a pod.
+                              description: A single application container that you
+                                want to run within a pod.
                               properties:
                                 args:
-                                  description: Arguments to the entrypoint. The docker image's CMD is used if this is not provided.
+                                  description: Arguments to the entrypoint. The docker
+                                    image's CMD is used if this is not provided.
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: Entrypoint array. Not executed within a shell.
+                                  description: Entrypoint array. Not executed within
+                                    a shell.
                                   items:
                                     type: string
                                   type: array
                                 env:
-                                  description: List of environment variables to set in the container. Cannot be updated.
+                                  description: List of environment variables to set
+                                    in the container. Cannot be updated.
                                   items:
-                                    description: EnvVar represents an environment variable present in a Container.
+                                    description: EnvVar represents an environment
+                                      variable present in a Container.
                                     properties:
                                       name:
-                                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                        description: Name of the environment variable.
+                                          Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the
+                                        description: Variable references $(VAR_NAME)
+                                          are expanded using the previous defined
+                                          environment variables in the
                                         type: string
                                       valueFrom:
-                                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                        description: Source for the environment variable's
+                                          value. Cannot be used if value is not empty.
                                         properties:
                                           configMapKeyRef:
                                             description: Selects a key of a ConfigMap.
@@ -446,56 +617,74 @@ spec:
                                                 description: The key to select.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: Specify whether the ConfigMap or its key must be defined
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
                                             type: object
                                           fieldRef:
-                                            description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.'
+                                            description: 'Selects a field of the pod:
+                                              supports metadata.name, metadata.namespace,
+                                              `metadata.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to select in the specified API version.
+                                                description: Path of the field to
+                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
+                                            description: 'Selects a resource of the
+                                              container: only resources limits and
+                                              requests (limits.cpu, limits.'
                                             properties:
                                               containerName:
-                                                description: 'Container name: required for volumes, optional for env vars'
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to select'
+                                                description: 'Required: resource to
+                                                  select'
                                                 type: string
                                             required:
                                             - resource
                                             type: object
                                           secretKeyRef:
-                                            description: Selects a key of a secret in the pod's namespace
+                                            description: Selects a key of a secret
+                                              in the pod's namespace
                                             properties:
                                               key:
-                                                description: The key of the secret to select from.  Must be a valid secret key.
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: Specify whether the Secret or its key must be defined
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
@@ -506,31 +695,39 @@ spec:
                                     type: object
                                   type: array
                                 envFrom:
-                                  description: List of sources to populate environment variables in the container.
+                                  description: List of sources to populate environment
+                                    variables in the container.
                                   items:
-                                    description: EnvFromSource represents the source of a set of ConfigMaps
+                                    description: EnvFromSource represents the source
+                                      of a set of ConfigMaps
                                     properties:
                                       configMapRef:
                                         description: The ConfigMap to select from
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap must be defined
+                                            description: Specify whether the ConfigMap
+                                              must be defined
                                             type: boolean
                                         type: object
                                       prefix:
-                                        description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                        description: An optional identifier to prepend
+                                          to each key in the ConfigMap. Must be a
+                                          C_IDENTIFIER.
                                         type: string
                                       secretRef:
                                         description: The Secret to select from
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret must be defined
+                                            description: Specify whether the Secret
+                                              must be defined
                                             type: boolean
                                         type: object
                                     type: object
@@ -539,39 +736,55 @@ spec:
                                   description: 'Docker image name. More info: https://kubernetes.'
                                   type: string
                                 imagePullPolicy:
-                                  description: Image pull policy. One of Always, Never, IfNotPresent.
+                                  description: Image pull policy. One of Always, Never,
+                                    IfNotPresent.
                                   type: string
                                 lifecycle:
-                                  description: Actions that the management system should take in response to container lifecycle events.
+                                  description: Actions that the management system
+                                    should take in response to container lifecycle
+                                    events.
                                   properties:
                                     postStart:
-                                      description: PostStart is called immediately after a container is created.
+                                      description: PostStart is called immediately
+                                        after a container is created.
                                       properties:
                                         exec:
-                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
                                           properties:
                                             command:
-                                              description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                              description: 'Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  '
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http request to perform.
+                                          description: HTTPGet specifies the http
+                                            request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to, defaults to the pod IP.
+                                              description: Host name to connect to,
+                                                defaults to the pod IP.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
                                               items:
-                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
                                                 properties:
                                                   name:
-                                                    description: The header field name
+                                                    description: The header field
+                                                      name
                                                     type: string
                                                   value:
-                                                    description: The header field value
+                                                    description: The header field
+                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -579,64 +792,86 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP server.
+                                              description: Path to access on the HTTP
+                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: TCPSocket specifies an action involving a TCP port.
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: PreStop is called immediately before a container is terminated due to an API request or management e
+                                      description: PreStop is called immediately before
+                                        a container is terminated due to an API request
+                                        or management e
                                       properties:
                                         exec:
-                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
                                           properties:
                                             command:
-                                              description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                              description: 'Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  '
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http request to perform.
+                                          description: HTTPGet specifies the http
+                                            request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to, defaults to the pod IP.
+                                              description: Host name to connect to,
+                                                defaults to the pod IP.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
                                               items:
-                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
                                                 properties:
                                                   name:
-                                                    description: The header field name
+                                                    description: The header field
+                                                      name
                                                     type: string
                                                   value:
-                                                    description: The header field value
+                                                    description: The header field
+                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -644,31 +879,39 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP server.
+                                              description: Path to access on the HTTP
+                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: TCPSocket specifies an action involving a TCP port.
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -676,31 +919,42 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: Periodic probe of container liveness. Container will be restarted if the probe fails.
+                                  description: Periodic probe of container liveness.
+                                    Container will be restarted if the probe fails.
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
                                       properties:
                                         command:
-                                          description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                          description: 'Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      description: Minimum consecutive failures for
+                                        the probe to be considered failed after having
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
+                                      description: HTTPGet specifies the http request
+                                        to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP.
+                                          description: Host name to connect to, defaults
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 description: The header field name
@@ -714,77 +968,101 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
+                                          description: Path to access on the HTTP
+                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: Number of seconds after the container has started before liveness probes are initiated.
+                                      description: Number of seconds after the container
+                                        has started before liveness probes are initiated.
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                      description: How often (in seconds) to perform
+                                        the probe. Default to 10 seconds. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      description: Minimum consecutive successes for
+                                        the probe to be considered successful after
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving a TCP port.
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
-                                  description: Name of the container specified as a DNS_LABEL.
+                                  description: Name of the container specified as
+                                    a DNS_LABEL.
                                   type: string
                                 ports:
                                   description: List of ports to expose from the container.
                                   items:
-                                    description: ContainerPort represents a network port in a single container.
+                                    description: ContainerPort represents a network
+                                      port in a single container.
                                     properties:
                                       containerPort:
-                                        description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                        description: Number of port to expose on the
+                                          pod's IP address. This must be a valid port
+                                          number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       hostIP:
-                                        description: What host IP to bind the external port to.
+                                        description: What host IP to bind the external
+                                          port to.
                                         type: string
                                       hostPort:
-                                        description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536.
+                                        description: Number of port to expose on the
+                                          host. If specified, this must be a valid
+                                          port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       name:
-                                        description: If specified, this must be an IANA_SVC_NAME and unique within the pod.
+                                        description: If specified, this must be an
+                                          IANA_SVC_NAME and unique within the pod.
                                         type: string
                                       protocol:
                                         default: TCP
-                                        description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                        description: Protocol for port. Must be UDP,
+                                          TCP, or SCTP. Defaults to "TCP".
                                         type: string
                                     required:
                                     - containerPort
@@ -795,31 +1073,42 @@ spec:
                                   - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
-                                  description: Periodic probe of container service readiness.
+                                  description: Periodic probe of container service
+                                    readiness.
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
                                       properties:
                                         command:
-                                          description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                          description: 'Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      description: Minimum consecutive failures for
+                                        the probe to be considered failed after having
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
+                                      description: HTTPGet specifies the http request
+                                        to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP.
+                                          description: Host name to connect to, defaults
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 description: The header field name
@@ -833,54 +1122,70 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
+                                          description: Path to access on the HTTP
+                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: Number of seconds after the container has started before liveness probes are initiated.
+                                      description: Number of seconds after the container
+                                        has started before liveness probes are initiated.
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                      description: How often (in seconds) to perform
+                                        the probe. Default to 10 seconds. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      description: Minimum consecutive successes for
+                                        the probe to be considered successful after
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving a TCP port.
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 resources:
-                                  description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.'
+                                  description: 'Compute Resources required by this
+                                    container. Cannot be updated. More info: https://kubernetes.'
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -889,7 +1194,8 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
+                                      description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.'
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -898,28 +1204,35 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: Requests describes the minimum amount of compute resources required.
+                                      description: Requests describes the minimum
+                                        amount of compute resources required.
                                       type: object
                                   type: object
                                 securityContext:
-                                  description: 'Security options the pod should run with. More info: https://kubernetes.'
+                                  description: 'Security options the pod should run
+                                    with. More info: https://kubernetes.'
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process
+                                      description: AllowPrivilegeEscalation controls
+                                        whether a process can gain more privileges
+                                        than its parent process
                                       type: boolean
                                     capabilities:
-                                      description: The capabilities to add/drop when running containers.
+                                      description: The capabilities to add/drop when
+                                        running containers.
                                       properties:
                                         add:
                                           description: Added capabilities
                                           items:
-                                            description: Capability represent POSIX capabilities type
+                                            description: Capability represent POSIX
+                                              capabilities type
                                             type: string
                                           type: array
                                         drop:
                                           description: Removed capabilities
                                           items:
-                                            description: Capability represent POSIX capabilities type
+                                            description: Capability represent POSIX
+                                              capabilities type
                                             type: string
                                           type: array
                                       type: object
@@ -927,90 +1240,120 @@ spec:
                                       description: Run container in privileged mode.
                                       type: boolean
                                     procMount:
-                                      description: procMount denotes the type of proc mount to use for the containers.
+                                      description: procMount denotes the type of proc
+                                        mount to use for the containers.
                                       type: string
                                     readOnlyRootFilesystem:
-                                      description: Whether this container has a read-only root filesystem. Default is false.
+                                      description: Whether this container has a read-only
+                                        root filesystem. Default is false.
                                       type: boolean
                                     runAsGroup:
-                                      description: The GID to run the entrypoint of the container process. Uses runtime default if unset.
+                                      description: The GID to run the entrypoint of
+                                        the container process. Uses runtime default
+                                        if unset.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
-                                      description: Indicates that the container must run as a non-root user.
+                                      description: Indicates that the container must
+                                        run as a non-root user.
                                       type: boolean
                                     runAsUser:
-                                      description: The UID to run the entrypoint of the container process.
+                                      description: The UID to run the entrypoint of
+                                        the container process.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
-                                      description: The SELinux context to be applied to the container.
+                                      description: The SELinux context to be applied
+                                        to the container.
                                       properties:
                                         level:
-                                          description: Level is SELinux level label that applies to the container.
+                                          description: Level is SELinux level label
+                                            that applies to the container.
                                           type: string
                                         role:
-                                          description: Role is a SELinux role label that applies to the container.
+                                          description: Role is a SELinux role label
+                                            that applies to the container.
                                           type: string
                                         type:
-                                          description: Type is a SELinux type label that applies to the container.
+                                          description: Type is a SELinux type label
+                                            that applies to the container.
                                           type: string
                                         user:
-                                          description: User is a SELinux user label that applies to the container.
+                                          description: User is a SELinux user label
+                                            that applies to the container.
                                           type: string
                                       type: object
                                     seccompProfile:
-                                      description: The seccomp options to use by this container.
+                                      description: The seccomp options to use by this
+                                        container.
                                       properties:
                                         localhostProfile:
-                                          description: localhostProfile indicates a profile defined in a file on the node should be used.
+                                          description: localhostProfile indicates
+                                            a profile defined in a file on the node
+                                            should be used.
                                           type: string
                                         type:
-                                          description: type indicates which kind of seccomp profile will be applied.
+                                          description: type indicates which kind of
+                                            seccomp profile will be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
-                                      description: The Windows specific settings applied to all containers.
+                                      description: The Windows specific settings applied
+                                        to all containers.
                                       properties:
                                         gmsaCredentialSpec:
-                                          description: GMSACredentialSpec is where the GMSA admission webhook (https://github.
+                                          description: GMSACredentialSpec is where
+                                            the GMSA admission webhook (https://github.
                                           type: string
                                         gmsaCredentialSpecName:
-                                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                          description: GMSACredentialSpecName is the
+                                            name of the GMSA credential spec to use.
                                           type: string
                                         runAsUserName:
-                                          description: The UserName in Windows to run the entrypoint of the container process.
+                                          description: The UserName in Windows to
+                                            run the entrypoint of the container process.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: StartupProbe indicates that the Pod has successfully initialized.
+                                  description: StartupProbe indicates that the Pod
+                                    has successfully initialized.
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
                                       properties:
                                         command:
-                                          description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                          description: 'Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      description: Minimum consecutive failures for
+                                        the probe to be considered failed after having
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
+                                      description: HTTPGet specifies the http request
+                                        to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP.
+                                          description: Host name to connect to, defaults
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 description: The header field name
@@ -1024,77 +1367,105 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
+                                          description: Path to access on the HTTP
+                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: Number of seconds after the container has started before liveness probes are initiated.
+                                      description: Number of seconds after the container
+                                        has started before liveness probes are initiated.
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                      description: How often (in seconds) to perform
+                                        the probe. Default to 10 seconds. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      description: Minimum consecutive successes for
+                                        the probe to be considered successful after
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving a TCP port.
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
-                                  description: Whether this container should allocate a buffer for stdin in the container runtime.
+                                  description: Whether this container should allocate
+                                    a buffer for stdin in the container runtime.
                                   type: boolean
                                 stdinOnce:
-                                  description: Whether the container runtime should close the stdin channel after it has been opened by a single at
+                                  description: Whether the container runtime should
+                                    close the stdin channel after it has been opened
+                                    by a single at
                                   type: boolean
                                 terminationMessagePath:
-                                  description: 'Optional: Path at which the file to which the container''s termination message will be written is mou'
+                                  description: 'Optional: Path at which the file to
+                                    which the container''s termination message will
+                                    be written is mou'
                                   type: string
                                 terminationMessagePolicy:
-                                  description: Indicate how the termination message should be populated.
+                                  description: Indicate how the termination message
+                                    should be populated.
                                   type: string
                                 tty:
-                                  description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                  description: Whether this container should allocate
+                                    a TTY for itself, also requires 'stdin' to be
+                                    true.
                                   type: boolean
                                 volumeDevices:
-                                  description: volumeDevices is the list of block devices to be used by the container.
+                                  description: volumeDevices is the list of block
+                                    devices to be used by the container.
                                   items:
-                                    description: volumeDevice describes a mapping of a raw block device within a container.
+                                    description: volumeDevice describes a mapping
+                                      of a raw block device within a container.
                                     properties:
                                       devicePath:
-                                        description: devicePath is the path inside of the container that the device will be mapped to.
+                                        description: devicePath is the path inside
+                                          of the container that the device will be
+                                          mapped to.
                                         type: string
                                       name:
-                                        description: name must match the name of a persistentVolumeClaim in the pod
+                                        description: name must match the name of a
+                                          persistentVolumeClaim in the pod
                                         type: string
                                     required:
                                     - devicePath
@@ -1102,27 +1473,39 @@ spec:
                                     type: object
                                   type: array
                                 volumeMounts:
-                                  description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                  description: Pod volumes to mount into the container's
+                                    filesystem. Cannot be updated.
                                   items:
-                                    description: VolumeMount describes a mounting of a Volume within a container.
+                                    description: VolumeMount describes a mounting
+                                      of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                        description: Path within the container at
+                                          which the volume should be mounted.  Must
+                                          not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: mountPropagation determines how mounts are propagated from the host to container and the other way a
+                                        description: mountPropagation determines how
+                                          mounts are propagated from the host to container
+                                          and the other way a
                                         type: string
                                       name:
-                                        description: This must match the Name of a Volume.
+                                        description: This must match the Name of a
+                                          Volume.
                                         type: string
                                       readOnly:
-                                        description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                        description: Mounted read-only if true, read-write
+                                          otherwise (false or unspecified). Defaults
+                                          to false.
                                         type: boolean
                                       subPath:
-                                        description: Path within the volume from which the container's volume should be mounted.
+                                        description: Path within the volume from which
+                                          the container's volume should be mounted.
                                         type: string
                                       subPathExpr:
-                                        description: Expanded path within the volume from which the container's volume should be mounted.
+                                        description: Expanded path within the volume
+                                          from which the container's volume should
+                                          be mounted.
                                         type: string
                                     required:
                                     - mountPath
@@ -1145,9 +1528,12 @@ spec:
                                   type: string
                                 type: array
                               options:
-                                description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy.
+                                description: A list of DNS resolver options. This
+                                  will be merged with the base options generated from
+                                  DNSPolicy.
                                 items:
-                                  description: PodDNSConfigOption defines DNS resolver options of a pod.
+                                  description: PodDNSConfigOption defines DNS resolver
+                                    options of a pod.
                                   properties:
                                     name:
                                       description: Required.
@@ -1157,7 +1543,8 @@ spec:
                                   type: object
                                 type: array
                               searches:
-                                description: A list of DNS search domains for host-name lookup.
+                                description: A list of DNS search domains for host-name
+                                  lookup.
                                 items:
                                   type: string
                                 type: array
@@ -1166,36 +1553,47 @@ spec:
                             description: Set DNS policy for the pod. Defaults to "ClusterFirst".
                             type: string
                           enableServiceLinks:
-                            description: EnableServiceLinks indicates whether information about services should be injected into pod's enviro
+                            description: EnableServiceLinks indicates whether information
+                              about services should be injected into pod's enviro
                             type: boolean
                           ephemeralContainers:
-                            description: List of ephemeral containers run in this pod.
+                            description: List of ephemeral containers run in this
+                              pod.
                             items:
-                              description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initi
+                              description: An EphemeralContainer is a container that
+                                may be added temporarily to an existing pod for user-initi
                               properties:
                                 args:
-                                  description: Arguments to the entrypoint. The docker image's CMD is used if this is not provided.
+                                  description: Arguments to the entrypoint. The docker
+                                    image's CMD is used if this is not provided.
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: Entrypoint array. Not executed within a shell.
+                                  description: Entrypoint array. Not executed within
+                                    a shell.
                                   items:
                                     type: string
                                   type: array
                                 env:
-                                  description: List of environment variables to set in the container. Cannot be updated.
+                                  description: List of environment variables to set
+                                    in the container. Cannot be updated.
                                   items:
-                                    description: EnvVar represents an environment variable present in a Container.
+                                    description: EnvVar represents an environment
+                                      variable present in a Container.
                                     properties:
                                       name:
-                                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                        description: Name of the environment variable.
+                                          Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the
+                                        description: Variable references $(VAR_NAME)
+                                          are expanded using the previous defined
+                                          environment variables in the
                                         type: string
                                       valueFrom:
-                                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                        description: Source for the environment variable's
+                                          value. Cannot be used if value is not empty.
                                         properties:
                                           configMapKeyRef:
                                             description: Selects a key of a ConfigMap.
@@ -1204,56 +1602,74 @@ spec:
                                                 description: The key to select.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: Specify whether the ConfigMap or its key must be defined
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
                                             type: object
                                           fieldRef:
-                                            description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.'
+                                            description: 'Selects a field of the pod:
+                                              supports metadata.name, metadata.namespace,
+                                              `metadata.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to select in the specified API version.
+                                                description: Path of the field to
+                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
+                                            description: 'Selects a resource of the
+                                              container: only resources limits and
+                                              requests (limits.cpu, limits.'
                                             properties:
                                               containerName:
-                                                description: 'Container name: required for volumes, optional for env vars'
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to select'
+                                                description: 'Required: resource to
+                                                  select'
                                                 type: string
                                             required:
                                             - resource
                                             type: object
                                           secretKeyRef:
-                                            description: Selects a key of a secret in the pod's namespace
+                                            description: Selects a key of a secret
+                                              in the pod's namespace
                                             properties:
                                               key:
-                                                description: The key of the secret to select from.  Must be a valid secret key.
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: Specify whether the Secret or its key must be defined
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
@@ -1264,31 +1680,39 @@ spec:
                                     type: object
                                   type: array
                                 envFrom:
-                                  description: List of sources to populate environment variables in the container.
+                                  description: List of sources to populate environment
+                                    variables in the container.
                                   items:
-                                    description: EnvFromSource represents the source of a set of ConfigMaps
+                                    description: EnvFromSource represents the source
+                                      of a set of ConfigMaps
                                     properties:
                                       configMapRef:
                                         description: The ConfigMap to select from
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap must be defined
+                                            description: Specify whether the ConfigMap
+                                              must be defined
                                             type: boolean
                                         type: object
                                       prefix:
-                                        description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                        description: An optional identifier to prepend
+                                          to each key in the ConfigMap. Must be a
+                                          C_IDENTIFIER.
                                         type: string
                                       secretRef:
                                         description: The Secret to select from
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret must be defined
+                                            description: Specify whether the Secret
+                                              must be defined
                                             type: boolean
                                         type: object
                                     type: object
@@ -1297,39 +1721,54 @@ spec:
                                   description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                   type: string
                                 imagePullPolicy:
-                                  description: Image pull policy. One of Always, Never, IfNotPresent.
+                                  description: Image pull policy. One of Always, Never,
+                                    IfNotPresent.
                                   type: string
                                 lifecycle:
-                                  description: Lifecycle is not allowed for ephemeral containers.
+                                  description: Lifecycle is not allowed for ephemeral
+                                    containers.
                                   properties:
                                     postStart:
-                                      description: PostStart is called immediately after a container is created.
+                                      description: PostStart is called immediately
+                                        after a container is created.
                                       properties:
                                         exec:
-                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
                                           properties:
                                             command:
-                                              description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                              description: 'Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  '
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http request to perform.
+                                          description: HTTPGet specifies the http
+                                            request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to, defaults to the pod IP.
+                                              description: Host name to connect to,
+                                                defaults to the pod IP.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
                                               items:
-                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
                                                 properties:
                                                   name:
-                                                    description: The header field name
+                                                    description: The header field
+                                                      name
                                                     type: string
                                                   value:
-                                                    description: The header field value
+                                                    description: The header field
+                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -1337,64 +1776,86 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP server.
+                                              description: Path to access on the HTTP
+                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: TCPSocket specifies an action involving a TCP port.
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: PreStop is called immediately before a container is terminated due to an API request or management e
+                                      description: PreStop is called immediately before
+                                        a container is terminated due to an API request
+                                        or management e
                                       properties:
                                         exec:
-                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
                                           properties:
                                             command:
-                                              description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                              description: 'Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  '
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http request to perform.
+                                          description: HTTPGet specifies the http
+                                            request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to, defaults to the pod IP.
+                                              description: Host name to connect to,
+                                                defaults to the pod IP.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
                                               items:
-                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
                                                 properties:
                                                   name:
-                                                    description: The header field name
+                                                    description: The header field
+                                                      name
                                                     type: string
                                                   value:
-                                                    description: The header field value
+                                                    description: The header field
+                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -1402,31 +1863,39 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP server.
+                                              description: Path to access on the HTTP
+                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: TCPSocket specifies an action involving a TCP port.
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -1434,31 +1903,42 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: Probes are not allowed for ephemeral containers.
+                                  description: Probes are not allowed for ephemeral
+                                    containers.
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
                                       properties:
                                         command:
-                                          description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                          description: 'Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      description: Minimum consecutive failures for
+                                        the probe to be considered failed after having
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
+                                      description: HTTPGet specifies the http request
+                                        to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP.
+                                          description: Host name to connect to, defaults
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 description: The header field name
@@ -1472,108 +1952,144 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
+                                          description: Path to access on the HTTP
+                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: Number of seconds after the container has started before liveness probes are initiated.
+                                      description: Number of seconds after the container
+                                        has started before liveness probes are initiated.
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                      description: How often (in seconds) to perform
+                                        the probe. Default to 10 seconds. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      description: Minimum consecutive successes for
+                                        the probe to be considered successful after
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving a TCP port.
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
-                                  description: Name of the ephemeral container specified as a DNS_LABEL.
+                                  description: Name of the ephemeral container specified
+                                    as a DNS_LABEL.
                                   type: string
                                 ports:
-                                  description: Ports are not allowed for ephemeral containers.
+                                  description: Ports are not allowed for ephemeral
+                                    containers.
                                   items:
-                                    description: ContainerPort represents a network port in a single container.
+                                    description: ContainerPort represents a network
+                                      port in a single container.
                                     properties:
                                       containerPort:
-                                        description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                        description: Number of port to expose on the
+                                          pod's IP address. This must be a valid port
+                                          number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       hostIP:
-                                        description: What host IP to bind the external port to.
+                                        description: What host IP to bind the external
+                                          port to.
                                         type: string
                                       hostPort:
-                                        description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536.
+                                        description: Number of port to expose on the
+                                          host. If specified, this must be a valid
+                                          port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       name:
-                                        description: If specified, this must be an IANA_SVC_NAME and unique within the pod.
+                                        description: If specified, this must be an
+                                          IANA_SVC_NAME and unique within the pod.
                                         type: string
                                       protocol:
                                         default: TCP
-                                        description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                        description: Protocol for port. Must be UDP,
+                                          TCP, or SCTP. Defaults to "TCP".
                                         type: string
                                     required:
                                     - containerPort
                                     type: object
                                   type: array
                                 readinessProbe:
-                                  description: Probes are not allowed for ephemeral containers.
+                                  description: Probes are not allowed for ephemeral
+                                    containers.
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
                                       properties:
                                         command:
-                                          description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                          description: 'Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      description: Minimum consecutive failures for
+                                        the probe to be considered failed after having
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
+                                      description: HTTPGet specifies the http request
+                                        to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP.
+                                          description: Host name to connect to, defaults
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 description: The header field name
@@ -1587,54 +2103,70 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
+                                          description: Path to access on the HTTP
+                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: Number of seconds after the container has started before liveness probes are initiated.
+                                      description: Number of seconds after the container
+                                        has started before liveness probes are initiated.
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                      description: How often (in seconds) to perform
+                                        the probe. Default to 10 seconds. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      description: Minimum consecutive successes for
+                                        the probe to be considered successful after
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving a TCP port.
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 resources:
-                                  description: Resources are not allowed for ephemeral containers.
+                                  description: Resources are not allowed for ephemeral
+                                    containers.
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -1643,7 +2175,8 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
+                                      description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.'
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -1652,28 +2185,35 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: Requests describes the minimum amount of compute resources required.
+                                      description: Requests describes the minimum
+                                        amount of compute resources required.
                                       type: object
                                   type: object
                                 securityContext:
-                                  description: SecurityContext is not allowed for ephemeral containers.
+                                  description: SecurityContext is not allowed for
+                                    ephemeral containers.
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process
+                                      description: AllowPrivilegeEscalation controls
+                                        whether a process can gain more privileges
+                                        than its parent process
                                       type: boolean
                                     capabilities:
-                                      description: The capabilities to add/drop when running containers.
+                                      description: The capabilities to add/drop when
+                                        running containers.
                                       properties:
                                         add:
                                           description: Added capabilities
                                           items:
-                                            description: Capability represent POSIX capabilities type
+                                            description: Capability represent POSIX
+                                              capabilities type
                                             type: string
                                           type: array
                                         drop:
                                           description: Removed capabilities
                                           items:
-                                            description: Capability represent POSIX capabilities type
+                                            description: Capability represent POSIX
+                                              capabilities type
                                             type: string
                                           type: array
                                       type: object
@@ -1681,90 +2221,120 @@ spec:
                                       description: Run container in privileged mode.
                                       type: boolean
                                     procMount:
-                                      description: procMount denotes the type of proc mount to use for the containers.
+                                      description: procMount denotes the type of proc
+                                        mount to use for the containers.
                                       type: string
                                     readOnlyRootFilesystem:
-                                      description: Whether this container has a read-only root filesystem. Default is false.
+                                      description: Whether this container has a read-only
+                                        root filesystem. Default is false.
                                       type: boolean
                                     runAsGroup:
-                                      description: The GID to run the entrypoint of the container process. Uses runtime default if unset.
+                                      description: The GID to run the entrypoint of
+                                        the container process. Uses runtime default
+                                        if unset.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
-                                      description: Indicates that the container must run as a non-root user.
+                                      description: Indicates that the container must
+                                        run as a non-root user.
                                       type: boolean
                                     runAsUser:
-                                      description: The UID to run the entrypoint of the container process.
+                                      description: The UID to run the entrypoint of
+                                        the container process.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
-                                      description: The SELinux context to be applied to the container.
+                                      description: The SELinux context to be applied
+                                        to the container.
                                       properties:
                                         level:
-                                          description: Level is SELinux level label that applies to the container.
+                                          description: Level is SELinux level label
+                                            that applies to the container.
                                           type: string
                                         role:
-                                          description: Role is a SELinux role label that applies to the container.
+                                          description: Role is a SELinux role label
+                                            that applies to the container.
                                           type: string
                                         type:
-                                          description: Type is a SELinux type label that applies to the container.
+                                          description: Type is a SELinux type label
+                                            that applies to the container.
                                           type: string
                                         user:
-                                          description: User is a SELinux user label that applies to the container.
+                                          description: User is a SELinux user label
+                                            that applies to the container.
                                           type: string
                                       type: object
                                     seccompProfile:
-                                      description: The seccomp options to use by this container.
+                                      description: The seccomp options to use by this
+                                        container.
                                       properties:
                                         localhostProfile:
-                                          description: localhostProfile indicates a profile defined in a file on the node should be used.
+                                          description: localhostProfile indicates
+                                            a profile defined in a file on the node
+                                            should be used.
                                           type: string
                                         type:
-                                          description: type indicates which kind of seccomp profile will be applied.
+                                          description: type indicates which kind of
+                                            seccomp profile will be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
-                                      description: The Windows specific settings applied to all containers.
+                                      description: The Windows specific settings applied
+                                        to all containers.
                                       properties:
                                         gmsaCredentialSpec:
-                                          description: GMSACredentialSpec is where the GMSA admission webhook (https://github.
+                                          description: GMSACredentialSpec is where
+                                            the GMSA admission webhook (https://github.
                                           type: string
                                         gmsaCredentialSpecName:
-                                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                          description: GMSACredentialSpecName is the
+                                            name of the GMSA credential spec to use.
                                           type: string
                                         runAsUserName:
-                                          description: The UserName in Windows to run the entrypoint of the container process.
+                                          description: The UserName in Windows to
+                                            run the entrypoint of the container process.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: Probes are not allowed for ephemeral containers.
+                                  description: Probes are not allowed for ephemeral
+                                    containers.
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
                                       properties:
                                         command:
-                                          description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                          description: 'Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      description: Minimum consecutive failures for
+                                        the probe to be considered failed after having
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
+                                      description: HTTPGet specifies the http request
+                                        to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP.
+                                          description: Host name to connect to, defaults
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 description: The header field name
@@ -1778,80 +2348,109 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
+                                          description: Path to access on the HTTP
+                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: Number of seconds after the container has started before liveness probes are initiated.
+                                      description: Number of seconds after the container
+                                        has started before liveness probes are initiated.
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                      description: How often (in seconds) to perform
+                                        the probe. Default to 10 seconds. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      description: Minimum consecutive successes for
+                                        the probe to be considered successful after
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving a TCP port.
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
-                                  description: Whether this container should allocate a buffer for stdin in the container runtime.
+                                  description: Whether this container should allocate
+                                    a buffer for stdin in the container runtime.
                                   type: boolean
                                 stdinOnce:
-                                  description: Whether the container runtime should close the stdin channel after it has been opened by a single at
+                                  description: Whether the container runtime should
+                                    close the stdin channel after it has been opened
+                                    by a single at
                                   type: boolean
                                 targetContainerName:
-                                  description: If set, the name of the container from PodSpec that this ephemeral container targets.
+                                  description: If set, the name of the container from
+                                    PodSpec that this ephemeral container targets.
                                   type: string
                                 terminationMessagePath:
-                                  description: 'Optional: Path at which the file to which the container''s termination message will be written is mou'
+                                  description: 'Optional: Path at which the file to
+                                    which the container''s termination message will
+                                    be written is mou'
                                   type: string
                                 terminationMessagePolicy:
-                                  description: Indicate how the termination message should be populated.
+                                  description: Indicate how the termination message
+                                    should be populated.
                                   type: string
                                 tty:
-                                  description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                  description: Whether this container should allocate
+                                    a TTY for itself, also requires 'stdin' to be
+                                    true.
                                   type: boolean
                                 volumeDevices:
-                                  description: volumeDevices is the list of block devices to be used by the container.
+                                  description: volumeDevices is the list of block
+                                    devices to be used by the container.
                                   items:
-                                    description: volumeDevice describes a mapping of a raw block device within a container.
+                                    description: volumeDevice describes a mapping
+                                      of a raw block device within a container.
                                     properties:
                                       devicePath:
-                                        description: devicePath is the path inside of the container that the device will be mapped to.
+                                        description: devicePath is the path inside
+                                          of the container that the device will be
+                                          mapped to.
                                         type: string
                                       name:
-                                        description: name must match the name of a persistentVolumeClaim in the pod
+                                        description: name must match the name of a
+                                          persistentVolumeClaim in the pod
                                         type: string
                                     required:
                                     - devicePath
@@ -1859,27 +2458,39 @@ spec:
                                     type: object
                                   type: array
                                 volumeMounts:
-                                  description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                  description: Pod volumes to mount into the container's
+                                    filesystem. Cannot be updated.
                                   items:
-                                    description: VolumeMount describes a mounting of a Volume within a container.
+                                    description: VolumeMount describes a mounting
+                                      of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                        description: Path within the container at
+                                          which the volume should be mounted.  Must
+                                          not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: mountPropagation determines how mounts are propagated from the host to container and the other way a
+                                        description: mountPropagation determines how
+                                          mounts are propagated from the host to container
+                                          and the other way a
                                         type: string
                                       name:
-                                        description: This must match the Name of a Volume.
+                                        description: This must match the Name of a
+                                          Volume.
                                         type: string
                                       readOnly:
-                                        description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                        description: Mounted read-only if true, read-write
+                                          otherwise (false or unspecified). Defaults
+                                          to false.
                                         type: boolean
                                       subPath:
-                                        description: Path within the volume from which the container's volume should be mounted.
+                                        description: Path within the volume from which
+                                          the container's volume should be mounted.
                                         type: string
                                       subPathExpr:
-                                        description: Expanded path within the volume from which the container's volume should be mounted.
+                                        description: Expanded path within the volume
+                                          from which the container's volume should
+                                          be mounted.
                                         type: string
                                     required:
                                     - mountPath
@@ -1894,9 +2505,13 @@ spec:
                               type: object
                             type: array
                           hostAliases:
-                            description: 'HostAliases is an optional list of hosts and IPs that will be injected into the pod''s hosts file if '
+                            description: 'HostAliases is an optional list of hosts
+                              and IPs that will be injected into the pod''s hosts
+                              file if '
                             items:
-                              description: 'HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod''s '
+                              description: 'HostAlias holds the mapping between IP
+                                and hostnames that will be injected as an entry in
+                                the pod''s '
                               properties:
                                 hostnames:
                                   description: Hostnames for the above IP address.
@@ -1909,21 +2524,27 @@ spec:
                               type: object
                             type: array
                           hostIPC:
-                            description: 'Use the host''s ipc namespace. Optional: Default to false.'
+                            description: 'Use the host''s ipc namespace. Optional:
+                              Default to false.'
                             type: boolean
                           hostNetwork:
-                            description: Host networking requested for this pod. Use the host's network namespace.
+                            description: Host networking requested for this pod. Use
+                              the host's network namespace.
                             type: boolean
                           hostPID:
-                            description: 'Use the host''s pid namespace. Optional: Default to false.'
+                            description: 'Use the host''s pid namespace. Optional:
+                              Default to false.'
                             type: boolean
                           hostname:
-                            description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defin
+                            description: Specifies the hostname of the Pod If not
+                              specified, the pod's hostname will be set to a system-defin
                             type: string
                           imagePullSecrets:
-                            description: ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulli
+                            description: ImagePullSecrets is an optional list of references
+                              to secrets in the same namespace to use for pulli
                             items:
-                              description: 'LocalObjectReference contains enough information to let you locate the referenced object inside the '
+                              description: 'LocalObjectReference contains enough information
+                                to let you locate the referenced object inside the '
                               properties:
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.'
@@ -1931,33 +2552,43 @@ spec:
                               type: object
                             type: array
                           initContainers:
-                            description: List of initialization containers belonging to the pod.
+                            description: List of initialization containers belonging
+                              to the pod.
                             items:
-                              description: A single application container that you want to run within a pod.
+                              description: A single application container that you
+                                want to run within a pod.
                               properties:
                                 args:
-                                  description: Arguments to the entrypoint. The docker image's CMD is used if this is not provided.
+                                  description: Arguments to the entrypoint. The docker
+                                    image's CMD is used if this is not provided.
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: Entrypoint array. Not executed within a shell.
+                                  description: Entrypoint array. Not executed within
+                                    a shell.
                                   items:
                                     type: string
                                   type: array
                                 env:
-                                  description: List of environment variables to set in the container. Cannot be updated.
+                                  description: List of environment variables to set
+                                    in the container. Cannot be updated.
                                   items:
-                                    description: EnvVar represents an environment variable present in a Container.
+                                    description: EnvVar represents an environment
+                                      variable present in a Container.
                                     properties:
                                       name:
-                                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                        description: Name of the environment variable.
+                                          Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the
+                                        description: Variable references $(VAR_NAME)
+                                          are expanded using the previous defined
+                                          environment variables in the
                                         type: string
                                       valueFrom:
-                                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                        description: Source for the environment variable's
+                                          value. Cannot be used if value is not empty.
                                         properties:
                                           configMapKeyRef:
                                             description: Selects a key of a ConfigMap.
@@ -1966,56 +2597,74 @@ spec:
                                                 description: The key to select.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: Specify whether the ConfigMap or its key must be defined
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
                                             type: object
                                           fieldRef:
-                                            description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.'
+                                            description: 'Selects a field of the pod:
+                                              supports metadata.name, metadata.namespace,
+                                              `metadata.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to select in the specified API version.
+                                                description: Path of the field to
+                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
+                                            description: 'Selects a resource of the
+                                              container: only resources limits and
+                                              requests (limits.cpu, limits.'
                                             properties:
                                               containerName:
-                                                description: 'Container name: required for volumes, optional for env vars'
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to select'
+                                                description: 'Required: resource to
+                                                  select'
                                                 type: string
                                             required:
                                             - resource
                                             type: object
                                           secretKeyRef:
-                                            description: Selects a key of a secret in the pod's namespace
+                                            description: Selects a key of a secret
+                                              in the pod's namespace
                                             properties:
                                               key:
-                                                description: The key of the secret to select from.  Must be a valid secret key.
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
                                                 type: string
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: Specify whether the Secret or its key must be defined
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
@@ -2026,31 +2675,39 @@ spec:
                                     type: object
                                   type: array
                                 envFrom:
-                                  description: List of sources to populate environment variables in the container.
+                                  description: List of sources to populate environment
+                                    variables in the container.
                                   items:
-                                    description: EnvFromSource represents the source of a set of ConfigMaps
+                                    description: EnvFromSource represents the source
+                                      of a set of ConfigMaps
                                     properties:
                                       configMapRef:
                                         description: The ConfigMap to select from
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap must be defined
+                                            description: Specify whether the ConfigMap
+                                              must be defined
                                             type: boolean
                                         type: object
                                       prefix:
-                                        description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                        description: An optional identifier to prepend
+                                          to each key in the ConfigMap. Must be a
+                                          C_IDENTIFIER.
                                         type: string
                                       secretRef:
                                         description: The Secret to select from
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret must be defined
+                                            description: Specify whether the Secret
+                                              must be defined
                                             type: boolean
                                         type: object
                                     type: object
@@ -2059,39 +2716,55 @@ spec:
                                   description: 'Docker image name. More info: https://kubernetes.'
                                   type: string
                                 imagePullPolicy:
-                                  description: Image pull policy. One of Always, Never, IfNotPresent.
+                                  description: Image pull policy. One of Always, Never,
+                                    IfNotPresent.
                                   type: string
                                 lifecycle:
-                                  description: Actions that the management system should take in response to container lifecycle events.
+                                  description: Actions that the management system
+                                    should take in response to container lifecycle
+                                    events.
                                   properties:
                                     postStart:
-                                      description: PostStart is called immediately after a container is created.
+                                      description: PostStart is called immediately
+                                        after a container is created.
                                       properties:
                                         exec:
-                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
                                           properties:
                                             command:
-                                              description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                              description: 'Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  '
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http request to perform.
+                                          description: HTTPGet specifies the http
+                                            request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to, defaults to the pod IP.
+                                              description: Host name to connect to,
+                                                defaults to the pod IP.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
                                               items:
-                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
                                                 properties:
                                                   name:
-                                                    description: The header field name
+                                                    description: The header field
+                                                      name
                                                     type: string
                                                   value:
-                                                    description: The header field value
+                                                    description: The header field
+                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -2099,64 +2772,86 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP server.
+                                              description: Path to access on the HTTP
+                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: TCPSocket specifies an action involving a TCP port.
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: PreStop is called immediately before a container is terminated due to an API request or management e
+                                      description: PreStop is called immediately before
+                                        a container is terminated due to an API request
+                                        or management e
                                       properties:
                                         exec:
-                                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                                          description: One and only one of the following
+                                            should be specified. Exec specifies the
+                                            action to take.
                                           properties:
                                             command:
-                                              description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                              description: 'Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  '
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http request to perform.
+                                          description: HTTPGet specifies the http
+                                            request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to, defaults to the pod IP.
+                                              description: Host name to connect to,
+                                                defaults to the pod IP.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
                                               items:
-                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
                                                 properties:
                                                   name:
-                                                    description: The header field name
+                                                    description: The header field
+                                                      name
                                                     type: string
                                                   value:
-                                                    description: The header field value
+                                                    description: The header field
+                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -2164,31 +2859,39 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP server.
+                                              description: Path to access on the HTTP
+                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         tcpSocket:
-                                          description: TCPSocket specifies an action involving a TCP port.
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -2196,31 +2899,42 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: Periodic probe of container liveness. Container will be restarted if the probe fails.
+                                  description: Periodic probe of container liveness.
+                                    Container will be restarted if the probe fails.
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
                                       properties:
                                         command:
-                                          description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                          description: 'Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      description: Minimum consecutive failures for
+                                        the probe to be considered failed after having
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
+                                      description: HTTPGet specifies the http request
+                                        to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP.
+                                          description: Host name to connect to, defaults
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 description: The header field name
@@ -2234,77 +2948,101 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
+                                          description: Path to access on the HTTP
+                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: Number of seconds after the container has started before liveness probes are initiated.
+                                      description: Number of seconds after the container
+                                        has started before liveness probes are initiated.
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                      description: How often (in seconds) to perform
+                                        the probe. Default to 10 seconds. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      description: Minimum consecutive successes for
+                                        the probe to be considered successful after
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving a TCP port.
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
-                                  description: Name of the container specified as a DNS_LABEL.
+                                  description: Name of the container specified as
+                                    a DNS_LABEL.
                                   type: string
                                 ports:
                                   description: List of ports to expose from the container.
                                   items:
-                                    description: ContainerPort represents a network port in a single container.
+                                    description: ContainerPort represents a network
+                                      port in a single container.
                                     properties:
                                       containerPort:
-                                        description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                        description: Number of port to expose on the
+                                          pod's IP address. This must be a valid port
+                                          number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       hostIP:
-                                        description: What host IP to bind the external port to.
+                                        description: What host IP to bind the external
+                                          port to.
                                         type: string
                                       hostPort:
-                                        description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536.
+                                        description: Number of port to expose on the
+                                          host. If specified, this must be a valid
+                                          port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       name:
-                                        description: If specified, this must be an IANA_SVC_NAME and unique within the pod.
+                                        description: If specified, this must be an
+                                          IANA_SVC_NAME and unique within the pod.
                                         type: string
                                       protocol:
                                         default: TCP
-                                        description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                        description: Protocol for port. Must be UDP,
+                                          TCP, or SCTP. Defaults to "TCP".
                                         type: string
                                     required:
                                     - containerPort
@@ -2315,31 +3053,42 @@ spec:
                                   - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
-                                  description: Periodic probe of container service readiness.
+                                  description: Periodic probe of container service
+                                    readiness.
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
                                       properties:
                                         command:
-                                          description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                          description: 'Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      description: Minimum consecutive failures for
+                                        the probe to be considered failed after having
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
+                                      description: HTTPGet specifies the http request
+                                        to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP.
+                                          description: Host name to connect to, defaults
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 description: The header field name
@@ -2353,54 +3102,70 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
+                                          description: Path to access on the HTTP
+                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: Number of seconds after the container has started before liveness probes are initiated.
+                                      description: Number of seconds after the container
+                                        has started before liveness probes are initiated.
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                      description: How often (in seconds) to perform
+                                        the probe. Default to 10 seconds. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      description: Minimum consecutive successes for
+                                        the probe to be considered successful after
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving a TCP port.
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 resources:
-                                  description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.'
+                                  description: 'Compute Resources required by this
+                                    container. Cannot be updated. More info: https://kubernetes.'
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -2409,7 +3174,8 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
+                                      description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.'
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -2418,28 +3184,35 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: Requests describes the minimum amount of compute resources required.
+                                      description: Requests describes the minimum
+                                        amount of compute resources required.
                                       type: object
                                   type: object
                                 securityContext:
-                                  description: 'Security options the pod should run with. More info: https://kubernetes.'
+                                  description: 'Security options the pod should run
+                                    with. More info: https://kubernetes.'
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process
+                                      description: AllowPrivilegeEscalation controls
+                                        whether a process can gain more privileges
+                                        than its parent process
                                       type: boolean
                                     capabilities:
-                                      description: The capabilities to add/drop when running containers.
+                                      description: The capabilities to add/drop when
+                                        running containers.
                                       properties:
                                         add:
                                           description: Added capabilities
                                           items:
-                                            description: Capability represent POSIX capabilities type
+                                            description: Capability represent POSIX
+                                              capabilities type
                                             type: string
                                           type: array
                                         drop:
                                           description: Removed capabilities
                                           items:
-                                            description: Capability represent POSIX capabilities type
+                                            description: Capability represent POSIX
+                                              capabilities type
                                             type: string
                                           type: array
                                       type: object
@@ -2447,90 +3220,120 @@ spec:
                                       description: Run container in privileged mode.
                                       type: boolean
                                     procMount:
-                                      description: procMount denotes the type of proc mount to use for the containers.
+                                      description: procMount denotes the type of proc
+                                        mount to use for the containers.
                                       type: string
                                     readOnlyRootFilesystem:
-                                      description: Whether this container has a read-only root filesystem. Default is false.
+                                      description: Whether this container has a read-only
+                                        root filesystem. Default is false.
                                       type: boolean
                                     runAsGroup:
-                                      description: The GID to run the entrypoint of the container process. Uses runtime default if unset.
+                                      description: The GID to run the entrypoint of
+                                        the container process. Uses runtime default
+                                        if unset.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
-                                      description: Indicates that the container must run as a non-root user.
+                                      description: Indicates that the container must
+                                        run as a non-root user.
                                       type: boolean
                                     runAsUser:
-                                      description: The UID to run the entrypoint of the container process.
+                                      description: The UID to run the entrypoint of
+                                        the container process.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
-                                      description: The SELinux context to be applied to the container.
+                                      description: The SELinux context to be applied
+                                        to the container.
                                       properties:
                                         level:
-                                          description: Level is SELinux level label that applies to the container.
+                                          description: Level is SELinux level label
+                                            that applies to the container.
                                           type: string
                                         role:
-                                          description: Role is a SELinux role label that applies to the container.
+                                          description: Role is a SELinux role label
+                                            that applies to the container.
                                           type: string
                                         type:
-                                          description: Type is a SELinux type label that applies to the container.
+                                          description: Type is a SELinux type label
+                                            that applies to the container.
                                           type: string
                                         user:
-                                          description: User is a SELinux user label that applies to the container.
+                                          description: User is a SELinux user label
+                                            that applies to the container.
                                           type: string
                                       type: object
                                     seccompProfile:
-                                      description: The seccomp options to use by this container.
+                                      description: The seccomp options to use by this
+                                        container.
                                       properties:
                                         localhostProfile:
-                                          description: localhostProfile indicates a profile defined in a file on the node should be used.
+                                          description: localhostProfile indicates
+                                            a profile defined in a file on the node
+                                            should be used.
                                           type: string
                                         type:
-                                          description: type indicates which kind of seccomp profile will be applied.
+                                          description: type indicates which kind of
+                                            seccomp profile will be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
-                                      description: The Windows specific settings applied to all containers.
+                                      description: The Windows specific settings applied
+                                        to all containers.
                                       properties:
                                         gmsaCredentialSpec:
-                                          description: GMSACredentialSpec is where the GMSA admission webhook (https://github.
+                                          description: GMSACredentialSpec is where
+                                            the GMSA admission webhook (https://github.
                                           type: string
                                         gmsaCredentialSpecName:
-                                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                          description: GMSACredentialSpecName is the
+                                            name of the GMSA credential spec to use.
                                           type: string
                                         runAsUserName:
-                                          description: The UserName in Windows to run the entrypoint of the container process.
+                                          description: The UserName in Windows to
+                                            run the entrypoint of the container process.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: StartupProbe indicates that the Pod has successfully initialized.
+                                  description: StartupProbe indicates that the Pod
+                                    has successfully initialized.
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
                                       properties:
                                         command:
-                                          description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                          description: 'Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  '
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      description: Minimum consecutive failures for
+                                        the probe to be considered failed after having
+                                        succeeded.
                                       format: int32
                                       type: integer
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
+                                      description: HTTPGet specifies the http request
+                                        to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP.
+                                          description: Host name to connect to, defaults
+                                            to the pod IP.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
                                             properties:
                                               name:
                                                 description: The header field name
@@ -2544,77 +3347,105 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
+                                          description: Path to access on the HTTP
+                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: Number of seconds after the container has started before liveness probes are initiated.
+                                      description: Number of seconds after the container
+                                        has started before liveness probes are initiated.
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                      description: How often (in seconds) to perform
+                                        the probe. Default to 10 seconds. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      description: Minimum consecutive successes for
+                                        the probe to be considered successful after
+                                        having failed.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving a TCP port.
+                                      description: TCPSocket specifies an action involving
+                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     timeoutSeconds:
-                                      description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                      description: Number of seconds after which the
+                                        probe times out. Defaults to 1 second. Minimum
+                                        value is 1.
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
-                                  description: Whether this container should allocate a buffer for stdin in the container runtime.
+                                  description: Whether this container should allocate
+                                    a buffer for stdin in the container runtime.
                                   type: boolean
                                 stdinOnce:
-                                  description: Whether the container runtime should close the stdin channel after it has been opened by a single at
+                                  description: Whether the container runtime should
+                                    close the stdin channel after it has been opened
+                                    by a single at
                                   type: boolean
                                 terminationMessagePath:
-                                  description: 'Optional: Path at which the file to which the container''s termination message will be written is mou'
+                                  description: 'Optional: Path at which the file to
+                                    which the container''s termination message will
+                                    be written is mou'
                                   type: string
                                 terminationMessagePolicy:
-                                  description: Indicate how the termination message should be populated.
+                                  description: Indicate how the termination message
+                                    should be populated.
                                   type: string
                                 tty:
-                                  description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                  description: Whether this container should allocate
+                                    a TTY for itself, also requires 'stdin' to be
+                                    true.
                                   type: boolean
                                 volumeDevices:
-                                  description: volumeDevices is the list of block devices to be used by the container.
+                                  description: volumeDevices is the list of block
+                                    devices to be used by the container.
                                   items:
-                                    description: volumeDevice describes a mapping of a raw block device within a container.
+                                    description: volumeDevice describes a mapping
+                                      of a raw block device within a container.
                                     properties:
                                       devicePath:
-                                        description: devicePath is the path inside of the container that the device will be mapped to.
+                                        description: devicePath is the path inside
+                                          of the container that the device will be
+                                          mapped to.
                                         type: string
                                       name:
-                                        description: name must match the name of a persistentVolumeClaim in the pod
+                                        description: name must match the name of a
+                                          persistentVolumeClaim in the pod
                                         type: string
                                     required:
                                     - devicePath
@@ -2622,27 +3453,39 @@ spec:
                                     type: object
                                   type: array
                                 volumeMounts:
-                                  description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                  description: Pod volumes to mount into the container's
+                                    filesystem. Cannot be updated.
                                   items:
-                                    description: VolumeMount describes a mounting of a Volume within a container.
+                                    description: VolumeMount describes a mounting
+                                      of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                        description: Path within the container at
+                                          which the volume should be mounted.  Must
+                                          not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: mountPropagation determines how mounts are propagated from the host to container and the other way a
+                                        description: mountPropagation determines how
+                                          mounts are propagated from the host to container
+                                          and the other way a
                                         type: string
                                       name:
-                                        description: This must match the Name of a Volume.
+                                        description: This must match the Name of a
+                                          Volume.
                                         type: string
                                       readOnly:
-                                        description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                        description: Mounted read-only if true, read-write
+                                          otherwise (false or unspecified). Defaults
+                                          to false.
                                         type: boolean
                                       subPath:
-                                        description: Path within the volume from which the container's volume should be mounted.
+                                        description: Path within the volume from which
+                                          the container's volume should be mounted.
                                         type: string
                                       subPathExpr:
-                                        description: Expanded path within the volume from which the container's volume should be mounted.
+                                        description: Expanded path within the volume
+                                          from which the container's volume should
+                                          be mounted.
                                         type: string
                                     required:
                                     - mountPath
@@ -2657,12 +3500,14 @@ spec:
                               type: object
                             type: array
                           nodeName:
-                            description: NodeName is a request to schedule this pod onto a specific node.
+                            description: NodeName is a request to schedule this pod
+                              onto a specific node.
                             type: string
                           nodeSelector:
                             additionalProperties:
                               type: string
-                            description: NodeSelector is a selector which must be true for the pod to fit on a node.
+                            description: NodeSelector is a selector which must be
+                              true for the pod to fit on a node.
                             type: object
                           overhead:
                             additionalProperties:
@@ -2671,98 +3516,126 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                            description: Overhead represents the resource overhead
+                              associated with running a pod for a given RuntimeClass.
                             type: object
                           preemptionPolicy:
-                            description: PreemptionPolicy is the Policy for preempting pods with lower priority.
+                            description: PreemptionPolicy is the Policy for preempting
+                              pods with lower priority.
                             type: string
                           priority:
-                            description: The priority value. Various system components use this field to find the priority of the pod.
+                            description: The priority value. Various system components
+                              use this field to find the priority of the pod.
                             format: int32
                             type: integer
                           priorityClassName:
                             description: If specified, indicates the pod's priority.
                             type: string
                           readinessGates:
-                            description: If specified, all readiness gates will be evaluated for pod readiness.
+                            description: If specified, all readiness gates will be
+                              evaluated for pod readiness.
                             items:
-                              description: PodReadinessGate contains the reference to a pod condition
+                              description: PodReadinessGate contains the reference
+                                to a pod condition
                               properties:
                                 conditionType:
-                                  description: ConditionType refers to a condition in the pod's condition list with matching type.
+                                  description: ConditionType refers to a condition
+                                    in the pod's condition list with matching type.
                                   type: string
                               required:
                               - conditionType
                               type: object
                             type: array
                           restartPolicy:
-                            description: Restart policy for all containers within the pod. One of Always, OnFailure, Never.
+                            description: Restart policy for all containers within
+                              the pod. One of Always, OnFailure, Never.
                             type: string
                           runtimeClassName:
-                            description: RuntimeClassName refers to a RuntimeClass object in the node.k8s.
+                            description: RuntimeClassName refers to a RuntimeClass
+                              object in the node.k8s.
                             type: string
                           schedulerName:
-                            description: If specified, the pod will be dispatched by specified scheduler.
+                            description: If specified, the pod will be dispatched
+                              by specified scheduler.
                             type: string
                           securityContext:
-                            description: SecurityContext holds pod-level security attributes and common container settings.
+                            description: SecurityContext holds pod-level security
+                              attributes and common container settings.
                             properties:
                               fsGroup:
-                                description: A special supplemental group that applies to all containers in a pod.
+                                description: A special supplemental group that applies
+                                  to all containers in a pod.
                                 format: int64
                                 type: integer
                               fsGroupChangePolicy:
-                                description: fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being
+                                description: fsGroupChangePolicy defines behavior
+                                  of changing ownership and permission of the volume
+                                  before being
                                 type: string
                               runAsGroup:
-                                description: The GID to run the entrypoint of the container process. Uses runtime default if unset.
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
                                 format: int64
                                 type: integer
                               runAsNonRoot:
-                                description: Indicates that the container must run as a non-root user.
+                                description: Indicates that the container must run
+                                  as a non-root user.
                                 type: boolean
                               runAsUser:
-                                description: The UID to run the entrypoint of the container process.
+                                description: The UID to run the entrypoint of the
+                                  container process.
                                 format: int64
                                 type: integer
                               seLinuxOptions:
-                                description: The SELinux context to be applied to all containers.
+                                description: The SELinux context to be applied to
+                                  all containers.
                                 properties:
                                   level:
-                                    description: Level is SELinux level label that applies to the container.
+                                    description: Level is SELinux level label that
+                                      applies to the container.
                                     type: string
                                   role:
-                                    description: Role is a SELinux role label that applies to the container.
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
                                     type: string
                                   type:
-                                    description: Type is a SELinux type label that applies to the container.
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
                                     type: string
                                   user:
-                                    description: User is a SELinux user label that applies to the container.
+                                    description: User is a SELinux user label that
+                                      applies to the container.
                                     type: string
                                 type: object
                               seccompProfile:
-                                description: The seccomp options to use by the containers in this pod.
+                                description: The seccomp options to use by the containers
+                                  in this pod.
                                 properties:
                                   localhostProfile:
-                                    description: localhostProfile indicates a profile defined in a file on the node should be used.
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
                                     type: string
                                   type:
-                                    description: type indicates which kind of seccomp profile will be applied.
+                                    description: type indicates which kind of seccomp
+                                      profile will be applied.
                                     type: string
                                 required:
                                 - type
                                 type: object
                               supplementalGroups:
-                                description: 'A list of groups applied to the first process run in each container, in addition to the container''s '
+                                description: 'A list of groups applied to the first
+                                  process run in each container, in addition to the
+                                  container''s '
                                 items:
                                   format: int64
                                   type: integer
                                 type: array
                               sysctls:
-                                description: Sysctls hold a list of namespaced sysctls used for the pod.
+                                description: Sysctls hold a list of namespaced sysctls
+                                  used for the pod.
                                 items:
-                                  description: Sysctl defines a kernel parameter to be set
+                                  description: Sysctl defines a kernel parameter to
+                                    be set
                                   properties:
                                     name:
                                       description: Name of a property to set
@@ -2776,82 +3649,109 @@ spec:
                                   type: object
                                 type: array
                               windowsOptions:
-                                description: The Windows specific settings applied to all containers.
+                                description: The Windows specific settings applied
+                                  to all containers.
                                 properties:
                                   gmsaCredentialSpec:
-                                    description: GMSACredentialSpec is where the GMSA admission webhook (https://github.
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.
                                     type: string
                                   gmsaCredentialSpecName:
-                                    description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
                                     type: string
                                   runAsUserName:
-                                    description: The UserName in Windows to run the entrypoint of the container process.
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process.
                                     type: string
                                 type: object
                             type: object
                           serviceAccount:
-                            description: DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                            description: DeprecatedServiceAccount is a depreciated
+                              alias for ServiceAccountName.
                             type: string
                           serviceAccountName:
-                            description: ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                            description: ServiceAccountName is the name of the ServiceAccount
+                              to use to run this pod.
                             type: string
                           setHostnameAsFQDN:
-                            description: If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the defa
+                            description: If true the pod's hostname will be configured
+                              as the pod's FQDN, rather than the leaf name (the defa
                             type: boolean
                           shareProcessNamespace:
-                            description: Share a single process namespace between all of the containers in a pod.
+                            description: Share a single process namespace between
+                              all of the containers in a pod.
                             type: boolean
                           subdomain:
-                            description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.
+                            description: If specified, the fully qualified Pod hostname
+                              will be "<hostname>.<subdomain>.<pod namespace>.svc.
                             type: string
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs to terminate gracefully.
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully.
                             format: int64
                             type: integer
                           tolerations:
                             description: If specified, the pod's tolerations.
                             items:
-                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
+                              description: The pod this Toleration is attached to
+                                tolerates any taint that matches the triple <key,value,effect
                               properties:
                                 effect:
-                                  description: Effect indicates the taint effect to match. Empty means match all taint effects.
+                                  description: Effect indicates the taint effect to
+                                    match. Empty means match all taint effects.
                                   type: string
                                 key:
-                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                  description: Key is the taint key that the toleration
+                                    applies to. Empty means match all taint keys.
                                   type: string
                                 operator:
-                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
+                                  description: Operator represents a key's relationship
+                                    to the value. Valid operators are Exists and Equal.
                                   type: string
                                 tolerationSeconds:
-                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
+                                  description: TolerationSeconds represents the period
+                                    of time the toleration (which must be of effect
+                                    NoExecute, o
                                   format: int64
                                   type: integer
                                 value:
-                                  description: Value is the taint value the toleration matches to.
+                                  description: Value is the taint value the toleration
+                                    matches to.
                                   type: string
                               type: object
                             type: array
                           topologySpreadConstraints:
-                            description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains.
+                            description: TopologySpreadConstraints describes how a
+                              group of pods ought to spread across topology domains.
                             items:
-                              description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                              description: TopologySpreadConstraint specifies how
+                                to spread matching pods among the given topology.
                               properties:
                                 labelSelector:
-                                  description: LabelSelector is used to find matching pods.
+                                  description: LabelSelector is used to find matching
+                                    pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values.
+                                            description: operator represents a key's
+                                              relationship to a set of values.
                                             type: string
                                           values:
-                                            description: values is an array of string values.
+                                            description: values is an array of string
+                                              values.
                                             items:
                                               type: string
                                             type: array
@@ -2863,18 +3763,22 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs.
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                 maxSkew:
-                                  description: MaxSkew describes the degree to which pods may be unevenly distributed.
+                                  description: MaxSkew describes the degree to which
+                                    pods may be unevenly distributed.
                                   format: int32
                                   type: integer
                                 topologyKey:
                                   description: TopologyKey is the key of node labels.
                                   type: string
                                 whenUnsatisfiable:
-                                  description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
+                                  description: WhenUnsatisfiable indicates how to
+                                    deal with a pod if it doesn't satisfy the spread
+                                    constraint.
                                   type: string
                               required:
                               - maxSkew
@@ -2887,62 +3791,86 @@ spec:
                             - whenUnsatisfiable
                             x-kubernetes-list-type: map
                           volumes:
-                            description: List of volumes that can be mounted by containers belonging to the pod.
+                            description: List of volumes that can be mounted by containers
+                              belonging to the pod.
                             items:
-                              description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                              description: Volume represents a named volume in a pod
+                                that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine an
+                                  description: AWSElasticBlockStore represents an
+                                    AWS Disk resource that is attached to a kubelet's
+                                    host machine an
                                   properties:
                                     fsType:
-                                      description: Filesystem type of the volume that you want to mount.
+                                      description: Filesystem type of the volume that
+                                        you want to mount.
                                       type: string
                                     partition:
-                                      description: The partition in the volume that you want to mount.
+                                      description: The partition in the volume that
+                                        you want to mount.
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+                                      description: Specify "true" to force and set
+                                        the ReadOnly property in VolumeMounts to "true".
                                       type: boolean
                                     volumeID:
-                                      description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.'
+                                      description: 'Unique ID of the persistent disk
+                                        resource in AWS (Amazon EBS volume). More
+                                        info: https://kubernetes.'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 azureDisk:
-                                  description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                  description: AzureDisk represents an Azure Data
+                                    Disk mount on the host and bind mount to the pod.
                                   properties:
                                     cachingMode:
-                                      description: 'Host Caching mode: None, Read Only, Read Write.'
+                                      description: 'Host Caching mode: None, Read
+                                        Only, Read Write.'
                                       type: string
                                     diskName:
-                                      description: The Name of the data disk in the blob storage
+                                      description: The Name of the data disk in the
+                                        blob storage
                                       type: string
                                     diskURI:
-                                      description: The URI the data disk in the blob storage
+                                      description: The URI the data disk in the blob
+                                        storage
                                       type: string
                                     fsType:
-                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                      description: Filesystem type to mount. Must
+                                        be a filesystem type supported by the host
+                                        operating system. Ex.
                                       type: string
                                     kind:
-                                      description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per sto'
+                                      description: 'Expected values Shared: multiple
+                                        blob disks per storage account  Dedicated:
+                                        single blob disk per sto'
                                       type: string
                                     readOnly:
-                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      description: Defaults to false (read/write).
+                                        ReadOnly here will force the ReadOnly setting
+                                        in VolumeMounts.
                                       type: boolean
                                   required:
                                   - diskName
                                   - diskURI
                                   type: object
                                 azureFile:
-                                  description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                  description: AzureFile represents an Azure File
+                                    Service mount on the host and bind mount to the
+                                    pod.
                                   properties:
                                     readOnly:
-                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      description: Defaults to false (read/write).
+                                        ReadOnly here will force the ReadOnly setting
+                                        in VolumeMounts.
                                       type: boolean
                                     secretName:
-                                      description: the name of secret that contains Azure Storage Account Name and Key
+                                      description: the name of secret that contains
+                                        Azure Storage Account Name and Key
                                       type: string
                                     shareName:
                                       description: Share Name
@@ -2952,78 +3880,101 @@ spec:
                                   - shareName
                                   type: object
                                 cephfs:
-                                  description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                                  description: CephFS represents a Ceph FS mount on
+                                    the host that shares a pod's lifetime
                                   properties:
                                     monitors:
-                                      description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.'
+                                      description: 'Required: Monitors is a collection
+                                        of Ceph monitors More info: https://examples.k8s.'
                                       items:
                                         type: string
                                       type: array
                                     path:
-                                      description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                      description: 'Optional: Used as the mounted
+                                        root, rather than the full Ceph tree, default
+                                        is /'
                                       type: string
                                     readOnly:
                                       description: 'Optional: Defaults to false (read/write).'
                                       type: boolean
                                     secretFile:
-                                      description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.'
+                                      description: 'Optional: SecretFile is the path
+                                        to key ring for User, default is /etc/ceph/user.'
                                       type: string
                                     secretRef:
-                                      description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty.'
+                                      description: 'Optional: SecretRef is reference
+                                        to the authentication secret for User, default
+                                        is empty.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.'
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     user:
-                                      description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.'
+                                      description: 'Optional: User is the rados user
+                                        name, default is admin More info: https://examples.k8s.'
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: Cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                  description: Cinder represents a cinder volume attached
+                                    and mounted on kubelets host machine.
                                   properties:
                                     fsType:
-                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system.
+                                      description: Filesystem type to mount. Must
+                                        be a filesystem type supported by the host
+                                        operating system.
                                       type: string
                                     readOnly:
                                       description: 'Optional: Defaults to false (read/write).'
                                       type: boolean
                                     secretRef:
-                                      description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                      description: 'Optional: points to a secret object
+                                        containing parameters used to connect to OpenStack.'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.'
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     volumeID:
-                                      description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.'
+                                      description: 'volume id used to identify the
+                                        volume in cinder. More info: https://examples.k8s.'
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 configMap:
-                                  description: ConfigMap represents a configMap that should populate this volume
+                                  description: ConfigMap represents a configMap that
+                                    should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'Optional: mode bits used to set permissions on created files by default.'
+                                      description: 'Optional: mode bits used to set
+                                        permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: 'If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected '
+                                      description: 'If unspecified, each key-value
+                                        pair in the Data field of the referenced ConfigMap
+                                        will be projected '
                                       items:
-                                        description: Maps a string key to a path within a volume.
+                                        description: Maps a string key to a path within
+                                          a volume.
                                         properties:
                                           key:
                                             description: The key to project.
                                             type: string
                                           mode:
-                                            description: 'Optional: mode bits used to set permissions on this file.'
+                                            description: 'Optional: mode bits used
+                                              to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: The relative path of the file to map the key to. May not be an absolute path.
+                                            description: The relative path of the
+                                              file to map the key to. May not be an
+                                              absolute path.
                                             type: string
                                         required:
                                         - key
@@ -3031,85 +3982,115 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.'
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or its keys must be defined
+                                      description: Specify whether the ConfigMap or
+                                        its keys must be defined
                                       type: boolean
                                   type: object
                                 csi:
-                                  description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external C
+                                  description: CSI (Container Storage Interface) represents
+                                    ephemeral storage that is handled by certain external
+                                    C
                                   properties:
                                     driver:
-                                      description: Driver is the name of the CSI driver that handles this volume.
+                                      description: Driver is the name of the CSI driver
+                                        that handles this volume.
                                       type: string
                                     fsType:
-                                      description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs".
+                                      description: Filesystem type to mount. Ex. "ext4",
+                                        "xfs", "ntfs".
                                       type: string
                                     nodePublishSecretRef:
-                                      description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to
+                                      description: NodePublishSecretRef is a reference
+                                        to the secret object containing sensitive
+                                        information to pass to
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.'
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     readOnly:
-                                      description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                      description: Specifies a read-only configuration
+                                        for the volume. Defaults to false (read/write).
                                       type: boolean
                                     volumeAttributes:
                                       additionalProperties:
                                         type: string
-                                      description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver.
+                                      description: VolumeAttributes stores driver-specific
+                                        properties that are passed to the CSI driver.
                                       type: object
                                   required:
                                   - driver
                                   type: object
                                 downwardAPI:
-                                  description: DownwardAPI represents downward API about the pod that should populate this volume
+                                  description: DownwardAPI represents downward API
+                                    about the pod that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: 'Optional: mode bits to use on created files by default.'
+                                      description: 'Optional: mode bits to use on
+                                        created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: Items is a list of downward API volume file
+                                      description: Items is a list of downward API
+                                        volume file
                                       items:
-                                        description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                        description: DownwardAPIVolumeFile represents
+                                          information to create the file containing
+                                          the pod field
                                         properties:
                                           fieldRef:
-                                            description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                            description: 'Required: Selects a field
+                                              of the pod: only annotations, labels,
+                                              name and namespace are supported.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to select in the specified API version.
+                                                description: Path of the field to
+                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                           mode:
-                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
+                                            description: 'Optional: mode bits used
+                                              to set permissions on this file, must
+                                              be an octal value between 0000 and 07'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: 'Required: Path is  the relative path name of the file to be created.'
+                                            description: 'Required: Path is  the relative
+                                              path name of the file to be created.'
                                             type: string
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
+                                            description: 'Selects a resource of the
+                                              container: only resources limits and
+                                              requests (limits.cpu, limits.'
                                             properties:
                                               containerName:
-                                                description: 'Container name: required for volumes, optional for env vars'
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to select'
+                                                description: 'Required: resource to
+                                                  select'
                                                 type: string
                                             required:
                                             - resource
@@ -3120,57 +4101,92 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: EmptyDir represents a temporary directory that shares a pod's lifetime.
+                                  description: EmptyDir represents a temporary directory
+                                    that shares a pod's lifetime.
                                   properties:
                                     medium:
-                                      description: What type of storage medium should back this directory.
+                                      description: What type of storage medium should
+                                        back this directory.
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Total amount of local storage required for this EmptyDir volume.
+                                      description: Total amount of local storage required
+                                        for this EmptyDir volume.
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: Ephemeral represents a volume that is handled by a cluster storage driver (Alpha feature).
+                                  description: Ephemeral represents a volume that
+                                    is handled by a cluster storage driver (Alpha
+                                    feature).
                                   properties:
                                     readOnly:
-                                      description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                      description: Specifies a read-only configuration
+                                        for the volume. Defaults to false (read/write).
                                       type: boolean
                                     volumeClaimTemplate:
-                                      description: Will be used to create a stand-alone PVC to provision the volume.
+                                      description: Will be used to create a stand-alone
+                                        PVC to provision the volume.
                                       properties:
                                         metadata:
-                                          description: May contain labels and annotations that will be copied into the PVC when creating it.
+                                          description: May contain labels and annotations
+                                            that will be copied into the PVC when
+                                            creating it.
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            finalizers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            labels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
                                           type: object
                                         spec:
                                           description: The specification for the PersistentVolumeClaim.
                                           properties:
                                             accessModes:
-                                              description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
+                                              description: 'AccessModes contains the
+                                                desired access modes the volume should
+                                                have. More info: https://kubernetes.'
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
-                                              description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.'
+                                              description: 'This field can be used
+                                                to specify either: * An existing VolumeSnapshot
+                                                object (snapshot.storage.k8s.'
                                               properties:
                                                 apiGroup:
-                                                  description: APIGroup is the group for the resource being referenced.
+                                                  description: APIGroup is the group
+                                                    for the resource being referenced.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of resource being referenced
+                                                  description: Kind is the type of
+                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of resource being referenced
+                                                  description: Name is the name of
+                                                    resource being referenced
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
                                             resources:
-                                              description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.'
+                                              description: 'Resources represents the
+                                                minimum resources the volume should
+                                                have. More info: https://kubernetes.'
                                               properties:
                                                 limits:
                                                   additionalProperties:
@@ -3179,7 +4195,9 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
+                                                  description: 'Limits describes the
+                                                    maximum amount of compute resources
+                                                    allowed. More info: https://kubernetes.'
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -3188,25 +4206,38 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: Requests describes the minimum amount of compute resources required.
+                                                  description: Requests describes
+                                                    the minimum amount of compute
+                                                    resources required.
                                                   type: object
                                               type: object
                                             selector:
-                                              description: A label query over volumes to consider for binding.
+                                              description: A label query over volumes
+                                                to consider for binding.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
                                                   items:
-                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates
                                                     properties:
                                                       key:
-                                                        description: key is the label key that the selector applies to.
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents a key's relationship to a set of values.
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values.
                                                         type: string
                                                       values:
-                                                        description: values is an array of string values.
+                                                        description: values is an
+                                                          array of string values.
                                                         items:
                                                           type: string
                                                         type: array
@@ -3218,17 +4249,24 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map of {key,value} pairs.
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs.
                                                   type: object
                                               type: object
                                             storageClassName:
-                                              description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.'
+                                              description: 'Name of the StorageClass
+                                                required by the claim. More info:
+                                                https://kubernetes.'
                                               type: string
                                             volumeMode:
-                                              description: volumeMode defines what type of volume is required by the claim.
+                                              description: volumeMode defines what
+                                                type of volume is required by the
+                                                claim.
                                               type: string
                                             volumeName:
-                                              description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                              description: VolumeName is the binding
+                                                reference to the PersistentVolume
+                                                backing this claim.
                                               type: string
                                           type: object
                                       required:
@@ -3236,10 +4274,14 @@ spec:
                                       type: object
                                   type: object
                                 fc:
-                                  description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed
+                                  description: FC represents a Fibre Channel resource
+                                    that is attached to a kubelet's host machine and
+                                    then exposed
                                   properties:
                                     fsType:
-                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                      description: Filesystem type to mount. Must
+                                        be a filesystem type supported by the host
+                                        operating system. Ex.
                                       type: string
                                     lun:
                                       description: 'Optional: FC target lun number'
@@ -3249,77 +4291,102 @@ spec:
                                       description: 'Optional: Defaults to false (read/write).'
                                       type: boolean
                                     targetWWNs:
-                                      description: 'Optional: FC target worldwide names (WWNs)'
+                                      description: 'Optional: FC target worldwide
+                                        names (WWNs)'
                                       items:
                                         type: string
                                       type: array
                                     wwids:
-                                      description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun'
+                                      description: 'Optional: FC volume world wide
+                                        identifiers (wwids) Either wwids or combination
+                                        of targetWWNs and lun'
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 flexVolume:
-                                  description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plu
+                                  description: FlexVolume represents a generic volume
+                                    resource that is provisioned/attached using an
+                                    exec based plu
                                   properties:
                                     driver:
-                                      description: Driver is the name of the driver to use for this volume.
+                                      description: Driver is the name of the driver
+                                        to use for this volume.
                                       type: string
                                     fsType:
-                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                      description: Filesystem type to mount. Must
+                                        be a filesystem type supported by the host
+                                        operating system. Ex.
                                       type: string
                                     options:
                                       additionalProperties:
                                         type: string
-                                      description: 'Optional: Extra command options if any.'
+                                      description: 'Optional: Extra command options
+                                        if any.'
                                       type: object
                                     readOnly:
                                       description: 'Optional: Defaults to false (read/write).'
                                       type: boolean
                                     secretRef:
-                                      description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to th'
+                                      description: 'Optional: SecretRef is reference
+                                        to the secret object containing sensitive
+                                        information to pass to th'
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.'
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                   required:
                                   - driver
                                   type: object
                                 flocker:
-                                  description: Flocker represents a Flocker volume attached to a kubelet's host machine.
+                                  description: Flocker represents a Flocker volume
+                                    attached to a kubelet's host machine.
                                   properties:
                                     datasetName:
-                                      description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as de
+                                      description: Name of the dataset stored as metadata
+                                        -> name on the dataset for Flocker should
+                                        be considered as de
                                       type: string
                                     datasetUUID:
-                                      description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                      description: UUID of the dataset. This is unique
+                                        identifier of a Flocker dataset
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and th
+                                  description: GCEPersistentDisk represents a GCE
+                                    Disk resource that is attached to a kubelet's
+                                    host machine and th
                                   properties:
                                     fsType:
-                                      description: Filesystem type of the volume that you want to mount.
+                                      description: Filesystem type of the volume that
+                                        you want to mount.
                                       type: string
                                     partition:
-                                      description: The partition in the volume that you want to mount.
+                                      description: The partition in the volume that
+                                        you want to mount.
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: Unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                      description: Unique name of the PD resource
+                                        in GCE. Used to identify the disk in GCE.
                                       type: string
                                     readOnly:
-                                      description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                      description: ReadOnly here will force the ReadOnly
+                                        setting in VolumeMounts. Defaults to false.
                                       type: boolean
                                   required:
                                   - pdName
                                   type: object
                                 gitRepo:
-                                  description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated.'
+                                  description: 'GitRepo represents a git repository
+                                    at a particular revision. DEPRECATED: GitRepo
+                                    is deprecated.'
                                   properties:
                                     directory:
-                                      description: Target directory name. Must not contain or start with '..'.  If '.
+                                      description: Target directory name. Must not
+                                        contain or start with '..'.  If '.
                                       type: string
                                     repository:
                                       description: Repository URL
@@ -3331,44 +4398,57 @@ spec:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                  description: Glusterfs represents a Glusterfs mount
+                                    on the host that shares a pod's lifetime.
                                   properties:
                                     endpoints:
-                                      description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.'
+                                      description: 'EndpointsName is the endpoint
+                                        name that details Glusterfs topology. More
+                                        info: https://examples.k8s.'
                                       type: string
                                     path:
-                                      description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.'
+                                      description: 'Path is the Glusterfs volume path.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.'
                                       type: string
                                     readOnly:
-                                      description: ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                      description: ReadOnly here will force the Glusterfs
+                                        volume to be mounted with read-only permissions.
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: HostPath represents a pre-existing file or directory on the host machine that is directly exposed to
+                                  description: HostPath represents a pre-existing
+                                    file or directory on the host machine that is
+                                    directly exposed to
                                   properties:
                                     path:
                                       description: Path of the directory on the host.
                                       type: string
                                     type:
-                                      description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.'
+                                      description: 'Type for HostPath Volume Defaults
+                                        to "" More info: https://kubernetes.'
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then expose
+                                  description: ISCSI represents an ISCSI Disk resource
+                                    that is attached to a kubelet's host machine and
+                                    then expose
                                   properties:
                                     chapAuthDiscovery:
-                                      description: whether support iSCSI Discovery CHAP authentication
+                                      description: whether support iSCSI Discovery
+                                        CHAP authentication
                                       type: boolean
                                     chapAuthSession:
-                                      description: whether support iSCSI Session CHAP authentication
+                                      description: whether support iSCSI Session CHAP
+                                        authentication
                                       type: boolean
                                     fsType:
-                                      description: Filesystem type of the volume that you want to mount.
+                                      description: Filesystem type of the volume that
+                                        you want to mount.
                                       type: string
                                     initiatorName:
                                       description: Custom iSCSI Initiator Name.
@@ -3377,7 +4457,9 @@ spec:
                                       description: Target iSCSI Qualified Name.
                                       type: string
                                     iscsiInterface:
-                                      description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                      description: iSCSI Interface Name that uses
+                                        an iSCSI transport. Defaults to 'default'
+                                        (tcp).
                                       type: string
                                     lun:
                                       description: iSCSI Target Lun number.
@@ -3389,13 +4471,16 @@ spec:
                                         type: string
                                       type: array
                                     readOnly:
-                                      description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                      description: ReadOnly here will force the ReadOnly
+                                        setting in VolumeMounts. Defaults to false.
                                       type: boolean
                                     secretRef:
-                                      description: CHAP Secret for iSCSI target and initiator authentication
+                                      description: CHAP Secret for iSCSI target and
+                                        initiator authentication
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.'
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     targetPortal:
@@ -3407,92 +4492,128 @@ spec:
                                   - targetPortal
                                   type: object
                                 name:
-                                  description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.'
+                                  description: 'Volume''s name. Must be a DNS_LABEL
+                                    and unique within the pod. More info: https://kubernetes.'
                                   type: string
                                 nfs:
-                                  description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.'
+                                  description: 'NFS represents an NFS mount on the
+                                    host that shares a pod''s lifetime More info:
+                                    https://kubernetes.'
                                   properties:
                                     path:
-                                      description: 'Path that is exported by the NFS server. More info: https://kubernetes.'
+                                      description: 'Path that is exported by the NFS
+                                        server. More info: https://kubernetes.'
                                       type: string
                                     readOnly:
-                                      description: ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false.
+                                      description: ReadOnly here will force the NFS
+                                        export to be mounted with read-only permissions.
+                                        Defaults to false.
                                       type: boolean
                                     server:
-                                      description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.'
+                                      description: 'Server is the hostname or IP address
+                                        of the NFS server. More info: https://kubernetes.'
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
+                                  description: PersistentVolumeClaimVolumeSource represents
+                                    a reference to a PersistentVolumeClaim in the
+                                    same name
                                   properties:
                                     claimName:
-                                      description: ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                      description: ClaimName is the name of a PersistentVolumeClaim
+                                        in the same namespace as the pod using this
+                                        volume.
                                       type: string
                                     readOnly:
-                                      description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                      description: Will force the ReadOnly setting
+                                        in VolumeMounts. Default false.
                                       type: boolean
                                   required:
                                   - claimName
                                   type: object
                                 photonPersistentDisk:
-                                  description: 'PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets '
+                                  description: 'PhotonPersistentDisk represents a
+                                    PhotonController persistent disk attached and
+                                    mounted on kubelets '
                                   properties:
                                     fsType:
-                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                      description: Filesystem type to mount. Must
+                                        be a filesystem type supported by the host
+                                        operating system. Ex.
                                       type: string
                                     pdID:
-                                      description: ID that identifies Photon Controller persistent disk
+                                      description: ID that identifies Photon Controller
+                                        persistent disk
                                       type: string
                                   required:
                                   - pdID
                                   type: object
                                 portworxVolume:
-                                  description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                                  description: PortworxVolume represents a portworx
+                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host opera
+                                      description: FSType represents the filesystem
+                                        type to mount Must be a filesystem type supported
+                                        by the host opera
                                       type: string
                                     readOnly:
-                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      description: Defaults to false (read/write).
+                                        ReadOnly here will force the ReadOnly setting
+                                        in VolumeMounts.
                                       type: boolean
                                     volumeID:
-                                      description: VolumeID uniquely identifies a Portworx volume
+                                      description: VolumeID uniquely identifies a
+                                        Portworx volume
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 projected:
-                                  description: Items for all in one resources secrets, configmaps, and downward API
+                                  description: Items for all in one resources secrets,
+                                    configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: Mode bits used to set permissions on created files by default.
+                                      description: Mode bits used to set permissions
+                                        on created files by default.
                                       format: int32
                                       type: integer
                                     sources:
                                       description: list of volume projections
                                       items:
-                                        description: Projection that may be projected along with other supported volume types
+                                        description: Projection that may be projected
+                                          along with other supported volume types
                                         properties:
                                           configMap:
-                                            description: information about the configMap data to project
+                                            description: information about the configMap
+                                              data to project
                                             properties:
                                               items:
-                                                description: 'If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected '
+                                                description: 'If unspecified, each
+                                                  key-value pair in the Data field
+                                                  of the referenced ConfigMap will
+                                                  be projected '
                                                 items:
-                                                  description: Maps a string key to a path within a volume.
+                                                  description: Maps a string key to
+                                                    a path within a volume.
                                                   properties:
                                                     key:
                                                       description: The key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'Optional: mode bits used to set permissions on this file.'
+                                                      description: 'Optional: mode
+                                                        bits used to set permissions
+                                                        on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: The relative path of the file to map the key to. May not be an absolute path.
+                                                      description: The relative path
+                                                        of the file to map the key
+                                                        to. May not be an absolute
+                                                        path.
                                                       type: string
                                                   required:
                                                   - key
@@ -3500,54 +4621,82 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: Specify whether the ConfigMap or its keys must be defined
+                                                description: Specify whether the ConfigMap
+                                                  or its keys must be defined
                                                 type: boolean
                                             type: object
                                           downwardAPI:
-                                            description: information about the downwardAPI data to project
+                                            description: information about the downwardAPI
+                                              data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume file
+                                                description: Items is a list of DownwardAPIVolume
+                                                  file
                                                 items:
-                                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                  description: DownwardAPIVolumeFile
+                                                    represents information to create
+                                                    the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                      description: 'Required: Selects
+                                                        a field of the pod: only annotations,
+                                                        labels, name and namespace
+                                                        are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                          description: Version of
+                                                            the schema the FieldPath
+                                                            is written in terms of,
+                                                            defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the field to select in the specified API version.
+                                                          description: Path of the
+                                                            field to select in the
+                                                            specified API version.
                                                           type: string
                                                       required:
                                                       - fieldPath
                                                       type: object
                                                     mode:
-                                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
+                                                      description: 'Optional: mode
+                                                        bits used to set permissions
+                                                        on this file, must be an octal
+                                                        value between 0000 and 07'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path is  the relative path name of the file to be created.'
+                                                      description: 'Required: Path
+                                                        is  the relative path name
+                                                        of the file to be created.'
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
+                                                      description: 'Selects a resource
+                                                        of the container: only resources
+                                                        limits and requests (limits.cpu,
+                                                        limits.'
                                                       properties:
                                                         containerName:
-                                                          description: 'Container name: required for volumes, optional for env vars'
+                                                          description: 'Container
+                                                            name: required for volumes,
+                                                            optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                           - type: integer
                                                           - type: string
-                                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                                          description: Specifies the
+                                                            output format of the exposed
+                                                            resources, defaults to
+                                                            "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required: resource to select'
+                                                          description: 'Required:
+                                                            resource to select'
                                                           type: string
                                                       required:
                                                       - resource
@@ -3558,22 +4707,32 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: information about the secret data to project
+                                            description: information about the secret
+                                              data to project
                                             properties:
                                               items:
-                                                description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected int
+                                                description: If unspecified, each
+                                                  key-value pair in the Data field
+                                                  of the referenced Secret will be
+                                                  projected int
                                                 items:
-                                                  description: Maps a string key to a path within a volume.
+                                                  description: Maps a string key to
+                                                    a path within a volume.
                                                   properties:
                                                     key:
                                                       description: The key to project.
                                                       type: string
                                                     mode:
-                                                      description: 'Optional: mode bits used to set permissions on this file.'
+                                                      description: 'Optional: mode
+                                                        bits used to set permissions
+                                                        on this file.'
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: The relative path of the file to map the key to. May not be an absolute path.
+                                                      description: The relative path
+                                                        of the file to map the key
+                                                        to. May not be an absolute
+                                                        path.
                                                       type: string
                                                   required:
                                                   - key
@@ -3581,24 +4740,32 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: 'Name of the referent. More info: https://kubernetes.'
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.'
                                                 type: string
                                               optional:
-                                                description: Specify whether the Secret or its key must be defined
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
                                                 type: boolean
                                             type: object
                                           serviceAccountToken:
-                                            description: information about the serviceAccountToken data to project
+                                            description: information about the serviceAccountToken
+                                              data to project
                                             properties:
                                               audience:
-                                                description: Audience is the intended audience of the token.
+                                                description: Audience is the intended
+                                                  audience of the token.
                                                 type: string
                                               expirationSeconds:
-                                                description: ExpirationSeconds is the requested duration of validity of the service account token.
+                                                description: ExpirationSeconds is
+                                                  the requested duration of validity
+                                                  of the service account token.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: Path is the path relative to the mount point of the file to project the token into.
+                                                description: Path is the path relative
+                                                  to the mount point of the file to
+                                                  project the token into.
                                                 type: string
                                             required:
                                             - path
@@ -3609,103 +4776,138 @@ spec:
                                   - sources
                                   type: object
                                 quobyte:
-                                  description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                                  description: Quobyte represents a Quobyte mount
+                                    on the host that shares a pod's lifetime
                                   properties:
                                     group:
-                                      description: Group to map volume access to Default is no group
+                                      description: Group to map volume access to Default
+                                        is no group
                                       type: string
                                     readOnly:
-                                      description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                      description: ReadOnly here will force the Quobyte
+                                        volume to be mounted with read-only permissions.
                                       type: boolean
                                     registry:
-                                      description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:por
+                                      description: Registry represents a single or
+                                        multiple Quobyte Registry services specified
+                                        as a string as host:por
                                       type: string
                                     tenant:
-                                      description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volu
+                                      description: Tenant owning the given Quobyte
+                                        volume in the Backend Used with dynamically
+                                        provisioned Quobyte volu
                                       type: string
                                     user:
-                                      description: User to map volume access to Defaults to serivceaccount user
+                                      description: User to map volume access to Defaults
+                                        to serivceaccount user
                                       type: string
                                     volume:
-                                      description: Volume is a string that references an already created Quobyte volume by name.
+                                      description: Volume is a string that references
+                                        an already created Quobyte volume by name.
                                       type: string
                                   required:
                                   - registry
                                   - volume
                                   type: object
                                 rbd:
-                                  description: RBD represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                  description: RBD represents a Rados Block Device
+                                    mount on the host that shares a pod's lifetime.
                                   properties:
                                     fsType:
-                                      description: Filesystem type of the volume that you want to mount.
+                                      description: Filesystem type of the volume that
+                                        you want to mount.
                                       type: string
                                     image:
-                                      description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                      description: 'The rados image name. More info:
+                                        https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                       type: string
                                     keyring:
-                                      description: Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring.
+                                      description: Keyring is the path to key ring
+                                        for RBDUser. Default is /etc/ceph/keyring.
                                       type: string
                                     monitors:
-                                      description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.'
+                                      description: 'A collection of Ceph monitors.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.'
                                       items:
                                         type: string
                                       type: array
                                     pool:
-                                      description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.'
+                                      description: 'The rados pool name. Default is
+                                        rbd. More info: https://examples.k8s.io/volumes/rbd/README.'
                                       type: string
                                     readOnly:
-                                      description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                      description: ReadOnly here will force the ReadOnly
+                                        setting in VolumeMounts. Defaults to false.
                                       type: boolean
                                     secretRef:
-                                      description: SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring.
+                                      description: SecretRef is name of the authentication
+                                        secret for RBDUser. If provided overrides
+                                        keyring.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.'
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     user:
-                                      description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.'
+                                      description: 'The rados user name. Default is
+                                        admin. More info: https://examples.k8s.io/volumes/rbd/README.'
                                       type: string
                                   required:
                                   - image
                                   - monitors
                                   type: object
                                 scaleIO:
-                                  description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                  description: ScaleIO represents a ScaleIO persistent
+                                    volume attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                      description: Filesystem type to mount. Must
+                                        be a filesystem type supported by the host
+                                        operating system. Ex.
                                       type: string
                                     gateway:
-                                      description: The host address of the ScaleIO API Gateway.
+                                      description: The host address of the ScaleIO
+                                        API Gateway.
                                       type: string
                                     protectionDomain:
-                                      description: The name of the ScaleIO Protection Domain for the configured storage.
+                                      description: The name of the ScaleIO Protection
+                                        Domain for the configured storage.
                                       type: string
                                     readOnly:
-                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      description: Defaults to false (read/write).
+                                        ReadOnly here will force the ReadOnly setting
+                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: SecretRef references to the secret for ScaleIO user and other sensitive information.
+                                      description: SecretRef references to the secret
+                                        for ScaleIO user and other sensitive information.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.'
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     sslEnabled:
-                                      description: Flag to enable/disable SSL communication with Gateway, default false
+                                      description: Flag to enable/disable SSL communication
+                                        with Gateway, default false
                                       type: boolean
                                     storageMode:
-                                      description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                      description: Indicates whether the storage for
+                                        a volume should be ThickProvisioned or ThinProvisioned.
                                       type: string
                                     storagePool:
-                                      description: The ScaleIO Storage Pool associated with the protection domain.
+                                      description: The ScaleIO Storage Pool associated
+                                        with the protection domain.
                                       type: string
                                     system:
-                                      description: The name of the storage system as configured in ScaleIO.
+                                      description: The name of the storage system
+                                        as configured in ScaleIO.
                                       type: string
                                     volumeName:
-                                      description: The name of a volume already created in the ScaleIO system that is associated with this volume sourc
+                                      description: The name of a volume already created
+                                        in the ScaleIO system that is associated with
+                                        this volume sourc
                                       type: string
                                   required:
                                   - gateway
@@ -3713,26 +4915,34 @@ spec:
                                   - system
                                   type: object
                                 secret:
-                                  description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.'
+                                  description: 'Secret represents a secret that should
+                                    populate this volume. More info: https://kubernetes.'
                                   properties:
                                     defaultMode:
-                                      description: 'Optional: mode bits used to set permissions on created files by default.'
+                                      description: 'Optional: mode bits used to set
+                                        permissions on created files by default.'
                                       format: int32
                                       type: integer
                                     items:
-                                      description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected int
+                                      description: If unspecified, each key-value
+                                        pair in the Data field of the referenced Secret
+                                        will be projected int
                                       items:
-                                        description: Maps a string key to a path within a volume.
+                                        description: Maps a string key to a path within
+                                          a volume.
                                         properties:
                                           key:
                                             description: The key to project.
                                             type: string
                                           mode:
-                                            description: 'Optional: mode bits used to set permissions on this file.'
+                                            description: 'Optional: mode bits used
+                                              to set permissions on this file.'
                                             format: int32
                                             type: integer
                                           path:
-                                            description: The relative path of the file to map the key to. May not be an absolute path.
+                                            description: The relative path of the
+                                              file to map the key to. May not be an
+                                              absolute path.
                                             type: string
                                         required:
                                         - key
@@ -3740,49 +4950,66 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: Specify whether the Secret or its keys must be defined
+                                      description: Specify whether the Secret or its
+                                        keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
+                                      description: 'Name of the secret in the pod''s
+                                        namespace to use. More info: https://kubernetes.'
                                       type: string
                                   type: object
                                 storageos:
-                                  description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                  description: StorageOS represents a StorageOS volume
+                                    attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                      description: Filesystem type to mount. Must
+                                        be a filesystem type supported by the host
+                                        operating system. Ex.
                                       type: string
                                     readOnly:
-                                      description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                      description: Defaults to false (read/write).
+                                        ReadOnly here will force the ReadOnly setting
+                                        in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.
+                                      description: SecretRef specifies the secret
+                                        to use for obtaining the StorageOS API credentials.
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More info: https://kubernetes.'
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.'
                                           type: string
                                       type: object
                                     volumeName:
-                                      description: VolumeName is the human-readable name of the StorageOS volume.
+                                      description: VolumeName is the human-readable
+                                        name of the StorageOS volume.
                                       type: string
                                     volumeNamespace:
-                                      description: VolumeNamespace specifies the scope of the volume within StorageOS.
+                                      description: VolumeNamespace specifies the scope
+                                        of the volume within StorageOS.
                                       type: string
                                   type: object
                                 vsphereVolume:
-                                  description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                                  description: VsphereVolume represents a vSphere
+                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                      description: Filesystem type to mount. Must
+                                        be a filesystem type supported by the host
+                                        operating system. Ex.
                                       type: string
                                     storagePolicyID:
-                                      description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                      description: Storage Policy Based Management
+                                        (SPBM) profile ID associated with the StoragePolicyName.
                                       type: string
                                     storagePolicyName:
-                                      description: Storage Policy Based Management (SPBM) profile name.
+                                      description: Storage Policy Based Management
+                                        (SPBM) profile name.
                                       type: string
                                     volumePath:
-                                      description: Path that identifies vSphere volume vmdk
+                                      description: Path that identifies vSphere volume
+                                        vmdk
                                       type: string
                                   required:
                                   - volumePath
@@ -3802,7 +5029,8 @@ spec:
                 - template
                 type: object
               rayVersion:
-                description: RayVersion is the version of ray being used. this affects the command used to start ray
+                description: RayVersion is the version of ray being used. this affects
+                  the command used to start ray
                 type: string
               workerGroupSpecs:
                 description: WorkerGroupSpecs are the specs for the worker pods
@@ -3810,7 +5038,8 @@ spec:
                   description: WorkerGroupSpec are the specs for the worker pods
                   properties:
                     groupName:
-                      description: we can have multiple worker groups, we distinguish them by name
+                      description: we can have multiple worker groups, we distinguish
+                        them by name
                       type: string
                     maxReplicas:
                       description: MaxReplicas defaults to maxInt32
@@ -3823,7 +5052,8 @@ spec:
                     rayStartParams:
                       additionalProperties:
                         type: string
-                      description: 'RayStartParams are the params of the start command: address, object-store-memory, ...'
+                      description: 'RayStartParams are the params of the start command:
+                        address, object-store-memory, ...'
                       type: object
                     replicas:
                       description: Replicas Number of desired pods in this pod group.
@@ -3843,41 +5073,75 @@ spec:
                       properties:
                         metadata:
                           description: 'Standard object''s metadata. More info: https://git.k8s.'
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the pod. More info: https://git.k8s.'
+                          description: 'Specification of the desired behavior of the
+                            pod. More info: https://git.k8s.'
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may be active on the node relative to StartTime before the syst
+                              description: Optional duration in seconds the pod may
+                                be active on the node relative to StartTime before
+                                the syst
                               format: int64
                               type: integer
                             affinity:
                               description: If specified, the pod's scheduling constraints
                               properties:
                                 nodeAffinity:
-                                  description: Describes node affinity scheduling rules for the pod.
+                                  description: Describes node affinity scheduling
+                                    rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
+                                      description: 'The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the affinity expressions
+                                        specified '
                                       items:
-                                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op).
+                                        description: An empty preferred scheduling
+                                          term matches all objects with implicit weight
+                                          0 (i.e. it's a no-op).
                                         properties:
                                           preference:
-                                            description: A node selector term, associated with the corresponding weight.
+                                            description: A node selector term, associated
+                                              with the corresponding weight.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
+                                                description: A list of node selector
+                                                  requirements by node's labels.
                                                 items:
-                                                  description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
+                                                  description: 'A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates '
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
+                                                      description: The label key that
+                                                        the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values.
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty.
                                                       items:
                                                         type: string
                                                       type: array
@@ -3887,18 +5151,26 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
+                                                description: A list of node selector
+                                                  requirements by node's fields.
                                                 items:
-                                                  description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
+                                                  description: 'A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates '
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
+                                                      description: The label key that
+                                                        the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values.
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty.
                                                       items:
                                                         type: string
                                                       type: array
@@ -3909,7 +5181,9 @@ spec:
                                                 type: array
                                             type: object
                                           weight:
-                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                            description: Weight associated with matching
+                                              the corresponding nodeSelectorTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -3918,26 +5192,39 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
+                                      description: If the affinity requirements specified
+                                        by this field are not met at scheduling time,
+                                        the pod will no
                                       properties:
                                         nodeSelectorTerms:
-                                          description: Required. A list of node selector terms. The terms are ORed.
+                                          description: Required. A list of node selector
+                                            terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector term matches no objects. The requirements of them are ANDed.
+                                            description: A null or empty node selector
+                                              term matches no objects. The requirements
+                                              of them are ANDed.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
+                                                description: A list of node selector
+                                                  requirements by node's labels.
                                                 items:
-                                                  description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
+                                                  description: 'A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates '
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
+                                                      description: The label key that
+                                                        the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values.
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty.
                                                       items:
                                                         type: string
                                                       type: array
@@ -3947,18 +5234,26 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
+                                                description: A list of node selector
+                                                  requirements by node's fields.
                                                 items:
-                                                  description: 'A node selector requirement is a selector that contains values, a key, and an operator that relates '
+                                                  description: 'A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates '
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
+                                                      description: The label key that
+                                                        the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values.
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty.
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty.
                                                       items:
                                                         type: string
                                                       type: array
@@ -3974,32 +5269,52 @@ spec:
                                       type: object
                                   type: object
                                 podAffinity:
-                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc.
+                                  description: Describes pod affinity scheduling rules
+                                    (e.g. co-locate this pod in the same node, zone,
+                                    etc.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified '
+                                      description: 'The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the affinity expressions
+                                        specified '
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values.
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values.
+                                                          description: values is an
+                                                            array of string values.
                                                           items:
                                                             type: string
                                                           type: array
@@ -4011,22 +5326,30 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs.
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: 'namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty '
+                                                description: 'namespaces specifies
+                                                  which namespaces the labelSelector
+                                                  applies to (matches against); null
+                                                  or empty '
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching th
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                            description: weight associated with matching
+                                              the corresponding podAffinityTerm, in
+                                              the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -4035,26 +5358,40 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will no
+                                      description: If the affinity requirements specified
+                                        by this field are not met at scheduling time,
+                                        the pod will no
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
+                                        description: Defines a set of pods (namely
+                                          those matching the labelSelector relative
+                                          to the given namespace(s)) t
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
+                                            description: A label query over a set
+                                              of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values.
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values.
+                                                      description: values is an array
+                                                        of string values.
                                                       items:
                                                         type: string
                                                       type: array
@@ -4066,16 +5403,21 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs.
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: 'namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty '
+                                            description: 'namespaces specifies which
+                                              namespaces the labelSelector applies
+                                              to (matches against); null or empty '
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching th
                                             type: string
                                         required:
                                         - topologyKey
@@ -4083,32 +5425,51 @@ spec:
                                       type: array
                                   type: object
                                 podAntiAffinity:
-                                  description: Describes pod anti-affinity scheduling rules (e.g.
+                                  description: Describes pod anti-affinity scheduling
+                                    rules (e.g.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions speci
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the anti-affinity
+                                        expressions speci
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values.
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values.
+                                                          description: values is an
+                                                            array of string values.
                                                           items:
                                                             type: string
                                                           type: array
@@ -4120,22 +5481,30 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs.
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: 'namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty '
+                                                description: 'namespaces specifies
+                                                  which namespaces the labelSelector
+                                                  applies to (matches against); null
+                                                  or empty '
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching th
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                            description: weight associated with matching
+                                              the corresponding podAffinityTerm, in
+                                              the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -4144,26 +5513,40 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod wi
+                                      description: If the anti-affinity requirements
+                                        specified by this field are not met at scheduling
+                                        time, the pod wi
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) t
+                                        description: Defines a set of pods (namely
+                                          those matching the labelSelector relative
+                                          to the given namespace(s)) t
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
+                                            description: A label query over a set
+                                              of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values.
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values.
+                                                      description: values is an array
+                                                        of string values.
                                                       items:
                                                         type: string
                                                       type: array
@@ -4175,16 +5558,21 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs.
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: 'namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty '
+                                            description: 'namespaces specifies which
+                                              namespaces the labelSelector applies
+                                              to (matches against); null or empty '
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching th
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching th
                                             type: string
                                         required:
                                         - topologyKey
@@ -4193,36 +5581,49 @@ spec:
                                   type: object
                               type: object
                             automountServiceAccountToken:
-                              description: AutomountServiceAccountToken indicates whether a service account token should be automatically mount
+                              description: AutomountServiceAccountToken indicates
+                                whether a service account token should be automatically
+                                mount
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod. Containers cannot currently be added or removed.
+                              description: List of containers belonging to the pod.
+                                Containers cannot currently be added or removed.
                               items:
-                                description: A single application container that you want to run within a pod.
+                                description: A single application container that you
+                                  want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The docker image's CMD is used if this is not provided.
+                                    description: Arguments to the entrypoint. The
+                                      docker image's CMD is used if this is not provided.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within a shell.
+                                    description: Entrypoint array. Not executed within
+                                      a shell.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the
+                                          description: Variable references $(VAR_NAME)
+                                            are expanded using the previous defined
+                                            environment variables in the
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
                                           properties:
                                             configMapKeyRef:
                                               description: Selects a key of a ConfigMap.
@@ -4231,56 +5632,75 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.'
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                `metadata.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -4291,31 +5711,39 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container.
+                                    description: List of sources to populate environment
+                                      variables in the container.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.'
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
+                                              description: Specify whether the ConfigMap
+                                                must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.'
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
+                                              description: Specify whether the Secret
+                                                must be defined
                                               type: boolean
                                           type: object
                                       type: object
@@ -4324,39 +5752,55 @@ spec:
                                     description: 'Docker image name. More info: https://kubernetes.'
                                     type: string
                                   imagePullPolicy:
-                                    description: Image pull policy. One of Always, Never, IfNotPresent.
+                                    description: Image pull policy. One of Always,
+                                      Never, IfNotPresent.
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events.
+                                    description: Actions that the management system
+                                      should take in response to container lifecycle
+                                      events.
                                     properties:
                                       postStart:
-                                        description: PostStart is called immediately after a container is created.
+                                        description: PostStart is called immediately
+                                          after a container is created.
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
                                             properties:
                                               command:
-                                                description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                                description: 'Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  '
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
+                                            description: HTTPGet specifies the http
+                                              request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP.
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
+                                                      description: The header field
+                                                        name
                                                       type: string
                                                     value:
-                                                      description: The header field value
+                                                      description: The header field
+                                                        value
                                                       type: string
                                                   required:
                                                   - name
@@ -4364,64 +5808,89 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
+                                                description: Path to access on the
+                                                  HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: TCPSocket specifies an action involving a TCP port.
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately before a container is terminated due to an API request or management e
+                                        description: PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management e
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
                                             properties:
                                               command:
-                                                description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                                description: 'Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  '
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
+                                            description: HTTPGet specifies the http
+                                              request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP.
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
+                                                      description: The header field
+                                                        name
                                                       type: string
                                                     value:
-                                                      description: The header field value
+                                                      description: The header field
+                                                        value
                                                       type: string
                                                   required:
                                                   - name
@@ -4429,31 +5898,42 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
+                                                description: Path to access on the
+                                                  HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: TCPSocket specifies an action involving a TCP port.
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -4461,31 +5941,42 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: Periodic probe of container liveness. Container will be restarted if the probe fails.
+                                    description: Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                            description: 'Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -4499,77 +5990,103 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: Number of seconds after the container has started before liveness probes are initiated.
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving a TCP port.
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                        description: Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL.
+                                    description: Name of the container specified as
+                                      a DNS_LABEL.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container.
+                                    description: List of ports to expose from the
+                                      container.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
+                                      description: ContainerPort represents a network
+                                        port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
+                                          description: What host IP to bind the external
+                                            port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536.
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod.
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -4580,31 +6097,42 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: Periodic probe of container service readiness.
+                                    description: Periodic probe of container service
+                                      readiness.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                            description: 'Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -4618,54 +6146,70 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: Number of seconds after the container has started before liveness probes are initiated.
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving a TCP port.
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                        description: Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.'
+                                    description: 'Compute Resources required by this
+                                      container. Cannot be updated. More info: https://kubernetes.'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -4674,7 +6218,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -4683,28 +6229,35 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: Requests describes the minimum amount of compute resources required.
+                                        description: Requests describes the minimum
+                                          amount of compute resources required.
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.'
+                                    description: 'Security options the pod should
+                                      run with. More info: https://kubernetes.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process
+                                        description: AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers.
+                                        description: The capabilities to add/drop
+                                          when running containers.
                                         properties:
                                           add:
                                             description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
+                                              description: Capability represent POSIX
+                                                capabilities type
                                               type: string
                                             type: array
                                           drop:
                                             description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
+                                              description: Capability represent POSIX
+                                                capabilities type
                                               type: string
                                             type: array
                                         type: object
@@ -4712,90 +6265,122 @@ spec:
                                         description: Run container in privileged mode.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers.
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset.
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user.
+                                        description: Indicates that the container
+                                          must run as a non-root user.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process.
+                                        description: The UID to run the entrypoint
+                                          of the container process.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container.
+                                        description: The SELinux context to be applied
+                                          to the container.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
+                                            description: Level is SELinux level label
+                                              that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
+                                            description: User is a SELinux user label
+                                              that applies to the container.
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by this container.
+                                        description: The seccomp options to use by
+                                          this container.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates a profile defined in a file on the node should be used.
+                                            description: localhostProfile indicates
+                                              a profile defined in a file on the node
+                                              should be used.
                                             type: string
                                           type:
-                                            description: type indicates which kind of seccomp profile will be applied.
+                                            description: type indicates which kind
+                                              of seccomp profile will be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers.
+                                        description: The Windows specific settings
+                                          applied to all containers.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process.
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod has successfully initialized.
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                            description: 'Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -4809,77 +6394,105 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: Number of seconds after the container has started before liveness probes are initiated.
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving a TCP port.
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                        description: Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime.
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single at
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single at
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mou'
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mou'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated.
+                                    description: Indicate how the termination message
+                                      should be populated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -4887,27 +6500,40 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way a
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way a
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
+                                          description: This must match the Name of
+                                            a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted.
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted.
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted.
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted.
                                           type: string
                                       required:
                                       - mountPath
@@ -4930,9 +6556,12 @@ spec:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy.
+                                  description: A list of DNS resolver options. This
+                                    will be merged with the base options generated
+                                    from DNSPolicy.
                                   items:
-                                    description: PodDNSConfigOption defines DNS resolver options of a pod.
+                                    description: PodDNSConfigOption defines DNS resolver
+                                      options of a pod.
                                     properties:
                                       name:
                                         description: Required.
@@ -4942,45 +6571,60 @@ spec:
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name lookup.
+                                  description: A list of DNS search domains for host-name
+                                    lookup.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to "ClusterFirst".
+                              description: Set DNS policy for the pod. Defaults to
+                                "ClusterFirst".
                               type: string
                             enableServiceLinks:
-                              description: EnableServiceLinks indicates whether information about services should be injected into pod's enviro
+                              description: EnableServiceLinks indicates whether information
+                                about services should be injected into pod's enviro
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this pod.
+                              description: List of ephemeral containers run in this
+                                pod.
                               items:
-                                description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initi
+                                description: An EphemeralContainer is a container
+                                  that may be added temporarily to an existing pod
+                                  for user-initi
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The docker image's CMD is used if this is not provided.
+                                    description: Arguments to the entrypoint. The
+                                      docker image's CMD is used if this is not provided.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within a shell.
+                                    description: Entrypoint array. Not executed within
+                                      a shell.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the
+                                          description: Variable references $(VAR_NAME)
+                                            are expanded using the previous defined
+                                            environment variables in the
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
                                           properties:
                                             configMapKeyRef:
                                               description: Selects a key of a ConfigMap.
@@ -4989,56 +6633,75 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.'
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                `metadata.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -5049,31 +6712,39 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container.
+                                    description: List of sources to populate environment
+                                      variables in the container.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.'
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
+                                              description: Specify whether the ConfigMap
+                                                must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.'
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
+                                              description: Specify whether the Secret
+                                                must be defined
                                               type: boolean
                                           type: object
                                       type: object
@@ -5082,39 +6753,54 @@ spec:
                                     description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
-                                    description: Image pull policy. One of Always, Never, IfNotPresent.
+                                    description: Image pull policy. One of Always,
+                                      Never, IfNotPresent.
                                     type: string
                                   lifecycle:
-                                    description: Lifecycle is not allowed for ephemeral containers.
+                                    description: Lifecycle is not allowed for ephemeral
+                                      containers.
                                     properties:
                                       postStart:
-                                        description: PostStart is called immediately after a container is created.
+                                        description: PostStart is called immediately
+                                          after a container is created.
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
                                             properties:
                                               command:
-                                                description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                                description: 'Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  '
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
+                                            description: HTTPGet specifies the http
+                                              request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP.
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
+                                                      description: The header field
+                                                        name
                                                       type: string
                                                     value:
-                                                      description: The header field value
+                                                      description: The header field
+                                                        value
                                                       type: string
                                                   required:
                                                   - name
@@ -5122,64 +6808,89 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
+                                                description: Path to access on the
+                                                  HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: TCPSocket specifies an action involving a TCP port.
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately before a container is terminated due to an API request or management e
+                                        description: PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management e
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
                                             properties:
                                               command:
-                                                description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                                description: 'Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  '
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
+                                            description: HTTPGet specifies the http
+                                              request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP.
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
+                                                      description: The header field
+                                                        name
                                                       type: string
                                                     value:
-                                                      description: The header field value
+                                                      description: The header field
+                                                        value
                                                       type: string
                                                   required:
                                                   - name
@@ -5187,31 +6898,42 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
+                                                description: Path to access on the
+                                                  HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: TCPSocket specifies an action involving a TCP port.
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -5219,31 +6941,42 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                            description: 'Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -5257,108 +6990,145 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: Number of seconds after the container has started before liveness probes are initiated.
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving a TCP port.
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                        description: Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified as a DNS_LABEL.
+                                    description: Name of the ephemeral container specified
+                                      as a DNS_LABEL.
                                     type: string
                                   ports:
-                                    description: Ports are not allowed for ephemeral containers.
+                                    description: Ports are not allowed for ephemeral
+                                      containers.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
+                                      description: ContainerPort represents a network
+                                        port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
+                                          description: What host IP to bind the external
+                                            port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536.
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod.
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
                                       type: object
                                     type: array
                                   readinessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                            description: 'Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -5372,54 +7142,70 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: Number of seconds after the container has started before liveness probes are initiated.
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving a TCP port.
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                        description: Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: Resources are not allowed for ephemeral containers.
+                                    description: Resources are not allowed for ephemeral
+                                      containers.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -5428,7 +7214,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -5437,28 +7225,35 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: Requests describes the minimum amount of compute resources required.
+                                        description: Requests describes the minimum
+                                          amount of compute resources required.
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for ephemeral containers.
+                                    description: SecurityContext is not allowed for
+                                      ephemeral containers.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process
+                                        description: AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers.
+                                        description: The capabilities to add/drop
+                                          when running containers.
                                         properties:
                                           add:
                                             description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
+                                              description: Capability represent POSIX
+                                                capabilities type
                                               type: string
                                             type: array
                                           drop:
                                             description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
+                                              description: Capability represent POSIX
+                                                capabilities type
                                               type: string
                                             type: array
                                         type: object
@@ -5466,90 +7261,122 @@ spec:
                                         description: Run container in privileged mode.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers.
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset.
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user.
+                                        description: Indicates that the container
+                                          must run as a non-root user.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process.
+                                        description: The UID to run the entrypoint
+                                          of the container process.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container.
+                                        description: The SELinux context to be applied
+                                          to the container.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
+                                            description: Level is SELinux level label
+                                              that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
+                                            description: User is a SELinux user label
+                                              that applies to the container.
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by this container.
+                                        description: The seccomp options to use by
+                                          this container.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates a profile defined in a file on the node should be used.
+                                            description: localhostProfile indicates
+                                              a profile defined in a file on the node
+                                              should be used.
                                             type: string
                                           type:
-                                            description: type indicates which kind of seccomp profile will be applied.
+                                            description: type indicates which kind
+                                              of seccomp profile will be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers.
+                                        description: The Windows specific settings
+                                          applied to all containers.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process.
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: Probes are not allowed for ephemeral containers.
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                            description: 'Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -5563,80 +7390,109 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: Number of seconds after the container has started before liveness probes are initiated.
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving a TCP port.
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                        description: Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime.
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single at
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single at
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container from PodSpec that this ephemeral container targets.
+                                    description: If set, the name of the container
+                                      from PodSpec that this ephemeral container targets.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mou'
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mou'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated.
+                                    description: Indicate how the termination message
+                                      should be populated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -5644,27 +7500,40 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way a
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way a
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
+                                          description: This must match the Name of
+                                            a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted.
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted.
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted.
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted.
                                           type: string
                                       required:
                                       - mountPath
@@ -5679,9 +7548,13 @@ spec:
                                 type: object
                               type: array
                             hostAliases:
-                              description: 'HostAliases is an optional list of hosts and IPs that will be injected into the pod''s hosts file if '
+                              description: 'HostAliases is an optional list of hosts
+                                and IPs that will be injected into the pod''s hosts
+                                file if '
                               items:
-                                description: 'HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod''s '
+                                description: 'HostAlias holds the mapping between
+                                  IP and hostnames that will be injected as an entry
+                                  in the pod''s '
                                 properties:
                                   hostnames:
                                     description: Hostnames for the above IP address.
@@ -5694,55 +7567,75 @@ spec:
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional: Default to false.'
+                              description: 'Use the host''s ipc namespace. Optional:
+                                Default to false.'
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod. Use the host's network namespace.
+                              description: Host networking requested for this pod.
+                                Use the host's network namespace.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional: Default to false.'
+                              description: 'Use the host''s pid namespace. Optional:
+                                Default to false.'
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defin
+                              description: Specifies the hostname of the Pod If not
+                                specified, the pod's hostname will be set to a system-defin
                               type: string
                             imagePullSecrets:
-                              description: ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulli
+                              description: ImagePullSecrets is an optional list of
+                                references to secrets in the same namespace to use
+                                for pulli
                               items:
-                                description: 'LocalObjectReference contains enough information to let you locate the referenced object inside the '
+                                description: 'LocalObjectReference contains enough
+                                  information to let you locate the referenced object
+                                  inside the '
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.'
                                     type: string
                                 type: object
                               type: array
                             initContainers:
-                              description: List of initialization containers belonging to the pod.
+                              description: List of initialization containers belonging
+                                to the pod.
                               items:
-                                description: A single application container that you want to run within a pod.
+                                description: A single application container that you
+                                  want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The docker image's CMD is used if this is not provided.
+                                    description: Arguments to the entrypoint. The
+                                      docker image's CMD is used if this is not provided.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within a shell.
+                                    description: Entrypoint array. Not executed within
+                                      a shell.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the
+                                          description: Variable references $(VAR_NAME)
+                                            are expanded using the previous defined
+                                            environment variables in the
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
                                           properties:
                                             configMapKeyRef:
                                               description: Selects a key of a ConfigMap.
@@ -5751,56 +7644,75 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.'
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                `metadata.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -5811,31 +7723,39 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container.
+                                    description: List of sources to populate environment
+                                      variables in the container.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.'
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
+                                              description: Specify whether the ConfigMap
+                                                must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.'
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
+                                              description: Specify whether the Secret
+                                                must be defined
                                               type: boolean
                                           type: object
                                       type: object
@@ -5844,39 +7764,55 @@ spec:
                                     description: 'Docker image name. More info: https://kubernetes.'
                                     type: string
                                   imagePullPolicy:
-                                    description: Image pull policy. One of Always, Never, IfNotPresent.
+                                    description: Image pull policy. One of Always,
+                                      Never, IfNotPresent.
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events.
+                                    description: Actions that the management system
+                                      should take in response to container lifecycle
+                                      events.
                                     properties:
                                       postStart:
-                                        description: PostStart is called immediately after a container is created.
+                                        description: PostStart is called immediately
+                                          after a container is created.
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
                                             properties:
                                               command:
-                                                description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                                description: 'Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  '
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
+                                            description: HTTPGet specifies the http
+                                              request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP.
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
+                                                      description: The header field
+                                                        name
                                                       type: string
                                                     value:
-                                                      description: The header field value
+                                                      description: The header field
+                                                        value
                                                       type: string
                                                   required:
                                                   - name
@@ -5884,64 +7820,89 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
+                                                description: Path to access on the
+                                                  HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: TCPSocket specifies an action involving a TCP port.
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately before a container is terminated due to an API request or management e
+                                        description: PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management e
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
                                             properties:
                                               command:
-                                                description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                                description: 'Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  '
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
+                                            description: HTTPGet specifies the http
+                                              request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP.
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
+                                                      description: The header field
+                                                        name
                                                       type: string
                                                     value:
-                                                      description: The header field value
+                                                      description: The header field
+                                                        value
                                                       type: string
                                                   required:
                                                   - name
@@ -5949,31 +7910,42 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
+                                                description: Path to access on the
+                                                  HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: TCPSocket specifies an action involving a TCP port.
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -5981,31 +7953,42 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: Periodic probe of container liveness. Container will be restarted if the probe fails.
+                                    description: Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                            description: 'Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -6019,77 +8002,103 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: Number of seconds after the container has started before liveness probes are initiated.
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving a TCP port.
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                        description: Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL.
+                                    description: Name of the container specified as
+                                      a DNS_LABEL.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container.
+                                    description: List of ports to expose from the
+                                      container.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
+                                      description: ContainerPort represents a network
+                                        port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
+                                          description: What host IP to bind the external
+                                            port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536.
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod.
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -6100,31 +8109,42 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: Periodic probe of container service readiness.
+                                    description: Periodic probe of container service
+                                      readiness.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                            description: 'Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -6138,54 +8158,70 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: Number of seconds after the container has started before liveness probes are initiated.
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving a TCP port.
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                        description: Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.'
+                                    description: 'Compute Resources required by this
+                                      container. Cannot be updated. More info: https://kubernetes.'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -6194,7 +8230,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -6203,28 +8241,35 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: Requests describes the minimum amount of compute resources required.
+                                        description: Requests describes the minimum
+                                          amount of compute resources required.
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.'
+                                    description: 'Security options the pod should
+                                      run with. More info: https://kubernetes.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process
+                                        description: AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers.
+                                        description: The capabilities to add/drop
+                                          when running containers.
                                         properties:
                                           add:
                                             description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
+                                              description: Capability represent POSIX
+                                                capabilities type
                                               type: string
                                             type: array
                                           drop:
                                             description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
+                                              description: Capability represent POSIX
+                                                capabilities type
                                               type: string
                                             type: array
                                         type: object
@@ -6232,90 +8277,122 @@ spec:
                                         description: Run container in privileged mode.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers.
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset.
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user.
+                                        description: Indicates that the container
+                                          must run as a non-root user.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process.
+                                        description: The UID to run the entrypoint
+                                          of the container process.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container.
+                                        description: The SELinux context to be applied
+                                          to the container.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
+                                            description: Level is SELinux level label
+                                              that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
+                                            description: User is a SELinux user label
+                                              that applies to the container.
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by this container.
+                                        description: The seccomp options to use by
+                                          this container.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates a profile defined in a file on the node should be used.
+                                            description: localhostProfile indicates
+                                              a profile defined in a file on the node
+                                              should be used.
                                             type: string
                                           type:
-                                            description: type indicates which kind of seccomp profile will be applied.
+                                            description: type indicates which kind
+                                              of seccomp profile will be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers.
+                                        description: The Windows specific settings
+                                          applied to all containers.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process.
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod has successfully initialized.
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
                                         properties:
                                           command:
-                                            description: 'Command is the command line to execute inside the container, the working directory for the command  '
+                                            description: 'Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  '
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
+                                        description: HTTPGet specifies the http request
+                                          to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP.
+                                            description: Host name to connect to,
+                                              defaults to the pod IP.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
                                               properties:
                                                 name:
                                                   description: The header field name
@@ -6329,77 +8406,105 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
+                                            description: Path to access on the HTTP
+                                              server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: Number of seconds after the container has started before liveness probes are initiated.
+                                        description: Number of seconds after the container
+                                          has started before liveness probes are initiated.
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: TCPSocket specifies an action involving a TCP port.
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535.
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+                                        description: Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1.
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime.
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single at
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single at
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mou'
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mou'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated.
+                                    description: Indicate how the termination message
+                                      should be populated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -6407,27 +8512,40 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way a
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way a
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
+                                          description: This must match the Name of
+                                            a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted.
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted.
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted.
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted.
                                           type: string
                                       required:
                                       - mountPath
@@ -6442,12 +8560,14 @@ spec:
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this pod onto a specific node.
+                              description: NodeName is a request to schedule this
+                                pod onto a specific node.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: NodeSelector is a selector which must be true for the pod to fit on a node.
+                              description: NodeSelector is a selector which must be
+                                true for the pod to fit on a node.
                               type: object
                             overhead:
                               additionalProperties:
@@ -6456,98 +8576,126 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                              description: Overhead represents the resource overhead
+                                associated with running a pod for a given RuntimeClass.
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting pods with lower priority.
+                              description: PreemptionPolicy is the Policy for preempting
+                                pods with lower priority.
                               type: string
                             priority:
-                              description: The priority value. Various system components use this field to find the priority of the pod.
+                              description: The priority value. Various system components
+                                use this field to find the priority of the pod.
                               format: int32
                               type: integer
                             priorityClassName:
                               description: If specified, indicates the pod's priority.
                               type: string
                             readinessGates:
-                              description: If specified, all readiness gates will be evaluated for pod readiness.
+                              description: If specified, all readiness gates will
+                                be evaluated for pod readiness.
                               items:
-                                description: PodReadinessGate contains the reference to a pod condition
+                                description: PodReadinessGate contains the reference
+                                  to a pod condition
                                 properties:
                                   conditionType:
-                                    description: ConditionType refers to a condition in the pod's condition list with matching type.
+                                    description: ConditionType refers to a condition
+                                      in the pod's condition list with matching type.
                                     type: string
                                 required:
                                 - conditionType
                                 type: object
                               type: array
                             restartPolicy:
-                              description: Restart policy for all containers within the pod. One of Always, OnFailure, Never.
+                              description: Restart policy for all containers within
+                                the pod. One of Always, OnFailure, Never.
                               type: string
                             runtimeClassName:
-                              description: RuntimeClassName refers to a RuntimeClass object in the node.k8s.
+                              description: RuntimeClassName refers to a RuntimeClass
+                                object in the node.k8s.
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched by specified scheduler.
+                              description: If specified, the pod will be dispatched
+                                by specified scheduler.
                               type: string
                             securityContext:
-                              description: SecurityContext holds pod-level security attributes and common container settings.
+                              description: SecurityContext holds pod-level security
+                                attributes and common container settings.
                               properties:
                                 fsGroup:
-                                  description: A special supplemental group that applies to all containers in a pod.
+                                  description: A special supplemental group that applies
+                                    to all containers in a pod.
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being
+                                  description: fsGroupChangePolicy defines behavior
+                                    of changing ownership and permission of the volume
+                                    before being
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset.
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run as a non-root user.
+                                  description: Indicates that the container must run
+                                    as a non-root user.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the container process.
+                                  description: The UID to run the entrypoint of the
+                                    container process.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to all containers.
+                                  description: The SELinux context to be applied to
+                                    all containers.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that applies to the container.
+                                      description: Level is SELinux level label that
+                                        applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that applies to the container.
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that applies to the container.
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that applies to the container.
+                                      description: User is a SELinux user label that
+                                        applies to the container.
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by the containers in this pod.
+                                  description: The seccomp options to use by the containers
+                                    in this pod.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile defined in a file on the node should be used.
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
                                       type: string
                                     type:
-                                      description: type indicates which kind of seccomp profile will be applied.
+                                      description: type indicates which kind of seccomp
+                                        profile will be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 supplementalGroups:
-                                  description: 'A list of groups applied to the first process run in each container, in addition to the container''s '
+                                  description: 'A list of groups applied to the first
+                                    process run in each container, in addition to
+                                    the container''s '
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls used for the pod.
+                                  description: Sysctls hold a list of namespaced sysctls
+                                    used for the pod.
                                   items:
-                                    description: Sysctl defines a kernel parameter to be set
+                                    description: Sysctl defines a kernel parameter
+                                      to be set
                                     properties:
                                       name:
                                         description: Name of a property to set
@@ -6561,82 +8709,111 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied to all containers.
+                                  description: The Windows specific settings applied
+                                    to all containers.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run the entrypoint of the container process.
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                              description: DeprecatedServiceAccount is a depreciated
+                                alias for ServiceAccountName.
                               type: string
                             serviceAccountName:
-                              description: ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                              description: ServiceAccountName is the name of the ServiceAccount
+                                to use to run this pod.
                               type: string
                             setHostnameAsFQDN:
-                              description: If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the defa
+                              description: If true the pod's hostname will be configured
+                                as the pod's FQDN, rather than the leaf name (the
+                                defa
                               type: boolean
                             shareProcessNamespace:
-                              description: Share a single process namespace between all of the containers in a pod.
+                              description: Share a single process namespace between
+                                all of the containers in a pod.
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.
+                              description: If specified, the fully qualified Pod hostname
+                                will be "<hostname>.<subdomain>.<pod namespace>.svc.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully.
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully.
                               format: int64
                               type: integer
                             tolerations:
                               description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect
+                                description: The pod this Toleration is attached to
+                                  tolerates any taint that matches the triple <key,value,effect
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    description: Effect indicates the taint effect
+                                      to match. Empty means match all taint effects.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    description: Key is the taint key that the toleration
+                                      applies to. Empty means match all taint keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal.
+                                    description: Operator represents a key's relationship
+                                      to the value. Valid operators are Exists and
+                                      Equal.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, o
+                                    description: TolerationSeconds represents the
+                                      period of time the toleration (which must be
+                                      of effect NoExecute, o
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration matches to.
+                                    description: Value is the taint value the toleration
+                                      matches to.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains.
+                              description: TopologySpreadConstraints describes how
+                                a group of pods ought to spread across topology domains.
                               items:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                                description: TopologySpreadConstraint specifies how
+                                  to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching pods.
+                                    description: LabelSelector is used to find matching
+                                      pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values.
+                                              description: operator represents a key's
+                                                relationship to a set of values.
                                               type: string
                                             values:
-                                              description: values is an array of string values.
+                                              description: values is an array of string
+                                                values.
                                               items:
                                                 type: string
                                               type: array
@@ -6648,18 +8825,22 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs.
+                                        description: matchLabels is a map of {key,value}
+                                          pairs.
                                         type: object
                                     type: object
                                   maxSkew:
-                                    description: MaxSkew describes the degree to which pods may be unevenly distributed.
+                                    description: MaxSkew describes the degree to which
+                                      pods may be unevenly distributed.
                                     format: int32
                                     type: integer
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint.
+                                    description: WhenUnsatisfiable indicates how to
+                                      deal with a pod if it doesn't satisfy the spread
+                                      constraint.
                                     type: string
                                 required:
                                 - maxSkew
@@ -6672,62 +8853,89 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: List of volumes that can be mounted by containers belonging to the pod.
+                              description: List of volumes that can be mounted by
+                                containers belonging to the pod.
                               items:
-                                description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                                description: Volume represents a named volume in a
+                                  pod that may be accessed by any container in the
+                                  pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine an
+                                    description: AWSElasticBlockStore represents an
+                                      AWS Disk resource that is attached to a kubelet's
+                                      host machine an
                                     properties:
                                       fsType:
-                                        description: Filesystem type of the volume that you want to mount.
+                                        description: Filesystem type of the volume
+                                          that you want to mount.
                                         type: string
                                       partition:
-                                        description: The partition in the volume that you want to mount.
+                                        description: The partition in the volume that
+                                          you want to mount.
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+                                        description: Specify "true" to force and set
+                                          the ReadOnly property in VolumeMounts to
+                                          "true".
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.'
+                                        description: 'Unique ID of the persistent
+                                          disk resource in AWS (Amazon EBS volume).
+                                          More info: https://kubernetes.'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                    description: AzureDisk represents an Azure Data
+                                      Disk mount on the host and bind mount to the
+                                      pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read Only, Read Write.'
+                                        description: 'Host Caching mode: None, Read
+                                          Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in the blob storage
+                                        description: The Name of the data disk in
+                                          the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the blob storage
+                                        description: The URI the data disk in the
+                                          blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                        description: Filesystem type to mount. Must
+                                          be a filesystem type supported by the host
+                                          operating system. Ex.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per sto'
+                                        description: 'Expected values Shared: multiple
+                                          blob disks per storage account  Dedicated:
+                                          single blob disk per sto'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                        description: Defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                    description: AzureFile represents an Azure File
+                                      Service mount on the host and bind mount to
+                                      the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                        description: Defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains Azure Storage Account Name and Key
+                                        description: the name of secret that contains
+                                          Azure Storage Account Name and Key
                                         type: string
                                       shareName:
                                         description: Share Name
@@ -6737,78 +8945,104 @@ spec:
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                                    description: CephFS represents a Ceph FS mount
+                                      on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.'
+                                        description: 'Required: Monitors is a collection
+                                          of Ceph monitors More info: https://examples.k8s.'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                        description: 'Optional: Used as the mounted
+                                          root, rather than the full Ceph tree, default
+                                          is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write).'
+                                        description: 'Optional: Defaults to false
+                                          (read/write).'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.'
+                                        description: 'Optional: SecretFile is the
+                                          path to key ring for User, default is /etc/ceph/user.'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty.'
+                                        description: 'Optional: SecretRef is reference
+                                          to the authentication secret for User, default
+                                          is empty.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.'
+                                        description: 'Optional: User is the rados
+                                          user name, default is admin More info: https://examples.k8s.'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: Cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                    description: Cinder represents a cinder volume
+                                      attached and mounted on kubelets host machine.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system.
+                                        description: Filesystem type to mount. Must
+                                          be a filesystem type supported by the host
+                                          operating system.
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write).'
+                                        description: 'Optional: Defaults to false
+                                          (read/write).'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                        description: 'Optional: points to a secret
+                                          object containing parameters used to connect
+                                          to OpenStack.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.'
+                                        description: 'volume id used to identify the
+                                          volume in cinder. More info: https://examples.k8s.'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap that should populate this volume
+                                    description: ConfigMap represents a configMap
+                                      that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to set permissions on created files by default.'
+                                        description: 'Optional: mode bits used to
+                                          set permissions on created files by default.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: 'If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected '
+                                        description: 'If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected '
                                         items:
-                                          description: Maps a string key to a path within a volume.
+                                          description: Maps a string key to a path
+                                            within a volume.
                                           properties:
                                             key:
                                               description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used to set permissions on this file.'
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path.
+                                              description: The relative path of the
+                                                file to map the key to. May not be
+                                                an absolute path.
                                               type: string
                                           required:
                                           - key
@@ -6816,85 +9050,118 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.'
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap or its keys must be defined
+                                        description: Specify whether the ConfigMap
+                                          or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external C
+                                    description: CSI (Container Storage Interface)
+                                      represents ephemeral storage that is handled
+                                      by certain external C
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI driver that handles this volume.
+                                        description: Driver is the name of the CSI
+                                          driver that handles this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs".
+                                        description: Filesystem type to mount. Ex.
+                                          "ext4", "xfs", "ntfs".
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to
+                                        description: NodePublishSecretRef is a reference
+                                          to the secret object containing sensitive
+                                          information to pass to
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                        description: Specifies a read-only configuration
+                                          for the volume. Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver.
+                                        description: VolumeAttributes stores driver-specific
+                                          properties that are passed to the CSI driver.
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API about the pod that should populate this volume
+                                    description: DownwardAPI represents downward API
+                                      about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default.'
+                                        description: 'Optional: mode bits to use on
+                                          created files by default.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: Items is a list of downward API volume file
+                                        description: Items is a list of downward API
+                                          volume file
                                         items:
-                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             mode:
-                                              description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                07'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the relative path name of the file to be created.'
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created.'
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
@@ -6905,57 +9172,93 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: EmptyDir represents a temporary directory that shares a pod's lifetime.
+                                    description: EmptyDir represents a temporary directory
+                                      that shares a pod's lifetime.
                                     properties:
                                       medium:
-                                        description: What type of storage medium should back this directory.
+                                        description: What type of storage medium should
+                                          back this directory.
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Total amount of local storage required for this EmptyDir volume.
+                                        description: Total amount of local storage
+                                          required for this EmptyDir volume.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: Ephemeral represents a volume that is handled by a cluster storage driver (Alpha feature).
+                                    description: Ephemeral represents a volume that
+                                      is handled by a cluster storage driver (Alpha
+                                      feature).
                                     properties:
                                       readOnly:
-                                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                        description: Specifies a read-only configuration
+                                          for the volume. Defaults to false (read/write).
                                         type: boolean
                                       volumeClaimTemplate:
-                                        description: Will be used to create a stand-alone PVC to provision the volume.
+                                        description: Will be used to create a stand-alone
+                                          PVC to provision the volume.
                                         properties:
                                           metadata:
-                                            description: May contain labels and annotations that will be copied into the PVC when creating it.
+                                            description: May contain labels and annotations
+                                              that will be copied into the PVC when
+                                              creating it.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              finalizers:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              labels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
                                             type: object
                                           spec:
-                                            description: The specification for the PersistentVolumeClaim.
+                                            description: The specification for the
+                                              PersistentVolumeClaim.
                                             properties:
                                               accessModes:
-                                                description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.'
+                                                description: 'AccessModes contains
+                                                  the desired access modes the volume
+                                                  should have. More info: https://kubernetes.'
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.'
+                                                description: 'This field can be used
+                                                  to specify either: * An existing
+                                                  VolumeSnapshot object (snapshot.storage.k8s.'
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group for the resource being referenced.
+                                                    description: APIGroup is the group
+                                                      for the resource being referenced.
                                                     type: string
                                                   kind:
-                                                    description: Kind is the type of resource being referenced
+                                                    description: Kind is the type
+                                                      of resource being referenced
                                                     type: string
                                                   name:
-                                                    description: Name is the name of resource being referenced
+                                                    description: Name is the name
+                                                      of resource being referenced
                                                     type: string
                                                 required:
                                                 - kind
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.'
+                                                description: 'Resources represents
+                                                  the minimum resources the volume
+                                                  should have. More info: https://kubernetes.'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -6964,7 +9267,10 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.'
+                                                    description: 'Limits describes
+                                                      the maximum amount of compute
+                                                      resources allowed. More info:
+                                                      https://kubernetes.'
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -6973,25 +9279,39 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: Requests describes the minimum amount of compute resources required.
+                                                    description: Requests describes
+                                                      the minimum amount of compute
+                                                      resources required.
                                                     type: object
                                                 type: object
                                               selector:
-                                                description: A label query over volumes to consider for binding.
+                                                description: A label query over volumes
+                                                  to consider for binding.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values.
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values.
+                                                          description: values is an
+                                                            array of string values.
                                                           items:
                                                             type: string
                                                           type: array
@@ -7003,17 +9323,24 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs.
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs.
                                                     type: object
                                                 type: object
                                               storageClassName:
-                                                description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.'
+                                                description: 'Name of the StorageClass
+                                                  required by the claim. More info:
+                                                  https://kubernetes.'
                                                 type: string
                                               volumeMode:
-                                                description: volumeMode defines what type of volume is required by the claim.
+                                                description: volumeMode defines what
+                                                  type of volume is required by the
+                                                  claim.
                                                 type: string
                                               volumeName:
-                                                description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                                description: VolumeName is the binding
+                                                  reference to the PersistentVolume
+                                                  backing this claim.
                                                 type: string
                                             type: object
                                         required:
@@ -7021,139 +9348,187 @@ spec:
                                         type: object
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed
+                                    description: FC represents a Fibre Channel resource
+                                      that is attached to a kubelet's host machine
+                                      and then exposed
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                        description: Filesystem type to mount. Must
+                                          be a filesystem type supported by the host
+                                          operating system. Ex.
                                         type: string
                                       lun:
                                         description: 'Optional: FC target lun number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write).'
+                                        description: 'Optional: Defaults to false
+                                          (read/write).'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide names (WWNs)'
+                                        description: 'Optional: FC target worldwide
+                                          names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun'
+                                        description: 'Optional: FC volume world wide
+                                          identifiers (wwids) Either wwids or combination
+                                          of targetWWNs and lun'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plu
+                                    description: FlexVolume represents a generic volume
+                                      resource that is provisioned/attached using
+                                      an exec based plu
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver to use for this volume.
+                                        description: Driver is the name of the driver
+                                          to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                        description: Filesystem type to mount. Must
+                                          be a filesystem type supported by the host
+                                          operating system. Ex.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options if any.'
+                                        description: 'Optional: Extra command options
+                                          if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write).'
+                                        description: 'Optional: Defaults to false
+                                          (read/write).'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to th'
+                                        description: 'Optional: SecretRef is reference
+                                          to the secret object containing sensitive
+                                          information to pass to th'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume attached to a kubelet's host machine.
+                                    description: Flocker represents a Flocker volume
+                                      attached to a kubelet's host machine.
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as de
+                                        description: Name of the dataset stored as
+                                          metadata -> name on the dataset for Flocker
+                                          should be considered as de
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                        description: UUID of the dataset. This is
+                                          unique identifier of a Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and th
+                                    description: GCEPersistentDisk represents a GCE
+                                      Disk resource that is attached to a kubelet's
+                                      host machine and th
                                     properties:
                                       fsType:
-                                        description: Filesystem type of the volume that you want to mount.
+                                        description: Filesystem type of the volume
+                                          that you want to mount.
                                         type: string
                                       partition:
-                                        description: The partition in the volume that you want to mount.
+                                        description: The partition in the volume that
+                                          you want to mount.
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: Unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                        description: Unique name of the PD resource
+                                          in GCE. Used to identify the disk in GCE.
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                        description: ReadOnly here will force the
+                                          ReadOnly setting in VolumeMounts. Defaults
+                                          to false.
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated.'
+                                    description: 'GitRepo represents a git repository
+                                      at a particular revision. DEPRECATED: GitRepo
+                                      is deprecated.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not contain or start with '..'.  If '.
+                                        description: Target directory name. Must not
+                                          contain or start with '..'.  If '.
                                         type: string
                                       repository:
                                         description: Repository URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified revision.
+                                        description: Commit hash for the specified
+                                          revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                    description: Glusterfs represents a Glusterfs
+                                      mount on the host that shares a pod's lifetime.
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.'
+                                        description: 'EndpointsName is the endpoint
+                                          name that details Glusterfs topology. More
+                                          info: https://examples.k8s.'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.'
+                                        description: 'Path is the Glusterfs volume
+                                          path. More info: https://examples.k8s.io/volumes/glusterfs/README.'
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                        description: ReadOnly here will force the
+                                          Glusterfs volume to be mounted with read-only
+                                          permissions.
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: HostPath represents a pre-existing file or directory on the host machine that is directly exposed to
+                                    description: HostPath represents a pre-existing
+                                      file or directory on the host machine that is
+                                      directly exposed to
                                     properties:
                                       path:
-                                        description: Path of the directory on the host.
+                                        description: Path of the directory on the
+                                          host.
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.'
+                                        description: 'Type for HostPath Volume Defaults
+                                          to "" More info: https://kubernetes.'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then expose
+                                    description: ISCSI represents an ISCSI Disk resource
+                                      that is attached to a kubelet's host machine
+                                      and then expose
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery CHAP authentication
+                                        description: whether support iSCSI Discovery
+                                          CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session CHAP authentication
+                                        description: whether support iSCSI Session
+                                          CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: Filesystem type of the volume that you want to mount.
+                                        description: Filesystem type of the volume
+                                          that you want to mount.
                                         type: string
                                       initiatorName:
                                         description: Custom iSCSI Initiator Name.
@@ -7162,7 +9537,9 @@ spec:
                                         description: Target iSCSI Qualified Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                        description: iSCSI Interface Name that uses
+                                          an iSCSI transport. Defaults to 'default'
+                                          (tcp).
                                         type: string
                                       lun:
                                         description: iSCSI Target Lun number.
@@ -7174,13 +9551,17 @@ spec:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                        description: ReadOnly here will force the
+                                          ReadOnly setting in VolumeMounts. Defaults
+                                          to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target and initiator authentication
+                                        description: CHAP Secret for iSCSI target
+                                          and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       targetPortal:
@@ -7192,92 +9573,129 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.'
+                                    description: 'Volume''s name. Must be a DNS_LABEL
+                                      and unique within the pod. More info: https://kubernetes.'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.'
+                                    description: 'NFS represents an NFS mount on the
+                                      host that shares a pod''s lifetime More info:
+                                      https://kubernetes.'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the NFS server. More info: https://kubernetes.'
+                                        description: 'Path that is exported by the
+                                          NFS server. More info: https://kubernetes.'
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false.
+                                        description: ReadOnly here will force the
+                                          NFS export to be mounted with read-only
+                                          permissions. Defaults to false.
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.'
+                                        description: 'Server is the hostname or IP
+                                          address of the NFS server. More info: https://kubernetes.'
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same name
+                                    description: PersistentVolumeClaimVolumeSource
+                                      represents a reference to a PersistentVolumeClaim
+                                      in the same name
                                     properties:
                                       claimName:
-                                        description: ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                        description: ClaimName is the name of a PersistentVolumeClaim
+                                          in the same namespace as the pod using this
+                                          volume.
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                        description: Will force the ReadOnly setting
+                                          in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: 'PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets '
+                                    description: 'PhotonPersistentDisk represents
+                                      a PhotonController persistent disk attached
+                                      and mounted on kubelets '
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                        description: Filesystem type to mount. Must
+                                          be a filesystem type supported by the host
+                                          operating system. Ex.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller persistent disk
+                                        description: ID that identifies Photon Controller
+                                          persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                                    description: PortworxVolume represents a portworx
+                                      volume attached and mounted on kubelets host
+                                      machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host opera
+                                        description: FSType represents the filesystem
+                                          type to mount Must be a filesystem type
+                                          supported by the host opera
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                        description: Defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies a Portworx volume
+                                        description: VolumeID uniquely identifies
+                                          a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets, configmaps, and downward API
+                                    description: Items for all in one resources secrets,
+                                      configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits used to set permissions on created files by default.
+                                        description: Mode bits used to set permissions
+                                          on created files by default.
                                         format: int32
                                         type: integer
                                       sources:
                                         description: list of volume projections
                                         items:
-                                          description: Projection that may be projected along with other supported volume types
+                                          description: Projection that may be projected
+                                            along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap data to project
+                                              description: information about the configMap
+                                                data to project
                                               properties:
                                                 items:
-                                                  description: 'If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected '
+                                                  description: 'If unspecified, each
+                                                    key-value pair in the Data field
+                                                    of the referenced ConfigMap will
+                                                    be projected '
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
+                                                    description: Maps a string key
+                                                      to a path within a volume.
                                                     properties:
                                                       key:
                                                         description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits used to set permissions on this file.'
+                                                        description: 'Optional: mode
+                                                          bits used to set permissions
+                                                          on this file.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path.
+                                                        description: The relative
+                                                          path of the file to map
+                                                          the key to. May not be an
+                                                          absolute path.
                                                         type: string
                                                     required:
                                                     - key
@@ -7285,54 +9703,85 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its keys must be defined
+                                                  description: Specify whether the
+                                                    ConfigMap or its keys must be
+                                                    defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI data to project
+                                              description: information about the downwardAPI
+                                                data to project
                                               properties:
                                                 items:
-                                                  description: Items is a list of DownwardAPIVolume file
+                                                  description: Items is a list of
+                                                    DownwardAPIVolume file
                                                   items:
-                                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                    description: DownwardAPIVolumeFile
+                                                      represents information to create
+                                                      the file containing the pod
+                                                      field
                                                     properties:
                                                       fieldRef:
-                                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                        description: 'Required: Selects
+                                                          a field of the pod: only
+                                                          annotations, labels, name
+                                                          and namespace are supported.'
                                                         properties:
                                                           apiVersion:
-                                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                            description: Version of
+                                                              the schema the FieldPath
+                                                              is written in terms
+                                                              of, defaults to "v1".
                                                             type: string
                                                           fieldPath:
-                                                            description: Path of the field to select in the specified API version.
+                                                            description: Path of the
+                                                              field to select in the
+                                                              specified API version.
                                                             type: string
                                                         required:
                                                         - fieldPath
                                                         type: object
                                                       mode:
-                                                        description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 07'
+                                                        description: 'Optional: mode
+                                                          bits used to set permissions
+                                                          on this file, must be an
+                                                          octal value between 0000
+                                                          and 07'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: 'Required: Path is  the relative path name of the file to be created.'
+                                                        description: 'Required: Path
+                                                          is  the relative path name
+                                                          of the file to be created.'
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.'
+                                                        description: 'Selects a resource
+                                                          of the container: only resources
+                                                          limits and requests (limits.cpu,
+                                                          limits.'
                                                         properties:
                                                           containerName:
-                                                            description: 'Container name: required for volumes, optional for env vars'
+                                                            description: 'Container
+                                                              name: required for volumes,
+                                                              optional for env vars'
                                                             type: string
                                                           divisor:
                                                             anyOf:
                                                             - type: integer
                                                             - type: string
-                                                            description: Specifies the output format of the exposed resources, defaults to "1"
+                                                            description: Specifies
+                                                              the output format of
+                                                              the exposed resources,
+                                                              defaults to "1"
                                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                             x-kubernetes-int-or-string: true
                                                           resource:
-                                                            description: 'Required: resource to select'
+                                                            description: 'Required:
+                                                              resource to select'
                                                             type: string
                                                         required:
                                                         - resource
@@ -7343,22 +9792,32 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret data to project
+                                              description: information about the secret
+                                                data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected int
+                                                  description: If unspecified, each
+                                                    key-value pair in the Data field
+                                                    of the referenced Secret will
+                                                    be projected int
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
+                                                    description: Maps a string key
+                                                      to a path within a volume.
                                                     properties:
                                                       key:
                                                         description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits used to set permissions on this file.'
+                                                        description: 'Optional: mode
+                                                          bits used to set permissions
+                                                          on this file.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path.
+                                                        description: The relative
+                                                          path of the file to map
+                                                          the key to. May not be an
+                                                          absolute path.
                                                         type: string
                                                     required:
                                                     - key
@@ -7366,24 +9825,32 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.'
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken data to project
+                                              description: information about the serviceAccountToken
+                                                data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended audience of the token.
+                                                  description: Audience is the intended
+                                                    audience of the token.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is the requested duration of validity of the service account token.
+                                                  description: ExpirationSeconds is
+                                                    the requested duration of validity
+                                                    of the service account token.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative to the mount point of the file to project the token into.
+                                                  description: Path is the path relative
+                                                    to the mount point of the file
+                                                    to project the token into.
                                                   type: string
                                               required:
                                               - path
@@ -7394,103 +9861,141 @@ spec:
                                     - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                                    description: Quobyte represents a Quobyte mount
+                                      on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to Default is no group
+                                        description: Group to map volume access to
+                                          Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                        description: ReadOnly here will force the
+                                          Quobyte volume to be mounted with read-only
+                                          permissions.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:por
+                                        description: Registry represents a single
+                                          or multiple Quobyte Registry services specified
+                                          as a string as host:por
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volu
+                                        description: Tenant owning the given Quobyte
+                                          volume in the Backend Used with dynamically
+                                          provisioned Quobyte volu
                                         type: string
                                       user:
-                                        description: User to map volume access to Defaults to serivceaccount user
+                                        description: User to map volume access to
+                                          Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references an already created Quobyte volume by name.
+                                        description: Volume is a string that references
+                                          an already created Quobyte volume by name.
                                         type: string
                                     required:
                                     - registry
                                     - volume
                                     type: object
                                   rbd:
-                                    description: RBD represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                    description: RBD represents a Rados Block Device
+                                      mount on the host that shares a pod's lifetime.
                                     properties:
                                       fsType:
-                                        description: Filesystem type of the volume that you want to mount.
+                                        description: Filesystem type of the volume
+                                          that you want to mount.
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'The rados image name. More info:
+                                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring.
+                                        description: Keyring is the path to key ring
+                                          for RBDUser. Default is /etc/ceph/keyring.
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.'
+                                        description: 'A collection of Ceph monitors.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.'
+                                        description: 'The rados pool name. Default
+                                          is rbd. More info: https://examples.k8s.io/volumes/rbd/README.'
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                        description: ReadOnly here will force the
+                                          ReadOnly setting in VolumeMounts. Defaults
+                                          to false.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring.
+                                        description: SecretRef is name of the authentication
+                                          secret for RBDUser. If provided overrides
+                                          keyring.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.'
+                                        description: 'The rados user name. Default
+                                          is admin. More info: https://examples.k8s.io/volumes/rbd/README.'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                    description: ScaleIO represents a ScaleIO persistent
+                                      volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                        description: Filesystem type to mount. Must
+                                          be a filesystem type supported by the host
+                                          operating system. Ex.
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO API Gateway.
+                                        description: The host address of the ScaleIO
+                                          API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection Domain for the configured storage.
+                                        description: The name of the ScaleIO Protection
+                                          Domain for the configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                        description: Defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret for ScaleIO user and other sensitive information.
+                                        description: SecretRef references to the secret
+                                          for ScaleIO user and other sensitive information.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication with Gateway, default false
+                                        description: Flag to enable/disable SSL communication
+                                          with Gateway, default false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                        description: Indicates whether the storage
+                                          for a volume should be ThickProvisioned
+                                          or ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated with the protection domain.
+                                        description: The ScaleIO Storage Pool associated
+                                          with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system as configured in ScaleIO.
+                                        description: The name of the storage system
+                                          as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already created in the ScaleIO system that is associated with this volume sourc
+                                        description: The name of a volume already
+                                          created in the ScaleIO system that is associated
+                                          with this volume sourc
                                         type: string
                                     required:
                                     - gateway
@@ -7498,26 +10003,34 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.'
+                                    description: 'Secret represents a secret that
+                                      should populate this volume. More info: https://kubernetes.'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to set permissions on created files by default.'
+                                        description: 'Optional: mode bits used to
+                                          set permissions on created files by default.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected int
+                                        description: If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected int
                                         items:
-                                          description: Maps a string key to a path within a volume.
+                                          description: Maps a string key to a path
+                                            within a volume.
                                           properties:
                                             key:
                                               description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used to set permissions on this file.'
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path.
+                                              description: The relative path of the
+                                                file to map the key to. May not be
+                                                an absolute path.
                                               type: string
                                           required:
                                           - key
@@ -7525,49 +10038,67 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or its keys must be defined
+                                        description: Specify whether the Secret or
+                                          its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.'
+                                        description: 'Name of the secret in the pod''s
+                                          namespace to use. More info: https://kubernetes.'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                    description: StorageOS represents a StorageOS
+                                      volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                        description: Filesystem type to mount. Must
+                                          be a filesystem type supported by the host
+                                          operating system. Ex.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                        description: Defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.
+                                        description: SecretRef specifies the secret
+                                          to use for obtaining the StorageOS API credentials.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.'
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.'
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable name of the StorageOS volume.
+                                        description: VolumeName is the human-readable
+                                          name of the StorageOS volume.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the scope of the volume within StorageOS.
+                                        description: VolumeNamespace specifies the
+                                          scope of the volume within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                                    description: VsphereVolume represents a vSphere
+                                      volume attached and mounted on kubelets host
+                                      machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex.
+                                        description: Filesystem type to mount. Must
+                                          be a filesystem type supported by the host
+                                          operating system. Ex.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                        description: Storage Policy Based Management
+                                          (SPBM) profile ID associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management (SPBM) profile name.
+                                        description: Storage Policy Based Management
+                                          (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere volume vmdk
+                                        description: Path that identifies vSphere
+                                          volume vmdk
                                         type: string
                                     required:
                                     - volumePath
@@ -7596,28 +10127,34 @@ spec:
             description: RayClusterStatus defines the observed state of RayCluster
             properties:
               availableWorkerReplicas:
-                description: AvailableWorkerReplicas indicates how many replicas are available in the cluster
+                description: AvailableWorkerReplicas indicates how many replicas are
+                  available in the cluster
                 format: int32
                 type: integer
               desiredWorkerReplicas:
-                description: DesiredWorkerReplicas indicates overall desired replicas claimed by the user at the cluster level.
+                description: DesiredWorkerReplicas indicates overall desired replicas
+                  claimed by the user at the cluster level.
                 format: int32
                 type: integer
               lastUpdateTime:
-                description: LastUpdateTime indicates last update timestamp for this cluster status.
+                description: LastUpdateTime indicates last update timestamp for this
+                  cluster status.
                 format: date-time
                 nullable: true
                 type: string
               maxWorkerReplicas:
-                description: MaxWorkerReplicas indicates sum of maximum replicas of each node group.
+                description: MaxWorkerReplicas indicates sum of maximum replicas of
+                  each node group.
                 format: int32
                 type: integer
               minWorkerReplicas:
-                description: MinWorkerReplicas indicates sum of minimum replicas of each node group.
+                description: MinWorkerReplicas indicates sum of minimum replicas of
+                  each node group.
                 format: int32
                 type: integer
               state:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerat'
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerat'
                 type: string
             type: object
         type: object


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The objectmeta in template is always nill. It is related to `controller-tools`.

## Related issue number

https://github.com/kubernetes-sigs/controller-tools/issues/448

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
