### PR TITLE
Helm: add service type configuration to head group for ray-cluster

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -12,7 +12,7 @@ spec:
   enableInTreeAutoscaling: {{ .Values.head.enableInTreeAutoscaling }}
   {{- end }}
   headGroupSpec:
-    serviceType: ClusterIP
+    serviceType: {{ .Values.service.type }}
     rayStartParams:
     {{- range $key, $val := .Values.head.initArgs }}
       {{ $key }}: {{ $val | quote }}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently service type is not used in helm and ClusterIP is hardcoded

https://github.com/ray-project/kuberay/blob/159d57f565cabee36c97fa55cbc5d401bfeef906/helm-chart/ray-cluster/templates/raycluster-cluster.yaml#L15

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
