### PR TITLE
[Feature][Helm] Enable sidecar configuration in Helm chart

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -113,7 +113,7 @@ spec:
             lifecycle:
             {{- toYaml $values.lifecycle | nindent 14 }}
             {{- end }}
-          {{- if (.Values.worker.fluentBitConfigMap.enabled | default false) }}
+          {{- if ($values.fluentBitConfigMap.enabled | default false) }}
           - name: fluentbit
             image: fluent/fluent-bit:1.9.6
             # These resource requests for Fluent Bit should be sufficient in production.
@@ -129,14 +129,14 @@ spec:
                 name: log-volume
               - mountPath: /fluent-bit/etc/fluent-bit.conf
                 subPath: fluent-bit.conf
-                name: {{ .Values.worker.fluentBitConfigMap.name }}
+                name: {{ $values.fluentBitConfigMap.name }}
           {{- end }}
         volumes:
         {{- toYaml $values.volumes | nindent 10 }}
-        {{- if (.Values.worker.fluentBitConfigMap.enabled | default false) }}
-        - name: {{ .Values.worker.fluentBitConfigMap.name }}
+        {{- if ($values.fluentBitConfigMap.enabled | default false) }}
+        - name: {{ $values.fluentBitConfigMap.name }}
           configMap:
-            name: {{ .Values.worker.fluentBitConfigMap.name }}
+            name: {{ $values.fluentBitConfigMap.name }}
         {{- end }}
         affinity: {{- toYaml $values.affinity | nindent 10 }}
         tolerations: {{- toYaml $values.tolerations | nindent 10 }}

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -58,16 +58,16 @@ spec:
                 name: {{ .Values.head.fluentBitConfigMap.logVolumeMount.name }}
               - mountPath: /fluent-bit/etc/fluent-bit.conf
                 subPath: fluent-bit.conf
-                name: {{ .Values.head.fluentBitConfigMap.configMap.name }}
+                name: {{ .Values.head.fluentBitConfigMap.configMapName }}
           {{- end }}
           {{- end }}
         volumes:
         {{- toYaml .Values.head.volumes | nindent 10 }}
         {{- if (.Values.head.fluentBitConfigMap | default false) }}
         {{- if (.Values.head.fluentBitConfigMap.enabled | default false) }}
-          - name: {{ .Values.head.fluentBitConfigMap.configMap.name }}
+          - name: {{ .Values.head.fluentBitConfigMap.configMapName }}
             configMap:
-              name: {{ .Values.head.fluentBitConfigMap.configMap.name }}
+              name: {{ .Values.head.fluentBitConfigMap.configMapName }}
         {{- end }}
         {{- end }}
         affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
@@ -130,22 +130,20 @@ spec:
                 cpu: 100m
                 memory: 128Mi
             volumeMounts:
-              - mountPath: /tmp/ray
-                name: log-volume
               - mountPath: {{ $values.fluentBitConfigMap.logVolumeMount.mountPath }}
                 name: {{ $values.fluentBitConfigMap.logVolumeMount.name }}
               - mountPath: /fluent-bit/etc/fluent-bit.conf
                 subPath: fluent-bit.conf
-                name: {{ $values.fluentBitConfigMap.configMap.name }}
+                name: {{ $values.fluentBitConfigMap.configMapName }}
           {{- end }}
           {{- end }}
         volumes:
         {{- toYaml $values.volumes | nindent 10 }}
         {{- if ($values.fluentBitConfigMap | default false) }}
         {{- if ($values.fluentBitConfigMap.enabled | default false) }}
-          - name: {{ $values.fluentBitConfigMap.configMap.name }}
+          - name: {{ $values.fluentBitConfigMap.configMapName }}
             configMap:
-              name: {{ $values.fluentBitConfigMap.configMap.name }}
+              name: {{ $values.fluentBitConfigMap.configMapName }}
         {{- end }}
         {{- end }}
         affinity: {{- toYaml $values.affinity | nindent 10 }}
