### PR TITLE
[Feature][Doc] Explain that RBAC should be synchronized manually

### DIFF
--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -110,7 +110,7 @@ We have several [consistency checks](https://github.com/ray-project/kuberay/blob
 2. `ray-operator/apis/ray/v1alpha1/*_types.go` should be synchronized with generated API (`ray-operator/pkg/client`)
 3. CRD YAML files in `ray-operator/config/crd/bases/` and `helm-chart/kuberay-operator/crds/` should be the same.
 4. Kubebuilder markers in `ray-operator/controllers/ray/*_controller.go` should be synchronized with RBAC YAML files in `ray-operator/config/rbac`. 
-5. RBAC YAML files in `helm-chart/kuberay-operator/templates` and `ray-operator/config/rbac` should be synchronized.
+5. RBAC YAML files in `helm-chart/kuberay-operator/templates` and `ray-operator/config/rbac` should be synchronized. **Currently, we need to synchronize this manually.** See [#631](https://github.com/ray-project/kuberay/pull/631) as an example.
 
 ```bash
 # Synchronize consistency 1 and 4:

--- a/scripts/rbac-check.py
+++ b/scripts/rbac-check.py
@@ -25,4 +25,6 @@ if __name__ == "__main__":
 			diff_files.append(f)
 
 	if diff_files:
-		sys.exit(f"{diff_files} are out of synchronization!")
+		sys.exit(f"{diff_files} are out of synchronization! RBAC YAML files in" + 
+			"\'helm-chart/kuberay-operator/templates\' and \'ray-operator/config/rbac\'" + 
+			"should be synchronized manually. See DEVELOPMENT.md for more details.")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, RBAC YAML files in `helm-chart/kuberay-operator/templates` and `ray-operator/config/rbac` should be synchronized manually. We have pointed this out in [DEVELOPMENT.md](https://github.com/ray-project/kuberay/blob/master/ray-operator/DEVELOPMENT.md#consistency-check), but it is not easy for users to find the messages. Hence, we need to make this information become more explicit in both [DEVELOPMENT.md](https://github.com/ray-project/kuberay/blob/master/ray-operator/DEVELOPMENT.md#consistency-check) and [rbac-check.py](https://github.com/ray-project/kuberay/blob/master/scripts/rbac-check.py).

## Related issue number
Closes #640 
#631 
<!-- For example: "Closes #1234" -->

## Checks
```bash
# Step1: Make `helm-chart/kuberay-operator/templates` and `ray-operator/config/rbac` inconsistent.
# Step2: (in `tests/`)
python3 ../scripts/rbac-check.py
```

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
