### PR TITLE
Update Helm doc.

### DIFF
--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -2,7 +2,7 @@
 
 Make sure ray-operator has been deployed.
 
-[Ray](https://ray.io/) is an open source framework that provides a simple, universal API for building distributed applications. Ray is packaged with RLlib, a scalable reinforcement learning library, and Tune, a scalable hyperparameter tuning library.
+[Ray](https://ray.io/) is a unified framework for scaling AI and Python applications. Ray consists of a core distributed runtime and a toolkit of libraries (Ray AIR) for simplifying ML compute.
 
 ## Helm
 
@@ -17,9 +17,6 @@ version.BuildInfo{Version:"v3.6.2", GitCommit:"ee407bdf364942bcb8e8c665f82e15aa2
 # Because the ray-cluster chart in release 0.3.0 has some bugs, we need to clone the KubeRay repo and install the latest ray-cluster chart until release 0.4.0.
 cd helm-chart/ray-cluster
 helm install ray-cluster --namespace ray-system --create-namespace .
-
-# Not working until release 0.4.0.
-helm install ray-cluster --namespace ray-system --create-namespace https://github.com/ray-project/kuberay/releases/download/v0.4.0/helm-chart-ray-cluster-0.4.0.tgz
 ```
 
 ## Installing the Chart
@@ -29,9 +26,6 @@ To install the chart with the release name `my-release`:
 # Because the ray-cluster chart in release 0.3.0 has some bugs, we need to clone the KubeRay repo and install the latest ray-cluster chart until release 0.4.0.
 cd helm-chart/ray-cluster
 helm install my-release --namespace ray-system --create-namespace .
-
-# Not working until release 0.4.0.
-helm install my-release --namespace ray-system --create-namespace https://github.com/ray-project/kuberay/releases/download/v0.4.0/helm-chart-ray-cluster-0.4.0.tgz
 ```
 
 > note: The chart will submit a RayCluster.


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR removes the reference to KubeRay 0.4.0 in the Helm documentation.
There's a comment indicating that the command to download an install the charts won't work until KubeRay 0.4.0.
However, some users may miss the comment and attempt to run the command.
We can re-introduce the command to the documentation when we release KubeRay 0.4.0.

This PR also updates the description of Ray to match the current description in the Ray repo.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
