### PR TITLE
sync up helm chart's role

### DIFF
--- a/helm-chart/kuberay-apiserver/templates/role.yaml
+++ b/helm-chart/kuberay-apiserver/templates/role.yaml
@@ -11,6 +11,7 @@ rules:
   - ray.io
   resources:
   - rayclusters
+  - rayjobs
   verbs:
   - create
   - delete
@@ -34,9 +35,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
-  - get 
+  - get
   - list
-  - watch
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/ray_rayjob_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayjob_editor_role.yaml
@@ -1,0 +1,28 @@
+# permissions for end users to edit rayjobs.
+{{- if .Values.rbacEnable }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+{{ include "kuberay-operator.labels" . | indent 4 }}
+  name: rayjob-editor-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  verbs:
+  - get
+{{- end }}

--- a/helm-chart/kuberay-operator/templates/ray_rayjob_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayjob_viewer_role.yaml
@@ -1,0 +1,24 @@
+# permissions for end users to view rayjobs.
+{{- if .Values.rbacEnable }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+{{ include "kuberay-operator.labels" . | indent 4 }}
+  name: rayjob-viewer-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  verbs:
+  - get
+{{- end }}

--- a/helm-chart/kuberay-operator/templates/ray_rayservice_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayservice_editor_role.yaml
@@ -1,0 +1,26 @@
+# permissions for end users to edit rayservices.
+{{- if .Values.rbacEnable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rayservice-editor-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/status
+  verbs:
+  - get
+{{- end }}

--- a/helm-chart/kuberay-operator/templates/ray_rayservice_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayservice_viewer_role.yaml
@@ -1,0 +1,22 @@
+# permissions for end users to view rayservices.
+{{- if .Values.rbacEnable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rayservice-viewer-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/status
+  verbs:
+  - get
+{{- end }}

--- a/helm-chart/kuberay-operator/templates/role.yaml
+++ b/helm-chart/kuberay-operator/templates/role.yaml
@@ -142,6 +142,32 @@ rules:
 - apiGroups:
   - ray.io
   resources:
+  - rayjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/finalizer
+  verbs:
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ray.io
+  resources:
   - rayservices
   verbs:
   - create


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The operator deployed by the helm chart need permission for the rayjobs resource, the role is already update in the `ray-operator/config/rbac`, we need sync up in the helm chart.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#440 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
