### PR TITLE
[RayService] Track whether Serve app is ready before switching clusters

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -11768,7 +11768,7 @@ spec:
                   serveDeploymentStatuses:
                     items:
                       description: ServeDeploymentStatus defines the current state
-                        of Serve Deployment
+                        of a Serve deployment
                       properties:
                         healthLastUpdateTime:
                           description: Keep track of how long the service is healthy.
@@ -11781,7 +11781,7 @@ spec:
                           type: string
                         name:
                           description: Name, Status, Message are from Ray Dashboard
-                            to represent the state of a serve deployment.
+                            and represent a Serve deployment's state.
                           type: string
                         status:
                           description: 'TODO: change status type to enum'
@@ -11875,7 +11875,7 @@ spec:
                   serveDeploymentStatuses:
                     items:
                       description: ServeDeploymentStatus defines the current state
-                        of Serve Deployment
+                        of a Serve deployment
                       properties:
                         healthLastUpdateTime:
                           description: Keep track of how long the service is healthy.
@@ -11888,7 +11888,7 @@ spec:
                           type: string
                         name:
                           description: Name, Status, Message are from Ray Dashboard
-                            to represent the state of a serve deployment.
+                            and represent a Serve deployment's state.
                           type: string
                         status:
                           description: 'TODO: change status type to enum'

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -21,6 +21,34 @@ const (
 	FailedToUpdateService            ServiceStatus = "FailedToUpdateService"
 )
 
+type ApplicationStatusType string
+
+// These statuses should match Ray Serve's application statuses
+var ApplicationStatus = struct {
+	NOT_STARTED   ApplicationStatusType
+	DEPLOYING     ApplicationStatusType
+	RUNNING       ApplicationStatusType
+	DEPLOY_FAILED ApplicationStatusType
+}{
+	NOT_STARTED:   "NOT_STARTED",
+	DEPLOYING:     "DEPLOYING",
+	RUNNING:       "RUNNING",
+	DEPLOY_FAILED: "DEPLOY_FAILED",
+}
+
+type DeploymentStatusType string
+
+// These statuses should match Ray Serve's deployment statuses
+var DeploymentStatus = struct {
+	UPDATING  DeploymentStatusType
+	HEALTHY   DeploymentStatusType
+	UNHEALTHY DeploymentStatusType
+}{
+	UPDATING:  "UPDATING",
+	HEALTHY:   "HEALTHY",
+	UNHEALTHY: "UNHEALTHY",
+}
+
 // RayServiceSpec defines the desired state of RayService
 type RayServiceSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -22,7 +22,7 @@ const (
 )
 
 // These statuses should match Ray Serve's application statuses
