### PR TITLE
[Bug] error: git cmd when following docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ We also recommend checking out the official Ray guides for deploying on Kubernet
 
 ## Quick Start
 
-### Use YAML
-
 Please choose the version you would like to install. The examples below use the latest stable version `v0.4.0`.
 
 | Version  |  Stable |  Suggested Kubernetes Version |
 |----------|:-------:|------------------------------:|
 |  master  |    N    | v1.19 - v1.25 |
 |  v0.4.0  |    Y    | v1.19 - v1.25 |
+
+### Use YAML (kubectl v1.22.0+)
 
 Make sure your Kubernetes and Kubectl versions are both within the suggested range.
 Once you have connected to a Kubernetes cluster, run the following commands to deploy the KubeRay Operator.
@@ -47,11 +47,23 @@ kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=${KUBERAY_VE
 
 > Observe that we must use `kubectl create` to install cluster-scoped resources. The corresponding `kubectl apply` command will not work. See [KubeRay issue #271](https://github.com/ray-project/kuberay/issues/271).
 
-### Use Helm
+### Use Helm (Helm v3+)
 
 A Helm chart is a collection of files that describe a related set of Kubernetes resources.
 It can help users to deploy the KubeRay Operator and Ray clusters conveniently.
 Please read [kuberay-operator](helm-chart/kuberay-operator/README.md) to deploy the operator and [ray-cluster](helm-chart/ray-cluster/README.md) to deploy a configurable Ray cluster. To deploy the optional KubeRay API Server, see [kuberay-apiserver](helm-chart/kuberay-apiserver/README.md).
+
+```sh
+helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+
+# Install both CRDs and KubeRay operator v0.4.0.
+helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0
+
+# Check the KubeRay operator Pod in `default` namespace
+kubectl get pods
+# NAME                                READY   STATUS    RESTARTS   AGE
+# kuberay-operator-6fcbb94f64-mbfnr   1/1     Running   0          17s
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -29,20 +29,33 @@ Please choose the version you would like to install. The examples below use the 
 |  master  |    N    | v1.19 - v1.25 |
 |  v0.4.0  |    Y    | v1.19 - v1.25 |
 
-### Use YAML (kubectl v1.22.0+)
+### Use YAML
 
 Make sure your Kubernetes and Kubectl versions are both within the suggested range.
 Once you have connected to a Kubernetes cluster, run the following commands to deploy the KubeRay Operator.
-```
+
+```sh
+# case 1: kubectl >= v1.22.0
 export KUBERAY_VERSION=v0.4.0
 kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/default?ref=${KUBERAY_VERSION}&timeout=90s"
+
+# case 2: kubectl < v1.22.0
+# Clone KubeRay repository and checkout to the desired branch e.g. `release-0.4`.
+kubectl create -k ray-operator/config/default
 ```
 
 To deploy both the KubeRay Operator and the optional KubeRay API Server run the following commands.
-```
+
+```sh
+# case 1: kubectl >= v1.22.0
 export KUBERAY_VERSION=v0.4.0
 kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=${KUBERAY_VERSION}&timeout=90s"
 kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=${KUBERAY_VERSION}&timeout=90s"
+
+# case 2: kubectl < v1.22.0
+# Clone KubeRay repository and checkout to the desired branch e.g. `release-0.4`.
+kubectl create -k manifests/cluster-scope-resources
+kubectl apply -k manifests/base
 ```
 
 > Observe that we must use `kubectl create` to install cluster-scoped resources. The corresponding `kubectl apply` command will not work. See [KubeRay issue #271](https://github.com/ray-project/kuberay/issues/271).


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See https://github.com/ray-project/kuberay/issues/288#issuecomment-1344955244 for more details.

* I can reproduce this issue with `kubectl v1.21.0` 
```console
$ kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=${KUBERAY_VERSION}&timeout=90s"
error: git cmd = '/usr/local/bin/git fetch --depth=1 origin v0.3.0&timeout=90s': exit status 128

$ kubectl version --client=true --short=true
Client Version: v1.21.0
```

* Fix this issue by updating `kubectl` to v1.22.0+
```console
$ kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=${KUBERAY_VERSION}&timeout=90s"
namespace/ray-system created
customresourcedefinition.apiextensions.k8s.io/rayclusters.ray.io created
customresourcedefinition.apiextensions.k8s.io/rayjobs.ray.io created
customresourcedefinition.apiextensions.k8s.io/rayservices.ray.io created

$ kubectl version --client=true --short=true
Client Version: v1.22.0
```

* You can upgrade your `kubectl` by the following commands
```bash
curl -LO "https://dl.k8s.io/release/v1.22.0/bin/darwin/amd64/kubectl"
chmod +x kubectl
sudo cp kubectl $YOUR_PATH
```

## Related issue number

Closes #288

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
