### PR TITLE
Add timeout to the query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Please choose the version you like to install. We will use nightly version `mast
 
 ```
 export KUBERAY_VERSION=master
-kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=${KUBERAY_VERSION}"
-kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=${KUBERAY_VERSION}"
+kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=${KUBERAY_VERSION}&timeout=90s"
+kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=${KUBERAY_VERSION}&timeout=90s"
 ```
 
 > Observe that we must use `kubectl create` to install cluster-scoped resources.


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

## Why are these changes needed?
Error massage
```
(base) ➜  kuberay git:(master) ✗ export KUBERAY_VERSION=master
kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=${KUBERAY_VERSION}"
kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=${KUBERAY_VERSION}"

error: hit 27s timeout running '/usr/local/bin/git fetch --depth=1 origin master'
error: hit 27s timeout running '/usr/local/bin/git fetch --depth=1 origin master'
```

Increasing timeout can fix the issue.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
