### PR TITLE
[Bug][apiserver] fix apiserver create rayservice missing serve port

### DIFF
--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -135,6 +135,7 @@ func buildHeadPodTemplate(imageVersion string, envs map[string]string, spec *api
 						},
 					},
 					// Customization is not allowed here. We should consider whether to make this part smart.
+					// For now we use serve 8000 port for rayservice and added at util/service.go, do not use the 8000 port here for other propose.
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "redis",

--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -135,7 +135,7 @@ func buildHeadPodTemplate(imageVersion string, envs map[string]string, spec *api
 						},
 					},
 					// Customization is not allowed here. We should consider whether to make this part smart.
-					// For now we use serve 8000 port for rayservice and added at util/service.go, do not use the 8000 port here for other propose.
+					// For now we use serve 8000 port for rayservice and added at util/service.go, do not use the 8000 port here for other purpose.
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "redis",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The rayservice need indicate the serve port for exposing the ray serve service, in the default raycluster template we are missing the serve port, here we need add it at the service part.

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
