### PR TITLE
config/prometheus: add metrics exporter for workers

### DIFF
--- a/config/prometheus/podMonitor.yaml
+++ b/config/prometheus/podMonitor.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ray-workers-monitor
+  namespace: prometheus-system
+spec:
+  jobLabel: ray-workers
+  namespaceSelector:
+    matchNames:
+      - default
+      - ray-system
+  selector:
+    matchLabels:
+      rayNodeType: worker
+      ray.io/node-type: worker
+      ray.io/is-ray-node: "yes"
+  podMetricsEndpoints:
+  - port: metrics
+    interval: 1m
+    scrapeTimeout: 10s
+  # - targetPort: 90001
+  #   interval: 1m
+  #   scrapeTimeout: 10s
+

--- a/config/prometheus/rules/prometheusRules.yaml
+++ b/config/prometheus/rules/prometheusRules.yaml
@@ -1,0 +1,205 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    prometheus-operator-validated: "true"
+  name: ray-cluster-gcs-rules
+  namespace: prometheus-system
+spec:
+  groups:
+  - interval: 30s
+    name: ray-cluster-main-staging-gcs.rules
+    rules:
+    - expr: |2
+                      (
+                        100 * (
+                                sum(
+                                     rate(
+                                           ray_gcs_update_resource_usage_time_bucket{container="ray-head", le="20.0"}[30d]
+                                     )
+                                )
+                                /
+                                sum(
+                                     rate(
+                                           ray_gcs_update_resource_usage_time_count{container="ray-head"}[30d]
+                                     )
+                                )
+                        )
+                      )
+      labels:
+        ray_io_cluster: ray-cluster-main
+      record: ray_gcs_availability_30d
+    - expr: |2
+                      100 - (
+                              100 * (
+                                      sum(
+                                           rate(
+                                                 ray_gcs_update_resource_usage_time_bucket{container="ray-head", le="20.0"}[5m]
+                                           )
+                                       )
+                                       /
+                                       sum(
+                                            rate(
+                                                  ray_gcs_update_resource_usage_time_count{container="ray-head"}[5m]
+                                            )
+                                       )
+                              )
+                      )
+      labels:
+        ray_io_cluster: ray-cluster-main
+      record: ray_gcs_error_budget_5m
+    - expr: |2
+                      100 - (
+                              100 * (
+                                      sum(
+                                           rate(
+                                                 ray_gcs_update_resource_usage_time_bucket{container="ray-head", le="20.0"}[1h]
+                                           )
+                                      )
+                                      /
+                                      sum(
+                                           rate(
+                                                 ray_gcs_update_resource_usage_time_count{container="ray-head"}[1h]
+                                           )
+                                      )
+                              )
+                      )
+      labels:
+        ray_io_cluster: ray-cluster-main
+      record: ray_gcs_error_budget_1h
+    - expr: |2
+                      100 - (
+                              100 * (
+                                      sum(
+                                           rate(
+                                                 ray_gcs_update_resource_usage_time_bucket{container="ray-head", le="20.0"}[30m]
+                                           )
+                                      )
+                                      /
+                                      sum(
+                                           rate(
+                                                 ray_gcs_update_resource_usage_time_count{container="ray-head"}[30m]
+                                           )
+                                      )
+                              )
+                      )
+      labels:
+        ray_io_cluster: ray-cluster-main
+      record: ray_gcs_error_budget_30m
+    - expr: |2
+                      100 - (
+                              100 * (
+                                      sum(
+                                           rate(
+                                                 ray_gcs_update_resource_usage_time_bucket{container="ray-head", le="20.0"}[6h]
+                                           )
+                                      )
+                                      /
+                                      sum(
+                                           rate(
+                                                 ray_gcs_update_resource_usage_time_count{container="ray-head"}[6h]
+                                           )
+                                      )
+                              )
+                      )
+      labels:
+        ray_io_cluster: ray-cluster-main
+      record: ray_gcs_error_budget_6h
+    - expr: |2
+                      100 - (
+                              100 * (
+                                      sum(
+                                           rate(
+                                                 ray_gcs_update_resource_usage_time_bucket{container="ray-head", le="20.0"}[2h]
+                                           )
+                                      )
+                                      /
+                                      sum(
+                                           rate(
+                                                 ray_gcs_update_resource_usage_time_count{container="ray-head"}[2h]
+                                           )
+                                      )
+                              )
+                      )
+      labels:
+        ray_io_cluster: ray-cluster-main
+      record: ray_gcs_error_budget_2h
+    - expr: |2
+                      100 - (
+                              100 * (
+                                      sum(
+                                           rate(
+                                                 ray_gcs_update_resource_usage_time_bucket{container="ray-head", le="20.0"}[1d]
+                                           )
+                                      )
+                                      /
+                                      sum(
+                                           rate(
+                                                 ray_gcs_update_resource_usage_time_count{container="ray-head"}[1d]
+                                           )
+                                      )
+                              )
+                      )
+      labels:
+        ray_io_cluster: ray-cluster-main
+      record: ray_gcs_error_budget_1d
+    - alert: RayGlobalControlStoreShortWindowSLO
+      annotations:
+        description: Ray GCS Resource Update requests are above the SLO (99.9 > 20ms).
+          Burning rate is 14.4 for short window (5m & 1h)
+        summary: Ray GCS is burning too much error budget (short window)
+      expr: |2
+                      (
+                        ray_gcs_error_budget_5m > 14.4*0.1
+                      )
+                      and
+                      (
+                        ray_gcs_error_budget_1h > 14.4*0.1
+                      )
+      for: 5m
+      labels:
+        severity: critical
+    - alert: RayGlobalControlStoreMidWindowSLO
+      annotations:
+        description: Ray GCS Resource Update requests are above the SLO (99.9 > 20ms).
+          Burning rate is 6 for short window (30m & 6h)
+        summary: Ray GCS is burning too much error budget (mid window)
+      expr: |2
+                      (
+                        ray_gcs_error_budget_30m > 6*0.1
+                      )
+                      and
+                      (
+                        ray_gcs_error_budget_6h > 6*0.1
+                      )
+      for: 5m
+      labels:
+        severity: critical
+    - alert: RayGlobalControlStoreLongWindowSLO
+      annotations:
+        description: Ray GCS Resource Update requests are above the SLO (99.9 > 20ms).
+          Burning rate is 3 for short window (2h & 1d)
+        summary: Ray GCS is burning too much error budget (long window)
+      expr: |2
+                      (
+                        ray_gcs_error_budget_2h > 3*0.1
+                      )
+                      and
+                      (
+                        ray_gcs_error_budget_1d > 3*0.1
+                      )
+      for: 5m
+      labels:
+        severity: critical
+    - alert: MissingMetricRayGlobalControlStore
+      annotations:
+        description: Ray GCS is not emitting any metrics for Resource Update requests
+        summary: Ray GCS is not emitting metrics anymore
+      expr: |2
+                      (
+                       absent(ray_gcs_update_resource_usage_time_bucket) == 1
+                      )
+      for: 5m
+      labels:
+        severity: critical
+