@@ -211,16 +209,16 @@ spec:
                 name: {{ .Values.worker.fluentBitConfigMap.logVolumeMount.name }}
               - mountPath: /fluent-bit/etc/fluent-bit.conf
                 subPath: fluent-bit.conf
-                name: {{ .Values.worker.fluentBitConfigMap.configMap.name }}
+                name: {{ .Values.worker.fluentBitConfigMap.configMapName }}
           {{- end }}
           {{- end }}
         volumes:
         {{- toYaml .Values.worker.volumes | nindent 10 }}
         {{- if (.Values.worker.fluentBitConfigMap | default false) }}
         {{- if (.Values.worker.fluentBitConfigMap.enabled | default false) }}
-          - name: {{ .Values.worker.fluentBitConfigMap.configMap.name }}
+          - name: {{ .Values.worker.fluentBitConfigMap.configMapName }}
             configMap:
-              name: {{ .Values.worker.fluentBitConfigMap.configMap.name }}
+              name: {{ .Values.worker.fluentBitConfigMap.configMapName }}
         {{- end }}
         {{- end }}
         affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}
@@ -237,18 +235,12 @@ spec:
 
 ---
 # Fluent Bit ConfigMaps
-{{- range tuple .Values.head.fluentBitConfigMap .Values.worker.fluentBitConfigMap .Values.additionalWorkerGroups.smallGroup.fluentBitConfigMap }}
-{{- if (. | default false) }}
-{{- if (.enabled | default false) }}
-{{- if (.configMap.fluentBitConf | default false) }}
+{{- range .Values.fluentBitConfigMaps }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .configMap.name }}
+  name: {{ .name }}
 data:
-  fluent-bit.conf: | {{ .configMap.fluentBitConf | nindent 4 }}
-{{- end }}
-{{- end }}
-{{- end }}
+  fluent-bit.conf: | {{ .fluentBitConf | nindent 4 }}
 ---
 {{- end }}

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -58,16 +58,16 @@ spec:
                 name: {{ .Values.head.fluentBitConfigMap.logVolumeMount.name }}
               - mountPath: /fluent-bit/etc/fluent-bit.conf
                 subPath: fluent-bit.conf
-                name: {{ .Values.head.fluentBitConfigMap.name }}
+                name: {{ .Values.head.fluentBitConfigMap.configMap.name }}
           {{- end }}
           {{- end }}
         volumes:
         {{- toYaml .Values.head.volumes | nindent 10 }}
         {{- if (.Values.head.fluentBitConfigMap | default false) }}
         {{- if (.Values.head.fluentBitConfigMap.enabled | default false) }}
-          - name: {{ .Values.head.fluentBitConfigMap.name }}
+          - name: {{ .Values.head.fluentBitConfigMap.configMap.name }}
             configMap:
-              name: {{ .Values.head.fluentBitConfigMap.name }}
+              name: {{ .Values.head.fluentBitConfigMap.configMap.name }}
         {{- end }}
         {{- end }}
         affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
@@ -117,6 +117,7 @@ spec:
             lifecycle:
             {{- toYaml $values.lifecycle | nindent 14 }}
             {{- end }}
+          {{- if ($values.fluentBitConfigMap | default false) }}
           {{- if ($values.fluentBitConfigMap.enabled | default false) }}
           - name: fluentbit
             image: fluent/fluent-bit:1.9.6
@@ -135,15 +136,18 @@ spec:
                 name: {{ $values.fluentBitConfigMap.logVolumeMount.name }}
               - mountPath: /fluent-bit/etc/fluent-bit.conf
                 subPath: fluent-bit.conf
-                name: {{ $values.fluentBitConfigMap.name }}
+                name: {{ $values.fluentBitConfigMap.configMap.name }}
+          {{- end }}
           {{- end }}
         volumes:
         {{- toYaml $values.volumes | nindent 10 }}
-          {{- if ($values.fluentBitConfigMap.enabled | default false) }}
-          - name: {{ $values.fluentBitConfigMap.name }}
+        {{- if ($values.fluentBitConfigMap | default false) }}
+        {{- if ($values.fluentBitConfigMap.enabled | default false) }}
+          - name: {{ $values.fluentBitConfigMap.configMap.name }}
             configMap:
-              name: {{ $values.fluentBitConfigMap.name }}
-          {{- end }}
+              name: {{ $values.fluentBitConfigMap.configMap.name }}
+        {{- end }}
+        {{- end }}
         affinity: {{- toYaml $values.affinity | nindent 10 }}
         tolerations: {{- toYaml $values.tolerations | nindent 10 }}
         nodeSelector: {{- toYaml $values.nodeSelector | nindent 10 }}
@@ -207,16 +211,16 @@ spec:
                 name: {{ .Values.worker.fluentBitConfigMap.logVolumeMount.name }}
               - mountPath: /fluent-bit/etc/fluent-bit.conf
                 subPath: fluent-bit.conf
-                name: {{ .Values.worker.fluentBitConfigMap.name }}
+                name: {{ .Values.worker.fluentBitConfigMap.configMap.name }}
           {{- end }}
           {{- end }}
         volumes:
         {{- toYaml .Values.worker.volumes | nindent 10 }}
         {{- if (.Values.worker.fluentBitConfigMap | default false) }}
         {{- if (.Values.worker.fluentBitConfigMap.enabled | default false) }}
-          - name: {{ .Values.worker.fluentBitConfigMap.name }}
+          - name: {{ .Values.worker.fluentBitConfigMap.configMap.name }}
             configMap:
-              name: {{ .Values.worker.fluentBitConfigMap.name }}
+              name: {{ .Values.worker.fluentBitConfigMap.configMap.name }}
         {{- end }}
         {{- end }}
         affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}
@@ -236,17 +240,13 @@ spec:
 {{- range tuple .Values.head.fluentBitConfigMap .Values.worker.fluentBitConfigMap .Values.additionalWorkerGroups.smallGroup.fluentBitConfigMap }}
 {{- if (. | default false) }}
 {{- if (.enabled | default false) }}
-{{- if (.fluentBitConf | default false) }}
+{{- if (.configMap.fluentBitConf | default false) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  {{- if .name }}
-  name: {{ .name }}
-  {{- end }}
+  name: {{ .configMap.name }}
 data:
-  {{- if .fluentBitConf }}
-  fluent-bit.conf: | {{ .fluentBitConf | nindent 4 }}
-  {{- end }}
+  fluent-bit.conf: | {{ .configMap.fluentBitConf | nindent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -41,6 +41,7 @@ spec:
             lifecycle:
             {{- toYaml .Values.head.lifecycle | nindent 14 }}
             {{- end }}
+          {{- if (.Values.head.fluentBitConfigMap | default false) }}
           {{- if (.Values.head.fluentBitConfigMap.enabled | default false) }}
           - name: fluentbit
             image: fluent/fluent-bit:1.9.6
@@ -59,12 +60,15 @@ spec:
                 subPath: fluent-bit.conf
                 name: {{ .Values.head.fluentBitConfigMap.name }}
           {{- end }}
+          {{- end }}
         volumes:
         {{- toYaml .Values.head.volumes | nindent 10 }}
+        {{- if (.Values.head.fluentBitConfigMap | default false) }}
         {{- if (.Values.head.fluentBitConfigMap.enabled | default false) }}
           - name: {{ .Values.head.fluentBitConfigMap.name }}
             configMap:
               name: {{ .Values.head.fluentBitConfigMap.name }}
+        {{- end }}
         {{- end }}
         affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.head.tolerations | nindent 10 }}
@@ -186,6 +190,7 @@ spec:
             lifecycle:
             {{- toYaml .Values.worker.lifecycle | nindent 14 }}
             {{- end }}
+          {{- if (.Values.worker.fluentBitConfigMap | default false) }}
           {{- if (.Values.worker.fluentBitConfigMap.enabled | default false) }}
           - name: fluentbit
             image: fluent/fluent-bit:1.9.6
@@ -204,13 +209,16 @@ spec:
                 subPath: fluent-bit.conf
                 name: {{ .Values.worker.fluentBitConfigMap.name }}
           {{- end }}
+          {{- end }}
         volumes:
         {{- toYaml .Values.worker.volumes | nindent 10 }}
-          {{- if (.Values.worker.fluentBitConfigMap.enabled | default false) }}
+        {{- if (.Values.worker.fluentBitConfigMap | default false) }}
+        {{- if (.Values.worker.fluentBitConfigMap.enabled | default false) }}
           - name: {{ .Values.worker.fluentBitConfigMap.name }}
             configMap:
               name: {{ .Values.worker.fluentBitConfigMap.name }}
-          {{- end }}
+        {{- end }}
+        {{- end }}
         affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.worker.tolerations | nindent 10 }}
         nodeSelector: {{- toYaml .Values.worker.nodeSelector | nindent 10 }}
