### PR TITLE
Initial support for external Redis and GCS HA

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -186,6 +186,23 @@ jobs:
       run: go build -o kuberay -a main.go
       working-directory: ${{env.cli-working-directory}}
 
+  test-compatibility-1_9_0:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Compatibility Test 1.9.0
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          # When checking out the repository that
+          # triggered a workflow, this defaults to the reference or SHA for that event.
+          # Default value should work for both pull_request and merge(push) event.
+          ref: ${{github.event.pull_request.head.sha}}
+
+      - uses: ./.github/workflows/actions/compatibility
+        with:
+          ray_version: 1.9.0
+
   test-compatibility-1_10_0:
     needs: build
     runs-on: ubuntu-latest
@@ -237,10 +254,10 @@ jobs:
         with:
           ray_version: 1.12.0
 
-  test-compatibility-1_13_0:
+  test-compatibility-nightly:
     needs: build
     runs-on: ubuntu-latest
-    name: Compatibility Test 1.13.0
+    name: Compatibility Test nightly
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -252,4 +269,4 @@ jobs:
 
       - uses: ./.github/workflows/actions/compatibility
         with:
-          ray_version: 1.13.0
+          ray_version: nightly

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -186,23 +186,6 @@ jobs:
       run: go build -o kuberay -a main.go
       working-directory: ${{env.cli-working-directory}}
 
-  test-compatibility-1_9_0:
-    needs: build
-    runs-on: ubuntu-latest
-    name: Compatibility Test 1.9.0
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-        with:
-          # When checking out the repository that
-          # triggered a workflow, this defaults to the reference or SHA for that event.
-          # Default value should work for both pull_request and merge(push) event.
-          ref: ${{github.event.pull_request.head.sha}}
-
-      - uses: ./.github/workflows/actions/compatibility
-        with:
-          ray_version: 1.9.0
-
   test-compatibility-1_10_0:
     needs: build
     runs-on: ubuntu-latest
@@ -253,3 +236,20 @@ jobs:
       - uses: ./.github/workflows/actions/compatibility
         with:
           ray_version: 1.12.0
+
+  test-compatibility-1_13_0:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Compatibility Test 1.13.0
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          # When checking out the repository that
+          # triggered a workflow, this defaults to the reference or SHA for that event.
+          # Default value should work for both pull_request and merge(push) event.
+          ref: ${{github.event.pull_request.head.sha}}
+
+      - uses: ./.github/workflows/actions/compatibility
+        with:
+          ray_version: 1.13.0

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -88,12 +88,92 @@ jobs:
         $(go env GOPATH)/bin/goimports -d apiserver/ ray-operator/ cli/
       if: failure()
 
-  build:
+  build_apiserver:
+    env:
+      working-directory: ./apiserver
+      cli-working-directory: ./cli
+    name: Build Apiserver, CLI Binaries and Docker Images
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Go 1.17.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          # When checking out the repository that
+          # triggered a workflow, this defaults to the reference or SHA for that event.
+          # Default value should work for both pull_request and merge(push) event.
+          ref: ${{github.event.pull_request.head.sha}}
+
+      - name: list directories
+        working-directory: ${{env.working-directory}}
+        run: |
+          pwd
+          ls -R
+
+      - name: install kubebuilder
+        run: |
+          wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.0.0/kubebuilder_$(go env GOOS)_$(go env GOARCH)
+          sudo mv kubebuilder_$(go env GOOS)_$(go env GOARCH) /usr/local/bin/kubebuilder
+
+      - name: Get revision SHA
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+      - name: Get dependencies
+        run: go mod download
+        working-directory: ${{env.working-directory}}
+
+      - name: Build
+        run: go build ./...
+        working-directory: ${{env.working-directory}}
+
+      - name: Test
+        run: go test ./...
+        working-directory: ${{env.working-directory}}
+
+      - name: Set up Docker
+        uses: docker-practice/actions-setup-docker@master
+
+      - name: Build Docker Image - Apiserver
+        run: |
+          docker build -t kuberay/apiserver:${{ steps.vars.outputs.sha_short }} -f apiserver/Dockerfile .
+          docker save -o /tmp/apiserver.tar kuberay/apiserver:${{ steps.vars.outputs.sha_short }}
+
+      - name: Upload Artifact Apiserver
+        uses: actions/upload-artifact@v2
+        with:
+          name: apiserver_img
+          path: /tmp/apiserver.tar
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Push Apiserver to DockerHub
+        run: |
+          docker push kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
+          docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:nightly;
+          docker push kuberay/apiserver:nightly
+
+        working-directory: ${{env.working-directory}}
+        if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Build CLI
+        run: go build -o kuberay -a main.go
+        working-directory: ${{env.cli-working-directory}}
+
+  build_operator:
     env:
       working-directory: ./ray-operator
-      cli-working-directory: ./cli
-      apiserver-working-directory: ./apiserver
-    name: Build Binaries and Docker Images
+    name: Build Operator Binaries and Docker Images
     runs-on: ubuntu-latest
     steps:
 
@@ -152,17 +232,6 @@ jobs:
         name: operator_img
         path: /tmp/operator.tar
 
-    - name: Build Docker Image - Apiserver
-      run: |
-        docker build -t kuberay/apiserver:${{ steps.vars.outputs.sha_short }} -f apiserver/Dockerfile .
-        docker save -o /tmp/apiserver.tar kuberay/apiserver:${{ steps.vars.outputs.sha_short }}
-
-    - name: Upload Artifact Apiserver
-      uses: actions/upload-artifact@v2
-      with:
-        name: apiserver_img
-        path: /tmp/apiserver.tar
-
     - name: Log in to Docker Hub
       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
       with:
@@ -170,26 +239,22 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
       if: ${{ github.ref == 'refs/heads/master' }}
 
-    - name: Push to DockerHub
+    - name: Push Operator to DockerHub
       run: |
         docker push kuberay/operator:${{ steps.vars.outputs.sha_short }};
         docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} kuberay/operator:nightly;
         docker push kuberay/operator:nightly
-        docker push kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:nightly;
-        docker push kuberay/apiserver:nightly
 
       working-directory: ${{env.working-directory}}
       if: ${{ github.ref == 'refs/heads/master' }}
 
-    - name: Build CLI
-      run: go build -o kuberay -a main.go
-      working-directory: ${{env.cli-working-directory}}
-
   test-compatibility-1_9_0:
-    needs: build
+    needs:
+      - build_operator
+      - build_apiserver
+      - lint
     runs-on: ubuntu-latest
-    name: Compatibility Test 1.9.0
+    name: Compatibility Test - 1.9.0
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -204,9 +269,12 @@ jobs:
           ray_version: 1.9.0
 
   test-compatibility-1_10_0:
-    needs: build
+    needs:
+      - build_operator
+      - build_apiserver
+      - lint
     runs-on: ubuntu-latest
-    name: Compatibility Test 1.10.0
+    name: Compatibility Test - 1.10.0
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -221,9 +289,12 @@ jobs:
           ray_version: 1.10.0
 
   test-compatibility-1_11_0:
-    needs: build
+    needs:
+      - build_operator
+      - build_apiserver
+      - lint
     runs-on: ubuntu-latest
-    name: Compatibility Test 1.11.0
+    name: Compatibility Test - 1.11.0
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -238,9 +309,12 @@ jobs:
           ray_version: 1.11.0
 
   test-compatibility-1_12_0:
-    needs: build
+    needs:
+      - build_operator
+      - build_apiserver
+      - lint
     runs-on: ubuntu-latest
-    name: Compatibility Test 1.12.0
+    name: Compatibility Test - 1.12.0
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -255,9 +329,12 @@ jobs:
           ray_version: 1.12.0
 
   test-compatibility-nightly:
-    needs: build
+    needs:
+      - build_operator
+      - build_apiserver
+      - lint
     runs-on: ubuntu-latest
-    name: Compatibility Test nightly
+    name: Compatibility Test - Nightly
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/docs/guidance/gcs-ha.md
+++ b/docs/guidance/gcs-ha.md
@@ -2,6 +2,9 @@
 
 > Note: This feature is still experimental, there are a few limitations and stabilization will be done in future release from both Ray and KubeRay side.
 
+Ray GCS HA enables GCS server to use external storage backend. As a result, Ray clusters can tolerant GCS failures and recover from failures
+without affecting important services such as detached Actors & RayServe deployments.
+
 ### Prerequisite
 
 * Ray 2.0 is required.
