### PR TITLE
[Bug] Fail to create ingress due to the deprecation of the ingress.class annotation

### DIFF
--- a/docs/guidance/ingress.md
+++ b/docs/guidance/ingress.md
@@ -2,23 +2,64 @@
 
 ### Prerequisite
 
-It's user's responsibility to install ingress controller by themselves. Technically, any ingress controller implementation should work well. 
+It's user's responsibility to install ingress controller by themselves. Technically, any ingress controller implementation should work well. In order to pass through the customized ingress configuration, you can annotate `RayCluster` object and the controller will pass the annotations to the ingress object.
 
-In order to pass through the customized ingress configuration, you can annotate `RayCluster` object and controller will pass to ingress object.
+### Example: Nginx Ingress on KinD
+```sh
+# Step1: Create a KinD cluster with `extraPortMappings` and `node-labels`
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+EOF
 
-`kubernetes.io/ingress.class` is recommended. 
+# Step2: Install NGINX ingress
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=90s
 
-> Note: If the ingressClassName is omitted, a default Ingress class should be defined. Please make sure default ingress class is created.
+# Step3: Install KubeRay operator
+pushd helm-chart/kuberay-operator
+helm install kuberay-operator .
 
-```
-apiVersion: ray.io/v1alpha1
-kind: RayCluster
-metadata:
-  annotations:
-    kubernetes.io/ingress.class: nginx -> this is required
-spec:
-  rayVersion: '1.9.2'
-  headGroupSpec:
-    serviceType: NodePort
-    enableIngress: true # enables ingress
+# Step4: Install RayCluster with Nginx ingress. See https://github.com/ray-project/kuberay/pull/646
+#        for the explanations of `ray-cluster.ingress.yaml`. Some fields are worth to discuss further:
+#
+#        (1) metadata.annotations.kubernetes.io/ingress.class: nginx => required
+#        (2) spec.headGroupSpec.enableIngress: true => required
+#        (3) metadata.annotations.nginx.ingress.kubernetes.io/rewrite-target: /$1 => required for nginx.
+popd
+kubectl apply -f ray-operator/config/samples/ray-cluster.ingress.yaml
+
+# Step5: Check ingress created by Step4.
+kubectl describe ingress raycluster-ingress-head-ingress
+
+# [Example]
+# ...
+# Rules:
+# Host        Path  Backends
+# ----        ----  --------
+# *
+#             /raycluster-ingress/(.*)   raycluster-ingress-head-svc:8265 (10.244.0.11:8265)
+# Annotations:  nginx.ingress.kubernetes.io/rewrite-target: /$1
+
+# Step6: Check `<ip>/raycluster-ingress/` on your browser. You will see the Ray Dashboard.
+#        [Note] The forward slash at the end of the address is necessary. `<ip>/raycluster-ingress`
+#               will report "404 Not Found".
 ```

--- a/ray-operator/config/samples/ray-cluster.ingress.yaml
+++ b/ray-operator/config/samples/ray-cluster.ingress.yaml
@@ -7,9 +7,10 @@ kind: RayCluster
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
   name: raycluster-ingress
 spec:
-  rayVersion: '1.12.1' # should match the Ray version in the image of the containers
+  rayVersion: '2.0.0' # should match the Ray version in the image of the containers
   headGroupSpec:
     serviceType: NodePort
     enableIngress: true
@@ -24,7 +25,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:1.12.1
+          image: rayproject/ray:2.0.0
           env:
           - name: MY_POD_IP
             valueFrom:

--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -23,11 +23,18 @@ func BuildIngressForHeadService(cluster rayiov1alpha1.RayCluster) (*networkingv1
 		KubernetesCreatedByLabelKey:       ComponentName,
 	}
 
-	// Copy other ingress configuration from cluster annotation
-	// This is to provide a generic way for user to customize their ingress settings.
+	// Copy other ingress configurations from cluster annotations to provide a generic way
+	// for user to customize their ingress settings. The `exclude_set` is used to avoid setting
+	// both IngressClassAnnotationKey annotation which is deprecated and `Spec.IngressClassName`
+	// at the same time.
+	exclude_set := map[string]struct{}{
+		IngressClassAnnotationKey: {},
+	}
 	annotation := map[string]string{}
 	for key, value := range cluster.Annotations {
-		annotation[key] = value
+		if _, ok := exclude_set[key]; !ok {
+			annotation[key] = value
+		}
 	}
 
 	var paths []networkingv1.HTTPIngressPath

--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -46,7 +46,7 @@ func BuildIngressForHeadService(cluster rayiov1alpha1.RayCluster) (*networkingv1
 	}
 	paths = []networkingv1.HTTPIngressPath{
 		{
-			Path:     "/" + cluster.Name,
+			Path:     "/" + cluster.Name + "/(.*)",
 			PathType: &pathType,
 			Backend: networkingv1.IngressBackend{
 				Service: &networkingv1.IngressServiceBackend{

--- a/ray-operator/controllers/ray/common/ingress_test.go
+++ b/ray-operator/controllers/ray/common/ingress_test.go
@@ -97,7 +97,7 @@ func TestBuildIngressForHeadService(t *testing.T) {
 	}
 
 	actualResult = ingress.Annotations[IngressClassAnnotationKey]
-	expectedResult = instanceWithIngressEnabled.Annotations[IngressClassAnnotationKey]
+	expectedResult = ""
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}

--- a/ray-operator/controllers/ray/common/ingress_test.go
+++ b/ray-operator/controllers/ray/common/ingress_test.go
@@ -96,8 +96,18 @@ func TestBuildIngressForHeadService(t *testing.T) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
 
+	// `annotations.kubernetes.io/ingress.class` was deprecated in Kubernetes 1.18,
+	// and `spec.ingressClassName` is a replacement for this annotation. See
+	// kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
+	// for more details.
 	actualResult = ingress.Annotations[IngressClassAnnotationKey]
 	expectedResult = ""
+	if !reflect.DeepEqual(expectedResult, actualResult) {
+		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
+	}
+
+	actualResult = *ingress.Spec.IngressClassName
+	expectedResult = instanceWithIngressEnabled.Annotations[IngressClassAnnotationKey]
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This issue is not totally same as #441, and thus I opened a new issue. Users cannot create `ingress` with the instructions in https://ray-project.github.io/kuberay/guidance/ingress/. The operator also reports the error message:

```
2022-10-18T00:34:38.187Z	ERROR	controllers.RayCluster	Ingress create error!	{"Ingress.Error": "Ingress.extensions \"raycluster-ingress-head-ingress\" is invalid: annotations.kubernetes.io/ingress.class: Invalid value: \"nginx\": can not be set when the class field is also set", "error": "Ingress.extensions \"raycluster-ingress-head-ingress\" is invalid: annotations.kubernetes.io/ingress.class: Invalid value: \"nginx\": can not be set when the class field is also set"}
github.com/ray-project/kuberay/ray-operator/controllers/ray.(*RayClusterReconciler).reconcileIngress
	/workspace/controllers/ray/raycluster_controller.go:256
