### PR TITLE
[Feature] Make head serviceType optional

### DIFF
--- a/docs/guidance/volcano-integration.md
+++ b/docs/guidance/volcano-integration.md
@@ -44,7 +44,6 @@ metadata:
 spec:
   rayVersion: '2.2.0'
   headGroupSpec:
-    serviceType: ClusterIP
     rayStartParams:
       block: 'true'
     replicas: 1
@@ -108,7 +107,6 @@ metadata:
 spec:
   rayVersion: '2.2.0'
   headGroupSpec:
-    serviceType: ClusterIP
     rayStartParams:
       block: 'true'
     replicas: 1
@@ -222,7 +220,6 @@ metadata:
 spec:
   rayVersion: '2.2.0'
   headGroupSpec:
-    serviceType: ClusterIP
     rayStartParams:
       block: 'true'
     replicas: 1

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -5706,7 +5706,6 @@ spec:
                     type: object
                 required:
                 - rayStartParams
-                - serviceType
                 - template
                 type: object
               headServiceAnnotations:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -5970,7 +5970,6 @@ spec:
                         type: object
                     required:
                     - rayStartParams
-                    - serviceType
                     - template
                     type: object
                   headServiceAnnotations:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -5956,7 +5956,6 @@ spec:
                         type: object
                     required:
                     - rayStartParams
-                    - serviceType
                     - template
                     type: object
                   headServiceAnnotations:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -199,5 +199,6 @@ additionalWorkerGroups:
         name: log-volume
     sidecarContainers: []
 
