### PR TITLE
[Feature] Run config tests with the latest release of KubeRay operator

### DIFF
--- a/.github/workflows/actions/configuration/action.yaml
+++ b/.github/workflows/actions/configuration/action.yaml
@@ -51,22 +51,22 @@ runs:
       docker images ls -a
     shell: bash
 
-  - name: Run configuration tests for sample YAML files.
+  - name: Run tests for sample YAML files with the nightly operator.
     # Depends on the KubeRay operator image built in previous steps.
-    if: "${{ github.event.inputs.operator_version == '' }}"
+    if: github.event.inputs.operator_version == ''
     run: |
-      echo "Using Ray image ${{ inputs.ray_version }}"
+      echo "Using Ray image ${{ inputs.ray_version }} and nightly operator."
       GITHUB_ACTIONS=true \
       RAY_IMAGE="rayproject/ray:${{ inputs.ray_version }}" \
       OPERATOR_IMAGE="kuberay/operator:${{ steps.vars.outputs.sha_short }}" \
       python tests/test_sample_raycluster_yamls.py
     shell: bash
 
-  - name: Run configuration tests for sample YAML files.
+  - name: Run tests for sample YAML files with the latest KubeRay release.
     # Depends on latest KubeRay release.
-    if: "${{ github.event.inputs.operator_version != '' }}"
+    if: github.event.inputs.operator_version != ''
     run: |
-      echo "Using Ray image ${{ inputs.ray_version }}"
+      echo "Using Ray image ${{ inputs.ray_version }} and ${{ inputs.operator_version }} operator."
       GITHUB_ACTIONS=true \
       RAY_IMAGE="rayproject/ray:${{ inputs.ray_version }}" \
       OPERATOR_IMAGE="kuberay/operator:${{ inputs.operator_version }}" \

--- a/.github/workflows/actions/configuration/action.yaml
+++ b/.github/workflows/actions/configuration/action.yaml
@@ -7,7 +7,7 @@ inputs:
     required: true
   operator_version:
     description: "version of KubeRay operator"
-    required: true
+    required: false
 
 runs:
   using: "composite"
@@ -53,6 +53,18 @@ runs:
 
   - name: Run configuration tests for sample YAML files.
     # Depends on the KubeRay operator image built in previous steps.
+    if: "${{ github.event.inputs.operator_version == '' }}"
+    run: |
+      echo "Using Ray image ${{ inputs.ray_version }}"
+      GITHUB_ACTIONS=true \
+      RAY_IMAGE="rayproject/ray:${{ inputs.ray_version }}" \
+      OPERATOR_IMAGE="kuberay/operator:${{ steps.vars.outputs.sha_short }}" \
+      python tests/test_sample_raycluster_yamls.py
+    shell: bash
+
+  - name: Run configuration tests for sample YAML files.
+    # Depends on latest KubeRay release.
+    if: "${{ github.event.inputs.operator_version != '' }}"
     run: |
       echo "Using Ray image ${{ inputs.ray_version }}"
       GITHUB_ACTIONS=true \

--- a/.github/workflows/actions/configuration/action.yaml
+++ b/.github/workflows/actions/configuration/action.yaml
@@ -57,6 +57,6 @@ runs:
       echo "Using Ray image ${{ inputs.ray_version }}"
       GITHUB_ACTIONS=true \
       RAY_IMAGE="rayproject/ray:${{ inputs.ray_version }}" \
-      OPERATOR_IMAGE="kuberay/operator:${{ operator_version }}" \
+      OPERATOR_IMAGE="kuberay/operator:${{ inputs.operator_version }}" \
       python tests/test_sample_raycluster_yamls.py
     shell: bash

--- a/.github/workflows/actions/configuration/action.yaml
+++ b/.github/workflows/actions/configuration/action.yaml
@@ -5,9 +5,6 @@ inputs:
   ray_version:
     description: "version of ray"
     required: true
-  operator_version:
-    description: "version of KubeRay operator"
-    required: false
 
 runs:
   using: "composite"
@@ -52,23 +49,21 @@ runs:
     shell: bash
 
   - name: Run tests for sample YAML files with the nightly operator.
