### PR TITLE
[Feature] Replace service name with Fully Qualified Domain Name 

### DIFF
--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -223,7 +223,7 @@ func buildWorkerPodTemplate(imageVersion string, envs map[string]string, spec *a
 					Command: []string{
 						"sh",
 						"-c",
-						"until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done",
+						"until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done",
 					},
 				},
 			},

--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -223,7 +223,7 @@ func buildWorkerPodTemplate(imageVersion string, envs map[string]string, spec *a
 					Command: []string{
 						"sh",
 						"-c",
-						"until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done",
+						"until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done",
 					},
 				},
 			},

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -97,7 +97,7 @@ spec:
         initContainers:
           - name: init
             image: {{ $values.initContainerImage | default "busybox:1.28" }}
-            command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+            command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
             securityContext:
             {{- toYaml $values.initContainerSecurityContext | nindent 14 }}
         containers:
@@ -163,7 +163,7 @@ spec:
         initContainers:
           - name: init
             image: {{ .Values.worker.initContainerImage | default "busybox:1.28" }}
-            command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+            command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
             securityContext:
             {{- toYaml .Values.worker.initContainerSecurityContext | nindent 14 }}
         containers:

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -97,7 +97,7 @@ spec:
         initContainers:
           - name: init
             image: {{ $values.initContainerImage | default "busybox:1.28" }}
-            command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+            command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
             securityContext:
             {{- toYaml $values.initContainerSecurityContext | nindent 14 }}
         containers:
@@ -163,7 +163,7 @@ spec:
         initContainers:
           - name: init
             image: {{ .Values.worker.initContainerImage | default "busybox:1.28" }}
-            command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+            command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
             securityContext:
             {{- toYaml .Values.worker.initContainerSecurityContext | nindent 14 }}
         containers:

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -131,7 +131,7 @@ spec:
         # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
         - name: init
           image: busybox:1.28
-          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker
           image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -128,10 +128,10 @@ spec:
           key: value
       spec:
         initContainers:
-        # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+        # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
         - name: init
           image: busybox:1.28
-          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker
           image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -131,7 +131,7 @@ spec:
         # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
         - name: init
           image: busybox:1.28
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker
           image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -125,7 +125,7 @@ spec:
         # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
         - name: init
           image: busybox:1.28
-          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker
           image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -125,7 +125,7 @@ spec:
         # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
         - name: init
           image: busybox:1.28
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker
           image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -122,10 +122,10 @@ spec:
     template:
       spec:
         initContainers:
-        # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+        # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
         - name: init
           image: busybox:1.28
-          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker
           image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -115,7 +115,7 @@ spec:
         - name: init
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -115,7 +115,7 @@ spec:
         - name: init
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -111,11 +111,11 @@ spec:
             - mountPath: /tmp/ray
               name: ray-logs
         initContainers:
-        # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+        # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
         - name: init
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -126,7 +126,7 @@ spec:
         - name: init
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -122,11 +122,11 @@ spec:
               # For production use-cases, we recommend allocating at least 8Gb memory for each Ray container.
               memory: "1G"
         initContainers:
-        # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+        # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
         - name: init
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -126,7 +126,7 @@ spec:
         - name: init
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -124,11 +124,11 @@ spec:
       template:
         spec:
           initContainers: # to avoid worker crashing before head service is created
-            # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+            # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
             - name: init
               image: busybox:1.28
               # Change the cluster postfix if you don't have a default setting
-              command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+              command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
           containers:
             - name: ray-worker
               image: rayproject/ray:2.3.0

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -128,7 +128,7 @@ spec:
             - name: init
               image: busybox:1.28
               # Change the cluster postfix if you don't have a default setting
-              command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
+              command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
           containers:
             - name: ray-worker
               image: rayproject/ray:2.3.0

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -128,7 +128,7 @@ spec:
             - name: init
               image: busybox:1.28
               # Change the cluster postfix if you don't have a default setting
-              command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+              command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
           containers:
             - name: ray-worker
               image: rayproject/ray:2.3.0

--- a/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
+++ b/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
@@ -81,11 +81,11 @@ spec:
     template:
       spec:
         initContainers: # to avoid worker crashing before head service is created
-        # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+        # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
         - name: init
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
           image: rayproject/ray:2.2.0
@@ -125,7 +125,7 @@ spec:
         - name: init
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
           image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
+++ b/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
@@ -85,7 +85,7 @@ spec:
         - name: init
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
           image: rayproject/ray:2.2.0
@@ -125,7 +125,7 @@ spec:
         - name: init
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup raycluster-heterogeneous-head-svc.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
           image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
+++ b/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
@@ -85,7 +85,7 @@ spec:
         - name: init
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
           image: rayproject/ray:2.2.0
@@ -125,7 +125,7 @@ spec:
         - name: init
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
           image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -65,10 +65,10 @@ spec:
         template:
           spec:
             initContainers:
-              # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+              # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
               - name: init
                 image: busybox:1.28
