### PR TITLE
Remove unused fields from KubeRay operator and RayCluster charts

### DIFF
--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -26,7 +26,7 @@ helm install kuberay-operator kuberay/kuberay-operator
 #### Method 2: Kustomize
 ```sh
 # Install CRDs
-kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.4.0"
+kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.4.0&timeout=90s"
 
 # Install KubeRay operator
 kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=v0.4.0"

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -35,14 +35,15 @@ helm version
   helm install kuberay-operator .
   ```
 
-* Install KubeRay operator without installing CRDs: Use Helm's built-in `--skip-crds` flag. See [this document](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) for more details.
+* Install KubeRay operator without installing CRDs
+  * In some cases, the installation of the CRDs and the installation of the operator may require different levels of admin permissions, so these two installations could be handled as different steps by different roles.
+  * Use Helm's built-in `--skip-crds` flag to install the operator only. See [this document](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) for more details.
   ```sh
-  # Step 1: Install KubeRay operator only.
-  helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0 --skip-crds
+  # Step 1: Install CRDs only (for cluster admin)
+  kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.4.0&timeout=90s"
 
-  # Step 2: Check no CRD will be installed.
-  kubectl get crds
-  # No resources found
+  # Step 2: Install KubeRay operator only. (for developer)
+  helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0 --skip-crds
   ``` 
 
 ## List the chart

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -35,6 +35,16 @@ helm version
   helm install kuberay-operator .
   ```
 
+* Install KubeRay operator only: Use Helm's built-in `--skip-crds` flag. See [this document](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) for more details.
+  ```sh
+  # Step 1: Install KubeRay operator only.
+  helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0 --skip-crds
+
+  # Step 2: Check no CRD will be installed.
+  kubectl get crds
+  # No resources found
+  ``` 
+
 ## List the chart
 
 To list the `my-release` deployment:

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -35,7 +35,7 @@ helm version
   helm install kuberay-operator .
   ```
 
