### PR TITLE
 Inject the --block option to ray start command automatically

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -321,7 +321,7 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayiov1alpha1.RayN
 			// sleep infinity is used to keep the pod `running` after the last command exits, and not go into `completed` state
 			args = args + " && sleep infinity"
 		}
-		
+
 		pod.Spec.Containers[rayContainerIndex].Args = []string{args}
 	}
 

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -723,17 +723,18 @@ func concatenateContainerCommand(nodeType rayiov1alpha1.RayNodeType, rayStartPar
 
 func convertParamMap(rayStartParams map[string]string) (s string) {
 	flags := new(bytes.Buffer)
-	// NonFlagParams with a value of true or false.
-	specialNonFlagParams := []string{"log-color", "include-dashboard"}
-	for k, v := range rayStartParams {
-		if utils.Contains([]string{"true", "false"}, strings.ToLower(v)) && !utils.Contains(specialNonFlagParams, k) {
-			// FlagParams
-			if strings.ToLower(v) == "true" {
-				fmt.Fprintf(flags, " --%s ", k)
+	// specialParameterOption's arguments can be true or false.
+	// For example, --log-color can be auto | false | true.
+	specialParameterOption := []string{"log-color", "include-dashboard"}
+	for option, argument := range rayStartParams {
+		if utils.Contains([]string{"true", "false"}, strings.ToLower(argument)) && !utils.Contains(specialParameterOption, option) {
+			// booleanOptions: do not require any argument. Essentially represent boolean on-off switches.
+			if strings.ToLower(argument) == "true" {
+				fmt.Fprintf(flags, " --%s ", option)
 			}
 		} else {
-			// nonFlagParams
-			fmt.Fprintf(flags, " --%s=%s ", k, v)
+			// parameterOption: require arguments to be provided along with the option.
+			fmt.Fprintf(flags, " --%s=%s ", option, argument)
 		}
 	}
 	return flags.String()

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -727,7 +727,7 @@ func convertParamMap(rayStartParams map[string]string) (s string) {
 	specialNonFlagParams := []string{"log-color", "include-dashboard"}
 	for k, v := range rayStartParams {
 		if utils.Contains([]string{"true", "false"}, strings.ToLower(v)) && !utils.Contains(specialNonFlagParams, k) {
-			//FlagParams
+			// FlagParams
 			if strings.ToLower(v) == "true" {
 				fmt.Fprintf(flags, " --%s ", k)
 			}

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -723,11 +723,11 @@ func concatenateContainerCommand(nodeType rayiov1alpha1.RayNodeType, rayStartPar
 
 func convertParamMap(rayStartParams map[string]string) (s string) {
 	flags := new(bytes.Buffer)
-	// specialParameterOption's arguments can be true or false.
+	// specialParameterOptions' arguments can be true or false.
 	// For example, --log-color can be auto | false | true.
-	specialParameterOption := []string{"log-color", "include-dashboard"}
+	specialParameterOptions := []string{"log-color", "include-dashboard"}
 	for option, argument := range rayStartParams {
-		if utils.Contains([]string{"true", "false"}, strings.ToLower(argument)) && !utils.Contains(specialParameterOption, option) {
+		if utils.Contains([]string{"true", "false"}, strings.ToLower(argument)) && !utils.Contains(specialParameterOptions, option) {
 			// booleanOptions: do not require any argument. Essentially represent boolean on-off switches.
 			if strings.ToLower(argument) == "true" {
 				fmt.Fprintf(flags, " --%s ", option)

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -321,6 +321,7 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayiov1alpha1.RayN
 			// sleep infinity is used to keep the pod `running` after the last command exits, and not go into `completed` state
 			args = args + " && sleep infinity"
 		}
+		
 		pod.Spec.Containers[rayContainerIndex].Args = []string{args}
 	}
 

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -321,7 +321,6 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayiov1alpha1.RayN
 			// sleep infinity is used to keep the pod `running` after the last command exits, and not go into `completed` state
 			args = args + " && sleep infinity"
 		}
-		log.Info("Hi, the final args is", "args", args)
 		pod.Spec.Containers[rayContainerIndex].Args = []string{args}
 	}
 
@@ -666,7 +665,6 @@ func setMissingRayStartParams(rayStartParams map[string]string, nodeType rayiov1
 	if _, ok := rayStartParams["block"]; !ok {
 		rayStartParams["block"] = "true"
 	}
-	log.Info("Hi, I have make sure rayStartParams[\"block\"] is set", "rayStartParams[\"block\"]", rayStartParams["block"])
 
 	return rayStartParams
 }

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -355,14 +355,22 @@ func TestBuildPod(t *testing.T) {
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, "", "")
 
-	// Check RAY_ADDRESS env.
+	// Check environment variables
 	checkPodEnv(t, pod, RAY_ADDRESS, "127.0.0.1:6379")
-	// Check usage stats env.
 	checkPodEnv(t, pod, RAY_USAGE_STATS_KUBERAY_IN_USE, "1")
+	checkPodEnv(t, pod, RAY_CLUSTER_NAME, fmt.Sprintf("metadata.labels['%s']", RayClusterLabelKey))
+
+	// Check RayStartParams
+	expectedResult := "true"
+	actualResult := cluster.Spec.HeadGroupSpec.RayStartParams["block"]
+
+	if !reflect.DeepEqual(expectedResult, actualResult) {
+		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
+	}
 
 	// Check labels.
-	actualResult := pod.Labels[RayClusterLabelKey]
-	expectedResult := cluster.Name
+	actualResult = pod.Labels[RayClusterLabelKey]
+	expectedResult = cluster.Name
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
@@ -407,6 +415,13 @@ func TestBuildPod(t *testing.T) {
 	// Check RayStartParams
 	expectedResult = fmt.Sprintf("%s:6379", fqdnRayIP)
 	actualResult = cluster.Spec.WorkerGroupSpecs[0].RayStartParams["address"]
+
+	if !reflect.DeepEqual(expectedResult, actualResult) {
+		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
+	}
+
+	expectedResult = "true"
+	actualResult = cluster.Spec.WorkerGroupSpecs[0].RayStartParams["block"]
 
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
 
This PR:
1. Inject the `--block` option to the ray start command automatically if the user has not set the `-- block` option. See https://github.com/ray-project/kuberay/pull/675 and https://github.com/ray-project/kuberay/pull/912#issuecomment-1436393712
2.  According to [ray start options document](https://docs.ray.io/en/latest/cluster/cli.html#ray-start), there are many parameters that the user should be able to set in the format `'parameters': 'true'` or `'parameters': 'false'` (e.g `--block`, `--disable-usage-stats`) in `rayStartParams`. However, kuberay can not handle(will fail to run all the pods) if the user set 'parameters': 'false' in rayStartParams. This PR enables the user to set a 'false' value.





**Prove that Without --block, it may take a much longer time to detect the unhealthy condition and restart the pod:**

You can find [without_block.yaml](https://github.com/Yicheng-Lu-llll/kuberay/blob/tmp/without_block.yaml) and [with_block.yaml](https://github.com/Yicheng-Lu-llll/kuberay/blob/tmp/with_block.yaml) here.
```sh
# without block case:
# Create head and worker pod
# Note, we need to enable Fault Tolerance. readiness probe and Liveness probe will only be installed if Fault Tolerance is enabled. 
# See https://github.com/ray-project/kuberay/blob/master/docs/guidance/gcs-ft.md
kubectl apply -f /home/lyc/without_block.yaml
#  ulimit -n 65536; ray start  --num-cpus=1  --metrics-export-port=8080  --address=raycluster-external-redis-head-svc:6379  && sleep infinity
#  ulimit -n 65536; ray start --head  --num-cpus=1  --metrics-export-port=8080  --dashboard-host=0.0.0.0  && sleep infinity

# kill gcs server, the pod will continue running.
# Note, you can also do ray stop -f to kill all the ray processes.
# The pod will always continue running due to "sleep infinity" process.
date && kubectl exec -it $(kubectl get pods -o=name | grep head) --  pkill gcs_server
# list all event based on the happening time and see when the liveness probe fail
kubectl get events --sort-by='{.metadata.creationTimestamp}' -o yaml | grep -E 'message|firstTimestamp' 
# get pod's last exit time
kubectl get  $(kubectl get pods -o=name | grep head) -o yaml | grep finishedAt
# get pod's restart time
kubectl get  $(kubectl get pods -o=name | grep head) -o yaml | grep startedAt


# I have run the above three times, here is the result:

#   kill gcs server at :                   Sun Feb 26 04:59:39 UTC 2023
#   liveness probe/readness probe fail at: "2023-02-26T05:01:41Z"
#   pod finishedAt :                       "2023-02-26T05:04:04Z"
#   pod restartedAt:                       "2023-02-26T05:04:04Z"

#   kill gcs server at :                   Sun Feb 26 05:23:51 UTC 2023
#   liveness probe/readness probe fail at: "2023-02-26T05:25:54Z"
#   pod finishedAt :                       "2023-02-26T05:28:17Z"
#   pod restartedAt:                       "2023-02-26T05:28:17Z"

#   kill gcs server at :                   Sun Feb 26 05:38:52 UTC 2023
#   liveness probe/readness probe fail at: "2023-02-26T05:40:56Z"
#   pod finishedAt :                       "2023-02-26T05:43:19Z"
# pod restartedAt:                         "2023-02-26T05:43:19Z"
```

```sh
# with block case:
# Create head and worker pod
kubectl apply -f /home/lyc/with_block.yaml
# 'ulimit -n 65536; ray start  --address=raycluster-complete-head-svc:6379  --metrics-export-port=8080  --num-cpus=1  --memory=1000000000  --block '
# 'ulimit -n 65536; ray start --head  --num-cpus=1  --memory=2000000000  --block  --dashboard-host=0.0.0.0  --metrics-export-port=8080 '

# kill all ray processes, the pod will exit immediately.
date && kubectl exec -it $(kubectl get pods -o=name | grep head) --  ray stop -f
# get pod's last exit time
kubectl get  $(kubectl get pods -o=name | grep head) -o yaml | grep finishedAt
# get pod's restart time
kubectl get  $(kubectl get pods -o=name | grep head) -o yaml | grep startedAt


# I have run the above three times, here is the result:

#   kill all ray processes at:   Sun Feb 26 04:44:50 UTC 2023
#   pod finishedAt :             "2023-02-26T04:44:53Z"
#   pod restartedAt:             "2023-02-26T04:44:53Z"

#   kill all ray processes at:   Sun Feb 26 04:51:07 UTC 2023
#   pod finishedAt :             "2023-02-26T04:51:09Z"
#   pod restartedAt:             "2023-02-26T04:51:10Z"

#   kill all ray processes at:   Sun Feb 26 04:55:09 UTC 2023
#   pod finishedAt :             "2023-02-26T04:55:11Z"
#   pod restartedAt:             "2023-02-26T04:55:12Z"
```

To summarize the result, In a single, healthy node environment:
 - with the -- block option, the pod will restart immediately after the ray process crash. 
 - Without -- block option, 
    - the liveness probe/readiness probe will fail **129.3 seconds** after killing the ray processes. 
    - The pod will restart **143 seconds** after the liveness probe/readiness probe fail.

**Questions:**

**Should we enforce adding the `--block` option (even if the user set `'block': 'false'`  in ` rayStartParams `)?**'

Because not every user will enable [Fault Tolerance](https://github.com/ray-project/kuberay/blob/master/docs/guidance/gcs-ft.md). But the readiness probe and Liveness probe will only be installed if Fault Tolerance is enabled. That is,  if running without Fault Tolerance and ray processes somehow crash, kuberay will never detect the failure and restart the pod for the user. 


## Related issue number
Closes #915 
<!-- For example: "Closes #1234" -->

## Checks

I've made sure the tests are passing in various situations:
 -  `'block' : 'false'`  in `rayStartParams`
![59a160e73483e85a7812d98eeabfb1c](https://user-images.githubusercontent.com/51814063/225739261-4a5339ca-7125-40b0-b617-a9508ed45f24.png)

 - `'block' : 'true'`    in `rayStartParams`
 ![642bab545267313905186747f46a092](https://user-images.githubusercontent.com/51814063/225736764-7e0f063c-3ca7-4dd5-afc0-1a95fb751c8c.png)

 -  `block` not set.
![497221a8428c87458669903e4291249](https://user-images.githubusercontent.com/51814063/225735319-43d88fe3-5515-4def-88c3-1468e0b94dc0.png)


- Test convertParamMap
```golang

func TestConvertParamMap(t *testing.T) {
	rayStartParams := map[string]string{
		"booleanOptionsTrue":  "true",
		"booleanOptionsFalse": "false",
		"ParameterOptions":    "arguments",
		"log-color":           "false",
		"include-dashboard":   "true",
	}
	s := convertParamMap(rayStartParams)
	// s will be:
       //  --booleanOptionsTrue  --ParameterOptions=arguments  --log-color=false  --include-dashboard=true 

}

```
 