### PR TITLE
[Post v0.5.0] Remove init containers from YAML files

### DIFF
--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -216,17 +216,6 @@ func buildWorkerPodTemplate(imageVersion string, envs map[string]string, spec *a
 			Annotations: buildNodeGroupAnnotations(computeRuntime, spec.Image),
 		},
 		Spec: v1.PodSpec{
-			InitContainers: []v1.Container{
-				{
-					Name:  "init",
-					Image: "busybox:1.28",
-					Command: []string{
-						"sh",
-						"-c",
-						"until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done",
-					},
-				},
-			},
 			Containers: []v1.Container{
 				{
 					Name:  "ray-worker",

--- a/clients/python-client/examples/use-raw-with-api.py
+++ b/clients/python-client/examples/use-raw-with-api.py
@@ -130,17 +130,6 @@ cluster_body2: dict = {
                                 },
                             }
                         ],
-                        "initContainers": [
-                            {
-                                "name": "init",
-                                "image": "busybox:1.28",
-                                "command": [
-                                    "sh",
-                                    "-c",
-                                    "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done",
-                                ],
-                            }
-                        ],
                         "volumes": [{"name": "ray-logs", "emptyDir": {}}],
                     }
                 },

--- a/clients/python-client/python_client_test/test_api.py
+++ b/clients/python-client/python_client_test/test_api.py
@@ -85,17 +85,6 @@ test_cluster_body: dict = {
                                 },
                             }
                         ],
-                        "initContainers": [
-                            {
-                                "name": "init",
-                                "image": "busybox:1.28",
-                                "command": [
-                                    "sh",
-                                    "-c",
-                                    "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done",
-                                ],
-                            }
-                        ],
                         "volumes": [{"name": "ray-logs", "emptyDir": {}}],
                     }
                 },

--- a/clients/python-client/python_client_test/test_utils.py
+++ b/clients/python-client/python_client_test/test_utils.py
@@ -84,17 +84,6 @@ test_cluster_body: dict = {
                                 },
                             }
                         ],
-                        "initContainers": [
-                            {
-                                "name": "init",
-                                "image": "busybox:1.28",
-                                "command": [
-                                    "sh",
-                                    "-c",
-                                    "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done",
-                                ],
-                            }
-                        ],
                         "volumes": [{"name": "ray-logs", "emptyDir": {}}],
                     }
                 },

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -97,12 +97,6 @@ spec:
     template:
       spec:
         imagePullSecrets: {{- toYaml $.Values.imagePullSecrets | nindent 10 }}
-        initContainers:
-          - name: init
-            image: {{ $values.initContainerImage | default "busybox:1.28" }}
-            command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
-            securityContext:
-            {{- toYaml $values.initContainerSecurityContext | nindent 14 }}
         {{- if $values.serviceAccountName }}
         serviceAccountName: {{ $values.serviceAccountName }}
         {{- end }}
@@ -166,12 +160,6 @@ spec:
     template:
       spec:
         imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
