### PR TITLE
Fix GPU-autofill for rayStartParams

### DIFF
--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -411,9 +411,9 @@ func concatenateContainerCommand(nodeType rayiov1alpha1.RayNodeType, rayStartPar
 	}
 
 	if _, ok := rayStartParams["num-gpus"]; !ok {
-		// Scan for resource keys ending with "/gpu" like "nvidia.com/gpu".
+		// Scan for resource keys ending with "gpu" like "nvidia.com/gpu".
 		for resourceKey, resource := range resource.Limits {
-			if strings.HasSuffix(string(resourceKey), "/gpu") && !resource.IsZero() {
+			if strings.HasSuffix(string(resourceKey), "gpu") && !resource.IsZero() {
 				rayStartParams["num-gpus"] = strconv.FormatInt(resource.Value(), 10)
 			}
 			// For now, only support one GPU type. Break on first match.

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -411,9 +411,13 @@ func concatenateContainerCommand(nodeType rayiov1alpha1.RayNodeType, rayStartPar
 	}
 
 	if _, ok := rayStartParams["num-gpus"]; !ok {
-		gpu := resource.Limits["gpu"]
-		if !gpu.IsZero() {
-			rayStartParams["num-gpus"] = strconv.FormatInt(gpu.Value(), 10)
+		// Scan for resource keys ending with "/gpu" like "nvidia.com/gpu".
+		for resourceKey, resource := range resource.Limits {
+			if strings.HasSuffix(string(resourceKey), "/gpu") && !resource.IsZero() {
+				rayStartParams["num-gpus"] = strconv.FormatInt(resource.Value(), 10)
+			}
+			// For now, only support one GPU type. Break on first match.
+			break
 		}
 	}
 

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -100,6 +100,11 @@ var instance = rayiov1alpha1.RayCluster{
 							{
 								Name:  "ray-worker",
 								Image: "rayproject/autoscaler",
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("3"),
+									},
+								},
 								Env: []v1.EnvVar{
 									{
 										Name: "MY_POD_IP",
@@ -274,7 +279,7 @@ func TestBuildPod(t *testing.T) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
 
-	expectedCommandArg := splitAndSort("ulimit -n 65536; ray start --block --num-cpus=1 --address=raycluster-sample-head-svc:6379 --port=6379 --redis-password=LetMeInRay --metrics-export-port=8080")
+	expectedCommandArg := splitAndSort("ulimit -n 65536; ray start --block --num-cpus=1 --num-gpus=3 --address=raycluster-sample-head-svc:6379 --port=6379 --redis-password=LetMeInRay --metrics-export-port=8080")
 	if !reflect.DeepEqual(expectedCommandArg, splitAndSort(pod.Spec.Containers[0].Args[0])) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedCommandArg, pod.Spec.Containers[0].Args[0])
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Closes https://github.com/ray-project/kuberay/issues/321

Fixes the logic that appends --num-gpus tp rayStartParams based on container resources.

The issue is that current logic looks for a resource named "gpu". However device plugins require extended resource names like "nvidia.com/gpu". 

This PR tweaks the logic so that we search for a resource key ending with ~~"/gpu"~~ "gpu".

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
