### PR TITLE
Expose head service ServiceSpec

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -353,6 +353,154 @@ spec:
                     description: EnableIngress indicates whether operator should create
                       ingress object for head service or not.
                     type: boolean
+                  headServiceSpec:
+                    description: HeadServiceSpec is the Kubernetes ServiceSpec of
+                      the head service.
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        description: allocateLoadBalancerNodePorts defines if NodePorts
+                          will be automatically allocated for services with
+                        type: boolean
+                      clusterIP:
+                        description: clusterIP is the IP address of the service and
+                          is usually assigned randomly.
+                        type: string
+                      clusterIPs:
+                        description: ClusterIPs is a list of IP addresses assigned
+                          to this service, and are usually assigned randomly.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for th
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that discovery
+                          mechanisms will return as an alias for this se
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or clu
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service.
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        description: InternalTrafficPolicy specifies if the cluster
+                          internal traffic should be routed to all endpoints or
+                        type: string
+                      ipFamilies:
+                        description: IPFamilies is a list of IP families (e.g. IPv4,
+                          IPv6) assigned to this service.
+                        items:
+                          description: IPFamily represents the IP Family (IPv4 or
+                            IPv6).
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service.
+                        type: string
+                      loadBalancerClass:
+                        description: loadBalancerClass is the class of the load balancer
+                          implementation this Service belongs to.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in th'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: If specified and supported by the platform, this
+                          will restrict traffic through the cloud-provider lo
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            appProtocol:
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                              type: string
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL.
+                              type: string
+                            nodePort:
+                              description: The port on each node on which this service
+                                is exposed when type is NodePort or LoadBalancer.
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the pods targeted by the service.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses indicates that any agent
+                          which deals with endpoints for this Service should
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: Route service traffic to pods with label keys
+                          and values matching this selector.
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sessionAffinity:
+                        description: Supports "ClientIP" and "None". Used to maintain
+                          session affinity.
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: type determines how the Service is exposed. Defaults
+                          to ClusterIP.
+                        type: string
+                    type: object
                   rayStartParams:
                     additionalProperties:
                       type: string

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -361,6 +361,160 @@ spec:
                         description: EnableIngress indicates whether operator should
                           create ingress object for head service or not.
                         type: boolean
