### PR TITLE
[fix][raycluster controller] No error if head ip cannot be determined.

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -841,14 +841,10 @@ func (r *RayClusterReconciler) getHeadPodIP(instance *rayiov1alpha1.RayCluster) 
 		r.Log.Error(err, "Failed to list pods while getting head pod ip.")
 		return "", err
 	}
-	if len(runtimePods.Items) < 1 {
-		r.Log.Info(fmt.Sprintf("unable to find head pod. cluster name %s, filter labels %v", instance.Name, filterLabels))
-		return "", nil
-	} else if len(runtimePods.Items) > 1 {
-		r.Log.Info(fmt.Sprintf("found multiple head pods. cluster name %s, filter labels %v", instance.Name, filterLabels))
+	if len(runtimePods.Items) != 1 {
+		r.Log.Info(fmt.Sprintf("Found %d head pods. cluster name %s, filter labels %v", len(runtimePods.Items), instance.Name, filterLabels))
 		return "", nil
 	}
-
 	return runtimePods.Items[0].Status.PodIP, nil
 }
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -833,7 +833,7 @@ func (r *RayClusterReconciler) updateStatus(instance *rayiov1alpha1.RayCluster) 
 	return nil
 }
 
-// Best effort to record the ip of the head node.
+// Best effort to obtain the ip of the head node.
 func (r *RayClusterReconciler) getHeadPodIP(instance *rayiov1alpha1.RayCluster) (string, error) {
 	runtimePods := corev1.PodList{}
 	filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeTypeLabelKey: string(rayiov1alpha1.HeadNode)}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -833,6 +833,7 @@ func (r *RayClusterReconciler) updateStatus(instance *rayiov1alpha1.RayCluster) 
 	return nil
 }
 
+// Best effort to record the ip of the head node.
 func (r *RayClusterReconciler) getHeadPodIP(instance *rayiov1alpha1.RayCluster) (string, error) {
 	runtimePods := corev1.PodList{}
 	filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeTypeLabelKey: string(rayiov1alpha1.HeadNode)}
@@ -840,11 +841,11 @@ func (r *RayClusterReconciler) getHeadPodIP(instance *rayiov1alpha1.RayCluster) 
 		return "", err
 	}
 	if len(runtimePods.Items) < 1 {
-		return "", fmt.Errorf("unable to find head pod. cluster name %s, filter labels %v", instance.Name, filterLabels)
+		r.Log.Info(fmt.Sprintf("unable to find head pod. cluster name %s, filter labels %v", instance.Name, filterLabels))
+		return "", nil
 	} else if len(runtimePods.Items) > 1 {
-		return "", fmt.Errorf("found multiple head pods. cluster name %s, filter labels %v", instance.Name, filterLabels)
-	} else if runtimePods.Items[0].Status.PodIP == "" {
-		return "", fmt.Errorf("head pod IP is empty. cluster name %s, filter labels %v", instance.Name, filterLabels)
+		r.Log.Info(fmt.Sprintf("found multiple head pods. cluster name %s, filter labels %v", instance.Name, filterLabels))
+		return "", nil
 	}
 
 	return runtimePods.Items[0].Status.PodIP, nil

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -838,6 +838,7 @@ func (r *RayClusterReconciler) getHeadPodIP(instance *rayiov1alpha1.RayCluster) 
 	runtimePods := corev1.PodList{}
 	filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeTypeLabelKey: string(rayiov1alpha1.HeadNode)}
 	if err := r.List(context.TODO(), &runtimePods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
+		r.Log.Error(err, "Failed to list pods while getting head pod ip.")
 		return "", err
 	}
 	if len(runtimePods.Items) < 1 {

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -231,16 +231,6 @@ func setupTest(t *testing.T) {
 					common.RayNodeGroupLabelKey: headGroupNameStr,
 				},
 			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:    "ray-head",
-						Image:   "rayproject/autoscaler",
-						Command: []string{"python"},
-						Args:    []string{"/opt/code.py"},
-					},
-				},
-			},
 			Status: corev1.PodStatus{
 				Phase: corev1.PodPending,
 				PodIP: "",


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

https://github.com/ray-project/kuberay/pull/468/ has the RayCluster controller throw an error if head ip can't be determined while updating RayCluster status
That is problematic for two reasons:
1. Head pod ip is not determined while the head pod is pending placement.
2. Status updating logic should be best-effort. If there's a brief inconsistency leading to multiple or no head pods listed, the reconciler should take appropriate action, but the status processing logic doesn't need to fail.

Throwing an error in the first situation might be leading to test failures:
https://github.com/ray-project/kuberay/actions/runs/3424423296/jobs/5706807752

This PR modifies the headIP status logic to be best effort -- if the IP cannot be determined, it is recorded as an empty string.

cc @davidxia 

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/ray-project/kuberay/pull/468/

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
