### PR TITLE
[Bug] Remove an unused field (ingress.enabled) from KubeRay operator chart

### DIFF
--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -26,9 +26,6 @@ service:
   type: ClusterIP
   port: 8080
 
-ingress:
-  enabled: false
-
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Search ".Values.ingress.enabled" in VS Code. Only one result matches in [helm-chart/kuberay-apiserver/templates/ingress.yaml](https://github.com/ray-project/kuberay/blob/781eed1e6b40093efc6e11c2dfc93777dadd9716/helm-chart/kuberay-apiserver/templates/ingress.yaml).

https://github.com/ray-project/kuberay/blob/781eed1e6b40093efc6e11c2dfc93777dadd9716/helm-chart/kuberay-apiserver/templates/ingress.yaml#L1

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

All integration tests in KubeRay CI deploy the KubeRay operator via Helm chart.
