### PR TITLE
refactor: use equivalent, shorter `Builder.Owns()` method

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -802,14 +802,8 @@ func (r *RayClusterReconciler) SetupWithManager(mgr ctrl.Manager, reconcileConcu
 		For(&rayiov1alpha1.RayCluster{}).Named("raycluster-controller").
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
 		Watches(&source.Kind{Type: &corev1.Event{}}, &handler.EnqueueRequestForObject{}).
-		Watches(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
-			IsController: true,
-			OwnerType:    &rayiov1alpha1.RayCluster{},
-		}).
-		Watches(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
-			IsController: true,
-			OwnerType:    &rayiov1alpha1.RayCluster{},
-		})
+		Owns(&corev1.Pod{}).
+		Owns(&corev1.Service{})
 
 	if EnableBatchScheduler {
 		b = batchscheduler.ConfigureReconciler(b)


### PR DESCRIPTION
instead of longer `Builder.Watches()`.

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
