### PR TITLE
Pass --timeout option to golangci-lint

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -37,6 +37,7 @@ jobs:
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
+          args: --timeout=3m
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true


### PR DESCRIPTION
## Why are these changes needed?

fix #115. with the change, we can fix the CI issue.

## Related issue number

#115 

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
