### PR TITLE
[Feature][Hotfix] Add observedGeneration to the status of CRDs

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -11277,6 +11277,11 @@ spec:
                   each node group.
                 format: int32
                 type: integer
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this RayCluster.
+                format: int64
+                type: integer
               reason:
                 description: Reason provides more information about current State
                 type: string

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -11772,6 +11772,11 @@ spec:
                 type: string
               message:
                 type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this RayJob.
+                format: int64
+                type: integer
               rayClusterName:
                 type: string
               rayClusterStatus:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -11816,6 +11816,11 @@ spec:
                       of each node group.
                     format: int32
                     type: integer
+                  observedGeneration:
+                    description: observedGeneration is the most recent generation
+                      observed for this RayCluster.
+                    format: int64
+                    type: integer
                   reason:
                     description: Reason provides more information about current State
                     type: string

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -11872,6 +11872,11 @@ spec:
                           of each node group.
                         format: int32
                         type: integer
+                      observedGeneration:
+                        description: observedGeneration is the most recent generation
+                          observed for this RayCluster.
+                        format: int64
+                        type: integer
                       reason:
                         description: Reason provides more information about current
                           State
@@ -11982,6 +11987,11 @@ spec:
                         description: MinWorkerReplicas indicates sum of minimum replicas
                           of each node group.
                         format: int32
