### PR TITLE
Update autoscaler image

### DIFF
--- a/docs/guidance/autoscaler.md
+++ b/docs/guidance/autoscaler.md
@@ -75,7 +75,7 @@ Demands:
       enableInTreeAutoscaling: true
     ```
 
-2. The autoscaler image is `rayproject/ray:836b08` which reflects the latest changes from [Ray PR #24718](https://github.com/ray-project/ray/pull/24718/files) in the master branch.
+2. The autoscaler image is `rayproject/ray:7d3ceb` which reflects the latest changes from the Ray master branch.
 
 3. Autoscaling functionality is supported only with Ray versions at least as new as 1.11.0. The autoscaler image used
 is compatible with all Ray versions >= 1.11.0.

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -186,8 +186,8 @@ func BuildAutoscalerContainer() v1.Container {
 	container := v1.Container{
 		Name: AutoscalerContainerName,
 		// TODO: choose right version based on instance.spec.Version
-		// The currently used image reflects changes up to https://github.com/ray-project/ray/pull/24718
-		Image:           "rayproject/ray:836b08",
+		// The currently used image reflects the latest changes from Ray master.
+		Image:           "rayproject/ray:7d3ceb",
 		ImagePullPolicy: v1.PullAlways,
 		Env: []v1.EnvVar{
 			{

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -181,7 +181,7 @@ var volumeMountsWithAutoscaler = []v1.VolumeMount{
 
 var autoscalerContainer = v1.Container{
 	Name:            "autoscaler",
-	Image:           "rayproject/ray:836b08",
+	Image:           "rayproject/ray:7d3ceb",
 	ImagePullPolicy: v1.PullAlways,
 	Env: []v1.EnvVar{
 		{


### PR DESCRIPTION
Update the autoscaler images reflect the latest changes, mitigate user issues.
After the upcoming release, we will no longer need to make these updates -- autoscaler images will be matched to Ray images.