### PR TITLE
[Bug] Misuse of Docker API and misunderstanding of Ray HA cause test_ray_serve flaky

### DIFF
--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -174,36 +174,50 @@ class RayFTTestCase(unittest.TestCase):
         assert rtn == 0
 
     def test_ray_serve(self):
-        client = docker.from_env()
-        container = client.containers.run(ray_image, remove=True, detach=True, stdin_open=True, tty=True,
+        docker_client = docker.from_env()
+        container = docker_client.containers.run(ray_image, remove=True, detach=True, stdin_open=True, tty=True,
                                           network_mode='host', command=["/bin/sh"])
         # Deploy a model with ray serve
         ray_namespace = ''.join(random.choices(string.ascii_lowercase, k=10))
         logger.info(f'namespace: {ray_namespace}')
 
         utils.copy_to_container(container, 'tests/scripts', '/usr/local/', 'test_ray_serve_1.py')
-        exit_code, output = utils.exec_run_container(container, f'python3 /usr/local/test_ray_serve_1.py {ray_namespace}', timeout_sec = 180)
+        exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_ray_serve_1.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
             raise Exception(f"There was an exception during the execution of test_ray_serve_1.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
-        # kill the gcs on head node. If fate sharing is enabled, the whole head node pod will terminate.
-        utils.shell_assert_success(
-            'kubectl exec -it $(kubectl get pods -A| grep -e "-head" | awk "{print \\$2}") -- /bin/bash -c "ps aux | grep gcs_server | grep -v grep | awk \'{print \$2}\' | xargs kill"')
-        # wait for new head node getting created
-        time.sleep(180)
+        # Initialize k8s client
+        config.load_kube_config()
+        k8s_api = client.CoreV1Api()
+
+        # KubeRay only allows at most 1 head pod per RayCluster instance at the same time. In addition,
+        # if we have 0 head pods at this moment, it indicates that the head pod crashes unexpectedly.
+        headpods = utils.get_pod(k8s_api, namespace='default', label_selector='rayNodeType=head')
+        assert(len(headpods.items) == 1)
+        old_head_pod = headpods.items[0]
+        old_head_pod_name = old_head_pod.metadata.name
+        restart_count = old_head_pod.status.container_statuses[0].restart_count
+
+        # Kill the gcs_server process on head node. If fate sharing is enabled, the whole head node pod
+        # will terminate.
+        exec_command = ['pkill gcs_server']
+        utils.pod_exec_command(k8s_api, pod_name=old_head_pod_name, namespace='default', exec_command=exec_command)
+
+        # Waiting for all pods become ready and running.
+        utils.wait_for_new_head(k8s_api, old_head_pod_name, restart_count, 'default', timeout=300, retry_interval_ms=1000)
 
         # Try to connect to the deployed model again
         utils.copy_to_container(container, 'tests/scripts', '/usr/local/', 'test_ray_serve_2.py')
-        exit_code, output = utils.exec_run_container(container, f'python3 /usr/local/test_ray_serve_2.py {ray_namespace}', timeout_sec = 180)
+        exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_ray_serve_2.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
             raise Exception(f"There was an exception during the execution of test_ray_serve_2.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
         container.stop()
-        client.close()
+        docker_client.close()
 
     def test_detached_actor(self):
         docker_client = docker.from_env()

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -176,94 +176,31 @@ class RayFTTestCase(unittest.TestCase):
     def test_ray_serve(self):
         client = docker.from_env()
         container = client.containers.run(ray_image, remove=True, detach=True, stdin_open=True, tty=True,
-                                          network_mode='host', command=["/bin/sh", "-c", "python"])
-        s = container.attach_socket(
-            params={'stdin': 1, 'stream': 1, 'stdout': 1, 'stderr': 1})
-        s._sock.setblocking(0)
-        s._sock.sendall(b'''
-import ray
-import time
-import ray.serve as serve
-import os
-import requests
-from ray._private.test_utils import wait_for_condition
+                                          network_mode='host', command=["/bin/sh"])
+        # Deploy a model with ray serve
+        ray_namespace = ''.join(random.choices(string.ascii_lowercase, k=10))
+        logger.info(f'namespace: {ray_namespace}')
 
-def retry_with_timeout(func, count=90):
-    tmp = 0
-    err = None
-    while tmp < count:
-        try:
-            return func()
-        except Exception as e:
-            err = e
-            tmp += 1
-    assert err is not None
-    raise err
+        utils.copy_to_container(container, 'tests/scripts', '/usr/local/', 'test_ray_serve_1.py')
+        exit_code, output = utils.exec_run_container(container, f'python3 /usr/local/test_ray_serve_1.py {ray_namespace}', timeout_sec = 180)
 
-ray.init(address='ray://127.0.0.1:10001')
+        if exit_code != 0:
+            raise Exception(f"There was an exception during the execution of test_ray_serve_1.py. The exit code is {exit_code}." +
+                "See above for command output. The output will be printed by the function exec_run_container.")
 
-@serve.deployment
-def d(*args):
-    return f"{os.getpid()}"
-
-d.deploy()
-pid1 = ray.get(d.get_handle().remote())
-
-print('ready')
-        ''')
-
-        count = 0
-        while count < 90:
-            try:
-                buf = s._sock.recv(4096)
-                logger.info(buf.decode())
-                if buf.decode().find('ready') != -1:
-                    break
-            except Exception as e:
-                pass
-            time.sleep(1)
-            count += 1
-        if count >= 90:
-            raise Exception('failed to run script')
-
-        # kill the gcs on head node. If fate sharing is enabled
-        # the whole head node pod will terminate.
+        # kill the gcs on head node. If fate sharing is enabled, the whole head node pod will terminate.
         utils.shell_assert_success(
             'kubectl exec -it $(kubectl get pods -A| grep -e "-head" | awk "{print \\$2}") -- /bin/bash -c "ps aux | grep gcs_server | grep -v grep | awk \'{print \$2}\' | xargs kill"')
         # wait for new head node getting created
-        time.sleep(10)
-        # make sure the new head is ready
-        utils.shell_assert_success(
-            'kubectl wait --for=condition=Ready pod/$(kubectl get pods -A | grep -e "-head" | awk "{print \$2}") --timeout=900s')
+        time.sleep(180)
 
-        s._sock.sendall(b'''
-def get_new_value():
-    return ray.get(d.get_handle().remote())
-pid2 = retry_with_timeout(get_new_value)
+        # Try to connect to the deployed model again
+        utils.copy_to_container(container, 'tests/scripts', '/usr/local/', 'test_ray_serve_2.py')
+        exit_code, output = utils.exec_run_container(container, f'python3 /usr/local/test_ray_serve_2.py {ray_namespace}', timeout_sec = 180)
 
-if pid1 == pid2:
-    print('successful: {} {}'.format(pid1, pid2))
-    sys.exit(0)
-else:
-    print('failed: {} {}'.format(pid1, pid2))
-    raise Exception('failed')
-        ''')
-
-        count = 0
-        while count < 90:
-            try:
-                buf = s._sock.recv(4096)
-                logger.info(buf.decode())
-                if buf.decode().find('successful') != -1:
-                    break
-                if buf.decode().find('failed') != -1:
-                    raise Exception('test failed {}'.format(buf.decode()))
-            except Exception as e:
-                pass
-            time.sleep(1)
-            count += 1
-        if count >= 90:
-            raise Exception('failed to run script')
+        if exit_code != 0:
+            raise Exception(f"There was an exception during the execution of test_ray_serve_2.py. The exit code is {exit_code}." +
+                "See above for command output. The output will be printed by the function exec_run_container.")
 
         container.stop()
         client.close()

--- a/tests/scripts/test_ray_serve_1.py
+++ b/tests/scripts/test_ray_serve_1.py
@@ -1,0 +1,17 @@
+import ray
+import sys
+import ray.serve as serve
+import os
+import requests
+from ray._private.test_utils import wait_for_condition
+
+ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1])
+serve.start(detached=True)
+
+@serve.deployment
+def d(*args):
+    return "HelloWorld"
+d.deploy()
+val = ray.get(d.get_handle().remote())
+print(val)
+assert(val == "HelloWorld")

--- a/tests/scripts/test_ray_serve_1.py
+++ b/tests/scripts/test_ray_serve_1.py
@@ -1,17 +1,23 @@
-import ray
-import sys
-import ray.serve as serve
-import os
 import requests
-from ray._private.test_utils import wait_for_condition
+from starlette.requests import Request
+import ray
+from ray import serve
+import time
+import sys
+
+# 1: Define a Ray Serve model.
+@serve.deployment(route_prefix="/")
+class MyModelDeployment:
+    def __init__(self, msg: str):
+        self._msg = msg
+
+    def __call__(self):
+        return self._msg
 
 ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1])
