### PR TITLE
Inject cluster name as an environment variable into head and worker pods

### DIFF
--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -72,7 +72,7 @@ const (
 
 	// Use as container env variable
 	NAMESPACE                               = "NAMESPACE"
-	CLUSTER_NAME                            = "CLUSTER_NAME"
+	RAY_CLUSTER_NAME                        = "RAY_CLUSTER_NAME"
 	RAY_IP                                  = "RAY_IP"
 	FQ_RAY_IP                               = "FQ_RAY_IP"
 	RAY_PORT                                = "RAY_PORT"

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -380,7 +380,7 @@ func BuildAutoscalerContainer(autoscalerImage string) v1.Container {
 		ImagePullPolicy: v1.PullAlways,
 		Env: []v1.EnvVar{
 			{
-				Name: "RAY_CLUSTER_NAME",
+				Name: RAY_CLUSTER_NAME,
 				ValueFrom: &v1.EnvVarSource{
 					FieldRef: &v1.ObjectFieldSelector{
 						FieldPath: fmt.Sprintf("metadata.labels['%s']", RayClusterLabelKey),
@@ -573,17 +573,17 @@ func setContainerEnvVars(pod *v1.Pod, rayContainerIndex int, rayNodeType rayiov1
 		container.Env = append(container.Env, portEnv)
 	}
 
-	if !envVarExists(RAY_CLUSTER_NAME, container.Env) {
-		clusterNameEnv := v1.EnvVar{
-			Name: RAY_CLUSTER_NAME,
-			ValueFrom: &v1.EnvVarSource{
-				FieldRef: &v1.ObjectFieldSelector{
-					FieldPath: fmt.Sprintf("metadata.labels['%s']", RayClusterLabelKey),
-				},
+	// The RAY_CLUSTER_NAME environment variable is managed by KubeRay and should not be modified by users.
+	// TODO: Audit all environment variables to identify which should not be modified by users.
+	clusterNameEnv := v1.EnvVar{
+		Name: RAY_CLUSTER_NAME,
+		ValueFrom: &v1.EnvVarSource{
+			FieldRef: &v1.ObjectFieldSelector{
+				FieldPath: fmt.Sprintf("metadata.labels['%s']", RayClusterLabelKey),
 			},
-		}
-		container.Env = append(container.Env, clusterNameEnv)
+		},
 	}
+	container.Env = append(container.Env, clusterNameEnv)
 
 	if strings.ToLower(creator) == RayServiceCreatorLabelValue {
 		// Only add this env for Ray Service cluster to improve service SLA.

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -191,10 +191,10 @@ var autoscalerContainer = v1.Container{
 	ImagePullPolicy: v1.PullAlways,
 	Env: []v1.EnvVar{
 		{
-			Name: "RAY_CLUSTER_NAME",
+			Name: RAY_CLUSTER_NAME,
 			ValueFrom: &v1.EnvVarSource{
 				FieldRef: &v1.ObjectFieldSelector{
-					FieldPath: "metadata.labels['ray.io/cluster']",
+					FieldPath: fmt.Sprintf("metadata.labels['%s']", RayClusterLabelKey),
 				},
 			},
 		},

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -326,9 +326,18 @@ func checkPodEnv(t *testing.T, pod v1.Pod, envName string, expectedValue string)
 	foundEnv := false
 	for _, env := range pod.Spec.Containers[0].Env {
 		if env.Name == envName {
-			if !(env.Value == expectedValue) {
-				t.Fatalf("Expected `%v` but got `%v`", expectedValue, env.Value)
+			// env.ValueFrom is the source for the environment variable's value. It will be nil if env.Value is not empty.
+			if env.ValueFrom == nil {
+				if !(env.Value == expectedValue) {
+					t.Fatalf("Expected `%v` but got `%v`", expectedValue, env.Value)
+				}
+			} else {
+				fmt.Println(env.Name, env.Value, env.ValueFrom.FieldRef.FieldPath)
+				if !(env.ValueFrom.FieldRef.FieldPath == expectedValue) {
+					t.Fatalf("Expected `%v` but got `%v`", expectedValue, env.ValueFrom.FieldRef.FieldPath)
+				}
 			}
+
 			foundEnv = true
 			break
 		}
@@ -393,6 +402,7 @@ func TestBuildPod(t *testing.T) {
 	checkPodEnv(t, pod, RAY_ADDRESS, "raycluster-sample-head-svc.default.svc.cluster.local:6379")
 	checkPodEnv(t, pod, FQ_RAY_IP, "raycluster-sample-head-svc.default.svc.cluster.local")
 	checkPodEnv(t, pod, RAY_IP, "raycluster-sample-head-svc")
+	checkPodEnv(t, pod, RAY_CLUSTER_NAME, fmt.Sprintf("metadata.labels['%s']", RayClusterLabelKey))
 
 	// Check RayStartParams
 	expectedResult = fmt.Sprintf("%s:6379", fqdnRayIP)

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -327,13 +327,13 @@ func checkPodEnv(t *testing.T, pod v1.Pod, envName string, expectedValue string)
 	for _, env := range pod.Spec.Containers[0].Env {
 		if env.Name == envName {
 			// env.ValueFrom is the source for the environment variable's value. It will be nil if env.Value is not empty.
+			// See https://pkg.go.dev/k8s.io/api/core/v1#EnvVar for more details.
 			if env.ValueFrom == nil {
-				if !(env.Value == expectedValue) {
+				if env.Value != expectedValue {
 					t.Fatalf("Expected `%v` but got `%v`", expectedValue, env.Value)
 				}
 			} else {
-				fmt.Println(env.Name, env.Value, env.ValueFrom.FieldRef.FieldPath)
-				if !(env.ValueFrom.FieldRef.FieldPath == expectedValue) {
+				if env.ValueFrom.FieldRef.FieldPath != expectedValue {
 					t.Fatalf("Expected `%v` but got `%v`", expectedValue, env.ValueFrom.FieldRef.FieldPath)
 				}
 			}

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -326,13 +326,13 @@ func checkPodEnv(t *testing.T, pod v1.Pod, envName string, expectedValue string)
 	foundEnv := false
 	for _, env := range pod.Spec.Containers[0].Env {
 		if env.Name == envName {
-			// env.ValueFrom is the source for the environment variable's value. It will be nil if env.Value is not empty.
-			// See https://pkg.go.dev/k8s.io/api/core/v1#EnvVar for more details.
-			if env.ValueFrom == nil {
+			if env.Value != "" {
 				if env.Value != expectedValue {
 					t.Fatalf("Expected `%v` but got `%v`", expectedValue, env.Value)
 				}
 			} else {
+				// env.ValueFrom is the source for the environment variable's value. Cannot be used if value is not empty.
+				// See https://pkg.go.dev/k8s.io/api/core/v1#EnvVar for more details.
 				if env.ValueFrom.FieldRef.FieldPath != expectedValue {
 					t.Fatalf("Expected `%v` but got `%v`", expectedValue, env.ValueFrom.FieldRef.FieldPath)
 				}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See https://github.com/ray-project/kuberay/issues/928.

Now user can get env var `RAY_CLUSTER_NAME` in head and worker pods.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #928
<!-- For example: "Closes #1234" -->

## Checks
```shell
rootPath={Your kuberay repo path}
# ray-cluster.complete.yaml will create one head pod and one worker pod.
kubectl apply -f $rootPath/ray-operator/config/samples/ray-cluster.complete.yaml
kubectl exec -it $(kubectl get pods -o=name | grep head) -- env | grep RAY_CLUSTER_NAME
kubectl exec -it $(kubectl get pods -o=name | grep worker) -- env | grep RAY_CLUSTER_NAME
# Now change the pod replicas to 2, kuberay operator will create a new worker pod, check if the newly created pod also have env vars.
kubectl apply -f $rootPath/ray-operator/config/samples/ray-cluster.complete.yaml
kubectl exec -it raycluster-complete-worker-small-group-fw6kk -- env | grep RAY_CLUSTER_NAME


# will always see:
# RAY_CLUSTER_NAME=raycluster-complete

```