github.com/ray-project/kuberay/ray-operator/controllers/ray.(*RayClusterReconciler).rayClusterReconcile
	/workspace/controllers/ray/raycluster_controller.go:192
github.com/ray-project/kuberay/ray-operator/controllers/ray.(*RayClusterReconciler).Reconcile
	/workspace/controllers/ray/raycluster_controller.go:97
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:114
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:311
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:227
```

As shown in the following code snippet, the error message is reported by the function `ValidateIngressCreate` ([Link](https://github.com/kubernetes/kubernetes/blob/v1.23.6/pkg/apis/networking/validation/validation.go#L243-L246)) in Kubernetes. When both `annotations.kubernetes.io/ingress.class` and `spec.IngressClassName` are set at the same time, the validation function will report the error "can not be set when the class field is also set". This PR only sets `spec.IngressClassName` and avoids setting `annotations.kubernetes.io/ingress.class`.

```go
if annotationIsSet && ingress.Spec.IngressClassName != nil {
   annotationPath := field.NewPath("annotations").Child(annotationIngressClass)
   allErrs = append(allErrs, field.Invalid(annotationPath, annotationVal, "can not be set when the class field is also set"))
}
```

In [doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation), it indicates that `annotations.kubernetes.io/ingress.class` was deprecated in Kubernetes 1.18, and `spec.ingressClassName` is a replacement for this annotation.


## Related issue number
Closes #645 
#441
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

## Update
Thank @rokiyer for pointing this out!

Based on @rokiyer comments, we need to add additional annotations and update the path-matching pattern in the ingress. To elaborate,  

(1) ingress.go: `Path:     "/" + cluster.Name` => `Path:     "/" + cluster.Name + "/(.*)"` (Note: `(.*)` is regex.)
(2) YAML file: `nginx.ingress.kubernetes.io/rewrite-target: /$1` ([rewrite-target doc](https://github.com/kubernetes/ingress-nginx/blob/main/docs/examples/rewrite/README.md#rewrite-target)) 

For example, the ingress definition above will result in the following rewrites:
* `$IP/$CLUSTER_NAME/` rewrites to `$IP/` (`$1` maps to nothing)
* `$IP/$CLUSTER_NAME/#/actors` rewrites to `$IP/#/actors` (`$1` maps to `#/actors`)
* `$IP/$CLUSTER_NAME/#/node` rewrites to `$IP/#/node` (`$1` maps to `#/node`)