@@ -9,7 +12,7 @@
 
 ### Enable Ray GCS HA
 
-To enable Ray GCS HA in your newly KubeRay-managed Ray cluster, you need to enable it by add an annotation to the
+To enable Ray GCS HA in your newly KubeRay-managed Ray cluster, you need to enable it by adding an annotation to the
 RayCluster YAML file.
 
 ```yaml
@@ -50,7 +53,7 @@ On Ray head node, we access a local Ray dashboard http endpoint and a Raylet htt
 healthy state. Since Ray dashboard does not reside Ray worker node, we only check the local Raylet http endpoint to make sure
 the worker node is healthy.
 
-#### Ray GCS HA Label
+#### Ray GCS HA Annotation
 
 Our Ray GCS HA feature checks if an annotation called `ray.io/ha-enabled` is set to `true` in `RayCluster` YAML file. If so, KubeRay
 will also add such annotation to the pod whenever the head/worker node is created.
@@ -75,6 +78,15 @@ After this, the controller will try to recover the failed pod. If controller can
 
 In every KubeRay Operator controller reconcile loop, it monitors any pod in Ray cluster that has `Unhealthy` value in annotation
 `ray.io/health-state`. If any pod is found, this pod is deleted and gets recreated.
+
+#### External Storage Namespace
+
+External storage namespaces can be used to share a single storage backend among multiple Ray clusters. By default, `ray.io/external-storage-namespace`
+uses the RayCluster UID as its value when GCS HA is enabled. Or if the user wants to use customized external storage namespace,
+the user can add `ray.io/external-storage-namespace` annotation to RayCluster yaml file.
+
+Whenever `ray.io/external-storage-namespace` annotation is set, the head/worker node will have `RAY_external_storage_namespace` environment
+variable set which Ray can pick up later.
 
 #### Known issues and limitations
 

--- a/docs/guidance/gcs-ha.md
+++ b/docs/guidance/gcs-ha.md
@@ -1,6 +1,6 @@
 ## Ray GCS HA (Experimental)
 
-> Note: This feature is still experimental, there're few limitations and stabilization will be done in future release from both Ray and KubeRay side.
+> Note: This feature is still experimental, there are a few limitations and stabilization will be done in future release from both Ray and KubeRay side.
 
 ### Prerequisite
 
@@ -9,25 +9,24 @@
 
 ### Enable Ray GCS HA
 
-To enable Ray GCS HA in your newly KubeRay-managed Ray cluster, you need to enable it by add a label to the
+To enable Ray GCS HA in your newly KubeRay-managed Ray cluster, you need to enable it by add an annotation to the
 RayCluster YAML file.
 
 ```yaml
 ...
 kind: RayCluster
 metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
-    ray.io/ha-enabled: "true" # <- add this label enable GCS HA
+  annotations:
+    ray.io/ha-enabled: "true" # <- add this annotation enable GCS HA
 ...
 ```
 An example can be found at [ray-cluster.external-redis.yaml](../../ray-operator/config/samples/ray-cluster.external-redis.yaml)
 
-When label `ray.io/ha-enabled` is added with a `true` value, KubeRay will enable Ray GCS HA feature. This feature
+When annotation `ray.io/ha-enabled` is added with a `true` value, KubeRay will enable Ray GCS HA feature. This feature
 contains several components:
 
 1. Newly created Ray cluster has `Readiness Probe` and `Liveness Probe` added to all the head/worker nodes.
-2. KubeRay Operator controller watches for `Event` object changes which can notify incase of readiness probe failures and mark them as `Unhealthy`.
+2. KubeRay Operator controller watches for `Event` object changes which can notify in case of readiness probe failures and mark them as `Unhealthy`.
 3. KubeRay Operator controller kills and recreate any `Unhealthy` Ray head/worker node.
 
 ### Implementation Details
@@ -52,8 +51,8 @@ the worker node is healthy.
 
 #### Ray GCS HA Label
 
-Our Ray GCS HA feature checks if a label called `ray.io/ha-enabled` is set to `true` in `RayCluster` YAML file. If so, KubeRay
-will also add such label to the pod whenever the head/worker node is created.
+Our Ray GCS HA feature checks if an annotation called `ray.io/ha-enabled` is set to `true` in `RayCluster` YAML file. If so, KubeRay
+will also add such annotation to the pod whenever the head/worker node is created.
 
 #### Use External Redis Cluster
 
@@ -65,18 +64,18 @@ An example can be found at [ray-cluster.external-redis.yaml](../../ray-operator/
 #### KubeRay Operator Controller
 
 KubeRay Operator controller watches for new `Event` reconcile call. If this Event object is to notify the failed readiness probe,
-controller checks if this pod has `ray.io/ha-enabled` set to `true`. If this pod has this label set to true, that means this pod
+controller checks if this pod has `ray.io/ha-enabled` set to `true`. If this pod has this annotation set to true, that means this pod
 belongs to a Ray cluster that has Ray GCS HA enabled.
 
-After this, the controller will try to recover the failed pod. If controller cannot recover it, a label named 
+After this, the controller will try to recover the failed pod. If controller cannot recover it, an annotation named 
 `ray.io/health-state` with a value `Unhealthy` is added to this pod.
 
-In every KubeRay Operator controller reconcile loop, it monitors any pod in Ray cluster that has `Unhealthy` value in label
+In every KubeRay Operator controller reconcile loop, it monitors any pod in Ray cluster that has `Unhealthy` value in annotation
 `ray.io/health-state`. If any pod is found, this pod is deleted and gets recreated.
 
 #### Known issues and limitations
 
-1. Currently, Python redis package is removed from Ray official image. We need to install Python redis package in the very begining of the container start. (This is done by KubeRay by adding commands to Ray container spec.)
+1. Currently, Python redis package is removed from Ray official image. We need to install Python redis package in the very beginning of the container start. (This is done by KubeRay by adding commands to Ray container spec.)
 2. For now, Ray head/worker node that fails the readiness probe recovers itself by restarting itself. More fine-grained control and recovery mechanisms are expected in the future.
 
 ### Test Ray GCS HA

--- a/docs/guidance/gcs-ha.md
+++ b/docs/guidance/gcs-ha.md
@@ -1,0 +1,94 @@
+## Ray GCS HA (Experimental)
+
+> Note: This feature is still experimental, there're few limitations and stabilization will be done in future release from both Ray and KubeRay side.
+
+### Prerequisite
+
+* Ray 2.0 is required.
+* You need to support external Redis server for Ray. (Redis HA cluster is highly recommended.)
+
+### Enable Ray GCS HA
+
+To enable Ray GCS HA in your newly KubeRay-managed Ray cluster, you need to enable it by add a label to the
+RayCluster YAML file.
+
+```yaml
+...
+kind: RayCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    ray.io/ha-enabled: "true" # <- add this label enable GCS HA
+...
+```
+An example can be found at [ray-cluster.external-redis.yaml](../../ray-operator/config/samples/ray-cluster.external-redis.yaml)
+
+When label `ray.io/ha-enabled` is added with a `true` value, KubeRay will enable Ray GCS HA feature. This feature
+contains several components:
+
+1. Newly created Ray cluster has `Readiness Probe` and `Liveness Probe` added to all the head/worker nodes.
+2. KubeRay Operator controller watches for `Event` object changes which can notify incase of readiness probe failures and mark them as `Unhealthy`.
+3. KubeRay Operator controller kills and recreate any `Unhealthy` Ray head/worker node.
+
+### Implementation Details
+
+#### Readiness Probe vs Liveness Probe
+
+These are the two types of probes we used in Ray GCS HA. 
+
+The readiness probe is used to notify KubeRay in case of failures in the corresponding Ray cluster. KubeRay can try its best to
+recover the Ray cluster. If KubeRay cannot recover the failed head/worker node, the liveness probe gets in, delete the old pod
+and create a new pod.
+
+By default, the liveness probe gets involved later than the readiness probe. The liveness probe is our last resort to recover the 
+Ray cluster. However, in our current implementation, for the readiness probe failures, we also kill & recreate the corresponding pod that runs head/worker node.
+
+Currently, the readiness probe and the liveness probe are using the same command to do the work. In the future, we may run
+ different commands for the readiness probe and the liveness probe.
+
+On Ray head node, we access a local Ray dashboard http endpoint and a Raylet http endpoint to make sure this head node is in
+healthy state. Since Ray dashboard does not reside Ray worker node, we only check the local Raylet http endpoint to make sure
+the worker node is healthy.
+
+#### Ray GCS HA Label
+
+Our Ray GCS HA feature checks if a label called `ray.io/ha-enabled` is set to `true` in `RayCluster` YAML file. If so, KubeRay
+will also add such label to the pod whenever the head/worker node is created.
+
+#### Use External Redis Cluster
+
+To use external Redis cluster as the backend storage(required by Ray GCS HA),
+you need to add `RAY_REDIS_ADDRESS` environment variable to the head node template.
+
+An example can be found at [ray-cluster.external-redis.yaml](../../ray-operator/config/samples/ray-cluster.external-redis.yaml)
+
+#### KubeRay Operator Controller
+
+KubeRay Operator controller watches for new `Event` reconcile call. If this Event object is to notify the failed readiness probe,
+controller checks if this pod has `ray.io/ha-enabled` set to `true`. If this pod has this label set to true, that means this pod
+belongs to a Ray cluster that has Ray GCS HA enabled.
+
+After this, the controller will try to recover the failed pod. If controller cannot recover it, a label named 
+`ray.io/health-state` with a value `Unhealthy` is added to this pod.
+
+In every KubeRay Operator controller reconcile loop, it monitors any pod in Ray cluster that has `Unhealthy` value in label
+`ray.io/health-state`. If any pod is found, this pod is deleted and gets recreated.
+
+#### Known issues and limitations
+
+1. Currently, Python redis package is removed from Ray official image. We need to install Python redis package in the very begining of the container start. (This is done by KubeRay by adding commands to Ray container spec.)
+2. For now, Ray head/worker node that fails the readiness probe recovers itself by restarting itself. More fine-grained control and recovery mechanisms are expected in the future.
+
+### Test Ray GCS HA
+
+Currently, two tests are responsible for ensuring Ray GCS HA is working correctly.
+
+1. Detached actor test
+2. RayServe test
+
+In detached actor test, a detached actor is created at first. Then, the head node is killed. KubeRay brings back another
+head node replacement pod. However, the detached actor is still expected to be available. (Note: the client that creates
+the detached actor does not exist and will retry in case of Ray cluster returns failure)
+
+In RayServe test, a simple RayServe app is deployed on the Ray cluster. In case of GCS server crash, the RayServe app
+continues to be accessible after the head node recovery.

--- a/docs/guidance/gcs-ha.md
+++ b/docs/guidance/gcs-ha.md
@@ -18,6 +18,7 @@ kind: RayCluster
 metadata:
   annotations:
     ray.io/ha-enabled: "true" # <- add this annotation enable GCS HA
+    ray.io/external-storage-namespace: "my-raycluster-storage-namespace" # <- optional, to specify the external storage namespace
 ...
 ```
 An example can be found at [ray-cluster.external-redis.yaml](../../ray-operator/config/samples/ray-cluster.external-redis.yaml)