-        initContainers:
-          - name: init
-            image: {{ .Values.worker.initContainerImage | default "busybox:1.28" }}
-            command: ['sh', '-c', "until nslookup $FQ_RAY_IP; do echo waiting for K8s Service $FQ_RAY_IP; sleep 2; done"]
-            securityContext:
-            {{- toYaml .Values.worker.initContainerSecurityContext | nindent 14 }}
         {{- if .Values.worker.serviceAccountName }}
         serviceAccountName: {{ .Values.worker.serviceAccountName }}
         {{- end }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -109,9 +109,6 @@ worker:
   serviceAccountName: ""
   rayStartParams:
     block: 'true'
-  initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
-  # Security context for the init container.
-  initContainerSecurityContext: {}
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
   containerEnv: []
@@ -173,9 +170,6 @@ additionalWorkerGroups:
     serviceAccountName: ""
     rayStartParams:
       block: 'true'
-    initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
-    # Security context for the init container.
-    initContainerSecurityContext: {}
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
     containerEnv: []

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -126,11 +126,6 @@ spec:
         annotations:
           key: value
       spec:
-        initContainers:
-        # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
-        - name: init
-          image: busybox:1.28
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker
           image: rayproject/ray:2.3.0

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -120,11 +120,6 @@ spec:
     #pod template
     template:
       spec:
-        initContainers:
-        # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
-        - name: init
-          image: busybox:1.28
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker
           image: rayproject/ray:2.3.0

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -110,12 +110,6 @@ spec:
           volumeMounts:
             - mountPath: /tmp/ray
               name: ray-logs
-        initContainers:
-        # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
-        - name: init
-          image: busybox:1.28
-          # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -121,12 +121,6 @@ spec:
               cpu: "500m"
               # For production use-cases, we recommend allocating at least 8Gb memory for each Ray container.
               memory: "1G"
-        initContainers:
-        # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
-        - name: init
-          image: busybox:1.28
-          # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -138,12 +138,6 @@ spec:
       #pod template
       template:
         spec:
-          initContainers: # to avoid worker crashing before head service is created
-            # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
-            - name: init
-              image: busybox:1.28
-              # Change the cluster postfix if you don't have a default setting
-              command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
           containers:
             - name: ray-worker
               image: rayproject/ray:2.3.0

--- a/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
+++ b/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
@@ -80,12 +80,6 @@ spec:
     #pod template
     template:
       spec:
-        initContainers: # to avoid worker crashing before head service is created
-        # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
-        - name: init
-          image: busybox:1.28
-          # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
           image: rayproject/ray:2.3.0
@@ -121,11 +115,6 @@ spec:
     #pod template
     template:
       spec:
-        initContainers:
-        - name: init
-          image: busybox:1.28
-          # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
           image: rayproject/ray:2.3.0

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -64,11 +64,6 @@ spec:
         #pod template
         template:
           spec:
-            initContainers:
-              # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
-              - name: init
-                image: busybox:1.28
-                command: [ 'sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done" ]
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.3.0

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -87,11 +87,6 @@ spec:
         #pod template
         template:
           spec:
-            initContainers:
-              # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
-              - name: init
-                image: busybox:1.28
-                command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.3.0

--- a/ray-operator/config/security/ray-cluster.pod-security.yaml
+++ b/ray-operator/config/security/ray-cluster.pod-security.yaml
@@ -117,20 +117,6 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-        initContainers:
-        # the env var $FQ_RAY_IP is set by the operator if missing, with the value of the head service name
-        - name: init-myservice
-          image: busybox:1.28
-          # Change the cluster postfix if you don't have a default setting
-          command: ['sh', '-c', "until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for K8s Service $RAY_IP; sleep 2; done"]
-          securityContext:
-            runAsUser: 1000
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
         # use volumes
         # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
         volumes:

--- a/tests/config/ray-cluster.mini.yaml.template
+++ b/tests/config/ray-cluster.mini.yaml.template
@@ -56,11 +56,6 @@ spec:
       #pod template
       template:
         spec:
-          initContainers: # to avoid worker crashing before head service is created
-          - name: init
-            image: busybox:1.28
-            # Change the cluster postfix if you don't have a default setting
-            command: ['sh', '-c', "until nslookup $$FQ_RAY_IP; do echo waiting for K8s Service $$FQ_RAY_IP; sleep 2; done"]
           containers:
           - name: ray-worker
             image: $ray_image

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -139,10 +139,6 @@ spec:
       #pod template
       template:
         spec:
-          initContainers: # to avoid worker crashing before head service is created
-            - name: init
-              image: busybox:1.28
-              command: ['sh', '-c', "until nslookup $$FQ_RAY_IP; do echo waiting for K8s Service $$FQ_RAY_IP; sleep 2; done"]
           containers:
             - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
               image: $ray_image

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -96,10 +96,6 @@ spec:
         #pod template
         template:
           spec:
-            initContainers:
-              - name: init
-                image: busybox:1.28
-                command: ['sh', '-c', "until nslookup $$FQ_RAY_IP; do echo waiting for K8s Service $$FQ_RAY_IP; sleep 2; done"]
             containers:
               - name: ray-worker
                 image: $ray_image


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
See https://github.com/ray-project/kuberay/pull/973 for more details.

* KubeRay APIServer
  - [ ] [apiserver/pkg/util/cluster.go](https://github.com/ray-project/kuberay/pull/1010/files#diff-08cd009406904b1508453b7045827cd8cfd8615dd7e472a15eeb38edee72a0c0)

* Python client
  - [x] [use-raw-with-api.py](https://github.com/ray-project/kuberay/pull/1010/files#diff-dd02cbc2621ebd2298dcedd3cd75b0649672bfb1b528996bd50d12ccf4e11746) => Follow the instructions in #1006
  - [x] [test_api.py](https://github.com/ray-project/kuberay/pull/1010/files#diff-bb86a204aa579af2ed4ed29d601b28d56898f8d169cf8b5e471f5a4da86d4781) => CI
  - [x] [test_utils.py](https://github.com/ray-project/kuberay/pull/1010/files#diff-f13b86b7a3076eccccb067d893aebfb24d63c0dc30c58ca941f920135f7a95a8) => CI

* Helm Charts
  - [x] [raycluster-cluster.yaml](https://github.com/ray-project/kuberay/pull/1010/files#diff-0608a77dcd03d9dcf63bacf238aae95f629e25a879576eb3f6c37869e0323a4d)
  - [x] [values.yaml](https://github.com/ray-project/kuberay/pull/1010/files#diff-ad1dc7aa5ec069f4705e1ba0794ebce1a8c6b6b0f1e40d3a53c8a361456127c7)

* Sample YAML files
  * RayCluster
    - [x] [ray-cluster.autoscaler.yaml](https://github.com/ray-project/kuberay/pull/1010/files#diff-ed960a0022f8c490179ee23f4613960565fb3be1d586610f4202bf85499710c1) => `test_sample_raycluster_yamls.py`
    - [x] [ray-cluster.complete.yaml](https://github.com/ray-project/kuberay/pull/1010/files#diff-86e923f54b3ab86289735db2b3039b4c708c9ac97e1ab3fade11b91b0f5c28a8) => `test_sample_raycluster_yamls.py`
    - [x] [ray-cluster.external-redis.yaml](https://github.com/ray-project/kuberay/pull/1010/files#diff-707d518994ba3c6fa7e1cfebdea406a73561e70693af3734a2e843bf22b16c60) => `test_sample_raycluster_yamls.py`
    - [x] [ray-cluster.heterogeneous.yaml](https://github.com/ray-project/kuberay/pull/1010/files#diff-2fd98ff6e59546edb40122b7d307c1e4a01805deebe8b141e0f53e3f2082fe49) => `test_sample_raycluster_yamls.py`
    - [x] [ray-cluster.pod-security.yaml](https://github.com/ray-project/kuberay/pull/1010/files#diff-5327e12f3256bf9b0c90257de425d3c1b5e5ea4d634cba6217258b9f4b550b03) => `test_security.py`
    - [ ] [ray-cluster.complete.large.yaml](https://github.com/ray-project/kuberay/pull/1010/files#diff-b5d96f9b9c6236e436787b0262def531f3a7f196502b27684a4e80ced1db2dca) (Skip)
    - [ ] [ray-cluster.autoscaler.large.yaml](https://github.com/ray-project/kuberay/pull/1010/files#diff-5428886074a0e504d7f686034641b93d72aecc83012125a93a0ae5eeb2aba69c) (Skip)
  * RayJob 
     - [x] [ray_v1alpha1_rayjob.yaml](https://github.com/ray-project/kuberay/pull/1010/files#diff-34362b000903ca7a976b237e27305ef781f9ff669ea369c39359293ce154211b)
  * RayService
     - [x] [ray_v1alpha1_rayservice.yaml](https://github.com/ray-project/kuberay/pull/1010/files#diff-346a6be1f98cd0012237fd9feff2bba563d5c3119cb3e879ea4fd99c2797c110) => `test_sample_rayservice_yamls.py`

* Template YAML files for end-to-end tests => KubeRay CI
  - [x] [ray-cluster.mini.yaml.template](https://github.com/ray-project/kuberay/pull/1010/files#diff-598c3332a77323d5b8bf6929231113d39aeb2f0d400b6ab2ce023ced9202efe3)
  - [x] [ray-cluster.ray-ft.yaml.template](https://github.com/ray-project/kuberay/pull/1010/files#diff-62f8a48fc70b61fc917b570ad6780f87b1e506806b66914f5d1ad4c9ac0abe21)
  - [x] [ray-service.yaml.template](https://github.com/ray-project/kuberay/pull/1010/files#diff-5358b1394f2550e4e384fd50e77d89365648185da533e2ae87698358493e659b)

### test_sample_raycluster_yamls.py
  <img width="1440" alt="Screen Shot 2023-04-05 at 12 25 18 AM" src="https://user-images.githubusercontent.com/20109646/230011491-6c46345b-c6b1-4ad5-b1b7-f4726b34b73d.png">

```sh
RAY_IMAGE=rayproject/ray:2.3.0 OPERATOR_IMAGE=kuberay/operator:v0.5.0 python3 tests/test_sample_raycluster_yamls.py 2>&1 | tee log
```

### test_sample_rayservice_yamls.py
<img width="1440" alt="Screen Shot 2023-04-05 at 12 38 33 AM" src="https://user-images.githubusercontent.com/20109646/230013546-9a630d45-4543-4936-b51e-21d6c6dd3fbf.png">

```sh
RAY_IMAGE=rayproject/ray:2.3.0 OPERATOR_IMAGE=kuberay/operator:v0.5.0 python3 tests/test_sample_rayservice_yamls.py 2>&1 | tee log
```

## Test RayCluster Helm chart
```sh
kind create cluster --image=kindest/node:v1.23.0
helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0
# path: helm-chart/ray-cluster
helm install raycluster .
```

## test_security.py
<img width="1440" alt="Screen Shot 2023-04-05 at 10 42 15 AM" src="https://user-images.githubusercontent.com/20109646/230160860-e4e3923a-4a07-4dd4-952a-870974ec85d7.png">

```sh
# path: kuberay/
OPERATOR_IMAGE=kuberay/operator:v0.5.0 python3 tests/test_security.py
```

## Test RayJob YAML (`ray_v1alpha1_rayjob.yaml`)
```sh
kind create cluster --image=kindest/node:v1.23.0
helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0
# path: ray-operator/config/samples
kubectl apply -f ray_v1alpha1_rayjob.yaml

# Wait for 1 min
kubectl describe rayjobs.ray.io rayjob-sample | grep "Job Status"
# Job Status:             SUCCEEDED
```

## Related issue number
https://github.com/ray-project/kuberay/pull/973
Closes #974 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
