### PR TITLE
[Helm] Clean up RayCluster Helm chart ahead of KubeRay 0.4.0 release

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -34,8 +34,6 @@ spec:
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             resources: {{- toYaml .Values.head.resources | nindent 14 }}
             env:
-              - name: TYPE
-                value: head
             {{- toYaml .Values.head.containerEnv | nindent 14}}
             {{- with .Values.head.envFrom }}
             envFrom: {{- toYaml . | nindent 14}}
@@ -57,8 +55,6 @@ spec:
       metadata:
         annotations: {{- toYaml .Values.head.annotations | nindent 10 }}
         labels:
-          groupName: {{ .Values.head.groupName }}
-          rayCluster: {{ include "ray-cluster.fullname" . }}
 {{ include "ray-cluster.labels" . | indent 10 }}
 
   workerGroupSpecs:
@@ -86,8 +82,6 @@ spec:
             imagePullPolicy: {{ $.Values.image.pullPolicy }}
             resources: {{- toYaml $values.resources | nindent 14 }}
             env:
-              - name: TYPE
-                value: worker
             {{- toYaml $values.containerEnv | nindent 14}}
             {{- with $values.envFrom }}
             envFrom: {{- toYaml $ | nindent 14}}
@@ -107,8 +101,6 @@ spec:
       metadata:
         annotations: {{- toYaml $values.annotations | nindent 10 }}
         labels:
-          groupName: {{ $groupName }}
-          rayCluster: {{ include "ray-cluster.fullname" $ }}
 {{ include "ray-cluster.labels" $ | indent 10 }}
   {{- end }}
   {{- end }}
@@ -135,8 +127,6 @@ spec:
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             resources: {{- toYaml .Values.worker.resources | nindent 14 }}
             env:
-              - name: TYPE
-                value: worker
             {{- toYaml .Values.worker.containerEnv | nindent 14}}
             {{- with .Values.worker.envFrom }}
             envFrom: {{- toYaml . | nindent 14}}
@@ -156,8 +146,6 @@ spec:
       metadata:
         annotations: {{- toYaml .Values.worker.annotations | nindent 10 }}
         labels:
-          groupName: {{ .Values.worker.groupName }}
-          rayCluster: {{ include "ray-cluster.fullname" . }}
 {{ include "ray-cluster.labels" . | indent 10 }}
   {{- end }}
 

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -23,7 +23,6 @@ spec:
     {{- range $key, $val := .Values.head.initArgs }}
       {{ $key }}: {{ $val | quote }}
     {{- end }}
-    replicas: {{ .Values.head.replicas }}
     template:
       spec:
         imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -20,6 +20,12 @@ spec:
   headGroupSpec:
     serviceType: {{ .Values.service.type }}
     rayStartParams:
+    {{- range $key, $val := .Values.head.rayStartParams }}
+      {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- /*
+    initArgs is a deprecated alias for rayStartParams.
+    */}}
     {{- range $key, $val := .Values.head.initArgs }}
       {{ $key }}: {{ $val | quote }}
     {{- end }}
@@ -60,6 +66,12 @@ spec:
   {{- range $groupName, $values := .Values.additionalWorkerGroups }}
   {{- if ne $values.disabled true }}
   - rayStartParams:
+    {{- range $key, $val := $values.rayStartParams }}
+      {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- /*
+    initArgs is a deprecated alias for rayStartParams.
+    */}}
     {{- range $key, $val := $values.initArgs }}
       {{ $key }}: {{ $val | quote }}
     {{- end }}
@@ -105,6 +117,12 @@ spec:
   {{- end }}
   {{- if ne (.Values.worker.disabled | default false) true }}
   - rayStartParams:
+    {{- range $key, $val := .Values.worker.rayStartParams }}
+      {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    {{- /*
+    initArgs is a deprecated alias for rayStartParams.
+    */}}
     {{- range $key, $val := .Values.worker.initArgs }}
       {{ $key }}: {{ $val | quote }}
     {{- end }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -36,7 +36,7 @@ head:
     #   requests:
     #     cpu: "500m"
     #     memory: "512Mi"
-  #labels:
+  # labels:
   # key: value
   rayStartParams:
     dashboard-host: '0.0.0.0'
@@ -44,7 +44,7 @@ head:
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
   containerEnv: []
-  #- name: EXAMPLE_ENV
+  # - name: EXAMPLE_ENV
   #   value: "1"
   envFrom: []
     # - secretRef:
@@ -82,7 +82,7 @@ worker:
   groupName: workergroup
   replicas: 1
   type: worker
-  #labels:
+  # labels:
   # key: value
   rayStartParams:
     block: 'true'
@@ -90,7 +90,7 @@ worker:
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
   containerEnv: []
-  #- name: EXAMPLE_ENV
+  # - name: EXAMPLE_ENV
   #   value: "1"
   envFrom: []
     # - secretRef:
@@ -139,7 +139,7 @@ additionalWorkerGroups:
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
     containerEnv: []
-      #- name: EXAMPLE_ENV
+      # - name: EXAMPLE_ENV
       #   value: "1"
     envFrom: []
         # - secretRef:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -38,7 +38,7 @@ head:
     #     memory: "512Mi"
   #labels:
   # key: value
-  initArgs:
+  rayStartParams:
     dashboard-host: '0.0.0.0'
     block: 'true'
   # containerEnv specifies environment variables for the Ray container,
@@ -82,7 +82,7 @@ worker:
   type: worker
   #labels:
   # key: value
-  initArgs:
+  rayStartParams:
     block: 'true'
   initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
   # containerEnv specifies environment variables for the Ray container,
@@ -132,7 +132,7 @@ additionalWorkerGroups:
     maxReplicas: 3
     type: worker
     labels: {}
-    initArgs:
+    rayStartParams:
       block: 'true'
     initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
   # containerEnv specifies environment variables for the Ray container,

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -37,7 +37,7 @@ head:
     #     cpu: "500m"
     #     memory: "512Mi"
   # labels:
-  # key: value
+  #   key: value
   rayStartParams:
     dashboard-host: '0.0.0.0'
     block: 'true'

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# The KubeRay community welcomes PRs to expose additional configuration
+# in this Helm chart.
+
 image:
   repository: rayproject/ray
   tag: 2.0.0
@@ -33,25 +36,25 @@ head:
     #   requests:
     #     cpu: "500m"
     #     memory: "512Mi"
+  # replicas for the head is deprecated. There is always 1 Ray head pod.
   replicas: 1
-  type: head
-  labels:
-    key: value
+  #labels:
+  # key: value
   initArgs:
-    port: '6379'
-    redis-password: 'LetMeInRay'  # Deprecated since Ray 1.11 due to GCS bootstrapping enabled
     dashboard-host: '0.0.0.0'
-    num-cpus: '1'  # can be auto-completed from the limits
-    node-ip-address: $MY_POD_IP  # auto-completed as the head pod IP
     block: 'true'
-  containerEnv:
-    - name: MY_POD_IP
-      valueFrom:
-        fieldRef:
-          fieldPath: status.podIP
+  # containerEnv specifies environment variables for the Ray container,
+  # Follows standard K8s container env schema.
+  containerEnv: []
+  #- name: EXAMPLE_ENV
+  #   value: "1"
   envFrom: []
     # - secretRef:
     #     name: my-env-secret
+  # resource requests and limits for the Ray head container.
+  # Modify as needed for your application.
+  # Note that the resources in this example are much too small for production.
+  # Ray pods should be sized to take up entire K8s nodes when possible.
   resources:
     limits:
       cpu: 1
@@ -67,6 +70,8 @@ head:
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
+  # sidecarContainers specifies additional containers to attach to the Ray pod.
+  # Follows standard K8s container spec.
   sidecarContainers: []
 
 
@@ -77,35 +82,26 @@ worker:
   groupName: workergroup
   replicas: 1
   type: worker
-  labels:
-    key: value
+  #labels:
+  # key: value
   initArgs:
-    node-ip-address: $MY_POD_IP
-    redis-password: LetMeInRay
     block: 'true'
   initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
-  containerEnv:
-    - name: MY_POD_IP
-      valueFrom:
-        fieldRef:
-          fieldPath: status.podIP
-    - name: RAY_DISABLE_DOCKER_CPU_WARNING
-      value: "1"
-    - name: CPU_REQUEST
-      valueFrom:
-        resourceFieldRef:
-          containerName: ray-worker
-          resource: requests.cpu
-    - name: MY_POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
+  # containerEnv specifies environment variables for the Ray container,
+  # Follows standard K8s container env schema.
+  containerEnv: []
+  #- name: EXAMPLE_ENV
+  #   value: "1"
   envFrom: []
     # - secretRef:
     #     name: my-env-secret
-  ports:
-    - containerPort: 80
-      protocol: TCP
+  # ports optionally allows specifying ports for the Ray container.
+  # ports are used to configure the Ray head service.
+  # ports: []
+  # resource requests and limits for the Ray head container.
+  # Modify as needed for your application.
+  # Note that the resources in this example are much too small for production.
+  # Ray pods should be sized to take up entire K8s nodes when possible.
   resources:
     limits:
       cpu: 1
@@ -122,6 +118,8 @@ worker:
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
+  # sidecarContainers specifies additional containers to attach to the Ray pod.
+  # Follows standard K8s container spec.
   sidecarContainers: []
 
 # The map's key is used as the groupName.
@@ -137,32 +135,23 @@ additionalWorkerGroups:
     type: worker
     labels: {}
     initArgs:
-      node-ip-address: $MY_POD_IP
-      redis-password: LetMeInRay
       block: 'true'
     initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
-    containerEnv:
-      - name: MY_POD_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      - name: RAY_DISABLE_DOCKER_CPU_WARNING
-        value: "1"
-      - name: CPU_REQUEST
-        valueFrom:
-          resourceFieldRef:
-            containerName: ray-worker
-            resource: requests.cpu
-      - name: MY_POD_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
+  # containerEnv specifies environment variables for the Ray container,
+  # Follows standard K8s container env schema.
+    containerEnv: []
+      #- name: EXAMPLE_ENV
+      #   value: "1"
     envFrom: []
-      # - secretRef:
-      #     name: my-env-secret
-    ports:
-      - containerPort: 80
-        protocol: TCP
+        # - secretRef:
+        #     name: my-env-secret
+    # ports optionally allows specifying ports for the Ray container.
+    # ports are used to configure the Ray head service.
+    # ports: []
+    # resource requests and limits for the Ray head container.
+    # Modify as needed for your application.
+    # Note that the resources in this example are much too small for production.
+    # Ray pods should be sized to take up entire K8s nodes when possible.
     resources:
       limits:
         cpu: 1
@@ -181,8 +170,5 @@ additionalWorkerGroups:
         name: log-volume
     sidecarContainers: []
 
-headServiceSuffix: "ray-operator.svc"
-
 service:
   type: ClusterIP
-  port: 8080

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -83,7 +83,7 @@ worker:
   replicas: 1
   type: worker
   # labels:
-  # key: value
+  #   key: value
   rayStartParams:
     block: 'true'
   initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -49,6 +49,8 @@ head:
   envFrom: []
     # - secretRef:
     #     name: my-env-secret
+  # ports optionally allows specifying ports for the Ray container.
+  # ports: []
   # resource requests and limits for the Ray head container.
   # Modify as needed for your application.
   # Note that the resources in this example are much too small for production.
@@ -94,7 +96,6 @@ worker:
     # - secretRef:
     #     name: my-env-secret
   # ports optionally allows specifying ports for the Ray container.
-  # ports are used to configure the Ray head service.
   # ports: []
   # resource requests and limits for the Ray head container.
   # Modify as needed for your application.
@@ -144,7 +145,6 @@ additionalWorkerGroups:
         # - secretRef:
         #     name: my-env-secret
     # ports optionally allows specifying ports for the Ray container.
-    # ports are used to configure the Ray head service.
     # ports: []
     # resource requests and limits for the Ray head container.
     # Modify as needed for your application.

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -36,8 +36,6 @@ head:
     #   requests:
     #     cpu: "500m"
     #     memory: "512Mi"
-  # replicas for the head is deprecated. There is always 1 Ray head pod.
-  replicas: 1
   #labels:
   # key: value
   initArgs:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR cleans up the ray-cluster Helm chart.

- Removes unnecessary and deprecated fields.
- Adds some comments
- Renames initArgs to rayStartParams in a backwards-compatible way.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/kuberay/issues/739

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests: I deployed a Ray cluster using the default chart.
   - [ ] This PR is not tested :(
