### PR TITLE
Helm: ensure RBAC rules are up to date with the latest autogenerated manifest

### DIFF
--- a/helm-chart/kuberay-operator/templates/role.yaml
+++ b/helm-chart/kuberay-operator/templates/role.yaml
@@ -9,49 +9,99 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - pods/log
-  - pods/status
-  - pods/exec
-  - services
-  - endpoints
-  - persistentvolumeclaims
   - events
-  - configmaps
-  - secrets
   verbs:
-  - "*"
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
-  - namespaces
+  - pods
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - deployments/status
-  - daemonsets
-  - replicasets
-  - statefulsets
-  - statefulsets/status
-  verbs:
-  - "*"
 - apiGroups:
   - ""
   resources:
-  - nodes
+  - pods/status
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
-  - "ray.io"
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
   resources:
   - rayclusters
   verbs:
-  - "*"
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
 {{- end }}


### PR DESCRIPTION
Updates RBAC rules in the Helm template to match those generated by the Operator Framework based on the application code.

## Why are these changes needed?

The update was initially needed because after deploying the `kuberay-operator` nightly build, its service account was unable to access `leases` in the `coordination.k8s.io` API group. Further investigation revealed that the Helm manifest was even further outdated, which is fixed by this PR.

Fixes #174 

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
