### PR TITLE
[Feature] The default ImagePullPolicy should be IfNotPresent

### DIFF
--- a/clients/python-client/examples/use-raw-config_map_with-api.py
+++ b/clients/python-client/examples/use-raw-config_map_with-api.py
@@ -47,7 +47,7 @@ cluster_body: dict = {
     "name": "raycluster-getting-started"
   },
   "spec": {
-    "rayVersion": "2.2.0",
+    "rayVersion": "2.3.0",
     "headGroupSpec": {
       "rayStartParams": {
         "dashboard-host": "0.0.0.0",
@@ -59,7 +59,7 @@ cluster_body: dict = {
           "containers": [
             {
               "name": "ray-head",
-              "image": "rayproject/ray:2.2.0",
+              "image": "rayproject/ray:2.3.0",
               "volumeMounts": [
                 {
                   "mountPath": "/opt",

--- a/clients/python-client/examples/use-raw-with-api.py
+++ b/clients/python-client/examples/use-raw-with-api.py
@@ -28,7 +28,7 @@ cluster_body: dict = {
         "name": "raycluster-mini-raw",
     },
     "spec": {
-        "rayVersion": "2.2.0",
+        "rayVersion": "2.3.0",
         "headGroupSpec": {
             "rayStartParams": {
                 "dashboard-host": "0.0.0.0",
@@ -40,7 +40,7 @@ cluster_body: dict = {
                     "containers": [
                         {
                             "name": "ray-head",
-                            "image": "rayproject/ray:2.2.0",
+                            "image": "rayproject/ray:2.3.0",
                             "resources": {
                                 "limits": {"cpu": 1, "memory": "2Gi"},
                                 "requests": {"cpu": "500m", "memory": "2Gi"},
@@ -67,7 +67,7 @@ cluster_body2: dict = {
         "name": "raycluster-complete-raw",
     },
     "spec": {
-        "rayVersion": "2.2.0",
+        "rayVersion": "2.3.0",
         "headGroupSpec": {
             "serviceType": "ClusterIP",
             "rayStartParams": {"dashboard-host": "0.0.0.0", "block": "true"},
@@ -77,7 +77,7 @@ cluster_body2: dict = {
                     "containers": [
                         {
                             "name": "ray-head",
-                            "image": "rayproject/ray:2.2.0",
+                            "image": "rayproject/ray:2.3.0",
                             "ports": [
                                 {"containerPort": 6379, "name": "gcs"},
                                 {"containerPort": 8265, "name": "dashboard"},
@@ -113,7 +113,7 @@ cluster_body2: dict = {
                         "containers": [
                             {
                                 "name": "ray-worker",
-                                "image": "rayproject/ray:2.2.0",
+                                "image": "rayproject/ray:2.3.0",
                                 "lifecycle": {
                                     "preStop": {
                                         "exec": {

--- a/clients/python-client/python_client/utils/kuberay_cluster_builder.py
+++ b/clients/python-client/python_client/utils/kuberay_cluster_builder.py
@@ -60,7 +60,7 @@ class ClusterBuilder(IClusterBuilder):
         name: str,
         k8s_namespace: str = "default",
         labels: dict = None,
-        ray_version: str = "2.2.0",
+        ray_version: str = "2.3.0",
     ):
         """Builds the metadata and ray version of the cluster.
 
@@ -68,7 +68,7 @@ class ClusterBuilder(IClusterBuilder):
         - name (str): The name of the cluster.
         - k8s_namespace (str, optional): The namespace in which the Ray cluster exists. Defaults to "default".
         - labels (dict, optional): A dictionary of key-value pairs to add as labels to the cluster. Defaults to None.
-        - ray_version (str, optional): The version of Ray to use for the cluster. Defaults to "2.2.0".
+        - ray_version (str, optional): The version of Ray to use for the cluster. Defaults to "2.3.0".
         """
         self.cluster = self.cluster_utils.populate_meta(
             cluster=self.cluster,
@@ -81,7 +81,7 @@ class ClusterBuilder(IClusterBuilder):
 
     def build_head(
         self,
-        ray_image: str = "rayproject/ray:2.2.0",
+        ray_image: str = "rayproject/ray:2.3.0",
         service_type: str = "ClusterIP",
         cpu_requests: str = "2",
         memory_requests: str = "3G",
@@ -95,7 +95,7 @@ class ClusterBuilder(IClusterBuilder):
         """Build head node of the ray cluster.
 
         Parameters:
-        - ray_image (str): Docker image for the head node. Default value is "rayproject/ray:2.2.0".
+        - ray_image (str): Docker image for the head node. Default value is "rayproject/ray:2.3.0".
         - service_type (str): Service type of the head node. Default value is "ClusterIP".
         - cpu_requests (str): CPU requests for the head node. Default value is "2".
         - memory_requests (str): Memory requests for the head node. Default value is "3G".
@@ -119,7 +119,7 @@ class ClusterBuilder(IClusterBuilder):
     def build_worker(
         self,
         group_name: str,
-        ray_image: str = "rayproject/ray:2.2.0",
+        ray_image: str = "rayproject/ray:2.3.0",
         ray_command: Any = ["/bin/bash", "-lc"],
         init_image: str = "busybox:1.28",
         cpu_requests: str = "1",
@@ -139,7 +139,7 @@ class ClusterBuilder(IClusterBuilder):
 
         Parameters:
         - group_name (str): name of the worker group.
-        - ray_image (str, optional): Docker image for the Ray process. Default is "rayproject/ray:2.2.0".
+        - ray_image (str, optional): Docker image for the Ray process. Default is "rayproject/ray:2.3.0".
         - ray_command (Any, optional): Command to run in the Docker container. Default is ["/bin/bash", "-lc"].
         - init_image (str, optional): Docker image for the init container. Default is "busybox:1.28".
         - cpu_requests (str, optional): CPU requests for the worker pods. Default is "1".

--- a/clients/python-client/python_client_test/test_api.py
+++ b/clients/python-client/python_client_test/test_api.py
@@ -14,7 +14,7 @@ test_cluster_body: dict = {
         "name": "raycluster-complete-raw",
     },
     "spec": {
-        "rayVersion": "2.2.0",
+        "rayVersion": "2.3.0",
         "headGroupSpec": {
             "serviceType": "ClusterIP",
             "rayStartParams": {"dashboard-host": "0.0.0.0", "block": "true"},
@@ -24,7 +24,7 @@ test_cluster_body: dict = {
                     "containers": [
                         {
                             "name": "ray-head",
-                            "image": "rayproject/ray:2.2.0",
+                            "image": "rayproject/ray:2.3.0",
                             "ports": [
                                 {"containerPort": 6379, "name": "gcs"},
                                 {"containerPort": 8265, "name": "dashboard"},
@@ -60,7 +60,7 @@ test_cluster_body: dict = {
                         "containers": [
                             {
                                 "name": "ray-worker",
-                                "image": "rayproject/ray:2.2.0",
+                                "image": "rayproject/ray:2.3.0",
                                 "lifecycle": {
                                     "preStop": {
                                         "exec": {
@@ -78,7 +78,7 @@ test_cluster_body: dict = {
                             },
                             {
                                 "name": "side-car",
-                                "image": "rayproject/ray:2.2.0",
+                                "image": "rayproject/ray:2.3.0",
                                 "resources": {
                                     "limits": {"cpu": "1", "memory": "1G"},
                                     "requests": {"cpu": "500m", "memory": "1G"},

--- a/clients/python-client/python_client_test/test_utils.py
+++ b/clients/python-client/python_client_test/test_utils.py
@@ -13,7 +13,7 @@ test_cluster_body: dict = {
         "name": "raycluster-complete-raw",
     },
     "spec": {
-        "rayVersion": "2.2.0",
+        "rayVersion": "2.3.0",
         "headGroupSpec": {
             "serviceType": "ClusterIP",
             "rayStartParams": {"dashboard-host": "0.0.0.0", "block": "true"},
@@ -23,7 +23,7 @@ test_cluster_body: dict = {
                     "containers": [
                         {
                             "name": "ray-head",
-                            "image": "rayproject/ray:2.2.0",
+                            "image": "rayproject/ray:2.3.0",
                             "ports": [
                                 {"containerPort": 6379, "name": "gcs"},
                                 {"containerPort": 8265, "name": "dashboard"},
@@ -59,7 +59,7 @@ test_cluster_body: dict = {
                         "containers": [
                             {
                                 "name": "ray-worker",
-                                "image": "rayproject/ray:2.2.0",
+                                "image": "rayproject/ray:2.3.0",
                                 "lifecycle": {
                                     "preStop": {
                                         "exec": {
@@ -77,7 +77,7 @@ test_cluster_body: dict = {
                             },
                             {
                                 "name": "side-car",
-                                "image": "rayproject/ray:2.2.0",
+                                "image": "rayproject/ray:2.3.0",
                                 "resources": {
                                     "limits": {"cpu": "1", "memory": "1G"},
                                     "requests": {"cpu": "500m", "memory": "1G"},

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -25,7 +25,11 @@ head:
   # The example configuration shown below below represents the DEFAULT values.
   # autoscalerOptions:
     # upscalingMode: Default
+    # idleTimeoutSeconds is the number of seconds to wait before scaling down a worker pod which is not using Ray resources.
     # idleTimeoutSeconds: 60
+    # imagePullPolicy optionally overrides the autoscaler container's default image pull policy (IfNotPresent).
+    # imagePullPolicy: IfNotPresent
+    # Optionally specify the autoscaler container's securityContext.
     # securityContext: {}
     # env: []
     # envFrom: []

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -7,7 +7,7 @@
 
 image:
   repository: rayproject/ray
-  tag: 2.0.0
+  tag: 2.3.0
   pullPolicy: IfNotPresent
 
 nameOverride: "kuberay"

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -40,8 +40,8 @@ spec:
     # If instance.spec.rayVersion is at least "2.0.0", the autoscaler will default to the same image as
     # the ray container by. For older Ray versions, the autoscaler will default to using the Ray 2.0.0 image.
     ## image: "my-repo/my-custom-autoscaler-image:tag"
-    # imagePullPolicy optionally overrides the autoscaler container's image pull policy.
-    imagePullPolicy: Always
+    # imagePullPolicy optionally overrides the autoscaler container's default image pull policy (IfNotPresent).
+    imagePullPolicy: IfNotPresent
     # Optionally specify the autoscaler container's securityContext.
     securityContext: {}
     env: []
@@ -75,7 +75,6 @@ spec:
         # The Ray head container
         - name: ray-head
           image: rayproject/ray:2.3.0
-          imagePullPolicy: Always
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
           # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -11,7 +11,7 @@ metadata:
   name: raycluster-autoscaler
 spec:
   # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
-  rayVersion: '2.2.0'
+  rayVersion: '2.3.0'
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -31,8 +31,7 @@ spec:
     # If instance.spec.rayVersion is at least "2.0.0", the autoscaler will default to the same image as
     # the ray container. For older Ray versions, the autoscaler will default to using the Ray 2.0.0 image.
     ## image: "my-repo/my-custom-autoscaler-image:tag"
-    # imagePullPolicy optionally overrides the autoscaler container's image pull policy. The default value
-    # is IfNotPresent.
+    # imagePullPolicy optionally overrides the autoscaler container's default image pull policy (IfNotPresent).
     imagePullPolicy: IfNotPresent
     # Optionally specify the autoscaler container's securityContext.
     securityContext: {}

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -30,9 +30,9 @@ spec:
     # image optionally overrides the autoscaler's container image.
     # If instance.spec.rayVersion is at least "2.0.0", the autoscaler will default to the same image as
     # the ray container. For older Ray versions, the autoscaler will default to using the Ray 2.0.0 image.
-    ## image: "my-repo/my-custom-autoscaler-image:tag"
+    image: "ray:test"
     # imagePullPolicy optionally overrides the autoscaler container's image pull policy.
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     # Optionally specify the autoscaler container's securityContext.
     securityContext: {}
     env: []
@@ -66,7 +66,6 @@ spec:
         # The Ray head container
         - name: ray-head
           image: rayproject/ray:2.3.0
-          imagePullPolicy: Always
           ports:
           - containerPort: 6379
             name: gcs

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -11,7 +11,7 @@ metadata:
   name: raycluster-autoscaler
 spec:
   # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
-  rayVersion: '2.3.0'
+  rayVersion: '2.2.0'
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
@@ -30,8 +30,9 @@ spec:
     # image optionally overrides the autoscaler's container image.
     # If instance.spec.rayVersion is at least "2.0.0", the autoscaler will default to the same image as
     # the ray container. For older Ray versions, the autoscaler will default to using the Ray 2.0.0 image.
-    image: "ray:test"
-    # imagePullPolicy optionally overrides the autoscaler container's image pull policy.
+    ## image: "my-repo/my-custom-autoscaler-image:tag"
+    # imagePullPolicy optionally overrides the autoscaler container's image pull policy. The default value
+    # is IfNotPresent.
     imagePullPolicy: IfNotPresent
     # Optionally specify the autoscaler container's securityContext.
     securityContext: {}

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -59,7 +59,6 @@ spec:
           containers:
             - name: ray-head
               image: rayproject/ray:2.3.0
-              imagePullPolicy: Always
               resources:
                 limits:
                   cpu: 2
@@ -96,7 +95,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.3.0
-                imagePullPolicy: Always
                 lifecycle:
                   preStop:
                     exec:

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -377,7 +377,7 @@ func BuildAutoscalerContainer(autoscalerImage string) v1.Container {
 	container := v1.Container{
 		Name:            AutoscalerContainerName,
 		Image:           autoscalerImage,
-		ImagePullPolicy: v1.PullAlways,
+		ImagePullPolicy: v1.PullIfNotPresent,
 		Env: []v1.EnvVar{
 			{
 				Name: "RAY_CLUSTER_NAME",

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -188,7 +188,7 @@ var volumeMountsWithAutoscaler = []v1.VolumeMount{
 var autoscalerContainer = v1.Container{
 	Name:            "autoscaler",
 	Image:           "repo/image:custom",
-	ImagePullPolicy: v1.PullAlways,
+	ImagePullPolicy: v1.PullIfNotPresent,
 	Env: []v1.EnvVar{
 		{
 			Name: "RAY_CLUSTER_NAME",

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -63,7 +63,6 @@ spec:
           containers:
             - name: ray-head
               image: $ray_image
-              imagePullPolicy: Always
               ports:
                 - containerPort: 6379
                   name: gcs-server
@@ -104,7 +103,6 @@ spec:
             containers:
               - name: ray-worker
                 image: $ray_image
-                imagePullPolicy: Always
                 lifecycle:
                   preStop:
                     exec:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Although we have `autoscalerOptions.imagePullPolicy` to overwrite the default `imagePullPolicy` (Always) in Autoscaler, there are still some reasons to update the default value for `imagePullPolicy`.

1. No Ray image with the tag `latest` is used in KubeRay. In that case, the default image pull policy for Pod should be `IfNotPresent`. See [this doc](https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting) for more details.

2. The default image pull policies for head Pod and worker Pods are `IfNotPresent`, but the default image pull policy is `Always`.

3. https://github.com/ray-project/ray/tree/master/python/ray/tests/kuberay => With this PR, we can run the tests locally without updating any line of code. 

## Related issue number
Closes #890
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(


## With this PR
```sh
# Step 1: Build your custom Ray image "ray:test"
# Step 2: Create a Kind cluster and load the Ray image into the Kind cluster
kind create cluster --image=kindest/node:v1.23.0
kind load docker-image ray:test

# Step 3: Build a KubeRay operator image for this PR "controller:latest"

# Step 4: Install KubeRay operator (with this PR)
helm repo add kuberay https://ray-project.github.io/kuberay-helm/
helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0 --set image.repository=controller,image.tag=latest

# Step 5: (path: ray-operator/config/samples) Create a Autoscaler RayCluster
# (1) set autoscalerOptions.image to "ray:test" (2) comment out autoscalerOptions.imagePullPolicy to "IfNotPresent"
kubectl apply -f ray-cluster.autoscaler.yaml

# Step 6: Check imagePullPolicy (The autoscaler container is the second container in the head Pod)
kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].imagePullPolicy}{"\n"}{end}'
```
<img width="1438" alt="Screen Shot 2023-03-07 at 12 02 10 PM" src="https://user-images.githubusercontent.com/20109646/223539352-bff9bd4b-ca61-41da-8dba-9704ca18df97.png">


## Without this PR
```sh
# Step 1: Build your custom Ray image "ray:test"
# Step 2: Create a Kind cluster and load the Ray image into the Kind cluster
kind create cluster --image=kindest/node:v1.23.0
kind load docker-image ray:test

# Step 3: Install KubeRay operator (without this PR)
helm repo add kuberay https://ray-project.github.io/kuberay-helm/
helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0

# Step 4: (path: ray-operator/config/samples) Create a Autoscaler RayCluster
# (1) set autoscalerOptions.image to "ray:test" (2) comment out autoscalerOptions.imagePullPolicy to "IfNotPresent"
kubectl apply -f ray-cluster.autoscaler.yaml

# Step 5: Check imagePullPolicy (The autoscaler container is the second container in the head Pod)
kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].imagePullPolicy}{"\n"}{end}'
```
<img width="1439" alt="Screen Shot 2023-03-07 at 11 45 50 AM" src="https://user-images.githubusercontent.com/20109646/223538157-be46c9bd-82b2-487d-8461-6b95fc2ce00d.png">
