### PR TITLE
[Post release v0.5.0] Remove block from rayStartParams

### DIFF
--- a/docs/guidance/volcano-integration.md
+++ b/docs/guidance/volcano-integration.md
@@ -44,8 +44,7 @@ metadata:
 spec:
   rayVersion: '2.3.0'
   headGroupSpec:
-    rayStartParams:
-      block: 'true'
+    rayStartParams: {}
     replicas: 1
     template:
       spec:
@@ -107,8 +106,7 @@ metadata:
 spec:
   rayVersion: '2.3.0'
   headGroupSpec:
-    rayStartParams:
-      block: 'true'
+    rayStartParams: {}
     replicas: 1
     template:
       spec:
@@ -124,8 +122,7 @@ spec:
               memory: "2Gi"
   workerGroupSpecs:
     - groupName: worker
-      rayStartParams:
-        block: 'true'
+      rayStartParams: {}
       replicas: 2
       minReplicas: 2
       maxReplicas: 2
@@ -220,8 +217,7 @@ metadata:
 spec:
   rayVersion: '2.3.0'
   headGroupSpec:
-    rayStartParams:
-      block: 'true'
+    rayStartParams: {}
     replicas: 1
     template:
       spec:
@@ -237,8 +233,7 @@ spec:
               memory: "2Gi"
   workerGroupSpecs:
     - groupName: worker
-      rayStartParams:
-        block: 'true'
+      rayStartParams: {}
       replicas: 2
       minReplicas: 2
       maxReplicas: 2

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -49,7 +49,6 @@ head:
   serviceAccountName: ""
   rayStartParams:
     dashboard-host: '0.0.0.0'
-    block: 'true'
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
   containerEnv: []
@@ -107,8 +106,7 @@ worker:
   replicas: 1
   labels: {}
   serviceAccountName: ""
-  rayStartParams:
-    block: 'true'
+  rayStartParams: {}
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
   containerEnv: []
@@ -168,8 +166,7 @@ additionalWorkerGroups:
     maxReplicas: 3
     labels: {}
     serviceAccountName: ""
-    rayStartParams:
-      block: 'true'
+    rayStartParams: {}
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
     containerEnv: []

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -61,7 +61,6 @@ spec:
     rayStartParams:
       # Flag "no-monitor" will be automatically set when autoscaling is enabled.
       dashboard-host: '0.0.0.0'
-      block: 'true'
       # num-cpus: '14' # can be auto-completed from the limits
       # Use `resources` to optionally specify custom resource annotations for the Ray node.
       # The value of `resources` is a string-integer mapping.
@@ -114,8 +113,7 @@ spec:
     #  - raycluster-complete-worker-large-group-hv457
     #  - raycluster-complete-worker-large-group-k8tj7
     # the following params are used to complete the ray start: ray start --block --node-ip-address= ...
-    rayStartParams:
-      block: 'true'
+    rayStartParams: {}
     #pod template
     template:
       metadata:

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -52,7 +52,6 @@ spec:
     # the following params are used to complete the ray start: ray start --head --block ...
     rayStartParams:
       dashboard-host: '0.0.0.0'
-      block: 'true'
       # num-cpus: '1' # can be auto-completed from the limits
       # Use `resources` to optionally specify custom resource annotations for the Ray node.
       # The value of `resources` is a string-integer mapping.
@@ -114,8 +113,7 @@ spec:
     #  - raycluster-complete-worker-small-group-hv457
     #  - raycluster-complete-worker-small-group-k8tj7
     # the following params are used to complete the ray start: ray start --block ...
-    rayStartParams:
-      block: 'true'
+    rayStartParams: {}
     #pod template
     template:
       spec:

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -25,7 +25,6 @@ spec:
     # the following params are used to complete the ray start: ray start --head --block --dashboard-host: '0.0.0.0' ...
     rayStartParams:
       dashboard-host: '0.0.0.0'
-      block: 'true'
     # pod template
     template:
       metadata:
@@ -82,8 +81,7 @@ spec:
     #  - raycluster-complete-worker-large-group-hv457
     #  - raycluster-complete-worker-large-group-k8tj7
     # the following params are used to complete the ray start: ray start --block ...
-    rayStartParams:
-      block: 'true'
+    rayStartParams: {}
     #pod template
     template:
       spec:

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -19,7 +19,6 @@ spec:
     # the following params are used to complete the ray start: ray start --head --block --dashboard-host: '0.0.0.0' ...
     rayStartParams:
       dashboard-host: '0.0.0.0'
-      block: 'true'
     # pod template
     template:
       metadata:
@@ -82,8 +81,7 @@ spec:
     #  - raycluster-complete-worker-small-group-hv457
     #  - raycluster-complete-worker-small-group-k8tj7
     # the following params are used to complete the ray start: ray start --block
-    rayStartParams:
-      block: 'true'
+    rayStartParams: {}
     #pod template
     template:
       spec:

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -93,7 +93,6 @@ spec:
     rayStartParams:
       dashboard-host: "0.0.0.0"
       num-cpus: "1" # can be auto-completed from the limits
-      block: "true"
       # redis-password should match "requirepass" in redis.conf in the ConfigMap above.
       # Ray 2.3.0 changes the default redis password from "5241590000000000" to "".
       redis-password: $REDIS_PASSWORD
@@ -132,8 +131,7 @@ spec:
       maxReplicas: 2
       # logical group name, for this called small-group, also can be functional
       groupName: small-group
-      rayStartParams:
-        block: 'true'
+      rayStartParams: {}
       #pod template
       template:
         spec:

--- a/ray-operator/config/samples/ray-cluster.head-command.yaml
+++ b/ray-operator/config/samples/ray-cluster.head-command.yaml
@@ -15,7 +15,6 @@ spec:
     rayStartParams:
       dashboard-host: '0.0.0.0'
       num-cpus: '1' # can be auto-completed from the limits
-      block: 'true'
     #pod template
     template:
       spec:

--- a/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
+++ b/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
@@ -42,7 +42,6 @@ spec:
     rayStartParams:
       dashboard-host: '0.0.0.0'
       num-cpus: '1' # can be auto-completed from Ray container resource limits
-      block: 'true'
     #pod template
     template:
       spec:
@@ -74,8 +73,7 @@ spec:
     # logical group name, for this called small-group, also can be functional
     groupName: small-group
     # the following params are used to complete the ray start: ray start --block ...
-    rayStartParams:
-      block: 'true'
+    rayStartParams: {}
     #pod template
     template:
       spec:
@@ -109,8 +107,7 @@ spec:
       #- raycluster-heterogeneous-worker-medium-group-7bv5h
     #  - worker-4k2ih 
     # the following params are used to complete the ray start: ray start --block --node-ip-address= ...
-    rayStartParams:
-      block: "true"
+    rayStartParams: {}
     #pod template
     template:
       spec:

--- a/ray-operator/config/samples/ray-cluster.mini.yaml
+++ b/ray-operator/config/samples/ray-cluster.mini.yaml
@@ -17,7 +17,6 @@ spec:
     rayStartParams:
       dashboard-host: '0.0.0.0'
       num-cpus: '1' # can be auto-completed from the limits
-      block: 'true'
     #pod template
     template:
       spec:

--- a/ray-operator/config/samples/ray-cluster.tls.yaml
+++ b/ray-operator/config/samples/ray-cluster.tls.yaml
@@ -96,8 +96,7 @@ spec:
     minReplicas: 1
     maxReplicas: 10
     groupName: small-group
-    rayStartParams:
-      block: 'true'
+    rayStartParams: {}
     #pod template
     template:
       spec:

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -22,7 +22,6 @@ spec:
       rayStartParams:
         dashboard-host: '0.0.0.0'
         num-cpus: '2' # can be auto-completed from the limits
-        block: 'true'
       #pod template
       template:
         spec:
@@ -58,8 +57,7 @@ spec:
         maxReplicas: 5
         # logical group name, for this called small-group, also can be functional
         groupName: small-group
-        rayStartParams:
-          block: 'true'
+        rayStartParams: {}
         #pod template
         template:
           spec:

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -51,7 +51,6 @@ spec:
         port: '6379' # should match container port named gcs-server
         dashboard-host: '0.0.0.0'
         num-cpus: '2' # can be auto-completed from the limits
-        block: 'true'
       #pod template
       template:
         spec:
@@ -81,8 +80,7 @@ spec:
         maxReplicas: 5
         # logical group name, for this called small-group, also can be functional
         groupName: small-group
-        rayStartParams:
-          block: 'true'
+        rayStartParams: {}
         #pod template
         template:
           spec:

--- a/ray-operator/config/security/ray-cluster.pod-security.yaml
+++ b/ray-operator/config/security/ray-cluster.pod-security.yaml
@@ -19,7 +19,6 @@ spec:
     # the following params are used to complete the ray start: ray start --head --block --dashboard-host: '0.0.0.0' ...
     rayStartParams:
       dashboard-host: '0.0.0.0'
-      block: 'true'
     #pod template
     template:
       spec:
@@ -83,8 +82,7 @@ spec:
     #  - raycluster-complete-worker-large-group-hv457
     #  - raycluster-complete-worker-large-group-k8tj7 
     # the following params are used to complete the ray start: ray start --block
-    rayStartParams:
-      block: 'true'
+    rayStartParams: {}
     #pod template
     template:
       spec:

--- a/tests/config/ray-cluster.mini.yaml.template
+++ b/tests/config/ray-cluster.mini.yaml.template
@@ -14,7 +14,6 @@ spec:
     rayStartParams:
       dashboard-host: '0.0.0.0'
       num-cpus: '1'
-      block: 'true'
     #pod template
     template:
       metadata:
@@ -51,7 +50,6 @@ spec:
       groupName: small-group
       # the following params are used to complete the ray start: ray start --num-cpus=1 --block
       rayStartParams:
-        block: 'true'
         num-cpus: '1'
       #pod template
       template:

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -76,7 +76,6 @@ spec:
     rayStartParams:
       dashboard-host: "0.0.0.0"
       num-cpus: "1"
-      block: "true"
       redis-password: "5241590000000000"
     #pod template
     template:
@@ -134,8 +133,7 @@ spec:
       maxReplicas: 2
       # logical group name, for this called small-group, also can be functional
       groupName: small-group
-      rayStartParams:
-        block: 'true'
+      rayStartParams: {}
       #pod template
       template:
         spec:

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -50,7 +50,6 @@ spec:
         # webui_host: "10.1.2.60"
         dashboard-host: '0.0.0.0'
         num-cpus: '2' # can be auto-completed from the limits
-        block: 'true'
         num-cpus: "1000"
       #pod template
       template:
@@ -91,7 +90,6 @@ spec:
         # the following params are used to complete the ray start: ray start --block --node-ip-address= ...
         rayStartParams:
           node-ip-address: $$MY_POD_IP
-          block: 'true'
           num-cpus: "1000"
         #pod template
         template:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

From v0.5.0, we inject `--block` in the `rayStartParams` automatically in #932. We remove `block` from YAML files after release v0.5.0 to follow the compatibility philosophy (#940) of KubeRay. 

There are still some instances of `block: "true"` in KubeRay operator tests and the Python client. However, since users will not touch them, it is okay to skip them for now and continue with the release process.

## Related issue number
#940 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
