### PR TITLE
[Feature] Helm chart supports multiple worker groups defs

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -41,43 +41,45 @@ spec:
 {{ include "ray-cluster.labels" . | indent 10 }}
 
   workerGroupSpecs:
-  - rayStartParams:
-    {{- range $key, $val := .Values.worker.initArgs }}
+  {{- range $key, $val := .Values.workers }}
+  - groupName: {{ $val.groupName }}
+    rayStartParams:
+    {{- range $key, $val := $val.initArgs }}
       {{ $key }}: {{ $val | quote }}
     {{- end }}
-    replicas: {{ .Values.worker.replicas }}
-    minReplicas: {{ .Values.worker.miniReplicas | default 1 }}
-    maxReplicas: {{ .Values.worker.maxiReplicas | default 2147483647 }}
-    groupName: {{ .Values.worker.groupName }}
+    replicas: {{ $val.replicas }}
+    minReplicas: {{ $val.miniReplicas | default 1 }}
+    maxReplicas: {{ $val.maxiReplicas | default 2147483647 }}
     template:
       spec:
-        imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
+        imagePullSecrets: {{- toYaml $.Values.imagePullSecrets | nindent 10 }}
         initContainers:
           - name: init-myservice
             image: busybox:1.28
             command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
         containers:
-          - volumeMounts: {{- toYaml .Values.worker.volumeMounts | nindent 12 }}
+          - volumeMounts: {{- toYaml $val.volumeMounts | nindent 12 }}
             name: ray-worker
-            image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-            imagePullPolicy: {{ .Values.image.pullPolicy }}
-            resources: {{- toYaml .Values.worker.resources | nindent 14 }}
+            image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
+            imagePullPolicy: {{ $.Values.image.pullPolicy }}
+            resources: {{- toYaml $val.resources | nindent 14 }}
             env:
               - name: TYPE
                 value: worker
-            {{- toYaml .Values.worker.containerEnv | nindent 14}}
-            {{- with .Values.worker.envFrom }}
+            {{- toYaml $val.containerEnv | nindent 14}}
+            {{- with $val.envFrom }}
             envFrom: {{- toYaml . | nindent 14}}
             {{- end }}
-            ports: {{- toYaml .Values.worker.ports | nindent 14}}
-        volumes: {{- toYaml .Values.worker.volumes | nindent 10 }}
-        affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}
-        tolerations: {{- toYaml .Values.worker.tolerations | nindent 10 }}
-        nodeSelector: {{- toYaml .Values.worker.nodeSelector | nindent 10 }}
+            ports: {{- toYaml $val.ports | nindent 14}}
+        volumes: {{- toYaml $val.volumes | nindent 10 }}
+        affinity: {{- toYaml $val.affinity | nindent 10 }}
+        tolerations: {{- toYaml $val.tolerations | nindent 10 }}
+        nodeSelector: {{- toYaml $val.nodeSelector | nindent 10 }}
       metadata:
-        annotations: {{- toYaml .Values.worker.annotations | nindent 10 }}
+        annotations: {{- toYaml $val.annotations | nindent 10 }}
         labels:
-          rayNodeType: {{ .Values.worker.type }}
-          groupName: {{ .Values.worker.groupName }}
-          rayCluster: {{ include "ray-cluster.fullname" . }}
+          rayNodeType: {{ $val.type }}
+          groupName: {{ $val.groupName }}
+          rayCluster: {{ include "ray-cluster.fullname" $ }}
+  {{- end }} 
 {{ include "ray-cluster.labels" . | indent 10 }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -51,54 +51,91 @@ head:
       name: log-volume
 
 
-worker:
-  groupName: workergroup
-  replicas: 1
-  type: worker
-  labels:
-    key: value
-  initArgs:
-    node-ip-address: $MY_POD_IP
-    redis-password: LetMeInRay
-    block: 'true'
-  containerEnv:
-    - name: MY_POD_IP
-      valueFrom:
-        fieldRef:
-          fieldPath: status.podIP
-    - name: RAY_DISABLE_DOCKER_CPU_WARNING
-      value: "1"
-    - name: CPU_REQUEST
-      valueFrom:
-        resourceFieldRef:
-          containerName: ray-worker
-          resource: requests.cpu
-    - name: MY_POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
-  envFrom: []
-    # - secretRef:
-    #     name: my-env-secret
-  ports:
-    - containerPort: 80
-      protocol: TCP
-  resources: 
-    limits:
-      cpu: 1
-    requests:
-       cpu: 200m
-  annotations:
-    key: value
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
-  volumes:
-    - name: log-volume
-      emptyDir: {}
-  volumeMounts:
-    - mountPath: /tmp/ray
-      name: log-volume
+workers:
+  # 1st worker group definition.
+  # NOTES:
+  # The underlying infrastructure that each worker type definition is run on can be specified using the CPU and MEMORY requests and limits.
+  # To explicitely specify underlying compute node types, us the nodeSelector field with dictionary mapping {"agentpool" : #POOLNAME#}, where #POOLNAME# is the 
+  # name of the underlying Kubernetes cluster compute name. In cloud based solutions, the node pool is the level at which computer instance types are specified e.g. 
+  # number of cpu cores, amount of memory, whether there are gpus etc. 
+  worker_type_default:
+    groupName: workergroupdefault
+    replicas: 1
+    minReplicas: 0
+    maxReplicas: 4
+    type: worker
+    labels:
+      key: value
+    initArgs:
+      node-ip-address: $MY_POD_IP
+      redis-password: LetMeInRay
+      block: 'true'
+    containerEnv:
+      - name: MY_POD_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      - name: RAY_DISABLE_DOCKER_CPU_WARNING
+        value: "1"
+      - name: CPU_REQUEST
+        valueFrom:
+          resourceFieldRef:
+            containerName: ray-worker
+            resource: requests.cpu
+      - name: CPU_LIMITS
+        valueFrom:
+          resourceFieldRef:
+            containerName: ray-worker
+            resource: limits.cpu
+      - name: MEMORY_REQUESTS
+        valueFrom:
+          resourceFieldRef:
+            containerName: ray-worker
+            resource: requests.memory
+      - name: MEMORY_LIMITS
+        valueFrom:
+          resourceFieldRef:
+            containerName: ray-worker
+            resource: limits.memory
+      - name: MY_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+    envFrom: []
+      # - secretRef:
+      #     name: my-env-secret
+    ports:
+      - containerPort: 80
+        protocol: TCP
+    # Resources section helps define what resources are available to the Ray cluster.
+    resources: 
+      limits:
+        cpu: 1
+      requests:
+        cpu: 200m
+    annotations:
+      key: value
+    # Use nodeSelector to specify specific node pools for deployment of these type of worker pods.
+    # e.g. {"agentpool" : "raypool"}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    volumes:
+      - name: log-volume
+        emptyDir: {}
+    volumeMounts:
+      - mountPath: /tmp/ray
+        name: log-volume
+  
+  # Repeat block above for additional worker types.
+  # e.g. 2nd definition of worker types
+  #worker_type_large:
+  #  groupName: workergroupdefault
+  #  replicas: 1
+  #  minReplicas: 0
+  #  maxReplicas: 4
+  #  type: worker
+  # ...
 
 headServiceSuffix: "ray-operator.svc"
 


### PR DESCRIPTION
## Why are these changes needed?

Ability to support multiple worker definitions in the Helm chart.
This allows for linking of worker types to the underlying Kubernetes compute resource instance types (in cloud deployments).

Helm chart supports definition of multiple worker group defintions.
Chart now features nested structure for workers.
Instead of single worker section, now renamed workers.
Additional level added where following line is now worker group name.
Config block then same as before, but allowed to be repeated.
raycluster-cluster.yaml changed to parse this change using range.
All values parsed relative to the range loop over workergrouptype.
All includes now have passed "$" rather than "." as this explictely refs
the root variables structure allowing values outside the range loo to be
referenced in helper functions e.g. ray-cluster.fullname helper.

## Related issue number

Potential candidate solution to issue #255 

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
