### PR TITLE
[ray job] support stop job after job cr is deleted in cluster selector mode

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -259,34 +259,36 @@ func (r *RayJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&rayv1alpha1.RayCluster{}).
 		Owns(&corev1.Service{}).
 		WithEventFilter(predicate.Funcs{
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				r.Log.Info("event to delete", "event", e)
-
-				job, ok := e.Object.(*rayv1alpha1.RayJob)
-				if !ok {
-					r.Log.Info("failed to get job object from event", "event", e)
-					return false
-				}
-
-				if job.Status.JobStatus == rayv1alpha1.JobStatusRunning || job.Status.JobStatus == rayv1alpha1.JobStatusPending {
-					if job.Status.DashboardURL == "" || job.Status.JobId == "" {
-						r.Log.Info("dashboardURL or job_id is empty", "job", job)
-						return false
-					}
-					rayDashboardClient := utils.GetRayDashboardClientFunc()
-					rayDashboardClient.InitClient(job.Status.DashboardURL)
-					err := rayDashboardClient.StopJob(job.Status.JobId, &r.Log)
-					if err != nil {
-						r.Log.Info("failed to stop job", "error", err)
-					}
-				}
-				// The reconciler adds a finalizer so we perform clean-up
-				// when the delete timestamp is added
-				// Suppress Delete events to avoid filtering them out in the Reconcile function
-				return false
-			},
+			DeleteFunc: r.DeleteEventFilter,
 		}).
 		Complete(r)
+}
+
+func (r *RayJobReconciler) DeleteEventFilter(e event.DeleteEvent) bool {
+	r.Log.Info("event to delete", "event", e)
+
+	job, ok := e.Object.(*rayv1alpha1.RayJob)
+	if !ok {
+		r.Log.Info("failed to get job object from event", "event", e)
+		return false
+	}
+
+	if job.Status.JobStatus == rayv1alpha1.JobStatusRunning || job.Status.JobStatus == rayv1alpha1.JobStatusPending {
+		if job.Status.DashboardURL == "" || job.Status.JobId == "" {
+			r.Log.Info("dashboardURL or job_id is empty", "job", job)
+			return false
+		}
+		rayDashboardClient := utils.GetRayDashboardClientFunc()
+		rayDashboardClient.InitClient(job.Status.DashboardURL)
+		err := rayDashboardClient.StopJob(job.Status.JobId, &r.Log)
+		if err != nil {
+			r.Log.Info("failed to stop job", "error", err)
+		}
+	}
+	// The reconciler adds a finalizer so we perform clean-up
+	// when the delete timestamp is added
+	// Suppress Delete events to avoid filtering them out in the Reconcile function
+	return false
 }
 
 func (r *RayJobReconciler) getRayJobInstance(ctx context.Context, request ctrl.Request) (*rayv1alpha1.RayJob, error) {

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -3,9 +3,10 @@ package ray
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"time"
 
 	"k8s.io/client-go/tools/record"
 

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -385,7 +385,7 @@ func (r *RayDashboardClient) SubmitJob(rayJob *rayv1alpha1.RayJob, log *logr.Log
 func (r *RayDashboardClient) StopJob(jobName string, log *logr.Logger) (err error) {
 	log.Info("Stop a ray job", "rayJob", jobName)
 
-	req, err := http.NewRequest(http.MethodPost, r.dashboardURL+JobPath + jobName + "/stop", nil)
+	req, err := http.NewRequest(http.MethodPost, r.dashboardURL+JobPath+jobName+"/stop", nil)
 	if err != nil {
 		return err
 	}
@@ -409,7 +409,6 @@ func (r *RayDashboardClient) StopJob(jobName string, log *logr.Logger) (err erro
 	}
 	return nil
 }
-
 
 func ConvertRayJobToReq(rayJob *rayv1alpha1.RayJob) (*RayJobRequest, error) {
 	req := &RayJobRequest{

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -81,6 +81,7 @@ type RayDashboardClientInterface interface {
 	ConvertServeConfig(specs []rayv1alpha1.ServeConfigSpec) []ServeConfigSpec
 	GetJobInfo(jobId string) (*RayJobInfo, error)
 	SubmitJob(rayJob *rayv1alpha1.RayJob, log *logr.Logger) (jobId string, err error)
+	StopJob(jobName string, log *logr.Logger) (err error)
 }
 
 // GetRayDashboardClientFunc Used for unit tests.
@@ -315,6 +316,10 @@ type RayJobResponse struct {
 	JobId string `json:"job_id"`
 }
 
+type RayJobStopResponse struct {
+	Stopped bool `json:"stopped"`
+}
+
 func (r *RayDashboardClient) GetJobInfo(jobId string) (*RayJobInfo, error) {
 	req, err := http.NewRequest("GET", r.dashboardURL+JobPath+jobId, nil)
 	if err != nil {
@@ -376,6 +381,35 @@ func (r *RayDashboardClient) SubmitJob(rayJob *rayv1alpha1.RayJob, log *logr.Log
 
 	return jobResp.JobId, nil
 }
+
+func (r *RayDashboardClient) StopJob(jobName string, log *logr.Logger) (err error) {
+	log.Info("Stop a ray job", "rayJob", jobName)
+
+	req, err := http.NewRequest(http.MethodPost, r.dashboardURL+JobPath + jobName + "/stop", nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	var jobStopResp RayJobStopResponse
+	if err = json.Unmarshal(body, &jobStopResp); err != nil {
+		return err
+	}
+
+	if !jobStopResp.Stopped {
+		return fmt.Errorf("failed to stopped job: %v", jobName)
+	}
+	return nil
+}
+
 
 func ConvertRayJobToReq(rayJob *rayv1alpha1.RayJob) (*RayJobRequest, error) {
 	req := &RayJobRequest{

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
@@ -98,5 +98,4 @@ var _ = Describe("RayFrameworkGenerator", func() {
 		err := rayDashboardClient.StopJob("stop-job-1", &ctrl.Log)
 		Expect(err).To(BeNil())
 	})
-
 })

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
@@ -82,4 +82,21 @@ var _ = Describe("RayFrameworkGenerator", func() {
 		Expect(rayJobInfo.Entrypoint).To(Equal(rayJob.Spec.Entrypoint))
 		Expect(rayJobInfo.JobStatus).To(Equal(rayv1alpha1.JobStatusRunning))
 	})
+
+	It("Test stop job", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		httpmock.RegisterResponder("POST", rayDashboardClient.dashboardURL+JobPath+"stop-job-1/stop",
+			func(req *http.Request) (*http.Response, error) {
+				body := &RayJobStopResponse{
+					Stopped: true,
+				}
+				bodyBytes, _ := json.Marshal(body)
+				return httpmock.NewBytesResponse(200, bodyBytes), nil
+			})
+
+		err := rayDashboardClient.StopJob("stop-job-1", &ctrl.Log)
+		Expect(err).To(BeNil())
+	})
+
 })

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
@@ -41,6 +41,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 				RuntimeEnv: encodedRuntimeEnv,
 			},
 		}
+		rayDashboardClient = &RayDashboardClient{}
 		rayDashboardClient.InitClient("127.0.0.1:8090")
 	})
 

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
@@ -63,7 +63,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 				bodyBytes, _ := json.Marshal(body)
 				return httpmock.NewBytesResponse(200, bodyBytes), nil
 			})
