### PR TITLE
update test files before separating them

### DIFF
--- a/.github/workflows/actions/compatibility/action.yaml
+++ b/.github/workflows/actions/compatibility/action.yaml
@@ -68,5 +68,5 @@ runs:
       kustomize edit set image kuberay/apiserver=kuberay/apiserver:${{ steps.vars.outputs.sha_short }}
       popd
       echo "Using Ray image ${{ inputs.ray_version }}"
-      RAY_VERSION="${{ inputs.ray_version }}" KUBERAY_IMG_SHA=${{ steps.vars.outputs.sha_short }} python ./tests/compatibility-test.py
+      PYTHONPATH="./tests/" RAY_VERSION="${{ inputs.ray_version }}" KUBERAY_IMG_SHA=${{ steps.vars.outputs.sha_short }} python ./tests/compatibility-test.py
     shell: bash

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -122,30 +122,12 @@ print(len(ray.nodes()))
         client.close()
 
 
-def ray_ft_supported(ray_version):
-    if ray_version == "nightly":
-        return True
-    major, minor, patch = parse_ray_version(ray_version)
-    if major * 100 + minor <= 113:
-        return False
-    return True
-
-
-def ray_service_supported(ray_version):
-    if ray_version == "nightly":
-        return True
-    major, minor, patch = parse_ray_version(ray_version)
-    if major * 100 + minor <= 113:
-        return False
-    return True
-
-
 class RayFTTestCase(unittest.TestCase):
     cluster_template_file = 'tests/config/ray-cluster.ray-ft.yaml.template'
 
     @classmethod
     def setUpClass(cls):
-        if not ray_ft_supported():
+        if not ray_ft_supported(ray_version):
             return
         delete_cluster()
         create_cluster()
@@ -155,7 +137,7 @@ class RayFTTestCase(unittest.TestCase):
                                ray_version, ray_image)
 
     def setUp(self):
