### PR TITLE
[Feature][Helm] Enable sidecar configuration in Helm chart

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -41,6 +41,9 @@ spec:
             lifecycle:
             {{- toYaml .Values.head.lifecycle | nindent 14 }}
             {{- end }}
+          {{- if .Values.head.sidecarContainers }}
+          {{- toYaml .Values.head.sidecarContainers | nindent 10 }}
+          {{- end }}
         volumes: {{- toYaml .Values.head.volumes | nindent 10 }}
         affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.head.tolerations | nindent 10 }}
@@ -89,6 +92,9 @@ spec:
             lifecycle:
             {{- toYaml $values.lifecycle | nindent 14 }}
             {{- end }}
+          {{- if $values.sidecarContainers }}
+          {{- toYaml $values.sidecarContainers | nindent 10 }}
+          {{- end }}
         volumes: {{- toYaml $values.volumes | nindent 10 }}
         affinity: {{- toYaml $values.affinity | nindent 10 }}
         tolerations: {{- toYaml $values.tolerations | nindent 10 }}
@@ -136,6 +142,9 @@ spec:
             lifecycle:
             {{- toYaml .Values.worker.lifecycle | nindent 14 }}
             {{- end }}
+          {{- if .Values.worker.sidecarContainers }}
+          {{- toYaml .Values.worker.sidecarContainers | nindent 10 }}
+          {{- end }}
         volumes: {{- toYaml .Values.worker.volumes | nindent 10 }}
         affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.worker.tolerations | nindent 10 }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -49,7 +49,7 @@ head:
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
-  sidecarContainers: {}
+  sidecarContainers: []
 
 
 worker:
@@ -103,7 +103,7 @@ worker:
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
-  sidecarContainers: {}
+  sidecarContainers: []
 
 # The map's key is used as the groupName.
 # For example, key:small-group in the map below
@@ -159,7 +159,7 @@ additionalWorkerGroups:
     volumeMounts:
       - mountPath: /tmp/ray
         name: log-volume
-    sidecarContainers: {}
+    sidecarContainers: []
 
 headServiceSuffix: "ray-operator.svc"
 

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -49,6 +49,7 @@ head:
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
+  sidecarContainers: {}
 
 
 worker:
@@ -102,12 +103,13 @@ worker:
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
+  sidecarContainers: {}
 
 # The map's key is used as the groupName.
 # For example, key:small-group in the map below
 # will be used as the groupName
 additionalWorkerGroups:
-  small-group:
+  smallGroup:
     # Disabled by default
     disabled: true
     replicas: 1
@@ -157,6 +159,7 @@ additionalWorkerGroups:
     volumeMounts:
       - mountPath: /tmp/ray
         name: log-volume
