### PR TITLE
[WIP] [RayService] Add liveness and readiness probes that track Serve app health

### DIFF
--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -84,17 +84,17 @@ const (
 
 	LOCAL_HOST = "127.0.0.1"
 	// Ray FT default readiness probe values
-	DefaultReadinessProbeInitialDelaySeconds = 10
+	DefaultReadinessProbeInitialDelaySeconds = 20
 	DefaultReadinessProbeTimeoutSeconds      = 1
 	DefaultReadinessProbePeriodSeconds       = 3
-	DefaultReadinessProbeSuccessThreshold    = 0
+	DefaultReadinessProbeSuccessThreshold    = 1
 	DefaultReadinessProbeFailureThreshold    = 20
 
 	// Ray FT default liveness probe values
-	DefaultLivenessProbeInitialDelaySeconds = 10
+	DefaultLivenessProbeInitialDelaySeconds = 20
 	DefaultLivenessProbeTimeoutSeconds      = 1
 	DefaultLivenessProbePeriodSeconds       = 3
-	DefaultLivenessProbeSuccessThreshold    = 0
+	DefaultLivenessProbeSuccessThreshold    = 1
 	DefaultLivenessProbeFailureThreshold    = 40
 
 	// Ray health check related configurations

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -225,48 +225,60 @@ func DefaultWorkerPodTemplate(instance rayiov1alpha1.RayCluster, workerSpec rayi
 }
 
 func initLivenessProbeHandler(probe *v1.Probe, rayNodeType rayiov1alpha1.RayNodeType) {
+	// Only create the probe if the user didn't specify any
 	if probe.Exec == nil {
-		// we only create the probe if user did not specify any.
 		if rayNodeType == rayiov1alpha1.HeadNode {
-			// head node liveness probe
-			cmd := []string{
-				"bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
-					DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
-				"&&", "bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
-					DefaultDashboardPort, RayDashboardGCSHealthPath),
-			}
+			cmd := rayClusterHeadLivenessProbeCmd()
 			probe.Exec = &v1.ExecAction{Command: cmd}
 		} else {
-			// worker node liveness probe
-			cmd := []string{
-				"bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
-					DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
-			}
+			cmd := rayClusterWorkerLivenessProbeCmd()
 			probe.Exec = &v1.ExecAction{Command: cmd}
 		}
 	}
 }
 
+func rayClusterHeadLivenessProbeCmd() []string {
+	return []string{
+		"bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
+			DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
+		"&&", "bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
+			DefaultDashboardPort, RayDashboardGCSHealthPath),
+	}
+}
+
+func rayClusterWorkerLivenessProbeCmd() []string {
+	return []string{
+		"bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
+			DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
+	}
+}
+
 func initReadinessProbeHandler(probe *v1.Probe, rayNodeType rayiov1alpha1.RayNodeType) {
+	// Only create the probe if the user didn't specify any
 	if probe.Exec == nil {
-		// we only create the probe if user did not specify any.
 		if rayNodeType == rayiov1alpha1.HeadNode {
-			// head node readiness probe
-			cmd := []string{
-				"bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
-					DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
-				"&&", "bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
-					DefaultDashboardPort, RayDashboardGCSHealthPath),
-			}
+			cmd := rayClusterHeadReadinessProbeCmd()
 			probe.Exec = &v1.ExecAction{Command: cmd}
 		} else {
-			// worker node readiness probe
-			cmd := []string{
-				"bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
-					DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
-			}
+			cmd := rayClusterWorkerReadinessProbeCmd()
 			probe.Exec = &v1.ExecAction{Command: cmd}
 		}
+	}
+}
+
+func rayClusterHeadReadinessProbeCmd() []string {
+	return []string{
+		"bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
+			DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
+		"&&", "bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
+			DefaultDashboardPort, RayDashboardGCSHealthPath),
+	}
+}
+
+func rayClusterWorkerReadinessProbeCmd() []string {
+	return []string{
+		"bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
+			DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
 	}
 }
 

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -264,7 +264,7 @@ func rayClusterWorkerLivenessProbeCmd() []string {
 func RayServiceHeadLivenessProbeCmd() []string {
 	clusterCmd := rayClusterHeadLivenessProbeCmd()
 	serviceCmd := []string{
-		"bash", "-c", fmt.Sprintf("! serve status | grep 'status: DEPLOYMENT_FAILED'"),
+		"bash", "-c", "! serve status | grep 'status: DEPLOYMENT_FAILED'",
 	}
 	return append(append(clusterCmd, "&&"), serviceCmd...)
 }
@@ -272,7 +272,7 @@ func RayServiceHeadLivenessProbeCmd() []string {
 func RayServiceWorkerLivenessProbeCmd() []string {
 	clusterCmd := rayClusterWorkerLivenessProbeCmd()
 	serviceCmd := []string{
-		"bash", "-c", fmt.Sprintf("! serve status | grep 'status: DEPLOYMENT_FAILED'"),
+		"bash", "-c", "! serve status | grep 'status: DEPLOYMENT_FAILED'",
 	}
 	return append(append(clusterCmd, "&&"), serviceCmd...)
 }
@@ -323,7 +323,7 @@ func RayServiceHeadReadinessProbeCmd(port int) []string {
 			port,
 		),
 		"&&",
-		fmt.Sprintf("serve status | grep 'status: RUNNING'"),
+		"serve status | grep 'status: RUNNING'",
 	}
 	return append(append(clusterCmd, "&&"), serviceCmd...)
 }