## Checks
```bash
# Step1: Create a KinD cluster with `extraPortMappings` and `node-labels`
cat <<EOF | kind create cluster --config=-
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  kubeadmConfigPatches:
  - |
    kind: InitConfiguration
    nodeRegistration:
      kubeletExtraArgs:
        node-labels: "ingress-ready=true"
  extraPortMappings:
  - containerPort: 80
    hostPort: 80
    protocol: TCP
  - containerPort: 443
    hostPort: 443
    protocol: TCP
EOF
# Step2: Install NGINX ingress
kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
kubectl wait --namespace ingress-nginx \
  --for=condition=ready pod \
  --selector=app.kubernetes.io/component=controller \
  --timeout=90s
# Step3: Install KubeRay operator
pushd helm-chart/kuberay-operator
helm install kuberay-operator .
# Step4: Install RayCluster with Nginx ingress. See https://github.com/ray-project/kuberay/pull/646
#        for the explanations of `ray-cluster.ingress.yaml`. Some fields are worth to discuss further:
#
#        (1) metadata.annotations.kubernetes.io/ingress.class: nginx => required
#        (2) spec.headGroupSpec.enableIngress: true => required
#        (3) metadata.annotations.nginx.ingress.kubernetes.io/rewrite-target: /$1 => required for nginx.
popd
kubectl apply -f ray-operator/config/samples/ray-cluster.ingress.yaml
# Step5: Check ingress created by Step4.
kubectl describe ingress raycluster-ingress-head-ingress
# [Example]
# ...
# Rules:
# Host        Path  Backends
# ----        ----  --------
# *
#             /raycluster-ingress/(.*)   raycluster-ingress-head-svc:8265 (10.244.0.11:8265)
# Annotations:  nginx.ingress.kubernetes.io/rewrite-target: /$1
# Step6: Check `<ip>/raycluster-ingress/` on your browser. You will see the Ray Dashboard.
#        [Note] The forward slash at the end of the address is necessary. `<ip>/raycluster-ingress`
#               will report "404 Not Found".
```

* [Set up an ingress controller on KinD cluster](https://kind.sigs.k8s.io/docs/user/ingress/)