+    sidecarContainers: {}
 
 headServiceSuffix: "ray-operator.svc"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR exposed an interface in KubeRay helm charts to enable users to configure sidecar containers (See the [logging documentation](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/logging.html) and https://github.com/ray-project/kuberay/issues/353 for more details).

## Example
<details>
<summary> configMap.yaml </summary>

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
    name: fluentbit-config
data:
    fluent-bit.conf: |
      [INPUT]
        Name tail
        Path /tmp/ray/session_latest/logs/*
        Tag ray
        Path_Key true
        Refresh_Interval 5
      [OUTPUT]
        Name stdout
        Match *
```

</details>

<details>
<summary> Updated values.yaml </summary>

* Update `head.volumes` and `head.sidecarContainers`

```yaml
# Default values for ray-cluster.
# This is a YAML-formatted file.
# Declare variables to be passed into your templates.

image:
  repository: rayproject/ray
  tag: 2.0.0
  pullPolicy: IfNotPresent

nameOverride: "kuberay"
fullnameOverride: ""

imagePullSecrets: []
  # - name: an-existing-secret

head:
  groupName: headgroup
  replicas: 1
  type: head
  labels:
    key: value
  initArgs:
    port: '6379'
    redis-password: 'LetMeInRay'  # Deprecated since Ray 1.11 due to GCS bootstrapping enabled
    dashboard-host: '0.0.0.0'
    num-cpus: '1'  # can be auto-completed from the limits
    node-ip-address: $MY_POD_IP  # auto-completed as the head pod IP
    block: 'true'
  containerEnv:
    - name: MY_POD_IP
      valueFrom:
        fieldRef:
          fieldPath: status.podIP
  envFrom: []
    # - secretRef:
    #     name: my-env-secret
  resources:
    limits:
      cpu: 1
    requests:
      cpu: 1
  annotations: {}
  nodeSelector: {}
  tolerations: []
  affinity: {}
  volumes:
    - name: log-volume
      emptyDir: {}
    - name: fluentbit-config
      configMap:
        name: fluentbit-config
  volumeMounts:
    - mountPath: /tmp/ray
      name: log-volume
  sidecarContainers:
    - name: fluentbit
      image: fluent/fluent-bit:1.9.6
      # These resource requests for Fluent Bit should be sufficient in production.
      resources:
        requests:
          cpu: 100m
          memory: 128Mi
        limits:
          cpu: 100m
          memory: 128Mi
      volumeMounts:
        - mountPath: /tmp/ray
          name: log-volume
        - mountPath: /fluent-bit/etc/fluent-bit.conf
          subPath: fluent-bit.conf
          name: fluentbit-config


worker:
  # If you want to disable the default workergroup
  # uncomment the line below
  # disabled: true
  groupName: workergroup
  replicas: 1
  type: worker
  labels:
    key: value
  initArgs:
    node-ip-address: $MY_POD_IP
    redis-password: LetMeInRay
    block: 'true'
  containerEnv:
    - name: MY_POD_IP
      valueFrom:
        fieldRef:
          fieldPath: status.podIP
    - name: RAY_DISABLE_DOCKER_CPU_WARNING
      value: "1"
    - name: CPU_REQUEST
      valueFrom:
        resourceFieldRef:
          containerName: ray-worker
          resource: requests.cpu
    - name: MY_POD_NAME
      valueFrom:
        fieldRef:
          fieldPath: metadata.name
  envFrom: []
    # - secretRef:
    #     name: my-env-secret
  ports:
    - containerPort: 80
      protocol: TCP
  resources:
    limits:
      cpu: 1
    requests:
      cpu: 200m
  annotations:
    key: value
  nodeSelector: {}
  tolerations: []
  affinity: {}
  volumes:
    - name: log-volume
      emptyDir: {}
  volumeMounts:
    - mountPath: /tmp/ray
      name: log-volume
  sidecarContainers: {}

# The map's key is used as the groupName.
# For example, key:small-group in the map below
# will be used as the groupName
additionalWorkerGroups:
  small-group:
    # Disabled by default
    disabled: true
    replicas: 1
    miniReplicas: 1
    maxiReplicas: 3
    type: worker
    labels: {}
    initArgs:
      node-ip-address: $MY_POD_IP
      redis-password: LetMeInRay
      block: 'true'
    containerEnv:
      - name: MY_POD_IP
        valueFrom:
          fieldRef:
            fieldPath: status.podIP
      - name: RAY_DISABLE_DOCKER_CPU_WARNING
        value: "1"
      - name: CPU_REQUEST
        valueFrom:
          resourceFieldRef:
            containerName: ray-worker
            resource: requests.cpu
      - name: MY_POD_NAME
        valueFrom:
          fieldRef:
            fieldPath: metadata.name
    envFrom: []
      # - secretRef:
      #     name: my-env-secret
    ports:
      - containerPort: 80
        protocol: TCP
    resources:
      limits:
        cpu: 1
      requests:
        cpu: 200m
    annotations:
      key: value
    nodeSelector: {}
    tolerations: []
    affinity: {}
    volumes:
      - name: log-volume
        emptyDir: {}
    volumeMounts:
      - mountPath: /tmp/ray
        name: log-volume
    sidecarContainers: {}

headServiceSuffix: "ray-operator.svc"

service:
  type: ClusterIP
  port: 8080

```

</details>

```bash
# Step0: Install KubeRay operator

# (Path: helm-chart/ray-cluster)
# Step1: Create a configMap.yaml file, and create the ConfigMap
kubectl apply -f configMap.yaml

# Step2: Install 
helm install ray-cluster .

# Step3: Check log
kubectl logs ray-cluster-kuberay-head-xxxxx-c fluentbit
```

![截圖 2022-09-28 下午11 35 14](https://user-images.githubusercontent.com/20109646/192956857-e54a1875-c2be-402e-b5b8-a4ec59074e3a.png)


## Related issue number
Closes #511 

## Checks
See the "Example" section.

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
