### PR TITLE
feat: enrich RayCluster status with head IPs

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -11122,6 +11122,14 @@ spec:
                   type: string
                 description: Service Endpoints
                 type: object
+              head:
+                description: Head info
+                properties:
+                  podIP:
+                    type: string
+                  serviceIP:
+                    type: string
+                type: object
               lastUpdateTime:
                 description: LastUpdateTime indicates last update timestamp for this
                   cluster status.

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -11680,6 +11680,14 @@ spec:
                       type: string
                     description: Service Endpoints
                     type: object
+                  head:
+                    description: Head info
+                    properties:
+                      podIP:
+                        type: string
+                      serviceIP:
+                        type: string
+                    type: object
                   lastUpdateTime:
                     description: LastUpdateTime indicates last update timestamp for
                       this cluster status.

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -11736,6 +11736,14 @@ spec:
                           type: string
                         description: Service Endpoints
                         type: object
+                      head:
+                        description: Head info
+                        properties:
+                          podIP:
+                            type: string
+                          serviceIP:
+                            type: string
+                        type: object
                       lastUpdateTime:
                         description: LastUpdateTime indicates last update timestamp
                           for this cluster status.
@@ -11834,6 +11842,14 @@ spec:
                         additionalProperties:
                           type: string
                         description: Service Endpoints
+                        type: object
+                      head:
+                        description: Head info
+                        properties:
+                          podIP:
+                            type: string
+                          serviceIP:
+                            type: string
                         type: object
                       lastUpdateTime:
                         description: LastUpdateTime indicates last update timestamp

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -117,6 +117,14 @@ type RayClusterStatus struct {
 	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty"`
 	// Service Endpoints
 	Endpoints map[string]string `json:"endpoints,omitempty"`
+	// Head info
+	Head HeadInfo `json:"head,omitempty"`
+}
+
+// HeadInfo gives info about head
+type HeadInfo struct {
+	PodIP     string `json:"podIP,omitempty"`
+	ServiceIP string `json:"serviceIP,omitempty"`
 }
 
 // RayNodeType  the type of a ray node: head/worker

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
@@ -378,7 +378,7 @@ var expected = `{
             
          },
          "rayClusterStatus":{
-            
+            "head":{}
          }
       },
       "pendingServiceStatus":{
@@ -389,7 +389,7 @@ var expected = `{
             
          },
          "rayClusterStatus":{
-            
+            "head":{}
          }
       }
    }

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -11122,6 +11122,14 @@ spec:
                   type: string
                 description: Service Endpoints
                 type: object
+              head:
+                description: Head info
+                properties:
+                  podIP:
+                    type: string
+                  serviceIP:
+                    type: string
+                type: object
               lastUpdateTime:
                 description: LastUpdateTime indicates last update timestamp for this
                   cluster status.

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -11680,6 +11680,14 @@ spec:
                       type: string
                     description: Service Endpoints
                     type: object
+                  head:
+                    description: Head info
+                    properties:
+                      podIP:
+                        type: string
+                      serviceIP:
+                        type: string
+                    type: object
                   lastUpdateTime:
                     description: LastUpdateTime indicates last update timestamp for
                       this cluster status.

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -11736,6 +11736,14 @@ spec:
                           type: string
                         description: Service Endpoints
                         type: object
+                      head:
+                        description: Head info
+                        properties:
+                          podIP:
+                            type: string
+                          serviceIP:
+                            type: string
+                        type: object
                       lastUpdateTime:
                         description: LastUpdateTime indicates last update timestamp
                           for this cluster status.
@@ -11834,6 +11842,14 @@ spec:
                         additionalProperties:
                           type: string
                         description: Service Endpoints
+                        type: object
+                      head:
+                        description: Head info
+                        properties:
+                          podIP:
+                            type: string
+                          serviceIP:
+                            type: string
                         type: object
                       lastUpdateTime:
                         description: LastUpdateTime indicates last update timestamp

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -8,6 +8,17 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 )
 
