### PR TITLE
feat: update RayCluster `.status.reason` field with pod creation error

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -11146,6 +11146,9 @@ spec:
                   each node group.
                 format: int32
                 type: integer
+              reason:
+                description: Reason provides more information about current State
+                type: string
               state:
                 description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerat'

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -11704,6 +11704,9 @@ spec:
                       of each node group.
                     format: int32
                     type: integer
+                  reason:
+                    description: Reason provides more information about current State
+                    type: string
                   state:
                     description: 'INSERT ADDITIONAL STATUS FIELD - define observed
                       state of cluster Important: Run "make" to regenerat'

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -11760,6 +11760,10 @@ spec:
                           of each node group.
                         format: int32
                         type: integer
+                      reason:
+                        description: Reason provides more information about current
+                          State
+                        type: string
                       state:
                         description: 'INSERT ADDITIONAL STATUS FIELD - define observed
                           state of cluster Important: Run "make" to regenerat'
@@ -11867,6 +11871,10 @@ spec:
                           of each node group.
                         format: int32
                         type: integer
+                      reason:
+                        description: Reason provides more information about current
+                          State
+                        type: string
                       state:
                         description: 'INSERT ADDITIONAL STATUS FIELD - define observed
                           state of cluster Important: Run "make" to regenerat'

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -169,5 +169,6 @@ func init() {
 type EventReason string
 
 const (
-	RayConfigError EventReason = "RayConfigError"
+	RayConfigError         EventReason = "RayConfigError"
+	PodReconciliationError EventReason = "PodReconciliationError"
 )

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -119,6 +119,8 @@ type RayClusterStatus struct {
 	Endpoints map[string]string `json:"endpoints,omitempty"`
 	// Head info
 	Head HeadInfo `json:"head,omitempty"`
+	// Reason provides more information about current State
+	Reason string `json:"reason,omitempty"`
 }
 
 // HeadInfo gives info about head

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -11146,6 +11146,9 @@ spec:
                   each node group.
                 format: int32
                 type: integer
+              reason:
+                description: Reason provides more information about current State
+                type: string
               state:
                 description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerat'

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -11704,6 +11704,9 @@ spec:
                       of each node group.
                     format: int32
                     type: integer
+                  reason:
+                    description: Reason provides more information about current State
+                    type: string
                   state:
                     description: 'INSERT ADDITIONAL STATUS FIELD - define observed
                       state of cluster Important: Run "make" to regenerat'

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -11760,6 +11760,10 @@ spec:
                           of each node group.
                         format: int32
                         type: integer
+                      reason:
+                        description: Reason provides more information about current
+                          State
+                        type: string
                       state:
                         description: 'INSERT ADDITIONAL STATUS FIELD - define observed
                           state of cluster Important: Run "make" to regenerat'
@@ -11867,6 +11871,10 @@ spec:
                           of each node group.
                         format: int32
                         type: integer
+                      reason:
+                        description: Reason provides more information about current
+                          State
+                        type: string
                       state:
                         description: 'INSERT ADDITIONAL STATUS FIELD - define observed
                           state of cluster Important: Run "make" to regenerat'

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -765,6 +766,7 @@ func (r *RayClusterReconciler) buildWorkerPod(instance rayiov1alpha1.RayCluster,
 func (r *RayClusterReconciler) SetupWithManager(mgr ctrl.Manager, reconcileConcurrency int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&rayiov1alpha1.RayCluster{}).Named("raycluster-controller").
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Watches(&source.Kind{Type: &corev1.Event{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
 			IsController: true,

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -214,6 +214,9 @@ func (r *RayClusterReconciler) rayClusterReconcile(request ctrl.Request, instanc
 		if updateErr := r.updateClusterState(instance, rayiov1alpha1.Failed); updateErr != nil {
 			r.Log.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
 		}
+		if updateErr := r.updateClusterReason(instance, err.Error()); updateErr != nil {
+			r.Log.Error(updateErr, "RayCluster update reason error", "cluster name", request.Name)
+		}
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
 	// update the status if needed
@@ -1047,5 +1050,10 @@ func (r *RayClusterReconciler) reconcileAutoscalerRoleBinding(instance *rayiov1a
 
 func (r *RayClusterReconciler) updateClusterState(instance *rayiov1alpha1.RayCluster, clusterState rayiov1alpha1.ClusterState) error {
 	instance.Status.State = clusterState
+	return r.Status().Update(context.Background(), instance)
+}
+
+func (r *RayClusterReconciler) updateClusterReason(instance *rayiov1alpha1.RayCluster, clusterReason string) error {
+	instance.Status.Reason = clusterReason
 	return r.Status().Update(context.Background(), instance)
 }

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -774,6 +774,39 @@ func TestReconcile_AutoscalerRoleBinding(t *testing.T) {
 	assert.Nil(t, err, "Fail to get autoscaler RoleBinding after reconciliation")
 }
 
+func TestReconcile_UpdateClusterReason(t *testing.T) {
+	setupTest(t)
+	defer tearDown(t)
+	newScheme := runtime.NewScheme()
+	_ = rayiov1alpha1.AddToScheme(newScheme)
+
+	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(testRayCluster).Build()
+
+	namespacedName := types.NamespacedName{
+		Name:      instanceName,
+		Namespace: namespaceStr,
+	}
+	cluster := rayiov1alpha1.RayCluster{}
+	err := fakeClient.Get(context.Background(), namespacedName, &cluster)
+	assert.Nil(t, err, "Fail to get RayCluster")
+	assert.Empty(t, cluster.Status.Reason, "Cluster reason should be empty")
+
+	testRayClusterReconciler := &RayClusterReconciler{
+		Client:   fakeClient,
+		Recorder: &record.FakeRecorder{},
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
+	}
+	reason := "test reason"
+
+	err = testRayClusterReconciler.updateClusterReason(testRayCluster, reason)
+	assert.Nil(t, err, "Fail to update cluster reason")
+
+	err = fakeClient.Get(context.Background(), namespacedName, &cluster)
+	assert.Nil(t, err, "Fail to get RayCluster after updating reason")
+	assert.Equal(t, cluster.Status.Reason, reason, "Cluster reason should be updated")
+}
+
 func TestUpdateEndpoints(t *testing.T) {
 	setupTest(t)
 	defer tearDown(t)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Makes RayCluster errors related to Pod creation easier more apparent to user.

### example before if Pod can't be created due to ResourceQuota exceeded

```
kubectl get rayclusters dxia-test2 -o yaml
...
status:
  state: failed

kubectl describe rayclusters dxia-test2
...
Status:
  State:   failed
```

### example after if Pod can't be created due to ResourceQuota exceeded

```
kubectl get rayclusters dxia-test2 -o yaml
...
status:
  reason: 'pods "dxia-test2-head-lbvdc" is forbidden: exceeded quota: quota, requested:
    limits.cpu=15,requests.cpu=15, used: limits.cpu=60,requests.cpu=60, limited: limits.cpu=10,requests.cpu=10'
  state: failed

kubectl describe rayclusters dxia-test2
...
Status:
  Reason:  pods "dxia-test2-head-9mdm5" is forbidden: exceeded quota: quota, requested: limits.cpu=15,requests.cpu=15, used: limits.cpu=60,requests.cpu=60, limited: limits.cpu=10,requests.cpu=10
  State:   failed
```

## Related issue number

fixes #603

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
