### PR TITLE
Fix panic in cleanupInvalidVolumeMounts 

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -775,7 +775,8 @@ func checkIfVolumeExists(pod *v1.Pod, volumeName string) bool {
 func cleanupInvalidVolumeMounts(container *v1.Container, pod *v1.Pod) {
 	// if a volumeMount is specified in the container,
 	// but has no corresponding pod volume, it is removed
-	for index, mountedVol := range container.VolumeMounts {
+	k := 0
+	for _, mountedVol := range container.VolumeMounts {
 		valid := false
 		for _, podVolume := range pod.Spec.Volumes {
 			if mountedVol.Name == podVolume.Name {
@@ -784,12 +785,13 @@ func cleanupInvalidVolumeMounts(container *v1.Container, pod *v1.Pod) {
 				break
 			}
 		}
-		if !valid {
+		if valid {
 			// remove the VolumeMount
-			container.VolumeMounts[index] = container.VolumeMounts[len(container.VolumeMounts)-1]
-			container.VolumeMounts = container.VolumeMounts[:len(container.VolumeMounts)-1]
+			container.VolumeMounts[k] = mountedVol
+			k++
 		}
 	}
+	container.VolumeMounts = container.VolumeMounts[:k]
 }
 
 func findMemoryReqOrLimit(container v1.Container) (res *resource.Quantity) {

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -777,18 +777,13 @@ func cleanupInvalidVolumeMounts(container *v1.Container, pod *v1.Pod) {
 	// but has no corresponding pod volume, it is removed
 	k := 0
 	for _, mountedVol := range container.VolumeMounts {
-		valid := false
 		for _, podVolume := range pod.Spec.Volumes {
 			if mountedVol.Name == podVolume.Name {
 				// valid mount, moving on...
-				valid = true
+				container.VolumeMounts[k] = mountedVol
+				k++
 				break
 			}
-		}
-		if valid {
-			// remove the VolumeMount
-			container.VolumeMounts[k] = mountedVol
-			k++
 		}
 	}
 	container.VolumeMounts = container.VolumeMounts[:k]

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -633,5 +633,7 @@ func TestCleanupInvalidVolumeMounts(t *testing.T) {
 			ReadOnly:  true,
 		},
 	}...)
+	assert.Equal(t, len(pod.Spec.Containers[0].VolumeMounts), 3)
 	cleanupInvalidVolumeMounts(&pod.Spec.Containers[0], &pod)
+	assert.Equal(t, len(pod.Spec.Containers[0].VolumeMounts), 1)
 }

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -611,3 +611,27 @@ func splitAndSort(s string) []string {
 	sort.Strings(result)
 	return result
 }
+
+func TestCleanupInvalidVolumeMounts(t *testing.T) {
+	cluster := instance.DeepCopy()
+
+	// Test head pod
+	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	svcName := utils.GenerateServiceName(cluster.Name)
+	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName, "6379")
+	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, "6379", nil, "")
+
+	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, []v1.VolumeMount{
+		{
+			Name:      "mock-name1",
+			MountPath: "/mock-path1",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "mock-name2",
+			MountPath: "/mock-path2",
+			ReadOnly:  true,
+		},
+	}...)
+	cleanupInvalidVolumeMounts(&pod.Spec.Containers[0], &pod)
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Removing elements while iterating over VolumeMounts slice causes panics.

```
WARN[0000] ingress class annotation is not set for cluster default/raycluster-sample 
--- FAIL: TestCleanupInvalidVolumeMounts (0.00s)
panic: runtime error: index out of range [2] with length 2 [recovered]
        panic: runtime error: index out of range [2] with length 2

goroutine 103 [running]:
testing.tRunner.func1.2({0x10543be80, 0x14000042468})
        /usr/local/go/src/testing/testing.go:1389 +0x1c8
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1392 +0x384
panic({0x10543be80, 0x14000042468})
        /usr/local/go/src/runtime/panic.go:838 +0x204
github.com/ray-project/kuberay/ray-operator/controllers/ray/common.cleanupInvalidVolumeMounts(...)
        /Users/wanxing/work/code/kuberay-github/ray-operator/controllers/ray/common/pod.go:789
github.com/ray-project/kuberay/ray-operator/controllers/ray/common.TestCleanupInvalidVolumeMounts(0x1400020b520?)
        /Users/wanxing/work/code/kuberay-github/ray-operator/controllers/ray/common/pod_test.go:636 +0x500
testing.tRunner(0x1400020b6c0, 0x1054f51c0)
        /usr/local/go/src/testing/testing.go:1439 +0x110
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1486 +0x300
exit status 2

```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
