### PR TITLE
fix: use head group's ServiceAccount in autoscaler RoleBinding

### DIFF
--- a/ray-operator/controllers/ray/common/rbac.go
+++ b/ray-operator/controllers/ray/common/rbac.go
@@ -63,7 +63,7 @@ func BuildRoleBinding(cluster *v1alpha1.RayCluster) (*rbacv1.RoleBinding, error)
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      rbacv1.ServiceAccountKind,
-				Name:      cluster.Name,
+				Name:      utils.GetHeadGroupServiceAccountName(cluster),
 				Namespace: cluster.Namespace,
 			},
 		},

--- a/ray-operator/controllers/ray/common/rbac_test.go
+++ b/ray-operator/controllers/ray/common/rbac_test.go
@@ -1,0 +1,65 @@
+package common
+
+import (
+	"testing"
+
+	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuildRoleBindingSubjectName(t *testing.T) {
+	tests := map[string]struct {
+		input *rayiov1alpha1.RayCluster
+		want  string
+	}{
+		"Ray cluster with head group service account": {
+			input: &rayiov1alpha1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "raycluster-sample",
+					Namespace: "default",
+				},
+				Spec: rayiov1alpha1.RayClusterSpec{
+					HeadGroupSpec: rayiov1alpha1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								ServiceAccountName: "my-service-account",
+							},
+						},
+					},
+				},
+			},
+			want: "my-service-account",
+		},
+		"Ray cluster without head group service account": {
+			input: &rayiov1alpha1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "raycluster-sample",
+					Namespace: "default",
+				},
+				Spec: rayiov1alpha1.RayClusterSpec{
+					HeadGroupSpec: rayiov1alpha1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{},
+						},
+					},
+				},
+			},
+			want: "raycluster-sample",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			rb, err := BuildRoleBinding(tc.input)
+			assert.Nil(t, err)
+			got := rb.Subjects[0].Name
+			if got != tc.want {
+				t.Fatalf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -30,6 +30,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/utils/pointer"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -183,6 +184,14 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: saName, Namespace: "default"}, sa),
 				time.Second*15, time.Millisecond*500).Should(BeNil(), "My head group ServiceAccount = %v", saName)
+		})
+
+		It("should create the autoscaler K8s RoleBinding if it doesn't exist", func() {
+			rbName := myRayCluster.Name
+			rb := &rbacv1.RoleBinding{}
+			Eventually(
+				getResourceFunc(ctx, client.ObjectKey{Name: rbName, Namespace: myRayCluster.Namespace}, rb),
+				time.Second*15, time.Millisecond*500).Should(BeNil(), "autoscaler RoleBinding = %v", rbName)
 		})
 
 		It("should re-create a deleted worker", func() {


### PR DESCRIPTION
instead of always using RayCluster name. Default to RayCluster
name if the ServiceAccount doesn't exist.

This is a follow up fix after
https://github.com/ray-project/kuberay/pull/259 and
https://github.com/ray-project/kuberay/pull/276.

## Why are these changes needed?

The use case is when using the RayCluster autoscaler. The autoscaler
will use the head group's K8s ServiceAccount to make K8s API requests.
Always using the RayCluster name as the RoleBinding's subject name won't
be correct and will result in the autoscaler sidecar container not being
authorized by the K8s API.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