--- a/config/prometheus/serviceMonitor.yaml
+++ b/config/prometheus/serviceMonitor.yaml
@@ -1,12 +1,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: ray-monitor
+  name: ray-head-monitor
   namespace: prometheus-system
   labels:
     release: prometheus-operator
     ray.io/node-type: head
 spec:
+  jobLabel: ray-head
   namespaceSelector:
     matchNames:
       - default
@@ -16,3 +17,6 @@ spec:
       ray.io/node-type: head
   endpoints:
     - port: metrics
+  targetLabels:
+  - ray.io/cluster
+

--- a/docs/guidance/observability.md
+++ b/docs/guidance/observability.md
@@ -49,15 +49,251 @@ curl --request GET '<baseUrl>/apis/v1alpha2/namespaces/<namespace>/clusters/<ray
 }
 ```
 
-## Monitor
+## Ray Cluster: Monitoring with Prometheus & Grafana
 
-We have added a parameter `--metrics-expose-port=8080` to open the port and expose metrics both for the ray cluster and our control plane. We also leverage the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) to start the whole monitoring system.
+In this section we will describe how to monitor Ray Clusters in Kubernetes using Prometheus & Grafana.
 
-You can quickly deploy one by the following on your own kubernetes cluster by using the scripts in install:
+We also leverage the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) to start the whole monitoring system.
 
-```shell
-./install/prometheus/install.sh
+Requirements:
+- Prometheus deployed in Kubernetes
+  - Required CRD: `servicemonitors.monitoring.coreos.com`
+  - Requered CRD: `podmonitors.monitoring.coreos.com`
+- Grafana up and running
+
+### Enable Ray Cluster Metrics
+
+Before we define any Prometheus objects, let us first enable and export metrics to a specific port.
+
+To enable ray metrics on Head node or a worker node, we need to pass the following option `--metrics-expose-port=9001`. We can set the specific option by adding `metrics-export-port: "9001"` to the head node & worker nodes in the rayclusters.ray.io manifest.
+
+We also need to export port `9001` in the head node & worker nodes
+
+```yaml
+apiVersion: ray.io/v1alpha1
+kind: RayCluster
+metadata:
+  ...
+  name: ray-cluster
+spec:
+  enableInTreeAutoscaling: true
+  headGroupSpec:
+    rayStartParams:
+      ...
+      metrics-export-port: "9001"      <--- Enable for the head node
+    ...
+    template:
+      metadata:
+        ...
+      spec:
+        ...
+        containers:
+        - ports:
+          - containerPort: 10001
+            name: client
+            protocol: TCP
+          - containerPort: 8265
+            name: dashboard
+            protocol: TCP
+          - containerPort: 8000
+            name: ray-serve
+            protocol: TCP
+          - containerPort: 6379
+            name: redis
+            protocol: TCP
+          - containerPort: 9001
+            name: metrics
+            protocol: TCP
+  workerGroupSpecs:
+  - groupName: workergroup
+    ...
+    rayStartParams:
+      ...
+      metrics-export-port: "9001"      <--- Enable for worker nodes
+    ...
+    template:
+      metadata:
+        ...
+      spec:
+        ...
+        containers:
+        - ports:
+          - containerPort: 9001
+            name: metrics
+            protocol: TCP
+        ...
+...
 ```
