### PR TITLE
Fix finalizer typo and re-create manifests

### DIFF
--- a/helm-chart/kuberay-operator/templates/role.yaml
+++ b/helm-chart/kuberay-operator/templates/role.yaml
@@ -128,7 +128,7 @@ rules:
 - apiGroups:
   - ray.io
   resources:
-  - rayclusters/finalizer
+  - rayclusters/finalizers
   verbs:
   - update
 - apiGroups:
@@ -154,7 +154,7 @@ rules:
 - apiGroups:
   - ray.io
   resources:
-  - rayjobs/finalizer
+  - rayjobs/finalizers
   verbs:
   - update
 - apiGroups:

--- a/ray-operator/config/rbac/role.yaml
+++ b/ray-operator/config/rbac/role.yaml
@@ -128,7 +128,7 @@ rules:
 - apiGroups:
   - ray.io
   resources:
-  - rayclusters/finalizer
+  - rayclusters/finalizers
   verbs:
   - update
 - apiGroups:
@@ -154,7 +154,7 @@ rules:
 - apiGroups:
   - ray.io
   resources:
-  - rayjobs/finalizer
+  - rayjobs/finalizers
   verbs:
   - update
 - apiGroups:

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -66,7 +66,7 @@ type RayClusterReconciler struct {
 // Automatically generate RBAC rules to allow the Controller to read and write workloads
 // +kubebuilder:rbac:groups=ray.io,resources=rayclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ray.io,resources=rayclusters/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=ray.io,resources=rayclusters/finalizer,verbs=update
+// +kubebuilder:rbac:groups=ray.io,resources=rayclusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch;create;update;patch;delete

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -49,7 +49,7 @@ func NewRayJobReconciler(mgr manager.Manager) *RayJobReconciler {
 
 // +kubebuilder:rbac:groups=ray.io,resources=rayjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ray.io,resources=rayjobs/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=ray.io,resources=rayjobs/finalizer,verbs=update
+// +kubebuilder:rbac:groups=ray.io,resources=rayjobs/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch;create;update;patch;delete

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -67,7 +67,7 @@ func NewRayServiceReconciler(mgr manager.Manager) *RayServiceReconciler {
 // +kubebuilder:rbac:groups=ray.io,resources=rayservices/finalizers,verbs=update
 // +kubebuilder:rbac:groups=ray.io,resources=rayclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ray.io,resources=rayclusters/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=ray.io,resources=rayclusters/finalizer,verbs=update
+// +kubebuilder:rbac:groups=ray.io,resources=rayclusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

These changes address issue #630

When trying to create one of the example `RayCluster` on OpenShift, it will fail with the operator reporting "cannot set blockOwnerDeletion if an ownerReference refers to a resource you can’t set finalizers on:".

As per https://sdk.operatorframework.io/docs/faqs/#after-deploying-my-operator-why-do-i-see-errors-like-is-forbidden-cannot-set-blockownerdeletion-if-an-ownerreference-refers-to-a-resource-you-cant-set-finalizers-on-, we were able to fix the issue by applying the new `role.yaml` that is created running `make manifests` after applying the changes in this PR. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #630 

<!-- For example: "Closes #1234" -->

## Checks

As mentioned, this PR was tested by applying the contents of the `role.yaml` file to the kuberay-operator `ClusterRole` 

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
