### PR TITLE
[Bug] Update wait function in test_detached_actor

### DIFF
--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -300,11 +300,12 @@ else:
         exec_command = ['pkill gcs_server']
         utils.pod_exec_command(k8s_api, pod_name=old_head_pod_name, namespace='default', exec_command=exec_command)
 
-        # When all pods are ready and running, it still needs few seconds to relaunch actors. Hence, when
-        # the cluster state converges, it will wait `post_wait_sec` seconds.
-        utils.wait_for_new_head(k8s_api, old_head_pod_name, restart_count, 'default', timeout=300, retry_interval_ms=1000, post_wait_sec=30)
+        # Waiting for all pods become ready and running.
+        utils.wait_for_new_head(k8s_api, old_head_pod_name, restart_count, 'default', timeout=300, retry_interval_ms=1000)
 
         # Try to connect to the detached actor again.
+        # [Note] When all pods become running and ready, the RayCluster still needs tens of seconds to relaunch actors. Hence,
+        #        `test_detached_actor_2.py` will retry until a Ray client connection succeeds.
         utils.copy_to_container(container, 'tests/scripts', '/usr/local/', 'test_detached_actor_2.py')
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_detached_actor_2.py {ray_namespace}', timeout_sec = 180)
 

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -8,6 +8,8 @@ import random
 import string
 
 import kuberay_utils.utils as utils
+from kubernetes import client, config
+from kubernetes.stream import stream
 
 
 logger = logging.getLogger(__name__)
@@ -267,37 +269,44 @@ else:
         client.close()
 
     def test_detached_actor(self):
