### PR TITLE
Fix config frequent update

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -545,9 +545,6 @@ func (r *RayServiceReconciler) checkIfNeedSubmitServeDeployment(rayServiceInstan
 	} else if !utils.CompareJsonStruct(cachedServeConfig, rayServiceInstance.Spec.ServeDeploymentGraphSpec) {
 		shouldUpdate = true
 		reason = fmt.Sprintf("Current Serve config doesn't match cached Serve config for cluster %s with key %s", rayClusterInstance.Name, cacheKey)
-	} else if len(serveStatus.ServeStatuses) == 0 {
-		shouldUpdate = true
-		reason = fmt.Sprintf("No Serve deployments have started deploying for cluster %s with key %s", rayClusterInstance.Name, cacheKey)
 	}
 
 	r.Log.V(1).Info("shouldUpdate", "shouldUpdateServe", shouldUpdate, "reason", reason, "cachedServeConfig", cachedServeConfig, "current Serve config", rayServiceInstance.Spec.ServeDeploymentGraphSpec)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Current logic will cause the ray-operator keep sending requests when there is no deployment statuses.  When the runtime env preparation time is long, ray-operator will keep redeploying the ray serve cluster.

So after ray-operator sends the config request, it will eventually get the status from ray serve.

Collaborating with customer to fix the runtime env issue, and verify RayService can be started with this change.
Config:

Change `serveConfig` in `ray-operator/config/samples/ray_v1alpha1_rayservice.yaml` to 

```
  serveConfig:
    importPath: test_grpc:entry
    runtimeEnv: |
      working_dir: "https://github.com/sihanwang41/test-placeholder/raw/main/grpc_test.zip"
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
