### PR TITLE
[Helm][minor] Make "disabled" flag for worker groups optional

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -102,7 +102,7 @@ spec:
 {{ include "ray-cluster.labels" $ | indent 10 }}
   {{- end }}
   {{- end }}
-  {{- if ne .Values.worker.disabled true }}
+  {{- if ne (.Values.worker.disabled | default false) true }}
   - rayStartParams:
     {{- range $key, $val := .Values.worker.initArgs }}
       {{ $key }}: {{ $val | quote }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -53,8 +53,8 @@ head:
 
 worker:
   # If you want to disable the default workergroup
-  # change the line below
-  disabled: false
+  # uncomment the line below
+  # disabled: true
   groupName: workergroup
   replicas: 1
   type: worker


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As mentioned by @tbabej in #537, an error will be reported if the `disabled` key on the default worker group is undefined. In old Helm versions, when `disabled` key is undefined, it will be set to `nil`. Hence, when we run the following command, it will report the error "incompatible types for comparison". Obviously, `nil` and boolean cannot be compared for equality. See https://github.com/helm/helm/issues/6376 for more details.



```
$ helm lint    
==> Linting .
[ERROR] templates/: template: ray-cluster/templates/raycluster-cluster.yaml:105:9: executing "ray-cluster/templates/raycluster-cluster.yaml" at <ne .Values.worker.disabled true>: error calling ne: incompatible types for comparison

Error: 1 chart(s) linted, 1 chart(s) failed
```

In this PR, I give the `disabled` key a default value to make it become an optional field.

* Helm version v3.4.1 => can reproduce #537 
* Helm version v3.9.4 => cannot reproduce #537 


## Related issue number

Closes https://github.com/ray-project/kuberay/issues/544
https://github.com/ray-project/kuberay/pull/499

## Checks
```bash
$ git diff | cat         
diff --git a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
index 67922d4..5432068 100644
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -102,7 +102,7 @@ spec:
 {{ include "ray-cluster.labels" $ | indent 10 }}
   {{- end }}
   {{- end }}
-  {{- if ne .Values.worker.disabled true }}
+  {{- if ne (.Values.worker.disabled | default false) true }}
   - rayStartParams:
     {{- range $key, $val := .Values.worker.initArgs }}
       {{ $key }}: {{ $val | quote }}
diff --git a/helm-chart/ray-cluster/values.yaml b/helm-chart/ray-cluster/values.yaml
index be80d86..a099a50 100644
--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -54,7 +54,7 @@ head:
 worker:
   # If you want to disable the default workergroup
   # change the line below
-  disabled: false
+  # disabled: false
   groupName: workergroup
   replicas: 1
   type: worker

$ helm lint     
==> Linting .

1 chart(s) linted, 0 chart(s) failed
```


- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

