### PR TITLE
[CI]enable ci test to check ctrl plane health state

### DIFF
--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -61,6 +61,7 @@ def create_kuberay_cluster():
         f.write(raycluster_spec_buf)
         raycluster_spec_file = f.name
 
+    shell_assert_success('kubectl wait --for=condition=ready pod -n ray-system --all --timeout=1600s')
     assert raycluster_spec_file is not None
     shell_assert_success('kubectl apply -f {}'.format(raycluster_spec_file))
 


### PR DESCRIPTION
enable ci test to check ctrl plane health state

## Why are these changes needed?

Enable ci test code to fail when cluster cannot be correctly set up.

## Related issue number

#251 

## Checks

- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
