### PR TITLE
Ensure all temp files are deleted after the compatibility test

### DIFF
--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -51,20 +51,16 @@ def create_ray_cluster(template_name, ray_version, ray_image):
                 context['cr'] = k8s_object
                 break
 
-        try:
-            # Create a RayCluster
-            ray_cluster_add_event = RayClusterAddCREvent(
-                custom_resource_object = context['cr'],
-                rulesets = [],
-                timeout = 90,
-                namespace='default',
-                filepath = context['filepath']
-            )
-            ray_cluster_add_event.trigger()
-            return ray_cluster_add_event
-        except Exception as ex:
-            logger.error(f"RayClusterAddCREvent fails to converge: {str(ex)}")
-        raise Exception("create_ray_cluster fails")
+        # Create a RayCluster
+        ray_cluster_add_event = RayClusterAddCREvent(
+            custom_resource_object = context['cr'],
+            rulesets = [],
+            timeout = 90,
+            namespace='default',
+            filepath = context['filepath']
+        )
+        ray_cluster_add_event.trigger()
+        return ray_cluster_add_event
 
 def create_ray_service(template_name, ray_version, ray_image):
     """Create a RayService without a NodePort service."""
@@ -84,20 +80,16 @@ def create_ray_service(template_name, ray_version, ray_image):
                 context['cr'] = k8s_object
                 break
 