-It will set up the prometheus stack and deploy the related service monitor in `config/prometheus`
 
-Then you can also use the json in `config/grafana` to generate the dashboards.
+If you use `$kuberay/helm-chart/ray-cluster`, then you can add it in the `values.yaml` 
+
+```yaml
+head:
+  groupName: headgroup
+  ...
+  initArgs:
+    metrics-export-port: "9001"      <--- Enable for the head node
+    ...
+  ports:
+  - containerPort: 10001
+    protocol: TCP
+    name: "client"
+  - containerPort: 8265
+    protocol: TCP
+    name: "dashboard"
+  - containerPort: 8000
+    protocol: TCP
+    name: "ray-serve"
+  - containerPort: 6379
+    protocol: TCP
+    name: "redis"
+  - containerPort: 9001              <--- Enable this port
+    protocol: TCP
+    name: "metrics"
+  ...
+worker:
+  groupName: workergroup
+  ...
+  initArgs:
+    ...
+    metrics-export-port: "9001"      <--- Enable for the head node
+  ports:
+  - containerPort: 9001              <--- Enable this port
+    protocol: TCP
+    name: "metrics"
+  ...
+...
+```
+
+Deploying the cluster with the above options should export metrics on port `9001`. To check, we can port-forward port `9001` to our localhost and query via curl.
+
+```bash
+k port-forward <ray-head-node-id> 9001:9001
+```
+
+From a second terminal issue
+
+```bash
+$> curl localhost:9001
+# TYPE ray_pull_manager_object_request_time_ms histogram
+...
+ray_pull_manager_object_request_time_ms_sum{Component="raylet",...
+...
+```
+
+Before we move on, first ensure that the required metrics port is also defined in the Ray's cluster Kubernetes service. This is done automatically via the Ray Operator if you define the metrics port `containerPort: 9001` along with the name and protocol. 
+
+```bash
+$> kubectl get svc <ray-cluster-name>-head-svc -o yaml
+NAME  TYPE       ...   PORT(S)                                         ...
+...   ClusterIP  ...   6379/TCP,9001/TCP,10001/TCP,8265/TCP,8000/TCP   ...
+```
+
+We are now ready to create the required Prometheus CRDs to collect metrics
+
+### Collect Head Node metrics with ServiceMonitors
+
+Prometheus provides a CRD that targets Kubernetes services to collect metrics. The idea is that we will define a CRD that will have selectors that match the Ray Cluster Kubernetes service labels and ports, the metrics port.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: <ray-cluster-name>-head-monitor              <-- Replace <ray-cluster-name> with the actual Ray Cluster name
+  namespace: <ray-cluster-namespace>                 <-- Add the namespace of your ray cluster
+spec:
+  endpoints:
+  - interval: 1m
+    path: /metrics
+    scrapeTimeout: 10s
+    port: metrics
+  jobLabel: <ray-cluster-name>-ray-head              <-- Replace <ray-cluster-name> with the actual Ray Cluster name
+  namespaceSelector:
+    matchNames:
+    - <ray-cluster-namespace>                        <-- Add the namespace of your ray cluster
+  selector:
+    matchLabels:
+      ray.io/cluster: <ray-cluster-name>             <-- Replace <ray-cluster-name> with the actual Ray Cluster name
+      ray.io/identifier: <ray-cluster-name>-head     <-- Replace <ray-cluster-name> with the actual Ray Cluster name
+      ray.io/node-type: head
+  targetLabels:
+  - ray.io/cluster
+```
+
+A notes for the `targetLabels`. We added `spec.targetLabels[0].ray.io/cluster` because we want to include the name of the ray cluster in the metrics that will be generated by this service monitor. The `ray.io/cluster` label is part of the Ray head node service and it will be transformed to a `ray_io_cluster` metric label. That is, any metric that will be imported, will also container the following label `ray_io_cluster=<ray-cluster-name>`. This may seem like optional but it becomes mandatory if you deploy multiple ray clusters.
+
+Create the above service monitor by issuing
+
+```bash
+k apply -f serviceMonitor.yaml
+```
+
+After a while, Prometheus should start scraping metrics from the head node. You can confirm that by visiting the Prometheus web ui and start typing `ray_`. Prometheus should create a dropdown list with suggested Ray metrics.
+
+```bash
+curl 'https://<prometheus-endpoint>/api/v1/query?query=ray_object_store_available_memory' -H 'Accept: */*'
+```
+
+### Collect Worker Node metrics with PodMonitors
+
+Ray operator does not create a Kubernetes service for the ray workers, therefore we can not use a Prometheus ServiceMonitors to scrape the metrics from our workers. 
+
+**Note**: We could create a Kubernetes service with selectors a common label subset from our worker pods, however this is not ideal because our workers are independent from each other, that is, they are not a collection of replicas spawned by replicaset controller. Due to that, we should avoid using a Kubernetes service for grouping them together.
+
+To collect worker metrics, we can use `Prometheus PodMonitros CRD`.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    ray.io/cluster: <ray-cluster-name>               <-- Replace <ray-cluster-name> with the actual Ray Cluster name
+  name: <ray-cluster-name>-workers-monitor           <-- Replace <ray-cluster-name> with the actual Ray Cluster name
+  namespace: <ray-cluster-namespace>                 <-- Add the namespace of your ray cluster
+spec:
+  jobLabel: <ray-cluster-name>-ray-workers           <-- Replace <ray-cluster-name> with the actual Ray Cluster name
+  namespaceSelector:
+    matchNames:
+    - <ray-cluster-namespace>                        <-- Add the namespace of your ray cluster
+  podMetricsEndpoints:
+  - interval: 30s
+    port: metrics
+    scrapeTimeout: 10s
+  podTargetLabels:
+  - ray.io/cluster
+  selector:
+    matchLabels:
+      ray.io/is-ray-node: "yes"
+      ray.io/node-type: worker
+      rayNodeType: worker
+```
+
+Since we are not selecting a Kubernetes service but pods, our `matchLabels` now define a set of labels that is common on all Ray workers.
+
+We also define `metadata.labels` by manually adding `ray.io/cluster: <ray-cluster-name>` and then instructing the PodMonitors resource to add that label in the scraped metrics via `spec.podTargetLabels[0].ray.io/cluster`.
+
+Apply the above PodMonitor manifest
+
+```bash
+k apply -f podMonitor.yaml
+```
+
+Last, wait a bit and then ensure that you can see Ray worker metrics in Prometheus
+
+```bash
+curl 'https://<prometheus-endpoint>/api/v1/query?query=ray_object_store_available_memory' -H 'Accept: */*'
+```
+
+The above http query should yield metrics from the head node and your worker nodes
+
+We have everything we need now and we can use Grafana to create some panels and visualize the scrapped metrics
+
+### Grafana: Visualize ingested Ray metrics
+
+You can use the json in `config/grafana` to import in Grafana the Ray dashboards.
+
+### Custom Metrics & Alerting 
+
+We can also define custom metrics, and create alerts by using `prometheusrules.monitoring.coreos.com` CRD. Because custom metrics, and alerting is different for each team and setup, we have included an example under `$kuberay/config/prometheus/rules` that you can use to build custom metrics and alerts
+
+


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Sample configuration for exporting metrics from ray cluster workers. This works with autoscaling and should cover new workers and remove destroyed worker pods as well

<!-- Please give a short summary of the change and the problem this solves. -->
The podMonitor CRD resource works in a similar way that serviceMonitor works but instead of targeting services, it targets pods.

Prometheus example after applying this manifest
```
ray_raylet_mem{..., container="ray-head", ...} | ...
...
ray_raylet_mem{..., container="ray-worker", ..., pod="ray-cluster-main-worker-generic-group-h2nhg",...} | ...
...
```