### PR TITLE
[Feature]Run kuberay in a single namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resour
 kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=v0.2.0"
 ```
 
+#### Single Namespace version
+
+It is possible that the user can only access one single namespace while deploying KubeRay. To deploy KubeRay in a single namespace, the user
+can use these commands:
+
+```
+# Nightly version
+export KUBERAY_NAMESPACE=<my-awesome-namespace>; kustomize build github.com/ray-project/kuberay/manifests/base | envsubst | kubectl apply -f -
+
+# Stable version
+export KUBERAY_NAMESPACE=<my-awesome-namespace>; kustomize build github.com/ray-project/kuberay/manifests/base?ref=v0.2.0 | envsubst | kubectl apply -f -
+
+```
+
 ### Use helm chart
 
 A helm chart is a collection of files that describe a related set of Kubernetes resources. It can help users to deploy ray-operator and ray clusters conveniently.

--- a/README.md
+++ b/README.md
@@ -44,10 +44,18 @@ can use these commands:
 
 ```
 # Nightly version
-export KUBERAY_NAMESPACE=<my-awesome-namespace>; kustomize build github.com/ray-project/kuberay/manifests/base | envsubst | kubectl apply -f -
+export KUBERAY_NAMESPACE=<my-awesome-namespace>
+# executed by cluster admin
+kustomize build "github.com/ray-project/kuberay/manifests/overlays/single-namespace-resources" | envsubst | kubectl create -f -
+# executed by user
+kustomize build "github.com/ray-project/kuberay/manifests/overlays/single-namespace" | envsubst | kubectl apply -f -
 
 # Stable version
-export KUBERAY_NAMESPACE=<my-awesome-namespace>; kustomize build github.com/ray-project/kuberay/manifests/base?ref=v0.2.0 | envsubst | kubectl apply -f -
+export KUBERAY_NAMESPACE=<my-awesome-namespace>
+# executed by cluster admin
+kustomize build "github.com/ray-project/kuberay/manifests/overlays/single-namespace-resources?ref=v0.2.0" | envsubst | kubectl create -f -
+# executed by user
+kustomize build "github.com/ray-project/kuberay/manifests/overlays/single-namespace?ref=v0.2.0" | envsubst | kubectl apply -f -
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=v0.2.0"
 #### Single Namespace version
 
 It is possible that the user can only access one single namespace while deploying KubeRay. To deploy KubeRay in a single namespace, the user
-can use these commands:
+can use following commands.
 
 ```
 # Nightly version

--- a/manifests/overlays/single-namespace-resources/kustomization.yaml
+++ b/manifests/overlays/single-namespace-resources/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ${KUBERAY_NAMESPACE}
+
+resources:
+- ../../cluster-scope-resources/

--- a/manifests/overlays/single-namespace/kustomization.yaml
+++ b/manifests/overlays/single-namespace/kustomization.yaml
@@ -15,8 +15,7 @@ patches:
 - path: patch-deployment.json
   target:
     kind: Deployment
-    metadata:
-      name: kuberay-operator
+    name: kuberay-operator
 - path: patch-others.json
   target:
     version: v1

--- a/manifests/overlays/single-namespace/kustomization.yaml
+++ b/manifests/overlays/single-namespace/kustomization.yaml
@@ -1,0 +1,17 @@
+# This overlay patches in KubeRay operator configuration
+# necessary for KubeRay single namespace support.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../base
+patches:
+- path: patch-cluster-role.json
+  target:
+    kind: ClusterRole
+- path: patch-cluster-role-binding.json
+  target:
+    kind: ClusterRoleBinding
+- path: patch-others.json
+  target:
+    version: v1

--- a/manifests/overlays/single-namespace/kustomization.yaml
+++ b/manifests/overlays/single-namespace/kustomization.yaml
@@ -12,6 +12,9 @@ patches:
 - path: patch-cluster-role-binding.json
   target:
     kind: ClusterRoleBinding
+- path: patch-deployment.json
+  target:
+    kind: Deployment
 - path: patch-others.json
   target:
     version: v1

--- a/manifests/overlays/single-namespace/kustomization.yaml
+++ b/manifests/overlays/single-namespace/kustomization.yaml
@@ -15,6 +15,8 @@ patches:
 - path: patch-deployment.json
   target:
     kind: Deployment
+    metadata:
+      name: kuberay-operator
 - path: patch-others.json
   target:
     version: v1

--- a/manifests/overlays/single-namespace/patch-cluster-role-binding.json
+++ b/manifests/overlays/single-namespace/patch-cluster-role-binding.json
@@ -1,0 +1,22 @@
+[
+  {
+    "op": "replace",
+    "path": "/kind",
+    "value": "RoleBinding"
+  },
+  {
+    "op": "replace",
+    "path": "/metadata/namespace",
+    "value": "${KUBERAY_NAMESPACE}"
+  },
+  {
+    "op": "replace",
+    "path": "/roleRef/kind",
+    "value": "Role"
+  },
+  {
+    "op": "replace",
+    "path": "/subjects/0/namespace",
+    "value": "${KUBERAY_NAMESPACE}"
+  }
+]

--- a/manifests/overlays/single-namespace/patch-cluster-role.json
+++ b/manifests/overlays/single-namespace/patch-cluster-role.json
@@ -1,0 +1,12 @@
+[
+  {
+    "op": "replace",
+    "path": "/kind",
+    "value": "Role"
+  },
+  {
+    "op": "replace",
+    "path": "/metadata/namespace",
+    "value": "${KUBERAY_NAMESPACE}"
+  }
+]

--- a/manifests/overlays/single-namespace/patch-deployment.json
+++ b/manifests/overlays/single-namespace/patch-deployment.json
@@ -2,6 +2,6 @@
   {
     "op": "replace",
     "path": "/spec/template/spec/containers/0/command",
-    "value": ["/manager", "--watch-namespace"]
+    "value": ["/manager", "-watch-namespace", "${KUBERAY_NAMESPACE}"]
   }
 ]

--- a/manifests/overlays/single-namespace/patch-deployment.json
+++ b/manifests/overlays/single-namespace/patch-deployment.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/spec/template/spec/containers/0/command",
+    "value": ["/manager", "--watch-namespace"]
+  }
+]

--- a/manifests/overlays/single-namespace/patch-others.json
+++ b/manifests/overlays/single-namespace/patch-others.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/metadata/namespace",
+    "value": "${KUBERAY_NAMESPACE}"
+  }
+]


### PR DESCRIPTION
## Why are these changes needed?

Run kuberay in a single namespace.

Instead of  setup kuberay using 
```bash
kubectl apply -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources"
kubectl apply -k "github.com/ray-project/kuberay/manifests/base"
```
now we use
```bash
kubectl apply -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources"
kubectl apply -k "github.com/ray-project/kuberay/manifests/singe-namespace"
```

## Related issue number

#227

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
