### PR TITLE
Fix issue with head pod not monitered by Prometheus under certain condition

### DIFF
--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -171,6 +171,11 @@ func getServicePorts(cluster rayiov1alpha1.RayCluster) map[string]int32 {
 		}
 	}
 
+	// check if metrics port is defined. If not, add default value for it.
+	if _, metricsDefined := ports[DefaultMetricsName]; !metricsDefined {
+		ports[DefaultMetricsName] = DefaultMetricsPort
+	}
+
 	return ports
 }
 

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -179,7 +179,7 @@ func TestGetServicePortsWithMetricsPort(t *testing.T) {
 
 	// Test case 2: Only a random port is specified by the user.
 	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
-		corev1.ContainerPort{
+		{
 			Name:          "random",
 			ContainerPort: 1234,
 		},
@@ -202,5 +202,4 @@ func TestGetServicePortsWithMetricsPort(t *testing.T) {
 	if ports[DefaultMetricsName] != customMetricsPort {
 		t.Fatalf("Expected `%v` but got `%v`", customMetricsPort, ports[DefaultMetricsName])
 	}
-
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

KubeRay is anticipated to provide a Prometheus metrics endpoint on port 8080. 

However, if users specify alternative ports in Spec.HeadGroupSpec.Template.Spec.Containers[ray_index].Ports without setting the metrics port, the head service will exclude the default metrics port. As a result, the service monitor will be unable to scrape metrics. Refer to the following code snippet for the existing logic.

https://github.com/ray-project/kuberay/blob/6490749f4c5044a0ce40fdc653e04b50c052784d/ray-operator/controllers/ray/common/service.go#L158-L163

This can be reproduced by using any [sample yaml files](https://github.com/ray-project/kuberay/tree/master/ray-operator/config/samples), for example, running:
```shell
kind delete cluster
kind create cluster
# kuberay repo path
rootPath="/home/ubuntu/kuberay" 
cd $rootPath
# install the kube-prometheus-stack chart and related custom resources, including ServiceMonitor, PodMonitor and PrometheusRule
./install/prometheus/install.sh  

# install kuberay-operator
helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0

# install ray cluster
kubectl apply -f $rootPath/ray-operator/config/samples/ray-cluster.complete.yaml

kubectl port-forward --address 0.0.0.0 prometheus-prometheus-kube-prometheus-prometheus-0 -n prometheus-system 9090:9090
# see result in http://localhost:9090/targets?search=ray. Only ray-workers-monitor is set.
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

After this PR, ray-workers-monitor and ray-head-monitor are all set.
![image](https://user-images.githubusercontent.com/51814063/225431206-eac1b788-0f06-4ffe-8f7f-b18b82e8c198.png)