+                      headServiceSpec:
+                        description: HeadServiceSpec is the Kubernetes ServiceSpec
+                          of the head service.
+                        properties:
+                          allocateLoadBalancerNodePorts:
+                            description: allocateLoadBalancerNodePorts defines if
+                              NodePorts will be automatically allocated for services
+                              with
+                            type: boolean
+                          clusterIP:
+                            description: clusterIP is the IP address of the service
+                              and is usually assigned randomly.
+                            type: string
+                          clusterIPs:
+                            description: ClusterIPs is a list of IP addresses assigned
+                              to this service, and are usually assigned randomly.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          externalIPs:
+                            description: externalIPs is a list of IP addresses for
+                              which nodes in the cluster will also accept traffic
+                              for th
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            description: externalName is the external reference that
+                              discovery mechanisms will return as an alias for this
+                              se
+                            type: string
+                          externalTrafficPolicy:
+                            description: externalTrafficPolicy denotes if this Service
+                              desires to route external traffic to node-local or clu
+                            type: string
+                          healthCheckNodePort:
+                            description: healthCheckNodePort specifies the healthcheck
+                              nodePort for the service.
+                            format: int32
+                            type: integer
+                          internalTrafficPolicy:
+                            description: InternalTrafficPolicy specifies if the cluster
+                              internal traffic should be routed to all endpoints or
+                            type: string
+                          ipFamilies:
+                            description: IPFamilies is a list of IP families (e.g.
+                              IPv4, IPv6) assigned to this service.
+                            items:
+                              description: IPFamily represents the IP Family (IPv4
+                                or IPv6).
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          ipFamilyPolicy:
+                            description: IPFamilyPolicy represents the dual-stack-ness
+                              requested or required by this Service.
+                            type: string
+                          loadBalancerClass:
+                            description: loadBalancerClass is the class of the load
+                              balancer implementation this Service belongs to.
+                            type: string
+                          loadBalancerIP:
+                            description: 'Only applies to Service Type: LoadBalancer
+                              LoadBalancer will get created with the IP specified
+                              in th'
+                            type: string
+                          loadBalancerSourceRanges:
+                            description: If specified and supported by the platform,
+                              this will restrict traffic through the cloud-provider
+                              lo
+                            items:
+                              type: string
+                            type: array
+                          ports:
+                            description: 'The list of ports that are exposed by this
+                              service. More info: https://kubernetes.'
+                            items:
+                              description: ServicePort contains information on service's
+                                port.
+                              properties:
+                                appProtocol:
+                                  description: The application protocol for this port.
+                                    This field follows standard Kubernetes label syntax.
+                                  type: string
+                                name:
+                                  description: The name of this port within the service.
+                                    This must be a DNS_LABEL.
+                                  type: string
+                                nodePort:
+                                  description: The port on each node on which this
+                                    service is exposed when type is NodePort or LoadBalancer.
+                                  format: int32
+                                  type: integer
+                                port:
+                                  description: The port that will be exposed by this
+                                    service.
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: The IP protocol for this port. Supports
+                                    "TCP", "UDP", and "SCTP". Default is TCP.
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the pods targeted by the service.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            - protocol
+                            x-kubernetes-list-type: map
+                          publishNotReadyAddresses:
+                            description: publishNotReadyAddresses indicates that any
+                              agent which deals with endpoints for this Service should
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            description: Route service traffic to pods with label
+                              keys and values matching this selector.
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          sessionAffinity:
+                            description: Supports "ClientIP" and "None". Used to maintain
+                              session affinity.
+                            type: string
+                          sessionAffinityConfig:
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
+                            properties:
+                              clientIP:
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
+                                properties:
+                                  timeoutSeconds:
+                                    description: timeoutSeconds specifies the seconds
+                                      of ClientIP type session sticky time.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          type:
+                            description: type determines how the Service is exposed.
+                              Defaults to ClusterIP.
+                            type: string
+                        type: object
                       rayStartParams:
                         additionalProperties:
                           type: string

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -347,6 +347,160 @@ spec:
                         description: EnableIngress indicates whether operator should
                           create ingress object for head service or not.
                         type: boolean
