### PR TITLE
Make replicas optional for the head spec.

### DIFF
--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -30,7 +30,7 @@ type HeadGroupSpec struct {
 	ServiceType v1.ServiceType `json:"serviceType"`
 	// EnableIngress indicates whether operator should create ingress object for head service or not.
 	EnableIngress *bool `json:"enableIngress,omitempty"`
-	// HeadGroupSpec.Replicas is deprecated and ignored; there can only be one head pod.
+	// HeadGroupSpec.Replicas is deprecated and ignored; there can only be one head pod per Ray cluster.
 	Replicas *int32 `json:"replicas,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -30,7 +30,7 @@ type HeadGroupSpec struct {
 	ServiceType v1.ServiceType `json:"serviceType"`
 	// EnableIngress indicates whether operator should create ingress object for head service or not.
 	EnableIngress *bool `json:"enableIngress,omitempty"`
-	// HeadGroupSpec. Replicas is deprecated and ignored; there can only be one head pod.
+	// HeadGroupSpec.Replicas is deprecated and ignored; there can only be one head pod.
 	Replicas *int32 `json:"replicas,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -30,8 +30,7 @@ type HeadGroupSpec struct {
 	ServiceType v1.ServiceType `json:"serviceType"`
 	// EnableIngress indicates whether operator should create ingress object for head service or not.
 	EnableIngress *bool `json:"enableIngress,omitempty"`
-	// Number of desired pods in this pod group. This is a pointer to distinguish between explicit
-	// zero and not specified. Defaults to 1.
+	// HeadGroupSpec. Replicas is deprecated and ignored; there can only be one head pod.
 	Replicas *int32 `json:"replicas,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -32,7 +32,7 @@ type HeadGroupSpec struct {
 	EnableIngress *bool `json:"enableIngress,omitempty"`
 	// Number of desired pods in this pod group. This is a pointer to distinguish between explicit
 	// zero and not specified. Defaults to 1.
-	Replicas *int32 `json:"replicas"`
+	Replicas *int32 `json:"replicas,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template is the eaxct pod template used in K8s depoyments, statefulsets, etc.

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -102,7 +102,7 @@ spec:
                       node-manager-port, object-store-memory, ...'
                     type: object
                   replicas:
-                    description: HeadGroupSpec. Replicas is deprecated and ignored;
+                    description: HeadGroupSpec.Replicas is deprecated and ignored;
                       there can only be one head pod.
                     format: int32
                     type: integer

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -103,7 +103,7 @@ spec:
                     type: object
                   replicas:
                     description: HeadGroupSpec.Replicas is deprecated and ignored;
-                      there can only be one head pod.
+                      there can only be one head pod per Ray cluster.
                     format: int32
                     type: integer
                   serviceType:

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -102,7 +102,8 @@ spec:
                       node-manager-port, object-store-memory, ...'
                     type: object
                   replicas:
-                    description: Number of desired pods in this pod group.
+                    description: HeadGroupSpec. Replicas is deprecated and ignored;
+                      there can only be one head pod.
                     format: int32
                     type: integer
                   serviceType:
@@ -5468,7 +5469,6 @@ spec:
                     type: object
                 required:
                 - rayStartParams
-                - replicas
                 - serviceType
                 - template
                 type: object

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -106,7 +106,7 @@ spec:
                           node-manager-port, object-store-memory, ...'
                         type: object
                       replicas:
-                        description: HeadGroupSpec. Replicas is deprecated and ignored;
+                        description: HeadGroupSpec.Replicas is deprecated and ignored;
                           there can only be one head pod.
                         format: int32
                         type: integer

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -106,7 +106,8 @@ spec:
                           node-manager-port, object-store-memory, ...'
                         type: object
                       replicas:
-                        description: Number of desired pods in this pod group.
+                        description: HeadGroupSpec. Replicas is deprecated and ignored;
+                          there can only be one head pod.
                         format: int32
                         type: integer
                       serviceType:
@@ -5707,7 +5708,6 @@ spec:
                         type: object
                     required:
                     - rayStartParams
-                    - replicas
                     - serviceType
                     - template
                     type: object

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -107,7 +107,7 @@ spec:
                         type: object
                       replicas:
                         description: HeadGroupSpec.Replicas is deprecated and ignored;
-                          there can only be one head pod.
+                          there can only be one head pod per Ray cluster.
                         format: int32
                         type: integer
                       serviceType:

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -58,7 +58,6 @@ var _ = Context("Inside the default namespace", func() {
 			EnableInTreeAutoscaling: &enableInTreeAutoscaling,
 			HeadGroupSpec: rayiov1alpha1.HeadGroupSpec{
 				ServiceType: "ClusterIP",
-				Replicas:    pointer.Int32Ptr(1),
 				RayStartParams: map[string]string{
 					"port":                "6379",
 					"object-manager-port": "12345",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

A Ray cluster only supports one head pod.
Accordingly, the KubeRay operator ignores headGroupSpec.Replicas and creates exactly one head pod.

To match this operator behavior and simplify configuration, this PR makes headGroupSpec.Replicas optional and labels the field as deprecated.

We might have anticipated HA or FT features might be implemented via multiple heads, but that's not the route we're going down.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
