### PR TITLE
[Feature] [Helm] KubeRay Helm chart support multiple worker group defs

### DIFF
--- a/helm-chart/ray-cluster/templates/_ray-cluster.tpl
+++ b/helm-chart/ray-cluster/templates/_ray-cluster.tpl
@@ -1,0 +1,193 @@
+{{- define "{{ .Chart.Name }}.head.env" }}
+- name: CPU_REQUEST
+  value: {{ .Values.ray.head.cpu.request }}
+- name: CPU_LIMITS
+  value: {{ .Values.ray.head.cpu.limit }}
+- name: MEMORY_LIMITS
+  valueFrom:
+    resourceFieldRef:
+      containerName: ray-head
+      resource: limits.memory
+- name: MEMORY_REQUESTS
+  valueFrom:
+    resourceFieldRef:
+      containerName: ray-head
+      resource: requests.memory
+- name: MY_POD_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
+- name: TYPE
+  value: head
+- name: AUTOSCALER_HEARTBEAT_TIMEOUT_S
+  value: "240"
+{{ if .Values.ray.head.containerEnv }}
+{{ toYaml .Values.ray.head.containerEnv }}
+{{ end }}
+{{ if .Values.ray.head.envFrom }}
+{{ toYaml .Values.ray.head.envFrom }}
+{{ end }}
+{{- end }}
+
+{{- define "{{ .Chart.Name }}.head.autoscaler" }}
+# The Ray autoscaler sidecar to the head pod
+- name: autoscaler
+  # TODO: Use released Ray version starting with Ray 1.12.0.
+  image: {{ .Values.ray.autoscaler.image }}
+  imagePullPolicy: IfNotPresent
+  env:
+  - name: RAY_CLUSTER_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  - name: RAY_CLUSTER_NAME
+    # This value must match the metadata.name of the RayCluster CR.
+    # The autoscaler uses this env variable to determine which Ray CR to interact with.
+    # TODO: Match with CR name automatically via operator, Helm, and/or Kustomize.
+    value: {{ include "ray-cluster.fullname" . }}
+  command: ["ray"]
+  args:
+  - "kuberay-autoscaler"
+  - "--cluster-name"
+  - "$(RAY_CLUSTER_NAME)"
+  - "--cluster-namespace"
+  - "$(RAY_CLUSTER_NAMESPACE)"
+  resources: {{- toYaml .Values.ray.autoscaler.resources | nindent 14 }}
+  volumeMounts: {{- toYaml .Values.ray.autoscaler.volumeMounts | nindent 12 }}
+{{- end }}
+
+{{- define "{{ .Chart.Name }}.worker.env" }}
+- name:  RAY_DISABLE_DOCKER_CPU_WARNING
+  value: "1"
+- name: TYPE
+  value: "worker"
+- name: CPU_REQUEST
+  valueFrom:
+    resourceFieldRef:
+      containerName: {{ $.containerName }}
+      resource: requests.cpu
+- name: CPU_LIMITS
+  valueFrom:
+    resourceFieldRef:
+      containerName: {{ $.containerName }}
+      resource: limits.cpu
+- name: MEMORY_LIMITS
+  valueFrom:
+    resourceFieldRef:
+      containerName: {{ $.containerName }}
+      resource: limits.memory
+- name: MEMORY_REQUESTS
+  valueFrom:
+    resourceFieldRef:
+      containerName: {{ $.containerName }}
+      resource: requests.memory
+- name: MY_POD_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.name
+- name: MY_POD_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
+- name: TYPE
+  value: worker
+{{ if $.containerEnv }}
+{{ toYaml $.containerEnv }}
+{{ end }}
+{{ if $.envFrom }}
+{{ toYaml $.envFrom }}
+{{ end }}
+{{- end }}
+
+{{- define "{{ .Chart.Name }}.lifecycle" }}
+  lifecycle:
+    preStop:
+      exec:
+        command: ["/bin/sh","-c","ray stop"]
+{{- end }}
+
+{{- define "{{ .Chart.Name }}.worker.initContainers" }}
+# the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+- name: init-myservice
+  image: busybox:1.28
+  command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
+  resources:
+    requests:
+      cpu: 100m
+      memory: 500Mi
+    limits:
+      cpu: 100m
+      memory: 500Mi
+{{- end }}
+
+{{- define "{{ .Chart.Name }}.image" }}
+image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- end }}
+
+{{- define "{{ .Chart.Name }}.worker.group" }}
+{{- $includeValues := . }}
+{{- $ogValues := .Values }}
+{{- range $key, $val := .Values.ray.workers }}
+- replicas: {{ $val.replicaCount }}
+  minReplicas: {{ $val.minReplicas }}
+  maxReplicas: {{ $val.maxReplicas }}
+  # logical group name
+  groupName: "{{ $key }}"
+  # if worker pods need to be added, we can simply increment the replicas
+  # if worker pods need to be removed, we decrement the replicas, and populate the podsToDelete list
+  # the operator will remove pods from the list until the number of replicas is satisfied
+  # when a pod is confirmed to be deleted, its name will be removed from the list below
+  #scaleStrategy:
+  #  workersToDelete:
+  #  - raycluster-complete-worker-small-group-bdtwh
+  #  - raycluster-complete-worker-small-group-hv457
+  #  - raycluster-complete-worker-small-group-k8tj7
+  # the following params are used to complete the ray start: ray start --block --node-ip-address= ...
+  rayStartParams:
+    {{- range $initKey, $initVal := $val.initArgs }}
+      {{ $initKey }}: {{ $initVal | quote }}
+    {{- end }}
+  #pod template
+  template:
+    metadata:
+      labels:
+        # custom labels. NOTE: do not define custom labels start with `raycluster.`, they may be used in controller.
+        # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+        rayCluster: {{ $includeValues.Release.Name }} # will be injected if missing
+        rayNodeType: worker # will be injected if missing, must be head or worker
+        groupName: {{ $key }} # will be injected if missing
+        {{- include "ray-cluster.labels" $includeValues | nindent 8 }}
+      {{- if $val.annotations }}
+      # annotations for pod
+      # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+      annotations: {{- toYaml $val.annotations | nindent 10}}
+      {{- end }}
+    spec:
+      {{- if $ogValues.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml $ogValues.imagePullSecrets | nindent 10 }}
+      {{- end }}
+      {{- if $val.nodeSelector }}
+      nodeSelector: {{- toYaml $val.nodeSelector | nindent 8 }}
+      {{- end }}
+      initContainers:
+      {{- include "{{ .Chart.Name }}.worker.initContainers" . | indent 8 }}
+      containers:
+        - name: {{ $val.containerName }}
+          {{- include "{{ .Chart.Name }}.image" $includeValues | indent 10 }}
+          # environment variables to set in the container.Optional.
+          # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+          env:
+            {{- include "{{ .Chart.Name }}.worker.env" $val | indent 12 -}}
+          {{- include "{{ .Chart.Name }}.lifecycle" . | indent 8 }}
+          resources: {{ toYaml $val.resources | nindent 12}}
+          ports:
+            {{- toYaml $val.ports | nindent 12 }}
+          volumeMounts:
+            {{- toYaml $val.volumeMounts | nindent 12 }}
+      # use volumes
+      # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+      volumes:
+        {{- toYaml $val.volumes | nindent 10 -}}
+{{ end }}
+{{- end }}

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -5,79 +5,75 @@ metadata:
 {{ include "ray-cluster.labels" . | indent 4 }}
   name: {{ include "ray-cluster.fullname" . }}
 spec:
+  rayVersion: {{ .Values.ray.version }}
+  enableInTreeAutoscaling: {{ .Values.ray.autoscaler.inTree }}
   headGroupSpec:
     serviceType: ClusterIP
+    # the pod replicas in this group typed head (assuming there could be more than 1 in the future)
+    replicas: {{ .Values.ray.head.replicas }}
     rayStartParams:
-    {{- range $key, $val := .Values.head.initArgs }}
-      {{ $key }}: {{ $val | quote }}
-    {{- end }}
-    replicas: {{ .Values.head.replicas }}
+      {{- if .Values.ray.autoscaler.inTree }}
+        no-monitor: "true"
+      {{- else }}
+        no-monitor: "false"
+      {{- end }}
+      {{- range $key, $val := .Values.ray.head.initArgs }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
     template:
+      metadata:
+        {{- if .Values.ray.head.annotations }}
+        annotations: {{- toYaml .Values.ray.head.annotations | nindent 10 }}
+        {{- end }}
+        labels:
+          # custom labels. NOTE: do not define custom labels start with `raycluster.`, they may be used in controller.
+          # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+          groupName: {{ .Values.ray.head.groupName }}
+          rayNodeType: {{ .Values.ray.head.type }}
+          rayCluster: {{ include "ray-cluster.fullname" . }}
+          {{- include "ray-cluster.labels" . | nindent 10 }}
+          {{- if .Values.ray.head.labels }}
+          {{- toYaml .Values.ray.head.labels | nindent 10 }}
+          {{- end }}
       spec:
+        {{- if not .Values.ray.autoscaler.inTree }}
+        # This is needed to give the autoscaler side car permissions to query and update
+        # definitions in the Kubernetes API server (see kuberay-autoscaler-rbac.yaml)
+        serviceAccountName: autoscaler-sa
+        {{- end }}
+        {{- if .Values.imagePullSecrets }}
         imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
+        {{- end }}
         containers:
-          - volumeMounts: {{- toYaml .Values.head.volumeMounts | nindent 12 }}
-            name: ray-head
+          - name: ray-head
             image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
             imagePullPolicy: {{ .Values.image.pullPolicy }}
-            resources: {{- toYaml .Values.head.resources | nindent 14 }}
+            resources: {{- toYaml .Values.ray.head.resources | nindent 14 }}
             env:
-              - name: TYPE
-                value: head
-            {{- toYaml .Values.head.containerEnv | nindent 14}}
-            {{- with .Values.head.envFrom }}
-            envFrom: {{- toYaml . | nindent 14}}
-            {{- end }}
-        volumes: {{- toYaml .Values.head.volumes | nindent 10 }}
-        affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
-        tolerations: {{- toYaml .Values.head.tolerations | nindent 10 }}
-        nodeSelector: {{- toYaml .Values.head.nodeSelector | nindent 10 }}
-      metadata:
-        annotations: {{- toYaml .Values.head.annotations | nindent 10 }}
-        labels:
-          groupName: {{ .Values.head.groupName }}
-          rayNodeType: {{ .Values.head.type }}
-          rayCluster: {{ include "ray-cluster.fullname" . }}
-{{ include "ray-cluster.labels" . | indent 10 }}
+              {{- include "{{ .Chart.Name }}.head.env" . | indent 14 }}
+            ports:
+              {{- toYaml .Values.ray.head.ports | nindent 14 }}
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            volumeMounts: {{- toYaml .Values.ray.head.volumeMounts | nindent 14 }}
+         {{- if not .Values.ray.autoscaler.inTree }}
+         {{- include "{{ .Chart.Name }}.head.autoscaler" . | nindent 10 }}
+         {{- end }}
+        {{- if .Values.ray.head.volumes }}
+        volumes: {{- toYaml .Values.ray.head.volumes | nindent 10 }}
+        {{- end }}
+        {{- if .Values.ray.head.affinity }}
+        affinity: {{- toYaml .Values.ray.head.affinity | nindent 10 }}
+        {{- end }}
+        {{- if .Values.ray.head.tolerations }}
+        tolerations: {{- toYaml .Values.ray.head.tolerations | nindent 10 }}
+        {{- end }}
+        {{- if .Values.ray.head.nodeSelector }}
+        nodeSelector: {{- toYaml .Values.ray.head.nodeSelector | nindent 10 }}
+        {{- end }}
 
   workerGroupSpecs:
-  - rayStartParams:
-    {{- range $key, $val := .Values.worker.initArgs }}
-      {{ $key }}: {{ $val | quote }}
-    {{- end }}
-    replicas: {{ .Values.worker.replicas }}
-    minReplicas: {{ .Values.worker.miniReplicas | default 1 }}
-    maxReplicas: {{ .Values.worker.maxiReplicas | default 2147483647 }}
-    groupName: {{ .Values.worker.groupName }}
-    template:
-      spec:
-        imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
-        initContainers:
-          - name: init-myservice
-            image: busybox:1.28
-            command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
-        containers:
-          - volumeMounts: {{- toYaml .Values.worker.volumeMounts | nindent 12 }}
-            name: ray-worker
-            image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-            imagePullPolicy: {{ .Values.image.pullPolicy }}
-            resources: {{- toYaml .Values.worker.resources | nindent 14 }}
-            env:
-              - name: TYPE
-                value: worker
-            {{- toYaml .Values.worker.containerEnv | nindent 14}}
-            {{- with .Values.worker.envFrom }}
-            envFrom: {{- toYaml . | nindent 14}}
-            {{- end }}
-            ports: {{- toYaml .Values.worker.ports | nindent 14}}
-        volumes: {{- toYaml .Values.worker.volumes | nindent 10 }}
-        affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}
-        tolerations: {{- toYaml .Values.worker.tolerations | nindent 10 }}
-        nodeSelector: {{- toYaml .Values.worker.nodeSelector | nindent 10 }}
-      metadata:
-        annotations: {{- toYaml .Values.worker.annotations | nindent 10 }}
-        labels:
-          rayNodeType: {{ .Values.worker.type }}
-          groupName: {{ .Values.worker.groupName }}
-          rayCluster: {{ include "ray-cluster.fullname" . }}
-{{ include "ray-cluster.labels" . | indent 10 }}
+    # the pod replicas in this group typed worker
+    {{- include "{{ .Chart.Name }}.worker.group" . | indent 4 -}}

