### PR TITLE
Add quick start deployment manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ KubeRay provides several tools to improve running and managing Ray's experience 
 - Operator Integration with Kubernetes node problem detector (future work)
 - Kubernetes based workspace to easily submit ray jobs (future work)
 
-## Use helm chart
+## Quick Start
+
+### Use Yaml
+
+```
+kubectl apply -k manifests/cluster-scope-resources
+kubectl apply -k manifests/base
+```
+
+### Use helm chart
 
 A helm chart is a collection of files that describe a related set of Kubernetes resources. It can help users to deploy ray-operator and ray clusters conveniently.
 Please read [kubray-operator](helm-chart/kubray-operator/README.md) to deploy an operator and [ray-cluster](helm-chart/ray-cluster/README.md) to deploy a custom cluster.

--- a/apiserver/deploy/base/apiserver.yaml
+++ b/apiserver/deploy/base/apiserver.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kuberay-apiserver
-  namespace: ray-system
 spec:
   selector:
     matchLabels:
@@ -16,7 +15,7 @@ spec:
       serviceAccountName: kuberay-apiserver
       containers:
       - name: kuberay-apiserver-container
-        image: kuberay/kuberay-apiserver:v0.1.0
+        image: kuberay/apiserver
         ports:
         - containerPort: 8888
         - containerPort: 8887
@@ -36,7 +35,6 @@ metadata:
     prometheus.io/path: /metrics
     prometheus.io/scrape: "true"
     prometheus.io/port: "8080"
-  namespace: ray-system
 spec:
   type: NodePort
   selector:
@@ -58,7 +56,6 @@ metadata:
   labels:
     app: kuberay-apiserver
   name: kuberay-apiserver
-  namespace: ray-system
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,11 @@
+# Install KubeRay using Kustomize Manifests
+
+This folder contains KubeRay Kustomize manifests.
+
+## Overview
+
+User facing manifest entrypoints are `cluster-scoped-resources` package, `base` and `overlay` package.
+
+- `cluster-scoped-resources` should collect all cluster-scoped resources.
+- `base` should collect base manifest 
+- `overlay` should collect specific namespace-scoped resources.

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ray-system
+
+resources:
+- ../../apiserver/deploy/base
+- ../../ray-operator/config/rbac
+- ../../ray-operator/config/manager
+
+images:
+- name: kuberay/apiserver
+  newName: kuberay/apiserver
+  newTag: nightly  
+- name: kuberay/operator
+  newName: kuberay/operator
+  newTag: nightly
+

--- a/manifests/cluster-scope-resources/kustomization.yaml
+++ b/manifests/cluster-scope-resources/kustomization.yaml
@@ -4,4 +4,8 @@ kind: Kustomization
 namespace: ray-system
 
 resources:
-- apiserver.yaml
+- namespace.yaml
+- ../../ray-operator/config/crd
+
+configurations:
+- params.yaml

--- a/manifests/cluster-scope-resources/namespace.yaml
+++ b/manifests/cluster-scope-resources/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ray-system

--- a/manifests/cluster-scope-resources/params.yaml
+++ b/manifests/cluster-scope-resources/params.yaml
@@ -1,0 +1,4 @@
+# Allow Kustomize var to replace following fields.
+varReference:
+- path: metadata/name
+  kind: Namespace

--- a/ray-operator/config/default/kustomization.yaml
+++ b/ray-operator/config/default/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
+- namespace.yaml
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 

--- a/ray-operator/config/default/namespace.yaml
+++ b/ray-operator/config/default/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: ray-operator
+  name: ray-system
+

--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -1,14 +1,7 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: ray-operator
-  name: ray-system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ray-operator
+  name: kuberay-operator
   namespace: system
   labels:
     control-plane: ray-operator


### PR DESCRIPTION
## Why are these changes needed?

Address #114. With this change, it's much easier for user to bring up the KubeRay in their environments. 

## Related issue number

#114 

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
