### PR TITLE
[docs] Add sample configs with larger Ray pods

### DIFF
--- a/docs/components/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/docs/components/config/samples/ray-cluster.autoscaler.large.yaml
@@ -1,0 +1,1 @@
+../../../../ray-operator/config/samples/ray-cluster.autoscaler.large.yaml

--- a/docs/components/config/samples/ray-cluster.autoscaler.yaml
+++ b/docs/components/config/samples/ray-cluster.autoscaler.yaml
@@ -1,0 +1,1 @@
+../../../../ray-operator/config/samples/ray-cluster.autoscaler.yaml

--- a/docs/components/config/samples/ray-cluster.complete.large.yaml
+++ b/docs/components/config/samples/ray-cluster.complete.large.yaml
@@ -1,0 +1,1 @@
+../../../../ray-operator/config/samples/ray-cluster.complete.large.yaml

--- a/ray-operator/README.md
+++ b/ray-operator/README.md
@@ -64,13 +64,24 @@ kubectl delete -k "github.com/ray-project/kuberay/ray-operator/config/default"
 
 ### Running an example cluster
 
-There are three example config files to deploy RayClusters included here:
+We include a few example config files to deploy RayClusters:
 
 Sample  | Description
 ------------- | -------------
 [ray-cluster.mini.yaml](config/samples/ray-cluster.mini.yaml)   | Small example consisting of 1 head pod.
 [ray-cluster.heterogeneous.yaml](config/samples/ray-cluster.heterogeneous.yaml)  | Example with heterogenous worker types. 1 head pod and 2 worker pods, each of which has a different resource quota.
