### PR TITLE
[CI] Add workflow to manually trigger release image push

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -62,7 +62,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-        if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
       - name: Push Apiserver to DockerHub
         run: |
@@ -124,7 +123,6 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-      if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
     - name: Push Operator to DockerHub
       run: |

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -1,0 +1,133 @@
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Desired release version tag (e.g. v0.4.0-rc.0)'
+        required: true
+
+jobs:
+  release_apiserver:
+    env:
+      working-directory: ./apiserver
+    name: Release APIServer Docker Image
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Go 1.17.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          # When checking out the repository that
+          # triggered a workflow, this defaults to the reference or SHA for that event.
+          # Default value should work for both pull_request and merge(push) event.
+          ref: ${{github.event.pull_request.head.sha}}
+
+      - name: install kubebuilder
+        run: |
+          wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.0.0/kubebuilder_$(go env GOOS)_$(go env GOARCH)
+          sudo mv kubebuilder_$(go env GOOS)_$(go env GOARCH) /usr/local/bin/kubebuilder
+
+      - name: Get revision SHA
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+      - name: Get dependencies
+        run: go mod download
+        working-directory: ${{env.working-directory}}
+
+      - name: Build
+        run: go build ./...
+        working-directory: ${{env.working-directory}}
+
+      - name: Test
+        run: go test ./...
+        working-directory: ${{env.working-directory}}
+
+      - name: Set up Docker
+        uses: docker-practice/actions-setup-docker@master
+
+      - name: Build Docker Image - Apiserver
+        run: |
+          docker build -t kuberay/apiserver:${{ steps.vars.outputs.sha_short }} -f apiserver/Dockerfile .
+          docker save -o /tmp/apiserver.tar kuberay/apiserver:${{ steps.vars.outputs.sha_short }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
+
+      - name: Push Apiserver to DockerHub
+        run: |
+          docker push kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
+          docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:${{ github.event.inputs.tag }};
+          docker push kuberay/apiserver:${{ github.event.inputs.tag }}
+
+  build_operator:
+    env:
+      working-directory: ./ray-operator
+    name: Build Operator Docker Images
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.17.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        # When checking out the repository that
+        # triggered a workflow, this defaults to the reference or SHA for that event.
+        # Default value should work for both pull_request and merge(push) event.
+        ref: ${{github.event.pull_request.head.sha}}
+
+    - name: install kubebuilder
+      run: |
+        wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.0.0/kubebuilder_$(go env GOOS)_$(go env GOARCH)
+        sudo mv kubebuilder_$(go env GOOS)_$(go env GOARCH) /usr/local/bin/kubebuilder
+
+    - name: Get revision SHA
+      id: vars
+      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+    - name: Get dependencies
+      run: go mod download
+      working-directory: ${{env.working-directory}}
+
+    - name: Build
+      run: make build
+      working-directory: ${{env.working-directory}}
+
+    - name: Test
+      run: make test
+      working-directory: ${{env.working-directory}}
+
+    - name: Set up Docker
+      uses: docker-practice/actions-setup-docker@master
+
+    - name: Build Docker Image - Operator
+      run: |
+        IMG=kuberay/operator:${{ steps.vars.outputs.sha_short }} make docker-image
+      working-directory: ${{env.working-directory}}
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+      if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
+
+    - name: Push Operator to DockerHub
+      run: |
+        docker push kuberay/operator:${{ steps.vars.outputs.sha_short }};
+        docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} kuberay/operator:${{ github.event.inputs.tag }};
+        docker push kuberay/operator:${{ github.event.inputs.tag }}
+
+      working-directory: ${{env.working-directory}}

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -3,8 +3,11 @@ name: release-image-build
 on:
   workflow_dispatch:
     inputs:
+      commit:
+        description: 'Commit reference (branch or SHA) from which to build the images.'
+        required: true
       tag:
-        description: 'Desired release version tag (e.g. v0.4.0-rc.0)'
+        description: 'Desired release version tag (e.g. v0.4.0-rc.0).'
         required: true
 
 jobs:
@@ -15,54 +18,56 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.17.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.17'
+    - name: Set up Go 1.17.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.inputs.commit }}
 