-    # Depends on the KubeRay operator image built in previous steps.
-    if: github.event.inputs.operator_version == ''
+    # Depends on the KubeRay operator image built in previous steps
+    env:
+      GITHUB_ACTIONS: true
+      RAY_IMAGE: rayproject/ray:${{ inputs.ray_version }}
+      OPERATOR_IMAGE: kuberay/operator:${{ steps.vars.outputs.sha_short }}
     run: |
-      echo "Using Ray image ${{ inputs.ray_version }} and nightly operator."
-      GITHUB_ACTIONS=true \
-      RAY_IMAGE="rayproject/ray:${{ inputs.ray_version }}" \
-      OPERATOR_IMAGE="kuberay/operator:${{ steps.vars.outputs.sha_short }}" \
       python tests/test_sample_raycluster_yamls.py
     shell: bash
 
   - name: Run tests for sample YAML files with the latest KubeRay release.
     # Depends on latest KubeRay release.
-    if: github.event.inputs.operator_version != ''
+    env:
+      GITHUB_ACTIONS: true
+      RAY_IMAGE: rayproject/ray:${{ inputs.ray_version }}
+      OPERATOR_IMAGE: kuberay/operator:v0.4.0 # The operator image in the latest KubeRay release.
     run: |
-      echo "Using Ray image ${{ inputs.ray_version }} and ${{ inputs.operator_version }} operator."
-      GITHUB_ACTIONS=true \
-      RAY_IMAGE="rayproject/ray:${{ inputs.ray_version }}" \
-      OPERATOR_IMAGE="kuberay/operator:${{ inputs.operator_version }}" \
       python tests/test_sample_raycluster_yamls.py
     shell: bash

--- a/.github/workflows/actions/configuration/action.yaml
+++ b/.github/workflows/actions/configuration/action.yaml
@@ -5,6 +5,9 @@ inputs:
   ray_version:
     description: "version of ray"
     required: true
+  operator_version:
+    description: "version of KubeRay operator"
+    required: true
 
 runs:
   using: "composite"
@@ -54,6 +57,6 @@ runs:
       echo "Using Ray image ${{ inputs.ray_version }}"
       GITHUB_ACTIONS=true \
       RAY_IMAGE="rayproject/ray:${{ inputs.ray_version }}" \
-      OPERATOR_IMAGE="kuberay/operator:${{ steps.vars.outputs.sha_short }}" \
+      OPERATOR_IMAGE="kuberay/operator:${{ operator_version }}" \
       python tests/test_sample_raycluster_yamls.py
     shell: bash

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -366,7 +366,7 @@ jobs:
       - build_apiserver
       - lint
     runs-on: ubuntu-latest
-    name: "Sample YAML Config Test - Ray: 2.1.0, KubeRay: nightly"
+    name: Sample YAML Config Test - Ray (2.1.0), KubeRay (nightly)
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -382,13 +382,13 @@ jobs:
 
   sample-yaml-config-test-2_1_0-latest-release:
     env:
-      KUBERAY_LATEST_RELEASE: 0.4.0
+      KUBERAY_LATEST_RELEASE: v0.4.0
     needs:
       - build_operator
       - build_apiserver
       - lint
     runs-on: ubuntu-latest
-    name: "Sample YAML Config Test - Ray: 2.1.0, KubeRay: ${{env.KUBERAY_LATEST_RELEASE}} (latest release)"
+    name: Sample YAML Config Test - Ray (2.1.0), KubeRay (latest release)
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -360,13 +360,13 @@ jobs:
         with:
           ray_version: nightly
 
-  sample-yaml-config-test-2_1_0-nightly:
+  sample-yaml-config-test-2_1_0:
     needs:
       - build_operator
       - build_apiserver
       - lint
     runs-on: ubuntu-latest
-    name: Sample YAML Config Test - Ray (2.1.0), KubeRay (nightly)
+    name: Sample YAML Config Test - 2.1.0
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -379,24 +379,3 @@ jobs:
         with:
           ray_version: 2.1.0
 
