### PR TITLE
[CI] Update github action to run latest release 0.5.0

### DIFF
--- a/.github/workflows/actions/configuration/action.yaml
+++ b/.github/workflows/actions/configuration/action.yaml
@@ -58,12 +58,12 @@ runs:
       python tests/test_sample_raycluster_yamls.py
     shell: bash
 
-  - name: Run tests for sample YAML files with the latest KubeRay release.
+  - name: Run tests for sample YAML files with the latest KubeRay release (0.5.0).
     # Depends on latest KubeRay release.
     env:
       GITHUB_ACTIONS: true
       RAY_IMAGE: rayproject/ray:${{ inputs.ray_version }}
-      OPERATOR_IMAGE: kuberay/operator:v0.4.0 # The operator image in the latest KubeRay release.
+      OPERATOR_IMAGE: kuberay/operator:v0.5.0 # The operator image in the latest KubeRay release.
     run: |
       python tests/test_sample_raycluster_yamls.py
     shell: bash

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -21,7 +21,7 @@ class CONST:
     # Docker images
     OPERATOR_IMAGE_KEY = "kuberay-operator-image"
     RAY_IMAGE_KEY = "ray-image"
-    KUBERAY_LATEST_RELEASE = "kuberay/operator:v0.4.0"
+    KUBERAY_LATEST_RELEASE = "kuberay/operator:v0.5.0"
 
     # Kubernetes API clients
     K8S_CR_CLIENT_KEY = "k8s-cr-api-client"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Updates the github actions CI to run the "latest" test on 0.5.0 instead of 0.4.0.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
