### PR TITLE
fix: worker node can't connect to head node service

### DIFF
--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -43,7 +43,7 @@ func BuildIngressForHeadService(cluster rayiov1alpha1.RayCluster) (*networkingv1
 			PathType: &pathType,
 			Backend: networkingv1.IngressBackend{
 				Service: &networkingv1.IngressServiceBackend{
-					Name: utils.GenerateServiceName(cluster.Name),
+					Name: utils.CheckName(utils.GenerateServiceName(cluster.Name)),
 					Port: networkingv1.ServiceBackendPort{
 						Number: dashboardPort,
 					},

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -685,6 +685,7 @@ func (r *RayClusterReconciler) buildHeadPod(instance rayiov1alpha1.RayCluster) c
 	podName := strings.ToLower(instance.Name + common.DashSymbol + string(rayiov1alpha1.HeadNode) + common.DashSymbol)
 	podName = utils.CheckName(podName) // making sure the name is valid
 	svcName := utils.GenerateServiceName(instance.Name)
+	svcName = utils.CheckName(svcName)
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
 	autoscalingEnabled := instance.Spec.EnableInTreeAutoscaling
@@ -717,6 +718,7 @@ func (r *RayClusterReconciler) buildWorkerPod(instance rayiov1alpha1.RayCluster,
 	podName := strings.ToLower(instance.Name + common.DashSymbol + string(rayiov1alpha1.WorkerNode) + common.DashSymbol + worker.GroupName + common.DashSymbol)
 	podName = utils.CheckName(podName) // making sure the name is valid
 	svcName := utils.GenerateServiceName(instance.Name)
+	svcName = utils.CheckName(svcName)
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
 	autoscalingEnabled := instance.Spec.EnableInTreeAutoscaling

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -47,11 +47,11 @@ func IsRunningAndReady(pod *corev1.Pod) bool {
 
 // CheckName makes sure the name does not start with a numeric value and the total length is < 63 char
 func CheckName(s string) string {
-	maxLenght := 50 // 63 - (max(8,6) + 5 ) // 6 to 8 char are consumed at the end with "-head-" or -worker- + 5 generated.
+	maxLength := 50 // 63 - (max(8,6) + 5 ) // 6 to 8 char are consumed at the end with "-head-" or -worker- + 5 generated.
 
-	if len(s) > maxLenght {
+	if len(s) > maxLength {
 		// shorten the name
-		offset := int(math.Abs(float64(maxLenght) - float64(len(s))))
+		offset := int(math.Abs(float64(maxLength) - float64(len(s))))
 		fmt.Printf("pod name is too long: len = %v, we will shorten it by offset = %v\n", len(s), offset)
 		s = s[offset:]
 	}


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

## Why are these changes needed?
If Ray job name is too long, the worker node will try to connect to the wrong head node service.

```bash
(base) ➜  ~ k get svc -n flytesnacks-development
NAME                                                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                         AGE
l94lnxh5ktptbgzsfnj-n0-0-raycluster-xg6hj-head-svc   NodePort    10.96.123.235   <none>        6379:32288/TCP,10001:31845/TCP,8265:32389/TCP   33s
(base) ➜  ~ k describe pods -n flytesnacks-development ptbgzsfnj-n0-0-raycluster-xg6hj-worker-test-group-5kbn5 | grep address 
      ulimit -n 65536; ray start  --node-ip-address=$MY_POD_IP  --address=al94lnxh5ktptbgzsfnj-n0-0-raycluster-xg6hj-head-svc:6379  --metrics-export-port=8080  --num-cpus=2  --memory=2097152000  && sleep infinity
```

The service name is `l94lnxh5ktptbgzsfnj-n0-0-raycluster-xg6hj-head-svc `, but worker node try to connect to `al94lnxh5ktptbgzsfnj-n0-0-raycluster-xg6hj-head-svc:6379`.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