+                      headServiceSpec:
+                        description: HeadServiceSpec is the Kubernetes ServiceSpec
+                          of the head service.
+                        properties:
+                          allocateLoadBalancerNodePorts:
+                            description: allocateLoadBalancerNodePorts defines if
+                              NodePorts will be automatically allocated for services
+                              with
+                            type: boolean
+                          clusterIP:
+                            description: clusterIP is the IP address of the service
+                              and is usually assigned randomly.
+                            type: string
+                          clusterIPs:
+                            description: ClusterIPs is a list of IP addresses assigned
+                              to this service, and are usually assigned randomly.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          externalIPs:
+                            description: externalIPs is a list of IP addresses for
+                              which nodes in the cluster will also accept traffic
+                              for th
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            description: externalName is the external reference that
+                              discovery mechanisms will return as an alias for this
+                              se
+                            type: string
+                          externalTrafficPolicy:
+                            description: externalTrafficPolicy denotes if this Service
+                              desires to route external traffic to node-local or clu
+                            type: string
+                          healthCheckNodePort:
+                            description: healthCheckNodePort specifies the healthcheck
+                              nodePort for the service.
+                            format: int32
+                            type: integer
+                          internalTrafficPolicy:
+                            description: InternalTrafficPolicy specifies if the cluster
+                              internal traffic should be routed to all endpoints or
+                            type: string
+                          ipFamilies:
+                            description: IPFamilies is a list of IP families (e.g.
+                              IPv4, IPv6) assigned to this service.
+                            items:
+                              description: IPFamily represents the IP Family (IPv4
+                                or IPv6).
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          ipFamilyPolicy:
+                            description: IPFamilyPolicy represents the dual-stack-ness
+                              requested or required by this Service.
+                            type: string
+                          loadBalancerClass:
+                            description: loadBalancerClass is the class of the load
+                              balancer implementation this Service belongs to.
+                            type: string
+                          loadBalancerIP:
+                            description: 'Only applies to Service Type: LoadBalancer
+                              LoadBalancer will get created with the IP specified
+                              in th'
+                            type: string
+                          loadBalancerSourceRanges:
+                            description: If specified and supported by the platform,
+                              this will restrict traffic through the cloud-provider
+                              lo
+                            items:
+                              type: string
+                            type: array
+                          ports:
+                            description: 'The list of ports that are exposed by this
+                              service. More info: https://kubernetes.'
+                            items:
+                              description: ServicePort contains information on service's
+                                port.
+                              properties:
+                                appProtocol:
+                                  description: The application protocol for this port.
+                                    This field follows standard Kubernetes label syntax.
+                                  type: string
+                                name:
+                                  description: The name of this port within the service.
+                                    This must be a DNS_LABEL.
+                                  type: string
+                                nodePort:
+                                  description: The port on each node on which this
+                                    service is exposed when type is NodePort or LoadBalancer.
+                                  format: int32
+                                  type: integer
+                                port:
+                                  description: The port that will be exposed by this
+                                    service.
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: The IP protocol for this port. Supports
+                                    "TCP", "UDP", and "SCTP". Default is TCP.
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the pods targeted by the service.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            - protocol
+                            x-kubernetes-list-type: map
+                          publishNotReadyAddresses:
+                            description: publishNotReadyAddresses indicates that any
+                              agent which deals with endpoints for this Service should
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            description: Route service traffic to pods with label
+                              keys and values matching this selector.
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          sessionAffinity:
+                            description: Supports "ClientIP" and "None". Used to maintain
+                              session affinity.
+                            type: string
+                          sessionAffinityConfig:
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
+                            properties:
+                              clientIP:
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
+                                properties:
+                                  timeoutSeconds:
+                                    description: timeoutSeconds specifies the seconds
+                                      of ClientIP type session sticky time.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          type:
+                            description: type determines how the Service is exposed.
+                              Defaults to ClusterIP.
+                            type: string
+                        type: object
                       rayStartParams:
                         additionalProperties:
                           type: string

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -19,6 +19,9 @@ spec:
   {{- end }}
   headGroupSpec:
     serviceType: {{ .Values.service.type }}