@@ -226,7 +234,9 @@ spec:
 ---
 # Fluent Bit ConfigMaps
 {{- range tuple .Values.head.fluentBitConfigMap .Values.worker.fluentBitConfigMap .Values.additionalWorkerGroups.smallGroup.fluentBitConfigMap }}
+{{- if (. | default false) }}
 {{- if (.enabled | default false) }}
+{{- if (.fluentBitConf | default false) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -237,6 +247,8 @@ data:
   {{- if .fluentBitConf }}
   fluent-bit.conf: | {{ .fluentBitConf | nindent 4 }}
   {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 ---
 {{- end }}

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -133,11 +133,11 @@ spec:
           {{- end }}
         volumes:
         {{- toYaml $values.volumes | nindent 10 }}
-        {{- if ($values.fluentBitConfigMap.enabled | default false) }}
-        - name: {{ $values.fluentBitConfigMap.name }}
-          configMap:
-            name: {{ $values.fluentBitConfigMap.name }}
-        {{- end }}
+          {{- if ($values.fluentBitConfigMap.enabled | default false) }}
+          - name: {{ $values.fluentBitConfigMap.name }}
+            configMap:
+              name: {{ $values.fluentBitConfigMap.name }}
+          {{- end }}
         affinity: {{- toYaml $values.affinity | nindent 10 }}
         tolerations: {{- toYaml $values.tolerations | nindent 10 }}
         nodeSelector: {{- toYaml $values.nodeSelector | nindent 10 }}
@@ -184,7 +184,31 @@ spec:
             lifecycle:
             {{- toYaml .Values.worker.lifecycle | nindent 14 }}
             {{- end }}
-        volumes: {{- toYaml .Values.worker.volumes | nindent 10 }}
+          {{- if (.Values.worker.fluentBitConfigMap.enabled | default false) }}
+          - name: fluentbit
+            image: fluent/fluent-bit:1.9.6
+            # These resource requests for Fluent Bit should be sufficient in production.
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
+            volumeMounts:
+              - mountPath: /tmp/ray
+                name: log-volume
+              - mountPath: /fluent-bit/etc/fluent-bit.conf
+                subPath: fluent-bit.conf
+                name: {{ .Values.worker.fluentBitConfigMap.name }}
+          {{- end }}
+        volumes:
+        {{- toYaml .Values.worker.volumes | nindent 10 }}
+          {{- if (.Values.worker.fluentBitConfigMap.enabled | default false) }}
+          - name: {{ .Values.worker.fluentBitConfigMap.name }}
+            configMap:
+              name: {{ .Values.worker.fluentBitConfigMap.name }}
+          {{- end }}
         affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.worker.tolerations | nindent 10 }}
         nodeSelector: {{- toYaml .Values.worker.nodeSelector | nindent 10 }}
@@ -199,7 +223,7 @@ spec:
 
 ---
 # Fluent Bit ConfigMaps
-{{- range tuple .Values.head.fluentBitConfigMap .Values.worker.fluentBitConfigMap }}
+{{- range tuple .Values.head.fluentBitConfigMap .Values.worker.fluentBitConfigMap .Values.additionalWorkerGroups.smallGroup.fluentBitConfigMap }}
 {{- if (.enabled | default false) }}
 apiVersion: v1
 kind: ConfigMap

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -41,7 +41,31 @@ spec:
             lifecycle:
             {{- toYaml .Values.head.lifecycle | nindent 14 }}
             {{- end }}
-        volumes: {{- toYaml .Values.head.volumes | nindent 10 }}
+          {{- if (.Values.head.fluentBitConfigMap.enabled | default false) }}
+          - name: fluentbit
+            image: fluent/fluent-bit:1.9.6
+            # These resource requests for Fluent Bit should be sufficient in production.
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
+            volumeMounts:
+              - mountPath: /tmp/ray
+                name: log-volume
+              - mountPath: /fluent-bit/etc/fluent-bit.conf
+                subPath: fluent-bit.conf
+                name: {{ .Values.head.fluentBitConfigMap.name }}
+          {{- end }}
+        volumes:
+        {{- toYaml .Values.head.volumes | nindent 10 }}
+        {{- if (.Values.head.fluentBitConfigMap.enabled | default false) }}
+          - name: {{ .Values.head.fluentBitConfigMap.name }}
+            configMap:
+              name: {{ .Values.head.fluentBitConfigMap.name }}
+        {{- end }}
         affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.head.tolerations | nindent 10 }}
         nodeSelector: {{- toYaml .Values.head.nodeSelector | nindent 10 }}
