### PR TITLE
[operator] enable bashrc before container start

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -304,7 +304,7 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayiov1alpha1.RayN
 	if !strings.Contains(cmd, "ray start") {
 		cont := concatenateContainerCommand(rayNodeType, rayStartParams, pod.Spec.Containers[rayContainerIndex].Resources)
 		// replacing the old command
-		pod.Spec.Containers[rayContainerIndex].Command = []string{"/bin/bash", "-c", "--"}
+		pod.Spec.Containers[rayContainerIndex].Command = []string{"/bin/bash", "-lc", "--"}
 		if cmd != "" {
 			// If 'ray start' has --block specified, commands after it will not get executed.
 			// so we need to put cmd before cont.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->



## Why are these changes needed?
The ray cluster will not load the .bashrc before the container start. The reason is the ray process starting command is like this:
```yaml
    Command:
      /bin/bash
      -c
      --
    Args:
      ulimit -n 65536; ray start --head  --system-config='{"gcs_rpc_server_reconnect_timeout_s": 20}'  --block  --num-cpus=4  --memory=8000000000  --dashboard-host=0.0.0.0  --node-ip-address=$MY_POD_IP  --port=6379  --metrics-export-port=8080
```
/bin/bash -c means non-Interactive mode to run bash. 
reference to https://www.gnu.org/software/bash/manual/bash.html#Bash-Startup-Files
non-Interactive mode would not load /etc/profile, .bashrc, ...
we can use login mode to get similar effect with the interactive mode

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/kuberay/issues/409

## Checks

- [*] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [*] Manual tests
   - [ ] This PR is not tested :(
