### PR TITLE
[RayJob] Fix example misconfiguration.

### DIFF
--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -29,7 +29,6 @@ spec:
       # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
       rayStartParams:
         port: '6379' # should match container port named gcs-server
-        object-store-memory: '100000000'
         dashboard-host: '0.0.0.0'
         num-cpus: '2' # can be auto-completed from the limits
         node-ip-address: $MY_POD_IP # auto-completed as the head pod IP


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The --object-store-memory flag in the sample RayJob config causes failed RayCluster setup, with this message:
https://github.com/ray-project/kuberay/blob/1694b9e2fba06f4d2378ea70c3fda679ee67b61d/ray-operator/controllers/ray/common/pod.go#L836-L837

This prevents the job from running to completion.

This PR fixes the issue by removing the `--object-store-memory` flag from the configuration.
Ray does a good enough job of figuring out appropriate object store memory itself.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
