### PR TITLE
[CLI] check viper error

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -75,6 +75,7 @@ func initConfig() {
 		viper.AddConfigPath(home)
 		viper.SetConfigType("yaml")
 		viper.SetConfigName(".kuberay")
+
 		viper.SetDefault("endpoint", fmt.Sprintf("%s:%s", cmdutil.DefaultRpcAddress, cmdutil.DefaultRpcPort))
 		// Do not write to file system if it already exists
 		if err := viper.SafeWriteConfig(); err != nil {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -75,11 +75,12 @@ func initConfig() {
 		viper.AddConfigPath(home)
 		viper.SetConfigType("yaml")
 		viper.SetConfigName(".kuberay")
-
 		viper.SetDefault("endpoint", fmt.Sprintf("%s:%s", cmdutil.DefaultRpcAddress, cmdutil.DefaultRpcPort))
 		// Do not write to file system if it already exists
 		if err := viper.SafeWriteConfig(); err != nil {
-			klog.Fatal(err)
+			if _, ok := err.(viper.ConfigFileAlreadyExistsError); !ok {
+				klog.Fatal(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We need to ignore `ConfigFileAlreadyExistsError` when write to config, otherwise it will panic.

## Related issue number

Closes #https://github.com/ray-project/kuberay/issues/171


## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
