### PR TITLE
Install: Fix directory path for prometheus install.sh

### DIFF
--- a/install/prometheus/install.sh
+++ b/install/prometheus/install.sh
@@ -8,7 +8,8 @@ helm repo update
 helm --namespace prometheus-system install prometheus-operator prometheus-community/kube-prometheus-stack --create-namespace 
 
 # set the place of monitor files
-monitor_dir=../../config/prometheus
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
+monitor_dir=${DIR}/../../config/prometheus
 
 # start to install monitor
 pushd ${monitor_dir}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Right now the `/install/prometheus/install.sh` script is assuming the directory path is `/install/prometheus/`. However, the main README instruction is asking users to run this script from the top directory which will result the following errors:
```
+ monitor_dir=../../config/prometheus
+ pushd ../../config/prometheus
./install/prometheus/install.sh: line 14: pushd: ../../config/prometheus: No such file or directory
```

Therefore, we need to make sure `monitor_dir` is set to the right directory without depending on the user's current directory path.

## Related issue number

<!-- For example: "Closes #1234" -->

None

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
