### PR TITLE
[minor] Add client and dashboard ports to ports in example configs.

### DIFF
--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -80,6 +80,11 @@ spec:
                 fieldPath: status.podIP
           ports:
           - containerPort: 6379
+            name: gcs
+          - containerPort: 8265
+            name: dashboard
+          - containerPort: 10001
+            name: client
           lifecycle:
             preStop:
               exec:

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -68,6 +68,11 @@ spec:
                 fieldPath: status.podIP
           ports:
           - containerPort: 6379
+            name: gcs
+          - containerPort: 8265
+            name: dashboard
+          - containerPort: 10001
+            name: client
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

These ports should be exposed by the Ray head service by default.

For now, this PR adds the container ports to the `raycluster.complete` and `raycluster.autoscaler` example files, so that the service configured for these examples exposes the relevant ports.

My main motivation right now is documenting Ray Cluster interaction methods in the Ray docs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
