### PR TITLE
add new 8000 port forwarding in kind

### DIFF
--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -126,6 +126,8 @@ def create_kuberay_service(template_name):
 
     time.sleep(20)
 
+    shell_assert_success('kubectl apply -f {}'.format(raycluster_service_file))
+
     wait_for_condition(
         lambda: shell_run('kubectl get service rayservice-sample-serve-svc -o jsonpath="{.status}"') == 0,
         timeout=900,
@@ -518,12 +520,11 @@ class RayServiceTestCase(unittest.TestCase):
             raise unittest.SkipTest("ray service is not supported")
 
     def test_ray_serve_work(self):
-        port_forwarding_proc = subprocess.Popen('kubectl port-forward service/rayservice-sample-serve-svc 8000', shell=True)
         time.sleep(5)
         curl_cmd = 'curl  -X POST -H \'Content-Type: application/json\' localhost:8000 -d \'["MANGO", 2]\''
         wait_for_condition(
             lambda: shell_run(curl_cmd) == 0,
-            timeout=5,
+            timeout=15,
         )
         create_kuberay_service(RayServiceTestCase.service_serve_update_template_file)
         curl_cmd = 'curl  -X POST -H \'Content-Type: application/json\' localhost:8000 -d \'["MANGO", 2]\''
@@ -534,17 +535,11 @@ class RayServiceTestCase(unittest.TestCase):
         )
         create_kuberay_service(RayServiceTestCase.service_cluster_update_template_file)
         time.sleep(5)
-        port_forwarding_proc.kill()
-        time.sleep(5)
-        port_forwarding_proc = subprocess.Popen('kubectl port-forward service/rayservice-sample-serve-svc 8000', shell=True)
-        time.sleep(5)
         curl_cmd = 'curl  -X POST -H \'Content-Type: application/json\' localhost:8000 -d \'["MANGO", 2]\''
-
         wait_for_condition(
             lambda: shell_run(curl_cmd) == 0,
             timeout=180,
         )
-        port_forwarding_proc.kill()
 
 def parse_environment():
     global ray_version, ray_image, kuberay_sha

--- a/tests/config/cluster-config.yaml
+++ b/tests/config/cluster-config.yaml
@@ -25,3 +25,7 @@ nodes:
         hostPort: 52365
         listenAddress: "0.0.0.0"
         protocol: tcp
+      - containerPort: 30800
+        hostPort: 8000
+        listenAddress: "0.0.0.0"
+        protocol: tcp

--- a/tests/config/ray-service-cluster-update.yaml.template
+++ b/tests/config/ray-service-cluster-update.yaml.template
@@ -66,7 +66,7 @@ spec:
           labels:
             # custom labels. NOTE: do not define custom labels start with `raycluster.`, they may be used in controller.
             # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-            rayCluster: raycluster-sample # will be injected if missing
+            rayCluster: raycluster-compatibility-test # will be injected if missing
             rayNodeType: head # will be injected if missing, must be head or wroker
             groupName: headgroup # will be injected if missing
           # annotations for pod

--- a/tests/config/ray-service-serve-update.yaml.template
+++ b/tests/config/ray-service-serve-update.yaml.template
@@ -66,7 +66,7 @@ spec:
           labels:
             # custom labels. NOTE: do not define custom labels start with `raycluster.`, they may be used in controller.
             # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-            rayCluster: raycluster-sample # will be injected if missing
+            rayCluster: raycluster-compatibility-test # will be injected if missing
             rayNodeType: head # will be injected if missing, must be head or wroker
             groupName: headgroup # will be injected if missing
           # annotations for pod

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -66,7 +66,7 @@ spec:
           labels:
             # custom labels. NOTE: do not define custom labels start with `raycluster.`, they may be used in controller.
             # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-            rayCluster: raycluster-sample # will be injected if missing
+            rayCluster: raycluster-compatibility-test # will be injected if missing
             rayNodeType: head # will be injected if missing, must be head or wroker
             groupName: headgroup # will be injected if missing
           # annotations for pod

--- a/tests/config/raycluster-service.yaml
+++ b/tests/config/raycluster-service.yaml
@@ -23,3 +23,7 @@ spec:
       port: 52365
       targetPort: 52365
       nodePort: 32365
+    - name: rayservice
+      port: 8000
+      targetPort: 8000
+      nodePort: 30800


### PR DESCRIPTION
## Why are these changes needed?

add 8000 port forwarding in kind and avoid using `kubectl port-forward`

## Related issue number

N/A

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
