### PR TITLE
[Feature] Enable namespaced installs via helm chart

### DIFF
--- a/helm-chart/kuberay-apiserver/templates/role.yaml
+++ b/helm-chart/kuberay-apiserver/templates/role.yaml
@@ -2,9 +2,9 @@
 {{- if .Values.rbacEnable }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.singleNamespaceInstall }}
-kind: ClusterRole
-{{- else }}
 kind: Role
+{{- else }}
+kind: ClusterRole
 {{- end }}
 metadata:
   labels:

--- a/helm-chart/kuberay-apiserver/templates/role.yaml
+++ b/helm-chart/kuberay-apiserver/templates/role.yaml
@@ -1,7 +1,11 @@
 
 {{- if .Values.rbacEnable }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.singleNamespaceInstall }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.name }}

--- a/helm-chart/kuberay-apiserver/templates/rolebinding.yaml
+++ b/helm-chart/kuberay-apiserver/templates/rolebinding.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.rbacEnable }}
 {{- if .Values.singleNamespaceInstall }}
-kind: ClusterRoleBinding
-{{- else }}
 kind: RoleBinding
+{{- else }}
+kind: ClusterRoleBinding
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -16,9 +16,9 @@ subjects:
 roleRef:
   
 {{- if .Values.singleNamespaceInstall }}
-kind: ClusterRole
-{{- else }}
 kind: Role
