### PR TITLE
enable force cluster upgrade

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -26,6 +26,9 @@ jobs:
         # Default value should work for both pull_request and merge(push) event.
         ref: ${{github.event.pull_request.head.sha}}
 
+    - name: Install goimports
+      run: go get golang.org/x/tools/cmd/goimports
+
     - name: Run gofmt
       uses: Jerome1337/gofmt-action@v1.0.4
       with:
@@ -74,9 +77,6 @@ jobs:
         args: --timeout=3m
         skip-go-installation: true
         skip-pkg-cache: true
-
-    - name: Install goimports
-      run: go get golang.org/x/tools/cmd/goimports
 
     - name: Run goimports
       run: test -z "$(set -o pipefail && $(go env GOPATH)/bin/goimports -l apiserver/ ray-operator/ cli/ | tee goimports.out)" || { cat goimports.out && exit 1; }

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -83,6 +83,16 @@ func setupTest(t *testing.T) {
 					common.RayNodeGroupLabelKey: headGroupNameStr,
 				},
 			},
+			Spec: corev1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "ray-head",
+						Image:   "rayproject/autoscaler",
+						Command: []string{"python"},
+						Args:    []string{"/opt/code.py"},
+					},
+				},
+			},
 			Status: corev1.PodStatus{
 				Phase: v1.PodRunning,
 			},
@@ -94,6 +104,16 @@ func setupTest(t *testing.T) {
 				Labels: map[string]string{
 					common.RayClusterLabelKey:   instanceName,
 					common.RayNodeGroupLabelKey: groupNameStr,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "ray-worker",
+						Image:   "rayproject/autoscaler",
+						Command: []string{"echo"},
+						Args:    []string{"Hello Ray"},
+					},
 				},
 			},
 			Status: corev1.PodStatus{
@@ -109,6 +129,16 @@ func setupTest(t *testing.T) {
 					common.RayNodeGroupLabelKey: groupNameStr,
 				},
 			},
+			Spec: corev1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "ray-worker",
+						Image:   "rayproject/autoscaler",
+						Command: []string{"echo"},
+						Args:    []string{"Hello Ray"},
+					},
+				},
+			},
 			Status: corev1.PodStatus{
 				Phase: v1.PodRunning,
 			},
@@ -120,6 +150,16 @@ func setupTest(t *testing.T) {
 				Labels: map[string]string{
 					common.RayClusterLabelKey:   instanceName,
 					common.RayNodeGroupLabelKey: groupNameStr,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "ray-worker",
+						Image:   "rayproject/autoscaler",
+						Command: []string{"echo"},
+						Args:    []string{"Hello Ray"},
+					},
 				},
 			},
 			Status: corev1.PodStatus{
@@ -135,6 +175,16 @@ func setupTest(t *testing.T) {
 					common.RayNodeGroupLabelKey: groupNameStr,
 				},
 			},
+			Spec: corev1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "ray-worker",
+						Image:   "rayproject/autoscaler",
+						Command: []string{"echo"},
+						Args:    []string{"Hello Ray"},
+					},
+				},
+			},
 			Status: corev1.PodStatus{
 				Phase: v1.PodRunning,
 			},
