### PR TITLE
[Post release v0.5.0] Remove serviceType

### DIFF
--- a/.github/workflows/actions/configuration/action.yaml
+++ b/.github/workflows/actions/configuration/action.yaml
@@ -63,7 +63,7 @@ runs:
     env:
       GITHUB_ACTIONS: true
       RAY_IMAGE: rayproject/ray:${{ inputs.ray_version }}
-      OPERATOR_IMAGE: kuberay/operator:v0.4.0 # The operator image in the latest KubeRay release.
+      OPERATOR_IMAGE: kuberay/operator:v0.5.0 # The operator image in the latest KubeRay release.
     run: |
       python tests/test_sample_raycluster_yamls.py
     shell: bash

--- a/clients/python-client/examples/use-raw-with-api.py
+++ b/clients/python-client/examples/use-raw-with-api.py
@@ -69,7 +69,6 @@ cluster_body2: dict = {
     "spec": {
         "rayVersion": "2.3.0",
         "headGroupSpec": {
-            "serviceType": "ClusterIP",
             "rayStartParams": {"dashboard-host": "0.0.0.0", "block": "true"},
             "template": {
                 "metadata": {"labels": {}},

--- a/clients/python-client/python_client_test/test_api.py
+++ b/clients/python-client/python_client_test/test_api.py
@@ -16,7 +16,6 @@ test_cluster_body: dict = {
     "spec": {
         "rayVersion": "2.3.0",
         "headGroupSpec": {
-            "serviceType": "ClusterIP",
             "rayStartParams": {"dashboard-host": "0.0.0.0", "block": "true"},
             "template": {
                 "metadata": {"labels": {}},

--- a/clients/python-client/python_client_test/test_utils.py
+++ b/clients/python-client/python_client_test/test_utils.py
@@ -15,7 +15,6 @@ test_cluster_body: dict = {
     "spec": {
         "rayVersion": "2.3.0",
         "headGroupSpec": {
-            "serviceType": "ClusterIP",
             "rayStartParams": {"dashboard-host": "0.0.0.0", "block": "true"},
             "template": {
                 "metadata": {"labels": {}},

--- a/docs/guidance/volcano-integration.md
+++ b/docs/guidance/volcano-integration.md
@@ -44,7 +44,6 @@ metadata:
 spec:
   rayVersion: '2.3.0'
   headGroupSpec:
-    serviceType: ClusterIP
     rayStartParams:
       block: 'true'
     replicas: 1
@@ -108,7 +107,6 @@ metadata:
 spec:
   rayVersion: '2.3.0'
   headGroupSpec:
-    serviceType: ClusterIP
     rayStartParams:
       block: 'true'
     replicas: 1
@@ -222,7 +220,6 @@ metadata:
 spec:
   rayVersion: '2.3.0'
   headGroupSpec:
-    serviceType: ClusterIP
     rayStartParams:
       block: 'true'
     replicas: 1

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
@@ -25,8 +25,7 @@ var expectedRayJob = RayJob{
 		RayClusterSpec: &RayClusterSpec{
 			RayVersion: "1.12.1",
 			HeadGroupSpec: HeadGroupSpec{
-				ServiceType: corev1.ServiceTypeClusterIP,
-				Replicas:    pointer.Int32Ptr(1),
+				Replicas: pointer.Int32Ptr(1),
 				RayStartParams: map[string]string{
 					"port":                "6379",
 					"object-store-memory": "100000000",
@@ -150,7 +149,6 @@ var testRayJobJSON = `{
         },
         "rayClusterSpec": {
             "headGroupSpec": {
-                "serviceType": "ClusterIP",
                 "replicas": 1,
                 "rayStartParams": {
                     "block": "true",

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
@@ -72,8 +72,7 @@ var myRayService = &RayService{
 		RayClusterSpec: RayClusterSpec{
 			RayVersion: "1.12.1",
 			HeadGroupSpec: HeadGroupSpec{
-				ServiceType: corev1.ServiceTypeClusterIP,
-				Replicas:    pointer.Int32Ptr(1),
+				Replicas: pointer.Int32Ptr(1),
 				RayStartParams: map[string]string{
 					"port":                        "6379",
 					"object-store-memory":         "100000000",
@@ -241,7 +240,6 @@ var expected = `{
       },
       "rayClusterConfig":{
          "headGroupSpec":{
-            "serviceType":"ClusterIP",
             "replicas":1,
             "rayStartParams":{
                "block":"true",

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -57,7 +57,6 @@ spec:
         memory: "512Mi"
   # Ray head pod template
   headGroupSpec:
-    serviceType: ClusterIP # optional
     # the following params are used to complete the ray start: ray start --head --block --port=6379 ...
     rayStartParams:
       # Flag "no-monitor" will be automatically set when autoscaling is enabled.

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -49,7 +49,6 @@ spec:
         memory: "512Mi"
   # Ray head pod template
   headGroupSpec:
-    serviceType: ClusterIP # optional
     # the following params are used to complete the ray start: ray start --head --block ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -89,7 +89,6 @@ metadata:
 spec:
   rayVersion: '2.3.0'
   headGroupSpec:
-    serviceType: ClusterIP # optional
     replicas: 1
     rayStartParams:
       dashboard-host: "0.0.0.0"

--- a/ray-operator/config/samples/ray-cluster.head-command.yaml
+++ b/ray-operator/config/samples/ray-cluster.head-command.yaml
@@ -11,7 +11,6 @@ spec:
   rayVersion: '2.3.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
-    serviceType: ClusterIP # optional
     # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
+++ b/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
@@ -38,7 +38,6 @@ spec:
   ######################headGroupSpecs#################################
   # Ray head pod template
   headGroupSpec:
-    serviceType: ClusterIP # optional
     # the following params are used to complete the ray start: ray start --head --block ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.mini.yaml
+++ b/ray-operator/config/samples/ray-cluster.mini.yaml
@@ -13,7 +13,6 @@ spec:
   rayVersion: '2.3.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
-    serviceType: ClusterIP # optional
     # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
     rayStartParams:
       dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-cluster.tls.yaml
+++ b/ray-operator/config/samples/ray-cluster.tls.yaml
@@ -8,9 +8,6 @@ spec:
   rayVersion: '2.3.0'
   # Ray head pod configuration
   headGroupSpec:
-    # Kubernetes Service Type. This is an optional field, and the default value is ClusterIP.
-    # Refer to https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types.
-    serviceType: ClusterIP
     rayStartParams:
       dashboard-host: '0.0.0.0'
     # pod template

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -18,7 +18,6 @@ spec:
     rayVersion: '2.3.0' # should match the Ray version in the image of the containers
     # Ray head pod template
     headGroupSpec:
-      serviceType: ClusterIP # optional
       # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
       rayStartParams:
         dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -46,7 +46,6 @@ spec:
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
-      serviceType: ClusterIP # optional
       # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
       rayStartParams:
         port: '6379' # should match container port named gcs-server

--- a/ray-operator/config/security/ray-cluster.pod-security.yaml
+++ b/ray-operator/config/security/ray-cluster.pod-security.yaml
@@ -13,7 +13,6 @@ spec:
   rayVersion: '2.2.0'
   # Ray head pod configuration
   headGroupSpec:
-    serviceType: ClusterIP # optional
     # for the head group, replicas should always be 1.
     # headGroupSpec.replicas is deprecated in KubeRay >= 0.3.0.
     replicas: 1

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -29,8 +29,7 @@ var instance = rayiov1alpha1.RayCluster{
 	Spec: rayiov1alpha1.RayClusterSpec{
 		RayVersion: "2.0.0",
 		HeadGroupSpec: rayiov1alpha1.HeadGroupSpec{
-			ServiceType: "ClusterIP",
-			Replicas:    pointer.Int32Ptr(1),
+			Replicas: pointer.Int32Ptr(1),
 			RayStartParams: map[string]string{
 				"port":                "6379",
 				"object-manager-port": "12345",

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -254,8 +254,7 @@ func setupTest(t *testing.T) {
 			RayVersion:              "1.0",
 			EnableInTreeAutoscaling: &enableInTreeAutoscaling,
 			HeadGroupSpec: rayiov1alpha1.HeadGroupSpec{
-				ServiceType: "ClusterIP",
-				Replicas:    pointer.Int32Ptr(1),
+				Replicas: pointer.Int32Ptr(1),
 				RayStartParams: map[string]string{
 					"port":                "6379",
 					"object-manager-port": "12345",

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -54,7 +54,6 @@ var _ = Context("Inside the default namespace", func() {
 			RayVersion:              "1.0",
 			EnableInTreeAutoscaling: &enableInTreeAutoscaling,
 			HeadGroupSpec: rayiov1alpha1.HeadGroupSpec{
-				ServiceType: "ClusterIP",
 				RayStartParams: map[string]string{
 					"port":                "6379",
 					"object-manager-port": "12345",

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -49,8 +49,7 @@ var _ = Context("Inside the default namespace", func() {
 			RayClusterSpec: &rayiov1alpha1.RayClusterSpec{
 				RayVersion: "1.12.1",
 				HeadGroupSpec: rayiov1alpha1.HeadGroupSpec{
-					ServiceType: corev1.ServiceTypeClusterIP,
-					Replicas:    pointer.Int32(1),
+					Replicas: pointer.Int32(1),
 					RayStartParams: map[string]string{
 						"port":                        "6379",
 						"object-store-memory":         "100000000",

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -87,8 +87,7 @@ var _ = Context("Inside the default namespace", func() {
 			RayClusterSpec: rayiov1alpha1.RayClusterSpec{
 				RayVersion: "1.12.1",
 				HeadGroupSpec: rayiov1alpha1.HeadGroupSpec{
-					ServiceType: corev1.ServiceTypeClusterIP,
-					Replicas:    pointer.Int32(1),
+					Replicas: pointer.Int32(1),
 					RayStartParams: map[string]string{
 						"port":                        "6379",
 						"object-store-memory":         "100000000",

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -21,7 +21,7 @@ class CONST:
     # Docker images
     OPERATOR_IMAGE_KEY = "kuberay-operator-image"
     RAY_IMAGE_KEY = "ray-image"
-    KUBERAY_LATEST_RELEASE = "kuberay/operator:v0.4.0"
+    KUBERAY_LATEST_RELEASE = "kuberay/operator:v0.5.0"
 
     # Kubernetes API clients
     K8S_CR_CLIENT_KEY = "k8s-cr-api-client"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For KubeRay, the configuration YAML files (e.g. files in ray-operator/config/samples) in the master branch must be compatible with:

* Nightly KubeRay operator
* Latest release of KubeRay operator (i.e. v0.5.0 at this moment)

The field `serviceType` is a required field before v0.5.0, but becomes optional from v0.5.0. Hence, when v0.5.0 becomes the "latest release of KubeRay operator", we can remove it from sample YAML files.

We only keep the optional fields in `ray-cluster.complete.yaml`, `ray-cluster.complete.large.yaml`, and RayCluster chart's `values.yaml`.


## Related issue number
Closes #856 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* KubeRay operator tests (i.e. `xxxx.go`)
   ```sh
   # path: kuberay/ray-operator
   make test
   ```

* Test RayCluster YAML files
   ```sh
   RAY_IMAGE=rayproject/ray:2.3.0 OPERATOR_IMAGE=kuberay/operator:v0.5.0 python3 tests/test_sample_raycluster_yamls.py 2>&1 | tee lo
   ```
   <img width="1339" alt="Screen Shot 2023-04-05 at 4 11 22 PM" src="https://user-images.githubusercontent.com/20109646/230231691-44baa437-7208-47a7-a204-31576d82210a.png">

* Python client: KubeRay CI