### PR TITLE
[doc] Config and doc updates ahead of KubeRay 0.3.0/Ray 2.0.0

### DIFF
--- a/docs/guidance/autoscaler.md
+++ b/docs/guidance/autoscaler.md
@@ -4,7 +4,7 @@
 ### Prerequisite
 
 Ray Autoscaler integration is beta with KubeRay 0.3.0 and Ray 2.0.0.
-The details of autoscaler behavior and configuration may change in future releases.
+While autoscaling functionality is stable, the details of autoscaler behavior and configuration may change in future releases.
 
 Start by deploying the latest stable version of the KubeRay operator:
 ```
@@ -79,7 +79,7 @@ Demands:
    For Ray versions older than 2.0.0, the image `rayproject/ray:2.0.0` will be used to run the autoscaler.
 
 3. Autoscaling functionality is supported only with Ray versions at least as new as 1.11.0. Autoscaler support
-   is beta as of Ray 2.0.0 and KubeRay 0.3.0. The details of autoscaler behavior and configuration may change in future releases.
+   is beta as of Ray 2.0.0 and KubeRay 0.3.0; while autoscaling functionality is stable, the details of autoscaler behavior and configuration may change in future releases.
 
 ### Test autoscaling
 

--- a/docs/guidance/autoscaler.md
+++ b/docs/guidance/autoscaler.md
@@ -1,9 +1,11 @@
-## Autoscaler (Beta)
+## Autoscaler (beta)
 
 
 ### Prerequisite
 
-Ray Autoscaler integration is Beta with KubeRay 0.3.0 and Ray 2.0.0.
+Ray Autoscaler integration is beta with KubeRay 0.3.0 and Ray 2.0.0.
+The details of autoscaler behavior and configuration may change in future releases.
+
 Start by deploying the latest stable version of the KubeRay operator:
 ```
 kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.3.0-rc.1&timeout=90s"
@@ -77,7 +79,7 @@ Demands:
    For Ray versions older than 2.0.0, the image `rayproject/ray:2.0.0` will be used to run the autoscaler.
 
 3. Autoscaling functionality is supported only with Ray versions at least as new as 1.11.0. Autoscaler support
-   is Beta as of Ray 2.0.0 and KubeRay 0.3.0
+   is beta as of Ray 2.0.0 and KubeRay 0.3.0. The details of autoscaler behavior and configuration may change in future releases.
 
 ### Test autoscaling
 

--- a/docs/guidance/autoscaler.md
+++ b/docs/guidance/autoscaler.md
@@ -6,8 +6,8 @@
 Ray Autoscaler integration is Beta with KubeRay 0.3.0 and Ray 2.0.0.
 Start by deploying the latest stable version of the KubeRay operator:
 ```
-kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.3.0&timeout=90s"
-kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=v0.3.0&timeout=90s"
+kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.3.0-rc.1&timeout=90s"
+kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=v0.3.0-rc.1&timeout=90s"
 ```
 
 ### Deploy a cluster with autoscaling enabled

--- a/docs/guidance/autoscaler.md
+++ b/docs/guidance/autoscaler.md
@@ -4,21 +4,17 @@
 ### Prerequisite
 
 Ray Autoscaler integration is Beta with KubeRay 0.3.0 and Ray 2.0.0.