+    {{- if .Values.service.headServiceSpec }}
+    headServiceSpec: {{- toYaml .Values.service.headServiceSpec | nindent 6 }}
+    {{- end }}
     rayStartParams:
     {{- range $key, $val := .Values.head.rayStartParams }}
       {{ $key }}: {{ $val | quote }}

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -27,8 +27,10 @@ type RayClusterSpec struct {
 
 // HeadGroupSpec are the spec for the head pod
 type HeadGroupSpec struct {
-	// ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod
+	// ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod.
 	ServiceType v1.ServiceType `json:"serviceType,omitempty"`
+	// HeadServiceSpec is the Kubernetes ServiceSpec of the head service.
+	HeadServiceSpec v1.ServiceSpec `json:"headServiceSpec,omitempty"`
 	// EnableIngress indicates whether operator should create ingress object for head service or not.
 	EnableIngress *bool `json:"enableIngress,omitempty"`
 	// HeadGroupSpec.Replicas is deprecated and ignored; there can only be one head pod per Ray cluster.

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
@@ -241,6 +241,7 @@ var expected = `{
       "rayClusterConfig":{
          "headGroupSpec":{
             "replicas":1,
+            "headServiceSpec":{},
             "rayStartParams":{
                "block":"true",
                "dashboard-agent-listen-port":"52365",

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -353,6 +353,154 @@ spec:
                     description: EnableIngress indicates whether operator should create
                       ingress object for head service or not.
                     type: boolean
+                  headServiceSpec:
+                    description: HeadServiceSpec is the Kubernetes ServiceSpec of
+                      the head service.
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        description: allocateLoadBalancerNodePorts defines if NodePorts
+                          will be automatically allocated for services with
+                        type: boolean
+                      clusterIP:
+                        description: clusterIP is the IP address of the service and
+                          is usually assigned randomly.
+                        type: string
+                      clusterIPs:
+                        description: ClusterIPs is a list of IP addresses assigned
+                          to this service, and are usually assigned randomly.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for th
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that discovery
+                          mechanisms will return as an alias for this se
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or clu
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service.
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        description: InternalTrafficPolicy specifies if the cluster
+                          internal traffic should be routed to all endpoints or
+                        type: string
+                      ipFamilies:
+                        description: IPFamilies is a list of IP families (e.g. IPv4,
+                          IPv6) assigned to this service.
+                        items:
+                          description: IPFamily represents the IP Family (IPv4 or
+                            IPv6).
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service.
+                        type: string
+                      loadBalancerClass:
+                        description: loadBalancerClass is the class of the load balancer
+                          implementation this Service belongs to.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in th'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: If specified and supported by the platform, this
+                          will restrict traffic through the cloud-provider lo
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            appProtocol:
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                              type: string
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL.
+                              type: string
+                            nodePort:
+                              description: The port on each node on which this service
+                                is exposed when type is NodePort or LoadBalancer.
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the pods targeted by the service.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses indicates that any agent
+                          which deals with endpoints for this Service should
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: Route service traffic to pods with label keys
+                          and values matching this selector.
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sessionAffinity:
+                        description: Supports "ClientIP" and "None". Used to maintain
+                          session affinity.
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: type determines how the Service is exposed. Defaults
+                          to ClusterIP.
+                        type: string
+                    type: object
                   rayStartParams:
                     additionalProperties:
                       type: string

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -361,6 +361,160 @@ spec:
                         description: EnableIngress indicates whether operator should
                           create ingress object for head service or not.
                         type: boolean
+                      headServiceSpec:
+                        description: HeadServiceSpec is the Kubernetes ServiceSpec
+                          of the head service.
+                        properties:
+                          allocateLoadBalancerNodePorts:
+                            description: allocateLoadBalancerNodePorts defines if
+                              NodePorts will be automatically allocated for services
+                              with
+                            type: boolean
+                          clusterIP:
+                            description: clusterIP is the IP address of the service
+                              and is usually assigned randomly.
+                            type: string
+                          clusterIPs:
+                            description: ClusterIPs is a list of IP addresses assigned
+                              to this service, and are usually assigned randomly.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          externalIPs:
+                            description: externalIPs is a list of IP addresses for
+                              which nodes in the cluster will also accept traffic
+                              for th
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            description: externalName is the external reference that
+                              discovery mechanisms will return as an alias for this
+                              se
+                            type: string
+                          externalTrafficPolicy:
+                            description: externalTrafficPolicy denotes if this Service
+                              desires to route external traffic to node-local or clu
+                            type: string
+                          healthCheckNodePort:
+                            description: healthCheckNodePort specifies the healthcheck
+                              nodePort for the service.
+                            format: int32
+                            type: integer
+                          internalTrafficPolicy:
+                            description: InternalTrafficPolicy specifies if the cluster
+                              internal traffic should be routed to all endpoints or
+                            type: string
+                          ipFamilies:
+                            description: IPFamilies is a list of IP families (e.g.
+                              IPv4, IPv6) assigned to this service.
+                            items:
+                              description: IPFamily represents the IP Family (IPv4
+                                or IPv6).
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          ipFamilyPolicy:
+                            description: IPFamilyPolicy represents the dual-stack-ness
+                              requested or required by this Service.
+                            type: string
+                          loadBalancerClass:
+                            description: loadBalancerClass is the class of the load
+                              balancer implementation this Service belongs to.
+                            type: string
+                          loadBalancerIP:
+                            description: 'Only applies to Service Type: LoadBalancer
+                              LoadBalancer will get created with the IP specified
+                              in th'
+                            type: string
+                          loadBalancerSourceRanges:
+                            description: If specified and supported by the platform,
+                              this will restrict traffic through the cloud-provider
+                              lo
+                            items:
+                              type: string
+                            type: array
+                          ports:
+                            description: 'The list of ports that are exposed by this
+                              service. More info: https://kubernetes.'
+                            items:
+                              description: ServicePort contains information on service's
+                                port.
+                              properties:
+                                appProtocol:
+                                  description: The application protocol for this port.
+                                    This field follows standard Kubernetes label syntax.
+                                  type: string
+                                name:
+                                  description: The name of this port within the service.
+                                    This must be a DNS_LABEL.
+                                  type: string
+                                nodePort:
+                                  description: The port on each node on which this
+                                    service is exposed when type is NodePort or LoadBalancer.
+                                  format: int32
+                                  type: integer
+                                port:
+                                  description: The port that will be exposed by this
+                                    service.
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: The IP protocol for this port. Supports
+                                    "TCP", "UDP", and "SCTP". Default is TCP.
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the pods targeted by the service.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            - protocol
+                            x-kubernetes-list-type: map
+                          publishNotReadyAddresses:
+                            description: publishNotReadyAddresses indicates that any
+                              agent which deals with endpoints for this Service should
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            description: Route service traffic to pods with label
+                              keys and values matching this selector.
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          sessionAffinity:
+                            description: Supports "ClientIP" and "None". Used to maintain
+                              session affinity.
+                            type: string
+                          sessionAffinityConfig:
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
+                            properties:
+                              clientIP:
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
+                                properties:
+                                  timeoutSeconds:
+                                    description: timeoutSeconds specifies the seconds
+                                      of ClientIP type session sticky time.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          type:
+                            description: type determines how the Service is exposed.
+                              Defaults to ClusterIP.
+                            type: string
+                        type: object
                       rayStartParams:
                         additionalProperties:
                           type: string

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -347,6 +347,160 @@ spec:
                         description: EnableIngress indicates whether operator should
                           create ingress object for head service or not.
                         type: boolean
+                      headServiceSpec:
+                        description: HeadServiceSpec is the Kubernetes ServiceSpec
+                          of the head service.
+                        properties:
+                          allocateLoadBalancerNodePorts:
+                            description: allocateLoadBalancerNodePorts defines if
+                              NodePorts will be automatically allocated for services
+                              with
+                            type: boolean
+                          clusterIP:
+                            description: clusterIP is the IP address of the service
+                              and is usually assigned randomly.
+                            type: string
+                          clusterIPs:
+                            description: ClusterIPs is a list of IP addresses assigned
+                              to this service, and are usually assigned randomly.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          externalIPs:
+                            description: externalIPs is a list of IP addresses for
+                              which nodes in the cluster will also accept traffic
+                              for th
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            description: externalName is the external reference that
+                              discovery mechanisms will return as an alias for this
+                              se
+                            type: string
+                          externalTrafficPolicy:
+                            description: externalTrafficPolicy denotes if this Service
+                              desires to route external traffic to node-local or clu
+                            type: string
+                          healthCheckNodePort:
+                            description: healthCheckNodePort specifies the healthcheck
+                              nodePort for the service.
+                            format: int32
+                            type: integer
+                          internalTrafficPolicy:
+                            description: InternalTrafficPolicy specifies if the cluster
+                              internal traffic should be routed to all endpoints or
+                            type: string
+                          ipFamilies:
+                            description: IPFamilies is a list of IP families (e.g.
+                              IPv4, IPv6) assigned to this service.
+                            items:
+                              description: IPFamily represents the IP Family (IPv4
+                                or IPv6).
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          ipFamilyPolicy:
+                            description: IPFamilyPolicy represents the dual-stack-ness
+                              requested or required by this Service.
+                            type: string
+                          loadBalancerClass:
+                            description: loadBalancerClass is the class of the load
+                              balancer implementation this Service belongs to.
+                            type: string
+                          loadBalancerIP:
+                            description: 'Only applies to Service Type: LoadBalancer
+                              LoadBalancer will get created with the IP specified
+                              in th'
+                            type: string
+                          loadBalancerSourceRanges:
+                            description: If specified and supported by the platform,
+                              this will restrict traffic through the cloud-provider
+                              lo
+                            items:
+                              type: string
+                            type: array
+                          ports:
+                            description: 'The list of ports that are exposed by this
+                              service. More info: https://kubernetes.'
+                            items:
+                              description: ServicePort contains information on service's
+                                port.
+                              properties:
+                                appProtocol:
+                                  description: The application protocol for this port.
+                                    This field follows standard Kubernetes label syntax.
+                                  type: string
+                                name:
+                                  description: The name of this port within the service.
+                                    This must be a DNS_LABEL.
+                                  type: string
+                                nodePort:
+                                  description: The port on each node on which this
+                                    service is exposed when type is NodePort or LoadBalancer.
+                                  format: int32
+                                  type: integer
+                                port:
+                                  description: The port that will be exposed by this
+                                    service.
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: The IP protocol for this port. Supports
+                                    "TCP", "UDP", and "SCTP". Default is TCP.
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the pods targeted by the service.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            - protocol
+                            x-kubernetes-list-type: map
+                          publishNotReadyAddresses:
+                            description: publishNotReadyAddresses indicates that any
+                              agent which deals with endpoints for this Service should
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            description: Route service traffic to pods with label
+                              keys and values matching this selector.
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          sessionAffinity:
+                            description: Supports "ClientIP" and "None". Used to maintain
+                              session affinity.
+                            type: string
+                          sessionAffinityConfig:
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
+                            properties:
+                              clientIP:
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
+                                properties:
+                                  timeoutSeconds:
+                                    description: timeoutSeconds specifies the seconds
+                                      of ClientIP type session sticky time.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          type:
+                            description: type determines how the Service is exposed.
+                              Defaults to ClusterIP.
+                            type: string
+                        type: object
                       rayStartParams:
                         additionalProperties:
                           type: string

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -42,7 +42,7 @@ func BuildServiceForHeadPod(cluster rayiov1alpha1.RayCluster, labels map[string]
 
 	serviceSpec := cluster.Spec.HeadGroupSpec.HeadServiceSpec
 
-	// For backward compatibility, use ServiceType if provided in HeadServiceSpec.
+	// For backward compatibility, use ServiceType if provided in HeadGroupSpec.
 	if cluster.Spec.HeadGroupSpec.ServiceType != "" {
 		serviceSpec.Type = cluster.Spec.HeadGroupSpec.ServiceType
 	}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -353,13 +353,18 @@ func (r *RayClusterReconciler) reconcileServices(instance *rayiov1alpha1.RayClus
 			for k, v := range instance.Spec.HeadServiceAnnotations {
 				annotations[k] = v
 			}
+			userServiceType := instance.Spec.HeadGroupSpec.ServiceType
+			userServiceSpecType := instance.Spec.HeadGroupSpec.HeadServiceSpec.Type
+			if userServiceType != "" {
+				r.Log.Info("reconcileServices ", "HeadGroupSpec.ServiceType ", userServiceType, "will take precedence over HeadGroupSpec.ServiceSpec.Type", userServiceSpecType)
+			}
 			raySvc, err = common.BuildServiceForHeadPod(*instance, labels, annotations)
 		} else if serviceType == common.AgentService {
 			raySvc, err = common.BuildDashboardService(*instance)
 		}
 
 		if raySvc == nil {
-			r.Log.Info("reconcileServices ", "Cannot create un-support service type ", serviceType)
+			r.Log.Info("reconcileServices ", "Cannot create unsupported service type ", serviceType)
 			return nil
 		}
 		if len(raySvc.Spec.Ports) == 0 {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
Exposes the `ServiceSpec` of the head pod service to the user.  Previously, we only exposed the `type` field. This led to limitations such as, for example, the user specifying `type: LoadBalancer` and having no way to set the associated field `LoadBalancerIPs`.

After this PR, we will have two ways of specifying the service type: the legacy `HeadGroupSpec.ServiceType`, and the new `HeadGroupSpec.HeadServiceSpec.Type`.  In this PR we make the former take precedence.

In the long term we should have only one way of specifying this.  One plan might involve a few PRs:
1. Update all sample YAMLS and documentation examples that currently use `HeadGroupSpec.ServiceType` to use `HeadGroupSpec.HeadServiceSpec.Type`, if any
2. Print a deprecation warning for `HeadGroupSpec.ServiceType` in v0.6
3. Remove `HeadGroupSpec.ServiceType` in v0.7.

Or, if we think it's convenient and harmless, we can leave them both in forever.
## Why are these changes needed?
Closes #877 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
