### PR TITLE
mark clusters with pending Pods as pending

### DIFF
--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -98,6 +98,7 @@ type UpscalingMode string
 type ClusterState string
 
 const (
+	Pending   ClusterState = "pending"
 	Ready     ClusterState = "ready"
 	Unhealthy ClusterState = "unhealthy"
 	Failed    ClusterState = "failed"

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -864,6 +864,8 @@ func (r *RayClusterReconciler) updateStatus(instance *rayiov1alpha1.RayCluster) 
 	} else {
 		if utils.CheckAllPodsRunnning(runtimePods) {
 			instance.Status.State = rayiov1alpha1.Ready
+		} else {
+			instance.Status.State = rayiov1alpha1.Pending
 		}
 	}
 


### PR DESCRIPTION
This change makes the controller set RayCluster's
`.status.state` to `pending` instead of empty.




## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
