### PR TITLE
Properly convert unix time into meta time

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Please choose the version you like to install. We will use nightly version `mast
 
 ```
 export KUBERAY_VERSION=master
-kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=${KUBERAY_VERSION}"
-kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=${KUBERAY_VERSION}"
+kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=${KUBERAY_VERSION}&timeout=90s"
+kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=${KUBERAY_VERSION}&timeout=90s"
 ```
 
 > Observe that we must use `kubectl create` to install cluster-scoped resources.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Please choose the version you like to install. We will use nightly version `mast
 
 ```
 export KUBERAY_VERSION=master
-kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=${KUBERAY_VERSION}&timeout=90s"
-kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=${KUBERAY_VERSION}&timeout=90s"
+kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=${KUBERAY_VERSION}"
+kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=${KUBERAY_VERSION}"
 ```
 
 > Observe that we must use `kubectl create` to install cluster-scoped resources.

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -291,7 +291,7 @@ func (r *RayDashboardClient) ConvertServeConfig(specs []rayv1alpha1.ServeConfigS
 }
 
 // RayJobInfo is the response of "ray job status" api.
-// Reference to https://docs.ray.io/en/master/cluster/jobs-package-ref.html#jobinfo.
+// Reference to https://docs.ray.io/en/latest/cluster/jobs-package-ref.html#jobinfo.
 type RayJobInfo struct {
 	JobStatus  rayv1alpha1.JobStatus `json:"status,omitempty"`
 	Entrypoint string                `json:"entrypoint,omitempty"`
@@ -303,7 +303,7 @@ type RayJobInfo struct {
 }
 
 // RayJobRequest is the request body to submit.
-// Reference to https://docs.ray.io/en/master/cluster/jobs-package-ref.html#jobsubmissionclient.
+// Reference to https://docs.ray.io/en/latest/cluster/jobs-package-ref.html#jobsubmissionclient.
 type RayJobRequest struct {
 	Entrypoint string                 `json:"entrypoint"`
 	JobId      string                 `json:"job_id,omitempty"`

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -336,7 +336,9 @@ func CompareJsonStruct(objA interface{}, objB interface{}) bool {
 }
 
 func ConvertUnixTimeToMetav1Time(unixTime int64) *metav1.Time {
-	t := time.Unix(unixTime, 0)
+	// The Ray jobInfo returns the start_time, which is a unix timestamp in milliseconds.
+	// https://docs.ray.io/en/latest/cluster/jobs-package-ref.html#jobinfo
+	t := time.Unix(unixTime/1000, unixTime%1000*1000000)
 	kt := metav1.NewTime(t)
 	return &kt
 }


### PR DESCRIPTION
## Why are these changes needed?

Failed to convert Unix time to meta time.
```
2022-08-16T10:29:43.043Z	DEBUG	controllers.RayJob	RayJob information	{"RayJob": "rayjob-sample", "jobInfo": {"status":"SUCCEEDED","entrypoint":"python /home/ray/samples/sample_code.py","message":"Job finished successfully.","start_time":1660645691607,"end_time":1660645710418}, "rayJobInstance": "PENDING"}
2022-08-16T10:29:43.043Z	INFO	controllers.RayJob	Update status from PENDING to SUCCEEDED	{"rayjob": "rayjob-sample-z7j5q"}
2022-08-16T10:29:43.043Z	INFO	controllers.RayJob	UpdateState	{"oldJobStatus": "PENDING", "newJobStatus": "SUCCEEDED", "oldJobDeploymentStatus": "Running", "newJobDeploymentStatus": "Running"}
2022-08-16T10:29:43.057Z	ERROR	controller.rayjob	Reconciler error	{"reconciler group": "ray.io", "reconciler kind": "RayJob", "name": "rayjob-sample", "namespace": "default", "error": "combined error: <nil> RayJob.ray.io \"rayjob-sample\" is invalid: [status.startTime: Invalid value: \"54593-10-07T05:53:27Z\": status.startTime in body must be of type date-time: \"54593-10-07T05:53:27Z\", status.endTime: Invalid value: \"54593-10-07T11:06:58Z\": status.endTime in body must be of type date-time: \"54593-10-07T11:06:58Z\"]", "errorVerbose": "combined error: <nil> RayJob.ray.io \"rayjob-sample\" is invalid: [status.startTime: Invalid value: \"54593-10-07T05:53:27Z\": status.startTime in body must be of type date-time: \"54593-10-07T05:53:27Z\", status.endTime: Invalid value: \"54593-10-07T11:06:58Z\": status.endTime in body must be of type date-time: \"54593-10-07T11:06:58Z\"]\ngithub.com/ray-project/kuberay/ray-operator/controllers/ray.(*RayJobReconciler).updateState\n\t/workspace/controllers/ray/rayjob_controller.go:311\ngithub.com/ray-project/kuberay/ray-operator/controllers/ray.(*RayJobReconciler).Reconcile\n\t/workspace/controllers/ray/rayjob_controller.go:181\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1581"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:227
```

We should divide Unix time by 1000 because Ray job info returns the start_time in ms format.
https://docs.ray.io/en/latest/cluster/jobs-package-ref.html#jobinfo

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
