### PR TITLE
Expose swallowed detail error messages

### DIFF
--- a/apiserver/pkg/interceptor/interceptor.go
+++ b/apiserver/pkg/interceptor/interceptor.go
@@ -14,7 +14,6 @@ func ApiServerInterceptor(ctx context.Context, req interface{}, info *grpc.Unary
 	klog.Infof("%v handler starting", info.FullMethod)
 	resp, err = handler(ctx, req)
 	if err != nil {
-		// TODO: handle errors
 		klog.Warning(err)
 	}
 	klog.Infof("%v handler finished", info.FullMethod)

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -219,11 +219,15 @@ func (e *UserError) String() string {
 		e.internalError)
 }
 
+func (e *UserError) ErrorStringWithoutStackTrace() string {
+	return fmt.Sprintf("%v: %v", e.externalMessage, e.internalError)
+}
+
 // GRPCStatus implements `GRPCStatus` to make sure `FromError` in grpc-go can honor the code.
 // Otherwise, it will always return codes.Unknown(2).
 // https://github.com/grpc/grpc-go/blob/2c0949c22d46095edc579d9e66edcd025192b98c/status/status.go#L91-L92
 func (e *UserError) GRPCStatus() *status.Status {
-	return status.New(e.externalStatusCode, e.externalMessage)
+	return status.New(e.externalStatusCode, e.ErrorStringWithoutStackTrace())
 }
 
 func (e *UserError) wrapf(format string, args ...interface{}) *UserError {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

![image](https://user-images.githubusercontent.com/4739316/181379793-a48d8c70-5227-4022-ab38-a13adface35f.png)

Current response doesn't give any detail clues on the failure

![image](https://user-images.githubusercontent.com/4739316/181379785-e3e1b3a8-d82f-4b41-9673-985bd5d0a9c8.png)

Detail logs are swallowed due to previous `GetStatus` change. I add them back now. 


## Related issue number

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
