### PR TITLE
[Bug] Allow zero replica for workers for Helm 

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -32,6 +32,7 @@ spec:
     template:
       spec:
         imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
+        serviceAccount: {{ .Values.raycluster.serviceAccount }}
         containers:
           - volumeMounts: {{- toYaml .Values.head.volumeMounts | nindent 12 }}
             name: ray-head
@@ -100,6 +101,7 @@ spec:
             command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
             securityContext:
             {{- toYaml $values.initContainerSecurityContext | nindent 14 }}
+        serviceAccount: {{ .Values.raycluster.serviceAccount }}
         containers:
           - volumeMounts: {{- toYaml $values.volumeMounts | nindent 12 }}
             name: ray-worker
@@ -166,6 +168,7 @@ spec:
             command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
             securityContext:
             {{- toYaml .Values.worker.initContainerSecurityContext | nindent 14 }}
+        serviceAccount: {{ .Values.raycluster.serviceAccount }}
         containers:
           - volumeMounts: {{- toYaml .Values.worker.volumeMounts | nindent 12 }}
             name: ray-worker

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -88,7 +88,7 @@ spec:
       {{ $key }}: {{ $val | quote }}
     {{- end }}
     replicas: {{ $values.replicas }}
-    minReplicas: {{ $values.minReplicas | default (default 1 $values.miniReplicas) }}
+    minReplicas: {{ $values.minReplicas | default (default 0 $values.miniReplicas) }}
     maxReplicas: {{ $values.maxReplicas | default (default 2147483647 $values.maxiReplicas) }}
     groupName: {{ $groupName }}
     template:
@@ -154,7 +154,7 @@ spec:
       {{ $key }}: {{ $val | quote }}
     {{- end }}
     replicas: {{ .Values.worker.replicas }}
-    minReplicas: {{ .Values.worker.minReplicas | default (default 1 .Values.worker.miniReplicas) }}
+    minReplicas: {{ .Values.worker.minReplicas | default (default 0 .Values.worker.miniReplicas) }}
     maxReplicas: {{ .Values.worker.maxReplicas | default (default 2147483647 .Values.worker.maxiReplicas) }}
     groupName: {{ .Values.worker.groupName }}
     template:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -157,8 +157,8 @@ additionalWorkerGroups:
   smallGroup:
     # Disabled by default
     disabled: true
-    replicas: 1
-    minReplicas: 1
+    replicas: 0
+    minReplicas: 0
     maxReplicas: 3
     labels: {}
     rayStartParams:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -13,6 +13,7 @@ image:
 nameOverride: "kuberay"
 fullnameOverride: ""
 
+serviceAccount: "kuberay-service-account"
 imagePullSecrets: []
   # - name: an-existing-secret
 


### PR DESCRIPTION
## Why are these changes needed?

We are currently using Ray for computing heavily tasks on GKE. When initializing, it spawns a worker each worker group. Then, it triggers GKE scale up node. It's money cost. 

This happens because ternary function in template file. `{{ 0 | 1 }} = 1`
https://github.com/ray-project/kuberay/blob/87dde227d95457949a22a6cfea41bfbaeca46116/helm-chart/ray-cluster/templates/raycluster-cluster.yaml#L91
https://github.com/ray-project/kuberay/blob/87dde227d95457949a22a6cfea41bfbaeca46116/helm-chart/ray-cluster/templates/raycluster-cluster.yaml#L157

workaround by setting default replica to zero.

## Related issue number
Open #965 
Open #967 

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