+// HeadServiceLabels returns the default labels for a cluster's head service.
+func HeadServiceLabels(cluster rayiov1alpha1.RayCluster) map[string]string {
+	return map[string]string{
+		RayClusterLabelKey:                cluster.Name,
+		RayNodeTypeLabelKey:               string(rayiov1alpha1.HeadNode),
+		RayIDLabelKey:                     utils.CheckLabel(utils.GenerateIdentifier(cluster.Name, rayiov1alpha1.HeadNode)),
+		KubernetesApplicationNameLabelKey: ApplicationName,
+		KubernetesCreatedByLabelKey:       ComponentName,
+	}
+}
+
 // BuildServiceForHeadPod Builds the service for a pod. Currently, there is only one service that allows
 // the worker nodes to connect to the head node.
 func BuildServiceForHeadPod(cluster rayiov1alpha1.RayCluster, labels map[string]string) (*corev1.Service, error) {
@@ -15,13 +26,7 @@ func BuildServiceForHeadPod(cluster rayiov1alpha1.RayCluster, labels map[string]
 		labels = make(map[string]string)
 	}
 
-	default_labels := map[string]string{
-		RayClusterLabelKey:                cluster.Name,
-		RayNodeTypeLabelKey:               string(rayiov1alpha1.HeadNode),
-		RayIDLabelKey:                     utils.CheckLabel(utils.GenerateIdentifier(cluster.Name, rayiov1alpha1.HeadNode)),
-		KubernetesApplicationNameLabelKey: ApplicationName,
-		KubernetesCreatedByLabelKey:       ComponentName,
-	}
+	default_labels := HeadServiceLabels(cluster)
 
 	for k, v := range default_labels {
 		if _, ok := labels[k]; !ok {

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -25,7 +25,7 @@ import (
 	rayiov1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
 	"github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
@@ -57,6 +57,7 @@ var (
 	testPods                []runtime.Object
 	testRayCluster          *rayiov1alpha1.RayCluster
 	headSelector            labels.Selector
+	headNodeIP              string
 	testServices            []runtime.Object
 	workerSelector          labels.Selector
 	workersToDelete         []string
@@ -75,6 +76,7 @@ func setupTest(t *testing.T) {
 	groupNameStr = "small-group"
 	expectReplicaNum = 3
 	workersToDelete = []string{"pod1", "pod2"}
+	headNodeIP = "1.2.3.4"
 	testPods = []runtime.Object{
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -98,6 +100,7 @@ func setupTest(t *testing.T) {
 			},
 			Status: corev1.PodStatus{
 				Phase: corev1.PodRunning,
+				PodIP: headNodeIP,
 			},
 		},
 		&corev1.Pod{
@@ -706,7 +709,7 @@ func TestReconcile_AutoscalerServiceAccount(t *testing.T) {
 	sa := corev1.ServiceAccount{}
 	err := fakeClient.Get(context.Background(), saNamespacedName, &sa)
 
-	assert.True(t, errors.IsNotFound(err), "Head group service account should not exist yet")
+	assert.True(t, k8serrors.IsNotFound(err), "Head group service account should not exist yet")
 
 	testRayClusterReconciler := &RayClusterReconciler{
 		Client:   fakeClient,
@@ -736,7 +739,7 @@ func TestReconcile_AutoscalerRoleBinding(t *testing.T) {
 	rb := rbacv1.RoleBinding{}
 	err := fakeClient.Get(context.Background(), rbNamespacedName, &rb)
 
-	assert.True(t, errors.IsNotFound(err), "autoscaler RoleBinding should not exist yet")
+	assert.True(t, k8serrors.IsNotFound(err), "autoscaler RoleBinding should not exist yet")
 
 	testRayClusterReconciler := &RayClusterReconciler{
 		Client:   fakeClient,
@@ -778,4 +781,134 @@ func TestUpdateEndpoints(t *testing.T) {
 		"serve":     "8000",
 	}
 	assert.Equal(t, expected, testRayCluster.Status.Endpoints, "RayCluster status endpoints not updated")
+}
+
+func TestGetHeadPodIP(t *testing.T) {
+	setupTest(t)
+	defer tearDown(t)
+
+	extraHeadPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unexpectedExtraHeadNode",
+			Namespace: namespaceStr,
+			Labels: map[string]string{
+				common.RayClusterLabelKey:   instanceName,
+				common.RayNodeTypeLabelKey:  string(rayiov1alpha1.HeadNode),
+				common.RayNodeGroupLabelKey: headGroupNameStr,
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		pods         []runtime.Object
+		expectedIP   string
+		returnsError bool
+	}{
+		"get expected Pod IP if there's one head node": {
+			pods:         testPods,
+			expectedIP:   headNodeIP,
+			returnsError: false,
+		},
+		"get error if there's no head node": {
+			pods:         []runtime.Object{},
+			expectedIP:   "",
+			returnsError: true,
+		},
+		"get error if there's more than one head node": {
+			pods:         append(testPods, extraHeadPod),
+			expectedIP:   "",
+			returnsError: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fakeClient := clientFake.NewClientBuilder().WithRuntimeObjects(tc.pods...).Build()
+
+			testRayClusterReconciler := &RayClusterReconciler{
+				Client:   fakeClient,
+				Recorder: &record.FakeRecorder{},
+				Scheme:   scheme.Scheme,
+				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
+			}
+
+			ip, err := testRayClusterReconciler.getHeadPodIP(testRayCluster)
+
+			if tc.returnsError {
+				assert.NotNil(t, err, "getHeadPodIP should return error")
+			} else {
+				assert.Nil(t, err, "getHeadPodIP should not return error")
+			}
+
+			assert.Equal(t, tc.expectedIP, ip, "getHeadPodIP returned unexpected IP")
+		})
+	}
+}
+
+func TestGetHeadServiceIP(t *testing.T) {
+	setupTest(t)
+	defer tearDown(t)
+
+	headServiceIP := "1.2.3.4"
+	headService, err := common.BuildServiceForHeadPod(*testRayCluster, nil)
+	if err != nil {
+		t.Errorf("failed to build head service: %v", err)
+	}
+	headService.Spec.ClusterIP = headServiceIP
+	testServices = []runtime.Object{
+		headService,
+	}
+
+	extraHeadService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unexpectedExtraHeadService",
+			Namespace: namespaceStr,
+			Labels:    common.HeadServiceLabels(*testRayCluster),
+		},
+	}
+
+	tests := map[string]struct {
+		services     []runtime.Object
+		expectedIP   string
+		returnsError bool
+	}{
+		"get expected Service IP if there's one head Service": {
+			services:     testServices,
+			expectedIP:   headServiceIP,
+			returnsError: false,
+		},
+		"get error if there's no head Service": {
+			services:     []runtime.Object{},
+			expectedIP:   "",
+			returnsError: true,
+		},
+		"get error if there's more than one head Service": {
+			services:     append(testServices, extraHeadService),
+			expectedIP:   "",
+			returnsError: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fakeClient := clientFake.NewClientBuilder().WithRuntimeObjects(tc.services...).Build()
+
+			testRayClusterReconciler := &RayClusterReconciler{
+				Client:   fakeClient,
+				Recorder: &record.FakeRecorder{},
+				Scheme:   scheme.Scheme,
+				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
+			}
+
+			ip, err := testRayClusterReconciler.getHeadServiceIP(testRayCluster)
+
+			if tc.returnsError {
+				assert.NotNil(t, err, "getHeadServiceIP should return error")
+			} else {
+				assert.Nil(t, err, "getHeadServiceIP should not return error")
+			}
+
+			assert.Equal(t, tc.expectedIP, ip, "getHeadServiceIP returned unexpected IP")
+		})
+	}
 }


### PR DESCRIPTION
like so. Missing IPs will be excluded.

```
status:
  head:
    podIP: string
    serviceIP: string
```

Motivation for this change is so that users can get the head IP from the
RayCluster CRD directly without knowing the underlying implementation
details of kuberay.

In a later commit we update the API server to parse the status
and return the IPs for each cluster.

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
