### PR TITLE
improve test stability

### DIFF
--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -59,14 +59,14 @@ fumpt: gofumpt
 	$(GOFUMPT) -l -w ../
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: manifests generate fmt vet fumpt ## Run tests.
+test: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
 
 ##@ Build
 
-build: generate fmt vet fumpt ## Build manager binary.
+build: generate fmt vet ## Build manager binary.
 	go build                                    \
     -ldflags                                    \
     "                                           \
@@ -75,7 +75,7 @@ build: generate fmt vet fumpt ## Build manager binary.
     "                                           \
     -o bin/manager main.go
 
-run: manifests generate fmt vet fumpt ## Run a controller from your host.
+run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-image: ## Build image only

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -71,14 +71,14 @@ const (
 	DefaultReadinessProbeTimeoutSeconds      = 0
 	DefaultReadinessProbePeriodSeconds       = 0
 	DefaultReadinessProbeSuccessThreshold    = 0
-	DefaultReadinessProbeFailureThreshold    = 15
+	DefaultReadinessProbeFailureThreshold    = 20
 
 	// Ray HA default liveness probe values
 	DefaultLivenessProbeInitialDelaySeconds = 10
 	DefaultLivenessProbeTimeoutSeconds      = 0
 	DefaultLivenessProbePeriodSeconds       = 0
 	DefaultLivenessProbeSuccessThreshold    = 0
-	DefaultLivenessProbeFailureThreshold    = 30
+	DefaultLivenessProbeFailureThreshold    = 40
 
 	// Ray health check related configurations
 	RayAgentRayletHealthPath  = "api/local_raylet_healthz"

--- a/tests/config/ray-cluster.ray-ha.yaml.template
+++ b/tests/config/ray-cluster.ray-ha.yaml.template
@@ -106,6 +106,12 @@ spec:
                 name: dashboard
               - containerPort: 10001
                 name: client
+            livenessProbe:
+              initialDelaySeconds: 30
+              failureThreshold: 200
+            readinessProbe:
+              initialDelaySeconds: 30
+              failureThreshold: 120
   workerGroupSpecs:
     # the pod replicas in this group typed worker
     - replicas: 2
@@ -162,6 +168,12 @@ spec:
                   cpu: "1"
                 requests:
                   cpu: "200m"
+              livenessProbe:
+                initialDelaySeconds: 30
+                failureThreshold: 200
+              readinessProbe:
+                initialDelaySeconds: 30
+                failureThreshold: 120
           volumes:
             - name: log-volume
               emptyDir: {}


### PR DESCRIPTION
## Why are these changes needed?

1. improve compatibility test stability by increasing the initial wait time in liveness/readiness probe.
2. remove unnecessary gofumpt run in Makefile.

## Related issue number

N/A

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
