### PR TITLE
Read cluster domain from resolv.conf or env

### DIFF
--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -120,9 +120,11 @@ func FetchDashboardAgentURL(ctx context.Context, log *logr.Logger, cli client.Cl
 		return "", fmtErrors.Errorf("dashboard port not found")
 	}
 
-	dashboardAgentURL := fmt.Sprintf("%s.%s.svc.cluster.local:%v",
+	domainName := GetClusterDomainName()
+	dashboardAgentURL := fmt.Sprintf("%s.%s.svc.%s:%v",
 		dashboardAgentService.Name,
 		dashboardAgentService.Namespace,
+		domainName,
 		dashboardPort)
 	log.V(1).Info("fetchDashboardAgentURL ", "dashboardURL", dashboardAgentURL)
 	return dashboardAgentURL, nil
@@ -150,9 +152,11 @@ func FetchDashboardURL(ctx context.Context, log *logr.Logger, cli client.Client,
 		return "", fmtErrors.Errorf("dashboard port not found")
 	}
 
-	dashboardURL := fmt.Sprintf("%s.%s.svc.cluster.local:%v",
+	domainName := GetClusterDomainName()
+	dashboardURL := fmt.Sprintf("%s.%s.svc.%s:%v",
 		headSvc.Name,
 		headSvc.Namespace,
+		domainName,
 		dashboardPort)
 	log.V(1).Info("fetchDashboardURL ", "dashboardURL", dashboardURL)
 	return dashboardURL, nil

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base32"
 	"fmt"
 	"math"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -24,10 +25,22 @@ import (
 )
 
 const (
-	RayClusterSuffix = "-raycluster-"
-	DashboardName    = "dashboard"
-	ServeName        = "serve"
+	RayClusterSuffix    = "-raycluster-"
+	DashboardName       = "dashboard"
+	ServeName           = "serve"
+	ClusterDomainEnvKey = "CLUSTER_DOMAIN"
+	DefaultDomainName   = "cluster.local"
 )
+
+// GetClusterDomainName returns cluster's domain name
+func GetClusterDomainName() string {
+	if domain := os.Getenv(ClusterDomainEnvKey); len(domain) > 0 {
+		return domain
+	}
+
+	// Return default domain name.
+	return DefaultDomainName
+}
 
 // IsCreated returns true if pod has been created and is maintained by the API server
 func IsCreated(pod *corev1.Pod) bool {
@@ -123,7 +136,7 @@ func GenerateServiceName(clusterName string) string {
 
 // GenerateFQDNServiceName generates a Fully Qualified Domain Name.
 func GenerateFQDNServiceName(clusterName string, namespace string) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", GenerateServiceName(clusterName), namespace)
+	return fmt.Sprintf("%s.%s.svc.%s", GenerateServiceName(clusterName), namespace, GetClusterDomainName())
 }
 
 // ExtractRayIPFromFQDN extracts the head service name (i.e., RAY_IP, deprecated) from a fully qualified

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -11,6 +11,34 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func TestGetClusterDomainName(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{{
+		name: "all good from env",
+		env:  "abc.com",
+		want: "abc.com",
+	}, {
+		name: "No env set",
+		env:  "",
+		want: DefaultDomainName,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.env) > 0 {
+				t.Setenv(ClusterDomainEnvKey, tt.env)
+			}
+			got := GetClusterDomainName()
+			if got != tt.want {
+				t.Errorf("Test %s failed expected: %s but got: %s", tt.name, tt.want, got)
+			}
+		})
+	}
+}
+
 func TestBefore(t *testing.T) {
 	if Before("a", "b") != "" {
 		t.Fail()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
1. In k8s,  [cluster domains](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#introduction) are configuration.  But now kuberay hard coded it to `cluster.local`. So fix this to either read cluster domain from `/etc/resolv.conf` or environmental variable


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
