### PR TITLE
Use k8sClient from client.New in controller test

### DIFF
--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -101,8 +101,6 @@ var _ = BeforeSuite(func(done Done) {
 		err = mgr.Start(ctrl.SetupSignalHandler())
 		Expect(err).ToNot(HaveOccurred())
 	}()
-	k8sClient = mgr.GetClient()
-	Expect(k8sClient).ToNot(BeNil())
 
 	close(done)
 }, 60)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test "should be able to update all Pods to Running" is flaky. The reason is that we get Kubernetes cluster information from the local cache. However, the local cache may have a jet lag with the Kubernetes API server. 

So, the thought is we should get the true status of the Pods directly from the API server in the operator test.

In [client.New doc](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.3/pkg/client#New),  it says:

> New returns a new Client using the provided config and Options. The returned client reads *and* writes directly from the server (it doesn't use object caches). It understands how to work with normal types (both custom resources and aggregated/built-in resources), as well as unstructured types.

In [kubebuilder's writing-tests doc](https://book.kubebuilder.io/cronjob-tutorial/writing-tests.html),  it says:

> Note that we set up both a “live” k8s client and a separate client from the manager. This is because when making assertions in tests, you generally want to assert against the live state of the API server. If you use the client from the manager (k8sManager.GetClient), you’d end up asserting against the contents of the cache instead, which is slower and can introduce flakiness into your tests. We could use the manager’s APIReader to accomplish the same thing, but that would leave us with two clients in our test assertions and setup (one for reading, one for writing), and it’d be easy to make mistakes.

**So, we should use k8sClient that are created from client.New instead of k8sManager.GetClient.**

In current [implementation](https://github.com/ray-project/kuberay/blob/master/ray-operator/controllers/ray/suite_test.go), we use k8sClient from k8sManager.GetClient:
```go

	k8sClient = mgr.GetClient()
	Expect(k8sClient).ToNot(BeNil())
```


Thus, I remove the above k8sClient from k8sManager.GetClient and use k8sClient from client.New:
```go
	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
	Expect(err).ToNot(HaveOccurred())
	Expect(k8sClient).ToNot(BeNil())
```









<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #894
<!-- For example: "Closes #1234" -->

## Checks

In a 2 core CPU, 7 GB RAM VM (to simulate the github's standard Linux runner), I ran the test 100 times:
**[Bug] "should be able to update all Pods to Running" never happened again after this change.**
**[Bug] "should be able to update all Pods to Running" fails 34/100 before this change.**