-        client = docker.from_env()
-        container = client.containers.run(ray_image, remove=True, detach=True, stdin_open=True, tty=True,
+        docker_client = docker.from_env()
+        container = docker_client.containers.run(ray_image, remove=True, detach=True, stdin_open=True, tty=True,
                                             network_mode='host', command=["/bin/sh"])
         ray_namespace = ''.join(random.choices(string.ascii_lowercase, k=10))
         logger.info(f'namespace: {ray_namespace}')
 
         # Register a detached actor
         utils.copy_to_container(container, 'tests/scripts', '/usr/local/', 'test_detached_actor_1.py')
-        exit_code, output = utils.exec_run_container(container, f'python3 /usr/local/test_detached_actor_1.py {ray_namespace}', timeout_sec = 180)
+        exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_detached_actor_1.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
             raise Exception(f"There was an exception during the execution of test_detached_actor_1.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
-        # Kill the gcs on head node. If fate sharing is enabled, the whole head node pod will terminate.
-        utils.shell_assert_success(
-            'kubectl exec -it $(kubectl get pods -A| grep -e "-head" | awk "{print \\$2}") -- /bin/bash -c "ps aux | grep gcs_server | grep -v grep | awk \'{print \$2}\' | xargs kill"')
-        # Wait for new head node getting created
-        # TODO (kevin85421): Need a better method to wait for the new head pod. (https://github.com/ray-project/kuberay/issues/618)
-        time.sleep(180)
+        # KubeRay only allows at most 1 head pod per RayCluster instance at the same time. In addition,
+        # if we have 0 head pods at this moment, it indicates that the head pod crashes unexpectedly.
+        headpods = utils.get_pod(namespace='default', label_selector='rayNodeType=head')
+        assert(len(headpods.items) == 1)
+        old_head_pod = headpods.items[0]
+        old_head_pod_name = old_head_pod.metadata.name
+        restart_count = old_head_pod.status.container_statuses[0].restart_count
+
+        # Kill the gcs_server process on head node. If fate sharing is enabled, the whole head node pod
+        # will terminate.
+        exec_command = ['pkill gcs_server']
+        utils.pod_exec_command(pod_name=old_head_pod_name, namespace='default', exec_command=exec_command)
+        utils.wait_for_new_head(old_head_pod_name, restart_count, 'default', timeout=300, retry_interval_ms=1000)
 
         # Try to connect to the detached actor again.
         utils.copy_to_container(container, 'tests/scripts', '/usr/local/', 'test_detached_actor_2.py')
-        exit_code, output = utils.exec_run_container(container, f'python3 /usr/local/test_detached_actor_2.py {ray_namespace}', timeout_sec = 180)
+        exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_detached_actor_2.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
             raise Exception(f"There was an exception during the execution of test_detached_actor_2.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
         container.stop()
-        client.close()
+        docker_client.close()
 
 class RayServiceTestCase(unittest.TestCase):
     service_template_file = 'tests/config/ray-service.yaml.template'

--- a/tests/config/requirements.txt
+++ b/tests/config/requirements.txt
@@ -1,1 +1,2 @@
 docker
+kubernetes

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -305,6 +305,5 @@ def wait_for_new_head(k8s_api, old_head_pod_name, old_restart_count, namespace, 
         return True
     wait_for_condition(check_status, timeout=timeout, retry_interval_ms=retry_interval_ms, k8s_api=k8s_api,
         old_head_pod_name=old_head_pod_name, old_restart_count=old_restart_count, namespace=namespace)
-    # After the cluster state converges, wait ray processes to become ready.
+    # After the cluster state converges, ray processes still need tens of seconds to become ready.
     # TODO (kevin85421): Make ray processes become ready when pods are "Ready" and "Running".
-    time.sleep(post_wait_sec)

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -245,7 +245,7 @@ def wait_for_new_head(k8s_api, old_head_pod_name, old_restart_count, namespace, 
     Next, we check the status of pods to ensure all pods should be "Running" and "Ready".
 
     After the cluster state converges (all pods are "Running" and "Ready"), ray processes still need tens of seconds to
-    become ready to serve new connections from ray clients. So, sleep `post_wait_sec` seconds in the end.
+    become ready to serve new connections from ray clients. So, users need to retry until a Ray client connection succeeds.
 
     Args:
         k8s_api: Kubernetes client (e.g. client.CoreV1Api())
@@ -254,7 +254,6 @@ def wait_for_new_head(k8s_api, old_head_pod_name, old_restart_count, namespace, 
         namespace: Namespace that the head pod is running in.
         timeout: Same as `wait_for_condition`.
         retry_interval_ms: Same as `wait_for_condition`.
-        post_wait_sec: After the cluster state converges, wait ray processes `post_wait_sec` seconds to become ready.
 
     Raises:
         RuntimeError: If the condition is not met before the timeout expires, raise the RuntimeError.

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -230,7 +230,7 @@ def pod_exec_command(k8s_api, pod_name, namespace, exec_command, stderr=True, st
         logger.info(f"response: {resp}")
     return resp
 
-def wait_for_new_head(k8s_api, old_head_pod_name, old_restart_count, namespace, timeout, retry_interval_ms, post_wait_sec = 10):
+def wait_for_new_head(k8s_api, old_head_pod_name, old_restart_count, namespace, timeout, retry_interval_ms):
     """
     `wait_for_new_head` is used to wait for new head is ready and running. For example, `test_detached_actor` kills
     the gcs_server process on the head pod. It takes nearly 1 min to kill the head pod, and the head pod will still

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -252,7 +252,7 @@ def wait_for_new_head(old_head_pod_name, old_restart_count, namespace, timeout, 
         if new_head_pod_name != old_head_pod_name:
             logger.info(f'If GCS server is killed, the head pod will restart the old one rather than create a new one.' +
                 f' new_head_pod_name: {new_head_pod_name}, old_head_pod_name: {old_head_pod_name}')
-            return False
+            # return False
         # When GCS server is killed, it takes nearly 1 min to kill the head pod. In the minute, the head
         # pod will still be in 'Running' and 'Ready'. Hence, we need to check `restart_count`.
         if new_restart_count != old_restart_count + 1:

--- a/tests/scripts/test_detached_actor_2.py
+++ b/tests/scripts/test_detached_actor_2.py
@@ -2,11 +2,10 @@ import ray
 import time
 import sys
 
-ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1])
-
 def retry_with_timeout(func, timeout=90):
     err = None
-    for _ in range(timeout):
+    start = time.time()
+    while time.time() - start <= timeout:
         try:
             return func()
         except BaseException as e:
@@ -18,7 +17,15 @@ def retry_with_timeout(func, timeout=90):
 def get_detached_actor():
     return ray.get_actor("testCounter")
 
+# Try to connect to Ray cluster.
+print("Try to connect to Ray cluster.")
+retry_with_timeout(lambda: ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1]), timeout = 180)
+
+# Get TestCounter actor
+print("Get TestCounter actor.")
 tc = retry_with_timeout(get_detached_actor)
+
+print("Try to call remote function \'increment\'.")
 val = retry_with_timeout(lambda: ray.get(tc.increment.remote()))
 print(f"val: {val}")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In KinD E2E tests, we use `kubectl wait` to block the process only when the system is not ready. However, it is not good to use `kubectl wait --for=condition=Ready` after deleting a resource. See the **Example 1** section in #618 for more details.

[Example]
The test `test_detached_actor` kills GCS on the head pod and uses `kubectl wait` to make sure that the new head pod is ready. However, in my experiment, the head pod will need 60 seconds to crash after the GCS server is killed. The head pod is `READY:1/1, STATUS: Running` before the crash. Hence, `kubectl wait` cannot make sure the new head pod is ready.

https://github.com/ray-project/kuberay/blob/ea6e8d1e5d36690c2a3577361db124fad1389a00/tests/compatibility-test.py#L319-L327

The workaround solution is to replace the `kubectl wait` with `time.sleep(180)` in #619. This PR implements a wait function for head pod restart.

## Explanations for some changes
* Kill the gcs_server process on the head pod
  * Replace `ps aux | grep gcs_server | ... | xargs kill` with `pkill gcs_server`. The results of `pgrep gcs_server` and `ps aux | grep gcs_server | grep -v grep | awk '{print $2}'` are the same.

* `restart_count`
  * The default container restartPolicy of a Pod is `Always`. Hence, when GCS server is killed, the head pod will restart the old one rather than create a new one.
     *  restart the old one => head pod name will not change, and `restart_count` will increase by 1.
     *  create a new one => head pod name will change, and `restart_count` will become 0.
  * When GCS server is killed, it takes nearly 1 min to kill the head pod. In the minute, the head pod will still be in 'Running' and 'Ready'. Hence, we need to check `restart_count` to ensure the head pod has been dead.
  * **HA in `ray:nightly` is buggy. It has a high possibility to create a new head pod instead of restarting the old one. Hence, the `restart_count` will become 0 and fail this test.**

* When all containers in pods are "READY" and all pods are "Running", it still takes tens of seconds to make all ray processes become ready.
  * [Solution]:
     * `time.sleep(post_wait_sec)`
     * `retry_with_timeout(lambda: ray.init(address='ray://127.0.0.1:10001', ...), timeout = 180)`
  * Does `ray.init` have any timeout argument?


* Why do I pass `client.CoreV1Api()` as a function argument?
  ```python
  k8s_api = client.CoreV1Api()
  headpods = utils.get_pod(k8s_api, namespace='default', label_selector='rayNodeType=head')
  ``` 
  * If I use different `client.CoreV1Api()` instances in each function call, `unittest` will report ["ResourceWarning: unclosed SSLSocket"](https://github.com/kubernetes-client/python/issues/309).

## Related issue number
This PR solved a part of #618.

## Checks
```
RAY_IMAGE=rayproject/ray:2.0.0 python3 tests/compatibility-test.py RayFTTestCase.test_detached_actor 2>&1 | tee log  
```
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