@@ -59,6 +60,8 @@ will also add such annotation to the pod whenever the head/worker node is create
 To use external Redis cluster as the backend storage(required by Ray GCS HA),
 you need to add `RAY_REDIS_ADDRESS` environment variable to the head node template.
 
+Also, you can specify a storage namespace for your Ray cluster by using an annotation `ray.io/external-storage-namespace`
+
 An example can be found at [ray-cluster.external-redis.yaml](../../ray-operator/config/samples/ray-cluster.external-redis.yaml)
 
 #### KubeRay Operator Controller
@@ -75,8 +78,7 @@ In every KubeRay Operator controller reconcile loop, it monitors any pod in Ray 
 
 #### Known issues and limitations
 
-1. Currently, Python redis package is removed from Ray official image. We need to install Python redis package in the very beginning of the container start. (This is done by KubeRay by adding commands to Ray container spec.)
-2. For now, Ray head/worker node that fails the readiness probe recovers itself by restarting itself. More fine-grained control and recovery mechanisms are expected in the future.
+1. For now, Ray head/worker node that fails the readiness probe recovers itself by restarting itself. More fine-grained control and recovery mechanisms are expected in the future.
 
 ### Test Ray GCS HA
 

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -67,7 +67,7 @@ kind: RayCluster
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-    ray.io/ha-enabled: "true"
+    ray.io/ha-enabled: "true" # enable Ray HA
     # An unique identifier for the head node and workers of this cluster.
   name: raycluster-external-redis
 spec:

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -67,6 +67,7 @@ kind: RayCluster
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
+    ray.io/ha-enabled: "true"
     # An unique identifier for the head node and workers of this cluster.
   name: raycluster-external-redis
 spec:

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -67,8 +67,9 @@ kind: RayCluster
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
+  annotations:
     ray.io/ha-enabled: "true" # enable Ray HA
-    # An unique identifier for the head node and workers of this cluster.
+  # An unique identifier for the head node and workers of this cluster.
   name: raycluster-external-redis
 spec:
   rayVersion: '1.13.0'

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -1,0 +1,176 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: redis-config
+  labels:
+    app: redis
+data:
+  redis.conf: |-
+    dir /data
+    port 6379
+    bind 0.0.0.0
+    appendonly yes
+    protected-mode no
+    requirepass 5241590000000000
+    pidfile /data/redis-6379.pid
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: 6379
+  selector:
+    app: redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:5.0.8
+          command:
+            - "sh"
+            - "-c"
+            - "redis-server /usr/local/etc/redis/redis.conf"
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/etc/redis/redis.conf
+              subPath: redis.conf
+      volumes:
+        - name: config
+          configMap:
+            name: redis-config
+---
+apiVersion: ray.io/v1alpha1
+kind: RayCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    # An unique identifier for the head node and workers of this cluster.
+  name: raycluster-external-redis
+spec:
+  rayVersion: '1.13.0'
+  headGroupSpec:
+    serviceType: ClusterIP
+    replicas: 1
+    rayStartParams:
+      dashboard-host: '0.0.0.0'
+      num-cpus: '1' # can be auto-completed from the limits
+      node-ip-address: $MY_POD_IP # auto-completed as the head pod IP
+      block: 'true'
+    #pod template
+    template:
+      metadata:
+        labels:
+          # custom labels. NOTE: do not define custom labels start with `raycluster.`, they may be used in controller.
+          # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+          rayCluster: raycluster-external-redis # will be injected if missing
+          rayNodeType: head # will be injected if missing, must be head or wroker
+          groupName: headgroup # will be injected if missing
+      spec:
+        containers:
+          - name: ray-head
+            image: rayproject/ray:nightly
+            env:
+              - name: MY_POD_IP
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.podIP
+              # RAY_REDIS_ADDRESS can force ray to use external redis
+              - name: RAY_REDIS_ADDRESS
+                value: redis:6379
+            ports:
+              - containerPort: 6379
+                name: redis
+              - containerPort: 8265
+                name: dashboard
+              - containerPort: 10001
+                name: client
+  workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 2
+      minReplicas: 1
+      maxReplicas: 2
+      # logical group name, for this called small-group, also can be functional
+      groupName: small-group
+      rayStartParams:
+        node-ip-address: $MY_POD_IP
+        block: 'true'
+      #pod template
+      template:
+        metadata:
+          labels:
+            rayCluster: raycluster-external-redis # will be injected if missing
+            rayNodeType: worker # will be injected if missing
+            groupName: small-group # will be injected if missing
+          # annotations for pod
+          annotations:
+            key: value
+        spec:
+          initContainers: # to avoid worker crashing before head service is created
+            # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+            - name: init-myservice
+              image: busybox:1.28
+              # Change the cluster postfix if you don't have a default setting
+              command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
+          containers:
+            - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+              image: rayproject/ray:nightly
+              # environment variables to set in the container.Optional.
+              # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+              env:
+                - name: TYPE
+                  value: "worker"
+                - name:  RAY_DISABLE_DOCKER_CPU_WARNING
+                  value: "1"
+                - name: CPU_REQUEST
+                  valueFrom:
+                    resourceFieldRef:
+                      containerName: machine-learning
+                      resource: requests.cpu
+                - name: MY_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: MY_POD_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.podIP
+              ports:
+                - containerPort: 80
+              # use volumeMounts.Optional.
+              # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+              volumeMounts:
+                - mountPath: /var/log
+                  name: log-volume
+              resources:
+                limits:
+                  cpu: "1"
+                requests:
+                  cpu: "200m"
+          # use volumes
+          # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+          volumes:
+            - name: log-volume
+              emptyDir: {}

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -69,6 +69,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   annotations:
     ray.io/ha-enabled: "true" # enable Ray HA
