### PR TITLE
fix flaky test issue

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -211,16 +211,16 @@ var _ = Context("Inside the default namespace", func() {
 
 		It("should update a raycluster object deleting a random pod", func() {
 			// adding a scale down
-			Eventually(
-				getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),
-				time.Second*9, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
-			rep := new(int32)
-			*rep = 2
-			myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = rep
-
-			// Operator may update revision after we get cluster earlier. Update may result in 409 conflict error.
-			// We need to handle conflict error and retry the update.
 			err := retryOnOldRevision(DefaultAttempts, DefaultSleepDurationInSeconds, func() error {
+				Eventually(
+					getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),
+					time.Second*9, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
+				rep := new(int32)
+				*rep = 2
+				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = rep
+
+				// Operator may update revision after we get cluster earlier. Update may result in 409 conflict error.
+				// We need to handle conflict error and retry the update.
 				return k8sClient.Update(ctx, myRayCluster)
 			})
 


### PR DESCRIPTION

## Why are these changes needed?

this PR fixed the flaky test issue. The root cause is that the RayCluster object gets updated in the middle of the test so we have to get the latest RayCluster object and try it again.

## Related issue number

#133

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [X] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