-You have to use nightly operator images because [autoscaler support](https://github.com/ray-project/kuberay/pull/163) is merged recently.
-To deploy the nightly RayCluster CRD and KubeRay, run
-
+Start by deploying the latest stable version of the KubeRay operator:
 ```
-git clone https://github.com/ray-project/kuberay.git
-cd kuberay
-kubectl create -k manifests/cluster-scope-resources
-kubectl apply -k manifests/overlays/autoscaling
+kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.3.0&timeout=90s"
+kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=v0.3.0&timeout=90s"
 ```
 
 ### Deploy a cluster with autoscaling enabled
 
 Next, to deploy a sample autoscaling Ray cluster, run
 ```
-kubectl apply -f ray-operator/config/samples/ray-cluster.autoscaler.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/release-0.3/ray-operator/config/samples/ray-cluster.autoscaler.yaml
 ```
 
 See the above config file for details on autoscaling configuration.

--- a/docs/guidance/observability.md
+++ b/docs/guidance/observability.md
@@ -3,16 +3,16 @@
 ## RayCluster Status
 
 ### State
-In the RayCluster resource definition, we use `State` to represent the current status of the ray cluster.
+In the RayCluster resource definition, we use `State` to represent the current status of the Ray cluster.
 
-For now, there are three types of the status exposed by the resouce status: `ready`, `unhealthy` and `failed`.
+For now, there are three types of the status exposed by the RayCluster's status.state: `ready`, `unhealthy` and `failed`.
 | State     | Description                                                                                     |
 | --------- | ----------------------------------------------------------------------------------------------- |
-| ready     | the ray cluster is ready for use.                                                               |
-| unhealthy | there is something miss configed in the `startParams` and the ray cluster may not act correctly |
-| failed    | there are some severe fatal and result in the head node or worker node start failed.            |
+| ready     | The Ray cluster is ready for use.                                                               |
+| unhealthy | The `rayStartParams` are misconfigured and the Ray cluster may not function properly.           |
+| failed    | A severe issue has prevented the head node or worker nodes from starting.                       |
 
-If you use apiserver to retrieve the resource, you may find the state in the `clusterState` field.
+If you use the apiserver to retrieve the resource, you may find the state in the `clusterState` field.
 
 ```json
 curl --request GET '<baseUrl>/apis/v1alpha2/namespaces/<namespace>/clusters/<raycluster-name>'

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -20,7 +20,7 @@ metadata:
   name: raycluster-autoscaler
 spec:
   # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
-  rayVersion: '1.13.0'
+  rayVersion: '2.0.0'
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
@@ -75,7 +75,7 @@ spec:
         containers:
         # The Ray head container
         - name: ray-head
-          image: rayproject/ray:1.13.0
+          image: rayproject/ray:2.0.0
           imagePullPolicy: Always
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
@@ -134,7 +134,7 @@ spec:
           command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
         containers:
         - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-          image: rayproject/ray:1.13.0
+          image: rayproject/ray:2.0.0
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
           # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -11,7 +11,7 @@ metadata:
   name: raycluster-autoscaler
 spec:
   # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
-  rayVersion: '1.13.0'
+  rayVersion: '2.0.0'
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
@@ -66,7 +66,7 @@ spec:
         containers:
         # The Ray head pod
         - name: ray-head
-          image: rayproject/ray:1.13.0
+          image: rayproject/ray:2.0.0
           imagePullPolicy: Always
           ports:
           - containerPort: 6379
@@ -121,7 +121,7 @@ spec:
           command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
         containers:
         - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-          image: rayproject/ray:1.13.0
+          image: rayproject/ray:2.0.0
           # environment variables to set in the container.Optional.
           # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
           lifecycle:

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -13,7 +13,7 @@ metadata:
     # A unique identifier for the head node and workers of this cluster.
   name: raycluster-complete
 spec:
-  rayVersion: '1.13.0'
+  rayVersion: '2.0.0'
   ######################headGroupSpecs#################################
   # head group template and specs, (perhaps 'group' is not needed in the name)
   headGroupSpec:
@@ -41,7 +41,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:1.13.0
+          image: rayproject/ray:2.0.0
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
           # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal
@@ -93,7 +93,7 @@ spec:
       spec:
         containers:
         - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-          image: rayproject/ray:1.13.0
+          image: rayproject/ray:2.0.0
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
           # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -10,7 +10,7 @@ metadata:
     # A unique identifier for the head node and workers of this cluster.
   name: raycluster-complete
 spec:
-  rayVersion: '1.13.0'
+  rayVersion: '2.0.0'
   ######################headGroupSpec#################################
   # head group template and specs, (perhaps 'group' is not needed in the name)
   headGroupSpec:
@@ -38,7 +38,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:1.13.0
+          image: rayproject/ray:2.0.0
           ports:
           - containerPort: 6379
             name: gcs
@@ -86,7 +86,7 @@ spec:
       spec:
         containers:
         - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-          image: rayproject/ray:1.13.0
+          image: rayproject/ray:2.0.0
           # environment variables to set in the container.Optional.
           # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
           lifecycle:

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -15,7 +15,7 @@ spec:
   #}'
   runtimeEnv: ewogICAgInBpcCI6IFsKICAgICAgICAicmVxdWVzdHM9PTIuMjYuMCIsCiAgICAgICAgInBlbmR1bHVtPT0yLjEuMiIKICAgIF0sCiAgICAiZW52X3ZhcnMiOiB7ImNvdW50ZXJfbmFtZSI6ICJ0ZXN0X2NvdW50ZXIifQp9Cg==
   rayClusterSpec:
-    rayVersion: 'nightly' # should match the Ray version in the image of the containers
+    rayVersion: '2.0.0' # should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################
     # head group template and specs, (perhaps 'group' is not needed in the name)
     headGroupSpec:
@@ -49,7 +49,7 @@ spec:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:nightly
+              image: rayproject/ray:2.0.0
               env:
                 - name: MY_POD_IP
                   valueFrom:
@@ -103,7 +103,7 @@ spec:
                 command: [ 'sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done" ]
             containers:
               - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-                image: rayproject/ray:nightly
+                image: rayproject/ray:2.0.0
                 # environment variables to set in the container.Optional.
                 # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
                 env:

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -42,7 +42,7 @@ spec:
         rayActorOptions:
           numCpus: 0.1
   rayClusterConfig:
-    rayVersion: 'nightly' # should match the Ray version in the image of the containers
+    rayVersion: '2.0.0' # should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################
     # head group template and specs, (perhaps 'group' is not needed in the name)
     headGroupSpec:
@@ -78,8 +78,7 @@ spec:
         spec:
           containers:
             - name: ray-head
-              #image: rayproject/ray:1.12.1
-              image: rayproject/ray:nightly
+              image: rayproject/ray:2.0.0
               imagePullPolicy: Always
               #image: bonsaidev.azurecr.io/bonsai/lazer-0-9-0-cpu:dev
               env:
@@ -139,7 +138,7 @@ spec:
                 command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
             containers:
               - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-                image: rayproject/ray:nightly
+                image: rayproject/ray:2.0.0
                 imagePullPolicy: Always
                 # environment variables to set in the container.Optional.
                 # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR
- Updates some configs to refer to Ray 2.0.0
- Updates autoscaler docs to reflect beta status for autoscaler integration
- Makes a couple of grammar edits

It would be good to pick this into the 0.3 branch, since some of the Ray docs refer to the configs in the release branch.

One viable strategy to manage docs for the release branch is just to check the master branch docs straight into the 0.3 branch. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
