### PR TITLE
[Feature] TLS authentication

### DIFF
--- a/docs/guidance/tls.md
+++ b/docs/guidance/tls.md
@@ -102,6 +102,8 @@ IP.1 = 127.0.0.1
 IP.2 = $POD_IP
 ```
 
+In [Kubernetes networking model](https://github.com/kubernetes/design-proposals-archive/blob/main/network/networking.md#pod-to-pod), the IP that a Pod sees itself as is the same IP that others see it as. That's why Ray Pods can self-register for the certificates.
+
 # Step 3 (Optional): Configure environment variables for Ray TLS authentication
 
 To enable TLS authentication in your Ray cluster, set the following environment variables:

--- a/docs/guidance/tls.md
+++ b/docs/guidance/tls.md
@@ -5,8 +5,8 @@ connecting to the Ray client on the head node will require an appropriate
 set of credentials and also that data exchanged between various processes 
 (client, head, workers) will be encrypted ([Ray's document](https://docs.ray.io/en/latest/ray-core/configure.html?highlight=tls#tls-authentication)).
 
-This document provides detailed instructions from generating public-private
-key pair and CA certificate to configuring KubeRay.
+This document provides detailed instructions for generating a public-private
+key pair and CA certificate for configuring KubeRay.
 
 > Warning: Enabling TLS will cause a performance hit due to the extra
 overhead of mutual authentication and encryption. Testing has shown that 

--- a/docs/guidance/tls.md
+++ b/docs/guidance/tls.md
@@ -1,7 +1,7 @@
 # TLS Authentication
 
 Ray can be configured to use TLS on its gRPC channels. This means that 
-connecting to the Ray client on the head node will require an appropriate 
+connecting to the Ray head will require an appropriate 
 set of credentials and also that data exchanged between various processes 
 (client, head, workers) will be encrypted ([Ray's document](https://docs.ray.io/en/latest/ray-core/configure.html?highlight=tls#tls-authentication)).
 

--- a/docs/guidance/tls.md
+++ b/docs/guidance/tls.md
@@ -1,6 +1,6 @@
 # TLS Authentication
 
-Ray can be configured to use TLS on it’s gRPC channels. This means that 
+Ray can be configured to use TLS on its gRPC channels. This means that 
 connecting to the Ray client on the head node will require an appropriate 
 set of credentials and also that data exchanged between various processes 
 (client, head, workers) will be encrypted ([Ray's document](https://docs.ray.io/en/latest/ray-core/configure.html?highlight=tls#tls-authentication)).

--- a/docs/guidance/tls.md
+++ b/docs/guidance/tls.md
@@ -30,6 +30,9 @@ This [YouTube video](https://youtu.be/T4Df5_cojAs) is a good start.
 
 > Please note that this document is designed to support KubeRay version 0.5.0 or later. If you are using an older version of KubeRay, some of the instructions or configurations may not apply or may require additional modifications.
 
+> Warning: Please note that the `ray-cluster.tls.yaml` file is intended for demo purposes only. It is crucial that you **do not** store
+your CA private key in a Kubernetes Secret in your production environment.
+
 ```sh
 # Install v0.5.0 KubeRay operator
 # Create a RayCluster with TLS authentication (path: kuberay/)
@@ -52,9 +55,13 @@ openssl req -x509 \
             -newkey rsa:2048 \
             -subj "/CN=*.kuberay.com/C=US/L=San Francisco" \
             -keyout ca.key -out ca.crt
-
-# Step 1-2: Use `cat $FILENAME | base64` to encode `ca.key` and `ca.crt`.
+# Step 1-2
+# Method 1: Use `cat $FILENAME | base64` to encode `ca.key` and `ca.crt`.
 #           Then, paste the encoding strings to the Kubernetes Secret in `ray-cluster.tls.yaml`.
