### PR TITLE
[Autoscaler] Match autoscaler image to Ray head image for Ray >= 2.0.0

### DIFF
--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -26,7 +26,7 @@ spec:
     # idleTimeoutSeconds is the number of seconds to wait before scaling down a worker pod which is not using Ray resources.
     idleTimeoutSeconds: 60
     # image optionally overrides the autoscaler's container image.
-    # If instance.spec.rayVersion is at least "2.0.0", the autoscaler will use the same image as
+    # If instance.spec.rayVersion is at least "2.0.0", the autoscaler will default to the same image as
     # the ray container by default. For older Ray versions, the autoscaler will default to using the Ray 2.0.0 image.
     ## image: "my-repo/my-custom-autoscaler-image:tag"
     # imagePullPolicy optionally overrides the autoscaler container's image pull policy.

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -26,7 +26,9 @@ spec:
     # idleTimeoutSeconds is the number of seconds to wait before scaling down a worker pod which is not using Ray resources.
     idleTimeoutSeconds: 60
     # image optionally overrides the autoscaler's container image.
-    image: "rayproject/ray:0860dd"
+    # If instance.spec.rayVersion is at least "2.0.0", the autoscaler will use the same image as
+    # the ray container by default. For older Ray versions, the autoscaler will default to using the Ray 2.0.0 image.
+    ## image: "my-repo/my-custom-autoscaler-image:tag"
     # imagePullPolicy optionally overrides the autoscaler container's image pull policy.
     imagePullPolicy: Always
     # resources specifies optional resource request and limit overrides for the autoscaler container.

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -92,6 +92,9 @@ const (
 	// Ray health check related configurations
 	RayAgentRayletHealthPath  = "api/local_raylet_healthz"
 	RayDashboardGCSHealthPath = "api/gcs_healthz"
+
+	// Default autoscaler image when running Ray at versions older than 2.0.0
+	FallbackDefaultAutoscalerImage = "rayproject/ray:2.0.0"
 )
 
 type ServiceType string

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -178,8 +178,7 @@ func autoscalerSupportIsStable(rayVersion string) bool {
 	if parsedMajorVersion {
 		return majorVersion >= 2
 	} else {
-		// The rayVersion field is not currently validated. If in doubt, just assume that
-		// the Ray version is >= 2.0.0, so that we use the Ray image to run the autoscaler.
+		// If in doubt, just assume that the Ray version is >= 2.0.0, so that we use the Ray image to run the autoscaler.
 		// Users can always override the operator's choice of image with autoscalerOptions.Image.
 		return true
 	}
@@ -280,7 +279,7 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayiov1alpha1.RayN
 		ObjectMeta: podTemplateSpec.ObjectMeta,
 		Spec:       podTemplateSpec.Spec,
 	}