--- a/helm-chart/ray-cluster/templates/service.yaml
+++ b/helm-chart/ray-cluster/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ray-cluster.fullname" . }}-dashboard
+spec:
+  ports:
+    - name: ray-submit-dashboard
+      port: {{ .Values.ray.head.dashboardPort }}
+      targetPort: {{ .Values.ray.head.dashboardPort }}
+  selector:
+    ray.io/cluster: {{ include "ray-cluster.fullname" . }}
+    ray.io/identifier: {{ include "ray-cluster.fullname" . }}-head
+    ray.io/node-type: head

--- a/helm-chart/ray-cluster/templates/serviceaccount.yaml
+++ b/helm-chart/ray-cluster/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.ray.autoscaler.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.ray.autoscaler.serviceAccount.name }}
+  labels:
+    {{- include "ray-cluster.labels" . | nindent 4 }}
+    {{- if .Values.ray.autoscaler.serviceAccount.labels }}
+    {{- toYaml .Values.ray.autoscaler.serviceAccount.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.ray.autoscaler.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.ray.autoscaler.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -13,95 +13,156 @@ fullnameOverride: ""
 imagePullSecrets: []
   # - name: an-existing-secret
 
-head:
-  groupName: headgroup
-  replicas: 1
-  type: head
-  labels:
-    key: value
-  initArgs:
-    port: '6379'
-    redis-password: 'LetMeInRay' # Deprecated since Ray 1.11 due to GCS bootstrapping enabled
-    dashboard-host: '0.0.0.0'
-    num-cpus: '1' # can be auto-completed from the limits
-    node-ip-address: $MY_POD_IP # auto-completed as the head pod IP
-    block: 'true'
-  containerEnv:
-    - name: MY_POD_IP
-      valueFrom:
-        fieldRef:
-          fieldPath: status.podIP
-  envFrom: []
-    # - secretRef:
-    #     name: my-env-secret
-  resources:
-    limits:
-      cpu: 1
-    requests:
-       cpu: 200m
-  annotations: {}
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
-  volumes:
-    - name: log-volume
-      emptyDir: { }
-  volumeMounts:
-    - mountPath: /tmp/ray
-      name: log-volume
+ray:
+  version: "1.11.0"
+  autoscaler:
+    inTree: false
+    serviceAccount:
+      create: true
+      name: autoscaler-sa
+      annotations: {}
+      labels: {}
+    image: rayproject/ray:413fe0
+    resources:
+      requests:
+        cpu: 250m
+        memory: 1024Mi
+      limits:
+        cpu: 500m
+        memory: 1024Mi
+  # use volumeMounts.Optional.
+  # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+    volumeMounts:
+      - mountPath: /tmp/ray
+        name: log-volume
+  head:
+    replicas: 1
+    # Leave the following 3 lines at 0 if the head node should not do work.
+    num-cpus: 0
+    cpu:
+      request: 0
+      limit: 0
+    groupName: headgroup
+    type: head
+    dashboardPort: &dashPort 8265
+    initArgs:
+      port: '6379'
+      dashboard-host: '0.0.0.0'
+      dashboard-port: *dashPort
+      num-cpus: '1' # can be auto-completed from the limits
+      node-ip-address: $MY_POD_IP # auto-completed as the head pod IP
+      block: 'true'
+    ports:
+      - containerPort: 8265
+        protocol: TCP
+      - containerPort: 6379
+        protocol: TCP
+    resources:
+      limits:
+        cpu: 1
+        memory: 5Gi
+      requests:
+        memory: 5Gi
+        cpu: 200m
+    containerEnv: []
+    envFrom: []
+    labels: {}
+    annotations: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    volumes:
+      - name: log-volume
+        emptyDir: { }
+    volumeMounts:
+      - mountPath: /tmp/ray
+        name: log-volume
 
+  workers:
+    # groupName is equivalent to the key of the map it's under e.g. cpuWorker has groupName cpuWorker
+    cpuWorker:
+      # name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+      containerName: cpu-machine-learning
+      replicaCount: 1
+      minReplicas: 1
+      maxReplicas: 300
+      resources:
+        requests:
+          cpu: 1
+          memory: 512Mi
+        limits:
+          cpu: 1
+          memory: 512Mi
+      initArgs:
+        node-ip-address: $MY_POD_IP
+        block: 'true'
+        num-cpus: $CPU_LIMITS
+      containerEnv: []
+      envFrom: []
+      nodeSelector: {}
+      annotations: {}
+      labels: {}
+      tolerations: {}
+      affinity: {}
+      ports:
+        - containerPort: 80
+          protocol: TCP
+      # use volumeMounts.Optional.
+      # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+      volumeMounts:
+        - mountPath: /tmp/ray
+          name: log-volume
+      volumes:
+        - name: log-volume
+          emptyDir: {}
 
-worker:
-  groupName: workergroup
-  replicas: 1
-  type: worker
-  labels:
-    key: value
-  initArgs:
-    node-ip-address: $MY_POD_IP
-    redis-password: LetMeInRay
-    block: 'true'
-  containerEnv:
-    - name: MY_POD_IP
-      valueFrom:
-        fieldRef:
-          fieldPath: status.podIP
-    - name: RAY_DISABLE_DOCKER_CPU_WARNING
-      value: "1"
-    - name: CPU_REQUEST
-      valueFrom:
-        resourceFieldRef:
-          containerName: ray-worker
-          resource: requests.cpu
-    - name: MY_POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
-  envFrom: []
-    # - secretRef:
-    #     name: my-env-secret
-  ports:
-    - containerPort: 80
-      protocol: TCP
-  resources: 
-    limits:
-      cpu: 1
-    requests:
-       cpu: 200m
-  annotations:
-    key: value
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
-  volumes:
-    - name: log-volume
-      emptyDir: {}
-  volumeMounts:
-    - mountPath: /tmp/ray
-      name: log-volume
+    # Example gpu worker group for more details see:
+    # https://docs.ray.io/en/latest/cluster/kubernetes-gpu.html
+    gpuWorker:
+      # name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+      containerName: gpu-machine-learning
+      replicaCount: 1
+      minReplicas: 1
+      maxReplicas: 3
+      resources:
+        requests:
+          cpu: 29
+          memory: 100Gi
+        limits:
+          cpu: 29
+          memory: 100Gi
+          nvidia.com/gpu: 1
+      initArgs:
+        node-ip-address: $MY_POD_IP
+        block: 'true'
+        num-cpus: $CPU_LIMITS
+        num-gpus: '1'
+      nodeSelector:
+        node.kubernetes.io/instance-type: g4dn.8xlarge
+        spot: "yes"
+      tolerations:
+        - effect: NoSchedule
+          key: nvidia.com/gpu
+          operator: Exists
+      annotations: {}
+      labels: {}
+      affinity: {}
+      ports:
+        - containerPort: 80
+          protocol: TCP
+      # use volumeMounts.Optional.
+      # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+      volumeMounts:
+        - mountPath: /tmp/ray
+          name: log-volume
+      volumes:
+        - name: log-volume
+          emptyDir: {}
 
+# This does not seem to be in use yet.
 headServiceSuffix: "ray-operator.svc"
 
+# This does not seem to be in use.
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The KubeRay CRD allows for multiple worker groups, however, as it stands creating more worker groups is a manual process.

This PR addresses that by allowing worker groups to be defined via maps in the values.yaml

It also moves a lot of boilerplate into `_ray-cluster.tpl`.
In addition, allows for no in tree autoscaler and resources for all possible containers.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Possible solution for #255 

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
