### PR TITLE
[Ray 2.3.0] Update --redis-password for RayCluster

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -360,13 +360,13 @@ jobs:
         with:
           ray_version: nightly
 
-  sample-yaml-config-test-2_1_0:
+  sample-yaml-config-test-2_3_0:
     needs:
       - build_operator
       - build_apiserver
       - lint
     runs-on: ubuntu-latest
-    name: Sample YAML Config Test - 2.1.0
+    name: Sample YAML Config Test - 2.3.0
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -377,5 +377,5 @@ jobs:
           ref: ${{github.event.pull_request.head.sha}}
       - uses: ./.github/workflows/actions/configuration
         with:
-          ray_version: 2.1.0
+          ray_version: 2.3.0
 

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -77,20 +77,23 @@ metadata:
   # An unique identifier for the head node and workers of this cluster.
   name: raycluster-external-redis
 spec:
-  rayVersion: '2.2.0'
+  rayVersion: '2.3.0'
   headGroupSpec:
     serviceType: ClusterIP # optional
     replicas: 1
     rayStartParams:
-      dashboard-host: '0.0.0.0'
-      num-cpus: '1' # can be auto-completed from the limits
-      block: 'true'
+      dashboard-host: "0.0.0.0"
+      num-cpus: "1" # can be auto-completed from the limits
+      block: "true"
+      # redis-password should match "requirepass" in redis.conf in the ConfigMap above.
+      # Ray 2.3.0 changes the default redis password from "5241590000000000" to "".
+      redis-password: "5241590000000000"
     #pod template
     template:
       spec:
         containers:
           - name: ray-head
-            image: rayproject/ray:2.2.0
+            image: rayproject/ray:2.3.0
             env:
               # RAY_REDIS_ADDRESS can force ray to use external redis
               - name: RAY_REDIS_ADDRESS
@@ -128,7 +131,7 @@ spec:
               command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
           containers:
             - name: ray-worker
-              image: rayproject/ray:2.2.0
+              image: rayproject/ray:2.3.0
               volumeMounts:
                 - mountPath: /tmp/ray
                   name: ray-logs

--- a/ray-operator/config/security/ray-cluster.pod-security.yaml
+++ b/ray-operator/config/security/ray-cluster.pod-security.yaml
@@ -26,7 +26,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray-ml:2.2.0
+          image: rayproject/ray-ml:2.3.0
           ports:
           - containerPort: 6379
             name: gcs
@@ -91,7 +91,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray-ml:2.2.0
+          image: rayproject/ray-ml:2.3.0
           # environment variables to set in the container.Optional.
           # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
           lifecycle:

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -31,10 +31,10 @@ logging.basicConfig(
 )
 
 # Default Ray version
-ray_version = '2.2.0'
+ray_version = '2.3.0'
 
 # Default docker images
-ray_image = 'rayproject/ray:2.2.0'
+ray_image = 'rayproject/ray:2.3.0'
 kuberay_operator_image = 'kuberay/operator:nightly'
 
 

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -74,9 +74,10 @@ spec:
   rayVersion: '$ray_version'
   headGroupSpec:
     rayStartParams:
-      dashboard-host: '0.0.0.0'
-      num-cpus: '1'
-      block: 'true'
+      dashboard-host: "0.0.0.0"
+      num-cpus: "1"
+      block: "true"
+      redis-password: "5241590000000000"
     #pod template
     template:
       metadata:

--- a/tests/test_sample_raycluster_yamls.py
+++ b/tests/test_sample_raycluster_yamls.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
 
     rs = RuleSet([HeadPodNameRule(), EasyJobRule(), HeadSvcRule()])
     image_dict = {
-        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.2.0'),
+        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.3.0'),
         CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
     }
     logger.info(image_dict)

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
 
     rs = RuleSet([EasyJobRule(), CurlServiceRule()])
     image_dict = {
-        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.2.0'),
+        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.3.0'),
         CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
     }
     logger.info(image_dict)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -55,7 +55,7 @@ class PodSecurityTestCase(unittest.TestCase):
                              {PodSecurityTestCase.namespace}.kubernetes.io/enforce-version=latest")
         # Install the KubeRay operator in the namespace pod-security.
         image_dict = {
-            CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.2.0',
+            CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.3.0',
             CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly'),
         }
         logger.info(image_dict)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Ray 2.3.0 changes `REDIS_DEFAULT_PASSWORD` from `"5241590000000000"` to `""` in [ray-project/ray#31257](https://github.com/ray-project/ray/pull/31257/files).


## Related issue number
Closes #927
https://github.com/ray-project/ray/issues/32794
#925 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* Ray FT related tests: 
   ```sh
   RAY_IMAGE=rayproject/ray:2.3.0 python3 tests/compatibility-test.py RayFTTestCase 2>&1 | tee log
   ```
  <img width="1440" alt="Screen Shot 2023-02-24 at 11 36 24 AM" src="https://user-images.githubusercontent.com/20109646/221274771-6274bdeb-7770-4478-9eff-940c530af109.png">
* RayService sample YAML test:
  ```sh
  RAY_IMAGE=rayproject/ray:2.3.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py 2>&1 | tee log
  ```
  <img width="1438" alt="Screen Shot 2023-02-24 at 11 47 08 AM" src="https://user-images.githubusercontent.com/20109646/221276702-7ad9a4b2-e1c4-4f64-9561-1c299ac125d5.png">

* RayCluster sample YAML test
  ```sh
  RAY_IMAGE=rayproject/ray:2.3.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_raycluster_yamls.py 2>&1 | tee log
  ```
  <img width="1440" alt="Screen Shot 2023-02-24 at 12 02 51 PM" src="https://user-images.githubusercontent.com/20109646/221279684-06cc760e-e255-4ba0-8cb2-87e975d135d0.png">

* Pod security test
  ```sh
  python3 tests/test_security.py 2>&1 | tee log
  ```
  <img width="1440" alt="Screen Shot 2023-02-24 at 3 42 22 PM" src="https://user-images.githubusercontent.com/20109646/221323191-2736a0c3-dc1c-443e-ad18-865171fcd518.png">

