### PR TITLE
[CI]use fixed version of gofumpt

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -28,8 +28,8 @@ jobs:
 
     - name: Install goimports and gofumpt
       run: |
-        go get golang.org/x/tools/cmd/goimports
-        go install mvdan.cc/gofumpt@latest
+        go install golang.org/x/tools/cmd/goimports@latest
+        go install mvdan.cc/gofumpt@v0.3.1
 
     - name: Run gofmt
       uses: Jerome1337/gofmt-action@v1.0.4


### PR DESCRIPTION
## Why are these changes needed?

With gofumpt version upgraded, there is some issue installing it. We now need to use a fixed version of gofumpt to avoid test issues from external.

## Related issue number


#597

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
