### PR TITLE
Validate namespace consistency in the request when creating the cluster and the compute template 

### DIFF
--- a/apiserver/pkg/server/cluster_server.go
+++ b/apiserver/pkg/server/cluster_server.go
@@ -141,6 +141,10 @@ func ValidateCreateClusterRequest(request *api.CreateClusterRequest) error {
 		return util.NewInvalidInputError("Namespace is empty. Please specify a valid value.")
 	}
 
+	if request.Namespace != request.Cluster.Namespace {
+		return util.NewInvalidInputError("The namespace in the request is different from the namespace in the cluster definition.")
+	}
+
 	if request.Cluster.Name == "" {
 		return util.NewInvalidInputError("Cluster name is empty. Please specify a valid value.")
 	}

--- a/apiserver/pkg/server/compute_template_server.go
+++ b/apiserver/pkg/server/compute_template_server.go
@@ -103,6 +103,10 @@ func ValidateCreateComputeTemplateRequest(request *api.CreateComputeTemplateRequ
 		return util.NewInvalidInputError("Namespace is empty. Please specify a valid value.")
 	}
 
+	if request.Namespace != request.ComputeTemplate.Namespace {
+		return util.NewInvalidInputError("The namespace in the request is different from the namespace defined in the compute template.")
+	}
+
 	if request.ComputeTemplate.Name == "" {
 		return util.NewInvalidInputError("Compute template name is empty. Please specify a valid value.")
 	}


### PR DESCRIPTION
Added a validation for cluster request to make sure the namespace in the request is same as the one defined in the Ray cluster.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
