### PR TITLE
[RayJob] Propagate error traceback string when GetJobInfo doesn't return valid JSON

### DIFF
--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -343,7 +343,8 @@ func (r *RayDashboardClient) GetJobInfo(jobId string) (*RayJobInfo, error) {
 
 	var jobInfo RayJobInfo
 	if err = json.Unmarshal(body, &jobInfo); err != nil {
-		return nil, err
+		// Maybe body is not valid json, raise an error with the body.
+		return nil, fmt.Errorf("GetJobInfo fail: %s %s", resp.Status, string(body))
 	}
 
 	return &jobInfo, nil

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -344,7 +344,7 @@ func (r *RayDashboardClient) GetJobInfo(jobId string) (*RayJobInfo, error) {
 	var jobInfo RayJobInfo
 	if err = json.Unmarshal(body, &jobInfo); err != nil {
 		// Maybe body is not valid json, raise an error with the body.
-		return nil, fmt.Errorf("GetJobInfo fail: %s %s", resp.Status, string(body))
+		return nil, fmt.Errorf("GetJobInfo fail: %s", string(body))
 	}
 
 	return &jobInfo, nil

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
@@ -22,7 +22,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 	var (
 		rayJob             *rayv1alpha1.RayJob
 		expectJobId        string
-		errorJobId 	       string
+		errorJobId         string
 		rayDashboardClient *RayDashboardClient
 	)
 
@@ -78,6 +78,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 			func(req *http.Request) (*http.Response, error) {
 				// return a string in the body
 				return httpmock.NewStringResponse(200, "Ray misbehaved and sent string, not JSON"), nil
+			})
 
 		jobId, err := rayDashboardClient.SubmitJob(rayJob, &ctrl.Log)
 		Expect(err).To(BeNil())

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
@@ -22,6 +22,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 	var (
 		rayJob             *rayv1alpha1.RayJob
 		expectJobId        string
+		errorJobId 	       string
 		rayDashboardClient *RayDashboardClient
 	)
 
@@ -73,6 +74,10 @@ var _ = Describe("RayFrameworkGenerator", func() {
 				bodyBytes, _ := json.Marshal(body)
 				return httpmock.NewBytesResponse(200, bodyBytes), nil
 			})
+		httpmock.RegisterResponder("GET", rayDashboardClient.dashboardURL+JobPath+errorJobId,
+			func(req *http.Request) (*http.Response, error) {
+				// return a string in the body
+				return httpmock.NewStringResponse(200, "Ray misbehaved and sent string, not JSON"), nil
 
 		jobId, err := rayDashboardClient.SubmitJob(rayJob, &ctrl.Log)
 		Expect(err).To(BeNil())
@@ -82,6 +87,11 @@ var _ = Describe("RayFrameworkGenerator", func() {
 		Expect(err).To(BeNil())
 		Expect(rayJobInfo.Entrypoint).To(Equal(rayJob.Spec.Entrypoint))
 		Expect(rayJobInfo.JobStatus).To(Equal(rayv1alpha1.JobStatusRunning))
+
+		_, err = rayDashboardClient.GetJobInfo(errorJobId)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("GetJobInfo fail"))
+		Expect(err.Error()).To(ContainSubstring("Ray misbehaved"))
 	})
 
 	It("Test stop job", func() {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Sometimes, the Ray Jobs API "GET" `/jobs/` endpoint returns a traceback string instead of valid JSON (which must begin with `'{'`). 
 We should look into whether this is a bug on the Ray side and whether we are returning the correct error code.

This PR propagates the underlying traceback string to the user, instead of hiding it behind a "JSON parse error" as before.  

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Partially addresses #897 but doesn't fix the root cause (jobs run at the same time seem to conflict with each other)
## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