-serve.start(detached=True)
-
-@serve.deployment
-def d(*args):
-    return "HelloWorld"
-d.deploy()
-val = ray.get(d.get_handle().remote())
+# 2: Deploy the model.
+handle = serve.run(MyModelDeployment.bind(msg="Hello world!"))
+# 3: Query the deployment and print the result.
+val = ray.get(handle.remote())
 print(val)
-assert(val == "HelloWorld")
+assert(val == "Hello world!")

--- a/tests/scripts/test_ray_serve_2.py
+++ b/tests/scripts/test_ray_serve_2.py
@@ -1,7 +1,7 @@
 import ray
-import sys
-import ray.serve as serve
 import time
+import sys
+from ray import serve
 
 def retry_with_timeout(func, timeout=90):
     err = None
@@ -15,12 +15,8 @@ def retry_with_timeout(func, timeout=90):
     raise err
 
 retry_with_timeout(lambda: ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1]))
-retry_with_timeout(lambda: serve.start(detached=True))
-
-@serve.deployment
-def d(*args):
-    return "HelloWorld"
-
-val = retry_with_timeout(lambda: ray.get(d.get_handle().remote()))
+retry_with_timeout(lambda:serve.start(detached=True))
+val = retry_with_timeout(lambda: ray.get(serve.get_deployment("MyModelDeployment").get_handle().remote()))
 print(val)
