### PR TITLE
fix operator: correctly set head pod service account

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -53,8 +53,6 @@ func DefaultHeadPodTemplate(instance rayiov1alpha1.RayCluster, headSpec rayiov1a
 		// Merge the user overrides from autoscalerOptions into the autoscaler container config.
 		mergeAutoscalerOverrides(&autoscalerContainer, instance.Spec.AutoscalerOptions)
 		podTemplate.Spec.Containers = append(podTemplate.Spec.Containers, autoscalerContainer)
-		// set custom service account which can be authorized to talk with apiserver
-		podTemplate.Spec.ServiceAccountName = instance.Name
 	}
 
 	// add metrics port for exposing to the promethues stack.

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -397,6 +397,56 @@ func TestDefaultHeadPodTemplate_WithAutoscalingEnabled(t *testing.T) {
 	}
 }
 
+// If no service account is specified in the RayCluster,
+// the head pod's service account should be an empty string.
+func TestHeadPodTemplate_WithNoServiceAccount(t *testing.T) {
+	cluster := instance.DeepCopy()
+	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	svcName := utils.GenerateServiceName(cluster.Name)
+	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName)
+
+	actualResult := pod.Spec.ServiceAccountName
+	expectedResult := ""
+	if !reflect.DeepEqual(expectedResult, actualResult) {
+		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
+	}
+}
+
+// If a service account is specified in the RayCluster and EnableInTreeAutoscaling is set to false,
+// the head pod's service account should be the same.
+func TestHeadPodTemplate_WithServiceAccountNoAutoscaling(t *testing.T) {
+	cluster := instance.DeepCopy()
+	serviceAccount := "head-service-account"
+	cluster.Spec.HeadGroupSpec.Template.Spec.ServiceAccountName = serviceAccount
+	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	svcName := utils.GenerateServiceName(cluster.Name)
+	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName)
+
+	actualResult := pod.Spec.ServiceAccountName
+	expectedResult := serviceAccount
+	if !reflect.DeepEqual(expectedResult, actualResult) {
+		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
+	}
+}
+
+// If a service account is specified in the RayCluster and EnableInTreeAutoscaling is set to true,
+// the head pod's service account should be the same.
+func TestHeadPodTemplate_WithServiceAccount(t *testing.T) {
+	cluster := instance.DeepCopy()
+	serviceAccount := "head-service-account"
+	cluster.Spec.HeadGroupSpec.Template.Spec.ServiceAccountName = serviceAccount
+	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
+	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	svcName := utils.GenerateServiceName(cluster.Name)
+	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName)
+
+	actualResult := pod.Spec.ServiceAccountName
+	expectedResult := serviceAccount
+	if !reflect.DeepEqual(expectedResult, actualResult) {
+		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
+	}
+}
+
 func splitAndSort(s string) []string {
 	strs := strings.Split(s, " ")
 	result := make([]string, 0, len(strs))


### PR DESCRIPTION
## Why are these changes needed?

Currently the patch in #259 isn't working because a later line overwrites with
the original bad value. This change sets the head pod's service account
to the one configured in the RayCluster.

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
