### PR TITLE
feat: make cluster name deterministic when created by RayService

### DIFF
--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -172,7 +172,7 @@ func GenerateIngressName(clusterName string) string {
 
 // GenerateRayClusterName generates a ray cluster name from ray service name
 func GenerateRayClusterName(serviceName string) string {
-	return fmt.Sprintf("%s%s%s", serviceName, RayClusterSuffix, rand.String(5))
+	return fmt.Sprintf("%s%s", serviceName, RayClusterSuffix)
 }
 
 // GenerateRayJobId generates a ray job id for submission


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
When creating a Ray Cluster through `RayService` CR the name of the cluster causes its head service name to contain randomised characters, making it impossible to reliable track the resource in Terraform.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #1016

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [x] This PR is not tested :(
