### PR TITLE
[Feature] Set default appProtocol for Ray head service to tcp

### DIFF
--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -50,6 +50,9 @@ const (
 	DefaultDashboardAgentListenPortName = "dashboard-agent"
 	DefaultServingPortName              = "serve"
 
+	// The default AppProtocol for Kubernetes service
+	DefaultServiceAppProtocol = "tcp"
+
 	// The default application name
 	ApplicationName = "kuberay"
 

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -43,8 +43,9 @@ func BuildServiceForHeadPod(cluster rayiov1alpha1.RayCluster, labels map[string]
 	}
 
 	ports := getServicePorts(cluster)
+	defaultAppProtocol := DefaultServiceAppProtocol
 	for name, port := range ports {
-		svcPort := corev1.ServicePort{Name: name, Port: port}
+		svcPort := corev1.ServicePort{Name: name, Port: port, AppProtocol: &defaultAppProtocol}
 		service.Spec.Ports = append(service.Spec.Ports, svcPort)
 	}
 

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -84,6 +84,14 @@ func TestBuildServiceForHeadPod(t *testing.T) {
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
+
+	ports := svc.Spec.Ports
+	expectedResult = DefaultServiceAppProtocol
+	for _, port := range ports {
+		if *port.AppProtocol != DefaultServiceAppProtocol {
+			t.Fatalf("Expected `%v` but got `%v`", expectedResult, *port.AppProtocol)
+		}
+	}
 }
 
 func TestBuildServiceForHeadPodWithAppNameLabel(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?
#625 indicates that the `appProtocol` field is required to integrate with [Open Service Mesh](https://release-v0-11.docs.openservicemesh.io/docs/guides/app_onboarding/app_protocol_selection/#application-protocol-selection). We discussed how to expose head service for users in the community sync Oct. 25. We did not reach a conclusion in that meeting. Setting the default `appProtocol` to `tcp` will not change any existing behaviors because the default value of `Protocol` is "TCP" ([Link](https://pkg.go.dev/k8s.io/api/core/v1#ServicePort)). This PR enables users to integrate KubeRay with Open Service Mesh.


* Some documents related to `appProtocol`
  * Proposal: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1507-app-protocol
  * Motivation: https://github.com/kubernetes/kubernetes/issues/40244
    * `Protocol` specifies the protocol for all ports, but ports in the same service may have different protocols. Hence, `AppProtocol` is proposed to specify the protocol for each service port. 

* Why do I use "tcp" rather than "TCP"?
  * I followed the [example](https://release-v0-11.docs.openservicemesh.io/docs/guides/app_onboarding/app_protocol_selection/#application-protocol-selection). 

## Related issue number
#625 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

For manually test, we need to use `kubectl edit $HEAD_SVC`. The `kubectl describe` command will not show the information of `appProtocol`. The following screenshot shows the values of `appProtocol`.

<img width="276" alt="Screen Shot 2022-10-28 at 6 09 02 PM" src="https://user-images.githubusercontent.com/20109646/198755044-1b0f0441-4823-4ab4-a022-7f201f13806a.png">

