### PR TITLE
[Bug] Fix raycluster updatestatus list wrong label

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -627,7 +627,7 @@ func (r *RayClusterReconciler) SetupWithManager(mgr ctrl.Manager, reconcileConcu
 
 func (r *RayClusterReconciler) updateStatus(instance *rayiov1alpha1.RayCluster) error {
 	runtimePods := corev1.PodList{}
-	filterLabels := client.MatchingLabels{"rayClusterName": instance.Name}
+	filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name}
 	if err := r.List(context.TODO(), &runtimePods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 		return err
 	}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -219,6 +219,10 @@ func GetHeadGroupServiceAccountName(cluster *rayiov1alpha1.RayCluster) string {
 
 // CheckAllPodsRunnning check if all pod in a list is running
 func CheckAllPodsRunnning(runningPods corev1.PodList) bool {
+	// check if there is no pods.
+	if len(runningPods.Items) == 0 {
+		return false
+	}
 	for _, pod := range runningPods.Items {
 		if pod.Status.Phase != corev1.PodRunning {
 			return false

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -33,6 +33,25 @@ func TestStatus(t *testing.T) {
 	}
 }
 
+func TestCheckAllPodsRunnning(t *testing.T) {
+	pods := []corev1.Pod{
+		*createSomePod(),
+		*createSomePod(),
+	}
+	pods[0].Status.Phase = corev1.PodPending
+	pods[1].Status.Phase = corev1.PodRunning
+	podList1 := corev1.PodList{
+		Items: pods,
+	}
+	if CheckAllPodsRunnning(podList1) {
+		t.Fail()
+	}
+	podList2 := corev1.PodList{}
+	if CheckAllPodsRunnning(podList2) {
+		t.Fail()
+	}
+}
+
 func TestCheckName(t *testing.T) {
 	// test 1 -> change
 	str := "72fbcc7e-a661-4b18e-ca41-e903-fc3ae634b18e-lazer090scholar-director-s"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The updateStatus method in reconcile was using wrong labels for the pods scraping.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