-var ApplicationStatus = struct {
+var ApplicationStatusEnum = struct {
 	NOT_STARTED   string
 	DEPLOYING     string
 	RUNNING       string
@@ -35,7 +35,7 @@ var ApplicationStatus = struct {
 }
 
 // These statuses should match Ray Serve's deployment statuses
-var DeploymentStatus = struct {
+var DeploymentStatusEnum = struct {
 	UPDATING  string
 	HEALTHY   string
 	UNHEALTHY string

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -96,20 +96,20 @@ type AppStatus struct {
 	Message        string       `json:"message,omitempty"`
 	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty"`
 	// Keep track of how long the service is healthy.
-	// Update when Serve Deployment is healthy or first time convert to unhealthy from healthy.
+	// Update when Serve deployment is healthy or first time convert to unhealthy from healthy.
 	HealthLastUpdateTime *metav1.Time `json:"healthLastUpdateTime,omitempty"`
 }
 
-// ServeDeploymentStatus defines the current state of Serve Deployment
+// ServeDeploymentStatus defines the current state of a Serve deployment
 type ServeDeploymentStatus struct {
-	// Name, Status, Message are from Ray Dashboard to represent the state of a serve deployment.
+	// Name, Status, Message are from Ray Dashboard and represent a Serve deployment's state.
 	Name string `json:"name,omitempty"`
 	// TODO: change status type to enum
 	Status         string       `json:"status,omitempty"`
 	Message        string       `json:"message,omitempty"`
 	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty"`
 	// Keep track of how long the service is healthy.
-	// Update when Serve Deployment is healthy or first time convert to unhealthy from healthy.
+	// Update when Serve deployment is healthy or first time convert to unhealthy from healthy.
 	HealthLastUpdateTime *metav1.Time `json:"healthLastUpdateTime,omitempty"`
 }
 

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -21,14 +21,12 @@ const (
 	FailedToUpdateService            ServiceStatus = "FailedToUpdateService"
 )
 
-type ApplicationStatusType string
-
 // These statuses should match Ray Serve's application statuses
 var ApplicationStatus = struct {
-	NOT_STARTED   ApplicationStatusType
-	DEPLOYING     ApplicationStatusType
-	RUNNING       ApplicationStatusType
-	DEPLOY_FAILED ApplicationStatusType
+	NOT_STARTED   string
+	DEPLOYING     string
+	RUNNING       string
+	DEPLOY_FAILED string
 }{
 	NOT_STARTED:   "NOT_STARTED",
 	DEPLOYING:     "DEPLOYING",
@@ -36,13 +34,11 @@ var ApplicationStatus = struct {
 	DEPLOY_FAILED: "DEPLOY_FAILED",
 }
 
-type DeploymentStatusType string
-
 // These statuses should match Ray Serve's deployment statuses
 var DeploymentStatus = struct {
-	UPDATING  DeploymentStatusType
-	HEALTHY   DeploymentStatusType
-	UNHEALTHY DeploymentStatusType
+	UPDATING  string
+	HEALTHY   string
+	UNHEALTHY string
 }{
 	UPDATING:  "UPDATING",
 	HEALTHY:   "HEALTHY",

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -11768,7 +11768,7 @@ spec:
                   serveDeploymentStatuses:
                     items:
                       description: ServeDeploymentStatus defines the current state
-                        of Serve Deployment
+                        of a Serve deployment
                       properties:
                         healthLastUpdateTime:
                           description: Keep track of how long the service is healthy.
@@ -11781,7 +11781,7 @@ spec:
                           type: string
                         name:
                           description: Name, Status, Message are from Ray Dashboard
-                            to represent the state of a serve deployment.
+                            and represent a Serve deployment's state.
                           type: string
                         status:
                           description: 'TODO: change status type to enum'
@@ -11875,7 +11875,7 @@ spec:
                   serveDeploymentStatuses:
                     items:
                       description: ServeDeploymentStatus defines the current state
-                        of Serve Deployment
+                        of a Serve deployment
                       properties:
                         healthLastUpdateTime:
                           description: Keep track of how long the service is healthy.
@@ -11888,7 +11888,7 @@ spec:
                           type: string
                         name:
                           description: Name, Status, Message are from Ray Dashboard
-                            to represent the state of a serve deployment.
+                            and represent a Serve deployment's state.
                           type: string
                         status:
                           description: 'TODO: change status type to enum'

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -813,7 +813,7 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 
 	r.updateAndCheckDashboardStatus(rayServiceStatus, true, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold)
 
-	logger.Info("Check serve health", "isHealthy", isHealthy, "isActive", isActive)
+	logger.Info("Check serve health", "isHealthy", isHealthy, "isReady", isReady, "isActive", isActive)
 
 	if isHealthy && isReady {
 		rayServiceInstance.Status.ServiceStatus = rayv1alpha1.Running

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -639,23 +639,6 @@ func (r *RayServiceReconciler) getAndCheckServeStatus(dashboardClient utils.RayD
 	return isHealthy, isReady, nil
 }
 
-func (r *RayServiceReconciler) allServeDeploymentsHealthy(rayServiceInstance *rayv1alpha1.RayService, rayServiceStatus *rayv1alpha1.RayServiceStatus) bool {
-	// Check if the serve deployment number is correct.
-	r.Log.V(1).Info("allServeDeploymentsHealthy", "rayServiceInstance.Status.ServeStatuses", rayServiceStatus.ServeStatuses)
-	if len(rayServiceStatus.ServeStatuses) == 0 {
-		return false
-	}
-
-	// Check if all the service deployments are healthy.
-	for _, status := range rayServiceStatus.ServeStatuses {
-		if status.Status != rayv1alpha1.DeploymentStatusEnum.HEALTHY {
-			return false
-		}
-	}
-
-	return true
-}
-
 func (r *RayServiceReconciler) generateConfigKey(rayServiceInstance *rayv1alpha1.RayService, clusterName string) string {
 	return r.generateConfigKeyPrefix(rayServiceInstance) + clusterName
 }

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -649,6 +649,8 @@ func (r *RayServiceReconciler) updateRayClusterInfo(rayServiceInstance *rayv1alp
 // TODO: When start Ingress in RayService, we can disable the Ingress from RayCluster.
 func (r *RayServiceReconciler) reconcileIngress(ctx context.Context, rayServiceInstance *rayv1alpha1.RayService, rayClusterInstance *rayv1alpha1.RayCluster) error {
 	if rayClusterInstance.Spec.HeadGroupSpec.EnableIngress == nil || !*rayClusterInstance.Spec.HeadGroupSpec.EnableIngress {
+		r.Log.Info("Ingress is disabled. Skipping ingress reconcilation. " +
+			"You can enable Ingress by setting enableIngress to true in HeadGroupSpec.")
 		return nil
 	}
 

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -139,7 +139,7 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	} else if activeRayClusterInstance != nil && pendingRayClusterInstance != nil {
 		logger.Info("Reconciling the Serve component. Active and pending Ray clusters exist.")
 		if err = r.updateStatusForActiveCluster(ctx, rayServiceInstance, activeRayClusterInstance, logger); err != nil {
-			logger.Error(err, "Active Ray cluster's status update failed.")
+			logger.Error(err, "Failed to update active Ray cluster's status.")
 		}
 
 		if ctrlResult, isHealthy, err = r.reconcileServe(ctx, rayServiceInstance, pendingRayClusterInstance, false, logger); err != nil {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -580,7 +580,7 @@ func (r *RayServiceReconciler) allServeDeploymentsHealthy(rayServiceInstance *ra
 
 	// Check if all the service deployments are healthy.
 	for _, status := range rayServiceStatus.ServeStatuses {
-		if status.Status != "HEALTHY" {
+		if status.Status != rayv1alpha1.DeploymentStatus.HEALTHY {
 			return false
 		}
 	}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -533,10 +533,10 @@ func (r *RayServiceReconciler) getAndCheckServeStatus(dashboardClient utils.RayD
 	for i := 0; i < len(serveStatuses.DeploymentStatuses); i++ {
 		serveStatuses.DeploymentStatuses[i].LastUpdateTime = &timeNow
 		serveStatuses.DeploymentStatuses[i].HealthLastUpdateTime = &timeNow
-		if serveStatuses.DeploymentStatuses[i].Status != "HEALTHY" {
+		if serveStatuses.DeploymentStatuses[i].Status != rayv1alpha1.DeploymentStatus.HEALTHY {
 			prevStatus, exist := statusMap[serveStatuses.DeploymentStatuses[i].Name]
 			if exist {
-				if prevStatus.Status != "HEALTHY" {
+				if prevStatus.Status != rayv1alpha1.DeploymentStatus.HEALTHY {
 					serveStatuses.DeploymentStatuses[i].HealthLastUpdateTime = prevStatus.HealthLastUpdateTime
 
 					if prevStatus.HealthLastUpdateTime != nil && time.Since(prevStatus.HealthLastUpdateTime.Time).Seconds() > serviceUnhealthySecondThreshold {
@@ -547,16 +547,18 @@ func (r *RayServiceReconciler) getAndCheckServeStatus(dashboardClient utils.RayD
 		}
 	}
 
-	// Check app status.
+	// Check app status
 	serveStatuses.ApplicationStatus.LastUpdateTime = &timeNow
 	serveStatuses.ApplicationStatus.HealthLastUpdateTime = &timeNow
-	if serveStatuses.ApplicationStatus.Status != "HEALTHY" {
-		// Check previously app status.
-		if rayServiceServeStatus.ApplicationStatus.Status != "HEALTHY" {
-			serveStatuses.ApplicationStatus.HealthLastUpdateTime = rayServiceServeStatus.ApplicationStatus.HealthLastUpdateTime
+	if serveStatuses.ApplicationStatus.Status != rayv1alpha1.ApplicationStatus.RUNNING {
+		// Check previous app status
+		if rayServiceServeStatus.ApplicationStatus.Status != rayv1alpha1.ApplicationStatus.RUNNING {
+			if rayServiceServeStatus.ApplicationStatus.HealthLastUpdateTime != nil {
+				serveStatuses.ApplicationStatus.HealthLastUpdateTime = rayServiceServeStatus.ApplicationStatus.HealthLastUpdateTime
 
-			if rayServiceServeStatus.ApplicationStatus.HealthLastUpdateTime != nil && time.Since(rayServiceServeStatus.ApplicationStatus.HealthLastUpdateTime.Time).Seconds() > serviceUnhealthySecondThreshold {
-				isHealthy = false
+				if time.Since(rayServiceServeStatus.ApplicationStatus.HealthLastUpdateTime.Time).Seconds() > serviceUnhealthySecondThreshold {
+					isHealthy = false
+				}
 			}
 		}
 	}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -548,10 +548,10 @@ func (r *RayServiceReconciler) getAndCheckServeStatus(dashboardClient utils.RayD
 	for i := 0; i < len(serveStatuses.DeploymentStatuses); i++ {
 		serveStatuses.DeploymentStatuses[i].LastUpdateTime = &timeNow
 		serveStatuses.DeploymentStatuses[i].HealthLastUpdateTime = &timeNow
-		if serveStatuses.DeploymentStatuses[i].Status != rayv1alpha1.DeploymentStatus.HEALTHY {
+		if serveStatuses.DeploymentStatuses[i].Status != rayv1alpha1.DeploymentStatusEnum.HEALTHY {
 			prevStatus, exist := statusMap[serveStatuses.DeploymentStatuses[i].Name]
 			if exist {
-				if prevStatus.Status != rayv1alpha1.DeploymentStatus.HEALTHY {
+				if prevStatus.Status != rayv1alpha1.DeploymentStatusEnum.HEALTHY {
 					serveStatuses.DeploymentStatuses[i].HealthLastUpdateTime = prevStatus.HealthLastUpdateTime
 
 					if prevStatus.HealthLastUpdateTime != nil && time.Since(prevStatus.HealthLastUpdateTime.Time).Seconds() > serviceUnhealthySecondThreshold {
@@ -565,9 +565,9 @@ func (r *RayServiceReconciler) getAndCheckServeStatus(dashboardClient utils.RayD
 	// Check app status
 	serveStatuses.ApplicationStatus.LastUpdateTime = &timeNow
 	serveStatuses.ApplicationStatus.HealthLastUpdateTime = &timeNow
-	if serveStatuses.ApplicationStatus.Status != rayv1alpha1.ApplicationStatus.RUNNING {
+	if serveStatuses.ApplicationStatus.Status != rayv1alpha1.ApplicationStatusEnum.RUNNING {
 		// Check previous app status
-		if rayServiceServeStatus.ApplicationStatus.Status != rayv1alpha1.ApplicationStatus.RUNNING {
+		if rayServiceServeStatus.ApplicationStatus.Status != rayv1alpha1.ApplicationStatusEnum.RUNNING {
 			if rayServiceServeStatus.ApplicationStatus.HealthLastUpdateTime != nil {
 				serveStatuses.ApplicationStatus.HealthLastUpdateTime = rayServiceServeStatus.ApplicationStatus.HealthLastUpdateTime
 
@@ -597,7 +597,7 @@ func (r *RayServiceReconciler) allServeDeploymentsHealthy(rayServiceInstance *ra
 
 	// Check if all the service deployments are healthy.
 	for _, status := range rayServiceStatus.ServeStatuses {
-		if status.Status != rayv1alpha1.DeploymentStatus.HEALTHY {
+		if status.Status != rayv1alpha1.DeploymentStatusEnum.HEALTHY {
 			return false
 		}
 	}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -567,9 +567,9 @@ func (r *RayServiceReconciler) getAndCheckServeStatus(dashboardClient utils.RayD
 					isHealthy = false
 				}
 			}
-		} else {
-			isReady = true
 		}
+	} else {
+		isReady = true
 	}
 
 	rayServiceServeStatus.ServeStatuses = serveStatuses.DeploymentStatuses

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -518,7 +518,7 @@ func (r *RayServiceReconciler) getAndCheckServeStatus(dashboardClient utils.RayD
 	var serveStatuses *utils.ServeDeploymentStatuses
 	var err error
 	if serveStatuses, err = dashboardClient.GetDeploymentsStatus(); err != nil {
-		r.Log.Error(err, "fail to get deployment status")
+		r.Log.Error(err, "Failed to get Serve deployment statuses from dashboard!")
 		return false, err
 	}
 

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -865,9 +865,11 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 		r.updateRayClusterInfo(rayServiceInstance, rayClusterInstance.Name)
 		r.Recorder.Event(rayServiceInstance, "Normal", "Running", "The Serve applicaton is now running and healthy.")
 	} else if isHealthy && !isReady {
-		if err := r.updateState(ctx, rayServiceInstance, rayv1alpha1.WaitForServeDeploymentReady, err); err != nil {
+		rayServiceInstance.Status.ServiceStatus = rayv1alpha1.WaitForServeDeploymentReady
+		if err := r.Status().Update(ctx, rayServiceInstance); err != nil {
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, true, false, err
 		}
+		logger.Info("Mark cluster as waiting for Serve deployments", "rayCluster", rayClusterInstance)
 	} else if !isHealthy {
 		// NOTE: When isHealthy is false, isReady is guaranteed to be false.
 		r.markRestart(rayServiceInstance)

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -165,11 +165,19 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 		return ctrl.Result{RequeueAfter: ServiceRestartRequeueDuration}, nil
 	}
 
-	logger.Info("Reconciling the ingress and service resources.")
 	// Get the healthy ray cluster instance for service and ingress update.
-	rayClusterInstance := activeRayClusterInstance
+	var rayClusterInstance *rayv1alpha1.RayCluster
 	if pendingRayClusterInstance != nil {
 		rayClusterInstance = pendingRayClusterInstance
+		logger.Info("Reconciling the ingress and service resources " +
+			"on the pending Ray cluster.")
+	} else if activeRayClusterInstance != nil {
+		rayClusterInstance = activeRayClusterInstance
+		logger.Info("Reconciling the ingress and service resources " +
+			"on the active Ray cluster. No pending Ray cluster found.")
+	} else {
+		rayClusterInstance = nil
+		logger.Info("No Ray cluster found. Skipping ingress and service reconciliation.")
 	}
 
 	if rayClusterInstance != nil {

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -315,7 +315,7 @@ var _ = Context("Inside the default namespace", func() {
 
 		It("should detect unhealthy status and try to switch to new RayCluster.", func() {
 			// Set a wrong serve status with unhealthy.
-			orignialServeDeploymentUnhealthySecondThreshold := ServiceUnhealthySecondThreshold
+			orignalServeDeploymentUnhealthySecondThreshold := ServiceUnhealthySecondThreshold
 			ServiceUnhealthySecondThreshold = 5
 			fakeRayDashboardClient.SetServeStatus(generateServeStatus(metav1.NewTime(time.Now().Add(time.Duration(-5)*time.Minute)), "UNHEALTHY"))
 
@@ -323,7 +323,7 @@ var _ = Context("Inside the default namespace", func() {
 				getPreparingRayClusterNameFunc(ctx, myRayService),
 				time.Second*60, time.Millisecond*500).Should(Not(BeEmpty()), "My new RayCluster name  = %v", myRayService.Status.PendingServiceStatus.RayClusterName)
 
-			ServiceUnhealthySecondThreshold = orignialServeDeploymentUnhealthySecondThreshold
+			ServiceUnhealthySecondThreshold = orignalServeDeploymentUnhealthySecondThreshold
 			pendingRayClusterName := myRayService.Status.PendingServiceStatus.RayClusterName
 			fakeRayDashboardClient.SetServeStatus(generateServeStatus(metav1.Now(), "HEALTHY"))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The `RayService` operator checks whether a pending `RayCluster`'s [Serve application is `"HEALTHY"`](https://github.com/ray-project/kuberay/blob/850fd486207294b97e143961b752d6c5ce7c0fa2/ray-operator/controllers/ray/rayservice_controller.go#L553) before it sets it as the active cluster. There's a few issues with this approach:

1. `"HEALTHY"` is not a valid [Serve `ApplicationStatus`](https://github.com/ray-project/ray/blob/65d0c0aa48be8f9f7faae857d3ab71444997755a/python/ray/serve/_private/common.py#L31-L35).
2. A Serve application can be healthy but not ready (e.g. if it's `NOT_STARTED` or still `DEPLOYING`). If the cluster switchover happens before the app is ready, incoming traffic is briefly dropped until the Serve app becomes ready.

This change updates `getAndCheckServeStatus` to track whether the Serve app `isHealthy` _and_ `isReady`. With this change, the cluster switchover only happens when the Serve app is both healthy and ready. It only initiates a cluster restart if the application is unhealthy (not if it's unready).

This change also makes the `RayService` operator delete dangling `RayClusters` after a 60 second grace period, instead of immediately. That gives the ingress enough time to switch traffic to the new cluster without any downtime.

**Uptime Impact**

This change's impact was measured with a Serve app that deploys a single deployment with two replicas. Each deployment replica sleeps for 15 seconds before becoming healthy. See [this gist](https://gist.github.com/shrekris-anyscale/9131cee8e454a7f35b2ae24de99192d7) for the code and config.

The Serve app was tested on GKE with[ a Locust workload](https://gist.github.com/shrekris-anyscale/af323b7beadfcb10392c9886494294e3) that reopened connections for each request. It created 100 users with a spawn rate of 50 users/second.

Without the change, there were distinct periods of downtime where all requests failed since the cluster switchover happened before the Serve app was ready.

<img width="352" alt="failures" src="https://user-images.githubusercontent.com/92341594/203455074-c7094d22-2d88-4c78-9b8c-e7d8ac07de9d.png">

<img width="1381" alt="Screen Shot 2022-11-22 at 5 50 44 PM" src="https://user-images.githubusercontent.com/92341594/203455019-186c87b5-b770-45d4-9f07-75fff96672a5.png">

With the change, there were no failures after two `RayCluster` config updates:

<img width="366" alt="zero_downtime" src="https://user-images.githubusercontent.com/92341594/203454274-1874d4e8-84be-4d62-a441-2b79c0167e55.png">

<img width="886" alt="Screen Shot 2022-11-22 at 5 43 51 PM" src="https://user-images.githubusercontent.com/92341594/203454354-2ab017a8-4074-4928-97d3-1333894cf0da.png">


**Follow-up Changes**

Kubernetes provides liveness and readiness probes to control which pods can serve traffic. Ideally, this status checking logic should be pushed into the probes, so if `HTTPProxies` temporarily crash, their pods can temporarily stop serving traffic. However, the `RayService` operator relies on the liveness and readiness probes to check if the `RayCluster` is ready to accept Serve deployments. This should be refactored, so the `RayService`'s probes can track Serve application-level behavior.

## Related issue number

<!-- For example: "Closes #1234" -->

Addresses #667

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [X] Unit tests
     - This change adds a unit test for zero-downtime deployments.
