### PR TITLE
Add the support to replace evicted head pod

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -268,6 +268,12 @@ func (r *RayClusterReconciler) reconcilePods(instance *rayiov1alpha1.RayCluster)
 		log.Info("reconcilePods ", "head pod found", headPod.Name)
 		if headPod.Status.Phase == corev1.PodRunning || headPod.Status.Phase == corev1.PodPending {
 			log.Info("reconcilePods", "head pod is up and running... checking workers", headPod.Name)
+		} else if headPod.Status.Phase == corev1.PodFailed && strings.Contains(headPod.Status.Reason, "Evicted") {
+			// Handle evicted pod
+			log.Info("reconcilePods", "head pod has been evicted and controller needs to replace the pod", headPod.Name)
+			if err := r.Delete(context.TODO(), &headPod); err != nil {
+				return err
+			}
 		} else {
 			return fmt.Errorf("head pod %s is not running nor pending", headPod.Name)
 		}


### PR DESCRIPTION
## Why are these changes needed?

Currently, operator doesn't handle the failed pods. When pod is evicted, it just raise error and operator keeps requeue the item.  From user journey side, we actually like to replace the head pod with a healthy one.  This change catch the evict pod and delete it in the current loop, the next reconcile loop triggered by pod deletion will find the head missing and create a new pod instead.

## Related issue number

https://github.com/ray-project/kuberay/issues/372

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
