### PR TITLE
Enable docker image push for release-0.3 branch

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -167,7 +167,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
       - name: Push Apiserver to DockerHub
         run: |
@@ -176,7 +176,7 @@ jobs:
           docker push kuberay/apiserver:nightly
 
         working-directory: ${{env.working-directory}}
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
       - name: Build CLI
         run: go build -o kuberay -a main.go
@@ -249,7 +249,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-      if: ${{ github.ref == 'refs/heads/master' }}
+      if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
     - name: Push Operator to DockerHub
       run: |
@@ -258,7 +258,7 @@ jobs:
         docker push kuberay/operator:nightly
 
       working-directory: ${{env.working-directory}}
-      if: ${{ github.ref == 'refs/heads/master' }}
+      if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
   test-compatibility-1_11_0:
     needs:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

https://github.com/ray-project/kuberay/issues/453

## Why are these changes needed?

With this change, release branch can update image to dockerhub.

## Related issue number

https://github.com/ray-project/kuberay/issues/453

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