-        if not ray_ft_supported():
+        if not ray_ft_supported(ray_version):
             raise unittest.SkipTest("ray ft is not supported")
 
     def test_kill_head(self):

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+
+import os
+import logging
+import time
+import tempfile
+import docker
+
+from string import Template
+
+kindcluster_config_file = 'tests/config/cluster-config.yaml'
+raycluster_service_file = 'tests/config/raycluster-service.yaml'
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def parse_ray_version(version_str):
+    tmp = version_str.split('.')
+    assert len(tmp) == 3
+    major = int(tmp[0])
+    minor = int(tmp[1])
+    patch = int(tmp[2])
+    return major, minor, patch
+
+
+def shell_run(cmd):
+    logger.info('executing cmd: {}'.format(cmd))
+    return os.system(cmd)
+
+
+def shell_assert_success(cmd):
+    assert shell_run(cmd) == 0
+
+
+def shell_assert_failure(cmd):
+    assert shell_run(cmd) != 0
+
+
+def create_cluster():
+    shell_assert_success(
+        'kind create cluster --config {}'.format(kindcluster_config_file))
+    time.sleep(60)
+    rtn = shell_run(
+        'kubectl wait --for=condition=ready pod -n kube-system --all --timeout=900s')
+    if rtn != 0:
+        shell_run('kubectl get pods -A')
+    assert rtn == 0
+
+
+def apply_kuberay_resources(img_sha='nightly'):
+    shell_assert_success(
+        'kind load docker-image kuberay/operator:{}'.format(img_sha))
+    shell_assert_success(
+        'kind load docker-image kuberay/apiserver:{}'.format(img_sha))
+    shell_assert_success(
+        'kubectl create -k manifests/cluster-scope-resources')
+    # use kustomize to build the yaml, then change the image to the one we want to testing.
+    shell_assert_success(
+        ('rm -f kustomization.yaml && kustomize create --resources manifests/base && ' +
+         'kustomize edit set image ' +
+         'kuberay/operator:nightly=kuberay/operator:{0} kuberay/apiserver:nightly=kuberay/apiserver:{0} && ' +
+         'kubectl apply -k .').format(img_sha))
+
+
+def create_kuberay_cluster(template_name, ray_version, ray_image):
+    template = None
+    with open(template_name, mode='r') as f:
+        template = Template(f.read())
+
+    raycluster_spec_buf = template.substitute(
+        {'ray_image': ray_image, 'ray_version': ray_version})
+
+    raycluster_spec_file = None
+    with tempfile.NamedTemporaryFile('w', delete=False) as f:
+        f.write(raycluster_spec_buf)
+        raycluster_spec_file = f.name
+
+    rtn = shell_run(
+        'kubectl wait --for=condition=ready pod -n ray-system --all --timeout=900s')
+    if rtn != 0:
+        shell_run('kubectl get pods -A')
+    assert rtn == 0
+    assert raycluster_spec_file is not None
+    shell_assert_success('kubectl apply -f {}'.format(raycluster_spec_file))
+
+    time.sleep(180)
+
+    shell_run('kubectl get pods -A')
+
+    rtn = shell_run(
+        'kubectl wait --for=condition=ready pod -l rayCluster=raycluster-compatibility-test --all --timeout=900s')
+    if rtn != 0:
+        shell_run('kubectl get pods -A')
+        shell_run(
+            'kubectl describe pod $(kubectl get pods | grep -e "-head" | awk "{print \$1}")')
+        shell_run(
+            'kubectl logs $(kubectl get pods | grep -e "-head" | awk "{print \$1}")')
+        shell_run(
+            'kubectl logs -n $(kubectl get pods -A | grep -e "-operator" | awk \'{print $1 "  " $2}\')')
+    assert rtn == 0
+
+    shell_assert_success('kubectl apply -f {}'.format(raycluster_service_file))
+
+
+def create_kuberay_service(template_name, ray_version, ray_image):
+    template = None
+    with open(template_name, mode='r') as f:
+        template = Template(f.read())
+
+    rayservice_spec_buf = template.substitute(
+        {'ray_image': ray_image, 'ray_version': ray_version})
+
+    service_config_file = None
+    with tempfile.NamedTemporaryFile('w', delete=False) as f:
+        f.write(rayservice_spec_buf)
+        service_config_file = f.name
+
+    rtn = shell_run(
+        'kubectl wait --for=condition=ready pod -n ray-system --all --timeout=900s')
+    if rtn != 0:
+        shell_run('kubectl get pods -A')
+    assert rtn == 0
+    assert service_config_file is not None
+    shell_assert_success('kubectl apply -f {}'.format(service_config_file))
+
+    shell_run('kubectl get pods -A')
+
+    time.sleep(20)
+
+    shell_assert_success('kubectl apply -f {}'.format(raycluster_service_file))
+
+    wait_for_condition(
+        lambda: shell_run(
+            'kubectl get service rayservice-sample-serve-svc -o jsonpath="{.status}"') == 0,
+        timeout=900,
+        retry_interval_ms=5000,
+    )
+
+
+def delete_cluster():
+    shell_run('kind delete cluster')
+
+
+def download_images(ray_image):
+    client = docker.from_env()
+    client.images.pull(ray_image)
+    # not enabled for now
+    # shell_assert_success('kind load docker-image \"{}\"'.format(ray_image))
+    client.close()
+
+
+def wait_for_condition(
+        condition_predictor, timeout=10, retry_interval_ms=100, **kwargs
+):
+    """Wait until a condition is met or time out with an exception.
+
+    Args:
+        condition_predictor: A function that predicts the condition.
+        timeout: Maximum timeout in seconds.
+        retry_interval_ms: Retry interval in milliseconds.
+
+    Raises:
+        RuntimeError: If the condition is not met before the timeout expires.
+    """
+    start = time.time()
+    last_ex = None
+    while time.time() - start <= timeout:
+        try:
+            if condition_predictor(**kwargs):
+                return
+        except Exception as ex:
+            last_ex = ex
+        time.sleep(retry_interval_ms / 1000.0)
+    message = "The condition wasn't met before the timeout expired."
+    if last_ex is not None:
+        message += f" Last exception: {last_ex}"
+    raise RuntimeError(message)

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -24,6 +24,24 @@ def parse_ray_version(version_str):
     return major, minor, patch
 
 
+def ray_ft_supported(ray_version):
+    if ray_version == "nightly":
+        return True
+    major, minor, patch = parse_ray_version(ray_version)
+    if major * 100 + minor <= 113:
+        return False
+    return True
+
+
+def ray_service_supported(ray_version):
+    if ray_version == "nightly":
+        return True
+    major, minor, patch = parse_ray_version(ray_version)
+    if major * 100 + minor <= 113:
+        return False
+    return True
+
+
 def shell_run(cmd):
     logger.info('executing cmd: {}'.format(cmd))
     return os.system(cmd)


### PR DESCRIPTION
## Why are these changes needed?

This is a patch that separate compatibility test into different files so that later we can only enable the necessary tests and delay other tests to nightly. 

## Related issue number

#514 #298

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
