### PR TITLE
helm: Uncomment the disabled key for the default workergroup

### DIFF
--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -53,8 +53,8 @@ head:
 
 worker:
   # If you want to disable the default workergroup
-  # uncomment the line below
-  # disabled: true
+  # change the line below
+  disabled: false
   groupName: workergroup
   replicas: 1
   type: worker


### PR DESCRIPTION
This allows comparison between boolean types, i.e. see ray-cluster/templates/raycluster-cluster.yaml:107, where we assert:

    {{- if ne .Values.worker.disabled true }}

The default setting for the default workergroup is now an explicit `disabled: false`.

Closes #537.