### PR TITLE
match selector of service to pod labels

### DIFF
--- a/helm-chart/kuberay-apiserver/templates/service.yaml
+++ b/helm-chart/kuberay-apiserver/templates/service.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   selector:
-    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/component: {{ include "kuberay-apiserver.name" . }}
+    app.kubernetes.io/name: {{ .Release.Name }}
   ports:
     {{- toYaml .Values.service.ports | nindent 12 }}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The selector in the kuberay-apiserver service doesn't match the label of the kuberay-apiserver.  So the kuberay-apiserver can not be accessed via the   the kuberay-apiserver service.
Pod labels:
```
      app.kubernetes.io/component: kuberay-apiserver
      app.kubernetes.io/name: ccccc
      pod-template-hash: 69b79f99c5
```
Service selector
```
      app.kubernetes.io/name: kuberay-apiserver
```

This PR changes the service selector to match the apiserver pod labels in the helm template. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
