### PR TITLE
[helm] Add memory limits and resource documentation.

### DIFF
--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -57,7 +57,7 @@ head:
   # resource requests and limits for the Ray head container.
   # Modify as needed for your application.
   # Note that the resources in this example are much too small for production;
-  # We don't recommend allocating less than 8G memory for a Ray pod in production.
+  # we don't recommend allocating less than 8G memory for a Ray pod in production.
   # Ray pods should be sized to take up entire K8s nodes when possible.
   # Always set CPU and memory limits for Ray pods.
   # It is usually best to set requests equal to limits.
@@ -116,7 +116,7 @@ worker:
   # resource requests and limits for the Ray head container.
   # Modify as needed for your application.
   # Note that the resources in this example are much too small for production;
-  # We don't recommend allocating less than 8G memory for a Ray pod in production.
+  # we don't recommend allocating less than 8G memory for a Ray pod in production.
   # Ray pods should be sized to take up entire K8s nodes when possible.
   # Always set CPU and memory limits for Ray pods.
   # It is usually best to set requests equal to limits.
@@ -177,7 +177,7 @@ additionalWorkerGroups:
   # resource requests and limits for the Ray head container.
   # Modify as needed for your application.
   # Note that the resources in this example are much too small for production;
-  # We don't recommend allocating less than 8G memory for a Ray pod in production.
+  # we don't recommend allocating less than 8G memory for a Ray pod in production.
   # Ray pods should be sized to take up entire K8s nodes when possible.
   # Always set CPU and memory limits for Ray pods.
   # It is usually best to set requests equal to limits.

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -56,13 +56,21 @@ head:
   # ports: []
   # resource requests and limits for the Ray head container.
   # Modify as needed for your application.
-  # Note that the resources in this example are much too small for production.
+  # Note that the resources in this example are much too small for production;
+  # We don't recommend allocating less than 8G memory for a Ray pod in production.
   # Ray pods should be sized to take up entire K8s nodes when possible.
+  # Always set CPU and memory limits for Ray pods.
+  # It is usually best to set requests equal to limits.
+  # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#resources
+  # for further guidance.
   resources:
     limits:
-      cpu: 1
+      cpu: "1"
+      # To avoid out-of-memory issues, never allocate less than 2G memory for the Ray head.
+      memory: "2G"
     requests:
-      cpu: 1
+      cpu: "1"
+      memory: "2G"
   annotations: {}
   nodeSelector: {}
   tolerations: []
@@ -72,6 +80,7 @@ head:
   volumes:
     - name: log-volume
       emptyDir: {}
+  # Ray writes logs to /tmp/ray/session_latests/logs
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
@@ -106,13 +115,20 @@ worker:
   # ports: []
   # resource requests and limits for the Ray head container.
   # Modify as needed for your application.
-  # Note that the resources in this example are much too small for production.
+  # Note that the resources in this example are much too small for production;
+  # We don't recommend allocating less than 8G memory for a Ray pod in production.
   # Ray pods should be sized to take up entire K8s nodes when possible.
+  # Always set CPU and memory limits for Ray pods.
+  # It is usually best to set requests equal to limits.
+  # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#resources
+  # for further guidance.
   resources:
     limits:
-      cpu: 1
+      cpu: "1"
+      memory: "1G"
     requests:
-      cpu: 200m
+      cpu: "1"
+      memory: "1G"
   annotations:
     key: value
   nodeSelector: {}
@@ -123,6 +139,7 @@ worker:
   volumes:
     - name: log-volume
       emptyDir: {}
+  # Ray writes logs to /tmp/ray/session_latests/logs
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
@@ -157,15 +174,22 @@ additionalWorkerGroups:
         #     name: my-env-secret
     # ports optionally allows specifying ports for the Ray container.
     # ports: []
-    # resource requests and limits for the Ray head container.
-    # Modify as needed for your application.
-    # Note that the resources in this example are much too small for production.
-    # Ray pods should be sized to take up entire K8s nodes when possible.
+  # resource requests and limits for the Ray head container.
+  # Modify as needed for your application.
+  # Note that the resources in this example are much too small for production;
+  # We don't recommend allocating less than 8G memory for a Ray pod in production.
+  # Ray pods should be sized to take up entire K8s nodes when possible.
+  # Always set CPU and memory limits for Ray pods.
+  # It is usually best to set requests equal to limits.
+  # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#resources
+  # for further guidance.
     resources:
       limits:
         cpu: 1
+        memory: "1G"
       requests:
-        cpu: 200m
+        cpu: 1
+        memory: "1G"
     annotations:
       key: value
     nodeSelector: {}
@@ -176,6 +200,7 @@ additionalWorkerGroups:
     volumes:
       - name: log-volume
         emptyDir: {}
+  # Ray writes logs to /tmp/ray/session_latests/logs
     volumeMounts:
       - mountPath: /tmp/ray
         name: log-volume


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

Closes https://github.com/ray-project/kuberay/issues/788
See the issue for further context.

Manually tested as follows:
```
helm install kuberay-operator kuberay-operator/
helm install raycluster ray-cluster/
```
Confirmed that resource requests and limits are as expected.
Confirmed correct Ray internal state using
```
kubectl exec -it <head-pod> -- ray status
```
which produced the output
```
======== Autoscaler status: 2022-12-05 11:34:13.524240 ========
Node status
---------------------------------------------------------------
Healthy:
 1 node_310f01ea0047365c5f0d8c09c360de5b030c14debaa3d109795a6cf7
 1 node_b9725b30f0d8e9b15eb1f10952e56d76538ceef949cff07a2cc78855
Pending:
 (no pending nodes)
Recent failures:
 (no failures)

Resources
---------------------------------------------------------------
Usage:
 0.0/2.0 CPU
 0.00/2.794 GiB memory
 0.00/0.739 GiB object_store_memory

Demands:
```
