### PR TITLE
Ray GettingStarted tutorial causes head node OOM

### DIFF
--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -82,10 +82,10 @@ spec:
           resources:
             limits:
               cpu: "1"
-              memory: "1G"
+              memory: "2G"
             requests:
               cpu: "500m"
-              memory: "512Mi"
+              memory: "1G"
   workerGroupSpecs:
   # the pod replicas in this group typed worker
   - replicas: 1
@@ -131,7 +131,7 @@ spec:
           resources:
             limits:
               cpu: "1"
-              memory: "512Mi"
+              memory: "1G"
             requests:
               cpu: "500m"
-              memory: "256Mi"
+              memory: "512Mi"

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -56,10 +56,10 @@ spec:
           resources:
             limits:
               cpu: "1"
-              memory: "1G"
+              memory: "2G"
             requests:
               cpu: "500m"
-              memory: "512Mi"
+              memory: "1G"
         volumes:
           - name: ray-logs
             emptyDir: {}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I tried to follow the [document](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started.html) to build a simple ray cluster (1 head node + 1 worker node) and run a simple job on the cluster. However, when I submitted a job to my head node, the job failed due to OOM as shown in the following picture.

<img width="1920" alt="Screen Shot 2022-09-01 at 3 42 17 PM" src="https://user-images.githubusercontent.com/20109646/188030203-4097ddab-06bd-41e1-909f-46e955c1b551.png">

I ran this experiment on GKE with autopilot. Some nodes in GKE may have just the same amount of memory as the resource request of head node. As shown in the figure, the node only have 0.5G memory (same as resource request) rather than 1G (resource limit). Hence, we need to increase the value of resource request of the head node.

## Related issue number
#528 

## Checks
```bash
# Step1: Deploy the operator
! kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/default?ref=v0.3.0&timeout=90s"

# Step2: Deploy a ray cluster
! kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/release-0.3/ray-operator/config/samples/ray-cluster.autoscaler.yaml

# Step3: port-forwarding
! kubectl port-forward service/raycluster-autoscaler-head-svc 8265:8265

# Step4: Run an application
! ray job submit --address http://localhost:8265 -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
```
<img width="1427" alt="Screen Shot 2022-09-01 at 4 33 12 PM" src="https://user-images.githubusercontent.com/20109646/188030518-d5a9e847-45a0-4a94-b4a2-816bb2a1f547.png">

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