-* Install KubeRay operator only: Use Helm's built-in `--skip-crds` flag. See [this document](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) for more details.
+* Install KubeRay operator without installing CRDs: Use Helm's built-in `--skip-crds` flag. See [this document](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) for more details.
   ```sh
   # Step 1: Install KubeRay operator only.
   helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0 --skip-crds

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -10,11 +10,6 @@ image:
 nameOverride: "kuberay-operator"
 fullnameOverride: "kuberay-operator"
 
-## Install Default RBAC roles and bindings
-rbac:
-  create: true
-  apiVersion: v1
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -50,7 +45,6 @@ readinessProbe:
   periodSeconds: 5
   failureThreshold: 5
 
-createCustomResource: true
 rbacEnable: true
 
 batchScheduler:

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -61,7 +61,7 @@ spec:
         nodeSelector: {{- toYaml .Values.head.nodeSelector | nindent 10 }}
       metadata:
         annotations: {{- toYaml .Values.head.annotations | nindent 10 }}
-        labels:
+        labels: {{- toYaml .Values.head.labels | nindent 10 }}
 {{ include "ray-cluster.labels" . | indent 10 }}
 
   workerGroupSpecs:
@@ -117,7 +117,7 @@ spec:
         nodeSelector: {{- toYaml $values.nodeSelector | nindent 10 }}
       metadata:
         annotations: {{- toYaml $values.annotations | nindent 10 }}
-        labels:
+        labels: {{- toYaml $values.labels | nindent 10 }}
 {{ include "ray-cluster.labels" $ | indent 10 }}
   {{- end }}
   {{- end }}
@@ -172,6 +172,6 @@ spec:
         nodeSelector: {{- toYaml .Values.worker.nodeSelector | nindent 10 }}
       metadata:
         annotations: {{- toYaml .Values.worker.annotations | nindent 10 }}
-        labels:
+        labels: {{- toYaml .Values.worker.labels | nindent 10 }}
 {{ include "ray-cluster.labels" . | indent 10 }}
   {{- end }}

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -61,8 +61,12 @@ spec:
         nodeSelector: {{- toYaml .Values.head.nodeSelector | nindent 10 }}
       metadata:
         annotations: {{- toYaml .Values.head.annotations | nindent 10 }}
+        {{- if .Values.head.labels }}
         labels: {{- toYaml .Values.head.labels | nindent 10 }}
 {{ include "ray-cluster.labels" . | indent 10 }}
+        {{ else }}
+        labels: {{ include "ray-cluster.labels" . | nindent 10 }}
+        {{- end }} 
 
   workerGroupSpecs:
   {{- range $groupName, $values := .Values.additionalWorkerGroups }}
@@ -117,8 +121,13 @@ spec:
         nodeSelector: {{- toYaml $values.nodeSelector | nindent 10 }}
       metadata:
         annotations: {{- toYaml $values.annotations | nindent 10 }}
+        {{- if $values.labels }}
         labels: {{- toYaml $values.labels | nindent 10 }}
 {{ include "ray-cluster.labels" $ | indent 10 }}
+        {{ else }}
+        labels: {{ include "ray-cluster.labels" $ | nindent 10 }}
+        {{- end }} 
+
   {{- end }}
   {{- end }}
   {{- if ne (.Values.worker.disabled | default false) true }}
@@ -172,6 +181,10 @@ spec:
         nodeSelector: {{- toYaml .Values.worker.nodeSelector | nindent 10 }}
       metadata:
         annotations: {{- toYaml .Values.worker.annotations | nindent 10 }}
+        {{- if .Values.worker.labels }}
         labels: {{- toYaml .Values.worker.labels | nindent 10 }}
 {{ include "ray-cluster.labels" . | indent 10 }}
+        {{ else }}
+        labels: {{ include "ray-cluster.labels" $ | nindent 10 }}
+        {{- end }}
   {{- end }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -38,8 +38,7 @@ head:
     #   requests:
     #     cpu: "500m"
     #     memory: "512Mi"
-  labels:
-    headkey: headval
+  labels: {}
   rayStartParams:
     dashboard-host: '0.0.0.0'
     block: 'true'
@@ -94,8 +93,7 @@ worker:
   # disabled: true
   groupName: workergroup
   replicas: 1
-  labels:
-    workerkey: workerval
+  labels: {}
   rayStartParams:
     block: 'true'
   initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
@@ -150,12 +148,11 @@ worker:
 additionalWorkerGroups:
   smallGroup:
     # Disabled by default
-    disabled: false
+    disabled: true
     replicas: 1
     minReplicas: 1
     maxReplicas: 3
-    labels:
-      smallGroupKey: smallGroupVal
+    labels: {}
     rayStartParams:
       block: 'true'
     initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -17,7 +17,6 @@ imagePullSecrets: []
   # - name: an-existing-secret
 
 head:
-  groupName: headgroup
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
@@ -39,8 +38,6 @@ head:
     #   requests:
     #     cpu: "500m"
     #     memory: "512Mi"
-  # labels:
-  #   key: value
   rayStartParams:
     dashboard-host: '0.0.0.0'
     block: 'true'
@@ -95,9 +92,6 @@ worker:
   # disabled: true
   groupName: workergroup
   replicas: 1
-  type: worker
-  # labels:
-  #   key: value
   rayStartParams:
     block: 'true'
   initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
@@ -157,8 +151,6 @@ additionalWorkerGroups:
     replicas: 1
     minReplicas: 1
     maxReplicas: 3
-    type: worker
-    labels: {}
     rayStartParams:
       block: 'true'
     initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -38,8 +38,7 @@ head:
     #   requests:
     #     cpu: "500m"
     #     memory: "512Mi"
-  labels:
-    headkey: headval
+  labels: {}
   rayStartParams:
     dashboard-host: '0.0.0.0'
     block: 'true'
@@ -94,8 +93,7 @@ worker:
   # disabled: true
   groupName: workergroup
   replicas: 1
-  labels:
-    workerkey: workerval
+  labels: {}
   rayStartParams:
     block: 'true'
   initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
@@ -150,12 +148,11 @@ worker:
 additionalWorkerGroups:
   smallGroup:
     # Disabled by default
-    disabled: false
+    disabled: true
     replicas: 1
     minReplicas: 1
     maxReplicas: 3
-    labels:
-      smallGroupKey: smallGroupValue
+    labels: {}
     rayStartParams:
       block: 'true'
     initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -38,6 +38,8 @@ head:
     #   requests:
     #     cpu: "500m"
     #     memory: "512Mi"
+  labels:
+    headkey: headval
   rayStartParams:
     dashboard-host: '0.0.0.0'
     block: 'true'
@@ -92,6 +94,8 @@ worker:
   # disabled: true
   groupName: workergroup
   replicas: 1
+  labels:
+    workerkey: workerval
   rayStartParams:
     block: 'true'
   initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
@@ -123,8 +127,7 @@ worker:
     requests:
       cpu: "1"
       memory: "1G"
-  annotations:
-    key: value
+  annotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -147,10 +150,12 @@ worker:
 additionalWorkerGroups:
   smallGroup:
     # Disabled by default
-    disabled: true
+    disabled: false
     replicas: 1
     minReplicas: 1
     maxReplicas: 3
+    labels:
+      smallGroupKey: smallGroupValue
     rayStartParams:
       block: 'true'
     initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
@@ -182,8 +187,7 @@ additionalWorkerGroups:
       requests:
         cpu: 1
         memory: "1G"
-    annotations:
-      key: value
+    annotations: {}
     nodeSelector: {}
     tolerations: []
     affinity: {}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -38,7 +38,8 @@ head:
     #   requests:
     #     cpu: "500m"
     #     memory: "512Mi"
-  labels: {}
+  labels:
+    headkey: headval
   rayStartParams:
     dashboard-host: '0.0.0.0'
     block: 'true'
@@ -93,7 +94,8 @@ worker:
   # disabled: true
   groupName: workergroup
   replicas: 1
-  labels: {}
+  labels:
+    workerkey: workerval
   rayStartParams:
     block: 'true'
   initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
@@ -148,11 +150,12 @@ worker:
 additionalWorkerGroups:
   smallGroup:
     # Disabled by default
-    disabled: true
+    disabled: false
     replicas: 1
     minReplicas: 1
     maxReplicas: 3
-    labels: {}
+    labels:
+      smallGroupKey: smallGroupVal
     rayStartParams:
       block: 'true'
     initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?


Some fields in KubeRay operator chart and RayCluster chart are useless.

## Related issue number
Closes #549 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* KubeRay operator chart is tested by KubeRay CI (compatibility test, configuration test, helm lint test)
* RayCluster chart is tested by KubeRay CI (helm lint test) and manually.

![截圖 2022-12-13 下午12 11 25](https://user-images.githubusercontent.com/20109646/207434170-cf981478-4e72-4905-a965-bc6821c2acdc.png)

## Verify `labels`
Run the following command based on the commit d30d76ddca6b01b3c0e698c6388ab2767e2f0801.
```sh
# helm-chart/ray-cluster
helm template .
```
<details>
<summary>output</summary>

```
---
# Source: ray-cluster/templates/raycluster-cluster.yaml
apiVersion: ray.io/v1alpha1
kind: RayCluster
metadata:
  labels:
    app.kubernetes.io/name: kuberay
    helm.sh/chart: ray-cluster-0.4.0
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
  name: release-name-kuberay
  
