### PR TITLE
fix duplicated port config and manager.yaml missing config

### DIFF
--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -24,6 +24,10 @@ spec:
 #        args:
 #        - --enable-leader-election
         image: kuberay/operator
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
         name: ray-manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/ray-operator/controllers/common/pod.go
+++ b/ray-operator/controllers/common/pod.go
@@ -90,7 +90,18 @@ func DefaultWorkerPodTemplate(instance rayiov1alpha1.RayCluster, workerSpec rayi
 		Name:          "metrics",
 		ContainerPort: int32(DefaultMetricsPort),
 	}
-	podTemplate.Spec.Containers[0].Ports = append(podTemplate.Spec.Containers[0].Ports, metricsPort)
+	dupIndex := -1
+	for i, port := range podTemplate.Spec.Containers[0].Ports {
+		if port.Name == metricsPort.Name {
+			dupIndex = i
+			break
+		}
+	}
+	if dupIndex < 0 {
+		podTemplate.Spec.Containers[0].Ports = append(podTemplate.Spec.Containers[0].Ports, metricsPort)
+	} else {
+		podTemplate.Spec.Containers[0].Ports[dupIndex] = metricsPort
+	}
 
 	return podTemplate
 }


### PR DESCRIPTION

## Why are these changes needed?

This patch fixed tow bugs:
1. add missing port declaration in manager.yaml file
2. avoid adding the same port again if it already exists in existing pod template.

## Related issue number

#249

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
