### PR TITLE
[RayCluster controller] [Bug] Unconditionally reconcile RayCluster every 60s instead of only upon change

### DIFF
--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -101,7 +101,6 @@ const (
 	Ready     ClusterState = "ready"
 	Unhealthy ClusterState = "unhealthy"
 	Failed    ClusterState = "failed"
-	Pending   ClusterState = "pending"
 )
 
 // RayClusterStatus defines the observed state of RayCluster

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -101,6 +101,7 @@ const (
 	Ready     ClusterState = "ready"
 	Unhealthy ClusterState = "unhealthy"
 	Failed    ClusterState = "failed"
+	Pending   ClusterState = "pending"
 )
 
 // RayClusterStatus defines the observed state of RayCluster

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -234,7 +234,8 @@ func (r *RayClusterReconciler) rayClusterReconcile(request ctrl.Request, instanc
 		}
 	}
 
-	return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
+	// Unconditionally requeue after 60 seconds.
+	return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
 }
 
 func (r *RayClusterReconciler) reconcileIngress(instance *rayiov1alpha1.RayCluster) error {

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -233,6 +233,9 @@ func (r *RayClusterReconciler) rayClusterReconcile(request ctrl.Request, instanc
 			r.Log.Error(err, "Update status error", "cluster name", request.Name)
 		}
 	}
+	if instance.Status.State == rayiov1alpha1.Pending {
+		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
+	}
 
 	return ctrl.Result{}, nil
 }
@@ -858,6 +861,8 @@ func (r *RayClusterReconciler) updateStatus(instance *rayiov1alpha1.RayCluster) 
 	} else {
 		if utils.CheckAllPodsRunnning(runtimePods) {
 			instance.Status.State = rayiov1alpha1.Ready
+		} else {
+			instance.Status.State = rayiov1alpha1.Pending
 		}
 	}
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -233,9 +233,6 @@ func (r *RayClusterReconciler) rayClusterReconcile(request ctrl.Request, instanc
 			r.Log.Error(err, "Update status error", "cluster name", request.Name)
 		}
 	}
-	if instance.Status.State == rayiov1alpha1.Pending {
-		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
-	}
 
 	return ctrl.Result{}, nil
 }
@@ -861,8 +858,6 @@ func (r *RayClusterReconciler) updateStatus(instance *rayiov1alpha1.RayCluster) 
 	} else {
 		if utils.CheckAllPodsRunnning(runtimePods) {
 			instance.Status.State = rayiov1alpha1.Ready
-		} else {
-			instance.Status.State = rayiov1alpha1.Pending
 		}
 	}
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -234,7 +234,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(request ctrl.Request, instanc
 		}
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
 }
 
 func (r *RayClusterReconciler) reconcileIngress(instance *rayiov1alpha1.RayCluster) error {


### PR DESCRIPTION
Signed-off-by: Archit Kulkarni <architkulkarni@users.noreply.github.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR fixes an issue where RayJobs would never be submitted even if the Ray Cluster was up and running. Debugged this with @brucez-anyscale .

The root cause is the following:

The cluster status is only marked "Ready" if all pods are RUNNING.  The cluster state only gets updated when a reconcile happens.

However, the Cluster reconcile doesn't get requeued if all the pods are in [RUNNING, PENDING] state. 

In particular, when the head pod becomes PENDING, the cluster never gets reconciled again. 

So the cluster is stuck in a state where it's status is not "Ready". Since the RayJob reconciler waits for the cluster status to be "Ready" before submission, the job hangs and is never submitted.

The fix in this PR is to ~requeue the cluster reconcile in the case where the cluster pods are not all running yet. This PR introduces a new cluster state "Pending" for this case.~ always requeue the cluster reconciliation (every 300s, for now.)

As for why the head node state change PENDING -> RUNNING didn't trigger a cluster reconcile before, we think it might be due to an event filter https://github.com/ray-project/kuberay/blob/633ff6375099b2737db4c74a51c31028d2e54bc3/ray-operator/controllers/ray/raycluster_controller.go#L803
which only does the reconcile when there's a config, label or annotation change. However we can't remove this filter because it's necessary to prevent reconciling in a tight loop, because `instance.Status.LastUpdateTime` is updated at each reconcile.

Conclusion after discussion on this PR: Fixing the event filters is a separate but related bug and will be addressed in a followup PR, the issue will be tracked here: https://github.com/ray-project/kuberay/issues/872. Once that is fixed, we could possibly consider a patch 0.4.1 release.  After this PR, there may be an up to 60s unnecessary delay between when the cluster is ready and when the Job is submitted, which is not ideal.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #845 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests

```
      # This script is used to rebuild the KubeRay operator image and load it into the Kind cluster. 
# Step 0: Delete the existing Kind cluster
kind delete cluster 

# Step 1: Create a Kind cluster
kind create cluster --image=kindest/node:v1.24.0

# Step 2: Modify KubeRay source code
# For example, add a log "Hello KubeRay" in the function `Reconcile` in `raycluster_controller.go`.

# Step 3: Build a Docker image
#         This command will copy the source code directory into the image, and build it.
# Command: IMG={IMG_REPO}:{IMG_TAG} make docker-build
IMG=kuberay/operator:nightly make docker-build

# Step 4: Load the custom KubeRay image into the Kind cluster.
# Command: kind load docker-image {IMG_REPO}:{IMG_TAG}
kind load docker-image kuberay/operator:nightly

# Step 5: Keep consistency
# If you update RBAC or CRD, you need to synchronize them.
# See the section "Consistency check" for more information.

# Step 6: Install KubeRay operator with the custom image via local Helm chart
# (Path: helm-chart/kuberay-operator)
# Command: helm install kuberay-operator --set image.repository={IMG_REPO} --set image.tag={IMG_TAG} .
helm install kuberay-operator --set image.repository=kuberay/operator --set image.tag=nightly ~/kuberay/helm-chart/kuberay-operator

# Step 7: Submit a RayJob
kubectl apply -f config/samples/ray_v1alpha1_rayjob.yaml   

# Step 8: Check the status of the pods
watch kubectl get pods

# When the pods are ready, check `kubectl logs` to see that the job has status SUCCEEDED
```
   - [ ] This PR is not tested :(
