### PR TITLE
Fix serviceaccount typo in operator role

### DIFF
--- a/ray-operator/config/rbac/role.yaml
+++ b/ray-operator/config/rbac/role.yaml
@@ -46,7 +46,7 @@ rules:
   - ""
   resources:
   - services
-  - serviceaccount
+  - serviceaccounts
   verbs:
   - create
   - delete


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

There's a type in cluster role and I didn't notice this because I used docker for desktop. After I change to kind, the problem surfaces

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
