### PR TITLE
Support scheduling constraints in Helm-deployed clusters

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -26,6 +26,8 @@ spec:
             {{- toYaml .Values.head.containerEnv | nindent 14}}
         volumes: {{- toYaml .Values.head.volumes | nindent 10 }}
         affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
+        tolerations: {{- toYaml .Values.head.tolerations | nindent 10 }}
+        nodeSelector: {{- toYaml .Values.head.nodeSelector | nindent 10 }}
       metadata:
         annotations: {{- toYaml .Values.head.annotations | nindent 10 }}
         labels:
@@ -62,6 +64,8 @@ spec:
             ports: {{- toYaml .Values.worker.ports | nindent 14}}
         volumes: {{- toYaml .Values.worker.volumes | nindent 10 }}
         affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}
+        tolerations: {{- toYaml .Values.worker.tolerations | nindent 10 }}
+        nodeSelector: {{- toYaml .Values.worker.nodeSelector | nindent 10 }}
       metadata:
         annotations: {{- toYaml .Values.worker.annotations | nindent 10 }}
         labels:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -34,6 +34,9 @@ head:
     requests:
        cpu: 200m
   annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
   volumes:
     - name: log-volume
       emptyDir: { }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, `tolerations` and `nodeSelector` specified in the `values.yaml` are not being passed to the Helm deployment. This PR fixes that.

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
