### PR TITLE
[Autoscaler] Pass pod name to autoscaler, add pod patch permission

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -395,6 +395,14 @@ func BuildAutoscalerContainer(autoscalerImage string) v1.Container {
 					},
 				},
 			},
+			{
+				Name: "RAY_HEAD_POD_NAME",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: "metadata.name",
+					},
+				},
+			},
 		},
 		Command: []string{
 			"ray",

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -212,6 +212,14 @@ var autoscalerContainer = v1.Container{
 				},
 			},
 		},
+		{
+			Name: "RAY_HEAD_POD_NAME",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
 	},
 	Command: []string{
 		"ray",

--- a/ray-operator/controllers/ray/common/rbac.go
+++ b/ray-operator/controllers/ray/common/rbac.go
@@ -41,7 +41,7 @@ func BuildRole(cluster *v1alpha1.RayCluster) (*rbacv1.Role, error) {
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     []string{"get", "list", "watch", "patch"},
 			},
 			{
 				APIGroups: []string{"ray.io"},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

I'd like to give the autoscaler
- The name of the pod it's running in, via an env variable
- Permission to patch the head pod

The goal is to enable more efficient "list pods" API calls in the autoscaler. Currently each autoscaler lists without specifying a resource version, which is [taxing on etcd](https://kubernetes.io/docs/reference/using-api/api-concepts/#the-resourceversion-parameter), especially if there are many Ray clusters in the K8s cluster.

We would like to specify a reasonably fresh pods resource version in the API call.
To that end, we will have the autoscaler patch the head pod's annotations.
The resource version carried in the response is the version at which the pod was modified, so it should be fresh enough.
After the autoscaler patches the head pod, it can read the resourceVersion in the response and use that in the list query.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [X] Manual tests: I did some benchmarking to confirm that the proposed changes improve autoscaling performance under load (many RayClusters, many pods).
