### PR TITLE
Release v0.5.0 doc validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ We also recommend checking out the official Ray guides for deploying on Kubernet
 ## Quick Start
 
 * Try this [end-to-end example](helm-chart/ray-cluster/README.md)!
-* Please choose the version you would like to install. The examples below use the latest stable version `v0.4.0`.
+* Please choose the version you would like to install. The examples below use the latest stable version `v0.5.0`.
 
 | Version  |  Stable |  Suggested Kubernetes Version |
 |----------|:-------:|------------------------------:|
 |  master  |    N    | v1.19 - v1.25 |
-|  v0.4.0  |    Y    | v1.19 - v1.25 |
+|  v0.5.0  |    Y    | v1.19 - v1.25 |
 
 ### Use YAML
 
@@ -37,11 +37,11 @@ Once you have connected to a Kubernetes cluster, run the following commands to d
 
 ```sh
 # case 1: kubectl >= v1.22.0
-export KUBERAY_VERSION=v0.4.0
+export KUBERAY_VERSION=v0.5.0
 kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/default?ref=${KUBERAY_VERSION}&timeout=90s"
 
 # case 2: kubectl < v1.22.0
-# Clone KubeRay repository and checkout to the desired branch e.g. `release-0.4`.
+# Clone KubeRay repository and checkout to the desired branch e.g. `release-0.5`.
 kubectl create -k ray-operator/config/default
 ```
 
