### PR TITLE
Release v0.5.0 python client library validation

### DIFF
--- a/clients/python-client/python_client/utils/kuberay_cluster_utils.py
+++ b/clients/python-client/python_client/utils/kuberay_cluster_utils.py
@@ -247,17 +247,6 @@ class ClusterUtils:
                             ],
                         }
                     ],
-                    "initContainers": [
-                        {
-                            "command": [
-                                "sh",
-                                "-c",
-                                "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done",
-                            ],
-                            "image": init_image,
-                            "name": "init",
-                        }
-                    ],
                     "volumes": [{"emptyDir": {}, "name": "ray-logs"}],
                 }
             },


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
1. Verify the built clusters in examples of the python client library are functional.
2. Remove init containers in template because there will be default init container in v0.5.0([#973](https://github.com/ray-project/kuberay/pull/973)).
<!-- Please give a short summary of the change and the problem this solves. -->
### Basic flow for verification cluster
Cover the following examples: [use-builder.py](https://github.com/ray-project/kuberay/blob/master/clients/python-client/examples/use-builder.py), [use-director.py](https://github.com/ray-project/kuberay/blob/master/clients/python-client/examples/use-director.py), [use-raw-config_map_with-api.py](https://github.com/ray-project/kuberay/blob/master/clients/python-client/examples/use-raw-config_map_with-api.py), [use-raw-with-api.py](https://github.com/ray-project/kuberay/blob/master/clients/python-client/examples/use-raw-with-api.py), [use-utils.py](https://github.com/ray-project/kuberay/blob/master/clients/python-client/examples/use-utils.py).
1. Setup Ray operator
      ```
     kind create cluster
     helm repo add kuberay https://ray-project.github.io/kuberay-helm/ 
     helm repo update
     helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0-rc.0
     ```
2. Comment out the cluster deletion section in the python file.
 https://github.com/ray-project/kuberay/blob/00dc45aec34fc3ae54962361221b41aaa4c338da/clients/python-client/examples/use-builder.py#L66-L72
3. Run the example
```python3 use-builder.py```
4. Submit a simple ray job to the cluster
    ![image](https://user-images.githubusercontent.com/35865970/229692704-7e3733c5-acfc-482a-aa9d-93732408e92b.png)

6. Port forwarding
      ![image](https://user-images.githubusercontent.com/35865970/229693054-3c3bb886-22eb-4e71-8331-22470b007b9f.png)
7. Check cluster dashboard
    <img width="1432" alt="image" src="https://user-images.githubusercontent.com/35865970/229693499-43b9ff90-8e1e-42de-bdaa-8e751d376b4a.png">

### Additional steps for [complete-example.py](https://github.com/ray-project/kuberay/blob/master/clients/python-client/examples/complete-example.py)
Because there is an update of cluster in [complete-example.py](https://github.com/ray-project/kuberay/blob/master/clients/python-client/examples/complete-example.py), we need to verify whether the cluster information is modified as expected. Hence,  ```input()``` is put before the call of modification cluster API(line 62 in [complete-example.py](https://github.com/ray-project/kuberay/blob/master/clients/python-client/examples/complete-example.py)) to pause the execution of the example, and two Ray jobs are submitted before and after the modification to see whether the cluster resource is updated as exected.  
![Screen Shot 2023-04-03 at 9 18 24 PM](https://user-images.githubusercontent.com/35865970/229695567-c0e22d45-a352-434e-955c-bd42b206ed8b.png)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
