### PR TITLE
Support envFrom in rayclusters deployed with Helm

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -24,6 +24,9 @@ spec:
               - name: TYPE
                 value: head
             {{- toYaml .Values.head.containerEnv | nindent 14}}
+            {{- with .Values.head.envFrom }}
+            envFrom: {{- toYaml . | nindent 14}}
+            {{- end }}
         volumes: {{- toYaml .Values.head.volumes | nindent 10 }}
         affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
       metadata:
@@ -59,6 +62,9 @@ spec:
               - name: TYPE
                 value: worker
             {{- toYaml .Values.worker.containerEnv | nindent 14}}
+            {{- with .Values.worker.envFrom }}
+            envFrom: {{- toYaml . | nindent 14}}
+            {{- end }}
             ports: {{- toYaml .Values.worker.ports | nindent 14}}
         volumes: {{- toYaml .Values.worker.volumes | nindent 10 }}
         affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -28,6 +28,9 @@ head:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+  envFrom: []
+    # - secretRef:
+    #     name: my-env-secret
   resources:
     limits:
       cpu: 1
@@ -68,6 +71,9 @@ worker:
       valueFrom:
         fieldRef:
           fieldPath: metadata.name
+  envFrom: []
+    # - secretRef:
+    #     name: my-env-secret
   ports:
     - containerPort: 80
       protocol: TCP


### PR DESCRIPTION
## Why are these changes needed?

It is often useful to populate the container environment with values specified as Kubernetes secrets or configmaps, using the `envFrom` key of the pod spec. For example, we use this technique to provide database credentials to our pods.

This PR implements such functionality for Ray clusters deployed with Helm.

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
