### PR TITLE
feat: enrich `kubectl get` output

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -16,7 +16,28 @@ spec:
     singular: raycluster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.desiredWorkerReplicas
+      name: desired workers
+      type: integer
+    - jsonPath: .status.availableWorkerReplicas
+      name: available workers
+      type: integer
+    - jsonPath: .status.state
+      name: status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    - jsonPath: .status.head.podIP
+      name: head pod IP
+      priority: 1
+      type: string
+    - jsonPath: .status.head.serviceIP
+      name: head service IP
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: RayCluster is the Schema for the RayClusters API

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -147,6 +147,12 @@ const (
 // RayCluster is the Schema for the RayClusters API
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="desired workers",type=integer,JSONPath=".status.desiredWorkerReplicas",priority=0
+//+kubebuilder:printcolumn:name="available workers",type=integer,JSONPath=".status.availableWorkerReplicas",priority=0
+//+kubebuilder:printcolumn:name="status",type="string",JSONPath=".status.state",priority=0
+//+kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp",priority=0
+//+kubebuilder:printcolumn:name="head pod IP",type="string",JSONPath=".status.head.podIP",priority=1
+//+kubebuilder:printcolumn:name="head service IP",type="string",JSONPath=".status.head.serviceIP",priority=1
 //+genclient
 type RayCluster struct {
 	// Standard object metadata.

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -16,7 +16,28 @@ spec:
     singular: raycluster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.desiredWorkerReplicas
+      name: desired workers
+      type: integer
+    - jsonPath: .status.availableWorkerReplicas
+      name: available workers
+      type: integer
+    - jsonPath: .status.state
+      name: status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    - jsonPath: .status.head.podIP
+      name: head pod IP
+      priority: 1
+      type: string
+    - jsonPath: .status.head.serviceIP
+      name: head service IP
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: RayCluster is the Schema for the RayClusters API


### PR DESCRIPTION
by adding additional printer columns for number of desired workers, number of available workers, status, age, head Pod IP, and head Service IP.

## Before

```
kubectl get rayclusters
NAME         AGE
dxia-test    53m
keshi-test   2d23h
```

## After

```
kubectl get rayclusters
NAME         DESIRED WORKERS   AVAILABLE WORKERS   STATUS   AGE
dxia-test    3                 4                   ready    60m
keshi-test   1                 2                   ready    2d23h

kubectl get rayclusters -o wide
NAME         DESIRED WORKERS   AVAILABLE WORKERS   STATUS   AGE     HEAD POD IP    HEAD SERVICE IP
dxia-test    3                 4                   ready    60m     10.169.4.130   10.160.217.214
keshi-test   1                 2                   ready    2d23h   10.169.6.102   10.160.218.91
```


## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