+    ray.io/external-storage-namespace: "my-raycluster-storage-namespace"
   # An unique identifier for the head node and workers of this cluster.
   name: raycluster-external-redis
 spec:

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -73,7 +73,7 @@ const (
 	DefaultLivenessProbeFailureThreshold    = 30
 
 	// Ray health check related configurations
-	DefaultRagAgentPort       = 52365
+	DefaultRayAgentPort       = 52365
 	DefaultRayDashboardPort   = 8265
 	RayAgentRayletHealthPath  = "api/local_raylet_healthz"
 	RayDashboardGCSHealthPath = "api/gcs_healthz"

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -69,6 +69,12 @@ const (
 	DefaultLivenessProbePeriodSeconds       = 0
 	DefaultLivenessProbeSuccessThreshold    = 0
 	DefaultLivenessProbeFailureThreshold    = 30
+
+	// Ray health check related configurations
+	DefaultRagAgentPort       = 52365
+	DefaultRayDashboardPort   = 8265
+	RayAgentRayletHealthPath  = "api/local_raylet_healthz"
+	RayDashboardGCSHealthPath = "api/gcs_healthz"
 )
 
 type ServiceType string

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -9,6 +9,10 @@ const (
 	RayNodeLabelKey                    = "ray.io/is-ray-node"
 	RayIDLabelKey                      = "ray.io/identifier"
 	RayClusterDashboardServiceLabelKey = "ray.io/cluster-dashboard"
+	RayNodeHealthStateLabelKey         = "ray.io/health-state"
+
+	// Pod health state values
+	PodUnhealthy = "Unhealthy"
 
 	EnableAgentServiceKey  = "ray.io/enableAgentService"
 	EnableAgentServiceTrue = "true"

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -55,6 +55,19 @@ const (
 
 	// Ray core default configurations
 	DefaultRedisPassword = "5241590000000000"
+
+	// Ray HA default readiness probe values
+	DefaultReadinessProbeInitialDelaySeconds = 10
+	DefaultReadinessProbeTimeoutSeconds      = 0
+	DefaultReadinessProbePeriodSeconds       = 0
+	DefaultReadinessProbeSuccessThreshold    = 0
+	DefaultReadinessProbeFailureThreshold    = 10
+	// Ray HA default liveness probe values
+	DefaultLivenessProbeInitialDelaySeconds = 10
+	DefaultLivenessProbeTimeoutSeconds      = 0
+	DefaultLivenessProbePeriodSeconds       = 0
+	DefaultLivenessProbeSuccessThreshold    = 0
+	DefaultLivenessProbeFailureThreshold    = 20
 )
 
 type ServiceType string

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -75,8 +75,6 @@ const (
 	DefaultLivenessProbeFailureThreshold    = 30
 
 	// Ray health check related configurations
-	DefaultRayAgentPort       = 52365
-	DefaultRayDashboardPort   = 8265
 	RayAgentRayletHealthPath  = "api/local_raylet_healthz"
 	RayDashboardGCSHealthPath = "api/gcs_healthz"
 )

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -10,9 +10,10 @@ const (
 	RayIDLabelKey                      = "ray.io/identifier"
 	RayClusterDashboardServiceLabelKey = "ray.io/cluster-dashboard"
 
-	// Ray GCS HA Annotations
-	RayHAEnabledAnnotationKey       = "ray.io/ha-enabled"
-	RayNodeHealthStateAnnotationKey = "ray.io/health-state"
+	// Ray GCS HA related annotations
+	RayHAEnabledAnnotationKey         = "ray.io/ha-enabled"
+	RayExternalStorageNSAnnotationKey = "ray.io/external-storage-namespace"
+	RayNodeHealthStateAnnotationKey   = "ray.io/health-state"
 
 	// Pod health state values
 	PodUnhealthy = "Unhealthy"
@@ -49,11 +50,12 @@ const (
 	PodReadyFilepath = "POD_READY_FILEPATH"
 
 	// Use as container env variable
-	NAMESPACE      = "NAMESPACE"
-	CLUSTER_NAME   = "CLUSTER_NAME"
-	RAY_IP         = "RAY_IP"
-	RAY_PORT       = "RAY_PORT"
-	REDIS_PASSWORD = "REDIS_PASSWORD"
+	NAMESPACE               = "NAMESPACE"
+	CLUSTER_NAME            = "CLUSTER_NAME"
+	RAY_IP                  = "RAY_IP"
+	RAY_PORT                = "RAY_PORT"
+	REDIS_PASSWORD          = "REDIS_PASSWORD"
+	RAY_EXTERNAL_STORAGE_NS = "RAY_external_storage_namespace"
 
 	// Ray core default configurations
 	DefaultRedisPassword = "5241590000000000"

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -61,13 +61,14 @@ const (
 	DefaultReadinessProbeTimeoutSeconds      = 0
 	DefaultReadinessProbePeriodSeconds       = 0
 	DefaultReadinessProbeSuccessThreshold    = 0
-	DefaultReadinessProbeFailureThreshold    = 10
+	DefaultReadinessProbeFailureThreshold    = 15
+
 	// Ray HA default liveness probe values
 	DefaultLivenessProbeInitialDelaySeconds = 10
 	DefaultLivenessProbeTimeoutSeconds      = 0
 	DefaultLivenessProbePeriodSeconds       = 0
 	DefaultLivenessProbeSuccessThreshold    = 0
-	DefaultLivenessProbeFailureThreshold    = 20
+	DefaultLivenessProbeFailureThreshold    = 30
 )
 
 type ServiceType string

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -10,6 +10,7 @@ const (
 	RayIDLabelKey                      = "ray.io/identifier"
 	RayClusterDashboardServiceLabelKey = "ray.io/cluster-dashboard"
 	RayNodeHealthStateLabelKey         = "ray.io/health-state"
+	RayHAEnabledLabelKey               = "ray.io/ha-enabled"
 
 	// Pod health state values
 	PodUnhealthy = "Unhealthy"

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -9,8 +9,10 @@ const (
 	RayNodeLabelKey                    = "ray.io/is-ray-node"
 	RayIDLabelKey                      = "ray.io/identifier"
 	RayClusterDashboardServiceLabelKey = "ray.io/cluster-dashboard"
-	RayNodeHealthStateLabelKey         = "ray.io/health-state"
-	RayHAEnabledLabelKey               = "ray.io/ha-enabled"
+
+	// Ray GCS HA Annotations
+	RayHAEnabledAnnotationKey       = "ray.io/ha-enabled"
+	RayNodeHealthStateAnnotationKey = "ray.io/health-state"
 
 	// Pod health state values
 	PodUnhealthy = "Unhealthy"

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -167,16 +167,16 @@ func initLivenessProbeHandler(probe *v1.Probe, rayNodeType rayiov1alpha1.RayNode
 			// head node liveness probe
 			cmd := []string{
 				"bash", "-c", fmt.Sprintf("wget -q -O- http://localhost:%d/%s | grep success",
-					DefaultRayAgentPort, RayAgentRayletHealthPath),
+					DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
 				"&&", "bash", "-c", fmt.Sprintf("wget -q -O- http://localhost:%d/%s | grep success",
-					DefaultRayDashboardPort, RayDashboardGCSHealthPath),
+					DefaultDashboardPort, RayDashboardGCSHealthPath),
 			}
 			probe.Exec = &v1.ExecAction{Command: cmd}
 		} else {
 			// worker node liveness probe
 			cmd := []string{
 				"bash", "-c", fmt.Sprintf("wget -q -O- http://localhost:%d/%s | grep success",
-					DefaultRayAgentPort, RayAgentRayletHealthPath),
+					DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
 			}
 			probe.Exec = &v1.ExecAction{Command: cmd}
 		}
@@ -190,16 +190,16 @@ func initReadinessProbeHandler(probe *v1.Probe, rayNodeType rayiov1alpha1.RayNod
 			// head node readiness probe
 			cmd := []string{
 				"bash", "-c", fmt.Sprintf("wget -q -O- http://localhost:%d/%s | grep success",
-					DefaultRayAgentPort, RayAgentRayletHealthPath),
+					DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
 				"&&", "bash", "-c", fmt.Sprintf("wget -q -O- http://localhost:%d/%s | grep success",
-					DefaultRayDashboardPort, RayDashboardGCSHealthPath),
+					DefaultDashboardPort, RayDashboardGCSHealthPath),
 			}
 			probe.Exec = &v1.ExecAction{Command: cmd}
 		} else {
 			// worker node readiness probe
 			cmd := []string{
 				"bash", "-c", fmt.Sprintf("wget -q -O- http://localhost:%d/%s | grep success",
-					DefaultRayAgentPort, RayAgentRayletHealthPath),
+					DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
 			}
 			probe.Exec = &v1.ExecAction{Command: cmd}
 		}

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -132,7 +132,6 @@ func DefaultWorkerPodTemplate(instance rayiov1alpha1.RayCluster, workerSpec rayi
 }
 
 func setLivenessProbe(probe *v1.Probe, rayNodeType rayiov1alpha1.RayNodeType) {
-	// TODO : implement me
 	if rayNodeType == rayiov1alpha1.HeadNode {
 		// head node liveness probe
 		cmd := []string{
@@ -168,7 +167,6 @@ func setLivenessProbe(probe *v1.Probe, rayNodeType rayiov1alpha1.RayNodeType) {
 }
 
 func setReadinessProbe(probe *v1.Probe, rayNodeType rayiov1alpha1.RayNodeType) {
-	// TODO : implement me
 	if rayNodeType == rayiov1alpha1.HeadNode {
 		// head node readiness probe
 		cmd := []string{

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -507,15 +507,6 @@ func setContainerEnvVars(pod *v1.Pod, rayContainerIndex int, rayNodeType rayiov1
 		}
 		container.Env = append(container.Env, port)
 	}
-	if !envVarExists(RAY_EXTERNAL_STORAGE_NS, container.Env) {
-		// setting the RAY_EXTERNAL_STORAGE_NS env var from the params
-		if pod.Annotations != nil {
-			if v, ok := pod.Annotations[RayExternalStorageNSAnnotationKey]; ok {
-				storageNS := v1.EnvVar{Name: RAY_EXTERNAL_STORAGE_NS, Value: v}
-				container.Env = append(container.Env, storageNS)
-			}
-		}
-	}
 }
 
 func envVarExists(envName string, envVars []v1.EnvVar) bool {

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -238,7 +238,7 @@ func TestBuildPod(t *testing.T) {
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
 	svcName := utils.GenerateServiceName(cluster.Name)
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName)
-	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, nil, "")
+	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, nil)
 
 	actualResult := pod.Labels[RayClusterLabelKey]
 	expectedResult := cluster.Name
@@ -272,7 +272,7 @@ func TestBuildPod(t *testing.T) {
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	podName = cluster.Name + DashSymbol + string(rayiov1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, svcName)
-	pod = BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, svcName, nil, "")
+	pod = BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, svcName, nil)
 
 	expectedResult = fmt.Sprintf("%s:6379", svcName)
 	actualResult = cluster.Spec.WorkerGroupSpecs[0].RayStartParams["address"]
@@ -281,7 +281,7 @@ func TestBuildPod(t *testing.T) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
 
-	expectedCommandArg := splitAndSort("/home/ray/anaconda3/bin/pip install redis; ulimit -n 65536; ray start --block --num-cpus=1 --num-gpus=3 --address=raycluster-sample-head-svc:6379 --port=6379 --redis-password=LetMeInRay --metrics-export-port=8080")
+	expectedCommandArg := splitAndSort("ulimit -n 65536; ray start --block --num-cpus=1 --num-gpus=3 --address=raycluster-sample-head-svc:6379 --port=6379 --redis-password=LetMeInRay --metrics-export-port=8080")
 	if !reflect.DeepEqual(expectedCommandArg, splitAndSort(pod.Spec.Containers[0].Args[0])) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedCommandArg, pod.Spec.Containers[0].Args[0])
 	}
@@ -293,7 +293,7 @@ func TestBuildPod_WithAutoscalerEnabled(t *testing.T) {
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
 	svcName := utils.GenerateServiceName(cluster.Name)
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName)
-	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, &trueFlag, "")
+	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, &trueFlag)
 
 	actualResult := pod.Labels[RayClusterLabelKey]
 	expectedResult := cluster.Name
@@ -373,7 +373,7 @@ func TestBuildPodWithAutoscalerOptions(t *testing.T) {
 		Resources:          &customResources,
 	}
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName)
-	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, &trueFlag, "")
+	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, &trueFlag)
 	expectedContainer := *autoscalerContainer.DeepCopy()
 	expectedContainer.Image = customAutoscalerImage
 	expectedContainer.ImagePullPolicy = customPullPolicy

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -238,7 +238,7 @@ func TestBuildPod(t *testing.T) {
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
 	svcName := utils.GenerateServiceName(cluster.Name)
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName)
-	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, nil)
+	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, nil, "")
 
 	actualResult := pod.Labels[RayClusterLabelKey]
 	expectedResult := cluster.Name
