### PR TITLE
[Bug][Doc] Increase default operator resource requirements, improve docs

### DIFF
--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -36,10 +36,12 @@ resources:
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 100m
-    memory: 128Mi
+    # One user said that a cluster with ~50 worker Pods (16 cores and
+    # 64 GB memory each) requires 500 MB memory.
+    memory: 512Mi 
   # requests:
   #   cpu: 100m
-  #   memory: 128Mi
+  #   memory: 512Mi
 
 livenessProbe:
   initialDelaySeconds: 10

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -36,7 +36,7 @@ resources:
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 100m
-    # Anecdotally, managing 500 Ray pods requires roughly 500MB memory.
+    # Anecdotally, managing 50 Ray pods requires roughly 500MB memory.
     # Monitor memory usage and adjust as needed.
     memory: 512Mi
   # requests:

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -38,7 +38,7 @@ resources:
     cpu: 100m
     # One user said that a cluster with ~50 worker Pods (16 cores and
     # 64 GB memory each) requires 500 MB memory.
-    memory: 512Mi 
+    memory: 512Mi
   # requests:
   #   cpu: 100m
   #   memory: 512Mi

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -36,7 +36,7 @@ resources:
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 100m
-    # Anecdotally, managing 50 Ray pods requires roughly 500MB memory.
+    # Anecdotally, managing 500 Ray pods requires roughly 500MB memory.
     # Monitor memory usage and adjust as needed.
     memory: 512Mi
   # requests:

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -36,8 +36,8 @@ resources:
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 100m
-    # One user said that a cluster with ~50 worker Pods (16 cores and
-    # 64 GB memory each) requires 500 MB memory.
+    # Anecdotally, managing 500 Ray pods requires roughly 500MB memory.
+    # Monitor memory usage and adjust as needed.
     memory: 512Mi
   # requests:
   #   cpu: 100m

--- a/ray-operator/README.md
+++ b/ray-operator/README.md
@@ -82,7 +82,7 @@ Sample  | Description
     See [ray-cluster.complete.large.yaml](config/samples/ray-cluster.complete.large.yaml) and
     [ray-cluster.autoscaler.large.yaml](config/samples/ray-cluster.autoscaler.yaml) for guidance. The rest of the sample configs above are geared towards experimentation in local kind or minikube environments.
 
-    For KubeRay operator, anecdotally, managing 500 Ray pods requires roughly 500MB memory. Monitor memory usage and adjust as needed.
+    The memory usage of the KubeRay operator depends on the number of pods and Ray clusters being managed. Anecdotally, managing 500 Ray pods requires roughly 500MB memory. Monitor memory usage and adjust requests and limits as needed.
 
 ```shell
 # Create a RayCluster and a ConfigMap with hello world Ray code.

--- a/ray-operator/README.md
+++ b/ray-operator/README.md
@@ -80,8 +80,9 @@ Sample  | Description
     For production use-cases, make sure to allocate sufficient resources for your Ray pods; it usually makes
     sense to run one large Ray pod per Kubernetes node.
     See [ray-cluster.complete.large.yaml](config/samples/ray-cluster.complete.large.yaml) and
-    [ray-cluster.autoscaler.large.yaml](config/samples/ray-cluster.autoscaler.yaml) for guidance. The rest of the sample configs above are geared towards
-    experimentation in local kind or minikube environments.
+    [ray-cluster.autoscaler.large.yaml](config/samples/ray-cluster.autoscaler.yaml) for guidance. The rest of the sample configs above are geared towards experimentation in local kind or minikube environments.
+
+    For KubeRay operator, anecdotally, managing 500 Ray pods requires roughly 500MB memory. Monitor memory usage and adjust as needed.
 
 ```shell
 # Create a RayCluster and a ConfigMap with hello world Ray code.

--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -53,8 +53,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            # One user said that a cluster with ~50 worker Pods (16 cores and
-            # 64 GB memory each) requires 500 MB memory.
+            # Anecdotally, managing 50 Ray pods requires roughly 500MB memory.
+            # Monitor memory usage and adjust as needed.
             memory: 512Mi
           requests:
             cpu: 100m

--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -53,8 +53,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 100Mi
+            # One user said that a cluster with ~50 worker Pods (16 cores and
+            # 64 GB memory each) requires 500 MB memory.
+            memory: 512Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 512Mi
       terminationGracePeriodSeconds: 10

--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -53,7 +53,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            # Anecdotally, managing 50 Ray pods requires roughly 500MB memory.
+            # Anecdotally, managing 500 Ray pods requires roughly 500MB memory.
             # Monitor memory usage and adjust as needed.
             memory: 512Mi
           requests:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We have some indication from users that the default resource limits for the KubeRay operator may be too small when managing many Ray pods.

See the discussion here: https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1667409518664019

* Increase the default resource limits  
* Document the fact that users need to observe resource usage and adjust as needed.

## Related issue number
Closes #685 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
