### PR TITLE
Fix wrong ray start command

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -675,8 +675,9 @@ func concatenateContainerCommand(nodeType rayiov1alpha1.RayNodeType, rayStartPar
 
 func convertParamMap(rayStartParams map[string]string) (s string) {
 	flags := new(bytes.Buffer)
+	nonFlagParams := []string{"log-color", "include-dashboard"}
 	for k, v := range rayStartParams {
-		if strings.ToLower(v) == "true" {
+		if strings.ToLower(v) == "true" && !utils.Contains(nonFlagParams, k) {
 			fmt.Fprintf(flags, " --%s ", k)
 		} else {
 			fmt.Fprintf(flags, " --%s=%s ", k, v)

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -38,6 +38,8 @@ var instance = rayiov1alpha1.RayCluster{
 				"object-store-memory": "100000000",
 				"redis-password":      "LetMeInRay",
 				"num-cpus":            "1",
+				"include-dashboard":   "true",
+				"log-color":           "true",
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -562,6 +564,9 @@ func TestValidateHeadRayStartParams_OK(t *testing.T) {
 	isValid, err := ValidateHeadRayStartParams(*input)
 	assert.Equal(t, true, isValid)
 	assert.Nil(t, err)
+	command := convertParamMap(input.RayStartParams)
+	assert.True(t, strings.Contains(command, "--include-dashboard=true"))
+	assert.True(t, strings.Contains(command, "--log-color=true"))
 }
 
 func TestValidateHeadRayStartParams_ValidWithObjectStoreMemoryError(t *testing.T) {

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -212,9 +211,13 @@ func CalculateAvailableReplicas(pods corev1.PodList) int32 {
 	return count
 }
 
-func Contains(s []string, searchTerm string) bool {
-	i := sort.SearchStrings(s, searchTerm)
-	return i < len(s) && s[i] == searchTerm
+func Contains(elems []string, searchTerm string) bool {
+	for _, s := range elems {
+		if searchTerm == s {
+			return true
+		}
+	}
+	return false
 }
 
 func FilterContainerByName(containers []corev1.Container, name string) (corev1.Container, error) {


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

## Why are these changes needed?

`include-dashboard` is not a flag parameter, so we should convert it to `--include-dashboard=true` instead of `--include-dashboard`

```bash
(base) ➜  ray-operator git:(ping-7) ray start --help                           
Usage: ray start [OPTIONS]

  Start Ray processes manually on the local machine. PublicAPI: This API is
  stable across Ray releases.

Options:
  --node-ip-address TEXT          the IP address of this node
  --address TEXT                  the address to use for Ray
  --port INTEGER                  the port of the head ray process. If not
                                  provided, defaults to 6379; if port is set
                                  to 0, we will allocate an available port.
  --object-manager-port INTEGER   the port to use for starting the object
                                  manager
  --node-manager-port INTEGER     the port to use for starting the node
                                  manager
  --gcs-server-port INTEGER       Port number for the GCS server.
  --min-worker-port INTEGER       the lowest port number that workers will
                                  bind on. If not set, random ports will be
                                  chosen.
  --max-worker-port INTEGER       the highest port number that workers will
                                  bind on. If set, '--min-worker-port' must
                                  also be set.
  --worker-port-list TEXT         a comma-separated list of open ports for
                                  workers to bind on. Overrides '--min-worker-
                                  port' and '--max-worker-port'.
  --ray-client-server-port INTEGER
                                  the port number the ray client server will
                                  bind on. If not set, the ray client server
                                  will not be started.
  --object-store-memory INTEGER   The amount of memory (in bytes) to start the
                                  object store with. By default, this is
                                  capped at 20GB but can be set higher.
  --num-cpus INTEGER              the number of CPUs on this node
  --num-gpus INTEGER              the number of GPUs on this node
  --resources TEXT                a JSON serialized dictionary mapping
                                  resource name to resource quantity
  --head                          provide this argument for the head node
  --include-dashboard BOOLEAN     provide this argument to start the Ray
                                  dashboard GUI
  --dashboard-host TEXT           the host to bind the dashboard server to,
                                  either localhost (127.0.0.1) or 0.0.0.0
                                  (available from all interfaces). By default,
                                  thisis localhost.
  --dashboard-port INTEGER        the port to bind the dashboard server to--
                                  defaults to 8265
  --block                         provide this argument to block forever in
                                  this command
  --plasma-directory TEXT         object store directory for memory mapped
                                  files
  --autoscaling-config TEXT       the file that contains the autoscaling
                                  config
  --no-redirect-output            do not redirect non-worker stdout and stderr
                                  to files
  --plasma-store-socket-name TEXT
                                  manually specify the socket name of the
                                  plasma store
  --raylet-socket-name TEXT       manually specify the socket path of the
                                  raylet process
  --storage TEXT                  the persistent storage URI for the cluster.
                                  Experimental.
  --ray-debugger-external         Make the Ray debugger available externally
                                  to the node. This is onlysafe to activate if
                                  the node is behind a firewall.
  --disable-usage-stats           If True, the usage stats collection will be
                                  disabled.
  --log-style [auto|record|pretty]
                                  If 'pretty', outputs with formatting and
                                  color. If 'record', outputs record-style
                                  without formatting. 'auto' defaults to
                                  'pretty', and disables pretty logging if
                                  stdin is *not* a TTY.
  --log-color [auto|false|true]   Use color logging. Auto enables color
                                  logging if stdout is a TTY.
  -v, --verbose
  --help                          Show this message and exit.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [x] This PR is not tested :(
