### PR TITLE
Improve ray-cluster.external-redis.yaml

### DIFF
--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -97,7 +97,7 @@ spec:
       block: "true"
       # redis-password should match "requirepass" in redis.conf in the ConfigMap above.
       # Ray 2.3.0 changes the default redis password from "5241590000000000" to "".
-      redis-password: $RAY_REDIS_PASSWORD
+      redis-password: $REDIS_PASSWORD
     #pod template
     template:
       spec:
@@ -108,7 +108,7 @@ spec:
               # RAY_REDIS_ADDRESS can force ray to use external redis
               - name: RAY_REDIS_ADDRESS
                 value: redis:6379
-              - name: RAY_REDIS_PASSWORD
+              - name: REDIS_PASSWORD
                 valueFrom:
                   secretKeyRef:
                     name: redis-password-secret


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have access to it, we will shortly find a reviewer and assign them to your PR. -->
## Why are these changes needed?
The [Kuberay pull request #950](https://github.com/ray-project/kuberay/pull/950) discusses using Redis password secrets as environment variables, as described in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables).

Specifically, a new environment variable `RAY_REDIS_PASSWORD` is created and assigned a value from a secret:

```yaml
 - name: RAY_REDIS_PASSWORD
            valueFrom:
              secretKeyRef:
                name: redis-password-secret
                key: password
```
Additionally, the rayStartParams configuration includes a reference to this environment variable:
 ```yaml
 rayStartParams:
    redis-password: $REDIS_PASSWORD
```

However, the current Kuberay implementation sets another environment variable, `REDIS_PASSWORD` based on rayStartParams["redis-password"] if the user does not define it.
```go
	if !envVarExists(REDIS_PASSWORD, container.Env) {
		// setting the REDIS_PASSWORD env var from the params
		port := v1.EnvVar{Name: REDIS_PASSWORD}
		if value, ok := rayStartParams["redis-password"]; ok {
			port.Value = value
		}
		container.Env = append(container.Env, port)
	}
```
This leads to issues:

- As shown below, the `REDIS_PASSWORD` environment variable is redundant, as it only points to the `RAY_REDIS_PASSWORD` environment variable. 
```shell
    Environment:
      RAY_REDIS_ADDRESS:               redis:6379
      RAY_REDIS_PASSWORD:              <set to the key 'password' in secret 'redis-password-secret'>  Optional: false
      RAY_CLUSTER_NAME:                 (v1:metadata.labels['ray.io/cluster'])
      RAY_PORT:                        6379
      RAY_ADDRESS:                     127.0.0.1:6379
      RAY_USAGE_STATS_KUBERAY_IN_USE:  1
      REDIS_PASSWORD:                  $RAY_REDIS_PASSWORD
      RAY_external_storage_namespace:  my-raycluster-storage-namespace
```

To resolve this, it is advisable to set `RAY_REDIS_PASSWORD` as `REDIS_PASSWORD` in the `ray-cluster.external-redis.yaml ` to eliminate duplicate environment variables.




<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
```shell
kubectl apply -f kuberay/ray-operator/config/samples/ray-cluster.external-redis.yaml
kubectl describe  $(kubectl get pods -o=name | grep head)
```
```shell
    Environment:
      RAY_REDIS_ADDRESS:               redis:6379
      REDIS_PASSWORD:                  <set to the key 'password' in secret 'redis-password-secret'>  Optional: false
      RAY_CLUSTER_NAME:                 (v1:metadata.labels['ray.io/cluster'])
      RAY_PORT:                        6379
      RAY_ADDRESS:                     127.0.0.1:6379
      RAY_USAGE_STATS_KUBERAY_IN_USE:  1
      RAY_external_storage_namespace:  my-raycluster-storage-namespace

```
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
