### PR TITLE
Replace kubectl wait command with RayClusterAddCREvent

### DIFF
--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -336,17 +336,3 @@ if __name__ == '__main__':
     logger.info('Setting KubeRay operator image to: {}'.format(kuberay_operator_image))
     logger.info('Setting KubeRay apiserver image to: {}'.format(kuberay_apiserver_image))
     unittest.main(verbosity=2)
-    # from string import Template
-    # import yaml
-    # from framework.prototype import RayClusterAddCREvent
-
-    # template_name = 'tests/config/ray-cluster.mini.yaml.template'
-    # with open(template_name, encoding="utf-8") as ray_cluster_template:
-    #     template = Template(ray_cluster_template.read())
-    # ray_cluster_cr = yaml.load(
-    #     template.substitute({'ray_image': ray_image, 'ray_version': ray_version}), 
-    #     Loader=yaml.FullLoader
-    # )
-    
-    # ray_cluster_add_event = RayClusterAddCREvent(ray_cluster_cr, [], 90, namespace='default')
-    # ray_cluster_add_event.trigger()

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python
 import logging
 import unittest
-import docker
 import time
 import os
 import random
 import string
+import docker
 
-import kuberay_utils.utils as utils
+from kuberay_utils import utils
 from kubernetes import client, config
-from kubernetes.stream import stream
-
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(format='%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
+logging.basicConfig(
+    format='%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
     datefmt='%Y-%m-%d:%H:%M:%S',
-    level=logging.INFO)
+    level=logging.INFO
+)
 
 # Image version
 ray_version = '1.9.0'
@@ -336,3 +336,17 @@ if __name__ == '__main__':
     logger.info('Setting KubeRay operator image to: {}'.format(kuberay_operator_image))
     logger.info('Setting KubeRay apiserver image to: {}'.format(kuberay_apiserver_image))
     unittest.main(verbosity=2)
+    # from string import Template
+    # import yaml
+    # from framework.prototype import RayClusterAddCREvent
+
+    # template_name = 'tests/config/ray-cluster.mini.yaml.template'
+    # with open(template_name, encoding="utf-8") as ray_cluster_template:
+    #     template = Template(ray_cluster_template.read())
+    # ray_cluster_cr = yaml.load(
+    #     template.substitute({'ray_image': ray_image, 'ray_version': ray_version}), 
+    #     Loader=yaml.FullLoader
+    # )
+    
+    # ray_cluster_add_event = RayClusterAddCREvent(ray_cluster_cr, [], 90, namespace='default')
+    # ray_cluster_add_event.trigger()

--- a/tests/config/requirements.txt
+++ b/tests/config/requirements.txt
@@ -1,2 +1,3 @@
 docker
 kubernetes
+jsonpatch

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -128,8 +128,6 @@ class CREvent:
         self.timeout = timeout
         self.namespace = namespace
         self.custom_resource_object = custom_resource_object
-        # Initialize Kubernetes API client
-        config.load_kube_config()
         # A file may consists of multiple Kubernetes resources (ex: ray-cluster.external-redis.yaml)
         self.filepath = filepath
 

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -10,6 +10,7 @@ import yaml
 import docker
 
 from kubernetes.stream import stream
+from kubernetes import config
 from framework.prototype import RayClusterAddCREvent
 
 kindcluster_config_file = 'tests/config/cluster-config.yaml'
@@ -68,6 +69,8 @@ def create_cluster():
     rtn = shell_run('kubectl wait --for=condition=ready pod -n kube-system --all --timeout=300s')
     if rtn != 0:
         shell_run('kubectl get pods -A')
+    # Initialize Kubernetes config
+    config.load_kube_config()
     assert rtn == 0
 
 

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -108,7 +108,12 @@ def create_kuberay_cluster(template_name, ray_version, ray_image):
         shell_assert_success(f'kubectl apply -f {raycluster_service_file}')
         # Create a RayCluster
         ray_cluster_add_event = RayClusterAddCREvent(
-            context['cr'], [], 90, namespace='default', filepath = context['filepath'])
+            custom_resource_object = context['cr'], 
+            rulesets = [],
+            timeout = 90,
+            namespace='default',
+            filepath = context['filepath']
+        )
         ray_cluster_add_event.trigger()
         return
     except Exception as ex:
@@ -159,7 +164,7 @@ def delete_cluster():
 
 
 def download_images(images):
-    """Pull images from DokcerHub if do not exist."""
+    """Pull images from DockerHub if do not exist."""
     client = docker.from_env()
     for image in images:
         if shell_run(f'docker image inspect {image}', silent=True) != 0:

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -1,23 +1,26 @@
 #!/usr/bin/env python
+from string import Template
 
 import os
 import logging
 import tarfile
 import time
 import tempfile
+import yaml
 import docker
 
-from string import Template
-from kubernetes import client, config
 from kubernetes.stream import stream