-  sample-yaml-config-test-2_1_0-latest-release:
-    env:
-      KUBERAY_LATEST_RELEASE: v0.4.0
-    needs:
-      - build_operator
-      - build_apiserver
-      - lint
-    runs-on: ubuntu-latest
-    name: Sample YAML Config Test - Ray (2.1.0), KubeRay (latest release)
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-        with:
-          # When checking out the repository that
-          # triggered a workflow, this defaults to the reference or SHA for that event.
-          # Default value should work for both pull_request and merge(push) event.
-          ref: ${{github.event.pull_request.head.sha}}
-      - uses: ./.github/workflows/actions/configuration
-        with:
-          ray_version: 2.1.0
-          operator_version: ${{env.KUBERAY_LATEST_RELEASE}}

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -360,13 +360,13 @@ jobs:
         with:
           ray_version: nightly
 
-  sample-yaml-config-test-2_1_0:
+  sample-yaml-config-test-2_1_0-nightly:
     needs:
       - build_operator
       - build_apiserver
       - lint
     runs-on: ubuntu-latest
-    name: Sample YAML Config Test - 2.1.0
+    name: "Sample YAML Config Test - Ray: 2.1.0, KubeRay: nightly"
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -378,3 +378,26 @@ jobs:
       - uses: ./.github/workflows/actions/configuration
         with:
           ray_version: 2.1.0
+          operator_version: ${{github.event.pull_request.head.sha}}
+
+  sample-yaml-config-test-2_1_0-latest-release:
+    env:
+      KUBERAY_LATEST_RELEASE: 0.4.0
+    needs:
+      - build_operator
+      - build_apiserver
+      - lint
+    runs-on: ubuntu-latest
+    name: "Sample YAML Config Test - Ray: 2.1.0, KubeRay: ${{env.KUBERAY_LATEST_RELEASE}} (latest release)"
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          # When checking out the repository that
+          # triggered a workflow, this defaults to the reference or SHA for that event.
+          # Default value should work for both pull_request and merge(push) event.
+          ref: ${{github.event.pull_request.head.sha}}
+      - uses: ./.github/workflows/actions/configuration
+        with:
+          ray_version: 2.1.0
+          operator_version: ${{env.KUBERAY_LATEST_RELEASE}}

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -378,7 +378,6 @@ jobs:
       - uses: ./.github/workflows/actions/configuration
         with:
           ray_version: 2.1.0
-          operator_version: ${{github.event.pull_request.head.sha}}
 
   sample-yaml-config-test-2_1_0-latest-release:
     env:

--- a/docs/guidance/volcano-integration.md
+++ b/docs/guidance/volcano-integration.md
@@ -44,6 +44,7 @@ metadata:
 spec:
   rayVersion: '2.2.0'
   headGroupSpec:
+    serviceType: ClusterIP
     rayStartParams:
       block: 'true'
     replicas: 1
@@ -107,6 +108,7 @@ metadata:
 spec:
   rayVersion: '2.2.0'
   headGroupSpec:
+    serviceType: ClusterIP
     rayStartParams:
       block: 'true'
     replicas: 1
@@ -220,6 +222,7 @@ metadata:
 spec:
   rayVersion: '2.2.0'
   headGroupSpec:
+    serviceType: ClusterIP
     rayStartParams:
       block: 'true'
     replicas: 1

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -201,4 +201,5 @@ additionalWorkerGroups:
 
 # Configuration for Head's Kubernetes Service
 service:
-  type: ClusterIP # This is optional, and the default is ClusterIP.
+  # This is optional, and the default is ClusterIP.
+  type: ClusterIP

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -200,5 +200,5 @@ additionalWorkerGroups:
     sidecarContainers: []
 
 # Configuration for Head's Kubernetes Service
-service: {}
-#   type: ClusterIP # The default type is ClusterIP.
+service:
+  type: ClusterIP # This is optional, and the default is ClusterIP.

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -57,6 +57,7 @@ spec:
         memory: "512Mi"
   # Ray head pod template
   headGroupSpec:
+    serviceType: ClusterIP # optional
     # the following params are used to complete the ray start: ray start --head --block --port=6379 ...
     rayStartParams:
       # Flag "no-monitor" will be automatically set when autoscaling is enabled.

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -49,6 +49,7 @@ spec:
         memory: "512Mi"
   # Ray head pod template
   headGroupSpec:
+    serviceType: ClusterIP # optional
     # the following params are used to complete the ray start: ray start --head --block ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -79,6 +79,7 @@ metadata:
 spec:
   rayVersion: '2.2.0'
   headGroupSpec:
+    serviceType: ClusterIP # optional
     replicas: 1
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.getting-started.yaml
+++ b/ray-operator/config/samples/ray-cluster.getting-started.yaml
@@ -13,6 +13,7 @@ spec:
   rayVersion: '2.2.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
+    serviceType: ClusterIP # optional
     # the following params are used to complete the ray start: ray start --head --block ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
+++ b/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
@@ -38,6 +38,7 @@ spec:
   ######################headGroupSpecs#################################
   # Ray head pod template
   headGroupSpec:
+    serviceType: ClusterIP # optional
     # the following params are used to complete the ray start: ray start --head --block ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.mini.yaml
+++ b/ray-operator/config/samples/ray-cluster.mini.yaml
@@ -13,6 +13,7 @@ spec:
   rayVersion: '2.2.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
+    serviceType: ClusterIP # optional
     # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -18,6 +18,7 @@ spec:
     rayVersion: '2.2.0' # should match the Ray version in the image of the containers
     # Ray head pod template
     headGroupSpec:
+      serviceType: ClusterIP # optional
       # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
       rayStartParams:
         dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -46,6 +46,7 @@ spec:
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
+      serviceType: ClusterIP # optional
       # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
       rayStartParams:
         port: '6379' # should match container port named gcs-server

--- a/ray-operator/config/security/ray-cluster.pod-security.yaml
+++ b/ray-operator/config/security/ray-cluster.pod-security.yaml
@@ -13,6 +13,7 @@ spec:
   rayVersion: '2.2.0'
   # Ray head pod configuration
   headGroupSpec:
+    serviceType: ClusterIP # optional
     # for the head group, replicas should always be 1.
     # headGroupSpec.replicas is deprecated in KubeRay >= 0.3.0.
     replicas: 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, we only run config tests with the nightly KubeRay operator. However, we also need to keep the compatibility of the current sample YAML files with the latest KubeRay operator release. If not, some bugs may happen (e.g. https://github.com/ray-project/kuberay/issues/856).

### Why do we install the latest release via Helm chart repo?

If we only update the KubeRay operator image to the latest release in the current KubeRay chart, #856 cannot be caught. This is because old CRD defined `serviceType` as a required field and #851 made it optional. Hence, we need to install both CRD and the KubeRay operator with the latest release to catch #856.

### Why do we test both the nightly operator and the latest release operator in a single GitHub Actions job?

We can parallelize them by dividing them into two GitHub Actions jobs. However, I need to work on a lot with GitHub Actions syntax to reach the goal, and we plan to move KubeRay CI from GitHub Actions to Buildkite soon. Hence, we can parallelize them when we move to the new CI system.

### Add serviceType back to sample YAML files.
* https://github.com/ray-project/kuberay/pull/858/commits/d4f8b5a7b744e44829cd6f03fa8116d4b4513082
* Add `serviceType` back to sample YAML files (i.e. revert part of #851).
* CRD YAML files (6 files) and `*.yaml.template` (3 files => only be used in compatibility tests) do not need to revert.

### Others (This is my personal note. Feel free to ignore this part.)

`github.event.pull_request.head.sha` is SHA, but Docker image tag is short SHA.

## Related issue number
#856 => Close it when the next release is ready and `serviceType` is removed.
Closes #857
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

### Before I add `serviceType` back, #856 is caught by v0.4.0 CRD validation.

* https://github.com/ray-project/kuberay/actions/runs/3839495499/jobs/6537454235

![Screen Shot 2023-01-04 at 8 27 04 AM](https://user-images.githubusercontent.com/20109646/210604545-99708fb4-5fb2-4c52-be22-b5559ad9a094.png)

### "Sample YAML Config Test - 2.1.0" becomes green when I add `serviceType` back.
* https://github.com/ray-project/kuberay/actions/runs/3839980191/jobs/6538591610