+{{- else }}
+kind: ClusterRole
 {{- end }}
   name: {{ include "kuberay-apiserver.fullname" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/helm-chart/kuberay-apiserver/templates/rolebinding.yaml
+++ b/helm-chart/kuberay-apiserver/templates/rolebinding.yaml
@@ -14,12 +14,11 @@ subjects:
   name: {{ .Values.serviceAccount.name  }}
   namespace: {{ .Release.Namespace }}
 roleRef:
-  
-{{- if .Values.singleNamespaceInstall }}
-kind: Role
-{{- else }}
-kind: ClusterRole
-{{- end }}
+  {{- if .Values.singleNamespaceInstall }}
+  kind: Role
+  {{- else }}
+  kind: ClusterRole
+  {{- end }}
   name: {{ include "kuberay-apiserver.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/helm-chart/kuberay-apiserver/templates/rolebinding.yaml
+++ b/helm-chart/kuberay-apiserver/templates/rolebinding.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.rbacEnable }}
+{{- if .Values.singleNamespaceInstall }}
 kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
@@ -10,7 +14,12 @@ subjects:
   name: {{ .Values.serviceAccount.name  }}
   namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: ClusterRole
+  
+{{- if .Values.singleNamespaceInstall }}
+kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
   name: {{ include "kuberay-apiserver.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -51,6 +51,5 @@ ingress:
 
 rbacEnable: true
 
-# Option to install without using clusterRoles or clusterRoleBindings
-# for multitenant clusters with limited permissions
+# the chart can be installed by users with permissions to a single namespace only
 singleNamespaceInstall: false

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -50,3 +50,7 @@ ingress:
   enabled: false
 
 rbacEnable: true
+
+# Option to install without using clusterRoles or clusterRoleBindings
+# for multitenant clusters with limited permissions
+singleNamespaceInstall: false

--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -48,7 +48,8 @@ spec:
             {{- $watchNamespace = .Release.Namespace -}}
             {{- end -}}
             {{- if $watchNamespace -}}
-            {{- $argList = append $argList (print "--watch-namespace=" $watchNamespace) -}}
+            {{- $argList = append $argList "--watch-namespace" -}}
+            {{- $argList = append $argList $watchNamespace -}}
             {{- end -}}
             {{- (printf "\n") -}}
             {{- $argList | toYaml | indent 12 }}

--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -37,11 +37,21 @@ spec:
           command:
             - /manager
           args:
-          {{- if .Values.batchScheduler.enabled }}
-            - --enable-batch-scheduler
-          {{- else }}
-            []
-          {{- end }}
+            {{- $argList := list -}}
+            {{- if .Values.batchScheduler.enabled -}}
+            {{- $argList = append $argList "--enable-batch-scheduler" -}}
+            {{- end -}}
+            {{- $watchNamespace := "" -}}
+            {{- if .Values.watchNamespace -}}
+            {{- $watchNamespace = .Values.watchNamespace -}}
+            {{- else if .Values.singleNamespaceInstall -}}
+            {{- $watchNamespace = .Release.Namespace -}}
+            {{- end -}}
+            {{- if $watchNamespace -}}
+            {{- $argList = append $argList (print "--watch-namespace=" $watchNamespace) -}}
+            {{- end -}}
+            {{- (printf "\n") -}}
+            {{- $argList | toYaml | indent 12 }}
           ports:
             - name: http
               containerPort: 8080

--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -42,10 +42,10 @@ spec:
             {{- $argList = append $argList "--enable-batch-scheduler" -}}
             {{- end -}}
             {{- $watchNamespace := "" -}}
-            {{- if .Values.watchNamespace -}}
-            {{- $watchNamespace = .Values.watchNamespace -}}
-            {{- else if .Values.singleNamespaceInstall -}}
+            {{- if .Values.singleNamespaceInstall -}}
             {{- $watchNamespace = .Release.Namespace -}}
+            {{- else if .Values.watchNamespace -}}
+            {{- $watchNamespace = .Values.watchNamespace -}}
             {{- end -}}
             {{- if $watchNamespace -}}
             {{- $argList = append $argList "--watch-namespace" -}}

--- a/helm-chart/kuberay-operator/templates/leader_election_role.yaml
+++ b/helm-chart/kuberay-operator/templates/leader_election_role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
 {{ include "kuberay-operator.labels" . | indent 4 }}
-  name: {{ include "kuberay-operator.fullname" . }}
+  name: {{ include "kuberay-operator.fullname" . }}-leader-election
 rules:
 - apiGroups:
   - ""

--- a/helm-chart/kuberay-operator/templates/leader_election_role_binding.yaml
+++ b/helm-chart/kuberay-operator/templates/leader_election_role_binding.yaml
@@ -4,13 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
 {{ include "kuberay-operator.labels" . | indent 4 }}
-  name: {{ include "kuberay-operator.fullname" . }}
+  name: {{ include "kuberay-operator.fullname" . }}-leader-election
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name  }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ include "kuberay-operator.fullname" . }}
+  name: {{ include "kuberay-operator.fullname" . }}-leader-election
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/ray_rayjob_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayjob_editor_role.yaml
@@ -2,9 +2,9 @@
 {{- if .Values.rbacEnable }}
 
 {{- if .Values.singleNamespaceInstall }}
-kind: ClusterRole
-{{- else }}
 kind: Role
+{{- else }}
+kind: ClusterRole
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/helm-chart/kuberay-operator/templates/ray_rayjob_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayjob_editor_role.yaml
@@ -1,6 +1,11 @@
 # permissions for end users to edit rayjobs.
 {{- if .Values.rbacEnable }}
+
+{{- if .Values.singleNamespaceInstall }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:

--- a/helm-chart/kuberay-operator/templates/ray_rayjob_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayjob_viewer_role.yaml
@@ -2,9 +2,9 @@
 {{- if .Values.rbacEnable }}
 
 {{- if .Values.singleNamespaceInstall }}
-kind: ClusterRole
-{{- else }}
 kind: Role
+{{- else }}
+kind: ClusterRole
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/helm-chart/kuberay-operator/templates/ray_rayjob_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayjob_viewer_role.yaml
@@ -1,6 +1,11 @@
 # permissions for end users to view rayjobs.
 {{- if .Values.rbacEnable }}
+
+{{- if .Values.singleNamespaceInstall }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:

--- a/helm-chart/kuberay-operator/templates/ray_rayservice_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayservice_editor_role.yaml
@@ -3,9 +3,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 
 {{- if .Values.singleNamespaceInstall }}
-kind: ClusterRole
-{{- else }}
 kind: Role
+{{- else }}
+kind: ClusterRole
 {{- end }}
 metadata:
   name: rayservice-editor-role

--- a/helm-chart/kuberay-operator/templates/ray_rayservice_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayservice_editor_role.yaml
@@ -1,7 +1,12 @@
 # permissions for end users to edit rayservices.
 {{- if .Values.rbacEnable }}
 apiVersion: rbac.authorization.k8s.io/v1
+
+{{- if .Values.singleNamespaceInstall }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 metadata:
   name: rayservice-editor-role
 rules:

--- a/helm-chart/kuberay-operator/templates/ray_rayservice_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayservice_viewer_role.yaml
@@ -1,7 +1,12 @@
 # permissions for end users to view rayservices.
 {{- if .Values.rbacEnable }}
 apiVersion: rbac.authorization.k8s.io/v1
+
+{{- if .Values.singleNamespaceInstall }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 metadata:
   name: rayservice-viewer-role
 rules:

--- a/helm-chart/kuberay-operator/templates/ray_rayservice_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayservice_viewer_role.yaml
@@ -3,9 +3,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 
 {{- if .Values.singleNamespaceInstall }}
-kind: ClusterRole
-{{- else }}
 kind: Role
+{{- else }}
+kind: ClusterRole
 {{- end }}
 metadata:
   name: rayservice-viewer-role

--- a/helm-chart/kuberay-operator/templates/role.yaml
+++ b/helm-chart/kuberay-operator/templates/role.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.rbacEnable }}
 
 {{- if .Values.singleNamespaceInstall }}
-kind: ClusterRole
-{{- else }}
 kind: Role
+{{- else }}
+kind: ClusterRole
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/helm-chart/kuberay-operator/templates/role.yaml
+++ b/helm-chart/kuberay-operator/templates/role.yaml
@@ -1,5 +1,10 @@
 {{- if .Values.rbacEnable }}
+
+{{- if .Values.singleNamespaceInstall }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:

--- a/helm-chart/kuberay-operator/templates/rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/rolebinding.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.rbacEnable }}
 {{- if .Values.singleNamespaceInstall }}
-kind: ClusterRoleBinding
-{{- else }}
 kind: RoleBinding
+{{- else }}
+kind: ClusterRoleBinding
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -16,9 +16,9 @@ subjects:
 roleRef:
   
 {{- if .Values.singleNamespaceInstall }}
-  kind: ClusterRole
-{{- else }}
   kind: Role
+{{- else }}
+  kind: ClusterRole
 {{- end }}
   name: {{ include "kuberay-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/helm-chart/kuberay-operator/templates/rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/rolebinding.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.rbacEnable }}
+{{- if .Values.singleNamespaceInstall }}
 kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
@@ -10,7 +14,12 @@ subjects:
   name: {{ .Values.serviceAccount.name  }}
   namespace: {{ .Release.Namespace }}
 roleRef:
+  
+{{- if .Values.singleNamespaceInstall }}
   kind: ClusterRole
+{{- else }}
+  kind: Role
+{{- end }}
   name: {{ include "kuberay-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/rolebinding.yaml
@@ -14,7 +14,6 @@ subjects:
   name: {{ .Values.serviceAccount.name  }}
   namespace: {{ .Release.Namespace }}
 roleRef:
-  
 {{- if .Values.singleNamespaceInstall }}
   kind: Role
 {{- else }}

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -53,3 +53,11 @@ batchScheduler:
 # Set up `securityContext` to improve Pod security.
 # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md for further guidance.
 securityContext: {}
+
+# Option to install without using clusterRoles or clusterRoleBindings
+# for multitenant clusters with limited permissions
+singleNamespaceInstall: false
+
+# Arg to set the --watch-namespace CLI flag, overrides singleNamespaceInstall if set,
+# which sets the --watch-namespace to the release namespace
+# watchNamespace: ray-user-namespace

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -54,10 +54,12 @@ batchScheduler:
 # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md for further guidance.
 securityContext: {}
 
-# Option to install without using clusterRoles or clusterRoleBindings
-# for multitenant clusters with limited permissions
+# When singleNamespaceInstall is true:
+# - the chart can be installed by users with permissions to a single namespace only
+#   (this excludes the CRDs which can only be installed at cluster-scope)
+# - the KubeRay operator will only listen to the resource 
+#   events from the operator's namespace by default (can be overriden by watchNamespace)
 singleNamespaceInstall: false
 
-# Arg to set the --watch-namespace CLI flag, overrides singleNamespaceInstall if set,
-# which sets the --watch-namespace to the release namespace
+# kuberay operator will only watch the resource events from the "watchNamespace" namespace.
 # watchNamespace: ray-user-namespace

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -57,7 +57,7 @@ securityContext: {}
 # When singleNamespaceInstall is true:
 # - the chart can be installed by users with permissions to a single namespace only
 #   (this excludes the CRDs which can only be installed at cluster-scope)
-# - the KubeRay operator will only listen to the resource 
+# - the KubeRay operator will only listen to the resource
 #   events from the operator's namespace by default
 singleNamespaceInstall: false
 

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -62,4 +62,6 @@ securityContext: {}
 singleNamespaceInstall: false
 
 # kuberay operator will only watch the resource events from the "watchNamespace" namespace.
+# this option has no effect if singleNamespaceInstall is true, because we assume there are no
+# permissions outside of the current namespace
 # watchNamespace: ray-user-namespace

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -58,7 +58,7 @@ securityContext: {}
 # - the chart can be installed by users with permissions to a single namespace only
 #   (this excludes the CRDs which can only be installed at cluster-scope)
 # - the KubeRay operator will only listen to the resource 
-#   events from the operator's namespace by default (can be overriden by watchNamespace)
+#   events from the operator's namespace by default
 singleNamespaceInstall: false
 
 # kuberay operator will only watch the resource events from the "watchNamespace" namespace.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change allows Kuberay to be used in multitenanted clusters.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

I have tested this by running a series of template commands e.g.

```sh
helm template blah ./helm-chart/kuberay-operator --debug --set batchScheduler.enabled=1 --set watchNamespace=x
```

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