@@ -272,7 +272,7 @@ func TestBuildPod(t *testing.T) {
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	podName = cluster.Name + DashSymbol + string(rayiov1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, svcName)
-	pod = BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, svcName, nil)
+	pod = BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, svcName, nil, "")
 
 	expectedResult = fmt.Sprintf("%s:6379", svcName)
 	actualResult = cluster.Spec.WorkerGroupSpecs[0].RayStartParams["address"]
@@ -281,7 +281,7 @@ func TestBuildPod(t *testing.T) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
 
-	expectedCommandArg := splitAndSort("ulimit -n 65536; ray start --block --num-cpus=1 --num-gpus=3 --address=raycluster-sample-head-svc:6379 --port=6379 --redis-password=LetMeInRay --metrics-export-port=8080")
+	expectedCommandArg := splitAndSort("/home/ray/anaconda3/bin/pip install redis; ulimit -n 65536; ray start --block --num-cpus=1 --num-gpus=3 --address=raycluster-sample-head-svc:6379 --port=6379 --redis-password=LetMeInRay --metrics-export-port=8080")
 	if !reflect.DeepEqual(expectedCommandArg, splitAndSort(pod.Spec.Containers[0].Args[0])) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedCommandArg, pod.Spec.Containers[0].Args[0])
 	}
@@ -293,7 +293,7 @@ func TestBuildPod_WithAutoscalerEnabled(t *testing.T) {
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
 	svcName := utils.GenerateServiceName(cluster.Name)
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName)
-	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, &trueFlag)
+	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, &trueFlag, "")
 
 	actualResult := pod.Labels[RayClusterLabelKey]
 	expectedResult := cluster.Name
@@ -373,7 +373,7 @@ func TestBuildPodWithAutoscalerOptions(t *testing.T) {
 		Resources:          &customResources,
 	}
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName)
-	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, &trueFlag)
+	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, &trueFlag, "")
 	expectedContainer := *autoscalerContainer.DeepCopy()
 	expectedContainer.Image = customAutoscalerImage
 	expectedContainer.ImagePullPolicy = customPullPolicy

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -134,6 +134,11 @@ func (r *RayClusterReconciler) eventReconcile(request ctrl.Request, event *v1.Ev
 		}
 	}
 
