### PR TITLE
add validation for envs in head start

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -848,6 +848,21 @@ func ValidateHeadRayStartParams(rayHeadGroupSpec rayiov1alpha1.HeadGroupSpec) (i
 			}
 		}
 	}
+	// validation for the environments variables
+	for _, val := range rayStartParams {
+		if strings.HasPrefix(val, "$") {
+			envName := strings.TrimPrefix(val, "$")
+			if strings.HasPrefix(envName, "(") && strings.HasSuffix(envName, ")") {
+				envName = strings.TrimPrefix(envName, "(")
+				envName = strings.TrimSuffix(envName, ")")
+			}
+			if !envVarExists(envName, rayHeadGroupSpec.Template.Spec.Containers[0].Env) {
+				isValid = false
+				err = errors.NewBadRequest(fmt.Sprintf("Environment variable %s is not set in headGroupSpec", envName))
+				return
+			}
+		}
+	}
 	// default return
 	return true, nil
 }

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -40,6 +40,7 @@ var instance = rayiov1alpha1.RayCluster{
 				"num-cpus":            "1",
 				"include-dashboard":   "true",
 				"log-color":           "true",
+				"node-ip-address":     "$MY_POD_IP",
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -600,6 +601,14 @@ func TestValidateHeadRayStartParams_ValidWithObjectStoreMemoryError(t *testing.T
 func TestValidateHeadRayStartParams_InvalidObjectStoreMemory(t *testing.T) {
 	input := instance.Spec.HeadGroupSpec.DeepCopy()
 	input.RayStartParams[ObjectStoreMemoryKey] = "2000000000"
+	isValid, err := ValidateHeadRayStartParams(*input)
+	assert.Equal(t, false, isValid)
+	assert.True(t, errors.IsBadRequest(err))
+}
+
+func TestValidateHeadRayStartParams_InvalidEnvironment(t *testing.T) {
+	input := instance.Spec.HeadGroupSpec.DeepCopy()
+	input.Template.Spec.Containers[0].Env = make([]v1.EnvVar, 0)
 	isValid, err := ValidateHeadRayStartParams(*input)
 	assert.Equal(t, false, isValid)
 	assert.True(t, errors.IsBadRequest(err))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We need more validation for the head start params, for example the user may create the ray cluster with some environments, however may forget to added those in the envs in the template, so we may need a validation to check for that.

here it is a little tricky, we only can check the envs added in the template, however when user built the envs in the images, we cannot find that.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
