### PR TITLE
[Feature] Expose initContainer image in RayCluster chart

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -75,7 +75,7 @@ spec:
         imagePullSecrets: {{- toYaml $.Values.imagePullSecrets | nindent 10 }}
         initContainers:
           - name: init-myservice
-            image: busybox:1.28
+            image: {{ $values.initContainerImage | default "busybox:1.28" }}
             command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
         containers:
           - volumeMounts: {{- toYaml $values.volumeMounts | nindent 12 }}
@@ -125,7 +125,7 @@ spec:
         imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
         initContainers:
           - name: init-myservice
-            image: busybox:1.28
+            image: {{ .Values.worker.initContainerImage | default "busybox:1.28" }}
             command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
         containers:
           - volumeMounts: {{- toYaml .Values.worker.volumeMounts | nindent 12 }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -65,7 +65,7 @@ worker:
     node-ip-address: $MY_POD_IP
     redis-password: LetMeInRay
     block: 'true'
-  initContainerImage: 'busybox:1.28' # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
+  initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
   containerEnv:
     - name: MY_POD_IP
       valueFrom:
@@ -122,7 +122,7 @@ additionalWorkerGroups:
       node-ip-address: $MY_POD_IP
       redis-password: LetMeInRay
       block: 'true'
-    initContainerImage: 'busybox:1.28' # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
+    initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
     containerEnv:
       - name: MY_POD_IP
         valueFrom:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -65,6 +65,7 @@ worker:
     node-ip-address: $MY_POD_IP
     redis-password: LetMeInRay
     block: 'true'
+  initContainerImage: 'busybox:1.28' # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
   containerEnv:
     - name: MY_POD_IP
       valueFrom:
@@ -121,6 +122,7 @@ additionalWorkerGroups:
       node-ip-address: $MY_POD_IP
       redis-password: LetMeInRay
       block: 'true'
+    initContainerImage: 'busybox:1.28' # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
     containerEnv:
       - name: MY_POD_IP
         valueFrom:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Some users hope to pull the busybox images from private repositories. Hence, this PR makes the image field of init container become configurable in the RayCluster helm chart.

Q1: Is it possible for us to have multiple init containers?
Q2: Is it possible to expose other fields for init containers? See [k8s doc](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container) for other container fields.



## Related issue number
Closes #673 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

## Manual tests
* `worker.initContainerImage` and `smallGroup.initContainerImage` (commented out `disabled: true`) are defined.
* `worker.initContainerImage` and `smallGroup.initContainerImage` (commented out `disabled: true`) are undefined.
