### PR TITLE
[RayService] Compare cached hashed config before triggering update

### DIFF
--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -10,6 +10,7 @@ const (
 	RayIDLabelKey                      = "ray.io/identifier"
 	RayClusterDashboardServiceLabelKey = "ray.io/cluster-dashboard"
 	RayClusterServingServiceLabelKey   = "ray.io/serve"
+	RayServiceClusterHashKey           = "ray.io/cluster-hash"
 
 	// Ray GCS FT related annotations
 	RayFTEnabledAnnotationKey         = "ray.io/ft-enabled"

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -338,6 +338,7 @@ func (r *RayServiceReconciler) shouldPrepareNewRayCluster(rayServiceInstance *ra
 				"Manual config updates will NOT be tracked accurately. " +
 				"Please manually tear down the cluster and apply a new config."
 			r.Log.Error(err, errContext)
+			return true
 		}
 
 		if activeClusterHash != goalClusterHash {
@@ -444,6 +445,7 @@ func (r *RayServiceReconciler) constructRayClusterForRayService(rayService *rayv
 			"Manual config updates will NOT be tracked accurately. " +
 			"Please tear down the cluster and apply a new config."
 		r.Log.Error(err, errContext)
+		return nil, err
 	}
 
 	rayCluster := &rayv1alpha1.RayCluster{

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -323,7 +323,6 @@ func (r *RayServiceReconciler) cleanUpServeConfigCache(rayServiceInstance *rayv1
 
 // shouldPrepareNewRayCluster checks if we need to generate a new pending cluster.
 func (r *RayServiceReconciler) shouldPrepareNewRayCluster(rayServiceInstance *rayv1alpha1.RayService, activeRayCluster *rayv1alpha1.RayCluster) bool {
-
 	// Prepare new RayCluster if:
 	// 1. No active cluster and no pending cluster
 	// 2. No pending cluster, and the active RayCluster has changed.

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -314,7 +314,7 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayCluster  = %v", myRayCluster.Name)
 		})
 
-		It("Should detect unhealthy status and try to switch to new RayCluster.", func() {
+		It("should detect unhealthy status and try to switch to new RayCluster.", func() {
 			// Set a wrong serve status with unhealthy.
 			orignialServeDeploymentUnhealthySecondThreshold := ServiceUnhealthySecondThreshold
 			ServiceUnhealthySecondThreshold = 5

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"crypto/sha1"
+	"encoding/base32"
 	"fmt"
 	"math"
 	"reflect"
@@ -352,6 +353,9 @@ func GenerateJsonHash(obj interface{}) (string, error) {
 	}
 
 	hashBytes := sha1.Sum(serialObj)
-	hashStr := string(hashBytes[:])
+
+	// Convert to an ASCII string
+	hashStr := string(base32.HexEncoding.EncodeToString(hashBytes[:]))
+
 	return hashStr, nil
 }

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"math"
 	"reflect"
@@ -341,4 +342,16 @@ func ConvertUnixTimeToMetav1Time(unixTime int64) *metav1.Time {
 	t := time.Unix(unixTime/1000, unixTime%1000*1000000)
 	kt := metav1.NewTime(t)
 	return &kt
+}
+
+// Json-serializes obj and returns its hash string
+func GenerateJsonHash(obj interface{}) (string, error) {
+	serialObj, err := json.Marshal(obj)
+	if err != nil {
+		return "", err
+	}
+
+	hashBytes := sha1.Sum(serialObj)
+	hashStr := string(hashBytes[:])
+	return hashStr, nil
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`RayServices` check the entire `RayCluster` config, and they issue an A/B update if any part of the config has changed. The Ray Kubernetes autoscaler uses the `replicas` and `workersToDelete` fields in the `RayCluster` config to guide the cluster's autoscaling. This means that whenever the autoscaler tries to update the cluster's goal status, the `RayService` restarts the entire cluster (see #649 for more details).

This change updates the `RayService`'s logic to (1) add an annotation to the `RayCluster` which points to a hash of the `RayCluster`'s original configuration, (2) compares the goal-state `RayCluster`'s hash to this cached hash, and (3) only. triggers an A/B update if the goal hash changes.

## Related issue number

<!-- For example: "Closes #1234" -->

Addresses #649.

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
