### PR TITLE
[raycluster controller] Make it clear that reconcilePods does not write to spec

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -329,14 +329,14 @@ func (r *RayClusterReconciler) reconcileServices(instance *rayiov1alpha1.RayClus
 	return nil
 }
 
+// Sync pods. Return the set of pods which have been deleted.
 func (r *RayClusterReconciler) reconcilePods(instance *rayiov1alpha1.RayCluster) error {
-	// check if all the pods exist
+	// Reconcile head Pod
 	headPods := corev1.PodList{}
 	filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeTypeLabelKey: string(rayiov1alpha1.HeadNode)}
 	if err := r.List(context.TODO(), &headPods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 		return err
 	}
-	// Reconcile head Pod
 	if len(headPods.Items) == 1 {
 		headPod := headPods.Items[0]
 		r.Log.Info("reconcilePods ", "head pod found", headPod.Name)


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Operators generally shouldn't write to the spec of the thing they manage.
I don't think the raycluster controller currently does that, but the logic around workersToDelete kind of makes it look that way.

This PR deep-copies worker group specs in the reconcile pods to make it clear that the spec is not being modified when we process workersToDelete.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
