### PR TITLE
Update apiserver chart location in readme

### DIFF
--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -49,7 +49,7 @@ helm version
 
   # Step2: Move to `helm-chart/kuberay-apiserver`
 
-  # Step3: Install KubeRay operator
+  # Step3: Install KubeRay APIServer
   helm install kuberay-apiserver .
   ```
   
@@ -66,10 +66,10 @@ helm ls
 ### Uninstall the Chart
 
 ```sh
-# Uninstall the `kuberay-operator` release
+# Uninstall the `kuberay-apiserver` release
 helm uninstall kuberay-apiserver
 
-# The operator Pod should be removed.
+# The KubeRay APIServer Pod should be removed.
 kubectl get pods
 # No resources found in default namespace.
 ```

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -34,7 +34,7 @@ helm version
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-  # Install both KubeRay APIServer v0.4.0.
+  # Install KubeRay APIServer v0.4.0.
   helm install kuberay-apiserver kuberay/kuberay-apiserver --version 0.4.0
 
   # Check the KubeRay APIServer Pod in `default` namespace

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -74,7 +74,7 @@ EOF
 1. Deploy the KubeRay APIServer within the same cluster of KubeRay operator 
 
 ```bash
-helm -n ray-system install kuberay-apiserver kuberay/helm-chart/kuberay-apiserver
+helm -n ray-system install kuberay-apiserver kuberay/kuberay-apiserver
 ```
 
 2. The APIServer expose service using `NodePort` by default. You can test access by your host and port, the default port is set to `31888`.

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -18,10 +18,63 @@ The KubeRay APIServer provides gRPC and HTTP APIs to manage KubeRay resources.
     KubeRay APIServer maintainer contacts (GitHub handles):
     @Jeffwan @scarlet25151
 
+## Installation
+
+### Helm
+
+Make sure the version of Helm is v3+. Currently, [existing CI tests](https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm-lint.yaml) are based on Helm v3.4.1 and v3.9.4.
+
+```sh
+helm version
+```
+
+### Install KubeRay APIServer
+
+* Install a stable version via Helm repository (only supports KubeRay v0.4.0+)
+  ```sh
+  helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+
+  # Install both KubeRay APIServer v0.4.0.
+  helm install kuberay-apiserver kuberay/kuberay-apiserver --version 0.4.0
+
+  # Check the KubeRay APIServer Pod in `default` namespace
+  kubectl get pods
+  # NAME                                 READY   STATUS    RESTARTS   AGE
+  # kuberay-apiserver-67b46b88bf-m7dzg   1/1     Running   0          6s
+  ```
+
+* Install the nightly version
+  ```sh
+  # Step1: Clone KubeRay repository
+
+  # Step2: Move to `helm-chart/kuberay-apiserver`
+
+  # Step3: Install KubeRay operator
+  helm install kuberay-apiserver .
+  ```
+  
+### List the chart
+
+To list the `my-release` deployment:
+
+```sh
+helm ls
+# NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS  CHART                    APP VERSION
+# kuberay-apiserver       default         1               2023-02-07 09:28:15.510869781 -0500 EST deployedkuberay-apiserver-0.4.0
+```
+
+### Uninstall the Chart
+
+```sh
+# Uninstall the `kuberay-operator` release
+helm uninstall kuberay-apiserver
+
+# The operator Pod should be removed.
+kubectl get pods
+# No resources found in default namespace.
+```
 
 ## Usage
-
-You can install the KubeRay APIServer by using the [helm chart](https://github.com/ray-project/kuberay/tree/master/helm-chart/kuberay-apiserver) or [kustomize](https://github.com/ray-project/kuberay/tree/master/apiserver/deploy/base)
 
 After the deployment we may use the `{{baseUrl}}` to access the 
 
@@ -74,6 +127,7 @@ EOF
 1. Deploy the KubeRay APIServer within the same cluster of KubeRay operator 
 
 ```bash
+helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm -n ray-system install kuberay-apiserver kuberay/kuberay-apiserver
 ```
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The README for the apiserver has an incorrect location for the helm chart (see below). This PR updates the READ to use the correct helm chart location.

```bash
$ helm -n ray-system install kuberay-apiserver kuberay/helm-chart/kuberay-apiserver
Error: INSTALLATION FAILED: chart "helm-chart/kuberay-apiserver" matching  not found in kuberay index. (try 'helm repo update'): no chart name found

$ helm -n ray-system install kuberay-apiserver kuberay/kuberay-apiserver
NAME: kuberay-apiserver
LAST DEPLOYED: Mon Feb  6 12:02:18 2023
NAMESPACE: ray-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
## Related issue number

n/a
<!-- For example: "Closes #1234" -->

## Checks

Note: this PR updates a readme, so there shouldn't be any impact to the tests.

- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [X] This PR is not tested :(


