### PR TITLE
[Bug] rayStartParams is required at this moment.

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -20,14 +20,18 @@ spec:
   headGroupSpec:
     serviceType: {{ .Values.service.type }}
     rayStartParams:
-    {{- range $key, $val := .Values.head.rayStartParams }}
-      {{ $key }}: {{ $val | quote }}
-    {{- end }}
-    {{- /*
-    initArgs is a deprecated alias for rayStartParams.
-    */}}
-    {{- range $key, $val := .Values.head.initArgs }}
-      {{ $key }}: {{ $val | quote }}
+    {{- if and (not .Values.head.rayStartParams) (not .Values.head.initArgs) }}
+      {}
+    {{- else }}
+      {{- range $key, $val := .Values.head.rayStartParams }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
+      {{- /*
+      initArgs is a deprecated alias for rayStartParams.
+      */}}
+      {{- range $key, $val := .Values.head.initArgs }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
     {{- end }}
     template:
       spec:
@@ -81,14 +85,18 @@ spec:
   {{- range $groupName, $values := .Values.additionalWorkerGroups }}
   {{- if ne $values.disabled true }}
   - rayStartParams:
-    {{- range $key, $val := $values.rayStartParams }}
-      {{ $key }}: {{ $val | quote }}
-    {{- end }}
-    {{- /*
-    initArgs is a deprecated alias for rayStartParams.
-    */}}
-    {{- range $key, $val := $values.initArgs }}
-      {{ $key }}: {{ $val | quote }}
+    {{- if and (not $values.rayStartParams) (not $values.head.initArgs) }}
+      {}
+    {{- else }}
+      {{- range $key, $val := $values.rayStartParams }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
+      {{- /*
+      initArgs is a deprecated alias for rayStartParams.
+      */}}
+      {{- range $key, $val := $values.initArgs }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
     {{- end }}
     replicas: {{ $values.replicas }}
     minReplicas: {{ $values.minReplicas | default (default 1 $values.miniReplicas) }}
@@ -144,14 +152,18 @@ spec:
   {{- end }}
   {{- if ne (.Values.worker.disabled | default false) true }}
   - rayStartParams:
-    {{- range $key, $val := .Values.worker.rayStartParams }}
-      {{ $key }}: {{ $val | quote }}
-    {{- end }}
-    {{- /*
-    initArgs is a deprecated alias for rayStartParams.
-    */}}
-    {{- range $key, $val := .Values.worker.initArgs }}
-      {{ $key }}: {{ $val | quote }}
+    {{- if and (not .Values.worker.rayStartParams) (not .Values.worker.initArgs) }}
+      {}
+    {{- else }}
+      {{- range $key, $val := .Values.worker.rayStartParams }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
+      {{- /*
+      initArgs is a deprecated alias for rayStartParams.
+      */}}
+      {{- range $key, $val := .Values.worker.initArgs }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
     {{- end }}
     replicas: {{ .Values.worker.replicas }}
     minReplicas: {{ .Values.worker.minReplicas | default (default 1 .Values.worker.miniReplicas) }}

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -85,7 +85,7 @@ spec:
   {{- range $groupName, $values := .Values.additionalWorkerGroups }}
   {{- if ne $values.disabled true }}
   - rayStartParams:
-    {{- if and (not $values.rayStartParams) (not $values.head.initArgs) }}
+    {{- if and (not $values.rayStartParams) (not $values.initArgs) }}
       {}
     {{- else }}
       {{- range $key, $val := $values.rayStartParams }}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```sh
(base) ➜  ray-cluster git:(fix-helm-chart) helm install raycluster .
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(RayCluster.spec.workerGroupSpecs[0]): missing required field "rayStartParams" in io.ray.v1alpha1.RayCluster.spec.workerGroupSpecs
```

Currently, `rayStartParams` is a required field now, so we need to use `rayStartParams: {}` if `rayStartParams` in values.yaml is empty. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```yaml
# head
rayStartParams:
  dashboard-host: '0.0.0.0'
initArgs:
  111: 222

# path: helm-chart/ray-cluster/
helm template .

# worker
rayStartParams: {}
initArgs:
  111: 222

# path: helm-chart/ray-cluster/
helm template .
```
