### PR TITLE
Support KubeRay management labels

### DIFF
--- a/apiserver/deploy/base/apiserver.yaml
+++ b/apiserver/deploy/base/apiserver.yaml
@@ -2,21 +2,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kuberay-apiserver
-  labels:
-    control-plane: kuberay-apiserver
 spec:
   selector:
     matchLabels:
-      control-plane: kuberay-apiserver
+      app.kubernetes.io/name: kuberay
+      app.kubernetes.io/component: kuberay-apiserver
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: kuberay-apiserver
+        app.kubernetes.io/name: kuberay
+        app.kubernetes.io/component: kuberay-apiserver
     spec:
       serviceAccountName: kuberay-apiserver
       containers:
-      - name: kuberay-apiserver-container
+      - name: kuberay-apiserver
         image: kuberay/apiserver
         ports:
         - containerPort: 8888
@@ -28,13 +28,12 @@ spec:
           requests:
             cpu: 300m
             memory: 300Mi
+
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: kuberay-apiserver-service
-  labels:
-    control-plane: kuberay-apiserver
+  name: kuberay-apiserver
   annotations:
     prometheus.io/path: /metrics
     prometheus.io/scrape: "true"
@@ -42,7 +41,8 @@ metadata:
 spec:
   type: NodePort
   selector:
-    control-plane: kuberay-apiserver
+    app.kubernetes.io/name: kuberay
+    app.kubernetes.io/component: kuberay-apiserver
   ports:
     - name: http
       port: 8888
@@ -57,16 +57,12 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    control-plane: kuberay-apiserver
   name: kuberay-apiserver
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  labels:
-    control-plane: kuberay-apiserver
   name: kuberay-apiserver
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -81,8 +77,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    control-plane: kuberay-apiserver
   name: kuberay-apiserver
 rules:
 - apiGroups:

--- a/apiserver/deploy/base/kustomization.yaml
+++ b/apiserver/deploy/base/kustomization.yaml
@@ -5,3 +5,7 @@ namespace: ray-system
 
 resources:
 - apiserver.yaml
+
+commonLabels:
+  app.kubernetes.io/name: kuberay
+  app.kubernetes.io/component: kuberay-apiserver

--- a/ray-operator/config/manager/kustomization.yaml
+++ b/ray-operator/config/manager/kustomization.yaml
@@ -4,3 +4,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+commonLabels:
+  app.kubernetes.io/name: kuberay
+  app.kubernetes.io/component: kuberay-operator

--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -4,16 +4,19 @@ metadata:
   name: kuberay-operator
   namespace: system
   labels:
-    control-plane: kuberay-operator
+    app.kubernetes.io/name: kuberay
+    app.kubernetes.io/component: kuberay-operator
 spec:
   selector:
     matchLabels:
-      control-plane: kuberay-operator
+      app.kubernetes.io/name: kuberay
+      app.kubernetes.io/component: kuberay-operator
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: kuberay-operator
+        app.kubernetes.io/name: kuberay
+        app.kubernetes.io/component: kuberay-operator
     spec:
       securityContext:
         runAsNonRoot: true
@@ -28,7 +31,7 @@ spec:
         - name: http
           containerPort: 8080
           protocol: TCP
-        name: ray-manager
+        name: kuberay-operator
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/ray-operator/config/manager/service.yaml
+++ b/ray-operator/config/manager/service.yaml
@@ -6,7 +6,8 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8080"
   labels:
-    control-plane: kuberay-operator
+    app.kubernetes.io/name: kuberay
+    app.kubernetes.io/component: kuberay-operator
   name: kuberay-operator
 spec:
   ports:
@@ -14,5 +15,6 @@ spec:
       port: 8080
       targetPort: 8080
   selector:
-    control-plane: kuberay-operator
+    app.kubernetes.io/name: kuberay
+    app.kubernetes.io/component: kuberay-operator
   type: ClusterIP

--- a/ray-operator/config/rbac/kustomization.yaml
+++ b/ray-operator/config/rbac/kustomization.yaml
@@ -4,3 +4,7 @@ resources:
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 - service_account.yaml
+
+commonLabels:
+  app.kubernetes.io/name: kuberay
+  app.kubernetes.io/component: kuberay-operator

--- a/ray-operator/config/rbac/role.yaml
+++ b/ray-operator/config/rbac/role.yaml
@@ -3,7 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: kuberay-operator
 rules:
 - apiGroups:

--- a/ray-operator/config/rbac/service_account.yaml
+++ b/ray-operator/config/rbac/service_account.yaml
@@ -1,6 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    control-plane: kuberay-operator
   name: kuberay-operator


### PR DESCRIPTION
We follow the best practice of https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/ and add following labels to better help filter and managed resources in Kubernetes
- app.kubernetes.io/name
- app.kubernetes.io/component

## Why are these changes needed?

These labels are needed to better manage resource in kubernetes especially the namespace is used for multiple types of workloads. Without the change, it's not that easy to filter and list the target components.

## Related issue number
#338 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