+from framework.prototype import RayClusterAddCREvent
 
 kindcluster_config_file = 'tests/config/cluster-config.yaml'
 raycluster_service_file = 'tests/config/raycluster-service.yaml'
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(format='%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
+logging.basicConfig(
+    format='%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
     datefmt='%Y-%m-%d:%H:%M:%S',
-    level=logging.INFO)
+    level=logging.INFO
+)
 
 
 def parse_ray_version(version_str):
@@ -59,6 +62,7 @@ def shell_assert_failure(cmd):
 
 
 def create_cluster():
+    """Create a KinD cluster"""
     # Use `--wait 10m` flag to block until the control plane reaches a ready status.
     shell_assert_success('kind create cluster --wait 10m --config {}'.format(kindcluster_config_file))
     rtn = shell_run('kubectl wait --for=condition=ready pod -n kube-system --all --timeout=300s')
@@ -80,37 +84,27 @@ def apply_kuberay_resources(images, kuberay_operator_image, kuberay_apiserver_im
 
 
 def create_kuberay_cluster(template_name, ray_version, ray_image):
-    template = None
-    with open(template_name, mode='r') as f:
-        template = Template(f.read())
-
-    raycluster_spec_buf = template.substitute(
-        {'ray_image': ray_image, 'ray_version': ray_version})
-
-    raycluster_spec_file = None
-    with tempfile.NamedTemporaryFile('w', delete=False) as f:
-        f.write(raycluster_spec_buf)
-        raycluster_spec_file = f.name
-
-    rtn = shell_run(
-        'kubectl wait --for=condition=ready pod -n ray-system --all --timeout=900s')
-    if rtn != 0:
-        shell_run('kubectl get pods -A')
-    assert rtn == 0
-    assert raycluster_spec_file is not None
-    shell_assert_success('kubectl apply -f {}'.format(raycluster_spec_file))
-    rtn = shell_run(
-        'kubectl wait --for=condition=ready pod -l rayCluster=raycluster-compatibility-test --all --timeout=900s')
-    shell_run('kubectl get pods -A')
-    if rtn != 0:
+    """Create a RayCluster and a NodePort service."""
+    with open(template_name, encoding="utf-8") as ray_cluster_template:
+        template = Template(ray_cluster_template.read())
+    ray_cluster_cr = yaml.load(
+        template.substitute({'ray_image': ray_image, 'ray_version': ray_version}),
+        Loader=yaml.FullLoader
+    )
+    try:
+        # Deploy a NodePort service to expose ports for users.
+        shell_assert_success(f'kubectl apply -f {raycluster_service_file}')
+        # Create a RayCluster
+        ray_cluster_add_event = RayClusterAddCREvent(ray_cluster_cr, [], 90, namespace='default')
+        ray_cluster_add_event.trigger()
+        return
+    except Exception as ex:
+        # RayClusterAddCREvent fails to converge.
+        logger.error(str(ex))
         shell_run('kubectl describe pod $(kubectl get pods | grep -e "-head" | awk "{print \$1}")')
         shell_run('kubectl logs $(kubectl get pods | grep -e "-head" | awk "{print \$1}")')
         shell_run('kubectl logs -n $(kubectl get pods -A | grep -e "-operator" | awk \'{print $1 "  " $2}\')')
-    assert rtn == 0
-
-    # Deploy a NodePort service to expose ports for users.
-    shell_assert_success('kubectl apply -f {}'.format(raycluster_service_file))
-
+    raise Exception("create_kuberay_cluster fails")
 
 def create_kuberay_service(template_name, ray_version, ray_image):
     template = None
@@ -152,12 +146,16 @@ def delete_cluster():
 
 
 def download_images(images):
+    """Pull images from DokcerHub if do not exist."""
     client = docker.from_env()
     for image in images:
-        if shell_run('docker image inspect {}'.format(image), silent=True) != 0:
+        if shell_run(f'docker image inspect {image}', silent=True) != 0:
             # Only pull the image from DockerHub when the image does not
             # exist in the local docker registry.
+            logger.info("Download docker image %s", image)
             client.images.pull(image)
+        else:
+            logger.info("Image %s exists", image)
     client.close()
 
 def copy_to_container(container, src, dest, filename):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
#704 causes `kubectl wait` to be flaky, and thus I used `RayClusterAddCREvent` to reduce flakiness.

In #704, `kubectl wait` sometimes waits for 1 head pod and 2 worker pods (goal state is 1 head pod and 1 worker pod) due to the inconsistency between Kubernetes API server and informer cache, and thus the function `create_kuberay_cluster` is flaky. `RayClusterAddCREvent` specifies the goal state (1 head pod and 1 worker pod) directly to reduce flakiness.

https://github.com/ray-project/kuberay/blob/17264a6f409208ee24cbb743c59fa40c9eed856a/tests/framework/prototype.py#L204-L231


## Related issue number
https://github.com/ray-project/kuberay/issues/704
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
