### PR TITLE
Add reminders to avoid RBAC synchronization bug

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -107,7 +107,6 @@ func (r *RayClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	return ctrl.Result{}, client.IgnoreNotFound(err)
 }
 
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete
 func (r *RayClusterReconciler) eventReconcile(request ctrl.Request, event *v1.Event) (ctrl.Result, error) {
 	var unhealthyPod *corev1.Pod
 	pods := corev1.PodList{}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -80,6 +80,7 @@ type RayClusterReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;delete
 
+// [WARNING]: There MUST be a newline after kubebuilder markers.
 // Reconcile used to bridge the desired state with the current state
 func (r *RayClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	var err error
@@ -106,6 +107,7 @@ func (r *RayClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	return ctrl.Result{}, client.IgnoreNotFound(err)
 }
 
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete
 func (r *RayClusterReconciler) eventReconcile(request ctrl.Request, event *v1.Event) (ctrl.Result, error) {
 	var unhealthyPod *corev1.Pod
 	pods := corev1.PodList{}

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -60,6 +60,7 @@ func NewRayJobReconciler(mgr manager.Manager) *RayJobReconciler {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;delete
 
+// [WARNING]: There MUST be a newline after kubebuilder markers.
 // Reconcile reads that state of a RayJob object and makes changes based on it
 // and what is in the RayJob.Spec
 // Automatically generate RBAC rules to allow the Controller to read and write workloads

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -81,6 +81,7 @@ func NewRayServiceReconciler(mgr manager.Manager) *RayServiceReconciler {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;delete
 
+// [WARNING]: There MUST be a newline after kubebuilder markers.
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 //


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In #164, @Jeffwan mentions that RBAC files cannot be updated automatically with the command `make manifests`. The root cause is the lack of a newline after kubebuilder markers. This issue is same as https://github.com/kubernetes-sigs/controller-tools/issues/551.

In addition, the permissions of `config/rbac/role.yaml` is the union of kubebuilder markers in `raycluster_controller.go`, `rayjob_controller.go`, and `rayservice_controller.go`.

## Related issue number

closes #164 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* Step1: Add the following marker in one of "xxxxx_controller.go"
  * `// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete`
* Step2: `make manifests`
* Step3: Check `config/role.yaml`
  * There is no kubebuilder marker defining permissions of Deployment, and thus `role.yaml` will be updated. 