spec:
  headGroupSpec:
    serviceType: ClusterIP
    rayStartParams:
      block: "true"
      dashboard-host: "0.0.0.0"
    template:
      spec:
        imagePullSecrets:
          []
        containers:
          - volumeMounts:
            - mountPath: /tmp/ray
              name: log-volume
            name: ray-head
            image: rayproject/ray:2.0.0
            imagePullPolicy: IfNotPresent
            resources:
              limits:
                cpu: "1"
                memory: 2G
              requests:
                cpu: "1"
                memory: 2G
            securityContext:
              {}
            env:
              []
        volumes:
          - emptyDir: {}
            name: log-volume
        affinity:
          {}
        tolerations:
          []
        nodeSelector:
          {}
      metadata:
        annotations:
          {}
        labels:
          headkey: headval
          app.kubernetes.io/name: kuberay
          helm.sh/chart: ray-cluster-0.4.0
          app.kubernetes.io/instance: release-name
          app.kubernetes.io/managed-by: Helm
         

  workerGroupSpecs:
  - rayStartParams:
      block: "true"
    replicas: 1
    minReplicas: 1
    maxReplicas: 3
    groupName: smallGroup
    template:
      spec:
        imagePullSecrets:
          []
        initContainers:
          - name: init
            image: busybox:1.28
            command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
            securityContext:
              {}
        containers:
          - volumeMounts:
            - mountPath: /tmp/ray
              name: log-volume
            name: ray-worker
            image: rayproject/ray:2.0.0
            imagePullPolicy: IfNotPresent
            resources:
              limits:
                cpu: 1
                memory: 1G
              requests:
                cpu: 1
                memory: 1G
            securityContext:
              {}
            env:
              []
            ports:
              null
        volumes:
          - emptyDir: {}
            name: log-volume
        affinity:
          {}
        tolerations:
          []
        nodeSelector:
          {}
      metadata:
        annotations:
          {}
        labels:
          smallGroupKey: smallGroupVal
          app.kubernetes.io/name: kuberay
          helm.sh/chart: ray-cluster-0.4.0
          app.kubernetes.io/instance: release-name
          app.kubernetes.io/managed-by: Helm
        
  - rayStartParams:
      block: "true"
    replicas: 1
    minReplicas: 1
    maxReplicas: 2147483647
    groupName: workergroup
    template:
      spec:
        imagePullSecrets:
          []
        initContainers:
          - name: init
            image: busybox:1.28
            command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
            securityContext:
              {}
        containers:
          - volumeMounts:
            - mountPath: /tmp/ray
              name: log-volume
            name: ray-worker
            image: rayproject/ray:2.0.0
            imagePullPolicy: IfNotPresent
            resources:
              limits:
                cpu: "1"
                memory: 1G
              requests:
                cpu: "1"
                memory: 1G
            securityContext:
              {}
            env:
              []
            ports:
              null
        volumes:
          - emptyDir: {}
            name: log-volume
        affinity:
          {}
        tolerations:
          []
        nodeSelector:
          {}
      metadata:
        annotations:
          {}
        labels:
          workerkey: workerval
          app.kubernetes.io/name: kuberay
          helm.sh/chart: ray-cluster-0.4.0
          app.kubernetes.io/instance: release-name
          app.kubernetes.io/managed-by: Helm
```
</details>

# Skip CRD
![截圖 2022-12-14 下午4 59 44](https://user-images.githubusercontent.com/20109646/207747744-12b2449c-72bd-40a9-b46c-a6cd6e7bd870.png)
