### PR TITLE
[draft][autoscaler] Add autoscaler container overrides and config options for scale behavior.

### DIFF
--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -20,6 +20,8 @@ type RayClusterSpec struct {
 	RayVersion string `json:"rayVersion,omitempty"`
 	// EnableInTreeAutoscaling indicates whether operator should create in tree autoscaling configs
 	EnableInTreeAutoscaling *bool `json:"enableInTreeAutoscaling,omitempty"`
+	// AutoscalerOptions specifies optional configuration for the Ray autoscaler.
+	AutoscalerOptions *AutoscalerOptions `json:"autoscalerOptions,omitempty"`
 }
 
 // HeadGroupSpec are the spec for the head pod
@@ -61,6 +63,25 @@ type ScaleStrategy struct {
 	// WorkersToDelete workers to be deleted
 	WorkersToDelete []string `json:"workersToDelete,omitempty"`
 }
+
+// AutoscalerOptions specifies optional configuration for the Ray autoscaler.
+type AutoscalerOptions struct {
+	// Resources specifies resource requests and limits for the autoscaler container.
+	// Default values: 256m CPU request, 512m CPU limit, 256Mi memory request, 512Mi memory limit.
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
+	// Image optionally overrides the autoscaler's container image. This override is for provided for testing and development use-cases.
+	Image *string `json:"image,omitempty"`
+	// IdleTimeoutSeconds is the number of seconds to wait before scaling down a worker pod which is not using Ray resources.
+	// Defaults to 300 (five minutes).
+	IdleTimeoutSeconds *int32 `json:"idleTimeoutSeconds,omitempty"`
+	// UpscalineMode is "Default" or "Aggressive."
+	// Default: Upscaling is rate-limited; the number of pending worker pods is at most the size of the Ray cluster.
+	// Aggressive: Upscaling is not rate-limited.
+	UpscalingMode *UpscalingMode `json:"upscalingMode,omitempty"`
+}
+
+// +kubebuilder:validation:Enum=Default;Aggressive
+type UpscalingMode string
 
 // The overall state of the Ray cluster.
 type ClusterState string

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -34,6 +34,51 @@ spec:
           spec:
             description: Specification of the desired behavior of the RayCluster.
             properties:
+              autoscalerOptions:
+                description: AutoscalerOptions specifies optional configuration for
+                  the Ray autoscaler.
+                properties:
+                  idleTimeoutSeconds:
+                    description: IdleTimeoutSeconds is the number of seconds to wait
+                      before scaling down a worker pod which is not us
+                    format: int32
+                    type: integer
+                  image:
+                    description: Image optionally overrides the autoscaler's container
+                      image.
+                    type: string
+                  resources:
+                    description: Resources specifies resource requests and limits
+                      for the autoscaler container.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute
+                          resources required.
+                        type: object
+                    type: object
+                  upscalingMode:
+                    description: UpscalineMode is "Default" or "Aggressive.
+                    enum:
+                    - Default
+                    - Aggressive
+                    type: string
+                type: object
               enableInTreeAutoscaling:
                 description: EnableInTreeAutoscaling indicates whether operator should
                   create in tree autoscaling configs

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -49,8 +49,10 @@ func DefaultHeadPodTemplate(instance rayiov1alpha1.RayCluster, headSpec rayiov1a
 		podTemplate.Spec.ServiceAccountName = utils.GetHeadGroupServiceAccountName(&instance)
 
 		// inject autoscaler container into head pod
-		container := BuildAutoscalerContainer()
-		podTemplate.Spec.Containers = append(podTemplate.Spec.Containers, container)
+		autoscalerContainer := BuildAutoscalerContainer()
+		// Merge the user overrides from autoscalerOptions into the autoscaler container config.
+		mergeAutoscalerOverrides(&autoscalerContainer, instance.Spec.AutoscalerOptions)
+		podTemplate.Spec.Containers = append(podTemplate.Spec.Containers, autoscalerContainer)
 		// set custom service account which can be authorized to talk with apiserver
 		podTemplate.Spec.ServiceAccountName = instance.Name
 	}
@@ -212,6 +214,18 @@ func BuildAutoscalerContainer() v1.Container {
 		},
 	}
 	return container
+}
+
+// Merge user the overrides in autoscalerOptions field into autoscaler container config.
+func mergeAutoscalerOverrides(autoscalerContainer *v1.Container, autoscalerOptions *rayiov1alpha1.AutoscalerOptions) {
+	if autoscalerOptions != nil {
+		if autoscalerOptions.Resources != nil {
+			autoscalerContainer.Resources = *autoscalerOptions.Resources
+		}
+		if autoscalerOptions.Image != nil {
+			autoscalerContainer.Image = *autoscalerOptions.Image
+		}
+	}
 }
 
 func isRayStartWithBlock(rayStartParams map[string]string) bool {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Closes https://github.com/ray-project/kuberay/issues/246. Takes a simpler and flatter config approach than the one suggested in the RFC.

Adds an `autoscalerOptions` field with the following subfields 
1. `upscalingMode` 
An upcoming Ray PR will have the autoscaler translate this field into `upscaling_speed`
The allowed values of `Default` and `Aggressive` translate into an `upscaling_speed` of 1 and 1000, respectively.
2.`idleTimeoutSeconds` 
An upcoming Ray PR will have the autoscaler translate this field into `idle_timeout_minutes`. Seconds are used because timeouts of under a minute are sometimes useful (especially in test environments). On the other hand, there are issues with using floats in CRDs. 
3.`resources`
Override for the autoscaler container's resource requests. For large clusters, users should monitor the autoscaler's resource usages and set this appropriately.
4. `image`
Override for the image used by the autoscaler container. The main application I have in mind for this is testing autoscaler changes in the Ray repo's CI.

This PR is a draft. Once we agree on the config changes, I'll add a simple test.

Documentation will be added in a future PR -- after the autoscaler is modified to use the new fields `upscalingMode` and `idleTimeoutSeconds`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
