### PR TITLE
fix ray-operator: `make build` error when using >= Go 1.18

### DIFF
--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -108,6 +108,8 @@ PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \
 set -e ;\
+GO_VERSION_1_17_OR_HIGHER=$(shell echo `go version | cut -d ' ' -f 3 | cut -c 3- | cut -d '.' -f1-2`\>=1.17 | bc) ;\
+if [[ $$GO_VERSION_1_17_OR_HIGHER -eq 1 ]]; then echo "The Go version you're using is 1.17 or higher. Using 'go install' instead of 'go get'"; GOBIN=$(PROJECT_DIR)/bin go install $(2); fi ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\


### PR DESCRIPTION
## Why are these changes needed?

The [dev docs] say to run `make build` in the ray-operator directory. Users
with Go 1.18 or higher will get the following error.

```
make build
go: creating new go.mod: module tmp
Downloading sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0
go: downloading sigs.k8s.io/controller-tools v0.6.0
go: downloading github.com/spf13/cobra v1.1.3
...
go: added sigs.k8s.io/yaml v1.2.0
... object:headerFile="hack/boilerplate.go.txt" paths="./..."
bash: .../ray-operator/bin/controller-gen: No such file or directory
make: *** [generate] Error 127
```

This is caused by `go get` being deprecated for installing executables in 1.17
and removed in 1.18 ([Go docs]). This PR updates the `Makefile` to account for
this change in a backwards compatible way.

[dev docs]: https://github.com/ray-project/kuberay/blob/master/ray-operator/DEVELOPMENT.md#build-the-source-code
[Go docs]: https://go.dev/doc/go-get-install-deprecation

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->


## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
