### PR TITLE
[Bug] Skip publishing new charts if they are existing

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -39,3 +39,4 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "{{ .Name }}-chart-latest"
+          CR_SKIP_EXISTING: true


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Github Action failed in this [PR](https://github.com/ray-project/kuberay/actions/runs/3040044978/jobs/4895656877) because the charts have already existed. We need to skip publishing new charts if the charts are existing. Although we added the `skip existing` flag, `chart-releaser-action` would still update `index.yaml` in the branch gh-pages. Hence, we can prevent `index.yaml` from overwriting by MkDocs. See #545 for more context.

[TODO]
Because charts in v0.3.0 have some bugs, we use #545 and this PR to host "xxxx-chart-latest" releases. It is not good to update release charts every commit merge. Hence, when we are ready for v0.4.0, we should:

(1) [release.yaml](https://github.com/ray-project/kuberay/blob/master/.github/workflows/release.yaml): Use `chart-releaser-action` (#545) to publish new chart releases with the name "xxxxx-chart-0.4.0"
(2) [site.yaml](https://github.com/ray-project/kuberay/blob/master/.github/workflows/site.yaml#L41): Update `CR_RELEASE_NAME_TEMPLATE` from "{{ .Name }}-chart-latest" to "{{ .Name }}-chart-{{ .Version }}". This is used to prevent `index.yaml` from overwriting by MkDocs.

We will follow up this in #553.

## Related issue number
Closes #556 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