-	rayContainerIndex := getRayContainerIndex(pod)
+	rayContainerIndex := getRayContainerIndex(pod.Spec)
 
 	// Add /dev/shm volumeMount for the object store to avoid performance degradation.
 	addEmptyDir(&pod.Spec.Containers[rayContainerIndex], &pod, SharedMemoryVolumeName, SharedMemoryVolumeMountPath, v1.StorageMediumMemory)

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -111,8 +111,13 @@ func DefaultHeadPodTemplate(instance rayiov1alpha1.RayCluster, headSpec rayiov1a
 		// set custom service account with proper roles bound.
 		podTemplate.Spec.ServiceAccountName = utils.GetHeadGroupServiceAccountName(&instance)
 
+		rayContainerIndex := getRayContainerIndex(podTemplate.Spec)
+		rayImage := podTemplate.Spec.Containers[rayContainerIndex].Image
+		// determine the default image to use for the Ray container
+		// (the image is subject to user override from autoscalerOptions.image)
+		autoscalerImage := getAutoscalerImage(instance.Spec.RayVersion, rayImage)
 		// inject autoscaler container into head pod
-		autoscalerContainer := BuildAutoscalerContainer()
+		autoscalerContainer := BuildAutoscalerContainer(autoscalerImage)
 		// Merge the user overrides from autoscalerOptions into the autoscaler container config.
 		mergeAutoscalerOverrides(&autoscalerContainer, instance.Spec.AutoscalerOptions)
 		podTemplate.Spec.Containers = append(podTemplate.Spec.Containers, autoscalerContainer)
@@ -137,6 +142,47 @@ func DefaultHeadPodTemplate(instance rayiov1alpha1.RayCluster, headSpec rayiov1a
 	}
 
 	return podTemplate
+}
+
+// getAutoscalerImage determines the default autoscaler image
+func getAutoscalerImage(rayImage string, rayVersion string) string {
+	if autoscalerSupportIsStable(rayVersion) {
+		// For Ray versions >= 2.0.0 use the Ray image to run the autoscaler.
+		return rayImage
+	} else {
+		// For older Ray versions, use the Ray 2.0.0 image to run the autoscaler.
+		return FallbackDefaultAutoscalerImage
+	}
+}
+
+// Determine if autoscaler support is stable in the given rayVersion.
+// Return false exactly when the major version is successfully parsed and less than 2.
+// Example rayVersion inputs that return true: "2.0.0", "2.0", "nightly", "latest", "unknown".
+// Example inputs that return false: "1.13.0", "1.12".
+func autoscalerSupportIsStable(rayVersion string) bool {
+	var majorVersion int
+	var parsedMajorVersion bool
+	firstDotIndex := strings.Index(rayVersion, ".")
+	if firstDotIndex == -1 {
+		parsedMajorVersion = false
+	} else {
+		majorVersionString := rayVersion[:firstDotIndex]
+		if versionInt, err := strconv.Atoi(majorVersionString); err == nil {
+			parsedMajorVersion = true
+			majorVersion = versionInt
+		} else {
+			parsedMajorVersion = false
+		}
+	}
+
+	if parsedMajorVersion {
+		return majorVersion >= 2
+	} else {
+		// The rayVersion field is not currently validated. If in doubt, just assume that
+		// the Ray version is >= 2.0.0, so that we use the Ray image to run the autoscaler.
+		// Users can always override the operator's choice of image with autoscalerOptions.Image.
+		return true
+	}
 }
 
 // DefaultWorkerPodTemplate sets the config values
@@ -327,12 +373,10 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayiov1alpha1.RayN
 }
 
 // BuildAutoscalerContainer builds a Ray autoscaler container which can be appended to the head pod.
-func BuildAutoscalerContainer() v1.Container {
+func BuildAutoscalerContainer(autoscalerImage string) v1.Container {
 	container := v1.Container{
-		Name: AutoscalerContainerName,
-		// TODO: choose right version based on instance.spec.Version
-		// The currently used image reflects the latest changes from Ray master.
-		Image:           "rayproject/ray:0860dd",
+		Name:            AutoscalerContainerName,
+		Image:           autoscalerImage,
 		ImagePullPolicy: v1.PullAlways,
 		Env: []v1.EnvVar{
 			{
@@ -412,11 +456,11 @@ func convertCmdToString(cmdArr []string) (cmd string) {
 	return cmdAggr.String()
 }
 
-func getRayContainerIndex(pod v1.Pod) (rayContainerIndex int) {
+func getRayContainerIndex(podSpec v1.PodSpec) (rayContainerIndex int) {
 	// a ray pod can have multiple containers.
 	// we identify the ray container based on env var: RAY=true
 	// if the env var is missing, we choose containers[0].
-	for i, container := range pod.Spec.Containers {
+	for i, container := range podSpec.Containers {
 		for _, env := range container.Env {
 			if env.Name == strings.ToLower("ray") && env.Value == strings.ToLower("true") {
 				log.Info("Head pod container with index " + strconv.Itoa(i) + " identified as Ray container based on env RAY=true.")

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -176,7 +176,7 @@ func autoscalerSupportIsStable(rayVersion string) bool {
 		// If in doubt, just assume that the Ray version is >= 2.0.0,
 		// so that we use the Ray image to run the autoscaler.
 		// Currently, there is a lot of "doubt," since the version string is not validated.
-		// Users can always override the operator's choice of image with autoscalerOptions.Image.
+		// Users can always override the operator's choice of image with autoscalerOptions.image.
 		return true
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR updates the logic that selects a default autoscaler image.

For Ray versions at least 2.0.0, use the same image for the autoscaler as for the Ray container.
This eliminates the possibility of autoscaler/Ray incompatibility and reduces docker pull time.

For earlier Ray versions, use `rayproject/ray:2.0.0` to guarantee up-to-date autoscaler functionality.
As of the Ray 2.0.0 branch cut earlier today, an image tagged `rayproject/ray:2.0.0` exists on Dockerhub.
Until the official Ray release in two weeks, this image is unofficial and its actual contents are a moving target -- but I think we can live with the inconsistency in the short term. (I'm open to other opinions on this choice.) 

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/kuberay/issues/360

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
