### PR TITLE
Support in-tree autoscaler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 **/.settings
 **/.vscode/
 **/bazel.iml
+**/.DS_Store
 # Ignore all bazel-* symlinks. There is no full list since this can change
 # based on the name of the directory bazel is cloned into.
 **/bazel-*

--- a/ray-operator/config/rbac/role.yaml
+++ b/ray-operator/config/rbac/role.yaml
@@ -46,6 +46,7 @@ rules:
   - ""
   resources:
   - services
+  - serviceaccount
   verbs:
   - create
   - delete
@@ -104,3 +105,16 @@ rules:
   - get
   - list
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/ray-operator/config/samples/ray-cluster.autoscaler.debug.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.debug.yaml
@@ -1,0 +1,219 @@
+# This is adapted from https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.complete.yaml
+# It is a general RayCluster that has most fields in it for maximum flexibility in the Ray/Kuberay integration MVP.
+apiVersion: ray.io/v1alpha1
+kind: RayCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    # An unique identifier for the head node and workers of this cluster.
+  name: raycluster-complete
+spec:
+  rayVersion: '1.9.2'
+  enableInTreeAutoscaling: false
+  ######################headGroupSpecs#################################
+  # head group template and specs, (perhaps 'group' is not needed in the name)
+  headGroupSpec:
+    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
+    serviceType: ClusterIP
+    # the pod replicas in this group typed head (assuming there could be more than 1 in the future)
+    replicas: 1
+    # logical group name, for this called head-group, also can be functional
+    # pod type head or worker
+    # rayNodeType: head # Not needed since it is under the headgroup
+    # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
+    rayStartParams:
+      # Flag "no-monitor" must be set when running the autoscaler in
+      # a sidecar container.
+      no-monitor: "true"
+      port: '6379'
+      dashboard-host: '0.0.0.0'
+      node-ip-address: $MY_POD_IP # auto-completed as the head pod IP
+      block: 'true'
+      num-cpus: '1' # can be auto-completed from the limits
+      # Use `resources` to optionally specify custom resource annotations for the Ray node.
+      # The value of `resources` is a string-integer mapping.
+      # Currently, `resources` must be provided in the unfortunate format demonstrated below.
+    #pod template
+    template:
+      spec:
+        serviceAccountName: autoscaler-sa
+        containers:
+        # The Ray head pod
+        - name: ray-head
+          image: rayproject/ray:nightly
+          imagePullPolicy: Always
+          env:
+          - name: CPU_REQUEST
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: requests.cpu
+          - name: CPU_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: limits.cpu
+          - name: MEMORY_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: limits.memory
+          - name: MEMORY_REQUESTS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: requests.memory
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          ports:
+          - containerPort: 6379
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1G"
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+          volumeMounts:
+            - mountPath: /tmp/ray
+              name: ray-logs
+        # The Ray autoscaler sidecar to the head pod
+        - name: autoscaler
+          image: kuberay/autoscaler:nightly
+          imagePullPolicy: Always
+          env:
+          - name: RAY_CLUSTER_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: RAY_CLUSTER_NAME
+            # This value must match the metadata.name of the RayCluster CR.
+            # The autoscaler uses this env variable to determine which Ray CR to interact with.
+            # TODO: Match with CR name automatically via operator, Helm, and/or Kustomize.
+            value: raycluster-complete
+          command: ["/home/ray/anaconda3/bin/python"]
+          args:
+          - "/home/ray/run_autoscaler_with_retries.py"
+          - "--cluster-name"
+          - "$(RAY_CLUSTER_NAME)"
+          - "--cluster-namespace"
+          - "$(RAY_CLUSTER_NAMESPACE)"
+          - "--redis-password"
+          - "5241590000000000"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1024Mi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /tmp/ray
+              name: ray-logs
+        volumes:
+        # You set volumes at the Pod level, then mount them into containers inside that Pod
+        - name: ray-logs
+          emptyDir: {}
+  workerGroupSpecs:
+  # the pod replicas in this group typed worker
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 300
+    # logical group name, for this called small-group, also can be functional
+    groupName: small-group
+    # if worker pods need to be added, we can simply increment the replicas
+    # if worker pods need to be removed, we decrement the replicas, and populate the podsToDelete list
+    # the operator will remove pods from the list until the number of replicas is satisfied
+    # when a pod is confirmed to be deleted, its name will be removed from the list below
+    #scaleStrategy:
+    #  workersToDelete:
+    #  - raycluster-complete-worker-small-group-bdtwh
+    #  - raycluster-complete-worker-small-group-hv457
+    #  - raycluster-complete-worker-small-group-k8tj7
+    # the following params are used to complete the ray start: ray start --block --node-ip-address= ...
+    rayStartParams:
+      redis-password: '5241590000000000'
+      node-ip-address: $MY_POD_IP
+      block: 'true'
+    #pod template
+    template:
+      metadata:
+        labels:
+          key: value
+        # annotations for pod
+        annotations:
+          key: value
+      spec:
+        initContainers:
+        # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+        - name: init-myservice
+          image: busybox:1.28
+          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
+        containers:
+        - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+          image: rayproject/ray:nightly
+          # environment variables to set in the container.Optional.
+          # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+          env:
+          - name:  RAY_DISABLE_DOCKER_CPU_WARNING
+            value: "1"
+          - name: TYPE
+            value: "worker"
+          - name: CPU_REQUEST
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: requests.cpu
+          - name: CPU_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: limits.cpu
+          - name: MEMORY_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: limits.memory
+          - name: MEMORY_REQUESTS
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: requests.memory
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          ports:
+          - containerPort: 80
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+          # use volumeMounts.Optional.
+          # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+          volumeMounts:
+            - mountPath: /var/log
+              name: log-volume
+          resources:
+            limits:
+              cpu: "1"
+              memory: "512Mi"
+            requests:
+              cpu: "500m"
+              memory: "256Mi"
+        # use volumes
+        # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+        volumes:
+          - name: log-volume
+            emptyDir: {}
+######################status#################################

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -1,0 +1,175 @@
+# This is adapted from https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.complete.yaml
+# It is a general RayCluster that has most fields in it for maximum flexibility in the Ray/Kuberay integration MVP.
+apiVersion: ray.io/v1alpha1
+kind: RayCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    # An unique identifier for the head node and workers of this cluster.
+  name: raycluster-autoscaler
+spec:
+  rayVersion: '1.9.2'
+  enableInTreeAutoscaling: true
+  ######################headGroupSpecs#################################
+  # head group template and specs, (perhaps 'group' is not needed in the name)
+  headGroupSpec:
+    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
+    serviceType: ClusterIP
+    # the pod replicas in this group typed head (assuming there could be more than 1 in the future)
+    replicas: 1
+    # logical group name, for this called head-group, also can be functional
+    # pod type head or worker
+    # rayNodeType: head # Not needed since it is under the headgroup
+    # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
+    rayStartParams:
+      # Flag "no-monitor" must be set when running the autoscaler in
+      # a sidecar container.
+      port: '6379'
+      dashboard-host: '0.0.0.0'
+      node-ip-address: $MY_POD_IP # auto-completed as the head pod IP
+      block: 'true'
+      num-cpus: '1' # can be auto-completed from the limits
+      redis-password: 'LetMeInRay'
+      # Use `resources` to optionally specify custom resource annotations for the Ray node.
+      # The value of `resources` is a string-integer mapping.
+      # Currently, `resources` must be provided in the unfortunate format demonstrated below.
+    #pod template
+    template:
+      spec:
+        containers:
+        # The Ray head pod
+        - name: ray-head
+          image: rayproject/ray:nightly
+          imagePullPolicy: Always
+          env:
+          - name: CPU_REQUEST
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: requests.cpu
+          - name: CPU_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: limits.cpu
+          - name: MEMORY_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: limits.memory
+          - name: MEMORY_REQUESTS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: requests.memory
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          ports:
+          - containerPort: 6379
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1G"
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+          volumeMounts:
+            - mountPath: /tmp/ray
+              name: ray-logs
+        volumes:
+        # You set volumes at the Pod level, then mount them into containers inside that Pod
+        - name: ray-logs
+          emptyDir: {}
+  workerGroupSpecs:
+  # the pod replicas in this group typed worker
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 300
+    # logical group name, for this called small-group, also can be functional
+    groupName: small-group
+    # if worker pods need to be added, we can simply increment the replicas
+    # if worker pods need to be removed, we decrement the replicas, and populate the podsToDelete list
+    # the operator will remove pods from the list until the number of replicas is satisfied
+    # when a pod is confirmed to be deleted, its name will be removed from the list below
+    #scaleStrategy:
+    #  workersToDelete:
+    #  - raycluster-complete-worker-small-group-bdtwh
+    #  - raycluster-complete-worker-small-group-hv457
+    #  - raycluster-complete-worker-small-group-k8tj7
+    # the following params are used to complete the ray start: ray start --block --node-ip-address= ...
+    rayStartParams:
+      #redis-password: '5241590000000000'
+      redis-password: 'LetMeInRay'
+      node-ip-address: $MY_POD_IP
+      block: 'true'
+    #pod template
+    template:
+      metadata:
+        labels:
+          key: value
+        # annotations for pod
+        annotations:
+          key: value
+      spec:
+        initContainers:
+        # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+        - name: init-myservice
+          image: busybox:1.28
+          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
+        containers:
+        - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+          image: rayproject/ray:nightly
+          # environment variables to set in the container.Optional.
+          # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+          env:
+          - name:  RAY_DISABLE_DOCKER_CPU_WARNING
+            value: "1"
+          - name: TYPE
+            value: "worker"
+          - name: CPU_REQUEST
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: requests.cpu
+          - name: CPU_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: limits.cpu
+          - name: MEMORY_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: limits.memory
+          - name: MEMORY_REQUESTS
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: requests.memory
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          ports:
+          - containerPort: 80
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+          resources:
+            limits:
+              cpu: "1"
+              memory: "512Mi"
+            requests:
+              cpu: "500m"
+              memory: "256Mi"

