### PR TITLE
helm-chart/ray-cluster: allow head autoscaling

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -5,6 +5,12 @@ metadata:
 {{ include "ray-cluster.labels" . | indent 4 }}
   name: {{ include "ray-cluster.fullname" . }}
 spec:
+  {{- if .Values.head.rayVersion }}
+  rayVersion: {{ .Values.head.rayVersion }}
+  {{- end }}
+  {{- if .Values.head.enableInTreeAutoscaling }}
+  enableInTreeAutoscaling: {{ .Values.head.enableInTreeAutoscaling }}
+  {{- end }}
   headGroupSpec:
     serviceType: ClusterIP
     rayStartParams:


### PR DESCRIPTION
Also allow setting rayVersion

Signed-off-by: Christos Kotsis <28815556+ulfox@users.noreply.github.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Include options to configure enableInTreeAutoscaling & rayVersion for rayCluster

<!-- Please give a short summary of the change and the problem this solves. -->

Configuring headNode autoscaling is not possible with the current helm chart without modification
