### PR TITLE
[Post Ray 2.3 Release] Update Ray versions to Ray 2.3.0

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -340,6 +340,26 @@ jobs:
         with:
           ray_version: 2.2.0
 
+  test-compatibility-2_3_0:
+    needs:
+      - build_operator
+      - build_apiserver
+      - lint
+    runs-on: ubuntu-latest
+    name: Compatibility Test - 2.3.0
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          # When checking out the repository that
+          # triggered a workflow, this defaults to the reference or SHA for that event.
+          # Default value should work for both pull_request and merge(push) event.
+          ref: ${{github.event.pull_request.head.sha}}
+
+      - uses: ./.github/workflows/actions/compatibility
+        with:
+          ray_version: 2.3.0
+
   test-compatibility-nightly:
     needs:
       - build_operator

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -280,26 +280,6 @@ jobs:
         with:
           ray_version: 1.13.0
 
-  test-compatibility-2_0_0:
-    needs:
-      - build_operator
-      - build_apiserver
-      - lint
-    runs-on: ubuntu-latest
-    name: Compatibility Test - 2.0.0
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-        with:
-          # When checking out the repository that
-          # triggered a workflow, this defaults to the reference or SHA for that event.
-          # Default value should work for both pull_request and merge(push) event.
-          ref: ${{github.event.pull_request.head.sha}}
-
-      - uses: ./.github/workflows/actions/compatibility
-        with:
-          ray_version: 2.0.0
-
   test-compatibility-2_1_0:
     needs:
       - build_operator

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -194,7 +194,7 @@ curl -X POST 'localhost:31888/apis/v1alpha2/namespaces/ray-system/services' \
   "clusterSpec": {
     "headGroupSpec": {
       "computeTemplate": "default-template",
-      "image": "rayproject/ray:2.2.0",
+      "image": "rayproject/ray:2.3.0",
       "serviceType": "NodePort",
       "rayStartParams": {
             "dashboard-host": "0.0.0.0",
@@ -206,7 +206,7 @@ curl -X POST 'localhost:31888/apis/v1alpha2/namespaces/ray-system/services' \
       {
         "groupName": "small-wg",
         "computeTemplate": "default-template",
-        "image": "rayproject/ray:2.2.0",
+        "image": "rayproject/ray:2.3.0",
         "replicas": 1,
         "minReplicas": 0,
         "maxReplicas": 5,

--- a/docs/guidance/pod-command.md
+++ b/docs/guidance/pod-command.md
@@ -21,7 +21,7 @@ Currently, for timing (1), we can set the container's `Command` and `Args` in Ra
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           resources:
             ...
           ports:

--- a/docs/guidance/volcano-integration.md
+++ b/docs/guidance/volcano-integration.md
@@ -42,7 +42,7 @@ metadata:
     ray.io/scheduler-name: volcano
     volcano.sh/queue-name: kuberay-test-queue
 spec:
-  rayVersion: '2.2.0'
+  rayVersion: '2.3.0'
   headGroupSpec:
     serviceType: ClusterIP
     rayStartParams:
@@ -52,7 +52,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           resources:
             limits:
               cpu: "1"
@@ -106,7 +106,7 @@ metadata:
     ray.io/scheduler-name: volcano
     volcano.sh/queue-name: kuberay-test-queue
 spec:
-  rayVersion: '2.2.0'
+  rayVersion: '2.3.0'
   headGroupSpec:
     serviceType: ClusterIP
     rayStartParams:
@@ -116,7 +116,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           resources:
             limits:
               cpu: "1"
@@ -135,7 +135,7 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray:2.2.0
+            image: rayproject/ray:2.3.0
             resources:
               limits:
                 cpu: "1"
@@ -220,7 +220,7 @@ metadata:
     ray.io/scheduler-name: volcano
     volcano.sh/queue-name: kuberay-test-queue
 spec:
-  rayVersion: '2.2.0'
+  rayVersion: '2.3.0'
   headGroupSpec:
     serviceType: ClusterIP
     rayStartParams:
@@ -230,7 +230,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           resources:
             limits:
               cpu: "1"
@@ -249,7 +249,7 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray:2.2.0
+            image: rayproject/ray:2.3.0
             resources:
               limits:
                 cpu: "1"

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -163,7 +163,7 @@ These tests operate small Ray clusters running within a [kind](https://kind.sigs
   # [Usage]: RAY_IMAGE=$RAY_IMAGE OPERATOR_IMAGE=$OPERATOR_IMAGE python3 tests/compatibility-test.py
   #          These 3 environment variables are optional.
   # [Example]:
-  RAY_IMAGE=rayproject/ray:2.2.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/compatibility-test.py
+  RAY_IMAGE=rayproject/ray:2.3.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/compatibility-test.py
   ```
 ### Running configuration tests locally.
 
@@ -173,9 +173,9 @@ and `tests/test_sample_rayservice_yamls.py`. Currently, only a few of these samp
 
 ```bash
 # Test RayCluster doc examples.
-RAY_IMAGE=rayproject/ray:2.2.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_raycluster_yamls.py
+RAY_IMAGE=rayproject/ray:2.3.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_raycluster_yamls.py
 # Test RayService doc examples.
-RAY_IMAGE=rayproject/ray:2.2.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
+RAY_IMAGE=rayproject/ray:2.3.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
 ```
 
 See [KubeRay PR #605](https://github.com/ray-project/kuberay/pull/605) for more details about the test framework.

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
@@ -49,7 +49,7 @@ var expectedRayJob = RayJob{
 						Containers: []corev1.Container{
 							{
 								Name:  "ray-head",
-								Image: "rayproject/ray:2.2.0",
+								Image: "rayproject/ray:2.3.0",
 								Env: []corev1.EnvVar{
 									{
 										Name: "MY_POD_IP",
@@ -111,7 +111,7 @@ var expectedRayJob = RayJob{
 							Containers: []corev1.Container{
 								{
 									Name:    "ray-worker",
-									Image:   "rayproject/ray:2.2.0",
+									Image:   "rayproject/ray:2.3.0",
 									Command: []string{"echo"},
 									Args:    []string{"Hello Ray"},
 									Env: []corev1.EnvVar{
@@ -175,7 +175,7 @@ var testRayJobJSON = `{
                         "containers": [
                             {
                                 "name": "ray-head",
-                                "image": "rayproject/ray:2.2.0",
+                                "image": "rayproject/ray:2.3.0",
                                 "ports": [
                                     {
                                         "name": "gcs-server",
@@ -238,7 +238,7 @@ var testRayJobJSON = `{
                             "containers": [
                                 {
                                     "name": "ray-worker",
-                                    "image": "rayproject/ray:2.2.0",
+                                    "image": "rayproject/ray:2.3.0",
                                     "command": [
                                         "echo"
                                     ],

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
@@ -97,7 +97,7 @@ var myRayService = &RayService{
 						Containers: []corev1.Container{
 							{
 								Name:  "ray-head",
-								Image: "rayproject/ray:2.2.0",
+								Image: "rayproject/ray:2.3.0",
 								Env: []corev1.EnvVar{
 									{
 										Name: "MY_POD_IP",
@@ -164,7 +164,7 @@ var myRayService = &RayService{
 							Containers: []corev1.Container{
 								{
 									Name:    "ray-worker",
-									Image:   "rayproject/ray:2.2.0",
+									Image:   "rayproject/ray:2.3.0",
 									Command: []string{"echo"},
 									Args:    []string{"Hello Ray"},
 									Env: []corev1.EnvVar{
@@ -267,7 +267,7 @@ var expected = `{
                   "containers":[
                      {
                         "name":"ray-head",
-                        "image":"rayproject/ray:2.2.0",
+                        "image":"rayproject/ray:2.3.0",
                         "ports":[
                            {
                               "name":"gcs-server",
@@ -335,7 +335,7 @@ var expected = `{
                      "containers":[
                         {
                            "name":"ray-worker",
-                           "image":"rayproject/ray:2.2.0",
+                           "image":"rayproject/ray:2.3.0",
                            "command":[
                               "echo"
                            ],

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -20,7 +20,7 @@ metadata:
   name: raycluster-autoscaler
 spec:
   # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
-  rayVersion: '2.2.0'
+  rayVersion: '2.3.0'
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
@@ -74,7 +74,7 @@ spec:
         containers:
         # The Ray head container
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           imagePullPolicy: Always
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
@@ -134,7 +134,7 @@ spec:
           command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
           # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -11,7 +11,7 @@ metadata:
   name: raycluster-autoscaler
 spec:
   # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
-  rayVersion: '2.2.0'
+  rayVersion: '2.3.0'
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
@@ -65,7 +65,7 @@ spec:
         containers:
         # The Ray head container
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           imagePullPolicy: Always
           ports:
           - containerPort: 6379
@@ -128,7 +128,7 @@ spec:
           command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           lifecycle:
             preStop:
               exec:

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -13,7 +13,7 @@ metadata:
     # A unique identifier for the head node and workers of this cluster.
   name: raycluster-complete
 spec:
-  rayVersion: '2.2.0'
+  rayVersion: '2.3.0'
   # Ray head pod template
   headGroupSpec:
     # Kubernetes Service Type. This is an optional field, and the default value is ClusterIP.
@@ -35,7 +35,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
           # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal
@@ -89,7 +89,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
           # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -10,7 +10,7 @@ metadata:
     # A unique identifier for the head node and workers of this cluster.
   name: raycluster-complete
 spec:
-  rayVersion: '2.2.0'
+  rayVersion: '2.3.0'
   # Ray head pod configuration
   headGroupSpec:
     # Kubernetes Service Type. This is an optional field, and the default value is ClusterIP.
@@ -29,7 +29,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           ports:
           - containerPort: 6379
             name: gcs
@@ -89,7 +89,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           lifecycle:
             preStop:
               exec:

--- a/ray-operator/config/samples/ray-cluster.getting-started.yaml
+++ b/ray-operator/config/samples/ray-cluster.getting-started.yaml
@@ -10,7 +10,7 @@ metadata:
     # An unique identifier for the head node and workers of this cluster.
   name: raycluster-getting-started
 spec:
-  rayVersion: '2.2.0' # should match the Ray version in the image of the containers
+  rayVersion: '2.3.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
     serviceType: ClusterIP # optional
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           volumeMounts:
           - mountPath: /opt
             name: config

--- a/ray-operator/config/samples/ray-cluster.head-command.yaml
+++ b/ray-operator/config/samples/ray-cluster.head-command.yaml
@@ -8,7 +8,7 @@ metadata:
     # An unique identifier for the head node and workers of this cluster.
   name: raycluster-mini
 spec:
-  rayVersion: '2.2.0' # should match the Ray version in the image of the containers
+  rayVersion: '2.3.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
     serviceType: ClusterIP # optional
@@ -22,7 +22,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           resources:
             limits:
               cpu: 1

--- a/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
+++ b/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
@@ -34,7 +34,7 @@ metadata:
     # An unique identifier for the head node and workers of this cluster.
   name: raycluster-heterogeneous
 spec:
-  rayVersion: '2.2.0'
+  rayVersion: '2.3.0'
   ######################headGroupSpecs#################################
   # Ray head pod template
   headGroupSpec:
@@ -49,7 +49,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           volumeMounts:
           - mountPath: /opt
             name: config
@@ -88,7 +88,7 @@ spec:
           command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           volumeMounts:
             - mountPath: /tmp/ray
               name: ray-logs
@@ -128,7 +128,7 @@ spec:
           command: ['sh', '-c', "until nslookup raycluster-heterogeneous-head-svc.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           # use volumeMounts.Optional.
           # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
           volumeMounts:

--- a/ray-operator/config/samples/ray-cluster.ingress.yaml
+++ b/ray-operator/config/samples/ray-cluster.ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
   name: raycluster-ingress
 spec:
-  rayVersion: '2.2.0' # should match the Ray version in the image of the containers
+  rayVersion: '2.3.0' # should match the Ray version in the image of the containers
   headGroupSpec:
     serviceType: NodePort
     enableIngress: true
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           ports:
           - containerPort: 6379
             name: gcs-server

--- a/ray-operator/config/samples/ray-cluster.mini.yaml
+++ b/ray-operator/config/samples/ray-cluster.mini.yaml
@@ -10,7 +10,7 @@ metadata:
     # An unique identifier for the head node and workers of this cluster.
   name: raycluster-mini
 spec:
-  rayVersion: '2.2.0' # should match the Ray version in the image of the containers
+  rayVersion: '2.3.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
     serviceType: ClusterIP # optional
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           resources:
             limits:
               cpu: 1

--- a/ray-operator/config/samples/ray-cluster.separate-ingress.yaml
+++ b/ray-operator/config/samples/ray-cluster.separate-ingress.yaml
@@ -7,7 +7,7 @@ kind: RayCluster
 metadata:
   name: raycluster-ingress
 spec:
-  rayVersion: '2.2.0' # should match the Ray version in the image of the containers
+  rayVersion: '2.3.0' # should match the Ray version in the image of the containers
   headGroupSpec:
     serviceType: NodePort
     replicas: 1
@@ -20,7 +20,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.2.0
+          image: rayproject/ray:2.3.0
           ports:
           - containerPort: 6379
             name: gcs-server

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -15,7 +15,7 @@ spec:
   #}'
   runtimeEnv: ewogICAgInBpcCI6IFsKICAgICAgICAicmVxdWVzdHM9PTIuMjYuMCIsCiAgICAgICAgInBlbmR1bHVtPT0yLjEuMiIKICAgIF0sCiAgICAiZW52X3ZhcnMiOiB7ImNvdW50ZXJfbmFtZSI6ICJ0ZXN0X2NvdW50ZXIifQp9Cg==
   rayClusterSpec:
-    rayVersion: '2.2.0' # should match the Ray version in the image of the containers
+    rayVersion: '2.3.0' # should match the Ray version in the image of the containers
     # Ray head pod template
     headGroupSpec:
       serviceType: ClusterIP # optional
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.2.0
+              image: rayproject/ray:2.3.0
               ports:
                 - containerPort: 6379
                   name: gcs-server
@@ -71,7 +71,7 @@ spec:
                 command: [ 'sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done" ]
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-                image: rayproject/ray:2.2.0
+                image: rayproject/ray:2.3.0
                 lifecycle:
                   preStop:
                     exec:

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -42,7 +42,7 @@ spec:
         rayActorOptions:
           numCpus: 0.1
   rayClusterConfig:
-    rayVersion: '2.2.0' # should match the Ray version in the image of the containers
+    rayVersion: '2.3.0' # should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
@@ -58,7 +58,7 @@ spec:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.2.0
+              image: rayproject/ray:2.3.0
               imagePullPolicy: Always
               resources:
                 limits:
@@ -95,7 +95,7 @@ spec:
                 command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-                image: rayproject/ray:2.2.0
+                image: rayproject/ray:2.3.0
                 imagePullPolicy: Always
                 lifecycle:
                   preStop:

--- a/ray-operator/config/security/ray-cluster.pod-security.yaml
+++ b/ray-operator/config/security/ray-cluster.pod-security.yaml
@@ -10,7 +10,7 @@ metadata:
     # A unique identifier for the head node and workers of this cluster.
   name: raycluster-pod-security
 spec:
-  rayVersion: '2.2.0'
+  rayVersion: '2.3.0'
   # Ray head pod configuration
   headGroupSpec:
     serviceType: ClusterIP # optional

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -186,7 +186,7 @@ func setupTest(t *testing.T) {
 				Containers: []corev1.Container{
 					{
 						Name:    "ray-worker",
-						Image:   "rayproject/ray:2.2.0",
+						Image:   "rayproject/ray:2.3.0",
 						Command: []string{"echo"},
 						Args:    []string{"Hello Ray"},
 					},
@@ -209,7 +209,7 @@ func setupTest(t *testing.T) {
 				Containers: []corev1.Container{
 					{
 						Name:    "ray-worker",
-						Image:   "rayproject/ray:2.2.0",
+						Image:   "rayproject/ray:2.3.0",
 						Command: []string{"echo"},
 						Args:    []string{"Hello Ray"},
 					},
@@ -261,7 +261,7 @@ func setupTest(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name:    "ray-head",
-								Image:   "rayproject/ray:2.2.0",
+								Image:   "rayproject/ray:2.3.0",
 								Command: []string{"python"},
 								Args:    []string{"/opt/code.py"},
 								Env: []corev1.EnvVar{
@@ -294,7 +294,7 @@ func setupTest(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:    "ray-worker",
-									Image:   "rayproject/ray:2.2.0",
+									Image:   "rayproject/ray:2.3.0",
 									Command: []string{"echo"},
 									Args:    []string{"Hello Ray"},
 									Env: []corev1.EnvVar{

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -67,7 +67,7 @@ var _ = Context("Inside the default namespace", func() {
 						Containers: []corev1.Container{
 							{
 								Name:    "ray-head",
-								Image:   "rayproject/ray:2.2.0",
+								Image:   "rayproject/ray:2.3.0",
 								Command: []string{"python"},
 								Args:    []string{"/opt/code.py"},
 								Env: []corev1.EnvVar{
@@ -100,7 +100,7 @@ var _ = Context("Inside the default namespace", func() {
 							Containers: []corev1.Container{
 								{
 									Name:    "ray-worker",
-									Image:   "rayproject/ray:2.2.0",
+									Image:   "rayproject/ray:2.3.0",
 									Command: []string{"echo"},
 									Args:    []string{"Hello Ray"},
 									Env: []corev1.EnvVar{

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -76,7 +76,7 @@ var _ = Context("Inside the default namespace", func() {
 							Containers: []corev1.Container{
 								{
 									Name:  "ray-head",
-									Image: "rayproject/ray:2.2.0",
+									Image: "rayproject/ray:2.3.0",
 									Env: []corev1.EnvVar{
 										{
 											Name: "MY_POD_IP",
@@ -143,7 +143,7 @@ var _ = Context("Inside the default namespace", func() {
 								Containers: []corev1.Container{
 									{
 										Name:    "ray-worker",
-										Image:   "rayproject/ray:2.2.0",
+										Image:   "rayproject/ray:2.3.0",
 										Command: []string{"echo"},
 										Args:    []string{"Hello Ray"},
 										Env: []corev1.EnvVar{

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -114,7 +114,7 @@ var _ = Context("Inside the default namespace", func() {
 							Containers: []corev1.Container{
 								{
 									Name:  "ray-head",
-									Image: "rayproject/ray:2.2.0",
+									Image: "rayproject/ray:2.3.0",
 									Env: []corev1.EnvVar{
 										{
 											Name: "MY_POD_IP",
@@ -189,7 +189,7 @@ var _ = Context("Inside the default namespace", func() {
 								Containers: []corev1.Container{
 									{
 										Name:    "ray-worker",
-										Image:   "rayproject/ray:2.2.0",
+										Image:   "rayproject/ray:2.3.0",
 										Command: []string{"echo"},
 										Args:    []string{"Hello Ray"},
 										Env: []corev1.EnvVar{


### PR DESCRIPTION
Inspired by https://github.com/ray-project/kuberay/pull/822

I think I got all references to 2.2.0:
```
$ ag '2\.2\.0' | grep -v 'third_party' | grep -v 'go.sum' | grep -v 'go.mod'
CHANGELOG.md:17:* Critical stability improvements to the [Ray Autoscaler integration](https://ray-project.github.io/kuberay/guidance/autoscaler/). (To benefit from these improvements, use KubeRay >=0.4.0 and Ray >=2.2.0.)
```