### PR TITLE
[operator] fix dashboard agent url

### DIFF
--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -119,7 +119,7 @@ func FetchDashboardAgentURL(ctx context.Context, log *logr.Logger, cli client.Cl
 		return "", fmtErrors.Errorf("dashboard port not found")
 	}
 
-	dashboardAgentURL := fmt.Sprintf("%s.%s.svc.cluster.local:%v",
+	dashboardAgentURL := fmt.Sprintf("%s.%s:%v",
 		dashboardAgentService.Name,
 		dashboardAgentService.Namespace,
 		dashboardPort)
@@ -149,7 +149,7 @@ func FetchDashboardURL(ctx context.Context, log *logr.Logger, cli client.Client,
 		return "", fmtErrors.Errorf("dashboard port not found")
 	}
 
-	dashboardURL := fmt.Sprintf("%s.%s.svc.cluster.local:%v",
+	dashboardURL := fmt.Sprintf("%s.%s:%v",
 		headSvc.Name,
 		headSvc.Namespace,
 		dashboardPort)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`svc.cluster.local` is not compatible in serveral k8s cluster settings,
recommend to just remove this suffix 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [*] Manual tests
   - [ ] This PR is not tested :(
