### PR TITLE
refactor: Fix flaky tests by using RetryOnConflict

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -39,11 +39,6 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-const (
-	DefaultAttempts               = 16
-	DefaultSleepDurationInSeconds = 3
-)
-
 var _ = Context("Inside the default namespace", func() {
 	ctx := context.TODO()
 	var workerPods corev1.PodList

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -87,9 +87,9 @@ var _ = Context("Inside the default namespace", func() {
 			},
 			WorkerGroupSpecs: []rayiov1alpha1.WorkerGroupSpec{
 				{
-					Replicas:    pointer.Int32Ptr(3),
-					MinReplicas: pointer.Int32Ptr(0),
-					MaxReplicas: pointer.Int32Ptr(4),
+					Replicas:    pointer.Int32(3),
+					MinReplicas: pointer.Int32(0),
+					MaxReplicas: pointer.Int32(4),
 					GroupName:   "small-group",
 					RayStartParams: map[string]string{
 						"port":     "6379",
@@ -224,7 +224,7 @@ var _ = Context("Inside the default namespace", func() {
 
 			pod := workerPods.Items[0]
 			err := k8sClient.Delete(ctx, &pod,
-				&client.DeleteOptions{GracePeriodSeconds: pointer.Int64Ptr(0)})
+				&client.DeleteOptions{GracePeriodSeconds: pointer.Int64(0)})
 
 			Expect(err).NotTo(HaveOccurred(), "failed delete a pod")
 
@@ -240,9 +240,7 @@ var _ = Context("Inside the default namespace", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),
 					time.Second*9, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
-				rep := new(int32)
-				*rep = 2
-				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = rep
+				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = pointer.Int32(2)
 
 				// Operator may update revision after we get cluster earlier. Update may result in 409 conflict error.
 				// We need to handle conflict error and retry the update.
@@ -265,11 +263,9 @@ var _ = Context("Inside the default namespace", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),
 					time.Second*9, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
-				podToDelete1 := workerPods.Items[0]
-				rep := new(int32)
-				*rep = 1
-				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = rep
-				myRayCluster.Spec.WorkerGroupSpecs[0].ScaleStrategy.WorkersToDelete = []string{podToDelete1.Name}
+				podToDelete := workerPods.Items[0]
+				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = pointer.Int32(1)
+				myRayCluster.Spec.WorkerGroupSpecs[0].ScaleStrategy.WorkersToDelete = []string{podToDelete.Name}
 				return k8sClient.Update(ctx, myRayCluster)
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to update test RayCluster resource")
@@ -288,9 +284,7 @@ var _ = Context("Inside the default namespace", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),
 					time.Second*9, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
-				rep := new(int32)
-				*rep = 5
-				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = rep
+				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = pointer.Int32(5)
 
 				// Operator may update revision after we get cluster earlier. Update may result in 409 conflict error.
 				// We need to handle conflict error and retry the update.

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -52,7 +52,7 @@ var _ = Context("Inside the default namespace", func() {
 				RayVersion: "1.12.1",
 				HeadGroupSpec: rayiov1alpha1.HeadGroupSpec{
 					ServiceType: corev1.ServiceTypeClusterIP,
-					Replicas:    pointer.Int32Ptr(1),
+					Replicas:    pointer.Int32(1),
 					RayStartParams: map[string]string{
 						"port":                        "6379",
 						"object-store-memory":         "100000000",
@@ -122,9 +122,9 @@ var _ = Context("Inside the default namespace", func() {
 				},
 				WorkerGroupSpecs: []rayiov1alpha1.WorkerGroupSpec{
 					{
-						Replicas:    pointer.Int32Ptr(3),
-						MinReplicas: pointer.Int32Ptr(0),
-						MaxReplicas: pointer.Int32Ptr(10000),
+						Replicas:    pointer.Int32(3),
+						MinReplicas: pointer.Int32(0),
+						MaxReplicas: pointer.Int32(10000),
 						GroupName:   "small-group",
 						RayStartParams: map[string]string{
 							"port":                        "6379",

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -305,9 +305,9 @@ var _ = Context("Inside the default namespace", func() {
 					getResourceFunc(ctx, client.ObjectKey{Name: myRayService.Name, Namespace: "default"}, myRayService),
 					time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayService  = %v", myRayService.Name)
 
-				podToDelete1 := workerPods.Items[0]
+				podToDelete := workerPods.Items[0]
 				myRayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas = pointer.Int32(1)
-				myRayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].ScaleStrategy.WorkersToDelete = []string{podToDelete1.Name}
+				myRayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].ScaleStrategy.WorkersToDelete = []string{podToDelete.Name}
 
 				return k8sClient.Update(ctx, myRayService)
 			})

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -90,7 +90,7 @@ var _ = Context("Inside the default namespace", func() {
 				RayVersion: "1.12.1",
 				HeadGroupSpec: rayiov1alpha1.HeadGroupSpec{
 					ServiceType: corev1.ServiceTypeClusterIP,
-					Replicas:    pointer.Int32Ptr(1),
+					Replicas:    pointer.Int32(1),
 					RayStartParams: map[string]string{
 						"port":                        "6379",
 						"object-store-memory":         "100000000",
@@ -168,9 +168,9 @@ var _ = Context("Inside the default namespace", func() {
 				},
 				WorkerGroupSpecs: []rayiov1alpha1.WorkerGroupSpec{
 					{
-						Replicas:    pointer.Int32Ptr(3),
-						MinReplicas: pointer.Int32Ptr(0),
-						MaxReplicas: pointer.Int32Ptr(10000),
+						Replicas:    pointer.Int32(3),
+						MinReplicas: pointer.Int32(0),
+						MaxReplicas: pointer.Int32(10000),
 						GroupName:   "small-group",
 						RayStartParams: map[string]string{
 							"port":                        "6379",
@@ -306,9 +306,7 @@ var _ = Context("Inside the default namespace", func() {
 					time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayService  = %v", myRayService.Name)
 
 				podToDelete1 := workerPods.Items[0]
-				rep := new(int32)
-				*rep = 1
-				myRayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas = rep
+				myRayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas = pointer.Int32(1)
 				myRayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].ScaleStrategy.WorkersToDelete = []string{podToDelete1.Name}
 
 				return k8sClient.Update(ctx, myRayService)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In a previous [experiment](https://github.com/ray-project/kuberay/issues/894#issuecomment-1416892144), it was shown that 86 runs succeed, and 14 runs failed with the following errors：

```
[Fail] Inside the default namespace When creating a raycluster [It] should update a raycluster object 
/home/lyc/Desktop/kuberay/ray-operator/controllers/ray/raycluster_controller_test.go:279

[Fail] Inside the default namespace When creating a raycluster [It] should have only 1 running worker 
/home/lyc/Desktop/kuberay/ray-operator/controllers/ray/raycluster_controller_test.go:286

[Fail] Inside the default namespace When creating a rayservice [It] should perform a zero-downtime update after a code change. 
/home/lyc/Desktop/kuberay/ray-operator/controllers/ray/rayservice_controller_test.go:354

```
The above errors are all due to [409 conflict](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency):

- In previous PR #73, retryOnOldRevision is used in certain places to retry updat call if facing a 409 conflict error. According to the previous experiment, it is necessary to apply the retry strategy to more k8sClient.Update calls especially those causing the above errors.
- Compare retryOnOldRevision with [RetryOnConflict ](https://pkg.go.dev/k8s.io/client-go/util/retry#RetryOnConflict), RetryOnConflict gives more advantages. It provides exponential backoff to avoid exhausting the apiserver.

So, two changes are made in this PR:
-   Replace retryOnOldRevision with [RetryOnConflict](https://pkg.go.dev/k8s.io/client-go/util/retry#RetryOnConflict)
-   Apply [RetryOnConflict](https://pkg.go.dev/k8s.io/client-go/util/retry#RetryOnConflict) to more k8sClient.Update calls.


If you have concerns about using RetryOnConflict to handle 409 conflict errors in testing or need some background information, see the below links :
- [k8s api-conventions document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency) describe the client action in the case of a conflict
- The [ [link](https://github.com/kubernetes/client-go/blob/master/examples/dynamic-create-update-delete-deployment/main.go#L118-L129) [link ](https://github.com/kubernetes-sigs/kubebuilder/blob/master/testdata/project-v4-with-deploy-image/internal/controller/busybox_controller.go#L245-L248) ] show how they implement the retry strategy.
-  [Don’t Retry on Conflict section in this article ](https://medium.com/@timebertt/kubernetes-controllers-at-scale-clients-caches-conflicts-patches-explained-aa0f7a8b4332) and [comment ](https://github.com/kubernetes-sigs/kubebuilder/issues/3212#issuecomment-1426794273 ) suggests not to use retry strategy in controllers and explain why. (Note, there are concerns and shortages to using the retry strategy in controllers as described above, but they are not for testing)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #902

## Checks
In a 2-core CPU, 7 GB RAM VM (to simulate the github's standard Linux runner), I ran the test 100 times:

```sh
rootPath="/home/lyc/Desktop/lessFlasky/kuberay"
cd $rootPath/ray-operator
for i in {1..100};
        do echo "iteration ${i}";
        make test | tee /home/lyc/Desktop/tmp/log${i}
done
```

_**All pass with no error. The test is stable now.**_






