### PR TITLE
[Hotfix][release blocker][RayJob] HTTP client from submitting jobs before dashboard initialization completes

### DIFF
--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -164,7 +164,7 @@ func FetchDashboardURL(ctx context.Context, log *logr.Logger, cli client.Client,
 
 func (r *RayDashboardClient) InitClient(url string) {
 	r.client = http.Client{
-		Timeout: 2 * time.Second,
+		Timeout: 120 * time.Second,
 	}
 	r.dashboardURL = "http://" + url
 }
@@ -381,7 +381,8 @@ func (r *RayDashboardClient) SubmitJob(rayJob *rayv1alpha1.RayJob, log *logr.Log
 
 	var jobResp RayJobResponse
 	if err = json.Unmarshal(body, &jobResp); err != nil {
-		return
+		// Maybe body is not valid json, raise an error with the body.
+		return "", fmt.Errorf("SubmitJob fail: %s", string(body))
 	}
 
 	return jobResp.JobId, nil


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In RayJob, the HTTP client submits a job to the RayCluster only when all Pods are running. However, the readiness of Pods does not necessarily imply that the dashboard is ready. Furthermore, the HTTP client has a timeout of 2 seconds, which is shorter than the time required for the dashboard to initialize. Hence, a weird behavior may happen: 

During job submission in KubeRay operator, HTTP clients may fail due to timeout, even though the RayCluster receives the request and launches the job successfully. The KubeRay operator resubmits the job because it thinks that the submission has failed. However, @architkulkarni discovered that resubmitting a job with the same name as a previously submitted job can cause the first submission to fail. This bug was fixed in Ray 2.4.0. Bug: https://github.com/ray-project/ray/issues/31356



The following is the log in my KubeRay operator. It takes at least 4 ~ 5 seconds to receive the response (the dashboard finishes the initialization).
```
2023-03-31T18:00:10.480Z	INFO	controllers.RayJob	Submit a ray job	{"rayJob": "rayjob-sample", "jobInfo": "{\"entrypoint\":\"python /home/ray/samples/sample_code.py\",\"job_id\":\"rayjob-sample-jh58c\",\"runtime_env\":{\"env_vars\":{\"counter_name\":\"test_counter\"},\"pip\":[\"requests==2.26.0\",\"pendulum==2.1.2\"]}}"}
2023-03-31T18:00:14.328Z	INFO	controllers.RayJob	Job successfully submitted	{"RayJob": "rayjob-sample", "jobId": "rayjob-sample-jh58c"}
```


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
