### PR TITLE
helm-charts/ray-cluster: Allow extra workers

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -34,6 +34,9 @@ spec:
             {{- with .Values.head.envFrom }}
             envFrom: {{- toYaml . | nindent 14}}
             {{- end }}
+            {{- if .Values.head.ports }}
+            ports: {{- toYaml .Values.head.ports | nindent 14}}
+            {{- end }}
         volumes: {{- toYaml .Values.head.volumes | nindent 10 }}
         affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.head.tolerations | nindent 10 }}
@@ -133,3 +136,4 @@ spec:
           rayCluster: {{ include "ray-cluster.fullname" . }}
 {{ include "ray-cluster.labels" . | indent 10 }}
   {{- end }}
+

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -47,6 +47,51 @@ spec:
 {{ include "ray-cluster.labels" . | indent 10 }}
 
   workerGroupSpecs:
+  {{- range $groupName, $values := .Values.additionalWorkerGroups }}
+  {{- if ne $values.disabled true }}
+  - rayStartParams:
+    {{- range $key, $val := $values.initArgs }}
+      {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    replicas: {{ $values.replicas }}
+    minReplicas: {{ $values.miniReplicas | default 1 }}
+    maxReplicas: {{ $values.maxiReplicas | default 2147483647 }}
+    groupName: {{ $groupName }}
+    template:
+      spec:
+        imagePullSecrets: {{- toYaml $.Values.imagePullSecrets | nindent 10 }}
+        initContainers:
+          - name: init-myservice
+            image: busybox:1.28
+            command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
+        containers:
+          - volumeMounts: {{- toYaml $values.volumeMounts | nindent 12 }}
+            name: ray-worker
+            image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
+            imagePullPolicy: {{ $.Values.image.pullPolicy }}
+            resources: {{- toYaml $values.resources | nindent 14 }}
+            env:
+              - name: TYPE
+                value: worker
+            {{- toYaml $values.containerEnv | nindent 14}}
+            {{- with $values.envFrom }}
+            envFrom: {{- toYaml $ | nindent 14}}
+            {{- end }}
+            ports: {{- toYaml $values.ports | nindent 14}}
+        volumes: {{- toYaml $values.volumes | nindent 10 }}
+        affinity: {{- toYaml $values.affinity | nindent 10 }}
+        tolerations: {{- toYaml $values.tolerations | nindent 10 }}
+        nodeSelector: {{- toYaml $values.nodeSelector | nindent 10 }}
+      metadata:
+        annotations: {{- toYaml $values.annotations | nindent 10 }}
+        labels:
+          rayNodeType: {{ $values.type }}
+          groupName: {{ $groupName }}
+          rayCluster: {{ include "ray-cluster.fullname" $ }}
+{{ include "ray-cluster.labels" $ | indent 10 }}
+  {{- end }}
+  {{- end }}
+  {{- if ne .Values.worker.disabled true }}
   - rayStartParams:
     {{- range $key, $val := .Values.worker.initArgs }}
       {{ $key }}: {{ $val | quote }}
@@ -87,3 +132,4 @@ spec:
           groupName: {{ .Values.worker.groupName }}
           rayCluster: {{ include "ray-cluster.fullname" . }}
 {{ include "ray-cluster.labels" . | indent 10 }}
+  {{- end }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -52,6 +52,9 @@ head:
 
 
 worker:
+  # If you want to disable the default workergroup
+  # uncomment the line below
+  # disabled: true
   groupName: workergroup
   replicas: 1
   type: worker
@@ -100,6 +103,62 @@ worker:
     - mountPath: /tmp/ray
       name: log-volume
 
+# The map's key is used as the groupName.
+# For example, key:small-group in the map below
+# will be used as the groupName
+additionalWorkerGroups:
+  small-group:
+    # Disabled by default
+    disabled: true
+    replicas: 1
+    miniReplicas: 1
+    maxiReplicas: 3
+    type: worker
+    labels: {}
+    initArgs:
+      node-ip-address: $MY_POD_IP
+      redis-password: LetMeInRay
+      block: 'true'
+    containerEnv:
+      - name: MY_POD_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      - name: RAY_DISABLE_DOCKER_CPU_WARNING
+        value: "1"
+      - name: CPU_REQUEST
+        valueFrom:
+          resourceFieldRef:
+            containerName: ray-worker
+            resource: requests.cpu
+      - name: MY_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+    envFrom: []
+      # - secretRef:
+      #     name: my-env-secret
+    ports:
+      - containerPort: 80
+        protocol: TCP
+    resources: 
+      limits:
+        cpu: 1
+      requests:
+         cpu: 200m
+    annotations:
+      key: value
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    volumes:
+      - name: log-volume
+        emptyDir: {}
+    volumeMounts:
+      - mountPath: /tmp/ray
+        name: log-volume
+  
+  
 headServiceSuffix: "ray-operator.svc"
 
 service:


### PR DESCRIPTION
## Why are these changes needed?

We can not set additional workers with the current helm chart.
There are some PRs that aim to fix this but they appear to be stale
https://github.com/ray-project/kuberay/pull/266

We wanted to keep untouched the default worker that is already
included in the helm chart but allow the addition of new workers.

The changes are adding the following logic:
- Allow to disable the default worker group, if needed, via worker.disabled = true
- Allow to set additional workers by using the extraWorkers map

The extraWorkers map has a different structure compared to the default worker because we
wanted to add additional flexibility. Due to that, some variables in the extraWorkers
have different naming (which matches the name of the related CRD attributed)

Note: PR was done to support additional workers in the infrastructure of Metrika.co