-		httpmock.RegisterResponder("Get", rayDashboardClient.dashboardURL+JobPath+expectJobId,
+		httpmock.RegisterResponder("GET", rayDashboardClient.dashboardURL+JobPath+expectJobId,
 			func(req *http.Request) (*http.Response, error) {
 				body := &RayJobInfo{
 					JobStatus:  rayv1alpha1.JobStatusRunning,

--- a/ray-operator/controllers/ray/utils/fake_serve_httpclient.go
+++ b/ray-operator/controllers/ray/utils/fake_serve_httpclient.go
@@ -87,3 +87,7 @@ func (r *FakeRayDashboardClient) GetJobInfo(jobId string) (*RayJobInfo, error) {
 func (r *FakeRayDashboardClient) SubmitJob(rayJob *rayv1alpha1.RayJob, log *logr.Logger) (jobId string, err error) {
 	return "", nil
 }
+
+func (r *FakeRayDashboardClient) StopJob(jobName string, log *logr.Logger) (err error) {
+	return nil
+}

--- a/ray-operator/controllers/ray/utils/utils_suite_test.go
+++ b/ray-operator/controllers/ray/utils/utils_suite_test.go
@@ -1,0 +1,13 @@
+package utils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

when submitting job in cluster selector mode, job will submit to the existing cluster.
If the job cr deleted, these cluster would not be deleted.
we will stop job in these condition

## Related issue number

https://github.com/ray-project/kuberay/issues/595
https://github.com/ray-project/kuberay/pull/470
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [*] Manual tests
   - [ ] This PR is not tested :(


## Manual test
1. apply the ray cluster (modify from ray-operator/config/samples/ray-cluster.complete.yaml, just add sample code) 
```yaml
......
          volumeMounts:
            - mountPath: /tmp/ray
              name: ray-logs
            - mountPath: /home/ray/samples
              name: code-sample
          resources:
            limits:
              cpu: "1"
              memory: "2G"
            requests:
              cpu: "500m"
              memory: "1G"
        volumes:
          - name: ray-logs
            emptyDir: {}
            # You set volumes at the Pod level, then mount them into containers inside that Pod
          - name: code-sample
            configMap:
              # Provide the name of the ConfigMap you want to mount.
              name: ray-job-code-sample
              # An array of keys from the ConfigMap to create as files
              items:
                - key: sample_code.py
                  path: sample_code.py
.....

---
apiVersion: v1
kind: ConfigMap
metadata:
  name: ray-job-code-sample
data:
  sample_code.py: |
    import ray
    import time

    @ray.remote
    class MyActor:
        def __init__(self):
            pass

        def func(self, v):
            return v

    seconds = 60
    actor = MyActor.remote()

    while seconds > 0:
        print(ray.get(actor.func.remote(seconds)))
        time.sleep(1)



```
2. apply the ray job 
```yaml
apiVersion: ray.io/v1alpha1
kind: RayJob
metadata:
  name: rayjob-sample-2
spec:
  entrypoint: python /home/ray/samples/sample_code.py
  clusterSelector:
    ray.io/cluster: "raycluster-complete"
```
3.  make sure the job is long running(through describe rayjob rayjob-sample-2 or exec into head node), 
4.  then delete the job (delete rayjob rayjob-sample-2)
5.  make sure the job is deleted and cluster is not deleted(by exec into the head pod, then ps -ef or use ray job list) 