@@ -89,7 +113,31 @@ spec:
             lifecycle:
             {{- toYaml $values.lifecycle | nindent 14 }}
             {{- end }}
-        volumes: {{- toYaml $values.volumes | nindent 10 }}
+          {{- if (.Values.worker.fluentBitConfigMap.enabled | default false) }}
+          - name: fluentbit
+            image: fluent/fluent-bit:1.9.6
+            # These resource requests for Fluent Bit should be sufficient in production.
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
+            volumeMounts:
+              - mountPath: /tmp/ray
+                name: log-volume
+              - mountPath: /fluent-bit/etc/fluent-bit.conf
+                subPath: fluent-bit.conf
+                name: {{ .Values.worker.fluentBitConfigMap.name }}
+          {{- end }}
+        volumes:
+        {{- toYaml $values.volumes | nindent 10 }}
+        {{- if (.Values.worker.fluentBitConfigMap.enabled | default false) }}
+        - name: {{ .Values.worker.fluentBitConfigMap.name }}
+          configMap:
+            name: {{ .Values.worker.fluentBitConfigMap.name }}
+        {{- end }}
         affinity: {{- toYaml $values.affinity | nindent 10 }}
         tolerations: {{- toYaml $values.tolerations | nindent 10 }}
         nodeSelector: {{- toYaml $values.nodeSelector | nindent 10 }}
@@ -149,3 +197,20 @@ spec:
 {{ include "ray-cluster.labels" . | indent 10 }}
   {{- end }}
 
