### PR TITLE
Use container to generate proto files

### DIFF
--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -1,0 +1,35 @@
+# Generate client code (go & json) from API protocol buffers
+FROM golang:1.16.6 as generator
+
+ENV PROTOC_VERSION 3.17.3
+ENV GOLANG_PROTOBUF_VERSION v1.5.2
+ENV GRPC_GATEWAY_VERSION v2.6.0
+ENV GRPC_GATEWAY_OPENAPI_VERSION v2.5.0
+ENV GRPC_VERSION v1.38.0
+ENV GOLANG_GRPC_VERSION v1.1.0
+
+ENV GOBIN=/go/bin
+
+# Install protoc.
+RUN apt-get update && apt-get install -y jq sed unzip
+RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+RUN unzip -o protoc.zip -d /usr/ bin/protoc
+RUN unzip -o protoc.zip -d /usr/ 'include/*'
+RUN rm -f protoc.zip
+ENV PROTOCCOMPILER /usr/bin/protoc
+ENV PROTOCINCLUDE /usr/include/google/protobuf
+
+# Install protoc-gen-go && protoc-gen-go-grpc
+RUN go install github.com/golang/protobuf/protoc-gen-go@$GOLANG_PROTOBUF_VERSION
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@$GOLANG_GRPC_VERSION
+
+# Install protoc-gen-rpc-gateway && protoc-gen-openapiv2.
+RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@$GRPC_GATEWAY_VERSION
+RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@$GRPC_GATEWAY_OPENAPI_VERSION
+
+# WORKAROUND: https://github.com/docker-library/golang/issues/225#issuecomment-403170792
+ENV XDG_CACHE_HOME /tmp/.cache
+# Make all files accessible to non-root users.
+RUN chmod -R 775 /usr/bin/
+RUN chmod -R 775 /usr/include/google
+RUN chmod -R 775 /go

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,10 +1,26 @@
 # Makefile to generate api clients from proto.
 
+IMAGE_NAME=kuberay/proto-generator
+IMAGE_TAG=$(shell git rev-parse HEAD)
+PREBUILT_REMOTE_IMAGE=kuberay/proto-generator:550d4af484e4e1d2f92117357cc49ffcdc2e41ce
+
 OUTPUT_MODE=import
 TMP_OUTPUT=/tmp
 
 .PHONY: generate
 generate:
+	docker run -it --rm \
+		--user $$(id -u):$$(id -g) \
+		--mount type=bind,source="$$(pwd)/..",target=/go/src/github.com/ray-project/kuberay/ \
+		$(PREBUILT_REMOTE_IMAGE) /go/src/github.com/ray-project/kuberay/proto/hack/generate.sh
+
+.PHONY: build-image
+build-image:
+	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile .
+
+.PHONY: generate-cmd
+generate-cmd:
+	# code is exact same to scripts ./hack/generate.sh
 	mkdir -p go_client && mkdir -p swagger && \
 	protoc -I ./ \
 		-I ./third_party/ --go_out ${TMP_OUTPUT} --go_opt paths=${OUTPUT_MODE} \
@@ -16,4 +32,3 @@ generate:
 .PHONY: clean
 clean:
 	rm -rf go_client && rm -rf swagger
-

--- a/proto/README.md
+++ b/proto/README.md
@@ -14,7 +14,7 @@ Run following command to build proto-generator image. We will use it to generate
 > Note: you can actually skip this step, and it will download a prebuilt image instead.
 
 ```
-make image
+make build-image
 ```
 
 ## Auto Generation

--- a/proto/README.md
+++ b/proto/README.md
@@ -9,25 +9,12 @@ In order to run generation commands successfully, please make sure you have foll
 - [Make](https://man7.org/linux/man-pages/man1/make.1.html)
 - [Docker](https://www.docker.com/)
 
-Currently, docker isnot being used for code generation. This is in the roadmap.
-User still have to install protoc, etc to successfully generate the code.
+Run following command to build proto-generator image. We will use it to generate apis.
+
+> Note: you can actually skip this step, and it will download a prebuilt image instead.
 
 ```
-# 1. Install Protocol Buffer
-
-$ brew install protobuf
-$ protoc --version  # Ensure compiler version is 3+
-
-# 2. Install go plugin for protoc and grpc
-
-$ go get -u google.golang.org/grpc
-$ go get -u github.com/golang/protobuf/protoc-gen-go
-
-# 3. Install grpc gateway and openapi plugin for protoc 
-
-$ go get -u github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
-$ go get -u github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 
-
+make image
 ```
 
 ## Auto Generation
@@ -49,7 +36,7 @@ and [html-inline](https://github.com/substack/html-inline) to generate the API r
 
 ### Third Party Protos
 
-Third party proto dependencies are sync back to `api/third_party` for easy development (IDE friendly).
+Third party proto dependencies are sync back to `proto/third_party` for easy development (IDE friendly).
 Actually, we should specify the directory in which to search for imports instead.
 
 ```
@@ -62,4 +49,3 @@ protoc -I.
 Source: 
 - [googleapis](https://github.com/googleapis/googleapis/tree/master/google/api)
 - [protoc-gen-openapiv2](https://github.com/grpc-ecosystem/grpc-gateway/tree/master/protoc-gen-openapiv2/options)
-

--- a/proto/hack/generate.sh
+++ b/proto/hack/generate.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -ex
+
+export TMP_OUTPUT=/tmp
+export OUTPUT_MODE=import
+
+# Change directory.
+cd /go/src/github.com/ray-project/kuberay/proto
+
+# Delete currently generated code and create new folder.
+rm -rf ./go_client/ ./swagger && mkdir -p ./go_client && mkdir -p ./swagger
+
+protoc -I. \
+  -I ./third_party/ --go_out ${TMP_OUTPUT} --go_opt paths=${OUTPUT_MODE} \
+  --go-grpc_out ${TMP_OUTPUT} --go-grpc_opt paths=${OUTPUT_MODE} \
+  --grpc-gateway_out ${TMP_OUTPUT}  --grpc-gateway_opt paths=${OUTPUT_MODE} \
+  --openapiv2_opt logtostderr=true --openapiv2_out=:swagger ./*.proto
+
+# Move *.pb.go and *.gw.go to go_client folder.
+cp ${TMP_OUTPUT}/github.com/ray-project/kuberay/proto/go_client/* ./go_client


### PR DESCRIPTION
1. Add instructions in README.md
2. Add proto-generator image and hack scripts


## Why are these changes needed?

With this change, user doesn't need to pollute their environment for proto generation. Everything is done inside the container and it's every clean, easy and consistent.

## Related issue number

Address https://github.com/ray-project/kuberay/issues/84

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
