### PR TITLE
Customize the Prometheus export port

### DIFF
--- a/docs/guidance/prometheus-grafana.md
+++ b/docs/guidance/prometheus-grafana.md
@@ -59,8 +59,8 @@ kubectl get service
 # raycluster-kuberay-head-svc   ClusterIP   10.96.201.142   <none>        6379/TCP,8265/TCP,8080/TCP,8000/TCP,10001/TCP   106m
 ```
 
-* Based on [kuberay/#230](https://github.com/ray-project/kuberay/pull/230), KubeRay will expose a Prometheus metrics endpoint in port **8080** via a built-in exporter by default. Hence, we do not need to install any external exporter.
-* If you want to configure the metrics endpoint to a different port, also see [kuberay/#230](https://github.com/ray-project/kuberay/pull/230) for more details.
+* KubeRay will expose a Prometheus metrics endpoint in port **8080** via a built-in exporter by default. Hence, we do not need to install any external exporter.
+* If you want to configure the metrics endpoint to a different port, see [kuberay/#954](https://github.com/ray-project/kuberay/pull/954) for more details.
 * Prometheus metrics format:
   * `# HELP`: Describe the meaning of this metric.
   * `# TYPE`: See [this document](https://prometheus.io/docs/concepts/metric_types/) for more details.

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -123,19 +123,19 @@ func DefaultHeadPodTemplate(instance rayiov1alpha1.RayCluster, headSpec rayiov1a
 		podTemplate.Spec.Containers = append(podTemplate.Spec.Containers, autoscalerContainer)
 	}
 
-	// add metrics port for exposing to the promethues stack.
-	metricsPort := v1.ContainerPort{
-		Name:          "metrics",
-		ContainerPort: int32(DefaultMetricsPort),
-	}
-	dupIndex := -1
-	for i, port := range podTemplate.Spec.Containers[0].Ports {
-		if port.Name == metricsPort.Name {
-			dupIndex = i
+	isMetricsPortExists := false
+	for _, port := range podTemplate.Spec.Containers[0].Ports {
+		if port.Name == DefaultMetricsName {
+			isMetricsPortExists = true
 			break
 		}
 	}
-	if dupIndex < 0 {
+	if !isMetricsPortExists {
+		// add metrics port for exposing to the promethues stack.
+		metricsPort := v1.ContainerPort{
+			Name:          DefaultMetricsName,
+			ContainerPort: int32(DefaultMetricsPort),
+		}
 		podTemplate.Spec.Containers[0].Ports = append(podTemplate.Spec.Containers[0].Ports, metricsPort)
 	}
 
@@ -201,19 +201,19 @@ func DefaultWorkerPodTemplate(instance rayiov1alpha1.RayCluster, workerSpec rayi
 
 	initTemplateAnnotations(instance, &podTemplate)
 
-	// add metrics port for exposing to the promethues stack.
-	metricsPort := v1.ContainerPort{
-		Name:          "metrics",
-		ContainerPort: int32(DefaultMetricsPort),
-	}
-	dupIndex := -1
-	for i, port := range podTemplate.Spec.Containers[0].Ports {
-		if port.Name == metricsPort.Name {
-			dupIndex = i
+	isMetricsPortExists := false
+	for _, port := range podTemplate.Spec.Containers[0].Ports {
+		if port.Name == DefaultMetricsName {
+			isMetricsPortExists = true
 			break
 		}
 	}
-	if dupIndex < 0 {
+	if !isMetricsPortExists {
+		// add metrics port for exposing to the promethues stack.
+		metricsPort := v1.ContainerPort{
+			Name:          DefaultMetricsName,
+			ContainerPort: int32(DefaultMetricsPort),
+		}
 		podTemplate.Spec.Containers[0].Ports = append(podTemplate.Spec.Containers[0].Ports, metricsPort)
 	}
 

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -137,8 +137,6 @@ func DefaultHeadPodTemplate(instance rayiov1alpha1.RayCluster, headSpec rayiov1a
 	}
 	if dupIndex < 0 {
 		podTemplate.Spec.Containers[0].Ports = append(podTemplate.Spec.Containers[0].Ports, metricsPort)
-	} else {
-		podTemplate.Spec.Containers[0].Ports[dupIndex] = metricsPort
 	}
 
 	return podTemplate
@@ -217,8 +215,6 @@ func DefaultWorkerPodTemplate(instance rayiov1alpha1.RayCluster, workerSpec rayi
 	}
 	if dupIndex < 0 {
 		podTemplate.Spec.Containers[0].Ports = append(podTemplate.Spec.Containers[0].Ports, metricsPort)
-	} else {
-		podTemplate.Spec.Containers[0].Ports[dupIndex] = metricsPort
 	}
 
 	return podTemplate

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -759,7 +759,7 @@ func TestDefaultHeadPodTemplateWithConfigurablePorts(t *testing.T) {
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	// DefaultHeadPodTemplate will add the default metrics port if user doesn't specify it.
-	// verify the default metrics port exists.
+	// Verify the default metrics port exists.
 	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, DefaultMetricsName, int32(DefaultMetricsPort)); err != nil {
 		t.Fatal(err)
 	}
@@ -770,7 +770,7 @@ func TestDefaultHeadPodTemplateWithConfigurablePorts(t *testing.T) {
 	}
 	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = []v1.ContainerPort{metricsPort}
 	podTemplateSpec = DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
-	//  verify the custom metrics port exists.
+	// Verify the custom metrics port exists.
 	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, DefaultMetricsName, customMetricsPort); err != nil {
 		t.Fatal(err)
 	}
@@ -784,7 +784,7 @@ func TestDefaultWorkerPodTemplateWithConfigurablePorts(t *testing.T) {
 	fqdnRayIP := utils.GenerateFQDNServiceName(cluster.Name, cluster.Namespace)
 	podTemplateSpec := DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	// DefaultWorkerPodTemplate will add the default metrics port if user doesn't specify it.
-	// verify the default metrics port exists.
+	// Verify the default metrics port exists.
 	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, DefaultMetricsName, int32(DefaultMetricsPort)); err != nil {
 		t.Fatal(err)
 	}
@@ -795,7 +795,7 @@ func TestDefaultWorkerPodTemplateWithConfigurablePorts(t *testing.T) {
 	}
 	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Ports = []v1.ContainerPort{metricsPort}
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
-	// verify the custom metrics port exists.
+	// Verify the custom metrics port exists.
 	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, DefaultMetricsName, customMetricsPort); err != nil {
 		t.Fatal(err)
 	}

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -755,42 +755,48 @@ func containerPortExists(ports []v1.ContainerPort, name string, containerPort in
 
 func TestDefaultHeadPodTemplateWithConfigurablePorts(t *testing.T) {
 	cluster := instance.DeepCopy()
+	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = []v1.ContainerPort{}
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayiov1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
-	// verify the default metrics port exists
-	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, DefaultMetricsName, DefaultMetricsPort); err != nil {
+	// DefaultHeadPodTemplate will add the default metrics port if user doesn't specify it.
+	// verify the default metrics port exists.
+	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, DefaultMetricsName, int32(DefaultMetricsPort)); err != nil {
 		t.Fatal(err)
 	}
+	customMetricsPort := int32(DefaultMetricsPort) + 1
 	metricsPort := v1.ContainerPort{
 		Name:          DefaultMetricsName,
-		ContainerPort: 9091,
+		ContainerPort: customMetricsPort,
 	}
 	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = []v1.ContainerPort{metricsPort}
 	podTemplateSpec = DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
-	//  verify the custom metrics port exists
-	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, DefaultMetricsName, 9091); err != nil {
+	//  verify the custom metrics port exists.
+	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, DefaultMetricsName, customMetricsPort); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestDefaultWorkerPodTemplateWithConfigurablePorts(t *testing.T) {
 	cluster := instance.DeepCopy()
+	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Ports = []v1.ContainerPort{}
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	podName := cluster.Name + DashSymbol + string(rayiov1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
 	fqdnRayIP := utils.GenerateFQDNServiceName(cluster.Name, cluster.Namespace)
 	podTemplateSpec := DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
-	// verify the default metrics port exists
-	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, DefaultMetricsName, DefaultMetricsPort); err != nil {
+	// DefaultWorkerPodTemplate will add the default metrics port if user doesn't specify it.
+	// verify the default metrics port exists.
+	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, DefaultMetricsName, int32(DefaultMetricsPort)); err != nil {
 		t.Fatal(err)
 	}
+	customMetricsPort := int32(DefaultMetricsPort) + 1
 	metricsPort := v1.ContainerPort{
 		Name:          DefaultMetricsName,
-		ContainerPort: 9091,
+		ContainerPort: customMetricsPort,
 	}
 	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Ports = []v1.ContainerPort{metricsPort}
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
-	// verify the custom metrics port exists
-	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, DefaultMetricsName, 9091); err != nil {
+	// verify the custom metrics port exists.
+	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, DefaultMetricsName, customMetricsPort); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, KubeRay always exposes a Prometheus metrics endpoint on port 8080, and users are unable to customize this export port (see issue #864). However, the [Ray documentation](https://docs.ray.io/en/latest/ray-observability/ray-metrics.html#customize-prometheus-export-port) indicates that users are able to set up a custom Prometheus export port.

To better meet the needs of users and maintain consistency with Ray's capabilities, I recommend enabling the customization of the Prometheus export port for KubeRay users.

<!-- Please give a short summary of the change and the problem this solves. -->

## How to set Prometheus export port ?

- Add `metrics-export-port: "{Port Number}"` to `rayStartParams` for head and worker pods.
- Add `containerPort: {Port Number}` to `template.spec.containers[0].ports` for head and worker pods.
**Note, It's user's responsibility to maintain rayStartParam ports and container ports mapping(see [here](https://github.com/ray-project/kuberay/blob/6490749f4c5044a0ce40fdc653e04b50c052784d/ray-operator/controllers/ray/common/service.go#L178))**

For example:
(full version can be found [here](https://github.com/Yicheng-Lu-llll/kuberay/blob/tmp/ray-cluster.custom-prometheus-export-port.yaml))

```yaml
apiVersion: ray.io/v1alpha1
kind: RayCluster
spec:
  headGroupSpec:
    rayStartParams:
      metrics-export-port: "9001"
    template:
      spec:
        containers:
        - name: ray-head
          image: rayproject/ray:2.3.0
          ports:
          - containerPort: 9001
            name: metrics
            protocol: TCP

  workerGroupSpecs:
  - replicas: 1
    minReplicas: 1
    maxReplicas: 10
    rayStartParams:
      metrics-export-port: "9001" 
    template:
      spec:
        containers:
        - name: ray-worker
          image: rayproject/ray:2.3.0
          ports:
          - containerPort: 9001
            name: metrics
            protocol: TCP


```
## Related issue number
Closes #864 
<!-- For example: "Closes #1234" -->

## Checks
`ray-cluster.custom-prometheus-export-port.yaml` set metrics endpoint in port 9091
(Can be found [here](https://github.com/Yicheng-Lu-llll/kuberay/blob/tmp/ray-cluster.custom-prometheus-export-port.yaml))
```shell
kubectl apply -f /home/ubuntu/kuberay/ray-cluster.custom-prometheus-export-port.yaml
# install the ServiceMonitor, PodMonitor and PrometheusRule
./install/prometheus/install.sh
kubectl port-forward --address 0.0.0.0 prometheus-prometheus-kube-prometheus-prometheus-0 -n prometheus-system 9090:9090
# go to http://localhost:9090
```

![1678424357945](https://user-images.githubusercontent.com/51814063/224227485-dc58eb33-2be8-4b49-bd20-03bf9e71673a.png)


- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
