### PR TITLE
[Feature] Add service account section in helm chart

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -32,6 +32,7 @@ spec:
     template:
       spec:
         imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
+        serviceAccount: {{ .Values.raycluster.serviceAccount }}
         containers:
           - volumeMounts: {{- toYaml .Values.head.volumeMounts | nindent 12 }}
             name: ray-head
@@ -100,6 +101,7 @@ spec:
             command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
             securityContext:
             {{- toYaml $values.initContainerSecurityContext | nindent 14 }}
+        serviceAccount: {{ .Values.raycluster.serviceAccount }}
         containers:
           - volumeMounts: {{- toYaml $values.volumeMounts | nindent 12 }}
             name: ray-worker
@@ -166,6 +168,7 @@ spec:
             command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
             securityContext:
             {{- toYaml .Values.worker.initContainerSecurityContext | nindent 14 }}
+        serviceAccount: {{ .Values.raycluster.serviceAccount }}
         containers:
           - volumeMounts: {{- toYaml .Values.worker.volumeMounts | nindent 12 }}
             name: ray-worker

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -32,7 +32,9 @@ spec:
     template:
       spec:
         imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
-        serviceAccount: {{ .Values.raycluster.serviceAccount }}
+        {{- if .Values.head.serviceAccountName }}
+        serviceAccountName: {{ .Values.head.serviceAccountName }}
+        {{- end }}
         containers:
           - volumeMounts: {{- toYaml .Values.head.volumeMounts | nindent 12 }}
             name: ray-head
@@ -101,7 +103,9 @@ spec:
             command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
             securityContext:
             {{- toYaml $values.initContainerSecurityContext | nindent 14 }}
-        serviceAccount: {{ .Values.raycluster.serviceAccount }}
+        {{- if $values.serviceAccountName }}
+        serviceAccountName: {{ $values.serviceAccountName }}
+        {{- end }}
         containers:
           - volumeMounts: {{- toYaml $values.volumeMounts | nindent 12 }}
             name: ray-worker
@@ -168,7 +172,9 @@ spec:
             command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
             securityContext:
             {{- toYaml .Values.worker.initContainerSecurityContext | nindent 14 }}
-        serviceAccount: {{ .Values.raycluster.serviceAccount }}
+        {{- if .Values.worker.serviceAccountName }}
+        serviceAccountName: {{ .Values.worker.serviceAccountName }}
+        {{- end }}
         containers:
           - volumeMounts: {{- toYaml .Values.worker.volumeMounts | nindent 12 }}
             name: ray-worker

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -13,7 +13,6 @@ image:
 nameOverride: "kuberay"
 fullnameOverride: ""
 
-serviceAccount: "kuberay-service-account"
 imagePullSecrets: []
   # - name: an-existing-secret
 
@@ -40,6 +39,7 @@ head:
     #     cpu: "500m"
     #     memory: "512Mi"
   labels: {}
+  serviceAccountName: ""
   rayStartParams:
     dashboard-host: '0.0.0.0'
     block: 'true'
@@ -99,6 +99,7 @@ worker:
   groupName: workergroup
   replicas: 1
   labels: {}
+  serviceAccountName: ""
   rayStartParams:
     block: 'true'
   initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
@@ -162,6 +163,7 @@ additionalWorkerGroups:
     minReplicas: 1
     maxReplicas: 3
     labels: {}
+    serviceAccountName: ""
     rayStartParams:
       block: 'true'
     initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -13,6 +13,7 @@ image:
 nameOverride: "kuberay"
 fullnameOverride: ""
 
+serviceAccount: "kuberay-service-account"
 imagePullSecrets: []
   # - name: an-existing-secret
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For computing on cloud, service account is important. For example, we need query data from a private database, but workers dont have permission because missing service account.

## Related issue number

Open #967 

## Checks

- [x ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