-                command: [ 'sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done" ]
+                command: [ 'sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done" ]
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -4,9 +4,9 @@ metadata:
   name: rayjob-sample
 spec:
   entrypoint: python /home/ray/samples/sample_code.py
-    # runtimeEnv decoded to '{
-    #    "pip": [
-    #        "requests==2.26.0",
+  # runtimeEnv decoded to '{
+  #    "pip": [
+  #        "requests==2.26.0",
   #        "pendulum==2.1.2"
   #    ],
   #    "env_vars": {
@@ -68,7 +68,7 @@ spec:
               # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
               - name: init
                 image: busybox:1.28
-                command: [ 'sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done" ]
+                command: [ 'sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done" ]
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -68,7 +68,7 @@ spec:
               # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
               - name: init
                 image: busybox:1.28
-                command: [ 'sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done" ]
+                command: [ 'sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done" ]
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -92,7 +92,7 @@ spec:
               # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
               - name: init
                 image: busybox:1.28
-                command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
+                command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -89,10 +89,10 @@ spec:
         template:
           spec:
             initContainers:
-              # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+              # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
               - name: init
                 image: busybox:1.28
-                command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+                command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.2.0

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -92,7 +92,7 @@ spec:
               # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
               - name: init
                 image: busybox:1.28
-                command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
+                command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.2.0

--- a/ray-operator/config/security/ray-cluster.pod-security.yaml
+++ b/ray-operator/config/security/ray-cluster.pod-security.yaml
@@ -122,7 +122,7 @@ spec:
         - name: init-myservice
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for myservice; sleep 2; done"]
           securityContext:
             runAsUser: 1000
             allowPrivilegeEscalation: false

--- a/ray-operator/config/security/ray-cluster.pod-security.yaml
+++ b/ray-operator/config/security/ray-cluster.pod-security.yaml
@@ -122,7 +122,7 @@ spec:
         - name: init-myservice
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for myservice; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
           securityContext:
             runAsUser: 1000
             allowPrivilegeEscalation: false

--- a/ray-operator/config/security/ray-cluster.pod-security.yaml
+++ b/ray-operator/config/security/ray-cluster.pod-security.yaml
@@ -118,11 +118,11 @@ spec:
             seccompProfile:
               type: RuntimeDefault
         initContainers:
-        # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
+        # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
         - name: init-myservice
           image: busybox:1.28
           # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP; do echo waiting for myservice; sleep 2; done"]
+          command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for myservice; sleep 2; done"]
           securityContext:
             runAsUser: 1000
             allowPrivilegeEscalation: false

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -73,6 +73,7 @@ const (
 	// Use as container env variable
 	NAMESPACE                               = "NAMESPACE"
 	CLUSTER_NAME                            = "CLUSTER_NAME"
+	RAY_IP                                  = "RAY_IP"
 	FQ_RAY_IP                               = "FQ_RAY_IP"
 	RAY_PORT                                = "RAY_PORT"
 	RAY_ADDRESS                             = "RAY_ADDRESS"

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -73,7 +73,7 @@ const (
 	// Use as container env variable
 	NAMESPACE                               = "NAMESPACE"
 	CLUSTER_NAME                            = "CLUSTER_NAME"
-	RAY_IP                                  = "RAY_IP"
+	FQ_RAY_IP                               = "FQ_RAY_IP"
 	RAY_PORT                                = "RAY_PORT"
 	RAY_ADDRESS                             = "RAY_ADDRESS"
 	REDIS_PASSWORD                          = "REDIS_PASSWORD"

--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -50,7 +50,7 @@ func BuildIngressForHeadService(cluster rayiov1alpha1.RayCluster) (*networkingv1
 			PathType: &pathType,
 			Backend: networkingv1.IngressBackend{
 				Service: &networkingv1.IngressServiceBackend{
-					Name: utils.CheckName(utils.GenerateServiceName(cluster.Name)),
+					Name: utils.GenerateServiceName(cluster.Name),
 					Port: networkingv1.ServiceBackendPort{
 						Number: dashboardPort,
 					},

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -85,7 +85,7 @@ func initTemplateAnnotations(instance rayiov1alpha1.RayCluster, podTemplate *v1.
 }
 
 // DefaultHeadPodTemplate sets the config values
-func DefaultHeadPodTemplate(instance rayiov1alpha1.RayCluster, headSpec rayiov1alpha1.HeadGroupSpec, podName string, svcName string, headPort string) v1.PodTemplateSpec {
+func DefaultHeadPodTemplate(instance rayiov1alpha1.RayCluster, headSpec rayiov1alpha1.HeadGroupSpec, podName string, fqdnRayIP string, headPort string) v1.PodTemplateSpec {
 	// TODO (Dmitri) The argument headPort is essentially unused;
 	// headPort is passed into setMissingRayStartParams but unused there for the head pod.
 	// To mitigate this awkwardness and reduce code redundancy, unify head and worker pod configuration logic.
@@ -100,7 +100,7 @@ func DefaultHeadPodTemplate(instance rayiov1alpha1.RayCluster, headSpec rayiov1a
 		podTemplate.Labels = make(map[string]string)
 	}
 	podTemplate.Labels = labelPod(rayiov1alpha1.HeadNode, instance.Name, "headgroup", instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels)
-	headSpec.RayStartParams = setMissingRayStartParams(headSpec.RayStartParams, rayiov1alpha1.HeadNode, svcName, headPort)
+	headSpec.RayStartParams = setMissingRayStartParams(headSpec.RayStartParams, rayiov1alpha1.HeadNode, fqdnRayIP, headPort)
 	headSpec.RayStartParams = setAgentListPortStartParams(instance, headSpec.RayStartParams)
 
 	initTemplateAnnotations(instance, &podTemplate)
@@ -183,7 +183,7 @@ func autoscalerSupportIsStable(rayVersion string) bool {
 }
 
 // DefaultWorkerPodTemplate sets the config values
-func DefaultWorkerPodTemplate(instance rayiov1alpha1.RayCluster, workerSpec rayiov1alpha1.WorkerGroupSpec, podName string, svcName string, headPort string) v1.PodTemplateSpec {
+func DefaultWorkerPodTemplate(instance rayiov1alpha1.RayCluster, workerSpec rayiov1alpha1.WorkerGroupSpec, podName string, fqdnRayIP string, headPort string) v1.PodTemplateSpec {
 	podTemplate := workerSpec.Template
 	podTemplate.GenerateName = podName
 	if podTemplate.ObjectMeta.Namespace == "" {
@@ -198,7 +198,7 @@ func DefaultWorkerPodTemplate(instance rayiov1alpha1.RayCluster, workerSpec rayi
 		podTemplate.Labels = make(map[string]string)
 	}
 	podTemplate.Labels = labelPod(rayiov1alpha1.WorkerNode, instance.Name, workerSpec.GroupName, workerSpec.Template.ObjectMeta.Labels)
-	workerSpec.RayStartParams = setMissingRayStartParams(workerSpec.RayStartParams, rayiov1alpha1.WorkerNode, svcName, headPort)
+	workerSpec.RayStartParams = setMissingRayStartParams(workerSpec.RayStartParams, rayiov1alpha1.WorkerNode, fqdnRayIP, headPort)
 	workerSpec.RayStartParams = setAgentListPortStartParams(instance, workerSpec.RayStartParams)
 
 	initTemplateAnnotations(instance, &podTemplate)
@@ -271,7 +271,7 @@ func initReadinessProbeHandler(probe *v1.Probe, rayNodeType rayiov1alpha1.RayNod
 }
 
 // BuildPod a pod config
-func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayiov1alpha1.RayNodeType, rayStartParams map[string]string, svcName string, headPort string, enableRayAutoscaler *bool, creator string) (aPod v1.Pod) {
+func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayiov1alpha1.RayNodeType, rayStartParams map[string]string, fqdnRayIP string, headPort string, enableRayAutoscaler *bool, creator string) (aPod v1.Pod) {
 	pod := v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -326,10 +326,10 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayiov1alpha1.RayN
 	}
 
 	for index := range pod.Spec.InitContainers {
-		setInitContainerEnvVars(&pod.Spec.InitContainers[index], fmt.Sprintf("%s.%s.svc.cluster.local", svcName, pod.ObjectMeta.Namespace))
+		setInitContainerEnvVars(&pod.Spec.InitContainers[index], fqdnRayIP)
 	}
 
-	setContainerEnvVars(&pod, rayContainerIndex, rayNodeType, rayStartParams, svcName, headPort, creator)
+	setContainerEnvVars(&pod, rayContainerIndex, rayNodeType, rayStartParams, fqdnRayIP, headPort, creator)
 
 	// health check only if FT enabled
 	if podTemplateSpec.Annotations != nil {
@@ -535,20 +535,18 @@ func labelPod(rayNodeType rayiov1alpha1.RayNodeType, rayClusterName string, grou
 	return labels
 }
 
-func setInitContainerEnvVars(container *v1.Container, svcName string) {
+func setInitContainerEnvVars(container *v1.Container, fqdnRayIP string) {
 	// RAY_IP can be used in the DNS lookup
 	if container.Env == nil || len(container.Env) == 0 {
 		container.Env = []v1.EnvVar{}
 	}
 	if !envVarExists("RAY_IP", container.Env) {
-		ip := v1.EnvVar{Name: "RAY_IP"}
-		ip.Value = svcName
+		ip := v1.EnvVar{Name: "RAY_IP", Value: fqdnRayIP}
 		container.Env = append(container.Env, ip)
 	}
 }
 
-func setContainerEnvVars(pod *v1.Pod, rayContainerIndex int, rayNodeType rayiov1alpha1.RayNodeType, rayStartParams map[string]string, svcName string, headPort string, creator string) {
-	// set IP to local host if head, or the the svc otherwise  RAY_IP
+func setContainerEnvVars(pod *v1.Pod, rayContainerIndex int, rayNodeType rayiov1alpha1.RayNodeType, rayStartParams map[string]string, fqdnRayIP string, headPort string, creator string) {
 	// set the port RAY_PORT
 	// set the password?
 	container := &pod.Spec.Containers[rayContainerIndex]
@@ -556,13 +554,11 @@ func setContainerEnvVars(pod *v1.Pod, rayContainerIndex int, rayNodeType rayiov1
 		container.Env = []v1.EnvVar{}
 	}
 
-	var rayIP string
+	// case 1: head   => Use LOCAL_HOST
+	// case 2: worker => Use fqdnRayIP (fully qualified domain name)
+	rayIP := fqdnRayIP
 	if rayNodeType == rayiov1alpha1.HeadNode {
-		// if head, use localhost
 		rayIP = LOCAL_HOST
-	} else {
-		// if worker, use the service name of the head
-		rayIP = fmt.Sprintf("%s.%s.svc.cluster.local", svcName, pod.ObjectMeta.Namespace)
 	}
 
 	if !envVarExists(RAY_IP, container.Env) {
@@ -636,11 +632,11 @@ func envVarExists(envName string, envVars []v1.EnvVar) bool {
 }
 
 // TODO auto complete params
-func setMissingRayStartParams(rayStartParams map[string]string, nodeType rayiov1alpha1.RayNodeType, svcName string, headPort string) (completeStartParams map[string]string) {
+func setMissingRayStartParams(rayStartParams map[string]string, nodeType rayiov1alpha1.RayNodeType, fqdnRayIP string, headPort string) (completeStartParams map[string]string) {
 	// Note: The argument headPort is unused for nodeType == rayiov1alpha1.HeadNode.
 	if nodeType == rayiov1alpha1.WorkerNode {
 		if _, ok := rayStartParams["address"]; !ok {
-			address := fmt.Sprintf("%s:%s", svcName, headPort)
+			address := fmt.Sprintf("%s:%s", fqdnRayIP, headPort)
 			rayStartParams["address"] = address
 		}
 	}

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -326,7 +326,7 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayiov1alpha1.RayN
 	}
 
 	for index := range pod.Spec.InitContainers {
-		setInitContainerEnvVars(&pod.Spec.InitContainers[index], svcName)
+		setInitContainerEnvVars(&pod.Spec.InitContainers[index], fmt.Sprintf("%s.%s.svc.cluster.local", svcName, pod.ObjectMeta.Namespace))
 	}
 
 	setContainerEnvVars(&pod, rayContainerIndex, rayNodeType, rayStartParams, svcName, headPort, creator)
@@ -562,7 +562,7 @@ func setContainerEnvVars(pod *v1.Pod, rayContainerIndex int, rayNodeType rayiov1
 		rayIP = LOCAL_HOST
 	} else {
 		// if worker, use the service name of the head
-		rayIP = svcName
+		rayIP = fmt.Sprintf("%s.%s.svc.cluster.local", svcName, pod.ObjectMeta.Namespace)
 	}
 
 	if !envVarExists(RAY_IP, container.Env) {

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -536,12 +536,12 @@ func labelPod(rayNodeType rayiov1alpha1.RayNodeType, rayClusterName string, grou
 }
 
 func setInitContainerEnvVars(container *v1.Container, fqdnRayIP string) {
-	// RAY_IP can be used in the DNS lookup
+	// FQ_RAY_IP can be used in the DNS lookup
 	if container.Env == nil || len(container.Env) == 0 {
 		container.Env = []v1.EnvVar{}
 	}
-	if !envVarExists("RAY_IP", container.Env) {
-		ip := v1.EnvVar{Name: "RAY_IP", Value: fqdnRayIP}
+	if !envVarExists("FQ_RAY_IP", container.Env) {
+		ip := v1.EnvVar{Name: "FQ_RAY_IP", Value: fqdnRayIP}
 		container.Env = append(container.Env, ip)
 	}
 }
@@ -556,13 +556,13 @@ func setContainerEnvVars(pod *v1.Pod, rayContainerIndex int, rayNodeType rayiov1
 
 	// case 1: head   => Use LOCAL_HOST
 	// case 2: worker => Use fqdnRayIP (fully qualified domain name)
-	rayIP := fqdnRayIP
+	ip := fqdnRayIP
 	if rayNodeType == rayiov1alpha1.HeadNode {
-		rayIP = LOCAL_HOST
+		ip = LOCAL_HOST
 	}
 
-	if !envVarExists(RAY_IP, container.Env) {
-		ipEnv := v1.EnvVar{Name: RAY_IP, Value: rayIP}
+	if !envVarExists(FQ_RAY_IP, container.Env) {
+		ipEnv := v1.EnvVar{Name: FQ_RAY_IP, Value: ip}
 		container.Env = append(container.Env, ipEnv)
 	}
 	if !envVarExists(RAY_PORT, container.Env) {
@@ -591,7 +591,7 @@ func setContainerEnvVars(pod *v1.Pod, rayContainerIndex int, rayNodeType rayiov1
 	// Setting the RAY_ADDRESS env allows connecting to Ray using ray.init() when connecting
 	// from within the cluster.
 	if !envVarExists(RAY_ADDRESS, container.Env) {
-		rayAddress := fmt.Sprintf("%s:%s", rayIP, headPort)
+		rayAddress := fmt.Sprintf("%s:%s", ip, headPort)
 		addressEnv := v1.EnvVar{Name: RAY_ADDRESS, Value: rayAddress}
 		container.Env = append(container.Env, addressEnv)
 	}

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -389,8 +389,10 @@ func TestBuildPod(t *testing.T) {
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	pod = BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, "6379", nil, "", fqdnRayIP)
 
-	// Check RAY_ADDRESS env
+	// Check environment variables
 	checkPodEnv(t, pod, RAY_ADDRESS, "raycluster-sample-head-svc.default.svc.cluster.local:6379")
+	checkPodEnv(t, pod, FQ_RAY_IP, "raycluster-sample-head-svc.default.svc.cluster.local")
+	checkPodEnv(t, pod, RAY_IP, "raycluster-sample-head-svc")
 
 	// Check RayStartParams
 	expectedResult = fmt.Sprintf("%s:6379", fqdnRayIP)

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -343,9 +343,8 @@ func TestBuildPod(t *testing.T) {
 
 	// Test head pod
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
-	svcName := utils.GenerateServiceName(cluster.Name)
-	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName, "6379")
-	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, "6379", nil, "")
+	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
+	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, "", "")
 
 	// Check RAY_ADDRESS env.
 	checkPodEnv(t, pod, RAY_ADDRESS, "127.0.0.1:6379")
@@ -386,21 +385,22 @@ func TestBuildPod(t *testing.T) {
 	// testing worker pod
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	podName = cluster.Name + DashSymbol + string(rayiov1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
-	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, svcName, "6379")
-	pod = BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, svcName, "6379", nil, "")
+	fqdnRayIP := utils.GenerateFQDNServiceName(cluster.Name, cluster.Namespace)
+	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
+	pod = BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, "6379", nil, "", fqdnRayIP)
 
 	// Check RAY_ADDRESS env
-	checkPodEnv(t, pod, RAY_ADDRESS, "raycluster-sample-head-svc:6379")
+	checkPodEnv(t, pod, RAY_ADDRESS, "raycluster-sample-head-svc.default.svc.cluster.local:6379")
 
 	// Check RayStartParams
-	expectedResult = fmt.Sprintf("%s:6379", svcName)
+	expectedResult = fmt.Sprintf("%s:6379", fqdnRayIP)
 	actualResult = cluster.Spec.WorkerGroupSpecs[0].RayStartParams["address"]
 
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
 
-	expectedCommandArg := splitAndSort("ulimit -n 65536; ray start --block --memory=1073741824 --num-cpus=1 --num-gpus=3 --address=raycluster-sample-head-svc:6379 --port=6379 --metrics-export-port=8080")
+	expectedCommandArg := splitAndSort("ulimit -n 65536; ray start --block --memory=1073741824 --num-cpus=1 --num-gpus=3 --address=raycluster-sample-head-svc.default.svc.cluster.local:6379 --port=6379 --metrics-export-port=8080")
 	actualCommandArg := splitAndSort(pod.Spec.Containers[0].Args[0])
 	if !reflect.DeepEqual(expectedCommandArg, actualCommandArg) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedCommandArg, actualCommandArg)
@@ -414,9 +414,8 @@ func TestBuildPod_WithAutoscalerEnabled(t *testing.T) {
 	cluster := instance.DeepCopy()
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
-	svcName := utils.GenerateServiceName(cluster.Name)
-	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName, "6379")
-	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, "6379", &trueFlag, "")
+	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
+	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", &trueFlag, "", "")
 
 	actualResult := pod.Labels[RayClusterLabelKey]
 	expectedResult := cluster.Name
@@ -470,9 +469,8 @@ func TestBuildPod_WithCreatedByRayService(t *testing.T) {
 	cluster := instance.DeepCopy()
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
-	svcName := utils.GenerateServiceName(cluster.Name)
-	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName, "6379")
-	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, "6379", &trueFlag, RayServiceCreatorLabelValue)
+	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
+	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", &trueFlag, RayServiceCreatorLabelValue, "")
 
 	hasCorrectDeathEnv := false
 	for _, container := range pod.Spec.Containers {
@@ -498,7 +496,6 @@ func TestBuildPodWithAutoscalerOptions(t *testing.T) {
 	cluster := instance.DeepCopy()
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
-	svcName := utils.GenerateServiceName(cluster.Name)
 
 	customAutoscalerImage := "custom-autoscaler-xxx"
 	customPullPolicy := v1.PullIfNotPresent
@@ -543,8 +540,8 @@ func TestBuildPodWithAutoscalerOptions(t *testing.T) {
 		EnvFrom:            customEnvFrom,
 		SecurityContext:    &customSecurityContext,
 	}
-	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName, "6379")
-	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, "6379", &trueFlag, "")
+	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
+	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", &trueFlag, "", "")
 	expectedContainer := *autoscalerContainer.DeepCopy()
 	expectedContainer.Image = customAutoscalerImage
 	expectedContainer.ImagePullPolicy = customPullPolicy
@@ -563,8 +560,7 @@ func TestHeadPodTemplate_WithAutoscalingEnabled(t *testing.T) {
 	cluster := instance.DeepCopy()
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
-	svcName := utils.GenerateServiceName(cluster.Name)
-	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName, "6379")
+	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 
 	// autoscaler container is injected into head pod
 	actualContainerCount := len(podTemplateSpec.Spec.Containers)
@@ -582,7 +578,7 @@ func TestHeadPodTemplate_WithAutoscalingEnabled(t *testing.T) {
 
 	// Repeat ServiceAccountName check with long cluster name.
 	cluster.Name = longString(t) // 200 chars long
-	podTemplateSpec = DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName, "6379")
+	podTemplateSpec = DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	actualResult = podTemplateSpec.Spec.ServiceAccountName
 	expectedResult = shortString(t) // 50 chars long, truncated by utils.CheckName
 	if !reflect.DeepEqual(expectedResult, actualResult) {
@@ -595,8 +591,7 @@ func TestHeadPodTemplate_WithAutoscalingEnabled(t *testing.T) {
 func TestHeadPodTemplate_WithNoServiceAccount(t *testing.T) {
 	cluster := instance.DeepCopy()
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
-	svcName := utils.GenerateServiceName(cluster.Name)
-	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName, "6379")
+	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 
 	actualResult := pod.Spec.ServiceAccountName
 	expectedResult := ""
@@ -612,8 +607,7 @@ func TestHeadPodTemplate_WithServiceAccountNoAutoscaling(t *testing.T) {
 	serviceAccount := "head-service-account"
 	cluster.Spec.HeadGroupSpec.Template.Spec.ServiceAccountName = serviceAccount
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
-	svcName := utils.GenerateServiceName(cluster.Name)
-	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName, "6379")
+	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 
 	actualResult := pod.Spec.ServiceAccountName
 	expectedResult := serviceAccount
@@ -630,8 +624,7 @@ func TestHeadPodTemplate_WithServiceAccount(t *testing.T) {
 	cluster.Spec.HeadGroupSpec.Template.Spec.ServiceAccountName = serviceAccount
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
-	svcName := utils.GenerateServiceName(cluster.Name)
-	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName, "6379")
+	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 
 	actualResult := pod.Spec.ServiceAccountName
 	expectedResult := serviceAccount
@@ -687,9 +680,8 @@ func TestCleanupInvalidVolumeMounts(t *testing.T) {
 
 	// Test head pod
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
-	svcName := utils.GenerateServiceName(cluster.Name)
-	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, svcName, "6379")
-	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, svcName, "6379", nil, "")
+	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
+	pod := BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, "", "")
 
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, []v1.VolumeMount{
 		{
@@ -710,14 +702,14 @@ func TestCleanupInvalidVolumeMounts(t *testing.T) {
 
 func TestDefaultWorkerPodTemplateWithName(t *testing.T) {
 	cluster := instance.DeepCopy()
-	svcName := utils.GenerateServiceName(cluster.Name)
+	fqdnRayIP := utils.GenerateFQDNServiceName(cluster.Name, cluster.Namespace)
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	worker.Template.ObjectMeta.Name = "ray-worker-test"
 	podName := cluster.Name + DashSymbol + string(rayiov1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
 	expectedWorker := *worker.DeepCopy()
 
 	// Pass a deep copy of worker (*worker.DeepCopy()) to prevent "worker" from updating.
-	podTemplateSpec := DefaultWorkerPodTemplate(*cluster, *worker.DeepCopy(), podName, svcName, "6379")
+	podTemplateSpec := DefaultWorkerPodTemplate(*cluster, *worker.DeepCopy(), podName, fqdnRayIP, "6379")
 	assert.Equal(t, podTemplateSpec.ObjectMeta.Name, "")
 	assert.Equal(t, worker, expectedWorker)
 }

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -757,15 +757,14 @@ func (r *RayClusterReconciler) createWorkerPod(instance rayiov1alpha1.RayCluster
 // Build head instance pod(s).
 func (r *RayClusterReconciler) buildHeadPod(instance rayiov1alpha1.RayCluster) corev1.Pod {
 	podName := strings.ToLower(instance.Name + common.DashSymbol + string(rayiov1alpha1.HeadNode) + common.DashSymbol)
-	podName = utils.CheckName(podName)                                                                                // making sure the name is valid
-	fqdnRayIP := fmt.Sprintf("%s.%s.svc.cluster.local", utils.GenerateServiceName(instance.Name), instance.Namespace) // Fully Qualified Domain Name
+	podName = utils.CheckName(podName) // making sure the name is valid
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
 	autoscalingEnabled := instance.Spec.EnableInTreeAutoscaling
-	podConf := common.DefaultHeadPodTemplate(instance, instance.Spec.HeadGroupSpec, podName, fqdnRayIP, headPort)
+	podConf := common.DefaultHeadPodTemplate(instance, instance.Spec.HeadGroupSpec, podName, headPort)
 	r.Log.Info("head pod labels", "labels", podConf.Labels)
 	creatorName := getCreator(instance)
-	pod := common.BuildPod(podConf, rayiov1alpha1.HeadNode, instance.Spec.HeadGroupSpec.RayStartParams, fqdnRayIP, headPort, autoscalingEnabled, creatorName)
+	pod := common.BuildPod(podConf, rayiov1alpha1.HeadNode, instance.Spec.HeadGroupSpec.RayStartParams, headPort, autoscalingEnabled, creatorName, "")
 	// Set raycluster instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&instance, &pod, r.Scheme); err != nil {
 		r.Log.Error(err, "Failed to set controller reference for raycluster pod")
@@ -790,14 +789,14 @@ func getCreator(instance rayiov1alpha1.RayCluster) string {
 // Build worker instance pods.
 func (r *RayClusterReconciler) buildWorkerPod(instance rayiov1alpha1.RayCluster, worker rayiov1alpha1.WorkerGroupSpec) corev1.Pod {
 	podName := strings.ToLower(instance.Name + common.DashSymbol + string(rayiov1alpha1.WorkerNode) + common.DashSymbol + worker.GroupName + common.DashSymbol)
-	podName = utils.CheckName(podName)                                                                                // making sure the name is valid
-	fqdnRayIP := fmt.Sprintf("%s.%s.svc.cluster.local", utils.GenerateServiceName(instance.Name), instance.Namespace) // Fully Qualified Domain Name
+	podName = utils.CheckName(podName)                                            // making sure the name is valid
+	fqdnRayIP := utils.GenerateFQDNServiceName(instance.Name, instance.Namespace) // Fully Qualified Domain Name
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
 	autoscalingEnabled := instance.Spec.EnableInTreeAutoscaling
 	podTemplateSpec := common.DefaultWorkerPodTemplate(instance, worker, podName, fqdnRayIP, headPort)
 	creatorName := getCreator(instance)
-	pod := common.BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, fqdnRayIP, headPort, autoscalingEnabled, creatorName)
+	pod := common.BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, headPort, autoscalingEnabled, creatorName, fqdnRayIP)
 	// Set raycluster instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&instance, &pod, r.Scheme); err != nil {
 		r.Log.Error(err, "Failed to set controller reference for raycluster pod")

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -130,7 +130,7 @@ func FetchDashboardAgentURL(ctx context.Context, log *logr.Logger, cli client.Cl
 
 func FetchDashboardURL(ctx context.Context, log *logr.Logger, cli client.Client, rayCluster *rayv1alpha1.RayCluster) (string, error) {
 	headSvc := &corev1.Service{}
-	headSvcName := CheckName(GenerateServiceName(rayCluster.Name))
+	headSvcName := GenerateServiceName(rayCluster.Name)
 	if err := cli.Get(ctx, client.ObjectKey{Name: headSvcName, Namespace: rayCluster.Namespace}, headSvc); err != nil {
 		return "", err
 	}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -126,6 +126,12 @@ func GenerateFQDNServiceName(clusterName string, namespace string) string {
 	return fmt.Sprintf("%s.%s.svc.cluster.local", GenerateServiceName(clusterName), namespace)
 }
 
+// ExtractRayIPFromFQDN extracts the head service name (i.e., RAY_IP, deprecated) from a fully qualified
+// domain name (FQDN). This function is provided for backward compatibility purposes only.
+func ExtractRayIPFromFQDN(fqdnRayIP string) string {
+	return strings.Split(fqdnRayIP, ".")[0]
+}
+
 // GenerateDashboardServiceName generates a ray head service name from cluster name
 func GenerateDashboardServiceName(clusterName string) string {
 	return fmt.Sprintf("%s-%s-%s", clusterName, DashboardName, "svc")

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -118,7 +118,7 @@ func GetNamespace(metaData metav1.ObjectMeta) string {
 
 // GenerateServiceName generates a ray head service name from cluster name
 func GenerateServiceName(clusterName string) string {
-	return fmt.Sprintf("%s-%s-%s", clusterName, rayiov1alpha1.HeadNode, "svc")
+	return CheckName(fmt.Sprintf("%s-%s-%s", clusterName, rayiov1alpha1.HeadNode, "svc"))
 }
 
 // GenerateDashboardServiceName generates a ray head service name from cluster name

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -121,6 +121,11 @@ func GenerateServiceName(clusterName string) string {
 	return CheckName(fmt.Sprintf("%s-%s-%s", clusterName, rayiov1alpha1.HeadNode, "svc"))
 }
 
+// GenerateFQDNServiceName generates a Fully Qualified Domain Name.
+func GenerateFQDNServiceName(clusterName string, namespace string) string {
+	return fmt.Sprintf("%s.%s.svc.cluster.local", GenerateServiceName(clusterName), namespace)
+}
+
 // GenerateDashboardServiceName generates a ray head service name from cluster name
 func GenerateDashboardServiceName(clusterName string) string {
 	return fmt.Sprintf("%s-%s-%s", clusterName, DashboardName, "svc")

--- a/tests/config/ray-cluster.mini.yaml.template
+++ b/tests/config/ray-cluster.mini.yaml.template
@@ -60,7 +60,7 @@ spec:
           - name: init
             image: busybox:1.28
             # Change the cluster postfix if you don't have a default setting
-            command: ['sh', '-c', "until nslookup $$RAY_IP.$$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $$RAY_IP; sleep 2; done"]
+            command: ['sh', '-c', "until nslookup $$RAY_IP; do echo waiting for K8s Service $$RAY_IP; sleep 2; done"]
           containers:
           - name: ray-worker
             image: $ray_image

--- a/tests/config/ray-cluster.mini.yaml.template
+++ b/tests/config/ray-cluster.mini.yaml.template
@@ -60,7 +60,7 @@ spec:
           - name: init
             image: busybox:1.28
             # Change the cluster postfix if you don't have a default setting
-            command: ['sh', '-c', "until nslookup $$RAY_IP; do echo waiting for K8s Service $$RAY_IP; sleep 2; done"]
+            command: ['sh', '-c', "until nslookup $$FQ_RAY_IP; do echo waiting for K8s Service $$FQ_RAY_IP; sleep 2; done"]
           containers:
           - name: ray-worker
             image: $ray_image

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -142,7 +142,7 @@ spec:
           initContainers: # to avoid worker crashing before head service is created
             - name: init
               image: busybox:1.28
-              command: ['sh', '-c', "until nslookup $$RAY_IP; do echo waiting for K8s Service $$RAY_IP; sleep 2; done"]
+              command: ['sh', '-c', "until nslookup $$FQ_RAY_IP; do echo waiting for K8s Service $$FQ_RAY_IP; sleep 2; done"]
           containers:
             - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
               image: $ray_image

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -142,7 +142,7 @@ spec:
           initContainers: # to avoid worker crashing before head service is created
             - name: init
               image: busybox:1.28
-              command: ['sh', '-c', "until nslookup $$RAY_IP.$$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $$RAY_IP; sleep 2; done"]
+              command: ['sh', '-c', "until nslookup $$RAY_IP; do echo waiting for K8s Service $$RAY_IP; sleep 2; done"]
           containers:
             - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
               image: $ray_image

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -100,7 +100,7 @@ spec:
             initContainers:
               - name: init
                 image: busybox:1.28
-                command: ['sh', '-c', "until nslookup $$RAY_IP; do echo waiting for K8s Service $$RAY_IP; sleep 2; done"]
+                command: ['sh', '-c', "until nslookup $$FQ_RAY_IP; do echo waiting for K8s Service $$FQ_RAY_IP; sleep 2; done"]
             containers:
               - name: ray-worker
                 image: $ray_image

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -100,7 +100,7 @@ spec:
             initContainers:
               - name: init
                 image: busybox:1.28
-                command: ['sh', '-c', "until nslookup $$RAY_IP.$$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $$RAY_IP; sleep 2; done"]
+                command: ['sh', '-c', "until nslookup $$RAY_IP; do echo waiting for K8s Service $$RAY_IP; sleep 2; done"]
             containers:
               - name: ray-worker
                 image: $ray_image


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some big tech companies do not use `kube-dns` as the DNS server for Kubernetes Pods. They have a lot of Kubernetes services in the cluster, but services in different namespaces may have the same name. Hence, IP address with the information of both Kubernetes service name and Kubernetes namespace is useful in this case. That is, **Fully Qualified Domain Name (FQDN)** is a must.

* Use `kube-dns` as the DNS server: We can use `${HEAD_SERVICE}` to access the head service.
* With FQDN, we need to use `${HEAD_SERVICE}.${NAMESPACE}.svc.cluster.local` to access the head service.

## Backward compatibility
~~Note: It breaks the **backward compatibility** (users need to update `until nslookup $RAY_IP ...` in their YAML files). However, this update is a must. It actually blocks some users to adopt KubeRay.~~

[Update]: We plan to maintain both $FQ_RAY_IP and $RAY_IP environment variables at the same time. Hence, user does not need to update their YAML files.
* $FQ_RAY_IP: `${HEAD_SERVICE}.${NAMESPACE}.svc.cluster.local`
* $RAY_IP: `${HEAD_SERVICE}`

## Why do I remove anything related to the head service (`svcName` & `fqdnRayIP`) in `buildHeadPod`?
* (function call graph) `buildHeadPod` calls:
  * `BuildPod` calls:
    * `SetInitContainerEnvVars`: Set RAY_IP for init container. (case 1)
    * `SetContainerEnvVars`: Set RAY_IP for the Ray head container. (case 2)
  * `DefaultHeadPodTemplate` calls:
    * `SetMissingRayStartParams`: Set `rayStartParams["address"]` for the Ray head container. (case 3)

* case 1: init container
  * "init containers run to completion before any app containers start" ([ref](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#using-init-containers)) => Before Ray head's init containers complete, it is impossible for the Ray cluster to be ready. => Init containers do not need `svcName` & `fqdnRayIP`.

* case 2: Ray head container
  * In case 2, the `RAY_IP` env variable for the head Pod is hardcoded to "LOCAL_HOST". (The following code is without this PR.) => Do not need the information of `svcName` & `fqdnRayIP`.
    https://github.com/ray-project/kuberay/blob/af8fb0c833a850cd925bed8c59321d7b4bde6514/ray-operator/controllers/ray/common/pod.go#L559-L566 
 
* case 3: `rayStartParams` for Ray head
  * If the node is a head node, the operator will not set `rayStartParams["address"]`. (The following code is without this PR.) => Do not need the information of `svcName` & `fqdnRayIP`.
    https://github.com/ray-project/kuberay/blob/af8fb0c833a850cd925bed8c59321d7b4bde6514/ray-operator/controllers/ray/common/pod.go#L641-L646

To conclude, we can remove anything related to the head service (`svcName` & `fqdnRayIP`) in `buildHeadPod`.

## function ExtractRayIPFromFQDN
```go
// GenerateFQDNServiceName generates a Fully Qualified Domain Name.
func GenerateFQDNServiceName(clusterName string, namespace string) string {
	return fmt.Sprintf("%s.%s.svc.cluster.local", GenerateServiceName(clusterName), namespace)
}

// ExtractRayIPFromFQDN extracts the head service name (i.e., RAY_IP, deprecated) from a fully qualified
// domain name (FQDN). This function is provided for backward compatibility purposes only.
func ExtractRayIPFromFQDN(fqdnRayIP string) string {
	return strings.Split(fqdnRayIP, ".")[0]
}
```
* $FQ_RAY_IP: `${HEAD_SERVICE}.${NAMESPACE}.svc.cluster.local`
* $RAY_IP: `${HEAD_SERVICE}`

In addition, "." is invalid in Kubernetes service name (the regex for Kubernetes service name is `[a-z]([-a-z0-9]*[a-z0-9])`). Thus, the implementation is valid.

```yaml
# svc.yaml 
apiVersion: v1
kind: Service
metadata:
  name: my.service # invalid service name
spec:
  selector:
    app: my-app
  ports:
    - name: http
      port: 80
      targetPort: 80
  type: ClusterIP
```
```
$ kubectl apply -f svc.yaml
The Service "my.service" is invalid: metadata.name: Invalid value: "my.service": a DNS-1035 label must consist of lower case alphanumeric characters, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')
```

## [Need discussion] FQ_RAY_IP and RAY_IP should not be set by users.
* In this PR, the values of `FQ_RAY_IP` and `RAY_IP` will always be determined by KubeRay operator. Users cannot set them. I cannot come up with any case that users need to specify these two values by themselves.

```go
# This PR removes this kind of check.
if !envVarExists("FQ_RAY_IP", container.Env) {
  ... 
}
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
# Step 1: Clone my repo, and check out to my branch.
# Step 2: Build the KubeRay operator image.
# Step 3: Install KubeRay operator with the new Docker image.
# Step 4: Install RayCluster with the repo's chart (path: helm-chart/ray-cluster)
helm install raycluster .
```
* Check worker Pod.
  * init container 
    * `FQ_RAY_IP` environment variable is `raycluster-kuberay-head-svc.default.svc.cluster.local`.
    * `RAY_IP` environment variable is `raycluster-kuberay-head-svc`.
  * `ray-worker`
    * `FQ_RAY_IP` environment variable is `raycluster-kuberay-head-svc.default.svc.cluster.local`.
    * `RAY_IP` environment variable is `raycluster-kuberay-head-svc`.
    * `ray start  --block  --address=raycluster-kuberay-head-svc.default.svc.cluster.local:6379  ...`

# Test backward compatibility
1. KubeRay operator in this PR is compatible with old configuration YAML files.
    ```sh
    # Step 1: Clone my repo, and check out to my branch. (image: controller:latest)
    # Step 2: Check out to the master's branch
    # Step 3: Test YAML files which use deprecated RAY_IP.
    RAY_IMAGE=rayproject/ray:2.3.0 OPERATOR_IMAGE=controller:latest python3 tests/test_sample_raycluster_yamls.py 2>&1 | tee log
    ```
    
    ![Screen Shot 2023-03-05 at 8 54 46 AM](https://user-images.githubusercontent.com/20109646/222974479-3a041cc9-4a86-4d1d-b5cf-164186e83487.png)

2. I will replace `RAY_IP` in the configuration files with `FQ_RAY_IP` after release 0.5.0 because we need to make sure the configuration YAML files in the master branch are compatible with both nightly and the latest release KubeRay operator. #941 