+                        type: integer
+                      observedGeneration:
+                        description: observedGeneration is the most recent generation
+                          observed for this RayCluster.
+                        format: int64
                         type: integer
                       reason:
                         description: Reason provides more information about current

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -11910,6 +11910,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this RayService.
+                format: int64
+                type: integer
               pendingServiceStatus:
                 description: Pending Service Status indicates a RayCluster will be
                   created or is being created.

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -126,6 +126,10 @@ type RayClusterStatus struct {
 	Head HeadInfo `json:"head,omitempty"`
 	// Reason provides more information about current State
 	Reason string `json:"reason,omitempty"`
+	// observedGeneration is the most recent generation observed for this RayCluster. It corresponds to the
+	// RayCluster's generation, which is updated on mutation by the API Server.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // HeadInfo gives info about head

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -80,6 +80,10 @@ type RayJobStatus struct {
 	// Represents time when the job was ended.
 	EndTime          *metav1.Time     `json:"endTime,omitempty"`
 	RayClusterStatus RayClusterStatus `json:"rayClusterStatus,omitempty"`
+	// observedGeneration is the most recent generation observed for this RayJob. It corresponds to the
+	// RayJob's generation, which is updated on mutation by the API Server.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -95,6 +95,10 @@ type RayServiceStatuses struct {
 	PendingServiceStatus RayServiceStatus `json:"pendingServiceStatus,omitempty"`
 	// ServiceStatus indicates the current RayService status.
 	ServiceStatus ServiceStatus `json:"serviceStatus,omitempty"`
+	// observedGeneration is the most recent generation observed for this RayService. It corresponds to the
+	// RayService's generation, which is updated on mutation by the API Server.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 type RayServiceStatus struct {

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -11277,6 +11277,11 @@ spec:
                   each node group.
                 format: int32
                 type: integer
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this RayCluster.
+                format: int64
+                type: integer
               reason:
                 description: Reason provides more information about current State
                 type: string

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -11772,6 +11772,11 @@ spec:
                 type: string
               message:
                 type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this RayJob.
+                format: int64
+                type: integer
               rayClusterName:
                 type: string
               rayClusterStatus:

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -11816,6 +11816,11 @@ spec:
                       of each node group.
                     format: int32
                     type: integer
+                  observedGeneration:
+                    description: observedGeneration is the most recent generation
+                      observed for this RayCluster.
+                    format: int64
+                    type: integer
                   reason:
                     description: Reason provides more information about current State
                     type: string

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -11872,6 +11872,11 @@ spec:
                           of each node group.
                         format: int32
                         type: integer
+                      observedGeneration:
+                        description: observedGeneration is the most recent generation
+                          observed for this RayCluster.
+                        format: int64
+                        type: integer
                       reason:
                         description: Reason provides more information about current
                           State
@@ -11982,6 +11987,11 @@ spec:
                         description: MinWorkerReplicas indicates sum of minimum replicas
                           of each node group.
                         format: int32
+                        type: integer
+                      observedGeneration:
+                        description: observedGeneration is the most recent generation
+                          observed for this RayCluster.
+                        format: int64
                         type: integer
                       reason:
                         description: Reason provides more information about current

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -11910,6 +11910,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this RayService.
+                format: int64
+                type: integer
               pendingServiceStatus:
                 description: Pending Service Status indicates a RayCluster will be
                   created or is being created.

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
@@ -25,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -828,31 +827,19 @@ func (r *RayClusterReconciler) SetupWithManager(mgr ctrl.Manager, reconcileConcu
 }
 
 func (r *RayClusterReconciler) updateStatus(instance *rayiov1alpha1.RayCluster) error {
+	// TODO (kevin85421): ObservedGeneration should be used to determine whether update this CR or not.
+	instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
+
 	runtimePods := corev1.PodList{}
 	filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name}
 	if err := r.List(context.TODO(), &runtimePods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 		return err
 	}
 
-	count := utils.CalculateAvailableReplicas(runtimePods)
-	if instance.Status.AvailableWorkerReplicas != count {
-		instance.Status.AvailableWorkerReplicas = count
-	}
-
-	count = utils.CalculateDesiredReplicas(instance)
-	if instance.Status.DesiredWorkerReplicas != count {
-		instance.Status.DesiredWorkerReplicas = count
-	}
-
-	count = utils.CalculateMinReplicas(instance)
-	if instance.Status.MinWorkerReplicas != count {
-		instance.Status.MinWorkerReplicas = count
-	}
-
-	count = utils.CalculateMaxReplicas(instance)
-	if instance.Status.MaxWorkerReplicas != count {
-		instance.Status.MaxWorkerReplicas = count
-	}
+	instance.Status.AvailableWorkerReplicas = utils.CalculateAvailableReplicas(runtimePods)
+	instance.Status.DesiredWorkerReplicas = utils.CalculateDesiredReplicas(instance)
+	instance.Status.MinWorkerReplicas = utils.CalculateMinReplicas(instance)
+	instance.Status.MaxWorkerReplicas = utils.CalculateMaxReplicas(instance)
 
 	// validation for the RayStartParam for the state.
 	isValid, err := common.ValidateHeadRayStartParams(instance.Spec.HeadGroupSpec)

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -827,7 +827,7 @@ func (r *RayClusterReconciler) SetupWithManager(mgr ctrl.Manager, reconcileConcu
 }
 
 func (r *RayClusterReconciler) updateStatus(instance *rayiov1alpha1.RayCluster) error {
-	// TODO (kevin85421): ObservedGeneration should be used to determine whether update this CR or not.
+	// TODO (kevin85421): ObservedGeneration should be used to determine whether to update this CR or not.
 	instance.Status.ObservedGeneration = instance.ObjectMeta.Generation
 
 	runtimePods := corev1.PodList{}

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -967,14 +967,14 @@ func TestGetHeadServiceIP(t *testing.T) {
 	}
 }
 
-func TestUpdateStatus(t *testing.T) {
+func TestUpdateStatusObservedGeneration(t *testing.T) {
 	setupTest(t)
 	defer tearDown(t)
 
 	// Create a new scheme with CRDs, Pod, Service schemes.
 	newScheme := runtime.NewScheme()
-	rayiov1alpha1.AddToScheme(newScheme)
-	corev1.AddToScheme(newScheme)
+	_ = rayiov1alpha1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
 
 	// To update the status of RayCluster with `r.Status().Update()`,
 	// initialize the runtimeObjects with appropriate context. In KubeRay, the `ClusterIP`

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -971,23 +971,31 @@ func TestUpdateStatus(t *testing.T) {
 	setupTest(t)
 	defer tearDown(t)
 
-	// Create a scheme with CRDs and Pod schemes
+	// Create a new scheme with CRDs, Pod, Service schemes.
 	newScheme := runtime.NewScheme()
 	rayiov1alpha1.AddToScheme(newScheme)
 	corev1.AddToScheme(newScheme)
 
-	// Initialize a fake client
+	// To update the status of RayCluster with `r.Status().Update()`,
+	// initialize the runtimeObjects with appropriate context. In KubeRay, the `ClusterIP`
+	// and `TargetPort` fields are typically set by the cluster's control plane.
 	headService, err := common.BuildServiceForHeadPod(*testRayCluster, nil, nil)
 	assert.Nil(t, err, "Failed to build head service.")
 	headService.Spec.ClusterIP = headNodeIP
 	for i, port := range headService.Spec.Ports {
 		headService.Spec.Ports[i].TargetPort = intstr.IntOrString{IntVal: port.Port}
 	}
-
 	runtimeObjects := append(testPods, headService, testRayCluster)
+
+	// To facilitate testing, we set an impossible value for ObservedGeneration.
+	// Note that ObjectMeta's `Generation` and `ResourceVersion` don't behave properly in the fake client.
+	// [Ref] https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.5/pkg/client/fake
 	testRayCluster.Status.ObservedGeneration = -1
+
+	// Initialize a fake client with newScheme and runtimeObjects.
 	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
 
+	// Verify the initial values of `Generation` and `ObservedGeneration`.
 	namespacedName := types.NamespacedName{
 		Name:      instanceName,
 		Namespace: namespaceStr,
@@ -996,7 +1004,9 @@ func TestUpdateStatus(t *testing.T) {
 	err = fakeClient.Get(context.Background(), namespacedName, &cluster)
 	assert.Nil(t, err, "Fail to get RayCluster")
 	assert.Equal(t, int64(-1), cluster.Status.ObservedGeneration)
+	assert.Equal(t, int64(0), cluster.ObjectMeta.Generation)
 
+	// Initialize RayCluster reconciler.
 	testRayClusterReconciler := &RayClusterReconciler{
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
@@ -1004,9 +1014,9 @@ func TestUpdateStatus(t *testing.T) {
 		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
+	// Compare the values of `Generation` and `ObservedGeneration` to check if they match.
 	err = testRayClusterReconciler.updateStatus(testRayCluster)
 	assert.Nil(t, err)
-
 	err = fakeClient.Get(context.Background(), namespacedName, &cluster)
 	assert.Nil(t, err)
 	assert.Equal(t, cluster.ObjectMeta.Generation, cluster.Status.ObservedGeneration)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -346,6 +346,9 @@ func (r *RayJobReconciler) updateState(ctx context.Context, rayJob *rayv1alpha1.
 		rayJob.Status.EndTime = utils.ConvertUnixTimeToMetav1Time(jobInfo.EndTime)
 	}
 
+	// TODO (kevin85421): ObservedGeneration should be used to determine whether update this CR or not.
+	rayJob.Status.ObservedGeneration = rayJob.ObjectMeta.Generation
+
 	if errStatus := r.Status().Update(ctx, rayJob); errStatus != nil {
 		return fmtErrors.Errorf("combined error: %v %v", err, errStatus)
 	}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -109,7 +109,7 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	}
 	r.cleanUpServeConfigCache(rayServiceInstance)
 
-	// TODO (kevin85421): ObservedGeneration should be used to determine whether update this CR or not.
+	// TODO (kevin85421): ObservedGeneration should be used to determine whether to update this CR or not.
 	rayServiceInstance.Status.ObservedGeneration = rayServiceInstance.ObjectMeta.Generation
 
 	logger.Info("Reconciling the cluster component.")

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -109,6 +109,9 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	}
 	r.cleanUpServeConfigCache(rayServiceInstance)
 
+	// TODO (kevin85421): ObservedGeneration should be used to determine whether update this CR or not.
+	rayServiceInstance.Status.ObservedGeneration = rayServiceInstance.ObjectMeta.Generation
+
 	logger.Info("Reconciling the cluster component.")
 	// Find active and pending ray cluster objects given current service name.
 	var activeRayClusterInstance *rayv1alpha1.RayCluster

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -45,10 +45,8 @@ var _ = Context("Inside the default namespace", func() {
 	ctx := context.TODO()
 	var workerPods corev1.PodList
 
-	var numReplicas int32
-	var numCpus float64
-	numReplicas = 1
-	numCpus = 0.1
+	var numReplicas int32 = 1
+	var numCpus float64 = 0.1
 
 	myRayService := &rayiov1alpha1.RayService{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`observedGeneration` is a common pattern in Kubernetes to determine whether the current status is out-of-date or not.
* Good article: [Kubernetes operator best practices: Implementing observedGeneration](https://alenkacz.medium.com/kubernetes-operator-best-practices-implementing-observedgeneration-250728868792)

* [StatefulSet](https://github.com/kubernetes/kubernetes/blob/d2be69ac11346d2a0fab8c3c168c4255db99c56f/pkg/controller/statefulset/stateful_set_utils.go#L575-L586) uses `ObservedGeneration` to determine whether update status or not.
  ```go
  // inconsistentStatus returns true if the ObservedGeneration of status is greater than set's
  // Generation or if any of the status's fields do not match those of set's status.
  func inconsistentStatus(set *apps.StatefulSet, status *apps.StatefulSetStatus) bool {
	  return status.ObservedGeneration > set.Status.ObservedGeneration ||
		  status.Replicas != set.Status.Replicas ||
		  status.CurrentReplicas != set.Status.CurrentReplicas ||
		  status.ReadyReplicas != set.Status.ReadyReplicas ||
		  status.UpdatedReplicas != set.Status.UpdatedReplicas ||
		  status.CurrentRevision != set.Status.CurrentRevision ||
		  status.AvailableReplicas != set.Status.AvailableReplicas ||
		  status.UpdateRevision != set.Status.UpdateRevision
  }
  ```

However, this PR does not use `observedGeneration` to do anything because:
* Currently, KubeRay lacks a well-defined strategy for updating the status of its resources. Furthermore, it's possible for multiple status updates to occur within a single reconciliation loop, which can lead to problematic patterns and outcomes. 
* As a result, merging a pull request that includes any changes related to status updates shortly before the release of v0.5.0 is very risky.

The main motivation for this PR is to unblock Shopify. Other works will be included in the release v0.6.0.

## ObservedGeneration definition at this moment
* `ObservedGeneration` in this PR only promises that `ObservedGeneration <= Generation`. 
* I did not promise any other behavior in this PR because there are a lot of code paths that will update the status and I do not check every path.

## Test
  * We currently only have a test for RayCluster because we do not have tests with fake clients for RayJob and RayService at this moment. These should be done in the next release which we plan to focus on the stability of RayJob and RayService. 

## Related issue number
Hotfix for #916 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* RayCluster
<img width="1095" alt="Screen Shot 2023-03-22 at 4 27 39 PM" src="https://user-images.githubusercontent.com/20109646/227061175-56e73034-86b3-445a-9c9e-e59cc1ee2d21.png">

* RayJob
<img width="927" alt="Screen Shot 2023-03-22 at 4 46 21 PM" src="https://user-images.githubusercontent.com/20109646/227063572-804e373b-c388-4de1-8680-f4b9ddd6d281.png">

* RayService
<img width="1012" alt="Screen Shot 2023-03-22 at 4 36 52 PM" src="https://user-images.githubusercontent.com/20109646/227062288-21e8d020-dd86-4cec-92f7-c0ff2a1ad44c.png">

