### PR TITLE
[CI] Pin go version in CRD consistency check

### DIFF
--- a/.github/workflows/consistency-check.yaml
+++ b/.github/workflows/consistency-check.yaml
@@ -40,6 +40,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Go 1.17.x
+        uses: actions/setup-go@v2
+        with:
+          # Use the same go version with build job
+          go-version: '1.17'
+
       - name: Update CRD/RBAC YAML files
         working-directory: ./ray-operator
         run: make manifests


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/kuberay/issues/791, which occurred due to CRD consistency job's automatic choice of an incompatible Go version (1.18.x).

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
