### PR TITLE
Build KubeRay Github site

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -1,0 +1,15 @@
+name: ci
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/docs/components/apiserver.md
+++ b/docs/components/apiserver.md
@@ -1,0 +1,1 @@
+../../apiserver/README.md

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -1,0 +1,1 @@
+../../cli/README.md

--- a/docs/components/operator.md
+++ b/docs/components/operator.md
@@ -1,0 +1,1 @@
+../../ray-operator/README.md

--- a/docs/deploy/helm-cluster.md
+++ b/docs/deploy/helm-cluster.md
@@ -1,0 +1,1 @@
+../../helm-chart/ray-cluster/README.md

--- a/docs/deploy/helm.md
+++ b/docs/deploy/helm.md
@@ -1,0 +1,1 @@
+../../helm-chart/kuberay-operator/README.md

--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -1,0 +1,15 @@
+## Installation
+
+#### Nightly version
+
+```
+kubectl apply -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources"
+kubectl apply -k "github.com/ray-project/kuberay/manifests/base"
+```
+
+#### Stable version
+
+```
+kubectl apply -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.2.0"
+kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=v0.2.0"
+```

--- a/docs/guidance/ingress.md
+++ b/docs/guidance/ingress.md
@@ -20,5 +20,5 @@ spec:
   rayVersion: '1.9.2'
   headGroupSpec:
     serviceType: NodePort
-    enableIngress: true -> enables ingress
+    enableIngress: true # enables ingress
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,48 @@
+# Welcome
+
+<p align="center">
+    <a href="https://github.com/ray-project/kuberay/issues">
+        <img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat" alt="contributions welcome"/>
+    </a>
+    <a href="https://github.com/ray-project/kuberay/issues">
+        <img src="https://img.shields.io/github/issues-raw/ray-project/kuberay?style=flat" alt="github issues"/>
+    </a>
+    <img src="https://img.shields.io/badge/status-alpha-brightgreen?style=flat" alt="status is alpha"/>
+    <img src="https://img.shields.io/github/license/ray-project/kuberay?style=flat" alt="apache license"/>
+</p>
+<p align="center">
+    <a href="https://goreportcard.com/report/github.com/ray-project/kuberay">
+        <img src="https://goreportcard.com/badge/github.com/ray-project/kuberay" alt="go report card"/>
+    </a>
+    <img src="https://img.shields.io/github/watchers/ray-project/kuberay?style=social" alt="github watchers"/>
+    <img src="https://img.shields.io/github/stars/ray-project/kuberay?style=social" alt="github stars"/>
+    <img src="https://img.shields.io/github/forks/ray-project/kuberay?style=social" alt="github forks"/>
+    <a href="https://hub.docker.com/r/kuberay/operator/">
+        <img src="https://img.shields.io/docker/pulls/kuberay/operator" alt="docker pulls"/>
+    </a>
+</p>
+
+## KubeRay
+
+KubeRay is an open source toolkit to run Ray applications on Kubernetes.
+
+KubeRay provides several tools to improve running and managing Ray's experience on Kubernetes.
+
+- Ray Operator
+- Backend services to create/delete cluster resources
+- Kubectl plugin/CLI to operate CRD objects
+- Data Scientist centric workspace for fast prototyping (incubating)
+- Native Job and Serving integration with Clusters (incubating)
+- Kubernetes event dumper for ray clusters/pod/services (future work)
+- Operator Integration with Kubernetes node problem detector (future work)
+
+## Security
+
+If you discover a potential security issue in this project, or think you may
+have discovered a security issue, we ask that you notify KubeRay Security via our
+[Slack Channel](https://ray-distributed.slack.com/archives/C02GFQ82JPM).
+Please do **not** create a public GitHub issue.
+
+## License
+
+This project is licensed under the [Apache-2.0 License](LICENSE).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,82 @@
+# Project Information
+site_name: KubeRay
+site_url: https://ray-project.github.io/kuberay
+
+# Repository
+repo_name: ray-project/kuberay
+repo_url: https://github.com/ray-project/kuberay
+edit_uri: ""
+
+# Configuration
+theme:
+  name: material
+  language: en
+  features:
+    - navigation.tabs
+  icon:
+    repo: fontawesome/brands/github
+
+# Navigation
+nav:
+  - Home:
+    - Welcome: index.md
+    - Installation(Yaml): deploy/installation.md
+    - Installation(Helm): deploy/helm.md
+    - Installation(Helm-cluster): deploy/helm-cluster.md
+  - Components:
+    - KubeRay Operator: components/operator.md
+    - KubeRay ApiServer: components/apiserver.md
+    - KubeRay CLI: components/cli.md
+  - Features:
+    - Autoscaling: guidance/autoscaler.md
+    - Ingress: guidance/ingress.md
+  - Best Practice:
+    - Worker reconnection: best-practice/worker-head-reconnection.md
+  - Troubleshooting:
+    - Guidance: troubleshooting.md
+  - Designs:
+    - Core API and Backend Service: design/protobuf-grpc-service.md
+
+# Customization
+extra:
+  version:
+    provider: mike
+
+plugins:
+  - tags
+  - search
+
+# Markdown Extension
+markdown_extensions:
+  # Python Markdown
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - meta
+  - md_in_html
+  - toc:
+      permalink: true
+
+  # Python Markdown Extensions
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde

--- a/ray-operator/README.md
+++ b/ray-operator/README.md
@@ -42,12 +42,12 @@ An example ray code is defined in this [configmap](msft-operator/ray-operator/co
 
 ### Deploy the operator
 
-```shell script
+```shell
 kubectl apply -k "github.com/ray-project/kuberay/ray-operator/config/default"
 ```
 
 Check that the controller is running.
-```shell script
+```shell
 $ kubectl get deployments -n ray-system
 NAME           READY   UP-TO-DATE   AVAILABLE   AGE
 ray-operator   1/1     1            1           40s
@@ -58,7 +58,7 @@ ray-operator-75dbbf8587-5lrvn   1/1     Running   0          31s
 ```
 
 Delete the operator
-```shell script
+```shell
 kubectl delete -k "github.com/ray-project/kuberay/ray-operator/config/default"
 ```
 
@@ -72,14 +72,14 @@ Sample  | Description
 [ray-cluster.heterogeneous.yaml](config/samples/ray-cluster.heterogeneous.yaml)  | Example with heterogenous worker types. 1 head pod and 2 worker pods, each of which has a different resource quota.
 [ray-cluster.complete.yaml](config/samples/ray-cluster.complete.yaml)  | Shows all available custom resouce properties.
 
-```shell script
+```shell
 # Create a configmap with a hello world Ray code.
 kubectl create -f config/samples/config-map-ray-code.yaml
 configmap/ray-code created
 ```
 
 
-```shell script
+```shell
 # Create a cluster.
 $ kubectl create -f config/samples/ray-cluster.heterogeneous.yaml
 raycluster.ray.io/raycluster-heterogeneous created


### PR DESCRIPTION
1. Use Material for MkDocs to generate a site
2. Add ci job for site rendering
3. Create soft links for operator,apiserver and cli components
4. Add some new pages to enrich content of the new site

Some README.md are soft links
```
ln -s  ../../ray-operator/README.md operator.md
ln -s ../../apiserver/README.md apiserver.md
ln -s ../../cli/README.md cli.md
```

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR help create a Github site that organize all the existing docs together. This help user to easily onboard KubeRay project. 

## Related issue number

https://github.com/ray-project/kuberay/issues/212

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