+---
+# Fluent Bit ConfigMaps
+{{- range tuple .Values.head.fluentBitConfigMap .Values.worker.fluentBitConfigMap }}
+{{- if (.enabled | default false) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  {{- if .name }}
+  name: {{ .name }}
+  {{- end }}
+data:
+  {{- if .fluentBitConf }}
+  fluent-bit.conf: | {{ .fluentBitConf | nindent 4 }}
+  {{- end }}
+{{- end }}
+---
+{{- end }}

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -53,8 +53,8 @@ spec:
                 cpu: 100m
                 memory: 128Mi
             volumeMounts:
-              - mountPath: /tmp/ray
-                name: log-volume
+              - mountPath: {{ .Values.head.fluentBitConfigMap.logVolumeMount.mountPath }}
+                name: {{ .Values.head.fluentBitConfigMap.logVolumeMount.name }}
               - mountPath: /fluent-bit/etc/fluent-bit.conf
                 subPath: fluent-bit.conf
                 name: {{ .Values.head.fluentBitConfigMap.name }}
@@ -127,6 +127,8 @@ spec:
             volumeMounts:
               - mountPath: /tmp/ray
                 name: log-volume
+              - mountPath: {{ $values.fluentBitConfigMap.logVolumeMount.mountPath }}
+                name: {{ $values.fluentBitConfigMap.logVolumeMount.name }}
               - mountPath: /fluent-bit/etc/fluent-bit.conf
                 subPath: fluent-bit.conf
                 name: {{ $values.fluentBitConfigMap.name }}
@@ -196,8 +198,8 @@ spec:
                 cpu: 100m
                 memory: 128Mi
             volumeMounts:
-              - mountPath: /tmp/ray
-                name: log-volume
+              - mountPath: {{ .Values.worker.fluentBitConfigMap.logVolumeMount.mountPath }}
+                name: {{ .Values.worker.fluentBitConfigMap.logVolumeMount.name }}
               - mountPath: /fluent-bit/etc/fluent-bit.conf
                 subPath: fluent-bit.conf
                 name: {{ .Values.worker.fluentBitConfigMap.name }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -52,6 +52,9 @@ head:
   fluentBitConfigMap:
     enabled: true
     name: fluentbit-config
+    logVolumeMount:
+      mountPath: /tmp/ray
+      name: log-volume
     fluentBitConf: |
           [INPUT]
               Name tail
@@ -117,6 +120,9 @@ worker:
   fluentBitConfigMap:
     enabled: true
     name: fluentbit-config-worker
+    logVolumeMount:
+      mountPath: /tmp/ray
+      name: log-volume
     fluentBitConf: |
       [INPUT]
           Name tail
@@ -185,6 +191,9 @@ additionalWorkerGroups:
     fluentBitConfigMap:
       enabled: true
       name: fluentbit-config-worker-group
+      logVolumeMount:
+        mountPath: /tmp/ray
+        name: log-volume
       fluentBitConf: |
         [INPUT]
             Name tail

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -54,18 +54,7 @@ head:
     logVolumeMount:
       mountPath: /tmp/ray
       name: log-volume
-    configMap:
-      name: fluentbit-config
-      fluentBitConf: |
-            [INPUT]
-                Name tail
-                Path /tmp/ray/session_latest/logs/*
-                Tag ray
-                Path_Key true
-                Refresh_Interval 5
-            [OUTPUT]
-                Name stdout
-                Match *
+    configMapName: fluentbit-config
 
 worker:
   # If you want to disable the default workergroup
@@ -123,18 +112,7 @@ worker:
     logVolumeMount:
       mountPath: /tmp/ray
       name: log-volume
-    configMap:
-      name: fluentbit-config-worker
-      fluentBitConf: |
-        [INPUT]
-            Name tail
-            Path /tmp/ray/session_latest/logs/*
-            Tag ray
-            Path_Key true
-            Refresh_Interval 5
-        [OUTPUT]
-            Name stdout
-            Match *
+    configMapName: fluentbit-config
 
 # The map's key is used as the groupName.
 # For example, key:small-group in the map below
@@ -195,21 +173,23 @@ additionalWorkerGroups:
       logVolumeMount:
         mountPath: /tmp/ray
         name: log-volume
-      configMap:
-        name: fluentbit-config-worker-group
-        fluentBitConf: |
-          [INPUT]
-              Name tail
-              Path /tmp/ray/session_latest/logs/*
-              Tag ray
-              Path_Key true
-              Refresh_Interval 5
-          [OUTPUT]
-              Name stdout
-              Match *
+      configMapName: fluentbit-config
 
 headServiceSuffix: "ray-operator.svc"
 
 service:
   type: ClusterIP
   port: 8080
+
+fluentBitConfigMaps:
+  - name: fluentbit-config
+    fluentBitConf: |
+      [INPUT]
+          Name tail
+          Path /tmp/ray/session_latest/logs/*
+          Tag ray
+          Path_Key true
+          Refresh_Interval 5
+      [OUTPUT]
+          Name stdout
+          Match *

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -51,20 +51,21 @@ head:
       name: log-volume
   fluentBitConfigMap:
     enabled: true
-    name: fluentbit-config
     logVolumeMount:
       mountPath: /tmp/ray
       name: log-volume
-    fluentBitConf: |
-          [INPUT]
-              Name tail
-              Path /tmp/ray/session_latest/logs/*
-              Tag ray
-              Path_Key true
-              Refresh_Interval 5
-          [OUTPUT]
-              Name stdout
-              Match *
+    configMap:
+      name: fluentbit-config
+      fluentBitConf: |
+            [INPUT]
+                Name tail
+                Path /tmp/ray/session_latest/logs/*
+                Tag ray
+                Path_Key true
+                Refresh_Interval 5
+            [OUTPUT]
+                Name stdout
+                Match *
 
 worker:
   # If you want to disable the default workergroup
@@ -119,20 +120,21 @@ worker:
       name: log-volume
   fluentBitConfigMap:
     enabled: true
-    name: fluentbit-config-worker
     logVolumeMount:
       mountPath: /tmp/ray
       name: log-volume
-    fluentBitConf: |
-      [INPUT]
-          Name tail
-          Path /tmp/ray/session_latest/logs/*
-          Tag ray
-          Path_Key true
-          Refresh_Interval 5
-      [OUTPUT]
-          Name stdout
-          Match *
+    configMap:
+      name: fluentbit-config-worker
+      fluentBitConf: |
+        [INPUT]
+            Name tail
+            Path /tmp/ray/session_latest/logs/*
+            Tag ray
+            Path_Key true
+            Refresh_Interval 5
+        [OUTPUT]
+            Name stdout
+            Match *
 
 # The map's key is used as the groupName.
 # For example, key:small-group in the map below
@@ -190,20 +192,21 @@ additionalWorkerGroups:
         name: log-volume
     fluentBitConfigMap:
       enabled: true
-      name: fluentbit-config-worker-group
       logVolumeMount:
         mountPath: /tmp/ray
         name: log-volume
-      fluentBitConf: |
-        [INPUT]
-            Name tail
-            Path /tmp/ray/session_latest/logs/*
-            Tag ray
-            Path_Key true
-            Refresh_Interval 5
-        [OUTPUT]
-            Name stdout
-            Match *
+      configMap:
+        name: fluentbit-config-worker-group
+        fluentBitConf: |
+          [INPUT]
+              Name tail
+              Path /tmp/ray/session_latest/logs/*
+              Tag ray
+              Path_Key true
+              Refresh_Interval 5
+          [OUTPUT]
+              Name stdout
+              Match *
 
 headServiceSuffix: "ray-operator.svc"
 

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -49,7 +49,19 @@ head:
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
-
+  fluentBitConfigMap:
+    enabled: true
+    name: fluentbit-config
+    fluentBitConf: |
+          [INPUT]
+              Name tail
+              Path /tmp/ray/session_latest/logs/*
+              Tag ray
+              Path_Key true
+              Refresh_Interval 5
+          [OUTPUT]
+              Name stdout
+              Match *
 
 worker:
   # If you want to disable the default workergroup
@@ -102,6 +114,19 @@ worker:
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
+  fluentBitConfigMap:
+    enabled: true
+    name: fluentbit-config-worker
+    fluentBitConf: |
+      [INPUT]
+          Name tail
+          Path /tmp/ray/session_latest/logs/*
+          Tag ray
+          Path_Key true
+          Refresh_Interval 5
+      [OUTPUT]
+          Name stdout
+          Match *
 
 # The map's key is used as the groupName.
 # For example, key:small-group in the map below

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -50,7 +50,7 @@ head:
     - mountPath: /tmp/ray
       name: log-volume
   fluentBitConfigMap:
-    enabled: true
+    enabled: false
     logVolumeMount:
       mountPath: /tmp/ray
       name: log-volume
@@ -108,7 +108,7 @@ worker:
     - mountPath: /tmp/ray
       name: log-volume
   fluentBitConfigMap:
-    enabled: true
+    enabled: false
     logVolumeMount:
       mountPath: /tmp/ray
       name: log-volume
@@ -169,7 +169,7 @@ additionalWorkerGroups:
       - mountPath: /tmp/ray
         name: log-volume
     fluentBitConfigMap:
-      enabled: true
+      enabled: false
       logVolumeMount:
         mountPath: /tmp/ray
         name: log-volume
@@ -181,15 +181,15 @@ service:
   type: ClusterIP
   port: 8080
 
-fluentBitConfigMaps:
-  - name: fluentbit-config
-    fluentBitConf: |
-      [INPUT]
-          Name tail
-          Path /tmp/ray/session_latest/logs/*
-          Tag ray
-          Path_Key true
-          Refresh_Interval 5
-      [OUTPUT]
-          Name stdout
-          Match *
+#fluentBitConfigMaps:
+#  - name: fluentbit-config
+#    fluentBitConf: |
+#      [INPUT]
+#          Name tail
+#          Path /tmp/ray/session_latest/logs/*
+#          Tag ray
+#          Path_Key true
+#          Refresh_Interval 5
+#      [OUTPUT]
+#          Name stdout
+#          Match *

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -182,6 +182,19 @@ additionalWorkerGroups:
     volumeMounts:
       - mountPath: /tmp/ray
         name: log-volume
+    fluentBitConfigMap:
+      enabled: true
+      name: fluentbit-config-worker-group
+      fluentBitConf: |
+        [INPUT]
+            Name tail
+            Path /tmp/ray/session_latest/logs/*
+            Tag ray
+            Path_Key true
+            Refresh_Interval 5
+        [OUTPUT]
+            Name stdout
+            Match *
 
 headServiceSuffix: "ray-operator.svc"
 

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -181,7 +181,7 @@ service:
   type: ClusterIP
   port: 8080
 
-#fluentBitConfigMaps:
+# fluentBitConfigMaps:
 #  - name: fluentbit-config
 #    fluentBitConf: |
 #      [INPUT]

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -132,7 +132,7 @@ worker:
 # For example, key:small-group in the map below
 # will be used as the groupName
 additionalWorkerGroups:
-  small-group:
+  smallGroup:
     # Disabled by default
     disabled: true
     replicas: 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR exposed an interface in KubeRay helm charts to enable users to configure sidecar containers (See the [logging documentation](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/logging.html) and https://github.com/ray-project/kuberay/issues/353 for more details).

Explanation of the interface:

<details>
<summary> .Values.fluentBitConfigMaps </summary>

```yaml
fluentBitConfigMaps:
  - name: fluentbit-config
    fluentBitConf: |
      [INPUT]
          Name tail
          Path /tmp/ray/session_latest/logs/*
          Tag ray
          Path_Key true
          Refresh_Interval 5
      [OUTPUT]
          Name stdout
          Match *
```
* `.Values.fluentBitConfigMaps[0].name`: Name of the ConfigMap.
* `.Values.fluentBitConfigMaps[0].fluentBitConf`: Used to configure `fluentBit`. Note that this configuration assumes logs are mounted on `/tmp/ray`.
</details>

<details>
<summary> .Values.{head, worker, additionalWorkerGroups.smallGroup}.fluentBitConfigMap </summary>

```yaml
fluentBitConfigMap:
  enabled: true
  logVolumeMount:
    mountPath: /tmp/ray
    name: log-volume
  configMapName: fluentbit-config
```
* `enabled`: Whether enable sidecar feature on the head, worker, and smallGroup pods. This configuration is optional, and the default value is false.
* `logVolumeMount.mountPath`: The mount path of the log volume should be synchronized with `.Values.fluentBitConfigMaps.fluentBitConf` 
* `logVolumeMount.name`: This field should be synchronized with `.Values.{head, worker, additionalWorkerGroups.smallGroup}.volumes`.
* `configMapName`: The config map name should exist in `.Values.fluentBitConfigMaps`.

</details>






<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #511 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
