### PR TITLE
Simplify k8s client creation

### DIFF
--- a/apiserver/pkg/client/cluster.go
+++ b/apiserver/pkg/client/cluster.go
@@ -1,20 +1,13 @@
 package client
 
 import (
-	"path/filepath"
 	"time"
 
-	"github.com/pkg/errors"
-	"github.com/ray-project/kuberay/apiserver/pkg/util"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
-
-	"github.com/cenkalti/backoff"
 	"github.com/golang/glog"
+	"github.com/ray-project/kuberay/apiserver/pkg/util"
 	rayclusterclient "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned"
 	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/raycluster/v1alpha1"
-	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 type ClusterClientInterface interface {
@@ -30,51 +23,13 @@ func (cc RayClusterClient) RayClusterClient(namespace string) rayiov1alpha1.RayC
 }
 
 func NewRayClusterClientOrFatal(initConnectionTimeout time.Duration, options util.ClientOptions) ClusterClientInterface {
-	var rayClusterClient rayiov1alpha1.RayV1alpha1Interface
-	var err error
-	var operation = func() error {
-		// in cluster
-		restConfig, err := rest.InClusterConfig()
-		if err != nil {
-			return errors.Wrap(err, "Failed to initialize RestConfig.")
-		}
-		restConfig.QPS = options.QPS
-		restConfig.Burst = options.Burst
-
-		rayClusterClient = rayclusterclient.NewForConfigOrDie(restConfig).RayV1alpha1()
-		return nil
-	}
-
-	// out of cluster
-	rayClusterClient, err = newOutOfClusterRayClusterClient()
-	if err == nil {
-		return &RayClusterClient{client: rayClusterClient}
-	}
-	klog.Infof("(Expected when in cluster) Failed to create RayCluster client by out of cluster kubeconfig. Error: %v", err)
-
-	klog.Infof("Starting to create RayCluster client by in cluster config.")
-	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = initConnectionTimeout
-	err = backoff.Retry(operation, b)
-
+	cfg, err := config.GetConfig()
 	if err != nil {
-		glog.Fatalf("Failed to create TokenReview client. Error: %v", err)
+		glog.Fatalf("Failed to create RayCluster client. Error: %v", err)
 	}
+	cfg.QPS = options.QPS
+	cfg.Burst = options.Burst
+
+	rayClusterClient := rayclusterclient.NewForConfigOrDie(cfg).RayV1alpha1()
 	return &RayClusterClient{client: rayClusterClient}
-}
-
-func newOutOfClusterRayClusterClient() (rayiov1alpha1.RayV1alpha1Interface, error) {
-	home := homedir.HomeDir()
-	if home == "" {
-		return nil, errors.New("Cannot get home dir")
-	}
-
-	defaultKubeConfigPath := filepath.Join(home, ".kube", "config")
-	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", defaultKubeConfigPath)
-	if err != nil {
-		return nil, err
-	}
-	rayClusterClient := rayclusterclient.NewForConfigOrDie(config).RayV1alpha1()
-	return rayClusterClient, nil
 }

--- a/apiserver/pkg/client/kubernetes.go
+++ b/apiserver/pkg/client/kubernetes.go
@@ -1,19 +1,15 @@
 package client
 
 import (
-	"path/filepath"
 	"time"
 
-	"k8s.io/client-go/rest"
+	"github.com/golang/glog"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	"github.com/cenkalti/backoff"
-	"github.com/pkg/errors"
 	"github.com/ray-project/kuberay/apiserver/pkg/util"
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 )
 
 type KubernetesClientInterface interface {
@@ -35,66 +31,16 @@ func (c *KubernetesClient) ConfigMapClient(namespace string) v1.ConfigMapInterfa
 
 // CreateKubernetesCoreOrFatal creates a new client for the Kubernetes pod.
 func CreateKubernetesCoreOrFatal(initConnectionTimeout time.Duration, options util.ClientOptions) KubernetesClientInterface {
-	var client KubernetesClientInterface
-	var err error
-	var operation = func() error {
-		// In cluster
-		kubernetesClient, err := newInClusterKubernetesClient(options)
-		if err != nil {
-			return err
-		}
-		client = kubernetesClient
-		return nil
+	cfg, err := config.GetConfig()
+	if err != nil {
+		glog.Fatalf("Failed to create TokenReview client. Error: %v", err)
 	}
+	cfg.QPS = options.QPS
+	cfg.Burst = options.Burst
 
-	// Out of cluster
-	kubernetesClient, err := newOutOfClusterKubernetesClient()
-	if err == nil {
-		return kubernetesClient
-	}
-	klog.Infof("(Expected when in cluster) Failed to create Kubernetes client by out of cluster kubeconfig. Error: %v", err)
-
-	klog.Infof("Starting to create Kubernetes client by in cluster config.")
-	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = initConnectionTimeout
-	if err := backoff.Retry(operation, b); err != nil {
+	clientSet, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
 		klog.Fatalf("Failed to create pod client. Error: %v", err)
 	}
-
-	return client
-}
-
-func newInClusterKubernetesClient(options util.ClientOptions) (*KubernetesClient, error) {
-	restConfig, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to initialize kubernetes client.")
-	}
-	restConfig.QPS = options.QPS
-	restConfig.Burst = options.Burst
-
-	clientSet, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to initialize kubernetes client set.")
-	}
-	return &KubernetesClient{clientSet.CoreV1()}, nil
-}
-
-func newOutOfClusterKubernetesClient() (*KubernetesClient, error) {
-	home := homedir.HomeDir()
-	if home == "" {
-		return nil, errors.New("Cannot get home dir")
-	}
-
-	defaultKubeConfigPath := filepath.Join(home, ".kube", "config")
-	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", defaultKubeConfigPath)
-	if err != nil {
-		return nil, err
-	}
-
-	clientSet, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to initialize kubernetes clientSet set.")
-	}
-	return &KubernetesClient{clientSet.CoreV1()}, nil
+	return &KubernetesClient{clientSet.CoreV1()}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently when we create kubernetes client, it will check if it is running in K8s' pod. And this logic is implemented in `sigs.k8s.io/controller-runtime/pkg/client/config`. Additional the `controller-runtime` support enviroment KUBECONFIG .

The official tool can help to simplify the code.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
