### PR TITLE
Update Ray cluster status

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -627,10 +627,14 @@ func (r *RayClusterReconciler) updateStatus(instance *rayiov1alpha1.RayCluster) 
 	}
 	// only in invalid status that we update the status to unhealthy.
 	if !isValid {
-		instance.Status.State = rayiov1alpha1.Unhealthy
+		if updateErr := r.updateClusterState(instance, rayiov1alpha1.Unhealthy); updateErr != nil {
+			log.Error(updateErr, "RayCluster update state error", "cluster name", instance.Name)
+		}
 	} else {
 		if utils.CheckAllPodsRunnning(runtimePods) {
-			instance.Status.State = rayiov1alpha1.Ready
+			if updateErr := r.updateClusterState(instance, rayiov1alpha1.Ready); updateErr != nil {
+				log.Error(updateErr, "RayCluster update state error", "cluster name", instance.Name)
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

## Why are these changes needed?

Use `updateClusterState()` to update the cluster state. Otherwise, the status will be empty when running `kubectl describe RayCluster ...`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
