### PR TITLE
[Feature][Helm] Align the key of minReplicas and maxReplicas

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -67,8 +67,8 @@ spec:
       {{ $key }}: {{ $val | quote }}
     {{- end }}
     replicas: {{ $values.replicas }}
-    minReplicas: {{ $values.minReplicas | default 1 }}
-    maxReplicas: {{ $values.maxReplicas | default 2147483647 }}
+    minReplicas: {{ $values.minReplicas | default (default 1 $values.miniReplicas) }}
+    maxReplicas: {{ $values.maxReplicas | default (default 2147483647 $values.maxiReplicas) }}
     groupName: {{ $groupName }}
     template:
       spec:
@@ -117,8 +117,8 @@ spec:
       {{ $key }}: {{ $val | quote }}
     {{- end }}
     replicas: {{ .Values.worker.replicas }}
-    minReplicas: {{ .Values.worker.minReplicas | default 1 }}
-    maxReplicas: {{ .Values.worker.maxReplicas | default 2147483647 }}
+    minReplicas: {{ .Values.worker.minReplicas | default (default 1 .Values.worker.miniReplicas) }}
+    maxReplicas: {{ .Values.worker.maxReplicas | default (default 2147483647 .Values.worker.maxiReplicas) }}
     groupName: {{ .Values.worker.groupName }}
     template:
       spec:

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -67,8 +67,8 @@ spec:
       {{ $key }}: {{ $val | quote }}
     {{- end }}
     replicas: {{ $values.replicas }}
-    minReplicas: {{ $values.miniReplicas | default 1 }}
-    maxReplicas: {{ $values.maxiReplicas | default 2147483647 }}
+    minReplicas: {{ $values.minReplicas | default 1 }}
+    maxReplicas: {{ $values.maxReplicas | default 2147483647 }}
     groupName: {{ $groupName }}
     template:
       spec:
@@ -117,8 +117,8 @@ spec:
       {{ $key }}: {{ $val | quote }}
     {{- end }}
     replicas: {{ .Values.worker.replicas }}
-    minReplicas: {{ .Values.worker.miniReplicas | default 1 }}
-    maxReplicas: {{ .Values.worker.maxiReplicas | default 2147483647 }}
+    minReplicas: {{ .Values.worker.minReplicas | default 1 }}
+    maxReplicas: {{ .Values.worker.maxReplicas | default 2147483647 }}
     groupName: {{ .Values.worker.groupName }}
     template:
       spec:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -113,8 +113,8 @@ additionalWorkerGroups:
     # Disabled by default
     disabled: true
     replicas: 1
-    miniReplicas: 1
-    maxiReplicas: 3
+    minReplicas: 1
+    maxReplicas: 3
     type: worker
     labels: {}
     initArgs:


### PR DESCRIPTION
Signed-off-by: Andrew Li <orcahmlee@gmail.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR aligns the `minReplicas` and `maxReplicas`.
Since the RayCluster CRD uses `minReplicas` and `maxReplicas`, the `values.yaml` should use it instead of using `miniReplicas` and `maxiReplicas`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
