### PR TITLE
[operator] Set operator strategy to Recreate in kustomize config

### DIFF
--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -12,6 +12,8 @@ spec:
       app.kubernetes.io/name: kuberay
       app.kubernetes.io/component: kuberay-operator
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Sets the operator's deployment strategy to Recreate for Kustomize configs.

This is a follow-up to https://github.com/ray-project/kuberay/pull/566/ which set the operator's deployment strategy to Recreate for Helm configs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