-      - name: install kubebuilder
-        run: |
-          wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.0.0/kubebuilder_$(go env GOOS)_$(go env GOARCH)
-          sudo mv kubebuilder_$(go env GOOS)_$(go env GOARCH) /usr/local/bin/kubebuilder
+    - name: install kubebuilder
+      run: |
+        wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.0.0/kubebuilder_$(go env GOOS)_$(go env GOARCH)
+        sudo mv kubebuilder_$(go env GOOS)_$(go env GOARCH) /usr/local/bin/kubebuilder
 
-      - name: Get revision SHA
-        id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+    - name: Get revision SHA
+      id: vars
+      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
-      - name: Get dependencies
-        run: go mod download
-        working-directory: ${{env.working-directory}}
+    - name: Get dependencies
+      run: go mod download
+      working-directory: ${{env.working-directory}}
 
-      - name: Build
-        run: go build ./...
-        working-directory: ${{env.working-directory}}
+    - name: Build
+      run: go build ./...
+      working-directory: ${{env.working-directory}}
 
-      - name: Test
-        run: go test ./...
-        working-directory: ${{env.working-directory}}
+    - name: Test
+      run: go test ./...
+      working-directory: ${{env.working-directory}}
 
-      - name: Set up Docker
-        uses: docker-practice/actions-setup-docker@master
+    - name: Set up Docker
+      uses: docker-practice/actions-setup-docker@master
 
-      - name: Build Docker Image - Apiserver
-        run: |
-          docker build -t kuberay/apiserver:${{ steps.vars.outputs.sha_short }} -f apiserver/Dockerfile .
-          docker save -o /tmp/apiserver.tar kuberay/apiserver:${{ steps.vars.outputs.sha_short }}
+    - name: Build Docker Image - Apiserver
+      run: |
+        docker build -t kuberay/apiserver:${{ steps.vars.outputs.sha_short }} -f apiserver/Dockerfile .
+        docker save -o /tmp/apiserver.tar kuberay/apiserver:${{ steps.vars.outputs.sha_short }}
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Log in to Docker Hub
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Push Apiserver to DockerHub
-        run: |
-          docker push kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-          docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:${{ github.event.inputs.tag }};
-          docker push kuberay/apiserver:${{ github.event.inputs.tag }}
+    - name: Push Apiserver to DockerHub
+      run: |
+        docker push kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
+        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:${{ github.event.inputs.tag }};
+        docker push kuberay/apiserver:${{ github.event.inputs.tag }}
 
   release_operator_image:
     env:
@@ -78,6 +83,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.inputs.commit }}
 
     - name: install kubebuilder
       run: |

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -1,3 +1,5 @@
+name: release-image-build
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -119,5 +119,3 @@ jobs:
         docker push kuberay/operator:${{ steps.vars.outputs.sha_short }};
         docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} kuberay/operator:${{ github.event.inputs.tag }};
         docker push kuberay/operator:${{ github.event.inputs.tag }}
-
-      working-directory: ${{env.working-directory}}

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -22,11 +22,6 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-        with:
-          # When checking out the repository that
-          # triggered a workflow, this defaults to the reference or SHA for that event.
-          # Default value should work for both pull_request and merge(push) event.
-          ref: ${{github.event.pull_request.head.sha}}
 
       - name: install kubebuilder
         run: |
@@ -83,11 +78,6 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-      with:
-        # When checking out the repository that
-        # triggered a workflow, this defaults to the reference or SHA for that event.
-        # Default value should work for both pull_request and merge(push) event.
-        ref: ${{github.event.pull_request.head.sha}}
 
     - name: install kubebuilder
       run: |

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -6,7 +6,7 @@ on:
         required: true
 
 jobs:
-  release_apiserver:
+  release_apiserver_image:
     env:
       working-directory: ./apiserver
     name: Release APIServer Docker Image
@@ -68,7 +68,7 @@ jobs:
           docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:${{ github.event.inputs.tag }};
           docker push kuberay/apiserver:${{ github.event.inputs.tag }}
 
-  build_operator:
+  release_operator_image:
     env:
       working-directory: ./ray-operator
     name: Build Operator Docker Images


### PR DESCRIPTION
Signed-off-by: Dmitri Gekhtman <dmitri.m.gekhtman@gmail.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR adds a GitHub Actions workflow to manually build and tag Operator and APIServer images.
It is based on the image build steps in https://github.com/ray-project/kuberay/blob/master/.github/workflows/test-job.yaml.
Instructions on how to use will be added to the release docs in a follow-up.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
