### PR TITLE
Pin release tag to v0.2.0

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,0 +1,19 @@
+OUTPUT_NAME := kuberay
+BUILD_GOOS = $(shell go env GOOS)
+
+COMMIT := $(shell git rev-parse --short HEAD)
+VERSION := $(shell git describe --tags $(shell git rev-list --tags --max-count=1))
+DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+REPO="github.com/ray-project/kuberay"
+
+BUILD_FLAGS = -ldflags="-X '${REPO}/cli/pkg/cmd/version.Version=$(VERSION)' \
+	-X '${REPO}/cli/pkg/cmd/version.gitCommit=$(COMMIT)' \
+	-X '${REPO}/cli/pkg/cmd/version.buildDate=$(DATE)'"
+
+build:
+	go build $(BUILD_FLAGS) -o $(OUTPUT_NAME) main.go
+	chmod +x $(OUTPUT_NAME)
+
+# GOOS=linux GOARCH=amd64 make build
+# GOOS=darwin GOARCH=amd64 make build
+

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -11,8 +11,8 @@ resources:
 images:
 - name: kuberay/apiserver
   newName: kuberay/apiserver
-  newTag: nightly  
+  newTag: v0.2.0
 - name: kuberay/operator
   newName: kuberay/operator
-  newTag: nightly
+  newTag: v0.2.0
 


### PR DESCRIPTION
## Why are these changes needed?

Pin manifests to v0.2.0 and I will cut tag later. 

## Related issue number

[<!-- For example: "Closes #1234" -->](https://github.com/ray-project/kuberay/issues/193)

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [x] This PR is not tested :(
