### PR TITLE
fix examples: bad K8s log config causing logs to be lost

### DIFF
--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -64,6 +64,12 @@ spec:
             preStop:
               exec:
                 command: ["/bin/sh","-c","ray stop"]
+          volumeMounts:
+            - mountPath: /tmp/ray
+              name: ray-logs
+        volumes:
+          - name: ray-logs
+            emptyDir: {}
   workerGroupSpecs:
   # the pod replicas in this group typed worker
   - replicas: 1
@@ -112,8 +118,8 @@ spec:
           # use volumeMounts.Optional.
           # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
           volumeMounts:
-            - mountPath: /var/log
-              name: log-volume
+            - mountPath: /tmp/ray
+              name: ray-logs
         initContainers:
         # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
         - name: init-myservice
@@ -123,6 +129,6 @@ spec:
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:
-          - name: log-volume
+          - name: ray-logs
             emptyDir: {}
 ######################status#################################

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -50,6 +50,9 @@ spec:
             preStop:
               exec:
                 command: ["/bin/sh","-c","ray stop"]
+          volumeMounts:
+            - mountPath: /tmp/ray
+              name: ray-logs
           resources:
             limits:
               cpu: "1"
@@ -57,6 +60,9 @@ spec:
             requests:
               cpu: "500m"
               memory: "512Mi"
+        volumes:
+          - name: ray-logs
+            emptyDir: {}
   workerGroupSpecs:
   # the pod replicas in this group typed worker
   - replicas: 1
@@ -96,8 +102,8 @@ spec:
           # use volumeMounts.Optional.
           # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
           volumeMounts:
-            - mountPath: /var/log
-              name: log-volume
+            - mountPath: /tmp/ray
+              name: ray-logs
           resources:
             limits:
               cpu: "1"
@@ -114,6 +120,6 @@ spec:
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:
-          - name: log-volume
+          - name: ray-logs
             emptyDir: {}
 ######################status#################################

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -114,6 +114,12 @@ spec:
                 name: dashboard
               - containerPort: 10001
                 name: client
+            volumeMounts:
+              - mountPath: /tmp/ray
+                name: ray-logs
+        volumes:
+          - name: ray-logs
+            emptyDir: {}
   workerGroupSpecs:
     # the pod replicas in this group typed worker
     - replicas: 2
@@ -169,8 +175,8 @@ spec:
               # use volumeMounts.Optional.
               # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
               volumeMounts:
-                - mountPath: /var/log
-                  name: log-volume
+                - mountPath: /tmp/ray
+                  name: ray-logs
               resources:
                 limits:
                   cpu: "1"
@@ -179,5 +185,5 @@ spec:
           # use volumes
           # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
           volumes:
-            - name: log-volume
+            - name: ray-logs
               emptyDir: {}

--- a/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
+++ b/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
@@ -63,6 +63,8 @@ spec:
           volumeMounts:
           - mountPath: /opt
             name: config
+          - mountPath: /tmp/ray
+            name: ray-logs
         volumes:
         # You set volumes at the Pod level, then mount them into containers inside that Pod
         - name: config
@@ -73,6 +75,8 @@ spec:
             items:
             - key: sample_code.py
               path: sample_code.py
+        - name: ray-logs
+          emptyDir: {}
   workerGroupSpecs:
   # the pod replicas in this group typed worker
   - replicas: 3
@@ -137,8 +141,8 @@ spec:
           # use volumeMounts.Optional.
           # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
           volumeMounts:
-            - mountPath: /var/log
-              name: log-volume
+            - mountPath: /tmp/ray
+              name: ray-logs
           resources:
             limits:
               cpu: "1"
@@ -147,7 +151,7 @@ spec:
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:
-          - name: log-volume
+          - name: ray-logs
             emptyDir: {}
   - replicas: 1
     minReplicas: 0
@@ -225,8 +229,8 @@ spec:
           # use volumeMounts.Optional.
           # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
           volumeMounts:
-            - mountPath: /var/log
-              name: log-volume
+            - mountPath: /tmp/ray
+              name: ray-logs
           resources:
             limits:
               cpu: "2"
@@ -235,6 +239,6 @@ spec:
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:
-          - name: log-volume
+          - name: ray-logs
             emptyDir: {}
 ######################status#################################


### PR DESCRIPTION
across Container restarts

Ray logs are written to `/tmp/ray` by default. Right now
various RayCluster example YAMLs use `volumeMounts` for `/var/log`
which doesn't have anything written to it.

So right now `/tmp/ray` logs are deleted after Container restarts.

This change sets `volumeMounts.mountPath` to `/tmp/ray` so that
logs in this dir are persisted across Container restarts for the life
of the Pod.

This change also adds volumes for head Pods which was missing before.

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
