### PR TITLE
Fix Ray Operator prometheus config

### DIFF
--- a/ray-operator/config/prometheus/monitor.yaml
+++ b/ray-operator/config/prometheus/monitor.yaml
@@ -12,4 +12,5 @@ spec:
     - path: /metrics
       port: monitoring-port
   selector:
-    control-plane: kuberay-operator
+    matchLabels:
+      control-plane: kuberay-operator


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
When applying the Ray Operator's prometheus config, the prometheus's ServiceMonitor spec.selector is missing the "matchLabels" spec. Therefore, we need to update the prometheus config with the proper selector spec.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #252 

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