+	if unhealthyPod == nil {
+		log.Info("pod not found", "pod name", event.InvolvedObject.Name)
+		return ctrl.Result{}, nil
+	}
+
 	if enabledString, ok := unhealthyPod.Labels[common.RayHAEnabledLabelKey]; ok {
 		if strings.ToLower(enabledString) != "true" {
 			log.Info("HA not enabled skipping event reconcile for pod.", "pod name", unhealthyPod.Name)

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -140,8 +140,8 @@ func (r *RayClusterReconciler) eventReconcile(request ctrl.Request, event *v1.Ev
 			return ctrl.Result{}, nil
 		}
 	} else {
-		err := fmt.Errorf("HAEnabled label not found")
-		log.Error(err, "HAEnabled label not found")
+		log.Info("HAEnabled label not found", "pod name", unhealthyPod.Name)
+		return ctrl.Result{}, nil
 	}
 
 	needUpdate := true

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -83,20 +83,80 @@ type RayClusterReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;delete
 // Reconcile used to bridge the desired state with the current state
 func (r *RayClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	var err error
+
+	// Try to fetch the Event instance
+	event := &v1.Event{}
+	if err = r.Get(context.TODO(), request.NamespacedName, event); err == nil {
+		return r.eventReconcile(request, event)
+	}
+
+	// Try to fetch the RayCluster instance
+	instance := &rayiov1alpha1.RayCluster{}
+	if err = r.Get(context.TODO(), request.NamespacedName, instance); err == nil {
+		return r.rayClusterReconcile(request, instance)
+	}
+
+	// No match found
+	if errors.IsNotFound(err) {
+		log.Info("Read request instance not found error!", "name", request.NamespacedName)
+	} else {
+		log.Error(err, "Read request instance error!")
+	}
+	// Error reading the object - requeue the request.
+	return ctrl.Result{}, client.IgnoreNotFound(err)
+}
+
+func (r *RayClusterReconciler) eventReconcile(request ctrl.Request, event *v1.Event) (ctrl.Result, error) {
+	var unhealthyPod *corev1.Pod
+	pods := corev1.PodList{}
+
+	// we only care about pod events
+	if event.InvolvedObject.Kind != "Pod" || event.Type != "Warning" || event.Reason != "Unhealthy" ||
+		!strings.Contains(event.Message, "Readiness probe failed") {
+		return ctrl.Result{}, nil
+	}
+
+	_ = r.Log.WithValues("event", request.NamespacedName)
+	log.Info("reconcile RayCluster Event", "event name", request.Name)
+
+	if err := r.List(context.TODO(), &pods,
+		client.InNamespace(event.InvolvedObject.Namespace)); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	for _, item := range pods.Items {
+		if item.Name == event.InvolvedObject.Name {
+			if unhealthyPod != nil {
+				return ctrl.Result{}, fmt.Errorf("duplicate pod found")
+			}
+			unhealthyPod = &item
+		}
+	}
+
+	needUpdate := true
+	if !utils.IsRunningAndReady(unhealthyPod) {
+		log.Info("mark pod unhealthy and need for a rebuild", "pod name", unhealthyPod.Name)
+		for k, v := range unhealthyPod.GetLabels() {
+			if k == common.RayNodeHealthStateLabelKey && v == common.PodUnhealthy {
+				needUpdate = false
+			}
+		}
+		if needUpdate {
+			updatedPod := unhealthyPod.DeepCopy()
+			updatedPod.Labels[common.RayNodeHealthStateLabelKey] = common.PodUnhealthy
+			if err := r.Update(context.TODO(), updatedPod); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *RayClusterReconciler) rayClusterReconcile(request ctrl.Request, instance *rayiov1alpha1.RayCluster) (ctrl.Result, error) {
 	_ = r.Log.WithValues("raycluster", request.NamespacedName)
 	log.Info("reconciling RayCluster", "cluster name", request.Name)
-
-	// Fetch the RayCluster instance
-	instance := &rayiov1alpha1.RayCluster{}
-	if err := r.Get(context.TODO(), request.NamespacedName, instance); err != nil {
-		if errors.IsNotFound(err) {
-			log.Info("Read request instance not found error!")
-		} else {
-			log.Error(err, "Read request instance error!")
-		}
-		// Error reading the object - requeue the request.
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
 
 	if instance.DeletionTimestamp != nil && !instance.DeletionTimestamp.IsZero() {
 		log.Info("RayCluster is being deleted, just ignore", "cluster name", request.Name)
@@ -298,6 +358,16 @@ func (r *RayClusterReconciler) reconcilePods(instance *rayiov1alpha1.RayCluster)
 				return err
 			}
 		}
+	} else {
+		// we have exactly one head pod running
+		if v, ok := headPods.Items[0].Labels[common.RayNodeHealthStateLabelKey]; ok && v == common.PodUnhealthy {
+			if err := r.Delete(context.TODO(), &headPods.Items[0]); err != nil {
+				return err
+			}
+			log.Info(fmt.Sprintf("need to delete unhealthy head pod %s", headPods.Items[0].Name))
+			// we are deleting the head pod now, let's reconcile again later
+			return nil
+		}
 	}
 
 	if ForcedClusterUpgrade {
@@ -344,6 +414,19 @@ func (r *RayClusterReconciler) reconcilePods(instance *rayiov1alpha1.RayCluster)
 		if err := r.List(context.TODO(), &workerPods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 			return err
 		}
+
+		// delete the worker pod if it is marked unhealthy
+		for _, workerPod := range workerPods.Items {
+			if v, ok := workerPod.Labels[common.RayNodeHealthStateLabelKey]; ok && v == common.PodUnhealthy {
+				if err := r.Delete(context.TODO(), &workerPod); err != nil {
+					return err
+				}
+				log.Info(fmt.Sprintf("need to delete unhealthy worker pod %s", workerPod.Name))
+				// we are deleting one worker pod now, let's reconcile again later
+				return nil
+			}
+		}
+
 		runningPods := corev1.PodList{}
 		for _, aPod := range workerPods.Items {
 			if (aPod.Status.Phase == corev1.PodRunning || aPod.Status.Phase == corev1.PodPending) && aPod.ObjectMeta.DeletionTimestamp == nil {
@@ -585,7 +668,7 @@ func (r *RayClusterReconciler) buildHeadPod(instance rayiov1alpha1.RayCluster) c
 	podName = utils.CheckName(podName) // making sure the name is valid
 	svcName := utils.GenerateServiceName(instance.Name)
 	podConf := common.DefaultHeadPodTemplate(instance, instance.Spec.HeadGroupSpec, podName, svcName)
-	pod := common.BuildPod(podConf, rayiov1alpha1.HeadNode, instance.Spec.HeadGroupSpec.RayStartParams, svcName, instance.Spec.EnableInTreeAutoscaling)
+	pod := common.BuildPod(podConf, rayiov1alpha1.HeadNode, instance.Spec.HeadGroupSpec.RayStartParams, svcName, instance.Spec.EnableInTreeAutoscaling, instance.Spec.RayVersion)
 	// Set raycluster instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&instance, &pod, r.Scheme); err != nil {
 		log.Error(err, "Failed to set controller reference for raycluster pod")
@@ -600,7 +683,7 @@ func (r *RayClusterReconciler) buildWorkerPod(instance rayiov1alpha1.RayCluster,
 	podName = utils.CheckName(podName) // making sure the name is valid
 	svcName := utils.GenerateServiceName(instance.Name)
 	podTemplateSpec := common.DefaultWorkerPodTemplate(instance, worker, podName, svcName)
-	pod := common.BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, svcName, instance.Spec.EnableInTreeAutoscaling)
+	pod := common.BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, svcName, instance.Spec.EnableInTreeAutoscaling, instance.Spec.RayVersion)
 	// Set raycluster instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&instance, &pod, r.Scheme); err != nil {
 		log.Error(err, "Failed to set controller reference for raycluster pod")
@@ -613,6 +696,7 @@ func (r *RayClusterReconciler) buildWorkerPod(instance rayiov1alpha1.RayCluster,
 func (r *RayClusterReconciler) SetupWithManager(mgr ctrl.Manager, reconcileConcurrency int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&rayiov1alpha1.RayCluster{}).Named("raycluster-controller").
+		Watches(&source.Kind{Type: &corev1.Event{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
 			IsController: true,
 			OwnerType:    &rayiov1alpha1.RayCluster{},

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -238,7 +238,7 @@ var _ = Context("Inside the default namespace", func() {
 			// adding a scale strategy
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
+				time.Second*9, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
 
 			podToDelete1 := workerPods.Items[0]
 			rep := new(int32)

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -30,6 +30,19 @@ func IsCreated(pod *corev1.Pod) bool {
 	return pod.Status.Phase != ""
 }
 
+// IsRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.
+func IsRunningAndReady(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
 // CheckName makes sure the name does not start with a numeric value and the total length is < 63 char
 func CheckName(s string) string {
 	maxLenght := 50 // 63 - (max(8,6) + 5 ) // 6 to 8 char are consumed at the end with "-head-" or -worker- + 5 generated.

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -85,7 +85,9 @@ def create_kuberay_cluster(template_name):
     assert raycluster_spec_file is not None
     shell_assert_success('kubectl apply -f {}'.format(raycluster_spec_file))
 
-    time.sleep(180)
+    time.sleep(120)
+
+    shell_run('kubectl get pods -A')
 
     rtn = shell_run(
         'kubectl wait --for=condition=ready pod -l rayCluster=raycluster-compatibility-test --all --timeout=1200s')
@@ -201,6 +203,8 @@ print(len(ray.nodes()))
 
 
 def ray_ha_supported():
+    if ray_version == "nightly":
+        return True
     major, minor, patch = parse_ray_version(ray_version)
     if major * 100 + minor < 113:
         return False
@@ -212,6 +216,8 @@ class RayHATestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        if not ray_ha_supported():
+            return
         delete_cluster()
         create_cluster()
         apply_kuberay_resources()

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -239,7 +239,13 @@ class RayHATestCase(unittest.TestCase):
         # make sure the new head is ready
         shell_assert_success('kubectl wait --for=condition=Ready pod/$(kubectl get pods -A | grep -e "-head" | awk "{print \$2}") --timeout=1200s')
         # make sure both head and worker pods are ready
-        shell_assert_success('kubectl wait --for=condition=ready pod -l rayCluster=raycluster-compatibility-test --all --timeout=1200s')
+        rtn = shell_run('kubectl wait --for=condition=ready pod -l rayCluster=raycluster-compatibility-test --all --timeout=1200s')
+        if rtn != 0:
+            shell_run('kubectl get pods -A')
+            shell_run('kubectl describe pod $(kubectl get pods | grep -e "-head" | awk "{print \$1}")')
+            shell_run('kubectl logs $(kubectl get pods | grep -e "-head" | awk "{print \$1}")')
+            shell_run('kubectl logs -n $(kubectl get pods -A | grep -e "-operator" | awk \'{print $1 "  " $2}\')')
+        assert  rtn == 0
 
     def test_ray_serve(self):
         client = docker.from_env()

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -6,21 +6,27 @@ import unittest
 from string import Template
 
 import docker
-import sys
 import time
 
 ray_version = '1.9.0'
 ray_image = "rayproject/ray:1.9.0"
 
 kindcluster_config_file = 'tests/config/cluster-config.yaml'
-
-raycluster_spec_template = 'tests/config/ray-cluster.mini.yaml.template'
 raycluster_service_file = 'tests/config/raycluster-service.yaml'
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 kuberay_sha = 'nightly'
+
+
+def parse_ray_version(version_str):
+    tmp = version_str.split('.')
+    assert len(tmp) == 3
+    major = int(tmp[0])
+    minor = int(tmp[1])
+    patch = int(tmp[2])
+    return major, minor, patch
 
 
 def shell_run(cmd):
@@ -39,6 +45,11 @@ def shell_assert_failure(cmd):
 def create_cluster():
     shell_assert_success(
         'kind create cluster --config {}'.format(kindcluster_config_file))
+    time.sleep(30)
+    rtn = shell_run('kubectl wait --for=condition=ready pod -n kube-system --all --timeout=1200s')
+    if rtn != 0:
+        shell_run('kubectl get pods -A')
+    assert rtn == 0
 
 
 def apply_kuberay_resources():
@@ -54,9 +65,9 @@ def apply_kuberay_resources():
          'kubectl apply -k .').format(kuberay_sha))
 
 
-def create_kuberay_cluster():
+def create_kuberay_cluster(template_name):
     template = None
-    with open(raycluster_spec_template, mode='r') as f:
+    with open(template_name, mode='r') as f:
         template = Template(f.read())
 
     raycluster_spec_buf = template.substitute(
@@ -67,21 +78,29 @@ def create_kuberay_cluster():
         f.write(raycluster_spec_buf)
         raycluster_spec_file = f.name
 
-    time.sleep(30)
-
-    shell_assert_success('kubectl wait --for=condition=ready pod -n ray-system --all --timeout=1600s')
+    rtn = shell_run('kubectl wait --for=condition=ready pod -n ray-system --all --timeout=1200s')
+    if rtn != 0:
+        shell_run('kubectl get pods -A')
+    assert rtn == 0
     assert raycluster_spec_file is not None
     shell_assert_success('kubectl apply -f {}'.format(raycluster_spec_file))
 
     time.sleep(180)
 
-    shell_assert_success(
-        'kubectl wait --for=condition=ready pod -l rayCluster=raycluster-compatibility-test --timeout=1600s')
+    rtn = shell_run(
+        'kubectl wait --for=condition=ready pod -l rayCluster=raycluster-compatibility-test --all --timeout=1200s')
+    if rtn != 0:
+        shell_run('kubectl get pods -A')
+        shell_run('kubectl describe pod $(kubectl get pods | grep -e "-head" | awk "{print \$1}")')
+        shell_run('kubectl logs $(kubectl get pods | grep -e "-head" | awk "{print \$1}")')
+        shell_run('kubectl logs -n $(kubectl get pods -A | grep -e "-operator" | awk \'{print $1 "  " $2}\')')
+    assert rtn == 0
+
     shell_assert_success('kubectl apply -f {}'.format(raycluster_service_file))
 
 
 def delete_cluster():
-    shell_assert_success('kind delete cluster')
+    shell_run('kind delete cluster')
 
 
 def download_images():
@@ -93,6 +112,7 @@ def download_images():
 
 
 class BasicRayTestCase(unittest.TestCase):
+    cluster_template_file = 'tests/config/ray-cluster.mini.yaml.template'
 
     @classmethod
     def setUpClass(cls):
@@ -101,10 +121,11 @@ class BasicRayTestCase(unittest.TestCase):
         # from another local ray container. The local ray container
         # outside Kind environment has the same ray version as the
         # ray cluster running inside Kind environment.
+        delete_cluster()
         create_cluster()
         apply_kuberay_resources()
         download_images()
-        create_kuberay_cluster()
+        create_kuberay_cluster(BasicRayTestCase.cluster_template_file)
 
     def test_simple_code(self):
         # connect from a ray containter client to ray cluster
@@ -178,9 +199,137 @@ print(len(ray.nodes()))
 
         client.close()
 
+
+def ray_ha_supported():
+    major, minor, patch = parse_ray_version(ray_version)
+    if major * 100 + minor < 113:
+        return False
+    return True
+
+
+class RayHATestCase(unittest.TestCase):
+    cluster_template_file = 'tests/config/ray-cluster.ray-ha.yaml.template'
+
     @classmethod
-    def tearDownClass(cls):
+    def setUpClass(cls):
         delete_cluster()
+        create_cluster()
+        apply_kuberay_resources()
+        download_images()
+        create_kuberay_cluster(RayHATestCase.cluster_template_file)
+
+    def setUp(self):
+        if not ray_ha_supported():
+            raise unittest.SkipTest("ray ha is not supported")
+
+    def test_kill_head(self):
+        # delete head node
+        shell_assert_success('kubectl delete pod $(kubectl get pods -A | grep -e "-head" | awk "{print \$2}")')
+        time.sleep(20)
+        # wait for new head node to start
+        shell_assert_success('kubectl get pod $(kubectl get pods -A | grep -e "-head" | awk "{print \$2}")')
+
+        # make sure the new head is ready
+        shell_assert_success('kubectl wait --for=condition=Ready pod/$(kubectl get pods -A | grep -e "-head" | awk "{print \$2}") --timeout=1200s')
+        # make sure both head and worker pods are ready
+        shell_assert_success('kubectl wait --for=condition=ready pod -l rayCluster=raycluster-compatibility-test --all --timeout=1200s')
+
+    def test_detached_actor(self):
+        client = docker.from_env()
+        container = client.containers.run(ray_image, remove=True, detach=True, stdin_open=True, tty=True,
+                                          network_mode='host', command=["/bin/sh", "-c", "python"])
+        s = container.attach_socket(params={'stdin': 1, 'stream': 1, 'stdout': 1, 'stderr': 1})
+        s._sock.setblocking(0)
+        s._sock.sendall(b'''
+import ray
+import time
+
+def retry_with_timeout(func, count=90):
+    tmp = 0
+    err = None
+    while tmp < count:
+        try:
+            return func()
+        except Exception as e:
+            err = e
+            tmp += 1
+    assert err is not None
+    raise err
+
+ray.init(address='ray://127.0.0.1:10001')
+
+@ray.remote
+class A:
+    def ready(self):
+        import os
+        return os.getpid()
+
+a = A.options(name="a", lifetime="detached", max_restarts=-1).remote()
+res1 = ray.get(a.ready.remote())
+print('ready')
+
+        ''')
+
+        count = 0
+        while count < 90:
+            try:
+                buf = s._sock.recv(4096)
+                logger.info(buf.decode())
+                if buf.decode().find('ready') != -1:
+                    break
+            except Exception as e:
+                pass
+            time.sleep(1)
+            count += 1
+        if count >= 90:
+            raise Exception('failed to run script')
+
+        shell_assert_success('kubectl exec -it $(kubectl get pods -A| grep -e "-head" | awk "{print \\$2}") -- /bin/bash -c "ps aux | grep gcs_server | grep -v grep | awk \'{print \$2}\' | xargs kill"')
+        # wait for new head node getting created
+        time.sleep(10)
+        # make sure the new head is ready
+        shell_assert_success('kubectl wait --for=condition=Ready pod/$(kubectl get pods -A | grep -e "-head" | awk "{print \$2}") --timeout=1200s')
+
+        s._sock.sendall(b'''
+def get_detached_actor():
+    return ray.get_actor("a")
+a = retry_with_timeout(get_detached_actor)
+
+def get_new_value():
+    return ray.get(a.ready.remote())
+res2 = retry_with_timeout(get_new_value)
+
+if res1 != res2:
+    print('successful: {} {}'.format(res1, res2))
+    sys.exit(0)
+else:
+    raise Exception('failed')
+        ''')
+
+        count = 0
+        while count < 90:
+            try:
+                buf = s._sock.recv(4096)
+                logger.info(buf.decode())
+                if buf.decode().find('successful') != -1:
+                    break
+                if buf.decode().find('failed') != -1:
+                    raise Exception('test failed')
+            except Exception as e:
+                pass
+            time.sleep(1)
+            count += 1
+        if count >= 90:
+            raise Exception('failed to run script')
+
+        container.stop()
+        client.close()
+
+    def test_kill_worker(self):
+        # if not ray_ha_supported():
+        #   raise unittest.SkipTest("ray ha is not supported")
+        # TODO: implement me
+        pass
 
 
 def parse_environment():
@@ -197,4 +346,4 @@ def parse_environment():
 
 if __name__ == '__main__':
     parse_environment()
-    unittest.main()
+    unittest.main(verbosity=2)

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -432,12 +432,6 @@ else:
         container.stop()
         client.close()
 
-    def test_kill_worker(self):
-        # if not ray_ha_supported():
-        #   raise unittest.SkipTest("ray ha is not supported")
-        # TODO: implement me
-        pass
-
 
 def parse_environment():
     global ray_version, ray_image, kuberay_sha

--- a/tests/config/ray-cluster.ray-ha.yaml.template
+++ b/tests/config/ray-cluster.ray-ha.yaml.template
@@ -1,0 +1,165 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: redis-config
+  labels:
+    app: redis
+data:
+  redis.conf: |-
+    dir /data
+    port 6379
+    bind 0.0.0.0
+    appendonly yes
+    protected-mode no
+    requirepass 5241590000000000
+    pidfile /data/redis-6379.pid
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: 6379
+  selector:
+    app: redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:5.0.8
+          command:
+            - "sh"
+            - "-c"
+            - "redis-server /usr/local/etc/redis/redis.conf"
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/etc/redis/redis.conf
+              subPath: redis.conf
+      volumes:
+        - name: config
+          configMap:
+            name: redis-config
+---
+apiVersion: ray.io/v1alpha1
+kind: RayCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: raycluster-external-redis
+spec:
+  rayVersion: '$ray_version'
+  headGroupSpec:
+    serviceType: ClusterIP
+    replicas: 1
+    rayStartParams:
+      dashboard-host: '0.0.0.0'
+      num-cpus: '1'
+      node-ip-address: $$MY_POD_IP
+      block: 'true'
+    #pod template
+    template:
+      metadata:
+        labels:
+          rayCluster: raycluster-compatibility-test
+          rayNodeType: head
+          groupName: headgroup # will be injected if missing
+      spec:
+        containers:
+          - name: ray-head
+            image: $ray_image
+            env:
+              - name: MY_POD_IP
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.podIP
+              # RAY_REDIS_ADDRESS can force ray to use external redis
+              - name: RAY_REDIS_ADDRESS
+                value: redis:6379
+            ports:
+              - containerPort: 6379
+                name: redis
+              - containerPort: 8265
+                name: dashboard
+              - containerPort: 10001
+                name: client
+  workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 2
+      minReplicas: 1
+      maxReplicas: 2
+      # logical group name, for this called small-group, also can be functional
+      groupName: small-group
+      rayStartParams:
+        node-ip-address: $$MY_POD_IP
+        block: 'true'
+      #pod template
+      template:
+        metadata:
+          labels:
+            rayCluster: raycluster-compatibility-test
+            rayNodeType: worker # will be injected if missing
+            groupName: small-group # will be injected if missing
+          # annotations for pod
+          annotations:
+            key: value
+        spec:
+          initContainers: # to avoid worker crashing before head service is created
+            - name: init-myservice
+              image: busybox:1.28
+              command: ['sh', '-c', "until nslookup $$RAY_IP.$$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
+          containers:
+            - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+              image: $ray_image
+              env:
+                - name: TYPE
+                  value: "worker"
+                - name:  RAY_DISABLE_DOCKER_CPU_WARNING
+                  value: "1"
+                - name: CPU_REQUEST
+                  valueFrom:
+                    resourceFieldRef:
+                      containerName: machine-learning
+                      resource: requests.cpu
+                - name: MY_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: MY_POD_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.podIP
+              ports:
+                - containerPort: 80
+              volumeMounts:
+                - mountPath: /var/log
+                  name: log-volume
+              resources:
+                limits:
+                  cpu: "1"
+                requests:
+                  cpu: "200m"
+          volumes:
+            - name: log-volume
+              emptyDir: {}

--- a/tests/config/ray-cluster.ray-ha.yaml.template
+++ b/tests/config/ray-cluster.ray-ha.yaml.template
@@ -67,7 +67,7 @@ kind: RayCluster
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-    ray.io/ha-enabled: "true"
+    ray.io/ha-enabled: "true" # enable Ray HA
   name: raycluster-external-redis
 spec:
   rayVersion: '$ray_version'

--- a/tests/config/ray-cluster.ray-ha.yaml.template
+++ b/tests/config/ray-cluster.ray-ha.yaml.template
@@ -67,6 +67,7 @@ kind: RayCluster
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
+    ray.io/ha-enabled: "true"
   name: raycluster-external-redis
 spec:
   rayVersion: '$ray_version'

--- a/tests/config/ray-cluster.ray-ha.yaml.template
+++ b/tests/config/ray-cluster.ray-ha.yaml.template
@@ -67,6 +67,7 @@ kind: RayCluster
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
+  annotations:
     ray.io/ha-enabled: "true" # enable Ray HA
   name: raycluster-external-redis
 spec:


### PR DESCRIPTION
## Why are these changes needed?

Initial support for GCS HA in kuberay. 

Design document is at: https://github.com/wilsonwang371/kuberay/blob/wilson/ray2.0_gcs_ha/docs/guidance/gcs-ha.md

### Changes
1. added yaml for Ray GCS HA + External Redis Deployment
2. a document describing Ray GCS HA details.
3. introduced new annotation in RayCluster to enable Ray GCS HA
4. Added Event reconcile function so that in case of Readiness Probe failure, we can try to recover head or worker node if possible.
5. Added Liveness and Readiness Probes based on new features introduced in https://github.com/ray-project/ray/pull/26408
6. Added Ray detached actor and Ray serve basic tests in Compatibility Test.
7. Updated github workflow to reduce its running time

### Enable GCS HA

To enable GCS HA, in RayCluster yaml file, a new annotation is required.

```yaml
apiVersion: ray.io/v1alpha1
kind: RayCluster
metadata:
  annotations:
    ray.io/ha-enabled: "true" # <- add this annotation enable GCS HA
...
```

When this annotation is added to RayCluster yaml file, all newly created head node and worker nodes pods in this ray cluster will have the same annotation attached.
```yaml
ray.io/ha-enabled: "true" 
```

### Readiness Probe & Liveness Probe

Readiness Probe and Liveness Probe are both used by kuberay to help Ray cluster recover from failures.

Readiness Probe is used to discover early failures and recover if possible. (recovery action is not implemented yet.)
Liveness Probe is used as the last resort to recover the cluster by restarting failed worker/head node

By default, if GCS HA is enabled, default Readiness Probe and default Liveness Probe will be added to the newly created pods in this Ray cluster. If user specified different Readiness Probe & Liveness Probe, default ones will not be added to the head & worker nodes created.

## Related issue number

#290

## Checks

- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
