### PR TITLE
[Feature] Add python client test to action

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -403,7 +403,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install package and run unittest for Python client
-        working-directory: ./ray-operator/clients/python-client
+        working-directory: ./clients/python-client
         run: |
           pip install -r requirements.txt
           pip install -e .

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -379,3 +379,32 @@ jobs:
         with:
           ray_version: 2.3.0
 
+  python-client-test:
+    runs-on: ubuntu-latest
+    name: Python Client Test
+    steps:
+      - name: Set up Docker
+        uses: docker-practice/actions-setup-docker@master
+
+      - name: Install Kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind create cluster
+        shell: bash
+
+      - name: Checkout Python
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install package and run unittest for Python client
+        working-directory: ./ray-operator/clients/python-client
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
+          python3 -m unittest discover 'python_client_test/'

--- a/clients/python-client/requirements.txt
+++ b/clients/python-client/requirements.txt
@@ -1,0 +1,1 @@
+kubernetes


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Testing python client library in CI.

### Why create a k8s cluster in the test?
Though currently, the test does not interact with the k8s cluster, the __init__ function in kuberay_cluster_api will load kube config, which will report errors if there is no k8s server.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
