### PR TITLE
Fixed download URL for Helm chart

### DIFF
--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -25,7 +25,7 @@ $ kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=
 
 Use the following command to install the chart:
 ```console
-$ helm install kuberay-operator --namespace ray-system --create-namespace $(curl -s https://api.github.com/repos/ray-project/kuberay/releases/latest | grep '"browser_download_url":' | sort | grep -om1 'https.*helm-chart-kuberay-operator.*tgz')
+$ helm install kuberay-operator --namespace ray-system --create-namespace $(curl -s https://api.github.com/repos/ray-project/kuberay/releases/tags/v0.3.0 | grep '"browser_download_url":' | sort | grep -om1 'https.*helm-chart-kuberay-operator.*tgz')
 ```
 
 ## List the Chart


### PR DESCRIPTION
Get the download URL from the release tagged with v0.3.0 instead of the latest release, which just returns the ray-cluster Helm chart

Signed-off-by: Sigmund Vestergaard <sigmundv@gmail.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The instructions given in `helm-chart/kuberay-operator/README.md` don't work, because the command that gets the download URL is wrong. This PR fixes the command such that it gets the correct download URL.

NOTE: The proposed fix gets the chart from release v0.3.0, but you might want to get it from the latest release, which is a different tag.

## Related issue number

Fixes #569

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