@@ -49,7 +49,7 @@ To deploy both the KubeRay Operator and the optional KubeRay API Server run the 
 
 ```sh
 # case 1: kubectl >= v1.22.0
-export KUBERAY_VERSION=v0.4.0
+export KUBERAY_VERSION=v0.5.0
 kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=${KUBERAY_VERSION}&timeout=90s"
 kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=${KUBERAY_VERSION}&timeout=90s"
 
@@ -70,8 +70,8 @@ Please read [kuberay-operator](helm-chart/kuberay-operator/README.md) to deploy 
 ```sh
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Install both CRDs and KubeRay operator v0.4.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0
+# Install both CRDs and KubeRay operator v0.5.0.
+helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0
 
 # Check the KubeRay operator Pod in `default` namespace
 kubectl get pods

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -3,7 +3,7 @@
 Find the Docker images for various KubeRay components on [Dockerhub](https://hub.docker.com/u/kuberay).
 
 #### Stable versions
-For stable releases, use version tags (e.g. `kuberay/operator:v0.4.0`).
+For stable releases, use version tags (e.g. `kuberay/operator:v0.5.0`).
 
 #### Master commits
 The first seven characters of the git SHA specify images built from specific commits

--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -26,10 +26,10 @@ helm install kuberay-operator kuberay/kuberay-operator
 #### Method 2: Kustomize
 ```sh
 # Install CRDs
-kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.4.0&timeout=90s"
+kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.5.0&timeout=90s"
 
 # Install KubeRay operator
-kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=v0.4.0"
+kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=v0.5.0"
 ```
 
 > Observe that we must use `kubectl create` to install cluster-scoped resources.

--- a/docs/guidance/autoscaler.md
+++ b/docs/guidance/autoscaler.md
@@ -7,16 +7,13 @@ See the [official Ray documentation](https://docs.ray.io/en/latest/cluster/kuber
 
 ### Prerequisite
 
-Start by deploying the latest stable version of the KubeRay operator:
-```
-kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/default?ref=v0.4.0&timeout=90s"
-```
+* Follow this [document](https://github.com/ray-project/kuberay/blob/master/helm-chart/kuberay-operator/README.md) to install the latest stable KubeRay operator via Helm repository.
 
 ### Deploy a cluster with autoscaling enabled
 
 Next, to deploy a sample autoscaling Ray cluster, run
 ```
-kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/release-0.3/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/release-0.5/ray-operator/config/samples/ray-cluster.autoscaler.yaml
 ```
 
 See the above config file for details on autoscaling configuration.
@@ -28,7 +25,7 @@ See the above config file for details on autoscaling configuration.
     each Ray pod should be sized to take up its entire K8s node. We don't recommend
     allocating less than 8 gigabytes of memory for Ray containers running in production.
     For an autoscaling configuration more suitable for production, see
-    [ray-cluster.autoscaler.large.yaml](https://raw.githubusercontent.com/ray-project/kuberay/release-0.3/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml).
+    [ray-cluster.autoscaler.large.yaml](https://raw.githubusercontent.com/ray-project/kuberay/release-0.5/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml).
 
 The output of `kubectl get pods` should indicate the presence of
 a Ray head pod with two containers,
@@ -95,18 +92,11 @@ Demands:
 
 ### Test autoscaling
 
-Let's now try out the autoscaler. We can run the following command to get a Python interpreter in the head pod:
+Let's now try out the autoscaler. Run the following commands to scale up the cluster:
 
 ```
-kubectl exec `kubectl get pods -o custom-columns=POD:metadata.name | grep raycluster-autoscaler-head` -it -c ray-head -- python
-```
-
-In the Python interpreter, run the following snippet to scale up the cluster:
-
-```
-import ray
-ray.init()
-ray.autoscaler.sdk.request_resources(num_cpus=4)
+export HEAD_POD=$(kubectl get pods -o custom-columns=POD:metadata.name | grep raycluster-autoscaler-head)
+kubectl exec $HEAD_POD -it -c ray-head -- python -c "import ray;ray.init();ray.autoscaler.sdk.request_resources(num_cpus=4)"
 ```
 
 You should then see two extra Ray nodes (pods) scale up to satisfy the 4 CPU demand.

--- a/docs/guidance/aws-eks-iam.md
+++ b/docs/guidance/aws-eks-iam.md
@@ -7,7 +7,7 @@ Applications in a pod's containers can use an AWS SDK or the AWS CLI to make API
 
 ## Pitfall
 
-* It's worth noting that this pitfall occurs in Ray images **prior to version 2.4.0**.
+* It's worth noting that this pitfall occurs in Ray images **prior to version 2.5.0**.
 
 For example, users may want to download their files from their S3 bucket with AWS Python SDK (`boto3`) in Ray Pods. However, there is a pitfall in the Ray images. When you execute the **boto3_example_1.py** in a Ray Pod, you will get an error like `An error occurred (403) when calling the HeadObject operation: Forbidden` even if your pod is attached to a service account which has an IAM role that is able to access the S3 bucket.
 

--- a/docs/guidance/kubeflow-integration.md
+++ b/docs/guidance/kubeflow-integration.md
@@ -37,7 +37,7 @@ kustomize version --short
 ```sh
 # Create a RayCluster CR, and the KubeRay operator will reconcile a Ray cluster
 # with 1 head Pod and 1 worker Pod.
-helm install raycluster kuberay/ray-cluster --version 0.4.0 --set image.tag=2.2.0-py38-cpu
+helm install raycluster kuberay/ray-cluster --version 0.5.0 --set image.tag=2.2.0-py38-cpu
 
 # Check RayCluster
 kubectl get pod -l ray.io/cluster=raycluster-kuberay

--- a/docs/guidance/prometheus-grafana.md
+++ b/docs/guidance/prometheus-grafana.md
@@ -34,7 +34,7 @@ kubectl get all -n prometheus-system
 ## Step 4: Install a RayCluster
 
 ```sh
-helm install raycluster kuberay/ray-cluster --version 0.4.0
+helm install raycluster kuberay/ray-cluster --version 0.5.0
 
 # Check ${RAYCLUSTER_HEAD_POD}
 kubectl get pod -l ray.io/node-type=head

--- a/helm-chart/kuberay-operator/Chart.yaml
+++ b/helm-chart/kuberay-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: kuberay-operator
-version: 0.4.0
+version: 0.5.0
 icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png
 type: application

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -16,8 +16,8 @@ helm version
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-  # Install both CRDs and KubeRay operator v0.4.0.
-  helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0
+  # Install both CRDs and KubeRay operator v0.5.0.
+  helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0
 
   # Check the KubeRay operator Pod in `default` namespace
   kubectl get pods
@@ -40,10 +40,10 @@ helm version
   * Use Helm's built-in `--skip-crds` flag to install the operator only. See [this document](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) for more details.
   ```sh
   # Step 1: Install CRDs only (for cluster admin)
-  kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.4.0&timeout=90s"
+  kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.5.0&timeout=90s"
 
   # Step 2: Install KubeRay operator only. (for developer)
-  helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0 --skip-crds
+  helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0 --skip-crds
   ``` 
 
 ## List the chart
@@ -53,7 +53,7 @@ To list the `my-release` deployment:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                   STATUS          CHART                   # APP VERSION
-# kuberay-operator        default         1               2022-12-02 02:13:37.514445313 +0000 UTC   deployed        kuberay-operator-0.4.0  1.0
+# kuberay-operator        default         1               2022-12-02 02:13:37.514445313 +0000 UTC   deployed        kuberay-operator-0.5.0  1.0
 ```
 
 ## Uninstall the Chart
@@ -83,7 +83,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v0.4.0
+    targetRevision: v0.5.0
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -103,7 +103,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v0.4.0
+    targetRevision: v0.5.0
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true

--- a/helm-chart/ray-cluster/Chart.yaml
+++ b/helm-chart/ray-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: ray-cluster
-version: 0.4.0
+version: 0.5.0
 icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -16,15 +16,15 @@ kind create cluster
 # Step 2: Register a Helm chart repo
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Step 3: Install both CRDs and KubeRay operator v0.4.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 0.4.0
+# Step 3: Install both CRDs and KubeRay operator v0.5.0.
+helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0
 
 # Step 4: Install a RayCluster custom resource
 # (For x86_64 users)
-helm install raycluster kuberay/ray-cluster --version 0.4.0
+helm install raycluster kuberay/ray-cluster --version 0.5.0
 # (For arm64 users, e.g. Mac M1)
 # See here for all available arm64 images: https://hub.docker.com/r/rayproject/ray/tags?page=1&name=aarch64
-helm install raycluster kuberay/ray-cluster --version 0.4.0 --set image.tag=nightly-aarch64
+helm install raycluster kuberay/ray-cluster --version 0.5.0 --set image.tag=nightly-aarch64
 
 # Step 5: Verify the installation of KubeRay operator and RayCluster 
 kubectl get pods

--- a/manifests/overlays/single-namespace-resources/kustomization.yaml
+++ b/manifests/overlays/single-namespace-resources/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 namespace: ${KUBERAY_NAMESPACE}
 
 resources:
-- ../../cluster-scope-resources/
+- ../../../ray-operator/config/crd

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -106,6 +106,3 @@ spec:
                   requests:
                     cpu: "500m"
                     memory: "2Gi"
-    headServiceAnnotations: {}
-      # annotations passed on for the Head Service
-      # service_key: "service_value"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. This PR mainly focuses on correctness validation rather than document improvement.
2. Use the nightly KubeRay operator image to test the documents.

### Sample YAML files
```sh
RAY_IMAGE=rayproject/ray:2.3.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_raycluster_yamls.py 2>&1 | tee log
```
<details>
<summary>Screenshot</summary>
<img width="1440" alt="Screen Shot 2023-03-29 at 2 58 46 PM" src="https://user-images.githubusercontent.com/20109646/228677658-e7f67c1f-1a57-407f-92df-9179b3823034.png">
</details>

   - [x] ray-cluster.ingress.yaml
   - [x] ray-cluster.mini.yaml
   - [x] ray-cluster.external-redis.yaml
   - [x] ray-cluster.heterogeneous.yaml
   - [x] ray-cluster.complete.yaml
   - [x] ray-cluster.tls.yaml
   - [x] ray-cluster.autoscaler.yaml
   - [x] ray-cluster.head-command.yaml
   - [x] ray-cluster.separate-ingress.yaml

```sh
RAY_IMAGE=rayproject/ray:2.3.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py 2>&1 | tee log
```

<details>
<summary>Screenshot</summary>
<img width="1439" alt="Screen Shot 2023-03-29 at 5 03 04 PM" src="https://user-images.githubusercontent.com/20109646/228694803-e817bb0b-e717-4099-9143-73ed75172fbe.png">
</details>

- [x] ray_v1alpha1_rayservice.yaml
    * Since we have chosen to make the entire Kubernetes Service configurable (https://github.com/ray-project/kuberay/issues/877) to users, this PR removes `headServiceAnnotations` from the YAML.

```sh
# Step 0: Create a GKE Kubernetes cluster with autopilot on GCP

# Step 1: Install KubeRay operator (path: helm-chart/kuberay-operator)
# I got the error "Error: INSTALLATION FAILED: create: failed to create: Request entity too large: limit is 3145728" when I use `helm install kuberay-operator .`
helm template kuberay-operator . | kubectl apply -f -

# Step 2: Create a RayCluster with large Ray Pods (14 CPUs & 54 GB RAM / Pod).
kubectl apply -f ray-cluster.complete.large.yaml

# Step 3: Delete the RayCluster
kubectl delete -f ray-cluster.complete.large.yaml

# Step 4: Create an autoscaling RayCluster with large Ray Pods (14 CPUs & 54 GB RAM / Pod).
kubectl apply -f ray-cluster.autoscaler.large.yaml

# Step 5: Scale up the RayCluster
# We currently have 28 CPUs in the RayCluster (1 head + 1 worker). Hence, we request 29 CPUs, and expect the autoscaler will scale up the cluster.
export HEAD_POD=$(kubectl get pods -o custom-columns=POD:metadata.name | grep raycluster-autoscaler-head)
kubectl exec $HEAD_POD -it -c ray-head -- python -c "import ray;ray.init();ray.autoscaler.sdk.request_resources(num_cpus=29)"
```

<details>
<summary>ray-cluster.autoscaler.large.yaml screenshot</summary>
<img width="1440" alt="Screen Shot 2023-03-30 at 5 58 08 PM" src="https://user-images.githubusercontent.com/20109646/228996365-e80ba116-8455-4c9a-8722-dedb531fd985.png">
</details>

<details>
<summary>ray-cluster.complete.large.yaml screenshot</summary>
<img width="1440" alt="Screen Shot 2023-03-30 at 5 33 24 PM" src="https://user-images.githubusercontent.com/20109646/228994347-bdd7f397-036e-4a40-9033-4717f5bdedaa.png">
</details>

- [x] [ray-cluster.complete.large.yaml](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.complete.large.yaml)
- [x] [ray-cluster.autoscaler.large.yaml](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml)

### User-facing Docs
- [x] [docker.md](https://github.com/ray-project/kuberay/blob/master/docs/deploy/docker.md)
- [x] [autoscaler.md](https://github.com/ray-project/kuberay/blob/master/docs/guidance/autoscaler.md) 

  ```sh
  kind create cluster --image=kindest/node:v1.23.0
  
  # My local branch I'm working on is currently at the latest commit of the cut branch `cd9b2e`.
  # Install the KubeRay operator from local Helm chart with the nightly Docker image (path: kuberay/helm-chart/kuberay-operator)
  helm install kuberay-operator . --set image.tag=nightly

  # Create an autoscaling RayCluster
  kubectl apply -f ray-cluster.autoscaler.yaml

  # Scale up the cluster
  export HEAD_POD=$(kubectl get pods -o custom-columns=POD:metadata.name | grep raycluster-autoscaler-head)
  kubectl exec $HEAD_POD -it -c ray-head -- python -c "import ray;ray.init();ray.autoscaler.sdk.request_resources(num_cpus=4)"
  ```
- [x] [development.md](https://github.com/ray-project/kuberay/blob/master/docs/development/development.md)
- [x] [manifests/README.md](https://github.com/ray-project/kuberay/blob/master/manifests/README.md) 
- [x] [helm-chart/ray-cluster/README.md](https://github.com/ray-project/kuberay/blob/master/helm-chart/ray-cluster/README.md): I haven't followed the instructions for installing a RayCluster. I only check for any updates required to move to version 0.5.0. Once version 0.5.0 is released, I will test this document again.
- [x] [helm-chart/kuberay-operator/README.md](https://github.com/ray-project/kuberay/blob/master/helm-chart/kuberay-operator/README.md): I haven't followed the instructions for installing a RayCluster. I only check for any updates required to move to version 0.5.0. Once version 0.5.0 is released, I will test this document again.
- [x] [kuberay-with-MCAD.md](https://github.com/ray-project/kuberay/blob/master/docs/guidance/kuberay-with-MCAD.md): We may need to improve the document. The document lacks information about how many resources should the Kubernetes cluster have to reproduce the experiment. In addition, it points to the [document](https://github.com/project-codeflare/multi-cluster-app-dispatcher/blob/quota-management/doc/usage/examples/kuberay/kuberay-mcad.md) in MCAD repo, and the document is really hard to follow if users do not have any context about MCAD. Open a PR https://github.com/project-codeflare/multi-cluster-app-dispatcher/pull/298 to fix some issues, and request the MCAD community to improve the document.
  ```sh
  kind create cluster --image=kindest/node:v1.23.0
  
  # Install MCAD
  # (path: https://github.com/project-codeflare/multi-cluster-app-dispatcher/tree/quota-management/deployment) 
  helm install mcad mcad-controller --namespace kube-system --set image.repository=quay.io/project-codeflare/mcad-controller,image.tag=release-v1.29.52
  
  # Update the ClusterRole created by the MCAD Helm chart to grant sufficient access for creating a RayCluster.
  # path: https://github.com/project-codeflare/multi-cluster-app-dispatcher/tree/quota-management/doc/usage/examples/kuberay/config
  kubectl apply -f xqueuejob-controller.yaml
  
  # Install KubeRay operator
  # path: kuberay/helm-chart/kuberay-operator
  helm install kuberay-operator . --set image.tag=nightly
  
  # Check the Kubernetes node's resource
  kubectl describe nodes kind-control-plane
  
  # CPU: (1) Request: 3050m (76%) (2) 2200m (55%)
  # I have 4 CPUs on my devbox, and I only remain 1 CPU at this moment. Hence, I updated `custompodresources` in `aw-raycluster.yaml` to 
  
  custompodresources:
  - replicas: 1
    requests:
      cpu: 600m
      ...
    limits:
      cpu: 600m
      ...
  
  # Create an AppWrapper
  # path: https://github.com/project-codeflare/multi-cluster-app-dispatcher/blob/quota-management/doc/usage/examples/kuberay/config/aw-raycluster.yaml
  kubectl apply -f aw-raycluster.yaml
  kubectl describe appwrappers.mcad.ibm.com raycluster-autoscaler | grep State
  # State:                         Running
  
  # However, if I update custompodresources's CPU request and limit to 2 and the names of the AppWrapper and RayCluster to `raycluster-autoscaler-2`, the RayCluster will not be dispatched.
  
  kubectl describe appwrappers.mcad.ibm.com raycluster-autoscaler-2 | grep State
  # State:                         Pending
  kubectl describe appwrappers.mcad.ibm.com raycluster-autoscaler-2 | grep Message
  # Message:                     Insufficient resources to dispatch AppWrapper.
  ```

- [x] [aws-eks-iam.md](https://github.com/ray-project/kuberay/blob/master/docs/guidance/aws-eks-iam.md): This issue is totally from Ray, and has no instruction from KubeRay, so I did not test this document. In addition, Ray 2.4.0 does not upgrade the version of boto3, so users may need to wait until Ray 2.5.0. See https://github.com/ray-project/ray/issues/33256 for more details.

- [x] [kubeflow-integration.md](https://github.com/ray-project/kuberay/blob/master/docs/guidance/kubeflow-integration.md)
   <img width="1920" alt="Screen Shot 2023-03-30 at 4 10 04 PM" src="https://user-images.githubusercontent.com/20109646/228984775-9b3af1f6-1edb-43db-9157-5a428be23d5c.png">

- [x] [index.md](https://github.com/ray-project/kuberay/blob/master/docs/index.md)

- [x] [README.md](https://github.com/ray-project/kuberay/blob/master/README.md): I haven't followed the instructions for installing a RayCluster. I only check for any updates required to move to version 0.5.0. Once version 0.5.0 is released, I will test this document again.

- [x] [installation.md](https://github.com/ray-project/kuberay/blob/master/docs/deploy/installation.md): `single-namespace-resources` will install `cluster-scope-resources`, including a namespace `ray-system` and CRDs. However, only CRDs are needed.
   ```sh
   # Test: single-namespaced KubeRay
   kind create cluster --image=kindest/node:v1.23.0

   # Install CRD (path: kuberay/)
   kustomize build manifests/overlays/single-namespace-resources | envsubst | kubectl create -f -

   # Create a namespace "kuberay"
   export KUBERAY_NAMESPACE=kuberay
   kubectl create ns kuberay

   # Install the KubeRay operator in the namespace "kuberay" (path: kuberay/)
   kustomize build manifests/overlays/single-namespace | envsubst | kubectl apply -f -

   # Create a RayCluster in the "default" namespace (path: kuberay/ray-operator/config/samples)
   # No Pod will be generated.
   kubectl apply -f ray-cluster.mini.yaml

   # Create a RayCluster in the "kuberay" namespace (path: kuberay/ray-operator/config/samples)
   # Ray Pods will be created.
   kubectl apply -f ray-cluster.mini.yaml -n kuberay
   ```
- [x] [prometheus-grafana.md](https://github.com/ray-project/kuberay/blob/master/docs/guidance/prometheus-grafana.md): I skipped few steps in the doc (e.g. defining custom alert). 

  <details>
  <summary>Prometheus / Grafana screenshots</summary>
     <img width="1440" alt="Screen Shot 2023-03-30 at 5 33 24 PM" src="https://user-images.githubusercontent.com/20109646/229269991-e532a4d7-e46f-4646-91ed-25d3962df2bb.png">
     <img width="1440" alt="Screen Shot 2023-03-30 at 5 33 24 PM" src="https://user-images.githubusercontent.com/20109646/229269998-360fe237-d9bf-4b19-8bf2-11553e36ded7.png">
  </details>


### Helm charts

- [x] [kuberay-operator](https://github.com/ray-project/kuberay/tree/master/helm-chart/kuberay-operator)
   ```sh
   # path: helm-chart/kuberay-operator
   helm install kuberay-operator . --set image.tag=nightly
   ```

- [x] [ray-cluster](https://github.com/ray-project/kuberay/tree/master/helm-chart/ray-cluster)
  ```sh
  # path: helm-chart/kuberay-operator
  helm install kuberay-operator . --set image.tag=nightly
  # path: helm-chart/ray-cluster
  helm install ray-cluster .
  ```

### KubeRay operator (YAML)
```sh
kubectl create -k manifests/cluster-scope-resource
kubectl apply -k manifests/base
```
- [x] [ray-operator/config/crd](https://github.com/ray-project/kuberay/tree/master/ray-operator/config/crd)
- [x] [ray-operator/config/default](https://github.com/ray-project/kuberay/tree/master/ray-operator/config/default)
- [x] [ray-operator/config/manager](https://github.com/ray-project/kuberay/tree/master/ray-operator/config/manager) 
- [x] [ray-operator/config/rbac](https://github.com/ray-project/kuberay/tree/master/ray-operator/config/rbac) 
- [x] [manifests](https://github.com/ray-project/kuberay/tree/master/manifests) 

### Documents for KubeRay contributors
- [x] [DEVELOPMENT.md](https://github.com/ray-project/kuberay/blob/master/ray-operator/DEVELOPMENT.md): I do not follow the documents to build & test KubeRay. I only check if there are any updates required to move to version 0.5.0.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
