### PR TITLE
helm-chart/ray-cluster: Allow setting pod lifecycle

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -37,6 +37,10 @@ spec:
             {{- if .Values.head.ports }}
             ports: {{- toYaml .Values.head.ports | nindent 14}}
             {{- end }}
+            {{- if .Values.head.lifecycle }}
+            lifecycle:
+            {{- toYaml .Values.head.lifecycle | nindent 14 }}
+            {{- end }}
         volumes: {{- toYaml .Values.head.volumes | nindent 10 }}
         affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.head.tolerations | nindent 10 }}
@@ -81,6 +85,10 @@ spec:
             envFrom: {{- toYaml $ | nindent 14}}
             {{- end }}
             ports: {{- toYaml $values.ports | nindent 14}}
+            {{- if $values.lifecycle }}
+            lifecycle:
+            {{- toYaml $values.lifecycle | nindent 14 }}
+            {{- end }}
         volumes: {{- toYaml $values.volumes | nindent 10 }}
         affinity: {{- toYaml $values.affinity | nindent 10 }}
         tolerations: {{- toYaml $values.tolerations | nindent 10 }}
@@ -124,6 +132,10 @@ spec:
             envFrom: {{- toYaml . | nindent 14}}
             {{- end }}
             ports: {{- toYaml .Values.worker.ports | nindent 14}}
+            {{- if .Values.worker.lifecycle }}
+            lifecycle:
+            {{- toYaml .Values.worker.lifecycle | nindent 14 }}
+            {{- end }}
         volumes: {{- toYaml .Values.worker.volumes | nindent 10 }}
         affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.worker.tolerations | nindent 10 }}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

In this commit we extend the capability of ray-cluster helm chart to allow adding pod lifecycle in the head & worker nodes 

## Why are these changes needed?

The changes are not needed, but can extend the customization of the head & worker pods.

We can use postStart and preStop lifecycles to run custom commands. For example, send a webhook after a headnode starts.

Example:
```
  lifecycle:
    preStop:
      exec:
        command: ["/bin/sh","-c","ray stop"]
```

<!-- Please give a short summary of the change and the problem this solves. -->

