### PR TITLE
[WIP]use pip to download ray package and run locally as client instead of docker container

### DIFF
--- a/.github/workflows/actions/compatibility/action.yaml
+++ b/.github/workflows/actions/compatibility/action.yaml
@@ -68,5 +68,6 @@ runs:
       kustomize edit set image kuberay/apiserver=kuberay/apiserver:${{ steps.vars.outputs.sha_short }}
       popd
       echo "Using Ray image ${{ inputs.ray_version }}"
+      pip install ray==${{ inputs.ray_version }} --extra-index-url https://test.pypi.org/simple || exit 1
       RAY_VERSION="${{ inputs.ray_version }}" KUBERAY_IMG_SHA=${{ steps.vars.outputs.sha_short }} python ./tests/compatibility-test.py
     shell: bash


### PR DESCRIPTION

## Why are these changes needed?

Use pip to download ray and use it as the client to connect to ray cluster inside kind instead of using docker container.

## Related issue number

N/A

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
