### PR TITLE
[WIP] Add LoadBalancerIP field to head service

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -353,6 +353,10 @@ spec:
                     description: EnableIngress indicates whether operator should create
                       ingress object for head service or not.
                     type: boolean
+                  loadBalancerIP:
+                    description: LoadBalancerIP is the IP address to assign to the
+                      head service.
+                    type: string
                   rayStartParams:
                     additionalProperties:
                       type: string

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -361,6 +361,10 @@ spec:
                         description: EnableIngress indicates whether operator should
                           create ingress object for head service or not.
                         type: boolean
+                      loadBalancerIP:
+                        description: LoadBalancerIP is the IP address to assign to
+                          the head service.
+                        type: string
                       rayStartParams:
                         additionalProperties:
                           type: string

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -347,6 +347,10 @@ spec:
                         description: EnableIngress indicates whether operator should
                           create ingress object for head service or not.
                         type: boolean
+                      loadBalancerIP:
+                        description: LoadBalancerIP is the IP address to assign to
+                          the head service.
+                        type: string
                       rayStartParams:
                         additionalProperties:
                           type: string

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -19,6 +19,9 @@ spec:
   {{- end }}
   headGroupSpec:
     serviceType: {{ .Values.service.type }}
+    {{- if .Values.headGroupSpec.loadBalancerIP }}
+    loadBalancerIP: {{ .Values.headGroupSpec.loadBalancerIP }}
+    {{- end }}    
     rayStartParams:
     {{- range $key, $val := .Values.head.rayStartParams }}
       {{ $key }}: {{ $val | quote }}

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -29,6 +29,8 @@ type RayClusterSpec struct {
 type HeadGroupSpec struct {
 	// ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod
 	ServiceType v1.ServiceType `json:"serviceType,omitempty"`
+	// LoadBalancerIP is the IP address to assign to the head service. This is only valid when ServiceType is LoadBalancer.
+	LoadBalancerIP string `json:"loadBalancerIP,omitempty"`
 	// EnableIngress indicates whether operator should create ingress object for head service or not.
 	EnableIngress *bool `json:"enableIngress,omitempty"`
 	// HeadGroupSpec.Replicas is deprecated and ignored; there can only be one head pod per Ray cluster.

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -353,6 +353,10 @@ spec:
                     description: EnableIngress indicates whether operator should create
                       ingress object for head service or not.
                     type: boolean
+                  loadBalancerIP:
+                    description: LoadBalancerIP is the IP address to assign to the
+                      head service.
+                    type: string
                   rayStartParams:
                     additionalProperties:
                       type: string

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -361,6 +361,10 @@ spec:
                         description: EnableIngress indicates whether operator should
                           create ingress object for head service or not.
                         type: boolean
+                      loadBalancerIP:
+                        description: LoadBalancerIP is the IP address to assign to
+                          the head service.
+                        type: string
                       rayStartParams:
                         additionalProperties:
                           type: string

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -347,6 +347,10 @@ spec:
                         description: EnableIngress indicates whether operator should
                           create ingress object for head service or not.
                         type: boolean
+                      loadBalancerIP:
+                        description: LoadBalancerIP is the IP address to assign to
+                          the head service.
+                        type: string
                       rayStartParams:
                         additionalProperties:
                           type: string

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -54,6 +54,10 @@ func BuildServiceForHeadPod(cluster rayiov1alpha1.RayCluster, labels map[string]
 		},
 	}
 
+    if cluster.Spec.HeadGroupSpec.LoadBalancerIP != "" {
+        service.Spec.LoadBalancerIP = cluster.Spec.HeadGroupSpec.LoadBalancerIP
+    }
+
 	ports := getServicePorts(cluster)
 	defaultAppProtocol := DefaultServiceAppProtocol
 	for name, port := range ports {
@@ -105,6 +109,7 @@ func BuildServeServiceForRayService(rayService rayiov1alpha1.RayService, rayClus
 			Selector: selectorLabels,
 			Ports:    []corev1.ServicePort{},
 			Type:     rayService.Spec.RayClusterSpec.HeadGroupSpec.ServiceType,
+			LoadBalancerIP: rayService.Spec.RayClusterSpec.HeadGroupSpec.LoadBalancerIP,
 		},
 	}
 
@@ -139,6 +144,7 @@ func BuildDashboardService(cluster rayiov1alpha1.RayCluster) (*corev1.Service, e
 			Selector: selectorLabels,
 			Ports:    []corev1.ServicePort{},
 			Type:     cluster.Spec.HeadGroupSpec.ServiceType,
+			LoadBalancerIP: cluster.Spec.HeadGroupSpec.LoadBalancerIP,
 		},
 	}
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -353,6 +353,11 @@ func (r *RayClusterReconciler) reconcileServices(instance *rayiov1alpha1.RayClus
 			for k, v := range instance.Spec.HeadServiceAnnotations {
 				annotations[k] = v
 			}
+			loadBalancerIP := instance.Spec.HeadGroupSpec.LoadBalancerIP
+			if loadBalancerIP != "" && instance.Spec.HeadGroupSpec.ServiceType != "LoadBalancer" {
+				r.Log.Info("reconcileServices ", "LoadBalancerIP is set but service type is not LoadBalancer", loadBalancerIP)
+				return nil
+			}
 			raySvc, err = common.BuildServiceForHeadPod(*instance, labels, annotations)
 		} else if serviceType == common.AgentService {
 			raySvc, err = common.BuildDashboardService(*instance)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Allows the Ray head to be accessible from outside Kubernetes by exposing the loadBalancerIP field to the user. Previously, if users specified the head service type as LoadBalancer, there was no way to specify loadBalancerIP.

TODO before merging: Add test
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #877 
Original discussion: https://discuss.ray.io/t/specify-ip-adress-for-the-head-as-a-loadbalancer-service-type/9008
## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
