### PR TITLE
Tidy custom resources

### DIFF
--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -36,8 +36,8 @@ type HeadGroupSpec struct {
 	// RayCustomResources is a string-int map representing optional, user-specified custom resource
 	// capacities of Ray pods in this group.
 	// Equivalent to RayStartParams.resources, which must be specified as a json string.
-	// Disallowed keys: "GPU", "CPU", "memory".
-	RayCustomResources map[RayCustomResourceKey]int64 `json:"rayCustomResources,omitempty"`
+	// Disallowed keys: "GPU", "CPU", "memory", "object_store_memory".
+	RayCustomResources map[string]int64 `json:"rayCustomResources,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template is the eaxct pod template used in K8s depoyments, statefulsets, etc.
@@ -59,7 +59,7 @@ type WorkerGroupSpec struct {
 	// capacities of Ray pods in this group.
 	// Equivalent to RayStartParams.resources, which must be specified as a json string.
 	// Disallowed keys: "GPU", "CPU", "memory", "object_store_memory".
-	RayCustomResources map[RayCustomResourceKey]int64 `json:"rayCustomResources,omitempty"`
+	RayCustomResources map[string]int64 `json:"rayCustomResources,omitempty"`
 	// RayStartParams are the params of the start command: address, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template a pod template for the worker
@@ -67,10 +67,6 @@ type WorkerGroupSpec struct {
 	// ScaleStrategy defines which pods to remove
 	ScaleStrategy ScaleStrategy `json:"scaleStrategy,omitempty"`
 }
-
-// Disallow keys meant to be passed via other Ray Start parameters (--num-cpus and so on.)
-// +kubebuilder:validation:Pattern=`(?!^(CPU|GPU|memory|object_store_memory)$)`
-type RayCustomResourceKey string
 
 // ScaleStrategy to remove workers
 type ScaleStrategy struct {

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -33,6 +33,11 @@ type HeadGroupSpec struct {
 	// Number of desired pods in this pod group. This is a pointer to distinguish between explicit
 	// zero and not specified. Defaults to 1.
 	Replicas *int32 `json:"replicas"`
+	// RayCustomResources is a string-int map representing optional, user-specified custom resource
+	// capacities of Ray pods in this group.
+	// Equivalent to RayStartParams.resources, which must be specified as a json string.
+	// Disallowed keys: "GPU", "CPU", "memory".
+	RayCustomResources map[RayCustomResourceKey]int64 `json:"rayCustomResources,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template is the eaxct pod template used in K8s depoyments, statefulsets, etc.
@@ -50,6 +55,11 @@ type WorkerGroupSpec struct {
 	MinReplicas *int32 `json:"minReplicas"`
 	// MaxReplicas defaults to maxInt32
 	MaxReplicas *int32 `json:"maxReplicas"`
+	// RayCustomResources is a string-int map representing optional, user-specified custom resource
+	// capacities of Ray pods in this group.
+	// Equivalent to RayStartParams.resources, which must be specified as a json string.
+	// Disallowed keys: "GPU", "CPU", "memory", "object_store_memory".
+	RayCustomResources map[RayCustomResourceKey]int64 `json:"rayCustomResources,omitempty"`
 	// RayStartParams are the params of the start command: address, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template a pod template for the worker
@@ -57,6 +67,10 @@ type WorkerGroupSpec struct {
 	// ScaleStrategy defines which pods to remove
 	ScaleStrategy ScaleStrategy `json:"scaleStrategy,omitempty"`
 }
+
+// Disallow keys meant to be passed via other Ray Start parameters (--num-cpus and so on.)
+// +kubebuilder:validation:Pattern=`(?!^(CPU|GPU|memory|object_store_memory)$)`
+type RayCustomResourceKey string
 
 // ScaleStrategy to remove workers
 type ScaleStrategy struct {

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -36,7 +36,7 @@ type HeadGroupSpec struct {
 	// RayCustomResources is a string-int map representing optional, user-specified custom resource
 	// capacities of Ray pods in this group.
 	// Equivalent to RayStartParams.resources, which must be specified as a json string.
-	// Disallowed keys: "GPU", "CPU", "memory", "object_store_memory".
+	// Disallowed keys: "GPU", "CPU", "memory", "object_store_memory". Instead, use rayStartParams["num-cpus"] etc.
 	RayCustomResources map[string]int64 `json:"rayCustomResources,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
@@ -58,7 +58,7 @@ type WorkerGroupSpec struct {
 	// RayCustomResources is a string-int map representing optional, user-specified custom resource
 	// capacities of Ray pods in this group.
 	// Equivalent to RayStartParams.resources, which must be specified as a json string.
-	// Disallowed keys: "GPU", "CPU", "memory", "object_store_memory".
+	// Disallowed keys: "CPU", "GPU", "memory", "object_store_memory". Instead, use rayStartParams["num-cpus"] etc.
 	RayCustomResources map[string]int64 `json:"rayCustomResources,omitempty"`
 	// RayStartParams are the params of the start command: address, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -108,6 +108,13 @@ func (in *HeadGroupSpec) DeepCopyInto(out *HeadGroupSpec) {
 		in, out := &in.Replicas, &out.Replicas
 		*out = new(int32)
 		**out = **in
+	}
+	if in.RayCustomResources != nil {
+		in, out := &in.RayCustomResources, &out.RayCustomResources
+		*out = make(map[string]int64, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.RayStartParams != nil {
 		in, out := &in.RayStartParams, &out.RayStartParams
@@ -553,6 +560,13 @@ func (in *WorkerGroupSpec) DeepCopyInto(out *WorkerGroupSpec) {
 		in, out := &in.MaxReplicas, &out.MaxReplicas
 		*out = new(int32)
 		**out = **in
+	}
+	if in.RayCustomResources != nil {
+		in, out := &in.RayCustomResources, &out.RayCustomResources
+		*out = make(map[string]int64, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.RayStartParams != nil {
 		in, out := &in.RayStartParams, &out.RayStartParams

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -95,6 +95,13 @@ spec:
                     description: EnableIngress indicates whether operator should create
                       ingress object for head service or not.
                     type: boolean
+                  rayCustomResources:
+                    additionalProperties:
+                      format: int64
+                      type: integer
+                    description: RayCustomResources is a string-int map representing
+                      optional, user-specified custom resource capacit
+                    type: object
                   rayStartParams:
                     additionalProperties:
                       type: string
@@ -5493,6 +5500,13 @@ spec:
                       description: MinReplicas defaults to 1
                       format: int32
                       type: integer
+                    rayCustomResources:
+                      additionalProperties:
+                        format: int64
+                        type: integer
+                      description: RayCustomResources is a string-int map representing
+                        optional, user-specified custom resource capacit
+                      type: object
                     rayStartParams:
                       additionalProperties:
                         type: string

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -99,6 +99,13 @@ spec:
                         description: EnableIngress indicates whether operator should
                           create ingress object for head service or not.
                         type: boolean
+                      rayCustomResources:
+                        additionalProperties:
+                          format: int64
+                          type: integer
+                        description: RayCustomResources is a string-int map representing
+                          optional, user-specified custom resource capacit
+                        type: object
                       rayStartParams:
                         additionalProperties:
                           type: string
@@ -5732,6 +5739,13 @@ spec:
                           description: MinReplicas defaults to 1
                           format: int32
                           type: integer
+                        rayCustomResources:
+                          additionalProperties:
+                            format: int64
+                            type: integer
+                          description: RayCustomResources is a string-int map representing
+                            optional, user-specified custom resource capacit
+                          type: object
                         rayStartParams:
                           additionalProperties:
                             type: string

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -425,14 +425,15 @@ func concatenateContainerCommand(nodeType rayiov1alpha1.RayNodeType, rayStartPar
 		}
 	}
 
-	// Use optional rayCustomResources field to fill resources rayStartParam.
+	// Use optional rayCustomResources field to fill rayStartParams["resources"].
 	hasRayCustomResources := len(rayCustomResources) > 0
 	if _, ok := rayStartParams["resources"]; !ok && hasRayCustomResources {
 		customResourceBytes, err := json.Marshal(rayCustomResources)
-		if err == nil {
+		if err != nil {
 			log.Error(err, "Could not marshal rayCustomResources map.")
 		} else {
 			customResourceJSONString := string(customResourceBytes)
+			fmt.Println(shellescape.Quote(customResourceJSONString))
 			rayStartParams["resources"] = shellescape.Quote(customResourceJSONString)
 		}
 	}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -556,7 +556,7 @@ func (r *RayClusterReconciler) buildHeadPod(instance rayiov1alpha1.RayCluster) c
 	podName = utils.CheckName(podName) // making sure the name is valid
 	svcName := utils.GenerateServiceName(instance.Name)
 	podConf := common.DefaultHeadPodTemplate(instance, instance.Spec.HeadGroupSpec, podName, svcName)
-	pod := common.BuildPod(podConf, rayiov1alpha1.HeadNode, instance.Spec.HeadGroupSpec.RayStartParams, svcName, instance.Spec.EnableInTreeAutoscaling)
+	pod := common.BuildPod(podConf, rayiov1alpha1.HeadNode, instance.Spec.HeadGroupSpec.RayStartParams, instance.Spec.HeadGroupSpec.RayCustomResources, svcName, instance.Spec.EnableInTreeAutoscaling)
 	// Set raycluster instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&instance, &pod, r.Scheme); err != nil {
 		log.Error(err, "Failed to set controller reference for raycluster pod")
@@ -571,7 +571,7 @@ func (r *RayClusterReconciler) buildWorkerPod(instance rayiov1alpha1.RayCluster,
 	podName = utils.CheckName(podName) // making sure the name is valid
 	svcName := utils.GenerateServiceName(instance.Name)
 	podTemplateSpec := common.DefaultWorkerPodTemplate(instance, worker, podName, svcName)
-	pod := common.BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, svcName, instance.Spec.EnableInTreeAutoscaling)
+	pod := common.BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, worker.RayCustomResources, svcName, instance.Spec.EnableInTreeAutoscaling)
 	// Set raycluster instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&instance, &pod, r.Scheme); err != nil {
 		log.Error(err, "Failed to set controller reference for raycluster pod")

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -3,8 +3,8 @@ module github.com/ray-project/kuberay/ray-operator
 go 1.17
 
 require (
+	github.com/alessio/shellescape v1.4.1
 	github.com/go-logr/logr v1.2.0
-	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/orcaman/concurrent-map v1.0.0

--- a/ray-operator/go.sum
+++ b/ray-operator/go.sum
@@ -60,6 +60,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -329,8 +331,6 @@ github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
-github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
-github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

### Background

Closes https://github.com/ray-project/kuberay/issues/167

Ray start has a `resources` option which allows users to specify custom resource capacities for a Ray node.
Custom resources serve as hints to the Ray scheduler and autoscaler: If a Ray node has custom resource `{"BLAH": 10}`, you can schedule 10 tasks decorated with `@ray.remote(resources={"BLAH": 1})`. Attempting to schedule an 11th such task will cause the autoscaler to bring up another Ray node to accommodate the request.

One way to use the `resources` field in the context of KubeRay is described in https://github.com/ray-project/kuberay/issues/167:

> A use case for this might be to deploy a heterogenous cluster with multiple worker groups, where each worker group uses a different image packaged with different 3rd-party utilities. Some tasks that require specific utilities could then be marked as requiring such resource, and only execute on the workers that provide it.

### Problem

The value of `resources` must be supplied as a json string, which makes it awkward to specify correctly in a yaml file:
```
rayStartParams:
   resources: "'{\"customRes\": 1, \"anotherOne\": 2}'"
```

### Solution

To provide a more convenient interface, this PR introduces an optional map field `rayCustomResources`.

Before:
```
rayStartParams:
   resources: "'{\"customRes\": 1, \"anotherOne\": 2}'"
```

After:
```
rayCustomResources:
    customRes: 1
    anotherOne: 2
```

### Properties of the change in this PR

- Purely cosmetic. Simply allows specifying Ray custom resources as a map rather than as a carefully quoted/escaped JSON string.
  * We can consider deeper integration with K8s extended resources later.
- Backwards-compatible -- specifying rayStartParams["resources"] will continue to work.

An upcoming Ray PR would update the autoscaler to read the newly introduced field when determining node resource capacities.

### Note on CPU/GPU/memory

The `resources` option for `ray start` does not support the keys `CPU`, `GPU`, or `memory`. These fields are inferred from the container spec and can be overridden with the optional `ray start` parameters `num-cpus`, `num-gpus`, `memory`.

Attempting to supply keys `CPU`, `GPU`, or `memory` to `resources` will cause Ray start to fail with an error message telling the user not to do that.

I considered adding CRD validation to exclude these keys. However, Kubernetes does not support "patternProperties" in CRDs -- you can't use a regex to restrict the keys of a map/object. A potential workaround would be to use a list of `key`, `value` pairs and add validation for `key`. However, that would make the interface and the code more complicated. 

We already do some validation of rayStartParams in the operator code. 
TODO in a follow-up PR: Validate absence of `CPU`, `GPU`, `memory` keys in the same spot, after https://github.com/ray-project/kuberay/pull/334 is merged.

### Autoscaler

A follow-up Ray PR would have the autoscaler consider the `rayCustomResources` field when determining resource capacities.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/kuberay/issues/167

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
