### PR TITLE
[Feature] Add default init container in workers to wait for GCS to be ready

### DIFF
--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -800,3 +800,17 @@ func TestDefaultWorkerPodTemplateWithConfigurablePorts(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestDefaultInitContainer(t *testing.T) {
+	// A default init container to check the health of GCS is expected to be added.
+	cluster := instance.DeepCopy()
+	fqdnRayIP := utils.GenerateFQDNServiceName(cluster.Name, cluster.Namespace)
+	worker := cluster.Spec.WorkerGroupSpecs[0]
+	podName := cluster.Name + DashSymbol + string(rayiov1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
+	expectedResult := len(cluster.Spec.WorkerGroupSpecs[0].Template.Spec.InitContainers) + 1
+
+	// Pass a deep copy of worker (*worker.DeepCopy()) to prevent "worker" from updating.
+	podTemplateSpec := DefaultWorkerPodTemplate(*cluster, *worker.DeepCopy(), podName, fqdnRayIP, "6379")
+	actualResult := len(podTemplateSpec.Spec.InitContainers)
+	assert.Equal(t, expectedResult, actualResult, "A default init container is expected to be added.")
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, the init container logic is wrong. It waits for the head service rather than GCS server. The head service will be ready when the image pull finishes. The current retry logic is implemented by Ray internal.

https://github.com/ray-project/kuberay/blob/71e260f2ae906a1a0646f11c9c3e5c332de2c70c/ray-operator/config/samples/ray-cluster.complete.yaml#L124-L129

For example, add `command: ["sleep 180"]` in the headGroupSpec. Then, the head Pod command will be `sleep 180 && ulimit -n 65536; ray start ...`. To clarify, the GCS server requires a minimum of 120 seconds to become ready after the head service is ready. It exceed the timeout of the Ray internal retry mechanism, so the worker will fail.

<img width="1440" alt="Screen Shot 2023-03-16 at 9 52 00 PM" src="https://user-images.githubusercontent.com/20109646/225815670-97995ba2-adac-4cd5-8ba2-5174880a5e3c.png">

In this PR, we add a default init container to use `ray health-check` to check the status of GCS so that can prevent this issue. In addition, each init container must complete successfully before the next one starts. Hence, it is fine for us to have two init containers at this moment to keep backward compatibility. We will remove the original init container from sample YAML files after release 0.5.0.

## Related issue number

Closes #476 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* We have two init containers at this moment. 
  <img width="1396" alt="Screen Shot 2023-03-16 at 10 05 51 PM" src="https://user-images.githubusercontent.com/20109646/225817448-8614e05e-7c2f-44b3-94f0-fb8eea754c4b.png">

