### PR TITLE
[raycluster controller] Always honor maxReplicas

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -440,7 +440,7 @@ func (r *RayClusterReconciler) reconcilePods(instance *rayiov1alpha1.RayCluster)
 			workerReplicas = *worker.MaxReplicas
 			r.Log.Info(
 				fmt.Sprintf(
-					"Replicas for group %s (%d) is greater than MaxReplicas (%d). Using MaxReplicas (%d) as the target replica count.",
+					"Replicas for worker group %s (%d) is greater than maxReplicas (%d). Using maxReplicas (%d) as the target replica count.",
 					worker.GroupName, *worker.Replicas, *worker.MaxReplicas, *worker.MaxReplicas,
 				),
 			)

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -430,6 +430,23 @@ func (r *RayClusterReconciler) reconcilePods(instance *rayiov1alpha1.RayCluster)
 
 	// Reconcile worker pods now
 	for _, worker := range instance.Spec.WorkerGroupSpecs {
+		// workerReplicas will store the target number of pods for this worker group.
+		var workerReplicas int32
+		// Always honor MaxReplicas if it is set:
+		// If MaxReplicas is set and Replicas > MaxReplicas, use MaxReplicas as the
+		// effective target replica count and log the discrepancy.
+		// See https://github.com/ray-project/kuberay/issues/560.
+		if worker.MaxReplicas != nil && *worker.MaxReplicas < *worker.Replicas {
+			workerReplicas = *worker.MaxReplicas
+			r.Log.Info(
+				fmt.Sprintf(
+					"Replicas for group %s (%d) is greater than MaxReplicas (%d). Using MaxReplicas (%d) as the target replica count.",
+					worker.GroupName, *worker.Replicas, *worker.MaxReplicas, *worker.MaxReplicas,
+				),
+			)
+		} else {
+			workerReplicas = *worker.Replicas
+		}
 		workerPods := corev1.PodList{}
 		filterLabels = client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeGroupLabelKey: worker.GroupName}
 		if err := r.List(context.TODO(), &workerPods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
@@ -458,7 +475,7 @@ func (r *RayClusterReconciler) reconcilePods(instance *rayiov1alpha1.RayCluster)
 			}
 		}
 		r.updateLocalWorkersToDelete(&worker, runningPods.Items)
-		diff := *worker.Replicas - int32(len(runningPods.Items))
+		diff := workerReplicas - int32(len(runningPods.Items))
 
 		if PrioritizeWorkersToDelete {
 			// Always remove the specified WorkersToDelete - regardless of the value of Replicas.
@@ -518,7 +535,7 @@ func (r *RayClusterReconciler) reconcilePods(instance *rayiov1alpha1.RayCluster)
 		} else {
 			// diff < 0 and not the same absolute value as int32(len(worker.ScaleStrategy.WorkersToDelete)
 			// we need to scale down
-			workersToRemove := int32(len(runningPods.Items)) - *worker.Replicas
+			workersToRemove := int32(len(runningPods.Items)) - workerReplicas
 			randomlyRemovedWorkers := workersToRemove - int32(len(worker.ScaleStrategy.WorkersToDelete))
 			// we only need to scale down the workers in the ScaleStrategy
 			r.Log.Info("reconcilePods", "removing all the pods in the scaleStrategy of", worker.GroupName)


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If maxReplicas < Replicas, treat maxReplicas as the target replica count and log the discrepancy.
Partly addresses https://github.com/ray-project/kuberay/issues/560 in which some entity (possibly the Ray autoscaler) set replicas > maxReplicas.

See https://github.com/ray-project/ray/pull/29770/ for the corresponding safeguard in the autoscaler code.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
