### PR TITLE
Enable test framework to install operator with custom config and put operator in a namespace with enforced PSS in security testing

### DIFF
--- a/docs/guidance/pod-security.md
+++ b/docs/guidance/pod-security.md
@@ -14,7 +14,7 @@ references can help you understand this document better:
 
 # Step 1: Create a KinD cluster
 ```bash
-# Path: /KUBERAY
+# Path: kuberay/
 kind create cluster --config ray-operator/config/security/kind-config.yaml --image=kindest/node:v1.24.0
 ```
 The `kind-config.yaml` enables audit logging with the audit policy defined in `audit-policy.yaml`. The `audit-policy.yaml`
@@ -58,7 +58,7 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# Path: helm-chart/kuberay-operator
+# Path: kuberay/helm-chart/kuberay-operator
 helm install -n pod-security kuberay-operator .
 ```
 
@@ -68,7 +68,7 @@ helm install -n pod-security kuberay-operator .
 
 ## Step 5.1: Create a RayCluster without proper `securityContext` configurations
 ```bash
-# Path: ray-operator/config/samples
+# Path: kuberay/ray-operator/config/samples
 kubectl apply -n pod-security -f ray-cluster.complete.yaml
 
 # Wait 20 seconds and check audit logs for the error messages.
@@ -89,7 +89,7 @@ No Pod will be created in the namespace `pod-security`, and check audit logs for
 
 ## Step 5.2: Create a RayCluster with proper `securityContext` configurations
 ```bash
-# Path: ray-operator/config/security
+# Path: kuberay/ray-operator/config/security
 kubectl apply -n pod-security -f ray-cluster.pod-security.yaml
 
 # Wait for the RayCluster convergence and check audit logs for the messages.

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -85,10 +85,10 @@ class OperatorManager:
                 raise Exception(f"Image {key} does not exist!")
         self.docker_image_dict = docker_image_dict
 
-    def prepare_operator(self,namespace='default',patch=jsonpatch.JsonPatch([])):
+    def prepare_operator(self, namespace = 'default', patch = jsonpatch.JsonPatch([])):
         """Prepare KubeRay operator for an existing KinD cluster"""
         self.__kind_prepare_images()
-        self.__install_crd_and_operator(namespace,patch)
+        self.__install_crd_and_operator(namespace, patch)
 
     def __kind_prepare_images(self):
         """Download images and load images into KinD cluster"""
@@ -111,7 +111,7 @@ class OperatorManager:
             image = self.docker_image_dict[key]
             shell_subprocess_run(f'kind load docker-image {image}')
 
-    def __install_crd_and_operator(self,namespace,patch):
+    def __install_crd_and_operator(self, namespace, patch):
         """
         Install both CRD and KubeRay operator by kuberay-operator chart.
         KubeRay operator will install in the {namespace} with custom config describe in {patch}.
@@ -122,6 +122,7 @@ class OperatorManager:
             with tempfile.NamedTemporaryFile('w') as values_fd:
                 helm_chart_values = yaml.safe_load(base_fd)
                 yaml.safe_dump(patch.apply(helm_chart_values),values_fd)
+                values_yaml = values_fd.name
                 repo, tag = self.docker_image_dict[CONST.OPERATOR_IMAGE_KEY].split(':')
                 if f"{repo}:{tag}" == CONST.KUBERAY_LATEST_RELEASE:
                     logger.info("Install both CRD and KubeRay operator with the latest release.")
@@ -129,7 +130,7 @@ class OperatorManager:
                         "helm repo add kuberay https://ray-project.github.io/kuberay-helm/"
                     )
                     shell_subprocess_run(
-                        f"helm install -n {namespace} -f {values_fd.name}"
+                        f"helm install -n {namespace} -f {values_yaml}"
                         f"kuberay-operator kuberay/kuberay-operator --version {tag[1:]}"
                     )
                 else:
@@ -137,7 +138,7 @@ class OperatorManager:
                         "Install both nightly CRD and KubeRay operator by kuberay-operator chart"
                     )
                     shell_subprocess_run(
-                        f"helm install -n {namespace} -f {values_fd.name} kuberay-operator "
+                        f"helm install -n {namespace} -f {values_yaml} kuberay-operator "
                         f"{CONST.HELM_CHART_ROOT}/kuberay-operator/ "
                         f"--set image.repository={repo},image.tag={tag}"
                     )

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -130,7 +130,7 @@ class OperatorManager:
                         "helm repo add kuberay https://ray-project.github.io/kuberay-helm/"
                     )
                     shell_subprocess_run(
-                        f"helm install -n {namespace} -f {values_yaml}"
+                        f"helm install -n {namespace} -f {values_yaml} "
                         f"kuberay-operator kuberay/kuberay-operator --version {tag[1:]}"
                     )
                 else:

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -115,7 +115,7 @@ class OperatorManager:
         """
         Install both CRD and KubeRay operator by kuberay-operator chart.
         KubeRay operator will install in the {namespace} with custom config describe in {patch}.
-        The default KubeRay operator config is in kuberay/helm-chart/kuberay-operator/values.yaml.
+        The default KubeRay operator config is in helm-chart/kuberay-operator/values.yaml.
         """
         base_yaml = CONST.HELM_CHART_ROOT.joinpath("kuberay-operator/values.yaml")
         with open(base_yaml,encoding = "utf-8") as base_fd:

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -125,7 +125,6 @@ class OperatorManager:
             with tempfile.NamedTemporaryFile('w') as updated_fd:
                 base_values = yaml.safe_load(base_fd)
                 yaml.safe_dump(self.patch.apply(base_values),updated_fd)
-                print(self.patch.apply(base_values))
                 updated_values = '-f ' + updated_fd.name if bool(self.patch) else ''
                 namespace = '-n ' + self.namespace
                 repo, tag = self.docker_image_dict[CONST.OPERATOR_IMAGE_KEY].split(':')

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 import tempfile
 import yaml
+import jsonpatch
 from kubernetes import client, config
 
 logger = logging.getLogger(__name__)
@@ -84,10 +85,10 @@ class OperatorManager:
                 raise Exception(f"Image {key} does not exist!")
         self.docker_image_dict = docker_image_dict
 
-    def prepare_operator(self,namespace='default',helm_chart_values=None):
+    def prepare_operator(self,namespace='default',patch=jsonpatch.JsonPatch([])):
         """Prepare KubeRay operator for an existing KinD cluster"""
         self.__kind_prepare_images()
-        self.__install_crd_and_operator(namespace,helm_chart_values)
+        self.__install_crd_and_operator(namespace,patch)
 
     def __kind_prepare_images(self):
         """Download images and load images into KinD cluster"""
@@ -110,28 +111,36 @@ class OperatorManager:
             image = self.docker_image_dict[key]
             shell_subprocess_run(f'kind load docker-image {image}')
 
-    def __install_crd_and_operator(self,namespace,helm_chart_values):
-        """Install both CRD and KubeRay operator by kuberay-operator chart"""
-        with tempfile.NamedTemporaryFile('w') as values_fd:
-            yaml.safe_dump(helm_chart_values,values_fd)
-            values_path = '' if helm_chart_values is None else '-f' + values_fd.name
-            repo, tag = self.docker_image_dict[CONST.OPERATOR_IMAGE_KEY].split(':')
-            if f"{repo}:{tag}" == CONST.KUBERAY_LATEST_RELEASE:
-                logger.info("Install both CRD and KubeRay operator with the latest release.")
-                shell_subprocess_run(
-                    "helm repo add kuberay https://ray-project.github.io/kuberay-helm/"
-                )
-                shell_subprocess_run(
-                    f"helm install -n {namespace} {values_path}"
-                    f"kuberay-operator kuberay/kuberay-operator --version {tag[1:]}"
-                )
-            else:
-                logger.info("Install both nightly CRD and KubeRay operator")
-                shell_subprocess_run(
-                    f"helm install -n {namespace} {values_path} kuberay-operator "
-                    f"{CONST.HELM_CHART_ROOT}/kuberay-operator/ "
-                    f"--set image.repository={repo},image.tag={tag}"
-                )
+    def __install_crd_and_operator(self,namespace,patch):
+        """
+        Install both CRD and KubeRay operator by kuberay-operator chart.
+        KubeRay operator will install in the {namespace} with custom config describe in {patch}.
+        The default KubeRay operator config is in kuberay/helm-chart/kuberay-operator/values.yaml.
+        """
+        base_yaml = CONST.HELM_CHART_ROOT.joinpath("kuberay-operator/values.yaml")
+        with open(base_yaml,encoding = "utf-8") as base_fd:
+            with tempfile.NamedTemporaryFile('w') as values_fd:
+                helm_chart_values = yaml.safe_load(base_fd)
+                yaml.safe_dump(patch.apply(helm_chart_values),values_fd)
+                repo, tag = self.docker_image_dict[CONST.OPERATOR_IMAGE_KEY].split(':')
+                if f"{repo}:{tag}" == CONST.KUBERAY_LATEST_RELEASE:
+                    logger.info("Install both CRD and KubeRay operator with the latest release.")
+                    shell_subprocess_run(
+                        "helm repo add kuberay https://ray-project.github.io/kuberay-helm/"
+                    )
+                    shell_subprocess_run(
+                        f"helm install -n {namespace} -f {values_fd.name}"
+                        f"kuberay-operator kuberay/kuberay-operator --version {tag[1:]}"
+                    )
+                else:
+                    logger.info(
+                        "Install both nightly CRD and KubeRay operator by kuberay-operator chart"
+                    )
+                    shell_subprocess_run(
+                        f"helm install -n {namespace} -f {values_fd.name} kuberay-operator "
+                        f"{CONST.HELM_CHART_ROOT}/kuberay-operator/ "
+                        f"--set image.repository={repo},image.tag={tag}"
+                    )
 
 def shell_subprocess_run(command, check = True):
     """

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -115,7 +115,7 @@ class OperatorManager:
         """
         Install both CRD and KubeRay operator by kuberay-operator chart.
         KubeRay operator will install in the {namespace} with custom config describe in {patch}.
-        The default KubeRay operator config is in helm-chart/kuberay-operator/values.yaml.
+        The default KubeRay operator config is in kuberay/helm-chart/kuberay-operator/values.yaml.
         """
         base_yaml = CONST.HELM_CHART_ROOT.joinpath("kuberay-operator/values.yaml")
         with open(base_yaml,encoding = "utf-8") as base_fd:

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -125,6 +125,7 @@ class OperatorManager:
             with tempfile.NamedTemporaryFile('w') as updated_fd:
                 base_values = yaml.safe_load(base_fd)
                 yaml.safe_dump(self.patch.apply(base_values),updated_fd)
+                print(self.patch.apply(base_values))
                 updated_values = '-f ' + updated_fd.name if bool(self.patch) else ''
                 namespace = '-n ' + self.namespace
                 repo, tag = self.docker_image_dict[CONST.OPERATOR_IMAGE_KEY].split(':')

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -41,30 +41,29 @@ def create_ray_cluster(template_name, ray_version, ray_image):
         yamlfile = template.substitute(
             {'ray_image': ray_image, 'ray_version': ray_version}
         )
-    with tempfile.NamedTemporaryFile('w', suffix = '_ray_cluster_yaml') as ray_cluster_yaml:
-        ray_cluster_yaml.write(yamlfile)
-        ray_cluster_yaml.flush()
-        context['filepath'] = ray_cluster_yaml.name
+        with tempfile.NamedTemporaryFile('w', delete=False) as ray_cluster_yaml:
+            ray_cluster_yaml.write(yamlfile)
+            context['filepath'] = ray_cluster_yaml.name
 
-        for k8s_object in yaml.safe_load_all(yamlfile):
-            if k8s_object['kind'] == 'RayCluster':
-                context['cr'] = k8s_object
-                break
+    for k8s_object in yaml.safe_load_all(yamlfile):
+        if k8s_object['kind'] == 'RayCluster':
+            context['cr'] = k8s_object
+            break
 
-        try:
-            # Create a RayCluster
-            ray_cluster_add_event = RayClusterAddCREvent(
-                custom_resource_object = context['cr'],
-                rulesets = [],
-                timeout = 90,
-                namespace='default',
-                filepath = context['filepath']
-            )
-            ray_cluster_add_event.trigger()
-            return ray_cluster_add_event
-        except Exception as ex:
-            logger.error(f"RayClusterAddCREvent fails to converge: {str(ex)}")
-        raise Exception("create_ray_cluster fails")
+    try:
+        # Create a RayCluster
+        ray_cluster_add_event = RayClusterAddCREvent(
+            custom_resource_object = context['cr'],
+            rulesets = [],
+            timeout = 90,
+            namespace='default',
+            filepath = context['filepath']
+        )
+        ray_cluster_add_event.trigger()
+        return ray_cluster_add_event
+    except Exception as ex:
+        logger.error(f"RayClusterAddCREvent fails to converge: {str(ex)}")
+    raise Exception("create_ray_cluster fails")
 
 def create_ray_service(template_name, ray_version, ray_image):
     """Create a RayService without a NodePort service."""
@@ -74,30 +73,29 @@ def create_ray_service(template_name, ray_version, ray_image):
         yamlfile = template.substitute(
             {'ray_image': ray_image, 'ray_version': ray_version}
         )
-    with tempfile.NamedTemporaryFile('w', suffix = '_ray_service_yaml') as ray_service_yaml:
-        ray_service_yaml.write(yamlfile)
-        ray_service_yaml.flush()
-        context['filepath'] = ray_service_yaml.name
+        with tempfile.NamedTemporaryFile('w', delete=False) as ray_service_yaml:
+            ray_service_yaml.write(yamlfile)
+            context['filepath'] = ray_service_yaml.name
 
-        for k8s_object in yaml.safe_load_all(yamlfile):
-            if k8s_object['kind'] == 'RayService':
-                context['cr'] = k8s_object
-                break
+    for k8s_object in yaml.safe_load_all(yamlfile):
+        if k8s_object['kind'] == 'RayService':
+            context['cr'] = k8s_object
+            break
 
-        try:
-            # Create a RayService
-            ray_service_add_event = RayServiceAddCREvent(
-                custom_resource_object = context['cr'],
-                rulesets = [],
-                timeout = 90,
-                namespace='default',
-                filepath = context['filepath']
-            )
-            ray_service_add_event.trigger()
-            return ray_service_add_event
-        except Exception as ex:
-            logger.error(f"RayServiceAddCREvent fails to converge: {str(ex)}")
-        raise Exception("create_ray_service fails")
+    try:
+        # Create a RayService
+        ray_service_add_event = RayServiceAddCREvent(
+            custom_resource_object = context['cr'],
+            rulesets = [],
+            timeout = 90,
+            namespace='default',
+            filepath = context['filepath']
+        )
+        ray_service_add_event.trigger()
+        return ray_service_add_event
+    except Exception as ex:
+        logger.error(f"RayServiceAddCREvent fails to converge: {str(ex)}")
+    raise Exception("create_ray_service fails")
 
 def wait_for_condition(
         condition_predictor, timeout=10, retry_interval_ms=100, **kwargs

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -41,29 +41,30 @@ def create_ray_cluster(template_name, ray_version, ray_image):
         yamlfile = template.substitute(
             {'ray_image': ray_image, 'ray_version': ray_version}
         )
-        with tempfile.NamedTemporaryFile('w', delete=False) as ray_cluster_yaml:
-            ray_cluster_yaml.write(yamlfile)
-            context['filepath'] = ray_cluster_yaml.name
+    with tempfile.NamedTemporaryFile('w', suffix = '_ray_cluster_yaml') as ray_cluster_yaml:
+        ray_cluster_yaml.write(yamlfile)
+        ray_cluster_yaml.flush()
+        context['filepath'] = ray_cluster_yaml.name
 
-    for k8s_object in yaml.safe_load_all(yamlfile):
-        if k8s_object['kind'] == 'RayCluster':
-            context['cr'] = k8s_object
-            break
+        for k8s_object in yaml.safe_load_all(yamlfile):
+            if k8s_object['kind'] == 'RayCluster':
+                context['cr'] = k8s_object
+                break
 
-    try:
-        # Create a RayCluster
-        ray_cluster_add_event = RayClusterAddCREvent(
-            custom_resource_object = context['cr'],
-            rulesets = [],
-            timeout = 90,
-            namespace='default',
-            filepath = context['filepath']
-        )
-        ray_cluster_add_event.trigger()
-        return ray_cluster_add_event
-    except Exception as ex:
-        logger.error(f"RayClusterAddCREvent fails to converge: {str(ex)}")
-    raise Exception("create_ray_cluster fails")
+        try:
+            # Create a RayCluster
+            ray_cluster_add_event = RayClusterAddCREvent(
+                custom_resource_object = context['cr'],
+                rulesets = [],
+                timeout = 90,
+                namespace='default',
+                filepath = context['filepath']
+            )
+            ray_cluster_add_event.trigger()
+            return ray_cluster_add_event
+        except Exception as ex:
+            logger.error(f"RayClusterAddCREvent fails to converge: {str(ex)}")
+        raise Exception("create_ray_cluster fails")
 
 def create_ray_service(template_name, ray_version, ray_image):
     """Create a RayService without a NodePort service."""
@@ -73,29 +74,30 @@ def create_ray_service(template_name, ray_version, ray_image):
         yamlfile = template.substitute(
             {'ray_image': ray_image, 'ray_version': ray_version}
         )
-        with tempfile.NamedTemporaryFile('w', delete=False) as ray_service_yaml:
-            ray_service_yaml.write(yamlfile)
-            context['filepath'] = ray_service_yaml.name
+    with tempfile.NamedTemporaryFile('w', suffix = '_ray_service_yaml') as ray_service_yaml:
+        ray_service_yaml.write(yamlfile)
+        ray_service_yaml.flush()
+        context['filepath'] = ray_service_yaml.name
 
-    for k8s_object in yaml.safe_load_all(yamlfile):
-        if k8s_object['kind'] == 'RayService':
-            context['cr'] = k8s_object
-            break
+        for k8s_object in yaml.safe_load_all(yamlfile):
+            if k8s_object['kind'] == 'RayService':
+                context['cr'] = k8s_object
+                break
 
-    try:
-        # Create a RayService
-        ray_service_add_event = RayServiceAddCREvent(
-            custom_resource_object = context['cr'],
-            rulesets = [],
-            timeout = 90,
-            namespace='default',
-            filepath = context['filepath']
-        )
-        ray_service_add_event.trigger()
-        return ray_service_add_event
-    except Exception as ex:
-        logger.error(f"RayServiceAddCREvent fails to converge: {str(ex)}")
-    raise Exception("create_ray_service fails")
+        try:
+            # Create a RayService
+            ray_service_add_event = RayServiceAddCREvent(
+                custom_resource_object = context['cr'],
+                rulesets = [],
+                timeout = 90,
+                namespace='default',
+                filepath = context['filepath']
+            )
+            ray_service_add_event.trigger()
+            return ray_service_add_event
+        except Exception as ex:
+            logger.error(f"RayServiceAddCREvent fails to converge: {str(ex)}")
+        raise Exception("create_ray_service fails")
 
 def wait_for_condition(
         condition_predictor, timeout=10, retry_interval_ms=100, **kwargs

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -68,7 +68,7 @@ class PodSecurityTestCase(unittest.TestCase):
             }
         patch = jsonpatch.JsonPatch([{
             'op': 'add',
-            'path': '/securityContext/',
+            'path': '/securityContext',
             'value': security_context
         }])
         operator_manager = OperatorManager(image_dict, PodSecurityTestCase.namespace, patch)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -56,7 +56,7 @@ class PodSecurityTestCase(unittest.TestCase):
         # Install the KubeRay operator in the namespace pod-security.
         image_dict = {
             CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.2.0',
-            CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly'),
+            CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly')
         }
         logger.info(image_dict)
         patch = jsonpatch.JsonPatch([{

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -38,67 +38,85 @@ class PodSecurityTestCase(unittest.TestCase):
         (1) (Step 4) Installs the operator in default namespace rather than pod-security namespace.
         (2) (Step 5.1) Installs a simple Pod without securityContext instead of a RayCluster.
         """
-        K8S_CLUSTER_MANAGER.delete_kind_cluster()
-        kind_config = CONST.REPO_ROOT.joinpath("ray-operator/config/security/kind-config.yaml")
-        K8S_CLUSTER_MANAGER.create_kind_cluster(kind_config = kind_config)
-        # Apply the restricted Pod security standard to all Pods in the namespace pod-security.
-        # The label pod-security.kubernetes.io/enforce=restricted means that the Pod that violates
-        # the policies will be rejected.
+        def create_cluster():
+            """Create a KinD cluster"""
+            K8S_CLUSTER_MANAGER.delete_kind_cluster()
+            kind_config = CONST.REPO_ROOT.joinpath("ray-operator/config/security/kind-config.yaml")
+            K8S_CLUSTER_MANAGER.create_kind_cluster(kind_config = kind_config) 
+        def create_namespace_with_restricted_mode(cluster_namespace):
+            """
+            Create a namespace and apply the restricted Pod security standard to all Pods.
+            The label pod-security.kubernetes.io/enforce=restricted means that the Pod
+            that violates the policies will be rejected.
+            """
+            shell_subprocess_run(f"kubectl create ns {cluster_namespace}")
+            shell_subprocess_run(f"kubectl label --overwrite ns {cluster_namespace} \
+                                {cluster_namespace}.kubernetes.io/warn=restricted \
+                                {cluster_namespace}.kubernetes.io/warn-version=latest \
+                                {cluster_namespace}.kubernetes.io/audit=restricted \
+                                {cluster_namespace}.kubernetes.io/audit-version=latest \
+                                {cluster_namespace}.kubernetes.io/enforce=restricted \
+                                {cluster_namespace}.kubernetes.io/enforce-version=latest")      
+        def install_operator():
+            """Install the KubeRay operator in default namespace(for now)"""
+            image_dict = {
+                CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.2.0',
+                CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly'),
+            }
+            logger.info(image_dict)
+            operator_manager = OperatorManager(image_dict)
+            operator_manager.prepare_operator()
+        def create_ray_cluster(cluster_namespace):
+            logger.info(
+                '[TEST]:Create RayCluster with securityContext config under restricted mode'
+            )
+            context = {}
+            cr_yaml = CONST.REPO_ROOT.joinpath(
+                "ray-operator/config/security/ray-cluster.pod-security.yaml"
+            )
+            with open(cr_yaml, encoding="utf-8") as ray_cluster_yaml:
+                context['filepath'] = ray_cluster_yaml.name
+                for k8s_object in yaml.safe_load_all(ray_cluster_yaml):
+                    if k8s_object['kind'] == 'RayCluster':
+                        context['cr'] = k8s_object
+                        break
+            ray_cluster_add_event = RayClusterAddCREvent(
+                custom_resource_object = context['cr'],
+                rulesets = [],
+                timeout = 90,
+                namespace = cluster_namespace,
+                filepath = context['filepath']
+            )
+            ray_cluster_add_event.trigger()
+
+        def install_non_compliant_pod(cluster_namespace):
+            logger.info('[TEST]:Create pod without securityContext config under restricted mode')
+            k8s_v1_api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_V1_CLIENT_KEY]
+            busybox_container = client.V1Container(name='busybox',image='busybox')
+            pod_spec = client.V1PodSpec(containers= [busybox_container])
+            pod_metadata = client.V1ObjectMeta(name='my-pod', namespace=cluster_namespace)
+            pod_body = client.V1Pod(
+                api_version='v1',
+                kind='Pod',
+                metadata=pod_metadata, spec=pod_spec
+            )
+            with self.assertRaises(
+                ApiException,
+                msg = 'A Pod that violates restricted security policies should be rejected.'
+            ) as ex:
+                k8s_v1_api.create_namespaced_pod(namespace=cluster_namespace, body=pod_body)
+            # check if raise forbidden error. Only forbidden error is allowed
+            error_code = ex.exception.status
+            self.assertEqual(
+                first = error_code,
+                second = 403,
+                msg = f'Error code 403 is expected but Pod creation failed with {error_code}'
+            )
         cluster_namespace = "pod-security"
-        shell_subprocess_run(f"kubectl create ns {cluster_namespace}")
-        shell_subprocess_run(f"kubectl label --overwrite ns {cluster_namespace} \
-                             {cluster_namespace}.kubernetes.io/warn=restricted \
-                             {cluster_namespace}.kubernetes.io/warn-version=latest \
-                             {cluster_namespace}.kubernetes.io/audit=restricted \
-                             {cluster_namespace}.kubernetes.io/audit-version=latest \
-                             {cluster_namespace}.kubernetes.io/enforce=restricted \
-                             {cluster_namespace}.kubernetes.io/enforce-version=latest")
-        # Install the KubeRay operator in default namespace(for now)
-        image_dict = {
-            CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.2.0',
-            CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly'),
-        }
-        logger.info(image_dict)
-        operator_manager = OperatorManager(image_dict)
-        operator_manager.prepare_operator()
-
-        context = {}
-        cr_yaml = CONST.REPO_ROOT.joinpath(
-            "ray-operator/config/security/ray-cluster.pod-security.yaml"
-        )
-        with open(cr_yaml, encoding="utf-8") as ray_cluster_yaml:
-            context['filepath'] = ray_cluster_yaml.name
-            for k8s_object in yaml.safe_load_all(ray_cluster_yaml):
-                if k8s_object['kind'] == 'RayCluster':
-                    context['cr'] = k8s_object
-                    break
-
-        logger.info('[TEST]:Create RayCluster with securityContext config under restricted mode')
-        ray_cluster_add_event = RayClusterAddCREvent(
-            custom_resource_object = context['cr'],
-            rulesets = [],
-            timeout = 90,
-            namespace = cluster_namespace,
-            filepath = context['filepath']
-        )
-        ray_cluster_add_event.trigger()
-
-        logger.info('[TEST]:Create pod without securityContext config under restricted mode')
-        k8s_v1_api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_V1_CLIENT_KEY]
-        pod_spec = client.V1PodSpec(containers=[client.V1Container(name='busybox',image='busybox')])
-        pod_metadata = client.V1ObjectMeta(name='my-pod', namespace=cluster_namespace)
-        pod_body = client.V1Pod(api_version='v1', kind='Pod', metadata=pod_metadata, spec=pod_spec)
-        with self.assertRaises(
-            ApiException,
-            msg = 'A Pod that violates restricted security policies should be rejected.'
-        ) as ex:
-            k8s_v1_api.create_namespaced_pod(namespace=cluster_namespace, body=pod_body)
-        # check if raise forbidden error. Only forbidden error is allowed
-        self.assertEqual(
-            first = ex.exception.status,
-            second = 403,
-            msg = f'Error code 403 is expected but Pod creation failed with {ex.exception.status}'
-        )
-
+        create_cluster()
+        create_namespace_with_restricted_mode(cluster_namespace)
+        install_operator()
+        create_ray_cluster(cluster_namespace)
+        install_non_compliant_pod(cluster_namespace)
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -57,19 +57,18 @@ class PodSecurityTestCase(unittest.TestCase):
         # Install the KubeRay operator in the namespace pod-security.
         image_dict = {
             CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.2.0',
-            CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly'),
+            CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly')
         }
         logger.info(image_dict)
-        security_context = {
+        patch = jsonpatch.JsonPatch([{
+            'op': 'add',
+            'path': '/securityContext',
+            'value': {
                 'allowPrivilegeEscalation': False,
                 'capabilities': {'drop':["ALL"]},
                 'runAsNonRoot': True,
                 'seccompProfile': {'type': 'RuntimeDefault'}
             }
-        patch = jsonpatch.JsonPatch([{
-            'op': 'add',
-            'path': '/securityContext',
-            'value': security_context
         }])
         operator_manager = OperatorManager(image_dict, PodSecurityTestCase.namespace, patch)
         operator_manager.prepare_operator()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -30,7 +30,7 @@ logging.basicConfig(
 class PodSecurityTestCase(unittest.TestCase):
     """
     https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md
-    Test for the document for the Pod security standard in CI
+    Test for the document for the Pod security standard in CI.
     The differences between this test and pod-security.md are:
     (1) (Step 4) Installs the operator in default namespace rather than pod-security namespace.
     (2) (Step 5.1) Installs a simple Pod without securityContext instead of a RayCluster.
@@ -53,7 +53,7 @@ class PodSecurityTestCase(unittest.TestCase):
                              {PodSecurityTestCase.namespace}.kubernetes.io/audit-version=latest \
                              {PodSecurityTestCase.namespace}.kubernetes.io/enforce=restricted \
                              {PodSecurityTestCase.namespace}.kubernetes.io/enforce-version=latest")
-        # Install the KubeRay operator in default namespace(for now)
+        # Install the KubeRay operator in default namespace(for now).
         image_dict = {
             CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.2.0',
             CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly'),
@@ -63,7 +63,7 @@ class PodSecurityTestCase(unittest.TestCase):
         operator_manager.prepare_operator()
     def test_ray_cluster_with_security_context(self):
         """
-        Create a RayCluster with securityContext config under restricted mode
+        Create a RayCluster with securityContext config under restricted mode.
         """
         context = {}
         cr_yaml = CONST.REPO_ROOT.joinpath(
@@ -88,7 +88,7 @@ class PodSecurityTestCase(unittest.TestCase):
 
     def test_pod_without_security_context(self):
         """
-        Create a pod without securityContext config under restricted mode
+        Create a pod without securityContext config under restricted mode.
         """
         k8s_v1_api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_V1_CLIENT_KEY]
         pod_spec = client.V1PodSpec(containers=[client.V1Container(name='busybox',image='busybox')])

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -32,9 +32,8 @@ class PodSecurityTestCase(unittest.TestCase):
     """
     https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md
     Test for the document for the Pod security standard in CI.
-    The differences between this test and pod-security.md are:
-    (1) (Step 4) Installs the operator in default namespace rather than pod-security namespace.
-    (2) (Step 5.1) Installs a simple Pod without securityContext instead of a RayCluster.
+    The differences between this test and pod-security.md is:
+    (Step 5.1) Installs a simple Pod without securityContext instead of a RayCluster.
     """
     namespace = "pod-security"
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -56,7 +56,7 @@ class PodSecurityTestCase(unittest.TestCase):
         # Install the KubeRay operator in the namespace pod-security.
         image_dict = {
             CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.2.0',
-            CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly')
+            CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly'),
         }
         logger.info(image_dict)
         patch = jsonpatch.JsonPatch([{

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -32,91 +32,75 @@ class PodSecurityTestCase(unittest.TestCase):
     https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md
     Test for the document for the Pod security standard in CI
     """
+    @classmethod
+    def setUpClass(cls):
+        K8S_CLUSTER_MANAGER.delete_kind_cluster()
+        kind_config = CONST.REPO_ROOT.joinpath("ray-operator/config/security/kind-config.yaml")
+        K8S_CLUSTER_MANAGER.create_kind_cluster(kind_config = kind_config)
+        # Apply the restricted Pod security standard to all Pods in the namespace pod-security.
+        # The label pod-security.kubernetes.io/enforce=restricted means that the Pod that violates
+        # the policies will be rejected.
+        cluster_namespace = "pod-security"
+        shell_subprocess_run(f"kubectl create ns {cluster_namespace}")
+        shell_subprocess_run(f"kubectl label --overwrite ns {cluster_namespace} \
+                             {cluster_namespace}.kubernetes.io/warn=restricted \
+                             {cluster_namespace}.kubernetes.io/warn-version=latest \
+                             {cluster_namespace}.kubernetes.io/audit=restricted \
+                             {cluster_namespace}.kubernetes.io/audit-version=latest \
+                             {cluster_namespace}.kubernetes.io/enforce=restricted \
+                             {cluster_namespace}.kubernetes.io/enforce-version=latest")
+        # Install the KubeRay operator in default namespace(for now)
+        image_dict = {
+            CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.2.0',
+            CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly'),
+        }
+        logger.info(image_dict)
+        operator_manager = OperatorManager(image_dict)
+        operator_manager.prepare_operator()
     def test_pod_security(self):
         """
         The differences between this test and pod-security.md are:
         (1) (Step 4) Installs the operator in default namespace rather than pod-security namespace.
         (2) (Step 5.1) Installs a simple Pod without securityContext instead of a RayCluster.
         """
-        def create_cluster():
-            """Create a KinD cluster"""
-            K8S_CLUSTER_MANAGER.delete_kind_cluster()
-            kind_config = CONST.REPO_ROOT.joinpath("ray-operator/config/security/kind-config.yaml")
-            K8S_CLUSTER_MANAGER.create_kind_cluster(kind_config = kind_config) 
-        def create_namespace_with_restricted_mode(cluster_namespace):
-            """
-            Create a namespace and apply the restricted Pod security standard to all Pods.
-            The label pod-security.kubernetes.io/enforce=restricted means that the Pod
-            that violates the policies will be rejected.
-            """
-            shell_subprocess_run(f"kubectl create ns {cluster_namespace}")
-            shell_subprocess_run(f"kubectl label --overwrite ns {cluster_namespace} \
-                                {cluster_namespace}.kubernetes.io/warn=restricted \
-                                {cluster_namespace}.kubernetes.io/warn-version=latest \
-                                {cluster_namespace}.kubernetes.io/audit=restricted \
-                                {cluster_namespace}.kubernetes.io/audit-version=latest \
-                                {cluster_namespace}.kubernetes.io/enforce=restricted \
-                                {cluster_namespace}.kubernetes.io/enforce-version=latest")      
-        def install_operator():
-            """Install the KubeRay operator in default namespace(for now)"""
-            image_dict = {
-                CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.2.0',
-                CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly'),
-            }
-            logger.info(image_dict)
-            operator_manager = OperatorManager(image_dict)
-            operator_manager.prepare_operator()
-        def create_ray_cluster(cluster_namespace):
-            logger.info(
-                '[TEST]:Create RayCluster with securityContext config under restricted mode'
-            )
-            context = {}
-            cr_yaml = CONST.REPO_ROOT.joinpath(
-                "ray-operator/config/security/ray-cluster.pod-security.yaml"
-            )
-            with open(cr_yaml, encoding="utf-8") as ray_cluster_yaml:
-                context['filepath'] = ray_cluster_yaml.name
-                for k8s_object in yaml.safe_load_all(ray_cluster_yaml):
-                    if k8s_object['kind'] == 'RayCluster':
-                        context['cr'] = k8s_object
-                        break
-            ray_cluster_add_event = RayClusterAddCREvent(
-                custom_resource_object = context['cr'],
-                rulesets = [],
-                timeout = 90,
-                namespace = cluster_namespace,
-                filepath = context['filepath']
-            )
-            ray_cluster_add_event.trigger()
-
-        def install_non_compliant_pod(cluster_namespace):
-            logger.info('[TEST]:Create pod without securityContext config under restricted mode')
-            k8s_v1_api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_V1_CLIENT_KEY]
-            busybox_container = client.V1Container(name='busybox',image='busybox')
-            pod_spec = client.V1PodSpec(containers= [busybox_container])
-            pod_metadata = client.V1ObjectMeta(name='my-pod', namespace=cluster_namespace)
-            pod_body = client.V1Pod(
-                api_version='v1',
-                kind='Pod',
-                metadata=pod_metadata, spec=pod_spec
-            )
-            with self.assertRaises(
-                ApiException,
-                msg = 'A Pod that violates restricted security policies should be rejected.'
-            ) as ex:
-                k8s_v1_api.create_namespaced_pod(namespace=cluster_namespace, body=pod_body)
-            # check if raise forbidden error. Only forbidden error is allowed
-            error_code = ex.exception.status
-            self.assertEqual(
-                first = error_code,
-                second = 403,
-                msg = f'Error code 403 is expected but Pod creation failed with {error_code}'
-            )
         cluster_namespace = "pod-security"
-        create_cluster()
-        create_namespace_with_restricted_mode(cluster_namespace)
-        install_operator()
-        create_ray_cluster(cluster_namespace)
-        install_non_compliant_pod(cluster_namespace)
+        context = {}
+        cr_yaml = CONST.REPO_ROOT.joinpath(
+            "ray-operator/config/security/ray-cluster.pod-security.yaml"
+        )
+        with open(cr_yaml, encoding="utf-8") as ray_cluster_yaml:
+            context['filepath'] = ray_cluster_yaml.name
+            for k8s_object in yaml.safe_load_all(ray_cluster_yaml):
+                if k8s_object['kind'] == 'RayCluster':
+                    context['cr'] = k8s_object
+                    break
+
+        logger.info('[TEST]:Create RayCluster with securityContext config under restricted mode')
+        ray_cluster_add_event = RayClusterAddCREvent(
+            custom_resource_object = context['cr'],
+            rulesets = [],
+            timeout = 90,
+            namespace = cluster_namespace,
+            filepath = context['filepath']
+        )
+        ray_cluster_add_event.trigger()
+
+        logger.info('[TEST]:Create pod without securityContext config under restricted mode')
+        k8s_v1_api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_V1_CLIENT_KEY]
+        pod_spec = client.V1PodSpec(containers=[client.V1Container(name='busybox',image='busybox')])
+        pod_metadata = client.V1ObjectMeta(name='my-pod', namespace=cluster_namespace)
+        pod_body = client.V1Pod(api_version='v1', kind='Pod', metadata=pod_metadata, spec=pod_spec)
+        with self.assertRaises(
+            ApiException,
+            msg = 'A Pod that violates restricted security policies should be rejected.'
+        ) as ex:
+            k8s_v1_api.create_namespaced_pod(namespace=cluster_namespace, body=pod_body)
+        # check if raise forbidden error. Only forbidden error is allowed
+        self.assertEqual(
+            first = ex.exception.status,
+            second = 403,
+            msg = f'Error code 403 is expected but Pod creation failed with {ex.exception.status}'
+        )
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -60,7 +60,6 @@ class PodSecurityTestCase(unittest.TestCase):
             CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly'),
         }
         logger.info(image_dict)
-        operator_manager = OperatorManager(image_dict,PodSecurityTestCase.namespace)
         security_context = {
                 'allowPrivilegeEscalation': False,
                 'capabilities': {'drop':["ALL"]},
@@ -72,10 +71,9 @@ class PodSecurityTestCase(unittest.TestCase):
             'path': '/securityContext/',
             'value': security_context
         }])
-        operator_manager.prepare_operator(
-            namespace = PodSecurityTestCase.namespace,
-            patch  = patch
-        )
+        operator_manager = OperatorManager(image_dict, PodSecurityTestCase.namespace, patch)
+        operator_manager.prepare_operator()
+
     def test_ray_cluster_with_security_context(self):
         """
         Create a RayCluster with securityContext config under restricted mode.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->



## Why are these changes needed?

This PR is a follow-up for #866. 

1. It enables the test framework to install the operator with custom configurations.
2. It put the operator in the pod security namespace rather than the default namespace in security testing.
3. It moves some logic into setUpClass and split the pod security test into:

  ```
  Test 1: Create RayCluster with securityContext config under restricted mode
  Test 2: Create pod without securityContext config under restricted mode
  ```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #880
<!-- For example: "Closes #1234" -->

## Checks

Check 1: It put the operator in the pod security namespace rather than the default namespace in security testing:
![86072c562ba22dc5b3485c9ce3c254d](https://user-images.githubusercontent.com/51814063/214191936-8ed84325-e31f-4923-9996-11c5dcc70666.png)

Check 2: It enables the test framework to install the operator with custom configurations:
Install KubeRay operator with custom config:
![e4c10018892f44f2e64e89b8279d63c](https://user-images.githubusercontent.com/51814063/215233380-764c5949-8903-4524-867f-65f042500d3e.png)
Install KubeRay’s latest release with custom config: (see #858 for more details)
![4a66775aa3617f5b395f18716ae5334](https://user-images.githubusercontent.com/51814063/215233382-b6d3f49d-a0d8-4d41-a48e-5e30d319df93.png)


- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
