### PR TITLE
Configuration Test Framework Prototype

### DIFF
--- a/tests/framework/config/ray-cluster.mini.yaml.template
+++ b/tests/framework/config/ray-cluster.mini.yaml.template
@@ -1,0 +1,118 @@
+apiVersion: ray.io/v1alpha1
+kind: RayCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    # An unique identifier for the head node and workers of this cluster.
+  name: raycluster-mini
+spec:
+  rayVersion: '$ray_version' # should match the Ray version in the image of the containers
+  ######################headGroupSpecs#################################
+  # head group template and specs, (perhaps 'group' is not needed in the name)
+  headGroupSpec:
+    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
+    serviceType: ClusterIP
+    # the pod replicas in this group typed head (assuming there could be more than 1 in the future)
+    replicas: 1
+    # logical group name, for this called head-group, also can be functional
+    # pod type head or worker
+    # rayNodeType: head # Not needed since it is under the headgroup
+    # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
+    rayStartParams:
+      port: '6379' # should match headService targetPort
+      #include_webui: 'true'
+      redis-password: 'LetMeInRay' # Deprecated since Ray 1.11 due to GCS bootstrapping enabled
+      # webui_host: "10.1.2.60"
+      dashboard-host: '0.0.0.0'
+      num-cpus: '1' # can be auto-completed from the limits
+      node-ip-address: $$MY_POD_IP # auto-completed as the head pod IP
+      block: 'true'
+    #pod template
+    template:
+      metadata:
+        labels:
+          # custom labels. NOTE: do not define custom labels start with `raycluster.`, they may be used in controller.
+          # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+          rayCluster: raycluster-compatibility-test
+          rayNodeType: head # will be injected if missing, must be head or wroker
+          groupName: headgroup # will be injected if missing
+        # annotations for pod
+        annotations:
+          key: value
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:1.9.0
+          env:
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          ports:
+          - containerPort: 6379
+            name: redis
+          - containerPort: 8265 # Ray dashboard
+            name: dashboard
+          - containerPort: 10001
+            name: client
+  workerGroupSpecs:
+    - replicas: 1
+      minReplicas: 1
+      maxReplicas: 1
+      groupName: small-group
+      # the following params are used to complete the ray start: ray start --block --node-ip-address= ...
+      rayStartParams:
+        redis-password: 'LetMeInRay' # Deprecated since Ray 1.11 due to GCS bootstrapping enabled
+        node-ip-address: $$MY_POD_IP
+        block: 'true'
+      #pod template
+      template:
+        metadata:
+          labels:
+            rayCluster: raycluster-compatibility-test
+            rayNodeType: worker # will be injected if missing
+            groupName: small-group # will be injected if missing
+          # annotations for pod
+          annotations:
+            key: value
+        spec:
+          initContainers: # to avoid worker crashing before head service is created
+          - name: init-myservice
+            image: busybox:1.28
+            # Change the cluster postfix if you don't have a default setting
+            command: ['sh', '-c', "until nslookup $$RAY_IP.$$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
+          containers:
+          - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+            image: rayproject/ray:1.9.0
+            # environment variables to set in the container.Optional.
+            # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+            env:
+            - name: TYPE
+              value: "worker"
+            - name:  RAY_DISABLE_DOCKER_CPU_WARNING
+              value: "1"
+            - name: CPU_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  containerName: machine-learning
+                  resource: requests.cpu
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            ports:
+            - containerPort: 80
+            # use volumeMounts.Optional.
+            # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+            volumeMounts:
+              - mountPath: /var/log
+                name: log-volume
+          # use volumes
+          # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+          volumes:
+            - name: log-volume
+              emptyDir: {}

--- a/tests/framework/config/ray-cluster.mini.yaml.template
+++ b/tests/framework/config/ray-cluster.mini.yaml.template
@@ -55,6 +55,13 @@ spec:
             name: dashboard
           - containerPort: 10001
             name: client
+          resources:
+            limits:
+              cpu: 1
+              memory: "1G"
+            requests:
+              cpu: 1
+              memory: "512Mi"
   workerGroupSpecs:
     - replicas: 1
       minReplicas: 1

--- a/tests/framework/config/ray-cluster.mini.yaml.template
+++ b/tests/framework/config/ray-cluster.mini.yaml.template
@@ -42,7 +42,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:1.9.0
+          image: rayproject/ray:2.0.0
           env:
           - name: MY_POD_IP
             valueFrom:
@@ -83,7 +83,7 @@ spec:
             command: ['sh', '-c', "until nslookup $$RAY_IP.$$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
           containers:
           - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-            image: rayproject/ray:1.9.0
+            image: rayproject/ray:2.0.0
             # environment variables to set in the container.Optional.
             # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
             env:

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -1,0 +1,162 @@
+import yaml
+import copy
+from typing import Optional
+from kubernetes import client, config
+import os
+import time
+import docker
+
+class DeltaSet:
+    def __init__(self, path, candidates):
+        self.path = path
+        self.candidates = candidates
+
+    def iterate(self):
+        for candidate in self.candidates:
+            yield candidate
+
+    # return value: (1) steps (2) None => this path does not exist
+    def find_path(self, cr) -> Optional[list[str]]:
+        steps = self.path.split('.')
+        return steps
+
+def search_path(cr, steps):
+    curr = cr
+    for step in steps:
+        if step.isnumeric():
+            int_step = int(step)
+            if int_step >= len(curr) or int_step < 0:
+                return None
+            curr = curr[int(step)]
+        elif step in curr:
+            curr = curr[step]
+        else:
+            return None
+    return curr
+
+class Mutator:
+    def __init__(self, baseCR, deltaSets: list[DeltaSet]):
+        self.baseCR = baseCR
+        self.deltaSets = deltaSets
+    def mutate(self):
+        pass
+    def apply_delta(self, base, delta, steps):
+        root = copy.deepcopy(base)
+        curr = search_path(root, steps[:-1])
+        curr[steps[-1]] = delta
+        return root
+
+class Rule:
+    def __init__(self):
+        pass
+    def trigger_condition(self, cr) -> bool:
+        pass
+    def assertRule(self, cr):
+        pass
+
+class RuleSet:
+    def __init__(self, rules: list[Rule]):
+        self.rules = rules
+    def checkRuleSet(self, cr, namespace):
+        for rule in self.rules:
+            if rule.trigger_condition(cr):
+                rule.assertRule(cr, namespace)
+
+class CREvent:
+    def __init__(self, cr, cmd, ruleSets: list[RuleSet], timeout, namespace):
+        self.ruleSets = ruleSets
+        self.cmd = cmd
+        self.timeout = timeout
+        self.cr = cr
+        self.namespace = namespace
+    def trigger(self):
+        self.exec()
+        self.wait()
+        self.checkRuleSets()
+    def exec(self):
+        os.system(self.cmd)
+    def wait(self):
+        time.sleep(self.timeout)
+    def checkRuleSets(self):
+        for rs in self.ruleSets:
+            rs.checkRuleSet(self.cr, self.namespace)
+
+class SimpleMutator(Mutator):
+    def mutate(self):
+        for deltaSet in self.deltaSets:
+            steps = deltaSet.find_path(self.baseCR)
+            if steps:
+                for delta in deltaSet.iterate():
+                    yield self.apply_delta(self.baseCR, delta, steps)
+            else:
+                print("The path does not exist")
+
+class HeadPodNameRule(Rule):
+    def trigger_condition(self, cr) -> bool:
+        steps = "spec.headGroupSpec".split('.')
+        print("trigger_condition: " + (search_path(cr, steps) != None))
+        return (search_path(cr, steps) != None)
+
+    def assertRule(self, cr, namespace):
+        expected_val = search_path(cr, "spec.headGroupSpec.template.spec.containers.0.name".split('.'))
+        config.load_kube_config()
+        v1 = client.CoreV1Api()
+        headpods = v1.list_namespaced_pod(namespace = namespace, label_selector='rayNodeType={}'.format('head'))
+        print("HeadPodNameRule: {} {}".format(expected_val, headpods.items[0].spec.containers[0].name))
+        assert(headpods.items[0].spec.containers[0].name == expected_val)
+
+def delete_kind_cluster():
+    os.system("kind delete cluster")
+
+def create_kind_cluster():
+    os.system("kind create cluster")
+    os.system("kubectl wait --for=condition=ready pod -n kube-system --all --timeout=900s")
+
+def install_crd():
+    KUBERAY_VERSION = "v0.3.0"
+    os.system("kubectl create -k \"github.com/ray-project/kuberay/manifests/cluster-scope-resources?" +
+              "ref={}&timeout=90s\"".format(KUBERAY_VERSION))
+
+def download_images(images):
+    client = docker.from_env()
+    for image in images:
+        client.images.pull(image)
+    client.close()
+
+def install_kuberay_operator():
+    KUBERAY_VERSION = "v0.3.0"
+    os.system("kubectl apply -k \"github.com/ray-project/kuberay/manifests/base?" +
+              "ref={}&timeout=90s\"".format(KUBERAY_VERSION))
+    time.sleep(60)
+
+def kind_load_images(images):
+    for image in images:
+        os.system('kind load docker-image {}'.format(image))
+
+if __name__ == '__main__':
+    template_name = 'config/ray-cluster.mini.yaml.template'
+    namespace = 'default'
+    with open(template_name) as base_yaml:
+        baseCR = yaml.load(base_yaml, Loader=yaml.FullLoader)
+    ds = DeltaSet("spec.headGroupSpec.template.spec.containers.0.name", ['ray-head-1', 'ray-head-2', 'ray-head-3'])
+    rs = RuleSet([HeadPodNameRule()])
+    mut = SimpleMutator(baseCR, [ds])
+    images = ['rayproject/ray:1.9.0', 'kuberay/operator:v0.3.0', 'kuberay/apiserver:v0.3.0']
+
+    for cr in mut.mutate():
+        delete_kind_cluster()
+        create_kind_cluster()
+        install_crd()
+        download_images(images)
+        kind_load_images(images)
+        install_kuberay_operator()
+        f = open('tmp.yaml', 'w')
+        f.write(yaml.dump(cr))
+        f.close()
+        addEvent = CREvent(cr, "kubectl apply -f tmp.yaml", [rs], 90, namespace)
+        addEvent.trigger()
+
+
+
+
+

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -249,6 +249,8 @@ if __name__ == '__main__':
     patch_list = [
         jsonpatch.JsonPatch([{'op': 'replace', 'path': '/spec/headGroupSpec/template/spec/containers/0/name', 'value': 'ray-head-1'}]),
         jsonpatch.JsonPatch([{'op': 'replace', 'path': '/spec/headGroupSpec/template/spec/containers/0/name', 'value': 'ray-head-2'}]),
+        # Reproduce #612
+        jsonpatch.JsonPatch([{'op': 'replace', 'path': '/spec/headGroupSpec/replicas', 'value': 2}]),
         # Reproduce #587
         jsonpatch.JsonPatch([
             {'op': 'replace', 'path': '/spec/workerGroupSpecs/0/replicas', 'value': 2},

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -26,10 +26,6 @@ def search_path(cr, steps):
             return None
     return curr
 
-def yaml_to_file(cr_yaml, fn):
-    f = open(fn, 'w')
-    f.write(yaml.dump(cr_yaml))
-    f.close()
 '''
 Functions for cluster preparation. Typical workflow:
   Delete KinD cluster -> Create KinD cluster -> Install CRD -> Download Images (from DockerHub) ->

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -67,11 +67,11 @@ def check_cluster_exist():
     return os.system("kubectl cluster-info --context kind-kind") == 0 
 
 '''
-Configuration Test Framework Abstractions: (1) DeltaSet (2) Mutator (3) Rule (4) RuleSet (5) CREvent
+Configuration Test Framework Abstractions: (1) Mutator (2) Rule (3) RuleSet (4) CREvent
 '''
 
-# Mutator: Mutator will start to mutate from `baseCR`. `deltaSets` is a list of DeltaSets, and each DeltaSet
-#          specifies a field that wants to mutate with multiple candidate values.
+# Mutator: Mutator will start to mutate from `baseCR`. `patch_list` is a list of JsonPatch, and you can
+#          specify multiple fields that want to mutate in a single JsonPatch.
 class Mutator:
     def __init__(self, baseCR, patch_list: list[jsonpatch.JsonPatch]):
         self.baseCR = baseCR

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -175,7 +175,7 @@ class EasyJobRule(Rule):
                         .format(headpodName))
         assert(rtn == 0)
 
-class AddCREvent(CREvent):
+class RayClusterAddCREvent(CREvent):
     def exec(self):
         client.CustomObjectsApi().create_namespaced_custom_object(
             group = 'ray.io',version = 'v1alpha1', namespace = self.namespace, plural = 'rayclusters', body = self.cr,
@@ -235,7 +235,7 @@ if __name__ == '__main__':
 
     test_cases = unittest.TestSuite()
     for cr in mut.mutate():
-        addEvent = AddCREvent(cr, [rs], 90, namespace)
+        addEvent = RayClusterAddCREvent(cr, [rs], 90, namespace)
         test_cases.addTest(GeneralTestCase('runTest', images, addEvent))
     runner=unittest.TextTestRunner()
     runner.run(test_cases)

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -249,18 +249,20 @@ if __name__ == '__main__':
     patch_list = [
         jsonpatch.JsonPatch([{'op': 'replace', 'path': '/spec/headGroupSpec/template/spec/containers/0/name', 'value': 'ray-head-1'}]),
         jsonpatch.JsonPatch([{'op': 'replace', 'path': '/spec/headGroupSpec/template/spec/containers/0/name', 'value': 'ray-head-2'}]),
-        # Reproduce #612
+        # Reproduce #612: https://github.com/ray-project/kuberay/issues/612
         jsonpatch.JsonPatch([{'op': 'replace', 'path': '/spec/headGroupSpec/replicas', 'value': 2}]),
-        # Reproduce #587
+        # Reproduce #587: https://github.com/ray-project/kuberay/pull/587
         jsonpatch.JsonPatch([
             {'op': 'replace', 'path': '/spec/workerGroupSpecs/0/replicas', 'value': 2},
             {'op': 'add', 'path': '/spec/workerGroupSpecs/0/template/metadata/name', 'value': 'haha'}
             ]),
-        # Reproduce #585
+        # Reproduce #585: https://github.com/ray-project/kuberay/pull/585
         jsonpatch.JsonPatch([{'op': 'add', 'path': '/spec/headGroupSpec/rayStartParams/object-manager-port', 'value': '12345'}]),
-        # Reproduce #572 #530
+        # Reproduce 
+        #   #572: https://github.com/ray-project/kuberay/pull/572
+        #   #530: https://github.com/ray-project/kuberay/pull/530
         jsonpatch.JsonPatch([{'op': 'add', 'path': '/spec/headGroupSpec/template/metadata/labels/app.kubernetes.io~1name', 'value': 'ray'}]),
-        # Reproduce #529
+        # Reproduce #529: https://github.com/ray-project/kuberay/pull/529
         jsonpatch.JsonPatch([
             {'op': 'replace', 'path': '/spec/headGroupSpec/template/spec/containers/0/resources/requests/memory', 'value': '256Mi'},
             {'op': 'replace', 'path': '/spec/headGroupSpec/template/spec/containers/0/resources/limits/memory', 'value': '512Mi'}

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -1,25 +1,12 @@
 import yaml
 import copy
 from typing import Optional
-from kubernetes import client, config
+from kubernetes import client, config, utils
 import os
 import time
 import docker
 
-class DeltaSet:
-    def __init__(self, path, candidates):
-        self.path = path
-        self.candidates = candidates
-
-    def iterate(self):
-        for candidate in self.candidates:
-            yield candidate
-
-    # return value: (1) steps (2) None => this path does not exist
-    def find_path(self, cr) -> Optional[list[str]]:
-        steps = self.path.split('.')
-        return steps
-
+# Utility functions
 def search_path(cr, steps):
     curr = cr
     for step in steps:
@@ -34,26 +21,95 @@ def search_path(cr, steps):
             return None
     return curr
 
+def yaml_to_file(cr_yaml, fn):
+    f = open(fn, 'w')
+    f.write(yaml.dump(cr_yaml))
+    f.close()
+'''
+Functions for cluster preparation. Typical workflow:
+  Delete KinD cluster -> Create KinD cluster -> Install CRD -> Download Images (from DockerHub) ->
+  Load images into KinD cluster -> Install KubeRay operator
+'''
+def delete_kind_cluster():
+    os.system("kind delete cluster")
+
+def create_kind_cluster():
+    os.system("kind create cluster")
+    os.system("kubectl wait --for=condition=ready pod -n kube-system --all --timeout=900s")
+
+def install_crd():
+    KUBERAY_VERSION = "v0.3.0"
+    os.system("kubectl create -k \"github.com/ray-project/kuberay/manifests/cluster-scope-resources?" +
+              "ref={}&timeout=90s\"".format(KUBERAY_VERSION))
+
+def download_images(images):
+    client = docker.from_env()
+    for image in images:
+        client.images.pull(image)
+    client.close()
+
+def kind_load_images(images):
+    for image in images:
+        os.system('kind load docker-image {}'.format(image))
+
+def install_kuberay_operator():
+    KUBERAY_VERSION = "v0.3.0"
+    os.system("kubectl apply -k \"github.com/ray-project/kuberay/manifests/base?" +
+              "ref={}&timeout=90s\"".format(KUBERAY_VERSION))
+    time.sleep(60)
+
+'''
+Configuration Test Framework Abstractions: (1) DeltaSet (2) Mutator (3) Rule (4) RuleSet (5) CREvent
+'''
+
+# DeltaSet: Use `path` to specify the field that wants to mutate, and `candidates` is a list of candidate
+#           value for the field.
+# Example:  DeltaSet("spec.headGroupSpec.template.spec.containers.0.name", ['ray-head-1', 'ray-head-2', 'ray-head-3'])
+class DeltaSet:
+    def __init__(self, path, candidates):
+        self.path = path
+        self.candidates = candidates
+
+    def iterate(self):
+        for candidate in self.candidates:
+            yield candidate
+
+    # return value: (1) steps (2) None => this path does not exist
+    def find_path(self, cr) -> Optional[list[str]]:
+        steps = self.path.split('.')
+        return steps
+
+# Mutator: Mutator will start to mutate from `baseCR`. `deltaSets` is a list of DeltaSets, and each DeltaSet
+#          specifies a field that wants to mutate with multiple candidate values.
+# Example: "SimpleMutator"
 class Mutator:
     def __init__(self, baseCR, deltaSets: list[DeltaSet]):
         self.baseCR = baseCR
         self.deltaSets = deltaSets
+    # You need to define your mutate() function by inheriting `Mutator`. It should return a new CR.
     def mutate(self):
         pass
+    # Apply delta to the base (custom resource).
     def apply_delta(self, base, delta, steps):
         root = copy.deepcopy(base)
         curr = search_path(root, steps[:-1])
         curr[steps[-1]] = delta
         return root
 
+# Rule: Rule is used to check whether the actual cluster state is the same as our expectation after a CREvent.
+#       We can infer the expected state by CR YAML file, and get the actual cluster state by Kubernetes API.
+# Example: "HeadPodNameRule"
 class Rule:
     def __init__(self):
         pass
-    def trigger_condition(self, cr) -> bool:
-        pass
-    def assertRule(self, cr):
+    # The rule will only be checked when `trigger_condition` is true. For example, we will only check
+    # "HeadPodNameRule" when "spec.headGroupSpec" is defined in CR YAML file.
+    def trigger_condition(self, cr=None) -> bool:
+        return True
+    def assertRule(self, cr=None, namespace='default'):
         pass
 
+# RuleSet: A set of Rule
 class RuleSet:
     def __init__(self, rules: list[Rule]):
         self.rules = rules
@@ -62,6 +118,14 @@ class RuleSet:
             if rule.trigger_condition(cr):
                 rule.assertRule(cr, namespace)
 
+# CREvent: Custom Resource Event can be mainly divided into 3 categories.
+#   (1) Add (create) CR (2) Update CR (3) Delete CR
+#
+# The member functions integrate together in `trigger()`.
+#   [Step1] exec(): Execute a command to trigger the CREvent. For example, create a CR by a
+#                  `kubectl apply` command.
+#   [Step2] wait(): Wait for the system to converge.
+#   [Step3] checkRuleSets(): When the system converges, check all registered RuleSets.
 class CREvent:
     def __init__(self, cr, cmd, ruleSets: list[RuleSet], timeout, namespace):
         self.ruleSets = ruleSets
@@ -81,6 +145,9 @@ class CREvent:
         for rs in self.ruleSets:
             rs.checkRuleSet(self.cr, self.namespace)
 
+'''
+My implementations
+'''
 class SimpleMutator(Mutator):
     def mutate(self):
         for deltaSet in self.deltaSets:
@@ -94,44 +161,19 @@ class SimpleMutator(Mutator):
 class HeadPodNameRule(Rule):
     def trigger_condition(self, cr) -> bool:
         steps = "spec.headGroupSpec".split('.')
-        print("trigger_condition: " + (search_path(cr, steps) != None))
         return (search_path(cr, steps) != None)
 
     def assertRule(self, cr, namespace):
         expected_val = search_path(cr, "spec.headGroupSpec.template.spec.containers.0.name".split('.'))
-        config.load_kube_config()
-        v1 = client.CoreV1Api()
-        headpods = v1.list_namespaced_pod(namespace = namespace, label_selector='rayNodeType={}'.format('head'))
-        print("HeadPodNameRule: {} {}".format(expected_val, headpods.items[0].spec.containers[0].name))
+        headpods = client.CoreV1Api().list_namespaced_pod(namespace = namespace, label_selector='rayNodeType={}'.format('head'))
         assert(headpods.items[0].spec.containers[0].name == expected_val)
 
-def delete_kind_cluster():
-    os.system("kind delete cluster")
-
-def create_kind_cluster():
-    os.system("kind create cluster")
-    os.system("kubectl wait --for=condition=ready pod -n kube-system --all --timeout=900s")
-
-def install_crd():
-    KUBERAY_VERSION = "v0.3.0"
-    os.system("kubectl create -k \"github.com/ray-project/kuberay/manifests/cluster-scope-resources?" +
-              "ref={}&timeout=90s\"".format(KUBERAY_VERSION))
-
-def download_images(images):
-    client = docker.from_env()
-    for image in images:
-        client.images.pull(image)
-    client.close()
-
-def install_kuberay_operator():
-    KUBERAY_VERSION = "v0.3.0"
-    os.system("kubectl apply -k \"github.com/ray-project/kuberay/manifests/base?" +
-              "ref={}&timeout=90s\"".format(KUBERAY_VERSION))
-    time.sleep(60)
-
-def kind_load_images(images):
-    for image in images:
-        os.system('kind load docker-image {}'.format(image))
+class EasyJobRule(Rule):
+    def assertRule(self, cr=None, namespace='default'):
+        headpods = client.CoreV1Api().list_namespaced_pod(namespace = namespace, label_selector='rayNodeType={}'.format('head'))
+        headpodName = headpods.items[0].metadata.name
+        rtn = os.system("kubectl exec {} -- python -c \"import ray; ray.init(); print(ray.cluster_resources())\"".format(headpodName))
+        assert(rtn == 0)
 
 if __name__ == '__main__':
     template_name = 'config/ray-cluster.mini.yaml.template'
@@ -139,21 +181,25 @@ if __name__ == '__main__':
     with open(template_name) as base_yaml:
         baseCR = yaml.load(base_yaml, Loader=yaml.FullLoader)
     ds = DeltaSet("spec.headGroupSpec.template.spec.containers.0.name", ['ray-head-1', 'ray-head-2', 'ray-head-3'])
-    rs = RuleSet([HeadPodNameRule()])
+    rs = RuleSet([HeadPodNameRule(), EasyJobRule()])
     mut = SimpleMutator(baseCR, [ds])
-    images = ['rayproject/ray:1.9.0', 'kuberay/operator:v0.3.0', 'kuberay/apiserver:v0.3.0']
+    images = ['rayproject/ray:2.0.0', 'kuberay/operator:v0.3.0', 'kuberay/apiserver:v0.3.0']
 
     for cr in mut.mutate():
+        # Convert CR object into YAML file
+        filename = "tmp.yaml"
+        yaml_to_file(cr, filename)
+        # Prepare for KinD cluster, CRD, images, and Kuberay operator.
         delete_kind_cluster()
         create_kind_cluster()
         install_crd()
         download_images(images)
         kind_load_images(images)
         install_kuberay_operator()
-        f = open('tmp.yaml', 'w')
-        f.write(yaml.dump(cr))
-        f.close()
-        addEvent = CREvent(cr, "kubectl apply -f tmp.yaml", [rs], 90, namespace)
+        # Prepare for Python k8s client
+        config.load_kube_config()
+        # Trigger CREvent
+        addEvent = CREvent(cr, "kubectl apply -f {}".format(filename), [rs], 90, namespace)
         addEvent.trigger()
 
 

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -249,8 +249,6 @@ if __name__ == '__main__':
     patch_list = [
         jsonpatch.JsonPatch([{'op': 'replace', 'path': '/spec/headGroupSpec/template/spec/containers/0/name', 'value': 'ray-head-1'}]),
         jsonpatch.JsonPatch([{'op': 'replace', 'path': '/spec/headGroupSpec/template/spec/containers/0/name', 'value': 'ray-head-2'}]),
-        # Reproduce #612: https://github.com/ray-project/kuberay/issues/612
-        jsonpatch.JsonPatch([{'op': 'replace', 'path': '/spec/headGroupSpec/replicas', 'value': 2}]),
         # Reproduce #587: https://github.com/ray-project/kuberay/pull/587
         jsonpatch.JsonPatch([
             {'op': 'replace', 'path': '/spec/workerGroupSpecs/0/replicas', 'value': 2},

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -112,7 +112,7 @@ class Rule:
     def trigger_condition(self, cr=None) -> bool:
         return True
     def assertRule(self, cr=None, namespace='default'):
-        pass
+        raise NotImplementedError
 
 # RuleSet: A set of Rule
 class RuleSet:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* [Design Doc](https://docs.google.com/document/d/1OyMBgQ9zx5FF0GV3f3WKVdW-Y4OXz_epaywYgTw893w/edit?usp=sharing)

Currently, existing tests for operators only test for the default configuration. However, from the last 6 weeks (the design doc is created on Sep. 26, 2022), 11 out of 34 commits are used to fix bugs caused by configurations. Hence, this project decided to focus on configuration. This PR is a prototype that can reproduce every YAML-related configuration bug (in the 11 reported config bugs) by adding a simple JsonPatch.

```python
if __name__ == '__main__':
    template_name = 'config/ray-cluster.mini.yaml.template'
    namespace = 'default'
    with open(template_name) as base_yaml:
        baseCR = yaml.load(base_yaml, Loader=yaml.FullLoader)

    patch_list = [
        jsonpatch.JsonPatch([{'op': 'replace', 'path': '/spec/headGroupSpec/template/spec/containers/0/name', 'value': 'ray-head-1'}]),
        jsonpatch.JsonPatch([{'op': 'replace', 'path': '/spec/headGroupSpec/template/spec/containers/0/name', 'value': 'ray-head-2'}]),
        # Reproduce #612
        jsonpatch.JsonPatch([{'op': 'replace', 'path': '/spec/headGroupSpec/replicas', 'value': 2}]),
        # Reproduce #587
        jsonpatch.JsonPatch([
            {'op': 'replace', 'path': '/spec/workerGroupSpecs/0/replicas', 'value': 2},
            {'op': 'add', 'path': '/spec/workerGroupSpecs/0/template/metadata/name', 'value': 'haha'}
            ]),
        # Reproduce #585
        jsonpatch.JsonPatch([{'op': 'add', 'path': '/spec/headGroupSpec/rayStartParams/object-manager-port', 'value': '12345'}]),
        # Reproduce #572 #530
        jsonpatch.JsonPatch([{'op': 'add', 'path': '/spec/headGroupSpec/template/metadata/labels/app.kubernetes.io~1name', 'value': 'ray'}]),
        # Reproduce #529
        jsonpatch.JsonPatch([
            {'op': 'replace', 'path': '/spec/headGroupSpec/template/spec/containers/0/resources/requests/memory', 'value': '256Mi'},
            {'op': 'replace', 'path': '/spec/headGroupSpec/template/spec/containers/0/resources/limits/memory', 'value': '512Mi'}
        ])
    ]

    rs = RuleSet([HeadPodNameRule(), EasyJobRule(), HeadSvcRule()])
    mut = Mutator(baseCR, patch_list)
    images = ['rayproject/ray:2.0.0', 'kuberay/operator:v0.3.0', 'kuberay/apiserver:v0.3.0']

    test_cases = unittest.TestSuite()
    for new_cr in mut.mutate():
        addEvent = RayClusterAddCREvent(new_cr, [rs], 90, namespace)
        test_cases.addTest(GeneralTestCase('runTest', images, addEvent))
    runner=unittest.TextTestRunner()
    runner.run(test_cases)

```


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
