### PR TITLE
[bugfix][apiserver helm]: Adding missing rbacenable value

### DIFF
--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -48,3 +48,5 @@ service:
 
 ingress:
   enabled: false
+
+rbacEnable: true


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `rbacEnable` value is being checked [here](https://github.com/ray-project/kuberay/blob/390002d1f3c0290d9b2e0f9ca09277713aec838d/helm-chart/kuberay-apiserver/templates/role.yaml#L2) to apply the default role and rolebinding. However, the value was missing from the `values.yaml`. 

## Related issue number

None

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