@@ -146,6 +196,16 @@ func setupTest(t *testing.T) {
 				Labels: map[string]string{
 					common.RayClusterLabelKey:   instanceName,
 					common.RayNodeGroupLabelKey: groupNameStr,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "ray-worker",
+						Image:   "rayproject/autoscaler",
+						Command: []string{"echo"},
+						Args:    []string{"Hello Ray"},
+					},
 				},
 			},
 			Status: corev1.PodStatus{

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -206,7 +206,7 @@ var _ = Context("Inside the default namespace", func() {
 			// adding a scale down
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
+				time.Second*9, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
 			rep := new(int32)
 			*rep = 2
 			myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = rep

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -175,3 +175,62 @@ func GetHeadGroupServiceAccountName(cluster *rayiov1alpha1.RayCluster) string {
 	}
 	return cluster.Name
 }
+
+func PodNotMatchingTemplate(pod corev1.Pod, template corev1.PodTemplateSpec) bool {
+	if pod.Status.Phase == corev1.PodRunning && pod.ObjectMeta.DeletionTimestamp == nil {
+		if len(template.Spec.Containers) != len(pod.Spec.Containers) {
+			return true
+		}
+		cmap := map[string]*corev1.Container{}
+		for _, container := range pod.Spec.Containers {
+			cmap[container.Name] = &container
+		}
+		for _, container1 := range template.Spec.Containers {
+			if container2, ok := cmap[container1.Name]; ok {
+				if container1.Image != container2.Image {
+					// image name do not match
+					return true
+				}
+				if len(container1.Resources.Requests) != len(container2.Resources.Requests) ||
+					len(container1.Resources.Limits) != len(container2.Resources.Limits) {
+					// resource entries do not match
+					return true
+				}
+
+				resources1 := []corev1.ResourceList{
+					container1.Resources.Requests,
+					container1.Resources.Limits,
+				}
+				resources2 := []corev1.ResourceList{
+					container2.Resources.Requests,
+					container2.Resources.Limits,
+				}
+				for i := range resources1 {
+					// we need to make sure all fields match
+					for name, quantity1 := range resources1[i] {
+						if quantity2, ok := resources2[i][name]; ok {
+							if quantity1.Cmp(quantity2) != 0 {
+								// request amount does not match
+								return true
+							}
+						} else {
+							// no such request
+							return true
+						}
+					}
+				}
+
+				// now we consider them equal
+				delete(cmap, container1.Name)
+			} else {
+				// container name do not match
+				return true
+			}
+		}
+		if len(cmap) != 0 {
+			// one or more containers do not match
+			return true
+		}
+	}
+	return false
+}

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
@@ -116,4 +118,179 @@ func TestGetHeadGroupServiceAccountName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcile_CheckNeedRemoveOldPod(t *testing.T) {
+	namespaceStr := "default"
+
+	headTemplate := corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "ray-head",
+					Image:   "rayproject/autoscaler",
+					Command: []string{"python"},
+					Args:    []string{"/opt/code.py"},
+					Env: []corev1.EnvVar{
+						{
+							Name: "MY_POD_IP",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "status.podIP",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "headNode",
+			Namespace: namespaceStr,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "ray-head",
+					Image:   "rayproject/autoscaler",
+					Command: []string{"python"},
+					Args:    []string{"/opt/code.py"},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+
+	assert.Equal(t, PodNotMatchingTemplate(pod, headTemplate), false, "expect template & pod matching")
+
+	pod.Spec.Containers = []corev1.Container{
+		{
+			Name:    "ray-head",
+			Image:   "rayproject/autoscaler",
+			Command: []string{"python"},
+			Args:    []string{"/opt/code.py"},
+		},
+		{
+			Name:    "ray-head",
+			Image:   "rayproject/autoscaler",
+			Command: []string{"python"},
+			Args:    []string{"/opt/code.py"},
+		},
+	}
+
+	assert.Equal(t, PodNotMatchingTemplate(pod, headTemplate), true, "expect template & pod with 2 containers not matching")
+
+	workerTemplate := corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "ray-worker",
+					Image:   "rayproject/autoscaler",
+					Command: []string{"echo"},
+					Args:    []string{"Hello Ray"},
+					Env: []corev1.EnvVar{
+						{
+							Name: "MY_POD_IP",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "status.podIP",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pod = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: namespaceStr,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "ray-worker",
+					Image:   "rayproject/autoscaler",
+					Command: []string{"echo"},
+					Args:    []string{"Hello Ray"},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+
+	assert.Equal(t, PodNotMatchingTemplate(pod, workerTemplate), false, "expect template & pod matching")
+
+	workerTemplate = corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "ray-worker",
+					Image:   "rayproject/autoscaler",
+					Command: []string{"echo"},
+					Args:    []string{"Hello Ray"},
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("500m"),
+							v1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("256m"),
+							v1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pod = corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: namespaceStr,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "ray-worker",
+					Image:   "rayproject/autoscaler",
+					Command: []string{"echo"},
+					Args:    []string{"Hello Ray"},
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("500m"),
+							v1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("256m"),
+							v1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+
+	assert.Equal(t, PodNotMatchingTemplate(pod, workerTemplate), false, "expect template & pod matching")
+
+	pod.Spec.Containers[0].Resources.Limits[v1.ResourceCPU] = resource.MustParse("50m")
+
+	assert.Equal(t, PodNotMatchingTemplate(pod, workerTemplate), true, "expect template & pod not matching")
+
+	pod.Spec.Containers[0].Resources.Limits[v1.ResourceCPU] = resource.MustParse("500m")
+	pod.Spec.Containers[0].Resources.Requests[v1.ResourceCPU] = resource.MustParse("250m")
+
+	assert.Equal(t, PodNotMatchingTemplate(pod, workerTemplate), true, "expect template & pod not matching")
 }

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -54,6 +54,8 @@ func main() {
 		"Watch custom resources in the namespace, ignore other namespaces. If empty, all namespaces will be watched.")
 	flag.BoolVar(&ray.PrioritizeWorkersToDelete, "prioritize-workers-to-delete", false,
 		"Temporary feature flag - to be deleted after testing")
+	flag.BoolVar(&ray.ForcedClusterUpgrade, "forced-cluster-upgrade", false,
+		"Forced cluster upgrade flag")
 	opts := zap.Options{
 		Development: true,
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
@@ -72,6 +74,9 @@ func main() {
 	setupLog.Info("the operator", "version:", os.Getenv("OPERATOR_VERSION"))
 	if ray.PrioritizeWorkersToDelete {
 		setupLog.Info("Feature flag prioritize-workers-to-delete is enabled.")
+	}
+	if ray.ForcedClusterUpgrade {
+		setupLog.Info("Feature flag forced-cluster-upgrade is enabled.")
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{


### PR DESCRIPTION

## Why are these changes needed?

This is a patch to bug #155. I added reconcile logic so that in case of following fields updated, we will rebuild the cluster.
1. head template container amount
2. head template container image
3. head template container resources
4. worker template container amount
5. worker template container image
6. worker template container resources


## Related issue number

#155

## Checks

- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
