### PR TITLE
[Bug] Pod reconciliation fails if worker pod name is supplied

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -190,6 +190,9 @@ func DefaultWorkerPodTemplate(instance rayiov1alpha1.RayCluster, workerSpec rayi
 		log.Info("Setting pod namespaces", "namespace", instance.Namespace)
 	}
 
+	// If the replica of workers is more than 1, `ObjectMeta.Name` may cause name conflict errors.
+	// Hence, we set `ObjectMeta.Name` to an empty string, and use GenerateName to prevent name conflicts.
+	podTemplate.ObjectMeta.Name = ""
 	if podTemplate.Labels == nil {
 		podTemplate.Labels = make(map[string]string)
 	}

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -642,3 +642,13 @@ func TestCleanupInvalidVolumeMounts(t *testing.T) {
 	cleanupInvalidVolumeMounts(&pod.Spec.Containers[0], &pod)
 	assert.Equal(t, len(pod.Spec.Containers[0].VolumeMounts), 1)
 }
+
+func TestDefaultWorkerPodTemplateWithName(t *testing.T) {
+	cluster := instance.DeepCopy()
+	svcName := utils.GenerateServiceName(cluster.Name)
+	worker := cluster.Spec.WorkerGroupSpecs[0]
+	worker.Template.ObjectMeta.Name = "ray-worker-test"
+	podName := cluster.Name + DashSymbol + string(rayiov1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
+	podTemplateSpec := DefaultWorkerPodTemplate(*cluster, worker, podName, svcName, "6379")
+	assert.Equal(t, podTemplateSpec.ObjectMeta.Name, "")
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Deploy a RayCluster with a worker group with replicas >= 2 and supply a name in the pod template. The operator will fail to generate multiple worker replicas and will show an error creating the second pod. See this [commit](https://github.com/kevin85421/kuberay/commit/fe80c7513e7345a968d2f43965e3d29105385033) for more details. The following instructions can reproduce this bug.

```bash
# Step1: Clone my Kuberay repo (kevin85421/kuberay), and check out to the `replicate-worker-name-control-group` branch.
git clone git@github.com:kevin85421/kuberay.git
git checkout replicate-worker-name-control-group

# Step2: Install kuberay-operator
cd helm-chart/kuberay-operator
helm install kuberay-operator .

# Step3: Install ray-cluster
cd helm-chart/ray-cluster
helm install ray-cluster .
```
[Solution]: Set `ObjectMeta.Name` to an empty string, and use `GenerateName` to prevent name conflicts.


[Note]: Relationship between `Name` and `GenerateName` ([Link](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta))

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #582 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

I tested this PR with the same config for ray-cluster in https://github.com/kevin85421/kuberay/commit/fe80c7513e7345a968d2f43965e3d29105385033, but used the new image for kuberay-operator. As shown in the screenshot, two workers are created successfully.

![截圖 2022-09-22 下午3 06 40](https://user-images.githubusercontent.com/20109646/191862427-10b4e5a9-f96e-496a-8bb9-f0727a6dca1a.png)
