### PR TITLE
[Feature] Define a general-purpose cleanup method for CREvent

### DIFF
--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -31,6 +31,11 @@ class CONST:
     RAY_FT = "RAY_FT"
     RAY_SERVICE = "RAY_SERVICE"
 
+    # Custom Resource Definitions
+    RAY_CLUSTER_CRD = "RAY_CLUSTER_CRD"
+    RAY_SERVICE_CRD = "RAY_SERVICE_CRD"
+    RAY_JOB_CRD = "RAY_JOB_CRD"
+
 CONST = CONST()
 
 class KubernetesClusterManager:
@@ -152,3 +157,31 @@ def pod_exec_command(pod_name, namespace, exec_command, check = True):
     Both STDOUT and STDERR of `exec_command` will be printed.
     """
     return shell_subprocess_run(f"kubectl exec {pod_name} -n {namespace} -- {exec_command}", check)
+
+def create_custom_object(crd, namespace, cr_object):
+    """Create a custom resource based on `cr_object` in the given `namespace`."""
+    k8s_cr_api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_CR_CLIENT_KEY]
+    if crd == CONST.RAY_CLUSTER_CRD:
+        k8s_cr_api.create_namespaced_custom_object(
+            group = 'ray.io', version = 'v1alpha1', namespace = namespace,
+            plural = 'rayclusters', body = cr_object)
+    elif crd == CONST.RAY_SERVICE_CRD:
+        k8s_cr_api.create_namespaced_custom_object(
+            group = 'ray.io', version = 'v1alpha1', namespace = namespace,
+            plural = 'rayservices', body = cr_object)
+    elif crd == CONST.RAY_JOB_CRD:
+        raise NotImplementedError
+
+def delete_custom_object(crd, namespace, cr_name):
+    """Delete the given `cr_name` custom resource in the given `namespace`."""
+    k8s_cr_api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_CR_CLIENT_KEY]
+    if crd == CONST.RAY_CLUSTER_CRD:
+        k8s_cr_api.delete_namespaced_custom_object(
+            group = 'ray.io', version = 'v1alpha1', namespace = namespace,
+            plural = 'rayclusters', name = cr_name)
+    elif crd == CONST.RAY_SERVICE_CRD:
+        k8s_cr_api.delete_namespaced_custom_object(
+            group = 'ray.io', version = 'v1alpha1', namespace = namespace,
+            plural = 'rayservices', name = cr_name)
+    elif crd == CONST.RAY_JOB_CRD:
+        raise NotImplementedError

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -32,9 +32,9 @@ class CONST:
     RAY_SERVICE = "RAY_SERVICE"
 
     # Custom Resource Definitions
-    RAY_CLUSTER_CRD = "RAY_CLUSTER_CRD"
-    RAY_SERVICE_CRD = "RAY_SERVICE_CRD"
-    RAY_JOB_CRD = "RAY_JOB_CRD"
+    RAY_CLUSTER_CRD = "RayCluster"
+    RAY_SERVICE_CRD = "RayService"
+    RAY_JOB_CRD = "RayJob"
 
 CONST = CONST()
 
@@ -158,9 +158,10 @@ def pod_exec_command(pod_name, namespace, exec_command, check = True):
     """
     return shell_subprocess_run(f"kubectl exec {pod_name} -n {namespace} -- {exec_command}", check)
 
-def create_custom_object(crd, namespace, cr_object):
+def create_custom_object(namespace, cr_object):
     """Create a custom resource based on `cr_object` in the given `namespace`."""
     k8s_cr_api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_CR_CLIENT_KEY]
+    crd = cr_object["kind"]
     if crd == CONST.RAY_CLUSTER_CRD:
         k8s_cr_api.create_namespaced_custom_object(
             group = 'ray.io', version = 'v1alpha1', namespace = namespace,

--- a/tests/test_sample_raycluster_yamls.py
+++ b/tests/test_sample_raycluster_yamls.py
@@ -34,7 +34,8 @@ if __name__ == '__main__':
     github_action_tests = {
         "ray-cluster.getting-started.yaml",
         "ray-cluster.ingress.yaml",
-        "ray-cluster.mini.yaml"
+        "ray-cluster.mini.yaml",
+        "ray-cluster.external-redis.yaml"
     }
 
     # Paths of untracked files, specified as strings, relative to KubeRay
@@ -61,8 +62,6 @@ if __name__ == '__main__':
 
     skip_tests = {
         'ray-cluster.complete.large.yaml': 'Skip this test because it requires a lot of resources.',
-        'ray-cluster.external-redis.yaml':
-            'It installs multiple Kubernetes resources and cannot clean up by DeleteCREvent.',
         'ray-cluster.autoscaler.large.yaml':
             'Skip this test because it requires a lot of resources.'
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, we did not test `ray-cluster.external-redis.yaml` in [test_sample_raycluster_yamls.py](https://github.com/ray-project/kuberay/blob/3a647129e248640f2314bfafd257f6b7a5db232f/tests/framework/test_sample_raycluster_yamls.py) because it installs multiple Kubernetes resources and cannot clean up by `clean_up()`. This PR defines a general-purpose cleanup method to remove related Kubernetes resources.

## Related issue number
Closes #772
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests (KubeRay CI: "Sample YAML Config Test")
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
RAY_IMAGE=rayproject/ray:2.1.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_raycluster_yamls.py
```
<img width="1439" alt="Screen Shot 2022-12-27 at 8 25 45 AM" src="https://user-images.githubusercontent.com/20109646/209694817-848cd95e-3448-46dd-98ff-5311e2781394.png">