### PR TITLE
[Feature] [RayJobs] Use finalizers to implement stopping a job upon cluster deletion

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -11656,7 +11656,7 @@ spec:
                   of cluster Important: Run "make" to regenerat'
                 type: string
               jobStatus:
-                description: JobStatus is the Ray Job Status. https://docs.ray.io/en/latest/cluster/jobs-package-ref.
+                description: JobStatus is the Ray Job Status.
                 type: string
               message:
                 type: string

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -7,7 +7,8 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// JobStatus is the Ray Job Status. https://docs.ray.io/en/latest/cluster/jobs-package-ref.html#jobstatus
+// JobStatus is the Ray Job Status.
+// https://docs.ray.io/en/latest/cluster/running-applications/job-submission/jobs-package-ref.html#jobstatus
 type JobStatus string
 
 const (
@@ -17,6 +18,15 @@ const (
 	JobStatusSucceeded JobStatus = "SUCCEEDED"
 	JobStatusFailed    JobStatus = "FAILED"
 )
+
+// This function should be synchronized with the function `is_terminal()` in Ray Job.
+func IsJobTerminal(status JobStatus) bool {
+	terminalStatusSet := map[JobStatus]struct{}{
+		JobStatusStopped: {}, JobStatusSucceeded: {}, JobStatusFailed: {},
+	}
+	_, ok := terminalStatusSet[status]
+	return ok
+}
 
 // JobDeploymentStatus indicates RayJob status including RayCluster lifecycle management and Job submission
 type JobDeploymentStatus string

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -8,9 +8,9 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // JobStatus is the Ray Job Status.
-// https://docs.ray.io/en/latest/cluster/running-applications/job-submission/jobs-package-ref.html#jobstatus
 type JobStatus string
 
+// https://docs.ray.io/en/latest/cluster/running-applications/job-submission/jobs-package-ref.html#jobstatus
 const (
 	JobStatusPending   JobStatus = "PENDING"
 	JobStatusRunning   JobStatus = "RUNNING"

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -11656,7 +11656,7 @@ spec:
                   of cluster Important: Run "make" to regenerat'
                 type: string
               jobStatus:
-                description: JobStatus is the Ray Job Status. https://docs.ray.io/en/latest/cluster/jobs-package-ref.
+                description: JobStatus is the Ray Job Status.
                 type: string
               message:
                 type: string

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -103,6 +103,9 @@ const (
 
 	// Default autoscaler image when running Ray at versions older than 2.0.0
 	FallbackDefaultAutoscalerImage = "rayproject/ray:2.0.0"
+
+	// Finalizers for RayJob
+	RayJobStopJobFinalizer = "ray.io/rayjob-stopjob-finalizer"
 )
 
 type ServiceType string

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -105,7 +105,7 @@ const (
 	FallbackDefaultAutoscalerImage = "rayproject/ray:2.0.0"
 
 	// Finalizers for RayJob
-	RayJobStopJobFinalizer = "ray.io/rayjob-stopjob-finalizer"
+	RayJobStopJobFinalizer = "ray.io/rayjob-finalizer"
 )
 
 type ServiceType string

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
 	"k8s.io/client-go/tools/record"
 
 	"github.com/go-logr/logr"
@@ -16,8 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,6 +75,33 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	var rayJobInstance *rayv1alpha1.RayJob
 	if rayJobInstance, err = r.getRayJobInstance(ctx, request); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if rayJobInstance.ObjectMeta.DeletionTimestamp.IsZero() {
+		// The object is not being deleted, so if it does not have our finalizer,
+		// then lets add the finalizer and update the object.
+		if !controllerutil.ContainsFinalizer(rayJobInstance, common.RayJobStopJobFinalizer) {
+			r.Log.Info("Add a finalizer", "finalizer", common.RayJobStopJobFinalizer)
+			controllerutil.AddFinalizer(rayJobInstance, common.RayJobStopJobFinalizer)
+			if err := r.Update(ctx, rayJobInstance); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	} else {
+		r.Log.Info("RayJob is being deleted", "DeletionTimestamp", rayJobInstance.ObjectMeta.DeletionTimestamp)
+		if isJobPendingOrRunning(rayJobInstance.Status.JobStatus) {
+			rayDashboardClient := utils.GetRayDashboardClientFunc()
+			rayDashboardClient.InitClient(rayJobInstance.Status.DashboardURL)
+			err := rayDashboardClient.StopJob(rayJobInstance.Status.JobId, &r.Log)
+			if err != nil {
+				r.Log.Info("Failed to stop job", "error", err)
+			}
+		}
+
+		r.Log.Info("Remove the finalizer no matter StopJob() succeeds or not.", "finalizer", common.RayJobStopJobFinalizer)
+		controllerutil.RemoveFinalizer(rayJobInstance, common.RayJobStopJobFinalizer)
+		err := r.Update(context.TODO(), rayJobInstance)
+		return ctrl.Result{}, err
 	}
 
 	// Do not reconcile the RayJob if the deployment status is marked as Complete
@@ -238,18 +264,12 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 
 // isJobSucceedOrFailed indicates whether the job comes into end status.
 func isJobSucceedOrFailed(status rayv1alpha1.JobStatus) bool {
-	if status == rayv1alpha1.JobStatusSucceeded || status == rayv1alpha1.JobStatusFailed {
-		return true
-	}
-	return false
+	return (status == rayv1alpha1.JobStatusSucceeded) || (status == rayv1alpha1.JobStatusFailed)
 }
 
 // isJobPendingOrRunning indicates whether the job is running.
 func isJobPendingOrRunning(status rayv1alpha1.JobStatus) bool {
-	if status == rayv1alpha1.JobStatusPending || status == rayv1alpha1.JobStatusRunning {
-		return true
-	}
-	return false
+	return (status == rayv1alpha1.JobStatusPending) || (status == rayv1alpha1.JobStatusRunning)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -258,37 +278,7 @@ func (r *RayJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&rayv1alpha1.RayJob{}).
 		Owns(&rayv1alpha1.RayCluster{}).
 		Owns(&corev1.Service{}).
-		WithEventFilter(predicate.Funcs{
-			DeleteFunc: r.DeleteEventFilter,
-		}).
 		Complete(r)
-}
-
-func (r *RayJobReconciler) DeleteEventFilter(e event.DeleteEvent) bool {
-	r.Log.Info("event to delete", "event", e)
-
-	job, ok := e.Object.(*rayv1alpha1.RayJob)
-	if !ok {
-		r.Log.Info("failed to get job object from event", "event", e)
-		return false
-	}
-
-	if job.Status.JobStatus == rayv1alpha1.JobStatusRunning || job.Status.JobStatus == rayv1alpha1.JobStatusPending {
-		if job.Status.DashboardURL == "" || job.Status.JobId == "" {
-			r.Log.Info("dashboardURL or job_id is empty", "job", job)
-			return false
-		}
-		rayDashboardClient := utils.GetRayDashboardClientFunc()
-		rayDashboardClient.InitClient(job.Status.DashboardURL)
-		err := rayDashboardClient.StopJob(job.Status.JobId, &r.Log)
-		if err != nil {
-			r.Log.Info("failed to stop job", "error", err)
-		}
-	}
-	// The reconciler adds a finalizer so we perform clean-up
-	// when the delete timestamp is added
-	// Suppress Delete events to avoid filtering them out in the Reconcile function
-	return false
 }
 
 func (r *RayJobReconciler) getRayJobInstance(ctx context.Context, request ctrl.Request) (*rayv1alpha1.RayJob, error) {

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -405,7 +405,14 @@ func (r *RayDashboardClient) StopJob(jobName string, log *logr.Logger) (err erro
 	}
 
 	if !jobStopResp.Stopped {
-		return fmt.Errorf("failed to stopped job: %v", jobName)
+		jobInfo, err := r.GetJobInfo(jobName)
+		if err != nil {
+			return err
+		}
+		// StopJob only returns an error when JobStatus is not in terminated states (STOPPED / SUCCEEDED / FAILED)
+		if (jobInfo.JobStatus == rayv1alpha1.JobStatusPending) || (jobInfo.JobStatus == rayv1alpha1.JobStatusRunning) {
+			return fmt.Errorf("Failed to stopped job: %v", jobInfo)
+		}
 	}
 	return nil
 }

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -409,8 +409,8 @@ func (r *RayDashboardClient) StopJob(jobName string, log *logr.Logger) (err erro
 		if err != nil {
 			return err
 		}
-		// StopJob only returns an error when JobStatus is not in terminated states (STOPPED / SUCCEEDED / FAILED)
-		if (jobInfo.JobStatus == rayv1alpha1.JobStatusPending) || (jobInfo.JobStatus == rayv1alpha1.JobStatusRunning) {
+		// StopJob only returns an error when JobStatus is not in terminal states (STOPPED / SUCCEEDED / FAILED)
+		if !rayv1alpha1.IsJobTerminal(jobInfo.JobStatus) {
 			return fmt.Errorf("Failed to stopped job: %v", jobInfo)
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
See #629 to get more context. The behavior of this PR is almost the same as #629. The only difference is that this PR promises that operator will try to stop the job at least once. In #629, if the RayJob is deleted when the operator is down, the operator will not try to stop the job.

* Finalizer reference
  * https://book-v1.book.kubebuilder.io/beyond_basics/using_finalizers.html
  * https://book.kubebuilder.io/reference/using-finalizers.html

* Need to discuss
  * I decide to remove the finalizer no matter StopJob() succeeds or not. If the operator does not stop the job successfully, users can still stop them by Dashboard, RESTful API, .. etc. However, it is hard for most users to use the following command to remove RayJob.
    * `kubectl patch rayjobs.ray.io/rayjob-sample-2 --type json --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'`

## Related issue number
Closes #676 
#629 
<!-- For example: "Closes #1234" -->

## Checks
We should add tests for RayJob when the integration tests are stable enough. Use #664 to track the progress.

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(


## Manual tests
* Step1: Install KubeRay operator
* Step2: Install a RayCluster
  <details>
  <summary>YAML</summary>
  
  ```yaml
  # The resource requests and limits in this config are too small for production!
  # For examples with more realistic resource configuration, see
  # ray-cluster.complete.large.yaml and
  # ray-cluster.autoscaler.large.yaml.
  apiVersion: ray.io/v1alpha1
  kind: RayCluster
  metadata:
    labels:
      controller-tools.k8s.io: "1.0"
      # A unique identifier for the head node and workers of this cluster.
    name: raycluster-complete
  spec:
    rayVersion: '2.0.0'
    ######################headGroupSpec#################################
    # head group template and specs, (perhaps 'group' is not needed in the name)
    headGroupSpec:
      # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
      serviceType: ClusterIP
      # for the head group, replicas should always be 1.
      # headGroupSpec.replicas is deprecated in KubeRay >= 0.3.0.
      replicas: 1
      # the following params are used to complete the ray start: ray start --head --block --dashboard-host: '0.0.0.0' ...
      rayStartParams:
        dashboard-host: '0.0.0.0'
        block: 'true'
      #pod template
      template:
        metadata:
          labels:
            # custom labels. NOTE: do not define custom labels start with `raycluster.`, they may be used in controller.
            # Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
            rayCluster: raycluster-sample # will be injected if missing
            groupName: headgroup # will be injected if missing
          # annotations for pod
          annotations:
            key: value
        spec:
          containers:
          - name: ray-head
            image: rayproject/ray:2.0.0
            ports:
            - containerPort: 6379
              name: gcs
            - containerPort: 8265
              name: dashboard
            - containerPort: 10001
              name: client
            lifecycle:
              preStop:
                exec:
                  command: ["/bin/sh","-c","ray stop"]
            volumeMounts:
              - mountPath: /tmp/ray
                name: ray-logs
              - mountPath: /home/ray/samples
                name: code-sample
            resources:
              limits:
                cpu: "1"
                memory: "2G"
              requests:
                cpu: "500m"
                memory: "1G"
          volumes:
            - name: ray-logs
              emptyDir: {}
              # You set volumes at the Pod level, then mount them into containers inside that Pod
            - name: code-sample
              configMap:
                # Provide the name of the ConfigMap you want to mount.
                name: ray-job-code-sample
                # An array of keys from the ConfigMap to create as files
                items:
                  - key: sample_code.py
                    path: sample_code.py
    workerGroupSpecs:
    # the pod replicas in this group typed worker
    - replicas: 1
      minReplicas: 1
      maxReplicas: 10
      # logical group name, for this called large-group, also can be functional
      groupName: large-group
      # if worker pods need to be added, we can simply increment the replicas
      # if worker pods need to be removed, we decrement the replicas, and populate the podsToDelete list
      # the operator will remove pods from the list until the number of replicas is satisfied
      # when a pod is confirmed to be deleted, its name will be removed from the list below
      #scaleStrategy:
      #  workersToDelete:
      #  - raycluster-complete-worker-large-group-bdtwh
      #  - raycluster-complete-worker-large-group-hv457
      #  - raycluster-complete-worker-large-group-k8tj7 
      # the following params are used to complete the ray start: ray start --block
      rayStartParams:
        block: 'true'
      #pod template
      template:
        metadata:
          labels:
            rayCluster: raycluster-complete # will be injected if missing
            groupName: small-group # will be injected if missing
        spec:
          containers:
          - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
            image: rayproject/ray:2.0.0
            # environment variables to set in the container.Optional.
            # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
            lifecycle:
              preStop:
                exec:
                  command: ["/bin/sh","-c","ray stop"]
            # use volumeMounts.Optional.
            # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
            volumeMounts:
              - mountPath: /tmp/ray
                name: ray-logs
            resources:
              limits:
                cpu: "1"
                memory: "512Mi"
              requests:
                cpu: "500m"
                memory: "256Mi"
          initContainers:
          # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
          - name: init-myservice
            image: busybox:1.28
            # Change the cluster postfix if you don't have a default setting
            command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
          # use volumes
          # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
          volumes:
            - name: ray-logs
              emptyDir: {}
  ######################status#################################
  ---
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: ray-job-code-sample
  data:
    sample_code.py: |
      import ray
      import time
  
      @ray.remote
      class MyActor:
          def __init__(self):
              pass
  
          def func(self, v):
              return v
  
      seconds = 60
      actor = MyActor.remote()
  
      while seconds > 0:
          print(ray.get(actor.func.remote(seconds)))
          time.sleep(1)
  ```
  </details>

* Step3: Submit a RayJob with `clusterSelector`
  <details>
  <summary>YAML</summary>
  
  ```yaml
  apiVersion: ray.io/v1alpha1
  kind: RayJob
  metadata:
    name: rayjob-sample-2
  spec:
    entrypoint: python /home/ray/samples/sample_code.py
    clusterSelector:
      ray.io/cluster: "raycluster-complete"
  ```
  </details>

* Step4: Use Dashboard or curl command to check the job status. 
  * Example: `curl localhost:8265/api/jobs/rayjob-sample-2-j2hnn` ([RESTful API doc](https://github.com/ray-project/ray/blob/5fb36d4a7d400fdceacab5b1ff823c383c1bda85/doc/source/cluster/running-applications/job-submission/rest.rst))  

* Step5: Use `kubectl describe rayjobs.ray.io rayjob-sample-2` to check the finalizer "ray.io/rayjob-finalizer".
  <details>
  <summary>Example</summary>
  
  ```yaml
  Name:         rayjob-sample-2
  Namespace:    default
  Labels:       <none>
  Annotations:  <none>
  API Version:  ray.io/v1alpha1
  Kind:         RayJob
  Metadata:
    Creation Timestamp:  2022-11-17T22:55:10Z
    Finalizers:
      ray.io/rayjob-finalizer
  ```
  </details>

* Step6: Delete the RayJob `kubectl delete rayjobs.ray.io rayjob-sample-2`. The finalizer in Step5 will be removed by the operator. Hence, RayJob can be removed successfully.

* Step7: Check operator's log
  ```
  2022-11-22T19:13:53.929Z        INFO    controllers.RayJob      Add a finalizer {"finalizer": "ray.io/rayjob-finalizer"}
  .
  .
  .
  2022-11-22T19:18:54.568Z        INFO    controllers.RayJob      reconciling RayJob      {"NamespacedName": "default/rayjob-sample-2"}
  2022-11-22T19:18:54.568Z        INFO    controllers.RayJob      RayJob is being deleted {"DeletionTimestamp": "2022-11-22 19:18:54 +0000 UTC"}
  2022-11-22T19:18:54.568Z        INFO    controllers.RayJob      Stop a ray job  {"rayJob": "rayjob-sample-2-cn9vg"}
  2022-11-22T19:18:54.576Z        INFO    controllers.RayJob      Remove the finalizer no matter StopJob() succeeds or not.       {"finalizer": "ray.io/rayjob-finalizer"}

  ```

# Others (Feel free to ignore this part)
* Stop job with curl: `curl -X POST -H 'Content-Type: application/json' localhost:8265/api/jobs/02000000/stop`
* If we stop a job with `STOPPED` status, `{"stopped": false}` will be returned.