-[ray-cluster.complete.yaml](config/samples/ray-cluster.complete.yaml)  | Shows all available custom resouce properties.
+[ray-cluster.complete.yaml](config/samples/ray-cluster.complete.yaml)  | Shows all available custom resource properties.
+[ray-cluster.autoscaler.yaml](config/samples/ray-cluster.autoscaler.yaml)  | Shows all available custom resource properties and demonstrates autoscaling.
+[ray-cluster.complete.large.yaml](config/samples/ray-cluster.complete.large.yaml)  | Demonstrates resource configuration for production use-cases.
+[ray-cluster.autoscaler.large.yaml](config/samples/ray-cluster.autoscaler.yaml)  | Demonstrates resource configuration for autoscaling Ray clusters in production.
+
+!!! note
+
+    For production use-cases, make sure to allocate sufficient resources for your Ray pods in production; it usually makes
+    sense to run one large Ray pod per Kubernetes node.
+    See [ray-cluster.complete.large.yaml](config/samples/ray-cluster.complete.large.yaml) and
+    [ray-cluster.autoscaler.large.yaml](config/samples/ray-cluster.autoscaler.yaml) for guidance. The rest of the sample configs above are geared towards
+    experimentation in local kind or minikube environments.
 
 ```shell
 # Create a configmap with a hello world Ray code.

--- a/ray-operator/README.md
+++ b/ray-operator/README.md
@@ -77,7 +77,7 @@ Sample  | Description
 
 !!! note
 
-    For production use-cases, make sure to allocate sufficient resources for your Ray pods in production; it usually makes
+    For production use-cases, make sure to allocate sufficient resources for your Ray pods; it usually makes
     sense to run one large Ray pod per Kubernetes node.
     See [ray-cluster.complete.large.yaml](config/samples/ray-cluster.complete.large.yaml) and
     [ray-cluster.autoscaler.large.yaml](config/samples/ray-cluster.autoscaler.yaml) for guidance. The rest of the sample configs above are geared towards

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -1,4 +1,7 @@
-
+# Make sure to increase resource requests and limits before using this example in production.
+# For examples with more realistic resource configuration, see
+# ray-cluster.complete.large.yaml and
+# ray-cluster.autoscaler.large.yaml.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -1,4 +1,4 @@
-# For most use-cases, it makes sense to schedule one Ray pod per Kubernetes node:
+# For most use-cases, it makes sense to schedule one Ray pod per Kubernetes node.
 # This is a configuration for an autoscaling RayCluster with 1 Ray head pod and 1 Ray worker pod,
 # with capacity to scale up to 10 worker pods.
 # Each pod requests 54 Gi memory and 14 CPU.

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -1,0 +1,218 @@
+# For most use-cases, it makes sense to schedule one Ray pod per Kubernetes node:
+# This is a configuration for an autoscaling RayCluster with 1 Ray head pod and 1 Ray worker pod,
+# with capacity to scale up to 10 worker pods.
+# Each pod requests 54 Gi memory and 14 CPU.
+# Each pod can be scheduled on a virtual machine with roughly 64 Gi memory and 16 CPU.
+# (AWS: m5.2xlarge GCP: e2-standard-16 Azure: Standard_D5_v2)
+# Optimal resource allocation will depend on your Kubernetes infrastructure and might
+# require some experimentation.
+
+# The Ray autoscaler and KubeRay operator scale Ray pod quantities.
+# To achieve Kubernetes node autoscaling with this example, we recommend setting up an autoscaling node group/pool with
+# - 2 nodes minimum for the Ray head pod and Ray worker pod
+# - 11 nodes maximum to accommodate up to 10 Ray worker pods.
+apiVersion: ray.io/v1alpha1
+kind: RayCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    # An unique identifier for the head node and workers of this cluster.
+  name: raycluster-autoscaler
+spec:
+  # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
+  rayVersion: '1.13.0'
+  # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
+  # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
+  # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
+  enableInTreeAutoscaling: true
+  # autoscalerOptions is an OPTIONAL field specifying configuration overrides for the Ray autoscaler.
+  # The example configuration shown below below represents the DEFAULT values.
+  # (You may delete autoscalerOptions if the defaults are suitable.)
+  autoscalerOptions:
+    # upscalingMode is "Default" or "Aggressive."
+    # Conservative: Upscaling is rate-limited; the number of pending worker pods is at most the size of the Ray cluster.
+    # Default: Upscaling is not rate-limited.
+    # Aggressive: An alias for Default; upscaling is not rate-limited.
+    upscalingMode: Default
+    # idleTimeoutSeconds is the number of seconds to wait before scaling down a worker pod which is not using Ray resources.
+    idleTimeoutSeconds: 60
+    # image optionally overrides the autoscaler's container image.
+    image: "rayproject/ray:0860dd"
+    # imagePullPolicy optionally overrides the autoscaler container's image pull policy.
+    imagePullPolicy: Always
+    # resources specifies optional resource request and limit overrides for the autoscaler container.
+    # For large Ray clusters, we recommend monitoring container resource usage to determine if overriding the defaults is required.
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+      requests:
+        cpu: "500m"
+        memory: "512Mi"
+  ######################headGroupSpecs#################################
+  # head group template and specs, (perhaps 'group' is not needed in the name)
+  headGroupSpec:
+    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
+    serviceType: ClusterIP
+    # logical group name, for this called head-group, also can be functional
+    # pod type head or worker
+    # rayNodeType: head # Not needed since it is under the headgroup
+    # the following params are used to complete the ray start: ray start --head --block --port=6379 ...
+    rayStartParams:
+      # Flag "no-monitor" must be set when running the autoscaler in
+      # a sidecar container.
+      port: '6379'
+      dashboard-host: '0.0.0.0'
+      node-ip-address: $MY_POD_IP # auto-completed as the head pod IP
+      block: 'true'
+      num-cpus: '1' # can be auto-completed from the limits
+      # Use `resources` to optionally specify custom resource annotations for the Ray node.
+      # The value of `resources` is a string-integer mapping.
+      # Currently, `resources` must be provided in the unfortunate format demonstrated below:
+      # resources: '"{\"Custom1\": 1, \"Custom2\": 5}"'
+    #pod template
+    template:
+      spec:
+        containers:
+        # The Ray head container
+        - name: ray-head
+          image: rayproject/ray:1.13.0
+          imagePullPolicy: Always
+          # Optimal resource allocation will depend on your Kubernetes infrastructure and might
+          # require some experimentation.
+          # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal
+          # resource accounting. K8s requests are not used by Ray.
+          resources:
+            limits:
+              cpu: "14"
+              memory: "54Gi"
+            requests:
+              cpu: "14"
+              memory: "54Gi"
+          env:
+          - name: CPU_REQUEST
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: requests.cpu
+          - name: CPU_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: limits.cpu
+          - name: MEMORY_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: limits.memory
+          - name: MEMORY_REQUESTS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: requests.memory
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          ports:
+          - containerPort: 6379
+            name: gcs
+          - containerPort: 8265
+            name: dashboard
+          - containerPort: 10001
+            name: client
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+  workerGroupSpecs:
+  # the pod replicas in this group typed worker
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 10
+    # logical group name, for this called small-group, also can be functional
+    groupName: small-group
+    # if worker pods need to be added, we can simply increment the replicas
+    # if worker pods need to be removed, we decrement the replicas, and populate the podsToDelete list
+    # the operator will remove pods from the list until the number of replicas is satisfied
+    # when a pod is confirmed to be deleted, its name will be removed from the list below
+    #scaleStrategy:
+    #  workersToDelete:
+    #  - raycluster-complete-worker-small-group-bdtwh
+    #  - raycluster-complete-worker-small-group-hv457
+    #  - raycluster-complete-worker-small-group-k8tj7
+    # the following params are used to complete the ray start: ray start --block --node-ip-address= ...
+    rayStartParams:
+      #redis-password: '5241590000000000'
+      redis-password: 'LetMeInRay' # Deprecated since Ray 1.11 due to GCS bootstrapping enabled
+      node-ip-address: $MY_POD_IP
+      block: 'true'
+    #pod template
+    template:
+      metadata:
+        labels:
+          key: value
+        # annotations for pod
+        annotations:
+          key: value
+      spec:
+        initContainers:
+        # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+        - name: init-myservice
+          image: busybox:1.28
+          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
+        containers:
+        - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+          image: rayproject/ray:1.13.0
+          # Optimal resource allocation will depend on your Kubernetes infrastructure and might
+          # require some experimentation.
+          # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal
+          # resource accounting. K8s requests are not used by Ray.
+          resources:
+            limits:
+              cpu: "14"
+              memory: "54Gi"
+            requests:
+              cpu: "14"
+              memory: "54Gi"
+          # environment variables to set in the container.Optional.
+          # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+          env:
+          - name: RAY_DISABLE_DOCKER_CPU_WARNING
+            value: "1"
+          - name: TYPE
+            value: "worker"
+          - name: CPU_REQUEST
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: requests.cpu
+          - name: CPU_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: limits.cpu
+          - name: MEMORY_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: limits.memory
+          - name: MEMORY_REQUESTS
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: requests.memory
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          ports:
+          - containerPort: 80
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -131,7 +131,7 @@ spec:
     minReplicas: 1
     maxReplicas: 10
     # logical group name, for this called small-group, also can be functional
-    groupName: small-group
+    groupName: large-group
     # if worker pods need to be added, we can simply increment the replicas
     # if worker pods need to be removed, we decrement the replicas, and populate the podsToDelete list
     # the operator will remove pods from the list until the number of replicas is satisfied

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
     # An unique identifier for the head node and workers of this cluster.
-  name: raycluster-autoscaler
+  name: raycluster-autoscaler-large
 spec:
   # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
   rayVersion: '1.13.0'

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -3,7 +3,7 @@
 # with capacity to scale up to 10 worker pods.
 # Each pod requests 54 Gi memory and 14 CPU.
 # Each pod can be scheduled on a virtual machine with roughly 64 Gi memory and 16 CPU.
-# (AWS: m5.2xlarge GCP: e2-standard-16 Azure: Standard_D5_v2)
+# (AWS: m5.2xlarge, GCP: e2-standard-16, Azure: Standard_D5_v2)
 # Optimal resource allocation will depend on your Kubernetes infrastructure and might
 # require some experimentation.
 

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -1,5 +1,7 @@
-# This is adapted from https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.complete.yaml
-# It is a general RayCluster that has most fields in it for maximum flexibility in the Ray/Kuberay integration MVP.
+# This config demonstrates KubeRay's Ray autoscaler integration.
+# The resource requests and limits in this config are too small for production!
+# For an example with more realistic resource configuration, see
+# ray-cluster.autoscaler.large.yaml.
 apiVersion: ray.io/v1alpha1
 kind: RayCluster
 metadata:

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -1,4 +1,4 @@
-# For most use-cases, it makes sense to schedule one Ray pod per Kubernetes node:
+# For most use-cases, it makes sense to schedule one Ray pod per Kubernetes node.
 # This is a configuration for a RayCluster with 1 Ray head pod and 1 Ray worker pod.
 # Each pod requests 54 Gi memory and 14 CPU.
 # Each pod can be scheduled on a virtual machine with roughly 64 Gi memory and 16 CPU.

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -1,0 +1,195 @@
+# For most use-cases, it makes sense to schedule one Ray pod per Kubernetes node:
+# This is a configuration for a RayCluster with 1 Ray head pod and 1 Ray worker pod.
+# Each pod requests 54 Gi memory and 14 CPU.
+# Each pod can be scheduled on a virtual machine with roughly 64 Gi memory and 16 CPU.
+# (AWS: m5.2xlarge GCP: e2-standard-16 Azure: Standard_D5_v2)
+# Optimal resource allocation will depend on your Kubernetes infrastructure and might
+# require some experimentation.
+apiVersion: ray.io/v1alpha1
+kind: RayCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    # An unique identifier for the head node and workers of this cluster.
+  name: raycluster-complete-large
+spec:
+  rayVersion: '1.13.0'
+  ######################headGroupSpecs#################################
+  # head group template and specs, (perhaps 'group' is not needed in the name)
+  headGroupSpec:
+    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
+    serviceType: ClusterIP
+    # for the head group, replicas should always be 1.
+    # headGroupSpec.replicas is deprecated in KubeRay >= 0.3.0.
+    replicas: 1
+    # logical group name, for this called head-group, also can be functional
+    # pod type head or worker
+    # rayNodeType: head # Not needed since it is under the headgroup
+    # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
+    rayStartParams:
+      port: '6379'
+      dashboard-host: '0.0.0.0'
+      block: 'true'
+    #pod template
+    template:
+      metadata:
+        labels:
+          # custom labels. NOTE: do not define custom labels start with `raycluster.`, they may be used in controller.
+          # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+          rayCluster: raycluster-sample # will be injected if missing
+          rayNodeType: head # will be injected if missing, must be head or wroker
+          groupName: headgroup # will be injected if missing
+        # annotations for pod
+        annotations:
+          key: value
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:1.13.0
+          # Optimal resource allocation will depend on your Kubernetes infrastructure and might
+          # require some experimentation.
+          # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal
+          # resource accounting. K8s requests are not used by Ray.
+          resources:
+            limits:
+              cpu: "14"
+              memory: "54Gi"
+            requests:
+              cpu: "14"
+              memory: "54Gi"
+          env:
+          - name: CPU_REQUEST
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: requests.cpu
+          - name: CPU_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: limits.cpu
+          - name: MEMORY_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: limits.memory
+          - name: MEMORY_REQUESTS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ray-head
+                resource: requests.memory
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          ports:
+          - containerPort: 6379
+            name: gcs
+          - containerPort: 8265
+            name: dashboard
+          - containerPort: 10001
+            name: client
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+  workerGroupSpecs:
+  # the pod replicas in this group typed worker
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 10
+    # logical group name, for this called large-group, also can be functional
+    groupName: large-group
+    # if worker pods need to be added, we can simply increment the replicas
+    # if worker pods need to be removed, we decrement the replicas, and populate the podsToDelete list
+    # the operator will remove pods from the list until the number of replicas is satisfied
+    # when a pod is confirmed to be deleted, its name will be removed from the list below
+    #scaleStrategy:
+    #  workersToDelete:
+    #  - raycluster-complete-worker-small-group-bdtwh
+    #  - raycluster-complete-worker-small-group-hv457
+    #  - raycluster-complete-worker-small-group-k8tj7 
+    # the following params are used to complete the ray start: ray start --block --node-ip-address= ...
+    rayStartParams:
+      block: 'true'
+    #pod template
+    template:
+      metadata:
+        labels:
+          rayCluster: raycluster-complete # will be injected if missing
+          rayNodeType: worker # will be injected if missing
+          groupName: small-group # will be injected if missing
+        # annotations for pod
+        annotations:
+          key: value
+      spec:
+        containers:
+        - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+          image: rayproject/ray:1.13.0
+          # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal
+          # resource accounting. K8s requests are not used by Ray.
+          resources:
+            limits:
+              cpu: "14"
+              memory: "54Gi"
+            requests:
+              cpu: "14"
+              memory: "54Gi"
+          # environment variables to set in the container.Optional.
+          # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+          env:
+          - name:  RAY_DISABLE_DOCKER_CPU_WARNING
+            value: "1"
+          - name: TYPE
+            value: "worker"
+          - name: CPU_REQUEST
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: requests.cpu
+          - name: CPU_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: limits.cpu
+          - name: MEMORY_LIMITS
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: limits.memory
+          - name: MEMORY_REQUESTS
+            valueFrom:
+              resourceFieldRef:
+                containerName: machine-learning
+                resource: requests.memory
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          ports:
+          - containerPort: 80
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+          # use volumeMounts.Optional.
+          # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+          volumeMounts:
+            - mountPath: /var/log
+              name: log-volume
+        initContainers:
+        # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+        - name: init-myservice
+          image: busybox:1.28
+          # Change the cluster postfix if you don't have a default setting
+          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]   
+        # use volumes
+        # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+        volumes:
+          - name: log-volume
+            emptyDir: {}
+######################status#################################

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -2,7 +2,7 @@
 # This is a configuration for a RayCluster with 1 Ray head pod and 1 Ray worker pod.
 # Each pod requests 54 Gi memory and 14 CPU.
 # Each pod can be scheduled on a virtual machine with roughly 64 Gi memory and 16 CPU.
-# (AWS: m5.2xlarge GCP: e2-standard-16 Azure: Standard_D5_v2)
+# (AWS: m5.2xlarge, GCP: e2-standard-16, Azure: Standard_D5_v2)
 # Optimal resource allocation will depend on your Kubernetes infrastructure and might
 # require some experimentation.
 apiVersion: ray.io/v1alpha1

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -1,3 +1,7 @@
+# The resource requests and limits in this config are too small for production!
+# For examples with more realistic resource configuration, see
+# ray-cluster.complete.large.yaml and
+# ray-cluster.autoscaler.large.yaml.
 apiVersion: ray.io/v1alpha1
 kind: RayCluster
 metadata:

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -1,3 +1,7 @@
+# Make sure to increase resource requests and limits before using this example in production.
+# For examples with more realistic resource configuration, see
+# ray-cluster.complete.large.yaml and
+# ray-cluster.autoscaler.large.yaml.
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/ray-operator/config/samples/ray-cluster.getting-started.yaml
+++ b/ray-operator/config/samples/ray-cluster.getting-started.yaml
@@ -1,3 +1,7 @@
+# This example config does not specify resource requests or limits.
+# For examples with more realistic resource configuration, see
+# ray-cluster.complete.large.yaml and
+# ray-cluster.autoscaler.large.yaml.
 apiVersion: ray.io/v1alpha1
 kind: RayCluster
 metadata:

--- a/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
+++ b/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
@@ -1,3 +1,7 @@
+# The resource requests and limits in this config are too small for production!
+# For examples with more realistic resource configuration, see
+# ray-cluster.complete.large.yaml and
+# ray-cluster.autoscaler.large.yaml.
 apiVersion: ray.io/v1alpha1
 kind: RayCluster
 metadata:

--- a/ray-operator/config/samples/ray-cluster.ingress.yaml
+++ b/ray-operator/config/samples/ray-cluster.ingress.yaml
@@ -1,3 +1,7 @@
+# This example config does not specify resource requests or limits.
+# For examples with more realistic resource configuration, see
+# ray-cluster.complete.large.yaml and
+# ray-cluster.autoscaler.large.yaml.
 apiVersion: ray.io/v1alpha1
 kind: RayCluster
 metadata:

--- a/ray-operator/config/samples/ray-cluster.mini.yaml
+++ b/ray-operator/config/samples/ray-cluster.mini.yaml
@@ -1,3 +1,7 @@
+# This example config does not specify resource requests or limits.
+# For examples with more realistic resource configuration, see
+# ray-cluster.complete.large.yaml and
+# ray-cluster.autoscaler.large.yaml.
 apiVersion: ray.io/v1alpha1
 kind: RayCluster
 metadata:

--- a/ray-operator/config/samples/ray-cluster.without-block.yaml
+++ b/ray-operator/config/samples/ray-cluster.without-block.yaml
@@ -1,3 +1,7 @@
+# This example config does not specify resource requests or limits.
+# For examples with more realistic resource configuration, see
+# ray-cluster.complete.large.yaml and
+# ray-cluster.autoscaler.large.yaml.
 apiVersion: ray.io/v1alpha1
 kind: RayCluster
 metadata:

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -1,3 +1,7 @@
+# Make sure to increase resource requests and limits before using this example in production.
+# For examples with more realistic resource configuration, see
+# ray-cluster.complete.large.yaml and
+# ray-cluster.autoscaler.large.yaml.
 apiVersion: ray.io/v1alpha1
 kind: RayService
 metadata:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR
- Adds two sample configs for clusters with large Ray pods meant to take up entire 16CPU K8s nodes.
- Adds warnings that resources should be increased for production use-cases 

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/kuberay/issues/417

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
