### PR TITLE
Helm: support imagePullSecrets for ray clusters

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -14,6 +14,7 @@ spec:
     replicas: {{ .Values.head.replicas }}
     template:
       spec:
+        imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
         containers:
           - volumeMounts: {{- toYaml .Values.head.volumeMounts | nindent 12 }}
             name: ray-head
@@ -45,6 +46,7 @@ spec:
     groupName: {{ .Values.worker.groupName }}
     template:
       spec:
+        imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
         initContainers:
           - name: init-myservice
             image: busybox:1.28

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -10,6 +10,9 @@ image:
 nameOverride: "ray"
 fullnameOverride: ""
 
+imagePullSecrets: []
+  # - name: an-existing-secret
+
 head:
   groupName: headgroup
   replicas: 1


### PR DESCRIPTION
## Why are these changes needed?

Currently the Helm chart offers no way of pulling images from a private registry. This PR adds such functionality.

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