+
+# Method 2: Use kubectl to encode the certifcate as Kubernetes Secret automatically.
+#           (Note: You should comment out the Kubernetes Secret in `ray-cluster.tls.yaml`.)
+kubectl create secret generic ca-tls --from-file=ca.key --from-file=ca.crt
 ```
 * `ca.key`: CA's private key
 * `ca.crt`: CA's self-signed certificate 

--- a/docs/guidance/tls.md
+++ b/docs/guidance/tls.md
@@ -91,7 +91,9 @@ certificate across different Pods.
 
 In the YAML file, you'll find a ConfigMap named `tls` that contains two shell scripts: 
 `gencert_head.sh` and `gencert_worker.sh`. These scripts are used to generate the private key 
-and self-signed certificate files (`tls.key` and `tls.crt`) for the Ray head and worker Pods. 
+and self-signed certificate files (`tls.key` and `tls.crt`) for the Ray head and worker Pods.
+An alternative approach for users is to prebake the shell scripts directly into the docker image that's utilized
+by the init containers, rather than relying on a ConfigMap.
 
 Please find below a brief explanation of what happens in each of these scripts:
 1. A 2048-bit RSA private key is generated and saved as `/etc/ray/tls/tls.key`.

--- a/docs/guidance/tls.md
+++ b/docs/guidance/tls.md
@@ -1,0 +1,138 @@
+# TLS Authentication
+
+Ray can be configured to use TLS on it’s gRPC channels. This means that 
+connecting to the Ray client on the head node will require an appropriate 
+set of credentials and also that data exchanged between various processes 
+(client, head, workers) will be encrypted ([Ray's document](https://docs.ray.io/en/latest/ray-core/configure.html?highlight=tls#tls-authentication)).
+
+This document provides detailed instructions from generating public-private
+key pair and CA certificate to configuring KubeRay.
+
+> Warning: Enabling TLS will cause a performance hit due to the extra
+overhead of mutual authentication and encryption. Testing has shown that 
+this overhead is large for small workloads and becomes relatively smaller
+for large workloads. The exact overhead will depend on the nature of your
+workload.
+
+# Prerequisites
+
+To fully understand this document, it's highly recommended that you have a
+solid understanding of the following concepts:
+
+* private/public key
+* CA (certificate authority)
+* CSR (certificate signing request)
+* self-signed certificate
+
+This [YouTube video](https://youtu.be/T4Df5_cojAs) is a good start.
+
+# TL;DR
+
+> Please note that this document is designed to support KubeRay version 0.5.0 or later. If you are using an older version of KubeRay, some of the instructions or configurations may not apply or may require additional modifications.
+
+```sh
+# Install v0.5.0 KubeRay operator
+# Create a RayCluster with TLS authentication (path: kuberay/)
+kubectl apply -f ray-operator/config/samples/ray-cluster.tls.yaml
+
+# Jump to Step 4 "Verify TLS authentication" to verify the connection.
+```
+
+# Step 1 (Optional): Generate a private key and self-signed certificate for CA
+
+In this document, a self-signed certificate is used, but users also have the
+option to choose a publicly trusted certificate authority (CA) for their TLS
+authentication.
+
+```sh
+# Step 1-1: Generate a self-signed certificate and a new private key file for CA.
+openssl req -x509 \
+            -sha256 -days 3650 \
+            -nodes \
+            -newkey rsa:2048 \
+            -subj "/CN=*.kuberay.com/C=US/L=San Francisco" \
+            -keyout ca.key -out ca.crt
+
+# Step 1-2: Use `cat $FILENAME | base64` to encode `ca.key` and `ca.crt`.
+#           Then, paste the encoding strings to the Kubernetes Secret in `ray-cluster.tls.yaml`.
+```
+* `ca.key`: CA's private key
+* `ca.crt`: CA's self-signed certificate 
+
+This step is optional because the `ca.key` and `ca.crt` files have
+already been included in the Kubernetes Secret specified in [ray-cluster.tls.yaml](../../ray-operator/config/samples/ray-cluster.tls.yaml).
+
+# Step 2 (Optional): Create separate private key and self-signed certificate for Ray Pods
+
+In [ray-cluster.tls.yaml](../../ray-operator/config/samples/ray-cluster.tls.yaml), each Ray
+Pod (both head and workers) generates its own private key file (`tls.key`) and self-signed
+certificate file (`tls.crt`) in its init container. We generate separate files for each Pod 
+because worker Pods do not have deterministic DNS names, and we cannot use the same 
+certificate across different Pods.
+
+In the YAML file, you'll find a ConfigMap named `tls` that contains two shell scripts: 
+`gencert_head.sh` and `gencert_worker.sh`. These scripts are used to generate the private key 
+and self-signed certificate files (`tls.key` and `tls.crt`) for the Ray head and worker Pods. 
+
+Please find below a brief explanation of what happens in each of these scripts:
+1. A 2048-bit RSA private key is generated and saved as `/etc/ray/tls/tls.key`.
+2. A Certificate Signing Request (CSR) is generated using the private key file (`tls.key`)
+and the `csr.conf` configuration file.
+3. A self-signed certificate (`tls.crt`) is generated using the private key of the 
+Certificate Authority (`ca.key`) and the previously generated CSR.
+
+The only difference between `gencert_head.sh` and `gencert_worker.sh` is the `[ alt_names ]`
+section in `csr.conf` and `cert.conf`. The worker Pods use the fully qualified domain name 
+(FQDN) of the head Kubernetes Service to establish a connection with the head Pod. 
+Therefore, the `[alt_names]` section for the head Pod needs to include the FQDN of the head 
+Kubernetes Service. By the way, the head Pod uses `$POD_IP` to communicate with worker Pods.
+
+```sh
+# gencert_head.sh
+[alt_names]
+DNS.1 = localhost
+DNS.2 = $FQ_RAY_IP
+IP.1 = 127.0.0.1
+IP.2 = $POD_IP
+
+# gencert_worker.sh
+[alt_names]
+DNS.1 = localhost
+IP.1 = 127.0.0.1
+IP.2 = $POD_IP
+```
+
+# Step 3 (Optional): Configure environment variables for Ray TLS authentication
+
+To enable TLS authentication in your Ray cluster, set the following environment variables:
+
+- `RAY_USE_TLS`: Either 1 or 0 to use/not-use TLS. If this is set to 1 then all of the environment variables below must be set. Default: 0.
+- `RAY_TLS_SERVER_CERT`: Location of a certificate file which is presented to other endpoints so as to achieve mutual authentication (i.e. `tls.crt`).
+- `RAY_TLS_SERVER_KEY`: Location of a private key file which is the cryptographic means to prove to other endpoints that you are the authorized user of a given certificate (i.e. `tls.key`). 
+- `RAY_TLS_CA_CERT`: Location of a CA certificate file which allows TLS to decide whether an endpoint’s certificate has been signed by the correct authority (i.e. `ca.crt`).
+
+For more information on how to configure Ray with TLS authentication, please refer to [Ray's document](https://docs.ray.io/en/latest/ray-core/configure.html#tls-authentication).
+
+# Step 4: Verify TLS authentication
+
+```sh
+# Log in to the worker Pod
+kubectl exec -it ${WORKER_POD} -- bash
+
+# Since the head Pod has the certificate of $FQ_RAY_IP, the connection to the worker Pods 
+# will be established successfully, and the exit code of the ray health-check command 
+# should be 0.
+ray health-check --address $FQ_RAY_IP:6379
+echo $? # 0
+
+# Since the head Pod has the certificate of $RAY_IP, the connection will fail and an error
+# message similar to the following will be displayed: "Peer name raycluster-tls-head-svc is
+# not in peer certificate".
+ray health-check --address $RAY_IP:6379
+
+# If you add `DNS.3 = $RAY_IP` to the [alt_names] section in `gencert_head.sh`,
+# the head Pod will generate the certificate of $RAY_IP. 
+# 
+# For KubeRay versions prior to 0.5.0, this step is necessary because Ray workers in earlier
+# versions use $RAY_IP to connect with Ray head.
+```

--- a/ray-operator/config/samples/ray-cluster.tls.yaml
+++ b/ray-operator/config/samples/ray-cluster.tls.yaml
@@ -263,7 +263,7 @@ data:
     L = San Fransisco
     O = test
     OU = test
-    CN = *.test.com
+    CN = *.kuberay.com
 
     [ req_ext ]
     subjectAltName = @alt_names
@@ -323,7 +323,7 @@ data:
     L = San Fransisco
     O = test
     OU = test
-    CN = *.test.com
+    CN = *.kuberay.com
 
     [ req_ext ]
     subjectAltName = @alt_names

--- a/ray-operator/config/samples/ray-cluster.tls.yaml
+++ b/ray-operator/config/samples/ray-cluster.tls.yaml
@@ -1,0 +1,362 @@
+apiVersion: ray.io/v1alpha1
+kind: RayCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: raycluster-tls
+spec:
+  rayVersion: '2.3.0'
+  # Ray head pod configuration
+  headGroupSpec:
+    # Kubernetes Service Type. This is an optional field, and the default value is ClusterIP.
+    # Refer to https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types.
+    serviceType: ClusterIP
+    rayStartParams:
+      dashboard-host: '0.0.0.0'
+    # pod template
+    template:
+      metadata:
+        labels: {}
+      spec:
+        initContainers:
+          # Generate head's private key and certificate before `ray start`.
+          - name: ray-head-tls
+            image: rayproject/ray:2.3.0
+            command: ["/bin/sh", "-c", "cp -R /etc/ca/tls /etc/ray && /etc/gen/tls/gencert_head.sh"]
+            volumeMounts:
+              - mountPath: /etc/ca/tls
+                name: ca-tls
+                readOnly: true
+              - mountPath: /etc/ray/tls
+                name: ray-tls
+              - mountPath: /etc/gen/tls
+                name: gen-tls-script
+            env:
+              - name: POD_IP
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.podIP
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.3.0
+          ports:
+          - containerPort: 6379
+            name: gcs
+          - containerPort: 8265
+            name: dashboard
+          - containerPort: 10001
+            name: client
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+          volumeMounts:
+            - mountPath: /tmp/ray
+              name: ray-logs
+            - mountPath: /etc/ca/tls
+              name: ca-tls
+              readOnly: true
+            - mountPath: /etc/ray/tls
+              name: ray-tls
+          resources:
+            limits:
+              cpu: "1"
+              memory: "2G"
+            requests:
+              cpu: "500m"
+              memory: "2G"
+          env:
+            # Environment variables for Ray TLS authentication. 
+            # See https://docs.ray.io/en/latest/ray-core/configure.html#tls-authentication for more details.
+            - name: RAY_USE_TLS
+              value: "1"
+            - name: RAY_TLS_SERVER_CERT
+              value: "/etc/ray/tls/tls.crt"
+            - name: RAY_TLS_SERVER_KEY
+              value: "/etc/ray/tls/tls.key"
+            - name: RAY_TLS_CA_CERT
+              value: "/etc/ca/tls/ca.crt"
+        volumes:
+          - name: ray-logs
+            emptyDir: {}
+          # Secret `ca-tls` has the information of CA's private key and certificate.
+          - name: ca-tls
+            secret:
+              secretName: ca-tls
+          - name: ray-tls
+            emptyDir: {}
+          # `gencert_head.sh` is a script to generate head Pod's private key and head's certificate.
+          - name: gen-tls-script
+            configMap:
+              name: tls
+              defaultMode: 0777
+              items:
+              - key: gencert_head.sh
+                path: gencert_head.sh
+  workerGroupSpecs:
+  # the pod replicas in this group typed worker
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 10
+    groupName: small-group
+    rayStartParams:
+      block: 'true'
+    #pod template
+    template:
+      spec:
+        initContainers:
+          # Generate worker's private key and certificate before `ray start`.
+          - name: ray-worker-tls
+            image: rayproject/ray:2.3.0
+            command: ["/bin/sh", "-c", "cp -R /etc/ca/tls /etc/ray && /etc/gen/tls/gencert_worker.sh"]
+            volumeMounts:
+              - mountPath: /etc/ca/tls
+                name: ca-tls
+                readOnly: true
+              - mountPath: /etc/ray/tls
+                name: ray-tls
+              - mountPath: /etc/gen/tls
+                name: gen-tls-script
+            env:
+              - name: POD_IP
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.podIP
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:2.3.0
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+          # use volumeMounts.Optional.
+          # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+          volumeMounts:
+            - mountPath: /tmp/ray
+              name: ray-logs
+            - mountPath: /etc/ca/tls
+              name: ca-tls
+              readOnly: true
+            - mountPath: /etc/ray/tls
+              name: ray-tls
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1G"
+            requests:
+              cpu: "500m"
+              memory: "1G"
+          env:
+            # Environment variables for Ray TLS authentication. 
+            # See https://docs.ray.io/en/latest/ray-core/configure.html#tls-authentication for more details.
+            - name: RAY_USE_TLS
+              value: "1"
+            - name: RAY_TLS_SERVER_CERT
+              value: "/etc/ray/tls/tls.crt"
+            - name: RAY_TLS_SERVER_KEY
+              value: "/etc/ray/tls/tls.key"
+            - name: RAY_TLS_CA_CERT
+              value: "/etc/ca/tls/ca.crt"
+        volumes:
+          - name: ray-logs
+            emptyDir: {}
+          # Secret `ca-tls` has the information of CA's private key and certificate.
+          - name: ca-tls
+            secret:
+              secretName: ca-tls
+          - name: ray-tls
+            emptyDir: {}
+          # `gencert_worker.sh` is a script to generate worker Pod's private key and worker's certificate.
+          - name: gen-tls-script
+            configMap:
+              name: tls
+              defaultMode: 0777
+              # An array of keys from the ConfigMap to create as files
+              items:
+              - key: gencert_worker.sh
+                path: gencert_worker.sh
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ca-tls
+data:
+  # cat ca.crt | base64
+  ca.crt: |
+    LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURXekNDQWtPZ0F3SUJBZ0lVVzQyUDZxZVEr
+    MU54M2xzazFaY2hCTjhSUmhnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1BURVdNQlFHQTFVRUF3d05L
+    aTVyZFdKbGNtRjVMbU52YlRFTE1Ba0dBMVVFQmhNQ1ZWTXhGakFVQmdOVgpCQWNNRFZOaGJpQkdj
+    bUZ1WTJselkyOHdIaGNOTWpNd016STJNREUxT1RNeVdoY05Nek13TXpJek1ERTFPVE15CldqQTlN
+    Ull3RkFZRFZRUUREQTBxTG10MVltVnlZWGt1WTI5dE1Rc3dDUVlEVlFRR0V3SlZVekVXTUJRR0Ex
+    VUUKQnd3TlUyRnVJRVp5WVc1amFYTmpiekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFE
+    Q0NBUW9DZ2dFQgpBTkh5Yk1PWjNlZ2hZS0gzTVJlcVhqSU83QlRHUGk3NXJ0ekpsMjN5WVhRdEFP
+    Y050eVNxZUllVk43YnJIYzAyCkN1RXNocUNpSHBDeVdYcDlVMWRCYlZwYWU3OXc3R1AySHBJclBr
+    WXZITm5ZZEF3a0dnYkpTeTNPSkJOb2N0MUEKbVdwYWI5N243dGlFbkw1bFFsR01vejBwR0FYQ1BK
+    Q3lVTWtsbDE2eUlSVUtjdjZkZThBcWZMU0FPRmxIY1BHRQo1SnhpRlhJcWtzbStqN0txZDVqQk14
+    b1RCV0puVmk4MTRVZ3U4eEMxZkV2ZlRKM1hMeWZ6cmtIbkJHZGYyUG4wCkJHVWtobzB3dDNoSGVt
+    QUs4NXV2OWZIUUdNMlpZOTYxVzhFT2ZQL3pCT3FIODZZMG9hU0VUQlpiSm45WEg2Y2UKdnIvWW9z
+    OU1wQU52K3dpemhqZFVPUWNDQXdFQUFhTlRNRkV3SFFZRFZSME9CQllFRkh2bk81LzdjakVMVXpt
+    NwpiaUJSay9Qc2N5dDdNQjhHQTFVZEl3UVlNQmFBRkh2bk81LzdjakVMVXptN2JpQlJrL1BzY3l0
+    N01BOEdBMVVkCkV3RUIvd1FGTUFNQkFmOHdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBTHg1cXZW
+    VUQvNVMwUjE2UUpFTWRlS3IKQzhaazhPL2dMa3ZkTlNEeUVzam5zU1JKWFF5aW4zdEJXQjhLaSs3
+    VXBlQ3Y4TCtjOUdHM05oNzBUdGhxTmNrOApHT0ZHVHdYTi9XLy9MbTNIZEJVK2UzSkJkbElOTEo4
+    alRuRjFQUXJvS2ZacURCZnVlR0FwSDdPT0JKYWl2KzFtCjdxalNsbkovYS9rRlRaWXNsNVpZU204
+    dWI4Q3RGQnFwOFliM0xBcU5YUG9zL3QzVFBVbG1wRHpOK0lPTTBSb1IKKy9vS3A3TUpCNFFoeFQ2
+    T2RYVy9Iekw3bndmbnZ6QU12NXREKzdUamJuaDFrS0d2b0ZBUW5neXRMQnAzcllxcQpBRWFYck8x
+    OUFNKzdCMmpQcHB4RVM1Rm01K3FPdS9BUnBzVDdzbUJ0eitudnlwdEM3Y2J2QUZzZFAwRnhHWjA9
+    Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  # cat ca.key | base64
+  ca.key: |
+    LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV1d0lCQURBTkJna3Foa2lHOXcwQkFRRUZB
+    QVNDQktVd2dnU2hBZ0VBQW9JQkFRRFI4bXpEbWQzb0lXQ2gKOXpFWHFsNHlEdXdVeGo0dSthN2N5
+    WmR0OG1GMExRRG5EYmNrcW5pSGxUZTI2eDNOTmdyaExJYWdvaDZRc2xsNgpmVk5YUVcxYVdudS9j
+    T3hqOWg2U0t6NUdMeHpaMkhRTUpCb0d5VXN0emlRVGFITGRRSmxxV20vZTUrN1loSnkrClpVSlJq
+    S005S1JnRndqeVFzbERKSlpkZXNpRVZDbkwrblh2QUtueTBnRGhaUjNEeGhPU2NZaFZ5S3BMSnZv
+    K3kKcW5lWXdUTWFFd1ZpWjFZdk5lRklMdk1RdFh4TDMweWQxeThuODY1QjV3Um5YOWo1OUFSbEpJ
+    YU5NTGQ0UjNwZwpDdk9ici9YeDBCak5tV1BldFZ2QkRuei84d1RxaC9PbU5LR2toRXdXV3laL1Z4
+    K25IcjYvMktMUFRLUURiL3NJCnM0WTNWRGtIQWdNQkFBRUNnZ0VBQkx0RzhqMlVmN2ZJMnIyY2NL
+    RVpVRjEvdXBRaE1LUFY2Z250RE1CS3EvaWIKclpsa2lFSURSMkw0aDNuVENSM3ZydFYzRDBXNEZL
+    REFYWDlYa243Wi9SQk8rNmlLMjFIZnJJR20vS1B4TFlPdwpVZG02Y0c2MjhBaFdUYzJyMFFxMHFt
+    M3hXWCsycFZDUHk4YXljTzRQZThCaVZ6YmljSXhrUDdSR0xnOHJxYkt4CkhYM1pOUnhIUy9NOW9X
+    YzYyM2RTZEJwZGdxUitLYlVVM21aWjJXc3ZBSjZiME5sZ0U0Vkc4aTFqUFBLbDVFV2kKRmtnTkVG
+    N0pNZ0RHRDQvODEvMlErUnRCdmtpQTlmZkk0NER4Z04rbVJBZmVaRFQvZWtOTDROVlRUWm9SZkpk
+    YwpKcGtqMmppNE5NUENJTGNnazN5QVBuSXRTamlsWGkrMXFiTjNmZXQwV1FLQmdRRDRGOTBreWhy
+    K0p1cWRrMnIwCjZPTXVVSk9GM3k0UDA2OFFOTHF4blNPOERaMndKL2cwdGJhWk5Senp4anZwWHFZ
+    VVpIWGVhVHdNYkNreE55TnEKb0kvQmYwYTJoUGcyeE9iTm5HVUF6MEgzVGZ2Y0JvcVIvVXlOTFZr
+    d0dtUUx5WVZuNWdmSXdnN1lsS2x2emtsegp3aHUxNnNSVGNPNXpBUkpaTHV3dy9MSWFjd0tCZ1FE
+    WW8xV2Z3N1pWeUQrSSszRlRMbzhCeXJZd2F2S3FjY1dQCjM5T20wdzB2ckZTc0tHQVFnY0ZwR2NX
+    cG5FM0FMWnZ6eHAyU2lRTkc0RkhWTmNZblNqM0tKY2lGRC9vOHJRSTgKNjRxOE82MW9QL2lQOWNt
+    MzFpNjRCYmhsaFhqeUZPZGc4bU9LSWZnOHB2Y1AzeDBMKzdRMy9GbmIzWmxkd1lkdAo5SjhXbDR0
+    ZUhRS0JnUUN4czNZbENkWjN3S3hBSGYxNFd1K09sd3h6MFQ0Ty9CTGl5c0lHd29WOEIweXhobytV
+    ClFhdis1VHBOcWVuejZHV1JLYnY3aU9rSUJOa2tkVmdhNGRMV1NESUFQaElFT05rUTRUcS9iN1RT
+    VEx0Z0NCZHQKSmorVXg2eWdkZWEvUXFNWm5ueG80Z2I4UHM5MlZBM3NxbFpxNFRPcWlMTmpFSnR4
+    NGRndjVuQXozUUtCZ0dtSwphVlNFVEhoT0xtWFYyY2ZranRjWW90bkR3S1U0K0Q2M2xLMVpkTHNk
+    QWNNOWlFK0NaMitFbHIraTNsNFoyamhSCk1zTUk3UWZDa1J1R0x4dEZHQVU3a3cwQVU3RHJ1SU5s
+    WFJtSEdWd0lqbGZVTG9uWlZybGdVQTFsa1I2ZkFIcEMKbkN2WGtOQTdwM0djQ05LbHRZN3c2Zlly
+    WjJROXZIVGRFQVE1b0RRaEFuOCtwUFFySEZ1aHhWMnBGb0RjcFFCSApPR0NjbHZJUGxOZTZzWmFO
+    YXQwb0pjUDkxbkI3TFoxMnVhUG9wa3dZckxGZXBtQVRiOElDbU9LMGNCUWNIenljCm5tM3lWVEt1
+    LzA1NnMvdVQwSnY3dFA0clluR3c3WG5acWV1bVNzd2pqbTZIRHBRNG5Ia1JmWFZ5VkVBZFVONUsK
+    VVc3Q01ubkQ2OGsranZLc2lXbmYKLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQo=
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tls
+data: 
+  gencert_head.sh: |
+    #!/bin/sh
+    ## Create tls.key
+    openssl genrsa -out /etc/ray/tls/tls.key 2048
+
+    ## Write CSR Config
+    cat > /etc/ray/tls/csr.conf <<EOF
+    [ req ]
+    default_bits = 2048
+    prompt = no
+    default_md = sha256
+    req_extensions = req_ext
+    distinguished_name = dn
+
+    [ dn ]
+    C = US
+    ST = California
+    L = San Fransisco
+    O = test
+    OU = test
+    CN = *.test.com
+
+    [ req_ext ]
+    subjectAltName = @alt_names
+
+    [ alt_names ]
+    DNS.1 = localhost
+    DNS.2 = $FQ_RAY_IP
+    IP.1 = 127.0.0.1
+    IP.2 = $POD_IP
+
+    EOF
+
+    ## Create CSR using tls.key
+    openssl req -new -key /etc/ray/tls/tls.key -out /etc/ray/tls/ca.csr -config /etc/ray/tls/csr.conf
+
+    ## Write cert config
+    cat > /etc/ray/tls/cert.conf <<EOF
+
+    authorityKeyIdentifier=keyid,issuer
+    basicConstraints=CA:FALSE
+    keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+    subjectAltName = @alt_names
+
+    [alt_names]
+    DNS.1 = localhost
+    DNS.2 = $FQ_RAY_IP
+    IP.1 = 127.0.0.1
+    IP.2 = $POD_IP
+
+    EOF
+
+    ## Generate tls.cert
+    openssl x509 -req \
+        -in /etc/ray/tls/ca.csr \
+        -CA /etc/ray/tls/ca.crt -CAkey /etc/ray/tls/ca.key \
+        -CAcreateserial -out /etc/ray/tls/tls.crt \
+        -days 365 \
+        -sha256 -extfile /etc/ray/tls/cert.conf
+
+  gencert_worker.sh: |
+    #!/bin/sh
+    ## Create tls.key
+    openssl genrsa -out /etc/ray/tls/tls.key 2048
+
+    ## Write CSR Config
+    cat > /etc/ray/tls/csr.conf <<EOF
+    [ req ]
+    default_bits = 2048
+    prompt = no
+    default_md = sha256
+    req_extensions = req_ext
+    distinguished_name = dn
+
+    [ dn ]
+    C = US
+    ST = California
+    L = San Fransisco
+    O = test
+    OU = test
+    CN = *.test.com
+
+    [ req_ext ]
+    subjectAltName = @alt_names
+
+    [ alt_names ]
+    DNS.1 = localhost
+    IP.1 = 127.0.0.1
+    IP.2 = $POD_IP
+
+    EOF
+
+    ## Create CSR using tls.key
+    openssl req -new -key /etc/ray/tls/tls.key -out /etc/ray/tls/ca.csr -config /etc/ray/tls/csr.conf
+
+    ## Write cert config
+    cat > /etc/ray/tls/cert.conf <<EOF
+
+    authorityKeyIdentifier=keyid,issuer
+    basicConstraints=CA:FALSE
+    keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+    subjectAltName = @alt_names
+
+    [alt_names]
+    DNS.1 = localhost
+    IP.1 = 127.0.0.1
+    IP.2 = $POD_IP
+
+    EOF
+
+    ## Generate tls.cert
+    openssl x509 -req \
+        -in /etc/ray/tls/ca.csr \
+        -CA /etc/ray/tls/ca.crt -CAkey /etc/ray/tls/ca.key \
+        -CAcreateserial -out /etc/ray/tls/tls.crt \
+        -days 365 \
+        -sha256 -extfile /etc/ray/tls/cert.conf

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -830,6 +830,7 @@ func TestDefaultInitContainer(t *testing.T) {
 	rayContainer := worker.Template.Spec.Containers[getRayContainerIndex(worker.Template.Spec)]
 	assert.Equal(t, len(rayContainer.Env), len(healthCheckContainer.Env))
 	for _, env := range rayContainer.Env {
+		// env.ValueFrom is the source for the environment variable's value. Cannot be used if value is not empty.
 		if env.Value != "" {
 			checkContainerEnv(t, healthCheckContainer, env.Name, env.Value)
 		} else {

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -756,14 +756,15 @@ func (r *RayClusterReconciler) createWorkerPod(instance rayiov1alpha1.RayCluster
 // Build head instance pod(s).
 func (r *RayClusterReconciler) buildHeadPod(instance rayiov1alpha1.RayCluster) corev1.Pod {
 	podName := strings.ToLower(instance.Name + common.DashSymbol + string(rayiov1alpha1.HeadNode) + common.DashSymbol)
-	podName = utils.CheckName(podName) // making sure the name is valid
+	podName = utils.CheckName(podName)                                            // making sure the name is valid
+	fqdnRayIP := utils.GenerateFQDNServiceName(instance.Name, instance.Namespace) // Fully Qualified Domain Name
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
 	autoscalingEnabled := instance.Spec.EnableInTreeAutoscaling
 	podConf := common.DefaultHeadPodTemplate(instance, instance.Spec.HeadGroupSpec, podName, headPort)
 	r.Log.Info("head pod labels", "labels", podConf.Labels)
 	creatorName := getCreator(instance)
-	pod := common.BuildPod(podConf, rayiov1alpha1.HeadNode, instance.Spec.HeadGroupSpec.RayStartParams, headPort, autoscalingEnabled, creatorName, "")
+	pod := common.BuildPod(podConf, rayiov1alpha1.HeadNode, instance.Spec.HeadGroupSpec.RayStartParams, headPort, autoscalingEnabled, creatorName, fqdnRayIP)
 	// Set raycluster instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&instance, &pod, r.Scheme); err != nil {
 		r.Log.Error(err, "Failed to set controller reference for raycluster pod")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray can be configured to use TLS on it’s gRPC channels ([ref](https://docs.ray.io/en/latest/ray-core/configure.html#tls-authentication)). However, the document requires users to have related knowledge about TLS, HTTPS, and basic cryptography to create correct public-private key pairs, self-signed certificates, and certificate authority.

In KubeRay, users also need to know how does head / workers communicate with each other.

* head uses `POD_IP` to communicate with worker.
* worker uses the fully qualified domain name of the head service (i.e. `FQ_RAY_IP`) to communicate with the head.

Hence, head needs to have `FQ_RAY_IP`'s certificate, and worker requires the certificate of its `POD_IP`.

Configuring TLS in KubeRay can be a challenging task for users. To ease this process, this PR offers detailed instructions and an example YAML file, simplifying the setup and configuration of TLS for users

Credit: This is a joint effort. Over the last two weeks, @YQ-Wang and I have been working closely together on this and other issues, synchronizing almost every day.
## Related issue number
Closes #889
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
# Create a Kubernetes cluster
kind create cluster --image=kindest/node:v1.23.0

# Build docker image (path: kuberay/ray-operator/)
make docker-image

# Load the image into the Kind cluster
kind load docker-image controller:latest

# Install the operator with the new image
helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0 --set image.repository=controller,image.tag=latest

# Create a RayCluster with TLS
kubectl apply -f ray-cluster.tls.yaml
```
* head Pod's log
  <img width="1440" alt="Screen Shot 2023-03-26 at 10 04 27 PM" src="https://user-images.githubusercontent.com/20109646/227845617-2f86291b-763b-4be2-9ba2-58fd64066d23.png">

* worker Pod's log
  <img width="1440" alt="Screen Shot 2023-03-26 at 10 04 42 PM" src="https://user-images.githubusercontent.com/20109646/227845628-c65b574d-e2fd-4822-bdc6-b1e4e7129cad.png">


# Verift the TLS authentication (Step 4 in the doc)

```sh
# Log in to the worker Pod
kubectl exec -it ${WORKER_POD} -- bash

# Since the head Pod has the certificate of $FQ_RAY_IP, the connection to the worker Pods 
# will be established successfully, and the exit code of the ray health-check command 
# should be 0.
ray health-check --address $FQ_RAY_IP:6379
echo $? # 0

# Since the head Pod has the certificate of $RAY_IP, the connection will fail and an error
# message similar to the following will be displayed: "Peer name raycluster-tls-head-svc is
# not in peer certificate".
ray health-check --address $RAY_IP:6379
```
* Screenshot for the verification
  <img width="1440" alt="Screen Shot 2023-03-26 at 10 08 50 PM" src="https://user-images.githubusercontent.com/20109646/227846134-c3177371-41f3-45bb-b69b-b4b0d90e4dae.png">

