### PR TITLE
Add kubernetes dependency in python client library

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -405,6 +405,5 @@ jobs:
       - name: Install package and run unittest for Python client
         working-directory: ./clients/python-client
         run: |
-          pip install -r requirements.txt
           pip install -e .
           python3 -m unittest discover 'python_client_test/'

--- a/clients/python-client/requirements.txt
+++ b/clients/python-client/requirements.txt
@@ -1,1 +1,0 @@
-kubernetes

--- a/clients/python-client/setup.cfg
+++ b/clients/python-client/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
 [options]
 packages = find:
 python_requires = >=3.6.5
+install_requires = kubernetes
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The kuberay python-client library uses Kubernetes Python Client. Hence, it is necessary to make Kubernetes Python Client be the prerequisite when installing kuberay python-client library.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