--- a/ray-operator/controllers/common/constant.go
+++ b/ray-operator/controllers/common/constant.go
@@ -29,4 +29,7 @@ const (
 	RAY_IP         = "RAY_IP"
 	RAY_PORT       = "RAY_PORT"
 	REDIS_PASSWORD = "REDIS_PASSWORD"
+
+	// Ray core default configurations
+	DefaultRedisPassword = "5241590000000000"
 )

--- a/ray-operator/controllers/common/pod.go
+++ b/ray-operator/controllers/common/pod.go
@@ -47,6 +47,9 @@ func DefaultHeadPodTemplate(instance rayiov1alpha1.RayCluster, headSpec rayiov1a
 		// set custom service account with proper roles bound.
 		podTemplate.Spec.ServiceAccountName = instance.Name
 
+		// Note: Starting with the upcoming Ray 1.11.0, Ray will by default no longer use Redis
+		// should be possible to drop some of the logic around Redis passwords at that point.
+		// TODO(jiaxin.shan): Add version compatibility for 1.11.0 later.
 		redisPasswd := instance.Spec.HeadGroupSpec.RayStartParams["redis-password"]
 		if len(redisPasswd) == 0 {
 			redisPasswd = DefaultRedisPassword
@@ -169,6 +172,7 @@ func BuildAutoscalerContainer(redisPasswd string) v1.Container {
 			"--redis-password",
 			redisPasswd,
 		},
+		// TODO: make resource requirement configurable.
 		Resources: v1.ResourceRequirements{
 			Limits: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("500m"),

--- a/ray-operator/controllers/common/rbac.go
+++ b/ray-operator/controllers/common/rbac.go
@@ -1,0 +1,77 @@
+package common
+
+import (
+	"github.com/ray-project/kuberay/ray-operator/api/raycluster/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// BuildServiceAccount creates a new ServiceAccount for a head pod with autoscaler.
+func BuildServiceAccount(cluster *v1alpha1.RayCluster) (*v1.ServiceAccount, error) {
+	sa := &v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+			Labels: map[string]string{
+				RayClusterLabelKey: cluster.Name,
+			},
+		},
+	}
+
+	return sa, nil
+}
+
+// BuildRole creates a new Role for an RayCluster resource.
+func BuildRole(cluster *v1alpha1.RayCluster) (*rbacv1.Role, error) {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+			Labels: map[string]string{
+				RayClusterLabelKey: cluster.Name,
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"ray.io"},
+				Resources: []string{"rayclusters"},
+				Verbs:     []string{"get", "patch"},
+			},
+		},
+	}
+
+	return role, nil
+}
+
+// BuildRole
+func BuildRoleBinding(cluster *v1alpha1.RayCluster) (*rbacv1.RoleBinding, error) {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+			Labels: map[string]string{
+				RayClusterLabelKey: cluster.Name,
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      cluster.Name,
+				Namespace: cluster.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     cluster.Name,
+		},
+	}
+
+	return rb, nil
+}

--- a/ray-operator/controllers/utils/util.go
+++ b/ray-operator/controllers/utils/util.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -148,4 +149,19 @@ func CalculateAvailableReplicas(pods corev1.PodList) int32 {
 	}
 
 	return count
+}
+
+func Contains(s []string, searchTerm string) bool {
+	i := sort.SearchStrings(s, searchTerm)
+	return i < len(s) && s[i] == searchTerm
+}
+
+func FilterContainerByName(containers []corev1.Container, name string) (corev1.Container, error) {
+	for _, container := range containers {
+		if strings.Compare(container.Name, name) == 0 {
+			return container, nil
+		}
+	}
+
+	return corev1.Container{}, fmt.Errorf("can not find container %s", name)
 }


### PR DESCRIPTION
## Why are these changes needed?
With this change, user doesn't have to manually configure service account/role/role binding etc and user can also save effort to configure autoscaler container. What user just need to do is configure `enableInTreeAutoscaling: true` in their cluster spec.


## Related issue number
Address
- https://github.com/ray-project/kuberay/issues/28
Related 
- https://github.com/ray-project/ray/pull/21086
- https://github.com/ray-project/ray/pull/22348

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