-service:
-  type: ClusterIP
+# Configuration for Head's Kubernetes Service
+service: {}
+#   type: ClusterIP # The default type is ClusterIP.

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -28,7 +28,7 @@ type RayClusterSpec struct {
 // HeadGroupSpec are the spec for the head pod
 type HeadGroupSpec struct {
 	// ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod
-	ServiceType v1.ServiceType `json:"serviceType"`
+	ServiceType v1.ServiceType `json:"serviceType,omitempty"`
 	// EnableIngress indicates whether operator should create ingress object for head service or not.
 	EnableIngress *bool `json:"enableIngress,omitempty"`
 	// HeadGroupSpec.Replicas is deprecated and ignored; there can only be one head pod per Ray cluster.

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -5706,7 +5706,6 @@ spec:
                     type: object
                 required:
                 - rayStartParams
-                - serviceType
                 - template
                 type: object
               headServiceAnnotations:

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -5970,7 +5970,6 @@ spec:
                         type: object
                     required:
                     - rayStartParams
-                    - serviceType
                     - template
                     type: object
                   headServiceAnnotations:

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -5956,7 +5956,6 @@ spec:
                         type: object
                     required:
                     - rayStartParams
-                    - serviceType
                     - template
                     type: object
                   headServiceAnnotations:

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -57,8 +57,6 @@ spec:
         memory: "512Mi"
   # Ray head pod template
   headGroupSpec:
-    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-    serviceType: ClusterIP
     # the following params are used to complete the ray start: ray start --head --block --port=6379 ...
     rayStartParams:
       # Flag "no-monitor" will be automatically set when autoscaling is enabled.

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -49,8 +49,6 @@ spec:
         memory: "512Mi"
   # Ray head pod template
   headGroupSpec:
-    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-    serviceType: ClusterIP
     # the following params are used to complete the ray start: ray start --head --block ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -16,8 +16,6 @@ spec:
   rayVersion: '2.2.0'
   # Ray head pod template
   headGroupSpec:
-    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-    serviceType: ClusterIP
     # for the head group, replicas should always be 1.
     # headGroupSpec.replicas is deprecated in KubeRay >= 0.3.0.
     replicas: 1

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -16,6 +16,9 @@ spec:
   rayVersion: '2.2.0'
   # Ray head pod template
   headGroupSpec:
+    # Kubernetes Service Type. This is an optional field, and the default value is ClusterIP.
+    # Refer to https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types.
+    serviceType: ClusterIP
     # for the head group, replicas should always be 1.
     # headGroupSpec.replicas is deprecated in KubeRay >= 0.3.0.
     replicas: 1
@@ -23,7 +26,7 @@ spec:
     rayStartParams:
       dashboard-host: '0.0.0.0'
       block: 'true'
-    #pod template
+    # pod template
     template:
       metadata:
         # Custom labels. NOTE: To avoid conflicts with KubeRay operator, do not define custom labels start with `raycluster`.

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -13,11 +13,14 @@ spec:
   rayVersion: '2.2.0'
   # Ray head pod configuration
   headGroupSpec:
+    # Kubernetes Service Type. This is an optional field, and the default value is ClusterIP.
+    # Refer to https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types.
+    serviceType: ClusterIP
     # the following params are used to complete the ray start: ray start --head --block --dashboard-host: '0.0.0.0' ...
     rayStartParams:
       dashboard-host: '0.0.0.0'
       block: 'true'
-    #pod template
+    # pod template
     template:
       metadata:
         # Custom labels. NOTE: To avoid conflicts with KubeRay operator, do not define custom labels start with `raycluster`.

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -13,8 +13,6 @@ spec:
   rayVersion: '2.2.0'
   # Ray head pod configuration
   headGroupSpec:
-    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-    serviceType: ClusterIP
     # the following params are used to complete the ray start: ray start --head --block --dashboard-host: '0.0.0.0' ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -79,7 +79,6 @@ metadata:
 spec:
   rayVersion: '2.2.0'
   headGroupSpec:
-    serviceType: ClusterIP
     replicas: 1
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.getting-started.yaml
+++ b/ray-operator/config/samples/ray-cluster.getting-started.yaml
@@ -13,8 +13,6 @@ spec:
   rayVersion: '2.2.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
-    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-    serviceType: ClusterIP
     # the following params are used to complete the ray start: ray start --head --block ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
+++ b/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
@@ -38,8 +38,6 @@ spec:
   ######################headGroupSpecs#################################
   # Ray head pod template
   headGroupSpec:
-    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-    serviceType: ClusterIP
     # the following params are used to complete the ray start: ray start --head --block ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.mini.yaml
+++ b/ray-operator/config/samples/ray-cluster.mini.yaml
@@ -13,8 +13,6 @@ spec:
   rayVersion: '2.2.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
-    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-    serviceType: ClusterIP
     # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -18,8 +18,6 @@ spec:
     rayVersion: '2.2.0' # should match the Ray version in the image of the containers
     # Ray head pod template
     headGroupSpec:
-      # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-      serviceType: ClusterIP
       # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
       rayStartParams:
         dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -46,8 +46,6 @@ spec:
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
-      # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-      serviceType: ClusterIP
       # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
       rayStartParams:
         port: '6379' # should match container port named gcs-server

--- a/ray-operator/config/security/ray-cluster.pod-security.yaml
+++ b/ray-operator/config/security/ray-cluster.pod-security.yaml
@@ -13,8 +13,6 @@ spec:
   rayVersion: '2.2.0'
   # Ray head pod configuration
   headGroupSpec:
-    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-    serviceType: ClusterIP
     # for the head group, replicas should always be 1.
     # headGroupSpec.replicas is deprecated in KubeRay >= 0.3.0.
     replicas: 1

--- a/tests/config/ray-cluster.mini.yaml.template
+++ b/tests/config/ray-cluster.mini.yaml.template
@@ -10,8 +10,6 @@ spec:
   ######################headGroupSpecs#################################
   # head group template and specs, (perhaps 'group' is not needed in the name)
   headGroupSpec:
-    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-    serviceType: ClusterIP
     # the following params are used to complete the ray start: ray start --head --block ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -73,8 +73,6 @@ metadata:
 spec:
   rayVersion: '$ray_version'
   headGroupSpec:
-    serviceType: ClusterIP
-    replicas: 1
     rayStartParams:
       dashboard-host: '0.0.0.0'
       num-cpus: '1'

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -42,8 +42,6 @@ spec:
     ######################headGroupSpecs#################################
     # head group template and specs, (perhaps 'group' is not needed in the name)
     headGroupSpec:
-      # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-      serviceType: ClusterIP
       # the following params are used to complete the ray start: ray start --head --block ...
       rayStartParams:
         port: '6379' # should match container port named gcs-server


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Minimal configuration for RayCluster CRs should be as simple as possible. This PR makes `serviceType` optional and the default is `ClusterIP`.

(from [Kubernetes official documentation](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types))
> ClusterIP: Exposes the Service on a cluster-internal IP. Choosing this value makes the Service only reachable from within the cluster. This is the default that is used if you don't explicitly specify a type for a Service.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Part of #368 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

## Test Helm chart
```sh
# Build docker image and install KubeRay operator

# Install RayCluster chart (path: helm-chart/ray-cluster)
helm install raycluster .

kubectl get svc
# NAME                          TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                         AGE
# kuberay-operator              ClusterIP   10.96.148.109   <none>        8080/TCP                                        3h57m
# kubernetes                    ClusterIP   10.96.0.1       <none>        443/TCP                                         3h59m
# raycluster-kuberay-head-svc   ClusterIP   10.96.88.220    <none>        10001/TCP,6379/TCP,8265/TCP,8080/TCP,8000/TCP   5s
```
* TYPE of `raycluster-kuberay-head-svc` is ClusterIP.