### PR TITLE
[Feature] Read Redis password from Kubernetes Secret

### DIFF
--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -66,6 +66,16 @@ spec:
           configMap:
             name: redis-config
 ---
+# Redis password
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-password-secret
+type: Opaque
+data:
+  # echo -n "5241590000000000" | base64
+  password: NTI0MTU5MDAwMDAwMDAwMA==
+---
 apiVersion: ray.io/v1alpha1
 kind: RayCluster
 metadata:
@@ -87,7 +97,7 @@ spec:
       block: "true"
       # redis-password should match "requirepass" in redis.conf in the ConfigMap above.
       # Ray 2.3.0 changes the default redis password from "5241590000000000" to "".
-      redis-password: "5241590000000000"
+      redis-password: $RAY_REDIS_PASSWORD
     #pod template
     template:
       spec:
@@ -98,6 +108,11 @@ spec:
               # RAY_REDIS_ADDRESS can force ray to use external redis
               - name: RAY_REDIS_ADDRESS
                 value: redis:6379
+              - name: RAY_REDIS_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: redis-password-secret
+                    key: password
             ports:
               - containerPort: 6379
                 name: redis


### PR DESCRIPTION
## Why are these changes needed?

https://github.com/ray-project/kuberay/issues/949

## Related issue number

Closes #949 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
# Step 1: Install a KubeRay operator
# Step 2: Create a RayCluster (path: ray-operator/config/samples)
kubectl apply -f ray-cluster.external-redis.yaml

# Step 3: Log in to the head Pod
kubectl exec -it ${HEAD_POD} -- bash
echo $RAY_REDIS_PASSWORD
# 5241590000000000
```