@@ -337,7 +337,7 @@ func RayServiceWorkerReadinessProbeCmd(port int) []string {
 			port,
 		),
 		"&&",
-		fmt.Sprintf("serve status | grep 'status: RUNNING'"),
+		"serve status | grep 'status: RUNNING'",
 	}
 	return append(append(clusterCmd, "&&"), serviceCmd...)
 }

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -249,20 +249,6 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayCluster  = %v", myRayCluster.Name)
 		})
 
-		It("should have default rayservice probes in the head pod", func() {
-			k8sClient.Get(ctx, client.ObjectKey{Name: myRayService.Status.ActiveServiceStatus.RayClusterName, Namespace: "default"}, myRayCluster)
-			container := myRayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[0]
-			Expect(container.LivenessProbe.ProbeHandler).Should(Equal(common.RayServiceHeadLivenessProbeCmd()))
-			Expect(container.ReadinessProbe.ProbeHandler).Should(Equal(common.RayServiceHeadReadinessProbeCmd(8000)))
-		})
-
-		It("should have default rayservice probes in the worker pod", func() {
-			k8sClient.Get(ctx, client.ObjectKey{Name: myRayService.Status.ActiveServiceStatus.RayClusterName, Namespace: "default"}, myRayCluster)
-			container := myRayCluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0]
-			Expect(container.LivenessProbe.ProbeHandler).Should(Equal(common.RayServiceWorkerLivenessProbeCmd()))
-			Expect(container.ReadinessProbe.ProbeHandler).Should(Equal(common.RayServiceWorkerReadinessProbeCmd(8000)))
-		})
-
 		It("should create more than 1 worker", func() {
 			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayService.Status.ActiveServiceStatus.RayClusterName, common.RayNodeGroupLabelKey: "small-group"}
 			Eventually(

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -249,6 +249,20 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayCluster  = %v", myRayCluster.Name)
 		})
 
+		It("should have default rayservice probes in the head pod", func() {
+			k8sClient.Get(ctx, client.ObjectKey{Name: myRayService.Status.ActiveServiceStatus.RayClusterName, Namespace: "default"}, myRayCluster)
+			container := myRayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[0]
+			Expect(container.LivenessProbe.ProbeHandler).Should(Equal(common.RayServiceHeadLivenessProbeCmd()))
+			Expect(container.ReadinessProbe.ProbeHandler).Should(Equal(common.RayServiceHeadReadinessProbeCmd(8000)))
+		})
+
+		It("should have default rayservice probes in the worker pod", func() {
+			k8sClient.Get(ctx, client.ObjectKey{Name: myRayService.Status.ActiveServiceStatus.RayClusterName, Namespace: "default"}, myRayCluster)
+			container := myRayCluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0]
+			Expect(container.LivenessProbe.ProbeHandler).Should(Equal(common.RayServiceWorkerLivenessProbeCmd()))
+			Expect(container.ReadinessProbe.ProbeHandler).Should(Equal(common.RayServiceWorkerReadinessProbeCmd(8000)))
+		})
+
 		It("should create more than 1 worker", func() {
 			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayService.Status.ActiveServiceStatus.RayClusterName, common.RayNodeGroupLabelKey: "small-group"}
 			Eventually(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`RayServices` rely on the `RayCluster` liveness and readiness probes to manage the cluster. However, it takes some additional time after the Ray cluster starts for Serve's HTTPProxies to start accepting traffic. The proxies may also crash while the Ray cluster itself is healthy.

This change adds new liveness and readiness probes at the `RayService` layer to track Serve application health. This prevents requests from getting dropped when Serve is unhealthy while the Ray cluster itself is healthy.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #667

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
