### PR TITLE
[Feature] Improve the observability of integration tests

### DIFF
--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "kuberay-operator.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: kuberay-operator
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -182,7 +182,7 @@ class RayFTTestCase(unittest.TestCase):
             raise Exception(f"Nonzero return code {rtn} in test_kill_head()")
 
     def test_ray_serve(self):
-        cluster_name_space = "default"
+        cluster_namespace = "default"
         docker_client = docker.from_env()
         container = docker_client.containers.run(ray_image, remove=True, detach=True, stdin_open=True, tty=True,
                                           network_mode='host', command=["/bin/sh"])
@@ -194,13 +194,13 @@ class RayFTTestCase(unittest.TestCase):
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_ray_serve_1.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
-            show_cluster_info(cluster_name_space)
+            show_cluster_info(cluster_namespace)
             raise Exception(f"There was an exception during the execution of test_ray_serve_1.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
         # KubeRay only allows at most 1 head pod per RayCluster instance at the same time. In addition,
         # if we have 0 head pods at this moment, it indicates that the head pod crashes unexpectedly.
-        headpods = utils.get_pod(namespace=cluster_name_space,
+        headpods = utils.get_pod(namespace=cluster_namespace,
             label_selector='ray.io/node-type=head')
         assert(len(headpods.items) == 1)
         old_head_pod = headpods.items[0]
@@ -211,18 +211,18 @@ class RayFTTestCase(unittest.TestCase):
         # will terminate.
         exec_command = ['pkill gcs_server']
         utils.pod_exec_command(pod_name=old_head_pod_name,
-            namespace=cluster_name_space, exec_command=exec_command)
+            namespace=cluster_namespace, exec_command=exec_command)
 
         # Waiting for all pods become ready and running.
         utils.wait_for_new_head(old_head_pod_name, restart_count,
-            cluster_name_space, timeout=300, retry_interval_ms=1000)
+            cluster_namespace, timeout=300, retry_interval_ms=1000)
 
         # Try to connect to the deployed model again
         utils.copy_to_container(container, 'tests/scripts', '/usr/local/', 'test_ray_serve_2.py')
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_ray_serve_2.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
-            show_cluster_info(cluster_name_space)
+            show_cluster_info(cluster_namespace)
             raise Exception(f"There was an exception during the execution of test_ray_serve_2.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
@@ -230,7 +230,7 @@ class RayFTTestCase(unittest.TestCase):
         docker_client.close()
 
     def test_detached_actor(self):
-        cluster_name_space = "default"
+        cluster_namespace = "default"
         docker_client = docker.from_env()
         container = docker_client.containers.run(ray_image, remove=True, detach=True, stdin_open=True, tty=True,
                                             network_mode='host', command=["/bin/sh"])
@@ -242,13 +242,13 @@ class RayFTTestCase(unittest.TestCase):
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_detached_actor_1.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
-            show_cluster_info(cluster_name_space)
+            show_cluster_info(cluster_namespace)
             raise Exception(f"There was an exception during the execution of test_detached_actor_1.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
         # KubeRay only allows at most 1 head pod per RayCluster instance at the same time. In addition,
         # if we have 0 head pods at this moment, it indicates that the head pod crashes unexpectedly.
-        headpods = utils.get_pod(namespace=cluster_name_space,
+        headpods = utils.get_pod(namespace=cluster_namespace,
             label_selector='ray.io/node-type=head')
         assert(len(headpods.items) == 1)
         old_head_pod = headpods.items[0]
@@ -259,11 +259,11 @@ class RayFTTestCase(unittest.TestCase):
         # will terminate.
         exec_command = ['pkill gcs_server']
         utils.pod_exec_command(pod_name=old_head_pod_name,
-            namespace=cluster_name_space, exec_command=exec_command)
+            namespace=cluster_namespace, exec_command=exec_command)
 
         # Waiting for all pods become ready and running.
         utils.wait_for_new_head(old_head_pod_name, restart_count,
-            cluster_name_space, timeout=300, retry_interval_ms=1000)
+            cluster_namespace, timeout=300, retry_interval_ms=1000)
 
         # Try to connect to the detached actor again.
         # [Note] When all pods become running and ready, the RayCluster still needs tens of seconds to relaunch actors. Hence,
@@ -272,7 +272,7 @@ class RayFTTestCase(unittest.TestCase):
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_detached_actor_2.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
-            show_cluster_info(cluster_name_space)
+            show_cluster_info(cluster_namespace)
             raise Exception(f"There was an exception during the execution of test_detached_actor_2.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -14,7 +14,8 @@ from framework.prototype import (
     K8S_CLUSTER_MANAGER,
     OperatorManager,
     RuleSet,
-    shell_subprocess_run
+    shell_subprocess_run,
+    show_cluster_info
 )
 
 logger = logging.getLogger(__name__)
@@ -177,13 +178,7 @@ class RayFTTestCase(unittest.TestCase):
         rtn = shell_subprocess_run(
                 'kubectl wait --for=condition=ready pod -l rayCluster=raycluster-compatibility-test --all --timeout=900s', check = False)
         if rtn != 0:
-            shell_subprocess_run('kubectl get pods -A')
-            shell_subprocess_run(
-                'kubectl describe pod $(kubectl get pods | grep -e "-head" | awk "{print \$1}")')
-            shell_subprocess_run(
-                'kubectl logs $(kubectl get pods | grep -e "-head" | awk "{print \$1}")')
-            shell_subprocess_run(
-                'kubectl logs -n $(kubectl get pods -A | grep -e "-operator" | awk \'{print $1 "  " $2}\')')
+            show_cluster_info("default")
         assert rtn == 0
 
     def test_ray_serve(self):
@@ -198,6 +193,7 @@ class RayFTTestCase(unittest.TestCase):
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_ray_serve_1.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
+            show_cluster_info("default")
             raise Exception(f"There was an exception during the execution of test_ray_serve_1.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
@@ -222,6 +218,7 @@ class RayFTTestCase(unittest.TestCase):
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_ray_serve_2.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
+            show_cluster_info("default")
             raise Exception(f"There was an exception during the execution of test_ray_serve_2.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
@@ -240,6 +237,7 @@ class RayFTTestCase(unittest.TestCase):
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_detached_actor_1.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
+            show_cluster_info("default")
             raise Exception(f"There was an exception during the execution of test_detached_actor_1.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
@@ -266,6 +264,7 @@ class RayFTTestCase(unittest.TestCase):
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_detached_actor_2.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
+            show_cluster_info("default")
             raise Exception(f"There was an exception during the execution of test_detached_actor_2.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -182,6 +182,7 @@ class RayFTTestCase(unittest.TestCase):
             raise Exception(f"Nonzero return code {rtn} in test_kill_head()")
 
     def test_ray_serve(self):
+        cluster_name_space = "default"
         docker_client = docker.from_env()
         container = docker_client.containers.run(ray_image, remove=True, detach=True, stdin_open=True, tty=True,
                                           network_mode='host', command=["/bin/sh"])
@@ -193,7 +194,7 @@ class RayFTTestCase(unittest.TestCase):
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_ray_serve_1.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
-            show_cluster_info("default")
+            show_cluster_info(cluster_name_space)
             raise Exception(f"There was an exception during the execution of test_ray_serve_1.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
@@ -218,7 +219,7 @@ class RayFTTestCase(unittest.TestCase):
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_ray_serve_2.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
-            show_cluster_info("default")
+            show_cluster_info(cluster_name_space)
             raise Exception(f"There was an exception during the execution of test_ray_serve_2.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
@@ -226,6 +227,7 @@ class RayFTTestCase(unittest.TestCase):
         docker_client.close()
 
     def test_detached_actor(self):
+        cluster_name_space = "default"
         docker_client = docker.from_env()
         container = docker_client.containers.run(ray_image, remove=True, detach=True, stdin_open=True, tty=True,
                                             network_mode='host', command=["/bin/sh"])
@@ -237,7 +239,7 @@ class RayFTTestCase(unittest.TestCase):
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_detached_actor_1.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
-            show_cluster_info("default")
+            show_cluster_info(cluster_name_space)
             raise Exception(f"There was an exception during the execution of test_detached_actor_1.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 
@@ -264,7 +266,7 @@ class RayFTTestCase(unittest.TestCase):
         exit_code, _ = utils.exec_run_container(container, f'python3 /usr/local/test_detached_actor_2.py {ray_namespace}', timeout_sec = 180)
 
         if exit_code != 0:
-            show_cluster_info("default")
+            show_cluster_info(cluster_name_space)
             raise Exception(f"There was an exception during the execution of test_detached_actor_2.py. The exit code is {exit_code}." +
                 "See above for command output. The output will be printed by the function exec_run_container.")
 

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -200,7 +200,8 @@ class RayFTTestCase(unittest.TestCase):
 
         # KubeRay only allows at most 1 head pod per RayCluster instance at the same time. In addition,
         # if we have 0 head pods at this moment, it indicates that the head pod crashes unexpectedly.
-        headpods = utils.get_pod(namespace='default', label_selector='ray.io/node-type=head')
+        headpods = utils.get_pod(namespace=cluster_name_space,
+            label_selector='ray.io/node-type=head')
         assert(len(headpods.items) == 1)
         old_head_pod = headpods.items[0]
         old_head_pod_name = old_head_pod.metadata.name
@@ -209,10 +210,12 @@ class RayFTTestCase(unittest.TestCase):
         # Kill the gcs_server process on head node. If fate sharing is enabled, the whole head node pod
         # will terminate.
         exec_command = ['pkill gcs_server']
-        utils.pod_exec_command(pod_name=old_head_pod_name, namespace='default', exec_command=exec_command)
+        utils.pod_exec_command(pod_name=old_head_pod_name,
+            namespace=cluster_name_space, exec_command=exec_command)
 
         # Waiting for all pods become ready and running.
-        utils.wait_for_new_head(old_head_pod_name, restart_count, 'default', timeout=300, retry_interval_ms=1000)
+        utils.wait_for_new_head(old_head_pod_name, restart_count,
+            cluster_name_space, timeout=300, retry_interval_ms=1000)
 
         # Try to connect to the deployed model again
         utils.copy_to_container(container, 'tests/scripts', '/usr/local/', 'test_ray_serve_2.py')
@@ -245,7 +248,8 @@ class RayFTTestCase(unittest.TestCase):
 
         # KubeRay only allows at most 1 head pod per RayCluster instance at the same time. In addition,
         # if we have 0 head pods at this moment, it indicates that the head pod crashes unexpectedly.
-        headpods = utils.get_pod(namespace='default', label_selector='ray.io/node-type=head')
+        headpods = utils.get_pod(namespace=cluster_name_space,
+            label_selector='ray.io/node-type=head')
         assert(len(headpods.items) == 1)
         old_head_pod = headpods.items[0]
         old_head_pod_name = old_head_pod.metadata.name
@@ -254,10 +258,12 @@ class RayFTTestCase(unittest.TestCase):
         # Kill the gcs_server process on head node. If fate sharing is enabled, the whole head node pod
         # will terminate.
         exec_command = ['pkill gcs_server']
-        utils.pod_exec_command(pod_name=old_head_pod_name, namespace='default', exec_command=exec_command)
+        utils.pod_exec_command(pod_name=old_head_pod_name,
+            namespace=cluster_name_space, exec_command=exec_command)
 
         # Waiting for all pods become ready and running.
-        utils.wait_for_new_head(old_head_pod_name, restart_count, 'default', timeout=300, retry_interval_ms=1000)
+        utils.wait_for_new_head(old_head_pod_name, restart_count,
+            cluster_name_space, timeout=300, retry_interval_ms=1000)
 
         # Try to connect to the detached actor again.
         # [Note] When all pods become running and ready, the RayCluster still needs tens of seconds to relaunch actors. Hence,

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -179,7 +179,7 @@ class RayFTTestCase(unittest.TestCase):
                 'kubectl wait --for=condition=ready pod -l rayCluster=raycluster-compatibility-test --all --timeout=900s', check = False)
         if rtn != 0:
             show_cluster_info("default")
-        assert rtn == 0
+            raise Exception(f"Nonzero return code {rtn} in test_kill_head()")
 
     def test_ray_serve(self):
         docker_client = docker.from_env()

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -155,7 +155,7 @@ def shell_subprocess_run(command, cr_namespace = None, check = True):
     if check is False or cr_namespace is None:
         return subprocess.run(command, shell = True, check = check).returncode
     return_code = subprocess.run(command, shell = True, check = False).returncode
-    if check and return_code != 0:
+    if return_code != 0:
         show_cluster_info(cr_namespace)
         raise Exception(f"Command exit with nonzero return code {return_code}. Command: {command}")
     return return_code


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add ```app.kubernetes.io/component: kuberay-operator``` label in [helm-chart/kuberay-operator/templates/deployment.yaml](https://github.com/ray-project/kuberay/blob/5177ebfbc885faa4abca8109f1fb692b3c85e880/helm-chart/kuberay-operator/templates/deployment.yaml) to make operator pod can be selected in ```show_cluster_info()```.

### Why not call ```show_cluster_info()``` in [tearDown()](https://docs.python.org/3/library/unittest.html#unittest.TestCase.tearDown)?
The only way I found to check if the test pass in ```teardown()``` is to access the private field ```self._outcome``` in unittest.TestCase object([reference](https://stackoverflow.com/questions/4414234/getting-pythons-unittest-results-in-a-teardown-method)). The fields in ```self._outcome``` changes in Python 3.11. It seems like accessing ```self._outcome``` in unittest.TestCase is not a robust approach.

### Why added  hard code label ```app.kubernetes.io/component=kuberay-operator```?
Because all of the labels app.kubernetes.io/component: for the operator is hard code with value kuberay-operato, I added app.kubernetes.io/component: kuberay-operator to the helm chart to make ```show_cluster_info``` able to get logs from the operator pod.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #766 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
