### PR TITLE
[0.4.0 pick] Remove ingress.enabled from KubeRay operator chart (#812)

### DIFF
--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -28,9 +28,6 @@ service:
   type: ClusterIP
   port: 8080
 
-ingress:
-  enabled: false
-
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Removes the unused ingress.Enabled field from the operator Helm chart.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Picking https://github.com/ray-project/kuberay/pull/812 into the release branch.
FYI @kevin85421 @sihanwang41

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