-        try:
-            # Create a RayService
-            ray_service_add_event = RayServiceAddCREvent(
-                custom_resource_object = context['cr'],
-                rulesets = [],
-                timeout = 90,
-                namespace='default',
-                filepath = context['filepath']
-            )
-            ray_service_add_event.trigger()
-            return ray_service_add_event
-        except Exception as ex:
-            logger.error(f"RayServiceAddCREvent fails to converge: {str(ex)}")
-        raise Exception("create_ray_service fails")
+        # Create a RayService
+        ray_service_add_event = RayServiceAddCREvent(
+            custom_resource_object = context['cr'],
+            rulesets = [],
+            timeout = 90,
+            namespace='default',
+            filepath = context['filepath']
+        )
+        ray_service_add_event.trigger()
+        return ray_service_add_event
 
 def wait_for_condition(
         condition_predictor, timeout=10, retry_interval_ms=100, **kwargs

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -41,29 +41,30 @@ def create_ray_cluster(template_name, ray_version, ray_image):
         yamlfile = template.substitute(
             {'ray_image': ray_image, 'ray_version': ray_version}
         )
-        with tempfile.NamedTemporaryFile('w', delete=False) as ray_cluster_yaml:
-            ray_cluster_yaml.write(yamlfile)
-            context['filepath'] = ray_cluster_yaml.name
+    with tempfile.NamedTemporaryFile('w', suffix = '_ray_cluster_yaml') as ray_cluster_yaml:
+        ray_cluster_yaml.write(yamlfile)
+        ray_cluster_yaml.flush()
+        context['filepath'] = ray_cluster_yaml.name
 
-    for k8s_object in yaml.safe_load_all(yamlfile):
-        if k8s_object['kind'] == 'RayCluster':
-            context['cr'] = k8s_object
-            break
+        for k8s_object in yaml.safe_load_all(yamlfile):
+            if k8s_object['kind'] == 'RayCluster':
+                context['cr'] = k8s_object
+                break
 
-    try:
-        # Create a RayCluster
-        ray_cluster_add_event = RayClusterAddCREvent(
-            custom_resource_object = context['cr'],
-            rulesets = [],
-            timeout = 90,
-            namespace='default',
-            filepath = context['filepath']
-        )
-        ray_cluster_add_event.trigger()
-        return ray_cluster_add_event
-    except Exception as ex:
-        logger.error(f"RayClusterAddCREvent fails to converge: {str(ex)}")
-    raise Exception("create_ray_cluster fails")
+        try:
+            # Create a RayCluster
+            ray_cluster_add_event = RayClusterAddCREvent(
+                custom_resource_object = context['cr'],
+                rulesets = [],
+                timeout = 90,
+                namespace='default',
+                filepath = context['filepath']
+            )
+            ray_cluster_add_event.trigger()
+            return ray_cluster_add_event
+        except Exception as ex:
+            logger.error(f"RayClusterAddCREvent fails to converge: {str(ex)}")
+        raise Exception("create_ray_cluster fails")
 
 def create_ray_service(template_name, ray_version, ray_image):
     """Create a RayService without a NodePort service."""
@@ -73,29 +74,30 @@ def create_ray_service(template_name, ray_version, ray_image):
         yamlfile = template.substitute(
             {'ray_image': ray_image, 'ray_version': ray_version}
         )
-        with tempfile.NamedTemporaryFile('w', delete=False) as ray_service_yaml:
-            ray_service_yaml.write(yamlfile)
-            context['filepath'] = ray_service_yaml.name
+    with tempfile.NamedTemporaryFile('w', suffix = '_ray_service_yaml') as ray_service_yaml:
+        ray_service_yaml.write(yamlfile)
+        ray_service_yaml.flush()
+        context['filepath'] = ray_service_yaml.name
 
-    for k8s_object in yaml.safe_load_all(yamlfile):
-        if k8s_object['kind'] == 'RayService':
-            context['cr'] = k8s_object
-            break
+        for k8s_object in yaml.safe_load_all(yamlfile):
+            if k8s_object['kind'] == 'RayService':
+                context['cr'] = k8s_object
+                break
 
-    try:
-        # Create a RayService
-        ray_service_add_event = RayServiceAddCREvent(
-            custom_resource_object = context['cr'],
-            rulesets = [],
-            timeout = 90,
-            namespace='default',
-            filepath = context['filepath']
-        )
-        ray_service_add_event.trigger()
-        return ray_service_add_event
-    except Exception as ex:
-        logger.error(f"RayServiceAddCREvent fails to converge: {str(ex)}")
-    raise Exception("create_ray_service fails")
+        try:
+            # Create a RayService
+            ray_service_add_event = RayServiceAddCREvent(
+                custom_resource_object = context['cr'],
+                rulesets = [],
+                timeout = 90,
+                namespace='default',
+                filepath = context['filepath']
+            )
+            ray_service_add_event.trigger()
+            return ray_service_add_event
+        except Exception as ex:
+            logger.error(f"RayServiceAddCREvent fails to converge: {str(ex)}")
+        raise Exception("create_ray_service fails")
 
 def wait_for_condition(
         condition_predictor, timeout=10, retry_interval_ms=100, **kwargs


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
1. This PR ensures all temp files are removed after the compatibility tests are completed. In the current implementation, some temporary files will not be deleted after the process exits due to:

    https://github.com/ray-project/kuberay/blob/683f0fa91928fda056027a6ccd6b564435898c72/tests/kuberay_utils/utils.py#L44
  
    With the option `delete=False`, the temporary files will not be deleted after the process exits, and need to be deleted manually. See [NamedTemporaryFile](https://docs.python.org/3/library/tempfile.html) for more details. Check `/tmp` to see the temporary files after the tests are completed.
  
    In this PR, temporary files will be deleted automatically once we close the files. See how [NamedTemporaryFile](https://docs.python.org/3/library/tempfile.html) works. 
    ```python
    with tempfile.NamedTemporaryFile('w', suffix = '_ray_cluster_yaml') as ray_cluster_yaml:
            ray_cluster_yaml.write(yamlfile)
            ray_cluster_yaml.flush()
    ```
* Note: We need to add a `flush` manually. Otherwise, the file will be empty when we try to read it because the flush normally does not happen until the file is closed.

2. This PR removes redundant `try/catch`. `RayServiceAddCREvent` and `RayClusterAddCREvent` already have the logic to raise and log errors. 



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
Make sure the compatibility tests still work. This can be proven through the CI test.

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