-assert(val == "HelloWorld")
+assert(val == "Hello world!")
+

--- a/tests/scripts/test_ray_serve_2.py
+++ b/tests/scripts/test_ray_serve_2.py
@@ -1,7 +1,7 @@
 import ray
-import sys
-import ray.serve as serve
 import time
+import sys
+from ray import serve
 
 def retry_with_timeout(func, timeout=90):
     err = None

--- a/tests/scripts/test_ray_serve_2.py
+++ b/tests/scripts/test_ray_serve_2.py
@@ -1,7 +1,7 @@
 import ray
-import time
 import sys
-from ray import serve
+import ray.serve as serve
+import time
 
 def retry_with_timeout(func, timeout=90):
     err = None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
### Misuse of Docker API
As shown in the following code segment, the existing ray-serve test in [compatibility-test.py](https://github.com/ray-project/kuberay/blob/2a7f0f2acd840f315e46596341c392c8153ae641/tests/compatibility-test.py) has the following pattern:

* Create a container that launches a Python REPL process by Docker API.
* Attach a socket to the container with parameters params={'stdin': 1, 'stream': 1, 'stdout': 1, 'stderr': 1}.
* Use the socket to interact with Python REPL.
* Use a while loop to check the received message of the socket.
https://github.com/ray-project/kuberay/blob/3f7b34c731bd2ee413fb622a05124b52f1588f20/tests/compatibility-test.py#L174-L267
However, this is buggy because the received message of the socket includes STDIN, STDOUT, and STDERR. That is, the received message includes the messages sent by the function sendall (STDIN) in the above example. Hence, the condition buf.decode().find('ready') != -1 will always be fulfilled by L210 def ready(self):. In addition, STDOUT may also cause some bugs, e.g. [#617](https://github.com/ray-project/kuberay/issues/617).
### Solution
Check exit_code instead.

### Misunderstanding of Ray HA
Originally, the test is defined as follows. First, the test will deploy a model on ray serve, which will simply return the PID. Then, it will get the PID from the deployed model. Next, kill the GCS server and wait for the new head pod ready. Finally, connect to the deployed model again and compare the PIDs. Check [this](https://github.com/ray-project/kuberay/blob/3f7b34c731bd2ee413fb622a05124b52f1588f20/tests/compatibility-test.py#L238-L247) for more details.
https://github.com/ray-project/kuberay/blob/3f7b34c731bd2ee413fb622a05124b52f1588f20/tests/compatibility-test.py#L242-L247
Ideally, the same PIDs are expected. However, there is a bug currently that when the GCS server on the old head pod is killed, all the head pod and worker pods will be recreated. Hence, the PID might be different, which will cause the failure of the test. 

### Solution
Design new test scripts for ray serve.

### Explanations for some changes
* Initialize a serve instance again in  [tests/scripts/test_ray_serve_2.py](https://github.com/jasoonn/kuberay/blob/ray-serve-test/tests/scripts/test_ray_serve_2.py)
    Despite running a serve application in [tests/scripts/test_ray_serve_1.py](https://github.com/jasoonn/kuberay/blob/ray-serve-test/tests/scripts/test_ray_serve_1.py), the serve instance is gone after killing the gcs_server process. It reports the error:  ``` ray.serve.exceptions.RayServeException: There is no instance running on this Ray cluster. Please call `serve.start(detached=True) to start one.``` when I tried to query the application. Hence, it needs to initialize the serve instance, and the previously deployed application will appear in the newly initialized serve instance. 
    

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #621
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
