### PR TITLE
[rayservice] Fix config names to match serve config format directly

### DIFF
--- a/docs/guidance/rayservice.md
+++ b/docs/guidance/rayservice.md
@@ -130,7 +130,7 @@ Then you can open your web browser with the url localhost:8265 to see your Ray d
 
 ### Update Ray Serve Deployment Graph
 
-You can update the `serveDeploymentGraphConfig` in your RayService config file.
+You can update the `serveConfig` in your RayService config file.
 For example, if you update the mango price to 4 in [ray_v1alpha1_rayservice.yaml](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml).
 ```shell
   - name: MangoStand

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -11471,7 +11471,7 @@ spec:
                 required:
                 - headGroupSpec
                 type: object
-              serveDeploymentGraphConfig:
+              serveConfig:
                 description: 'Important: Run "make" to regenerate code after modifying
                   this file'
                 properties:
@@ -11479,7 +11479,7 @@ spec:
                     type: string
                   runtimeEnv:
                     type: string
-                  serveConfigs:
+                  deployments:
                     items:
                       description: ServeConfigSpec defines the desired state of RayService
                         Reference to http://rayserve.org

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -24,7 +24,7 @@ const (
 // RayServiceSpec defines the desired state of RayService
 type RayServiceSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
-	ServeDeploymentGraphSpec           ServeDeploymentGraphSpec `json:"serveDeploymentGraphConfig,omitempty"`
+	ServeDeploymentGraphSpec           ServeDeploymentGraphSpec `json:"serveConfig,omitempty"`
 	RayClusterSpec                     RayClusterSpec           `json:"rayClusterConfig,omitempty"`
 	ServiceUnhealthySecondThreshold    *int32                   `json:"serviceUnhealthySecondThreshold,omitempty"`
 	DeploymentUnhealthySecondThreshold *int32                   `json:"deploymentUnhealthySecondThreshold,omitempty"`
@@ -33,7 +33,7 @@ type RayServiceSpec struct {
 type ServeDeploymentGraphSpec struct {
 	ImportPath       string            `json:"importPath"`
 	RuntimeEnv       string            `json:"runtimeEnv,omitempty"`
-	ServeConfigSpecs []ServeConfigSpec `json:"serveConfigs,omitempty"`
+	ServeConfigSpecs []ServeConfigSpec `json:"deployments,omitempty"`
 }
 
 // ServeConfigSpec defines the desired state of RayService

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
@@ -195,10 +195,10 @@ var expected = `{
       "creationTimestamp":null
    },
    "spec":{
-      "serveDeploymentGraphConfig":{
+      "serveConfig":{
          "importPath":"fruit.deployment_graph",
          "runtimeEnv":"working_dir:\n - \"https://github.com/ray-project/test_dag/archive/c620251044717ace0a4c19d766d43c5099af8a77.zip\"",
-         "serveConfigs":[
+         "deployments":[
             {
                "name":"MangoStand",
                "numReplicas":1,

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -11610,7 +11610,7 @@ spec:
                 required:
                 - headGroupSpec
                 type: object
-              serveDeploymentGraphConfig:
+              serveConfig:
                 description: 'Important: Run "make" to regenerate code after modifying
                   this file'
                 properties:
@@ -11618,7 +11618,7 @@ spec:
                     type: string
                   runtimeEnv:
                     type: string
-                  serveConfigs:
+                  deployments:
                     items:
                       description: ServeConfigSpec defines the desired state of RayService
                         Reference to http://rayserve.org

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -9,11 +9,11 @@ metadata:
 spec:
   serviceUnhealthySecondThreshold: 300 # Config for the health check threshold for service. Default value is 60.
   deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for deployments. Default value is 60.
-  serveDeploymentGraphConfig:
+  serveConfig:
     importPath: fruit.deployment_graph
     runtimeEnv: |
       working_dir: "https://github.com/ray-project/test_dag/archive/c620251044717ace0a4c19d766d43c5099af8a77.zip"
-    serveConfigs:
+    deployments:
       - name: MangoStand
         numReplicas: 1
         userConfig: |

--- a/tests/config/ray-service-cluster-update.yaml.template
+++ b/tests/config/ray-service-cluster-update.yaml.template
@@ -5,11 +5,11 @@ metadata:
 spec:
   serviceUnhealthySecondThreshold: 300
   deploymentUnhealthySecondThreshold: 300
-  serveDeploymentGraphConfig:
+  serveConfig:
     importPath: fruit.deployment_graph
     runtimeEnv: |
       working_dir: "https://github.com/ray-project/test_dag/archive/c620251044717ace0a4c19d766d43c5099af8a77.zip"
-    serveConfigs:
+    deployments:
       - name: MangoStand
         numReplicas: 1
         userConfig: |

--- a/tests/config/ray-service-serve-update.yaml.template
+++ b/tests/config/ray-service-serve-update.yaml.template
@@ -5,11 +5,11 @@ metadata:
 spec:
   serviceUnhealthySecondThreshold: 300
   deploymentUnhealthySecondThreshold: 300
-  serveDeploymentGraphConfig:
+  serveConfig:
     importPath: fruit.deployment_graph
     runtimeEnv: |
       working_dir: "https://github.com/ray-project/test_dag/archive/c620251044717ace0a4c19d766d43c5099af8a77.zip"
-    serveConfigs:
+    deployments:
       - name: MangoStand
         numReplicas: 1
         userConfig: |

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -5,11 +5,11 @@ metadata:
 spec:
   serviceUnhealthySecondThreshold: 300
   deploymentUnhealthySecondThreshold: 300
-  serveDeploymentGraphConfig:
+  serveConfig:
     importPath: fruit.deployment_graph
     runtimeEnv: |
       working_dir: "https://github.com/ray-project/test_dag/archive/c620251044717ace0a4c19d766d43c5099af8a77.zip"
-    serveConfigs:
+    deployments:
       - name: MangoStand
         numReplicas: 1
         userConfig: |


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Renames the config fields to match more directly:
- `serveDeploymentGraphConfig` -> `serveConfig`
- `serveConfigs` -> `deployments`

We should also make the fields support `snake_case` so that they can be copy-pasted directly from `serve build`, but that would be a larger change.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
