### PR TITLE
[autoscaler] Make log file mount path more specific.

### DIFF
--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -45,10 +45,12 @@ spec:
                   Important: Run "make" to regenerate code af'
                 type: string
               jobId:
+                description: If jobId is not set, a new jobId will be auto-generated.
                 type: string
               metadata:
                 additionalProperties:
                   type: string
+                description: Metadata is data to store along with this job.
                 type: object
               rayClusterSpec:
                 description: 'EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -97,7 +99,7 @@ spec:
                             type: object
                         type: object
                       upscalingMode:
-                        description: UpscalineMode is "Default" or "Aggressive.
+                        description: UpscalingMode is "Default" or "Aggressive.
                         enum:
                         - Default
                         - Aggressive
@@ -122,7 +124,8 @@ spec:
                           node-manager-port, object-store-memory, ...'
                         type: object
                       replicas:
-                        description: Number of desired pods in this pod group.
+                        description: HeadGroupSpec.Replicas is deprecated and ignored;
+                          there can only be one head pod per Ray cluster.
                         format: int32
                         type: integer
                       serviceType:
@@ -5723,7 +5726,6 @@ spec:
                         type: object
                     required:
                     - rayStartParams
-                    - replicas
                     - serviceType
                     - template
                     type: object
@@ -11491,6 +11493,8 @@ spec:
                 description: RuntimeEnv is base64 encoded.
                 type: string
               shutdownAfterJobFinishes:
+                description: 'TODO: If set to true, the rayCluster will be deleted
+                  after the rayJob finishes'
                 type: boolean
             required:
             - entrypoint

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -22,7 +22,7 @@ const (
 	SharedMemoryVolumeName      = "shared-mem"
 	SharedMemoryVolumeMountPath = "/dev/shm"
 	RayLogVolumeName            = "ray-logs"
-	RayLogVolumeMountPath       = "/tmp/ray"
+	RayLogVolumeMountPath       = "/tmp/ray/session_latest/logs"
 	AutoscalerContainerName     = "autoscaler"
 	RayHeadContainer            = "ray-head"
 	ObjectStoreMemoryKey        = "object-store-memory"

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -174,7 +174,7 @@ var volumeMountsWithAutoscaler = []v1.VolumeMount{
 	},
 	{
 		Name:      "ray-logs",
-		MountPath: "/tmp/ray",
+		MountPath: "/tmp/ray/session_latest/logs",
 		ReadOnly:  false,
 	},
 }
@@ -223,7 +223,7 @@ var autoscalerContainer = v1.Container{
 	},
 	VolumeMounts: []v1.VolumeMount{
 		{
-			MountPath: "/tmp/ray",
+			MountPath: "/tmp/ray/session_latest/logs",
 			Name:      "ray-logs",
 		},
 	},


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Should resolve https://github.com/ray-project/ray/issues/26064, where users report the autoscaler crash-looping due to a missing log directory.

Gives the shared log mount configured by the KubeRay operator for Ray logs a more specific path.
(This log mount was introduced in https://github.com/ray-project/kuberay/pull/274)

Previously the path was `/tmp/ray`. Instead, we should use `/tmp/ray/session_latest/logs`, which is where Ray and the autoscaler would like to write logs.

By using the more specific path, we ensure that the path will exist on container startup, preventing the file-not-found issues described in https://github.com/ray-project/ray/issues/26064.

Ray attempts to create this directory with `os.makedirs(path, exist_ok=True)`, so this should not interfere with Ray. (Obviously, this will be confirmed by the tests.)

To be extra safe, I'll go ahead and make the autoscaler also `os.makedirs(path, exist_ok=True)`: https://github.com/ray-project/ray/pull/26748

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
