### PR TITLE
Enable docker image push against release-0.3 branch

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -170,7 +170,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
       - name: Push Apiserver to DockerHub
         run: |
@@ -179,7 +179,7 @@ jobs:
           docker push kuberay/apiserver:nightly
 
         working-directory: ${{env.working-directory}}
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: contains(fromJson('["refs/heads/master", "refs/heads/main"]'), github.ref)
 
       - name: Build CLI
         run: go build -o kuberay -a main.go


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

0.3 post submit test doesn't upgrade the image actually.  I determine to make this change instead of manually build the image. 

![image](https://user-images.githubusercontent.com/4739316/184071028-7f9f65cb-f05f-4da0-a0fa-cf4d195806b4.png)


## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [x] This PR is not tested :(
