### PR TITLE
Allow annotations in ray cluster helm chart

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -4,7 +4,9 @@ metadata:
   labels:
 {{ include "ray-cluster.labels" . | indent 4 }}
   name: {{ include "ray-cluster.fullname" . }}
+  {{ if .Values.annotations }}
   annotations: {{ toYaml .Values.annotations | nindent 4 }}
+  {{ end }}
 spec:
   {{- if .Values.head.rayVersion }}
   rayVersion: {{ .Values.head.rayVersion }}

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
 {{ include "ray-cluster.labels" . | indent 4 }}
   name: {{ include "ray-cluster.fullname" . }}
+  annotations: {{ toYaml .Values.annotations | nindent 4 }}
 spec:
   {{- if .Values.head.rayVersion }}
   rayVersion: {{ .Values.head.rayVersion }}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Extra annotations on the RayCluster custom resource are needed to enable functions like GCS FT for a Ray cluster. These annotations should be configurable in the Helm chart without editing the `raycluster-cluster.yaml` template.

## Related issue number

I couldn't find any related issue.

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
