### PR TITLE
[Bug][GCS FT] Worker pods crash unexpectedly when gcs_server on head pod is killed

### DIFF
--- a/ray-operator/apis/ray/v1alpha1/raycluster_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types_test.go
@@ -30,8 +30,7 @@ var myRayCluster = &RayCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Labels: map[string]string{
-						"rayCluster": "raycluster-sample",
-						"groupName":  "headgroup",
+						"groupName": "headgroup",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -71,8 +70,7 @@ var myRayCluster = &RayCluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
 						Labels: map[string]string{
-							"rayCluster": "raycluster-sample",
-							"groupName":  "small-group",
+							"groupName": "small-group",
 						},
 					},
 					Spec: corev1.PodSpec{

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
@@ -37,8 +37,7 @@ var expectedRayJob = RayJob{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"rayCluster": "raycluster-sample",
-							"groupName":  "headgroup",
+							"groupName": "headgroup",
 						},
 						Annotations: map[string]string{
 							"key": "value",
@@ -102,8 +101,7 @@ var expectedRayJob = RayJob{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "default",
 							Labels: map[string]string{
-								"rayCluster": "raycluster-sample",
-								"groupName":  "small-group",
+								"groupName": "small-group",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -162,8 +160,7 @@ var testRayJobJSON = `{
                     "metadata": {
                         "creationTimestamp": null,
                         "labels": {
-                            "groupName": "headgroup",
-                            "rayCluster": "raycluster-sample"
+                            "groupName": "headgroup"
                         },
                         "annotations": {
                             "key": "value"
@@ -228,8 +225,7 @@ var testRayJobJSON = `{
                             "namespace": "default",
                             "creationTimestamp": null,
                             "labels": {
-                                "groupName": "small-group",
-                                "rayCluster": "raycluster-sample"
+                                "groupName": "small-group"
                             }
                         },
                         "spec": {

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
@@ -85,8 +85,7 @@ var myRayService = &RayService{
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"rayCluster": "raycluster-sample",
-							"groupName":  "headgroup",
+							"groupName": "headgroup",
 						},
 						Annotations: map[string]string{
 							"key": "value",
@@ -155,8 +154,7 @@ var myRayService = &RayService{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "default",
 							Labels: map[string]string{
-								"rayCluster": "raycluster-sample",
-								"groupName":  "small-group",
+								"groupName": "small-group",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -254,8 +252,7 @@ var expected = `{
                "metadata":{
                   "creationTimestamp":null,
                   "labels":{
-                     "groupName":"headgroup",
-                     "rayCluster":"raycluster-sample"
+                     "groupName": "headgroup"
                   },
                   "annotations":{
                      "key":"value"
@@ -325,8 +322,7 @@ var expected = `{
                      "namespace":"default",
                      "creationTimestamp":null,
                      "labels":{
-                        "groupName":"small-group",
-                        "rayCluster":"raycluster-sample"
+                        "groupName":"small-group"
                      }
                   },
                   "spec":{

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -138,9 +138,6 @@ spec:
           containers:
             - name: ray-worker
               image: rayproject/ray:2.3.0
-              env: 
-                - name: RAY_gcs_rpc_server_reconnect_timeout_s
-                  value: "120"
               volumeMounts:
                 - mountPath: /tmp/ray
                   name: ray-logs

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -138,6 +138,9 @@ spec:
           containers:
             - name: ray-worker
               image: rayproject/ray:2.3.0
+              env: 
+                - name: RAY_gcs_rpc_server_reconnect_timeout_s
+                  value: "120"
               volumeMounts:
                 - mountPath: /tmp/ray
                   name: ray-logs

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -79,6 +79,7 @@ const (
 	RAY_ADDRESS                             = "RAY_ADDRESS"
 	REDIS_PASSWORD                          = "REDIS_PASSWORD"
 	RAY_EXTERNAL_STORAGE_NS                 = "RAY_external_storage_namespace"
+	RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S  = "RAY_gcs_rpc_server_reconnect_timeout_s"
 	RAY_TIMEOUT_MS_TASK_WAIT_FOR_DEATH_INFO = "RAY_timeout_ms_task_wait_for_death_info"
 	RAY_GCS_SERVER_REQUEST_TIMEOUT_SECONDS  = "RAY_gcs_server_request_timeout_seconds"
 	RAY_SERVE_KV_TIMEOUT_S                  = "RAY_SERVE_KV_TIMEOUT_S"
@@ -88,7 +89,8 @@ const (
 	RAYCLUSTER_DEFAULT_REQUEUE_SECONDS      = 300
 
 	// Ray core default configurations
-	DefaultRedisPassword = "5241590000000000"
+	DefaultRedisPassword                 = "5241590000000000"
+	DefaultWorkerRayGcsReconnectTimeoutS = "600"
 
 	LOCAL_HOST = "127.0.0.1"
 	// Ray FT default readiness probe values

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -649,7 +649,6 @@ func setContainerEnvVars(pod *v1.Pod, rayContainerIndex int, rayNodeType rayiov1
 	if !envVarExists(RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, container.Env) && rayNodeType == rayiov1alpha1.WorkerNode {
 		// If GCS FT is enabled and RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S is not set, set the worker's
 		// RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S to 600s.
-		// See https://github.com/ray-project/kuberay/blob/master/docs/guidance/gcs-ft.md for more details.
 		if ftEnabled := pod.Annotations[RayFTEnabledAnnotationKey] == "true"; ftEnabled {
 			gcsTimeout := v1.EnvVar{Name: RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: DefaultWorkerRayGcsReconnectTimeoutS}
 			container.Env = append(container.Env, gcsTimeout)

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -648,7 +648,10 @@ func setContainerEnvVars(pod *v1.Pod, rayContainerIndex int, rayNodeType rayiov1
 	}
 	if !envVarExists(RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, container.Env) && rayNodeType == rayiov1alpha1.WorkerNode {
 		// If GCS FT is enabled and RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S is not set, set the worker's
-		// RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S to 600s.
+		// RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S to 600s. If the worker cannot reconnect to GCS within
+		// 600s, the Raylet will exit the process. By default, the value is 60s, so the head node will
+		// crash if the GCS server is down for more than 60s. Typically, the new GCS server will be available
+		// in 120 seconds, so we set the timeout to 600s to avoid the worker nodes crashing.
 		if ftEnabled := pod.Annotations[RayFTEnabledAnnotationKey] == "true"; ftEnabled {
 			gcsTimeout := v1.EnvVar{Name: RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: DefaultWorkerRayGcsReconnectTimeoutS}
 			container.Env = append(container.Env, gcsTimeout)

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -552,9 +552,8 @@ func TestBuildPod_WithGcsFtEnabled(t *testing.T) {
 	}
 
 	// Add "RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S" env var in the head group spec.
-	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[rayContainerIndex].Env =
-		append(cluster.Spec.HeadGroupSpec.Template.Spec.Containers[rayContainerIndex].Env,
-			v1.EnvVar{Name: RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: "60"})
+	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[rayContainerIndex].Env = append(cluster.Spec.HeadGroupSpec.Template.Spec.Containers[rayContainerIndex].Env,
+		v1.EnvVar{Name: RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: "60"})
 	podTemplateSpec = DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	pod = BuildPod(podTemplateSpec, rayiov1alpha1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, "", "")
 	rayContainer = pod.Spec.Containers[rayContainerIndex]
@@ -586,9 +585,8 @@ func TestBuildPod_WithGcsFtEnabled(t *testing.T) {
 	}
 
 	// Add "RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S" env var in the worker group spec.
-	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[rayContainerIndex].Env =
-		append(cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[rayContainerIndex].Env,
-			v1.EnvVar{Name: RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: "120"})
+	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[rayContainerIndex].Env = append(cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[rayContainerIndex].Env,
+		v1.EnvVar{Name: RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: "120"})
 	worker = cluster.Spec.WorkerGroupSpecs[0]
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	pod = BuildPod(podTemplateSpec, rayiov1alpha1.WorkerNode, worker.RayStartParams, "6379", nil, "", fqdnRayIP)

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -35,8 +35,7 @@ var instanceWithWrongSvc = &rayiov1alpha1.RayCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Labels: map[string]string{
-						"rayCluster": "raycluster-sample",
-						"groupName":  "headgroup",
+						"groupName": "headgroup",
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -62,8 +62,7 @@ var _ = Context("Inside the default namespace", func() {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"rayCluster": "raycluster-sample",
-								"groupName":  "headgroup",
+								"groupName": "headgroup",
 							},
 							Annotations: map[string]string{
 								"key": "value",
@@ -132,8 +131,7 @@ var _ = Context("Inside the default namespace", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Namespace: "default",
 								Labels: map[string]string{
-									"rayCluster": "raycluster-sample",
-									"groupName":  "small-group",
+									"groupName": "small-group",
 								},
 							},
 							Spec: corev1.PodSpec{

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -100,8 +100,7 @@ var _ = Context("Inside the default namespace", func() {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"rayCluster": "raycluster-sample",
-								"groupName":  "headgroup",
+								"groupName": "headgroup",
 							},
 							Annotations: map[string]string{
 								"key": "value",
@@ -178,8 +177,7 @@ var _ = Context("Inside the default namespace", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Namespace: "default",
 								Labels: map[string]string{
-									"rayCluster": "raycluster-sample",
-									"groupName":  "small-group",
+									"groupName": "small-group",
 								},
 							},
 							Spec: corev1.PodSpec{

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -41,6 +41,7 @@ kuberay_operator_image = 'kuberay/operator:nightly'
 class BasicRayTestCase(unittest.TestCase):
     """Test the basic functionalities of RayCluster by executing simple jobs."""
     cluster_template = CONST.REPO_ROOT.joinpath("tests/config/ray-cluster.mini.yaml.template")
+    ray_cluster_ns = "default"
 
     @classmethod
     def setUpClass(cls):
@@ -60,10 +61,10 @@ class BasicRayTestCase(unittest.TestCase):
         Run a simple example in the head Pod to test the basic functionality of the Ray cluster.
         The example is from https://docs.ray.io/en/latest/ray-core/walkthrough.html#running-a-task.
         """
-        cluster_namespace = "default"
-        headpod = get_head_pod(cluster_namespace)
+        headpod = get_head_pod(BasicRayTestCase.ray_cluster_ns)
         headpod_name = headpod.metadata.name
-        pod_exec_command(headpod_name, cluster_namespace, "python samples/simple_code.py")
+        pod_exec_command(
+            headpod_name, BasicRayTestCase.ray_cluster_ns, "python samples/simple_code.py")
 
     def test_cluster_info(self):
         """Execute "print(ray.cluster_resources())" in the head Pod."""
@@ -73,6 +74,7 @@ class BasicRayTestCase(unittest.TestCase):
 class RayFTTestCase(unittest.TestCase):
     """Test Ray GCS Fault Tolerance"""
     cluster_template = CONST.REPO_ROOT.joinpath("tests/config/ray-cluster.ray-ft.yaml.template")
+    ray_cluster_ns = "default"
 
     @classmethod
     def setUpClass(cls):
@@ -110,8 +112,7 @@ class RayFTTestCase(unittest.TestCase):
 
     def test_ray_serve(self):
         """Kill GCS process on the head Pod and then test a deployed Ray Serve model."""
-        cluster_namespace = "default"
-        headpod = get_head_pod(cluster_namespace)
+        headpod = get_head_pod(RayFTTestCase.ray_cluster_ns)
         headpod_name = headpod.metadata.name
 
         # RAY_NAMESPACE is an abstraction in Ray. It is not a Kubernetes namespace.
@@ -119,47 +120,46 @@ class RayFTTestCase(unittest.TestCase):
         logger.info('Ray namespace: %s', ray_namespace)
 
         # Deploy a Ray Serve model.
-        exit_code = pod_exec_command(headpod_name, cluster_namespace,
+        exit_code = pod_exec_command(headpod_name, RayFTTestCase.ray_cluster_ns,
             f" python samples/test_ray_serve_1.py {ray_namespace}",
             check = False
         )
 
         if exit_code != 0:
-            show_cluster_info(cluster_namespace)
+            show_cluster_info(RayFTTestCase.ray_cluster_ns)
             raise Exception(
                 f"Fail to execute test_ray_serve_1.py. The exit code is {exit_code}."
             )
 
-        old_head_pod = get_head_pod(cluster_namespace)
+        old_head_pod = get_head_pod(RayFTTestCase.ray_cluster_ns)
         old_head_pod_name = old_head_pod.metadata.name
         restart_count = old_head_pod.status.container_statuses[0].restart_count
 
         # Kill the gcs_server process on head node. If fate sharing is enabled, the whole head
         # node pod will be terminated.
-        pod_exec_command(old_head_pod_name, cluster_namespace, "pkill gcs_server")
+        pod_exec_command(old_head_pod_name, RayFTTestCase.ray_cluster_ns, "pkill gcs_server")
 
         # Waiting for all pods become ready and running.
         utils.wait_for_new_head(old_head_pod_name, restart_count,
-            cluster_namespace, timeout=300, retry_interval_ms=1000)
+            RayFTTestCase.ray_cluster_ns, timeout=300, retry_interval_ms=1000)
 
         # Try to connect to the deployed model again
-        headpod = get_head_pod(cluster_namespace)
+        headpod = get_head_pod(RayFTTestCase.ray_cluster_ns)
         headpod_name = headpod.metadata.name
-        exit_code = pod_exec_command(headpod_name, cluster_namespace,
+        exit_code = pod_exec_command(headpod_name, RayFTTestCase.ray_cluster_ns,
             f" python samples/test_ray_serve_2.py {ray_namespace}",
             check = False
         )
 
         if exit_code != 0:
-            show_cluster_info(cluster_namespace)
+            show_cluster_info(RayFTTestCase.ray_cluster_ns)
             raise Exception(
                 f"Fail to execute test_ray_serve_2.py. The exit code is {exit_code}."
             )
 
     def test_detached_actor(self):
         """Kill GCS process on the head Pod and then test a detached actor."""
-        cluster_namespace = "default"
-        headpod = get_head_pod(cluster_namespace)
+        headpod = get_head_pod(RayFTTestCase.ray_cluster_ns)
         headpod_name = headpod.metadata.name
 
         # RAY_NAMESPACE is an abstraction in Ray. It is not a Kubernetes namespace.
@@ -167,42 +167,42 @@ class RayFTTestCase(unittest.TestCase):
         logger.info('Ray namespace: %s', ray_namespace)
 
         # Register a detached actor
-        exit_code = pod_exec_command(headpod_name, cluster_namespace,
+        exit_code = pod_exec_command(headpod_name, RayFTTestCase.ray_cluster_ns,
             f" python samples/test_detached_actor_1.py {ray_namespace}",
             check = False
         )
 
         if exit_code != 0:
-            show_cluster_info(cluster_namespace)
+            show_cluster_info(RayFTTestCase.ray_cluster_ns)
             raise Exception(
                 f"Fail to execute test_detached_actor_1.py. The exit code is {exit_code}."
             )
 
-        old_head_pod = get_head_pod(cluster_namespace)
+        old_head_pod = get_head_pod(RayFTTestCase.ray_cluster_ns)
         old_head_pod_name = old_head_pod.metadata.name
         restart_count = old_head_pod.status.container_statuses[0].restart_count
 
         # Kill the gcs_server process on head node. If fate sharing is enabled, the whole head
         # node pod will be terminated.
-        pod_exec_command(old_head_pod_name, cluster_namespace, "pkill gcs_server")
+        pod_exec_command(old_head_pod_name, RayFTTestCase.ray_cluster_ns, "pkill gcs_server")
 
         # Waiting for all pods become ready and running.
         utils.wait_for_new_head(old_head_pod_name, restart_count,
-            cluster_namespace, timeout=300, retry_interval_ms=1000)
+            RayFTTestCase.ray_cluster_ns, timeout=300, retry_interval_ms=1000)
 
         # Try to connect to the detached actor again.
         # [Note] When all pods become running and ready, the RayCluster still needs tens of seconds
         # to relaunch actors. Hence, `test_detached_actor_2.py` will retry until a Ray client
         # connection succeeds.
-        headpod = get_head_pod(cluster_namespace)
+        headpod = get_head_pod(RayFTTestCase.ray_cluster_ns)
         headpod_name = headpod.metadata.name
-        exit_code = pod_exec_command(headpod_name, cluster_namespace,
+        exit_code = pod_exec_command(headpod_name, RayFTTestCase.ray_cluster_ns,
             f" python samples/test_detached_actor_2.py {ray_namespace}",
             check = False
         )
 
         if exit_code != 0:
-            show_cluster_info(cluster_namespace)
+            show_cluster_info(RayFTTestCase.ray_cluster_ns)
             raise Exception(
                 f"Fail to execute test_detached_actor_2.py. The exit code is {exit_code}."
             )

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -135,8 +135,9 @@ class RayFTTestCase(unittest.TestCase):
         old_head_pod_name = old_head_pod.metadata.name
         restart_count = old_head_pod.status.container_statuses[0].restart_count
 
-        # Kill the gcs_server process on head node. If fate sharing is enabled, the whole head
-        # node pod will be terminated.
+        # Kill the gcs_server process on head node. The head node will crash after 20 seconds
+        # because the value of `RAY_gcs_rpc_server_reconnect_timeout_s` is "20" in the
+        # `ray-cluster.ray-ft.yaml.template` file.
         pod_exec_command(old_head_pod_name, RayFTTestCase.ray_cluster_ns, "pkill gcs_server")
 
         # Waiting for all pods become ready and running.
@@ -182,8 +183,9 @@ class RayFTTestCase(unittest.TestCase):
         old_head_pod_name = old_head_pod.metadata.name
         restart_count = old_head_pod.status.container_statuses[0].restart_count
 
-        # Kill the gcs_server process on head node. If fate sharing is enabled, the whole head
-        # node pod will be terminated.
+        # Kill the gcs_server process on head node. The head node will crash after 20 seconds
+        # because the value of `RAY_gcs_rpc_server_reconnect_timeout_s` is "20" in the
+        # `ray-cluster.ray-ft.yaml.template` file.
         pod_exec_command(old_head_pod_name, RayFTTestCase.ray_cluster_ns, "pkill gcs_server")
 
         # Waiting for all pods become ready and running.

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -92,6 +92,8 @@ spec:
               # RAY_REDIS_ADDRESS can force ray to use external redis
               - name: RAY_REDIS_ADDRESS
                 value: redis:6379
+              - name: RAY_gcs_rpc_server_reconnect_timeout_s
+                value: "20"
             ports:
               - containerPort: 6379
                 name: redis
@@ -140,6 +142,9 @@ spec:
           containers:
             - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
               image: $ray_image
+              env:
+                - name: RAY_gcs_rpc_server_reconnect_timeout_s
+                  value: "120"
               resources:
                 limits:
                   cpu: "1"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

### Major changes

When we kill the GCS server process (`pkill gcs_server`) on the head Pod, a Raylet (?) will exit the process if it cannot connect to the GCS server after `RAY_gcs_rpc_server_reconnect_timeout_s` ([code](https://sourcegraph.com/github.com/ray-project/ray@3aa6ede43743a098b5e0eb37ec11505f46100313/-/blob/src/ray/rpc/gcs_server/gcs_rpc_client.h?L527-L546)). By default, the value is 60s.

In #634, the `RAY_gcs_rpc_server_reconnect_timeout_s` values for both head and workers are set to 60 seconds. This means that the head and workers will crash almost simultaneously, 60 seconds after the GCS server process is terminated. Therefore, we need to ensure that the `RAY_gcs_rpc_server_reconnect_timeout_s` for the workers is greater than the time it takes for a new GCS server process to become available after the old one is terminated. That is, 

```
WORKER_RECONNECTION_TIMEOUT > HEAD_RECONNECTION_TIMEOUT + restart the head Pod + new GCS server process become ready
```

This PR injects `RAY_gcs_rpc_server_reconnect_timeout_s` env variable to workers with default value 600s if GCS FT is enabled. Hence, head will crash 60 seconds after the process is terminated, and the new GCS server process will be ready before 600 seconds. Hence, the workers will not crash.

### Minor changes
* Remove `rayCluster` label: The label has been removed by #761 from sample YAML files. This PR removes the label from unit tests.

* [compatibility-test.py](https://github.com/ray-project/kuberay/pull/1036/files#diff-db7eeddbec6895cf05cb70312b97d42f54bdd61ac34ee18d3f74d02ab349b5bf): This is just for refactoring.

* [ray-cluster.ray-ft.yaml.template](https://github.com/ray-project/kuberay/pull/1036/files#diff-62f8a48fc70b61fc917b570ad6780f87b1e506806b66914f5d1ad4c9ac0abe21): Set `RAY_gcs_rpc_server_reconnect_timeout_s` to make the compatibility test become faster.

## Related issue number
Closes #634 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
# Build the KubeRay image (controller:latest)
helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0 --set image.repository=controller,image.tag=latest

# Create a RayCluster with GCS FT
kubectl apply -f ray-cluster.external-redis.yaml

# This env var should not be set on head Pod by default
kubectl describe pod $YOUR_HEAD_POD | grep RAY_gcs_rpc_server_reconnect_timeout_s

# The env should be injected to worker Pods by default.
kubectl describe pod $YOUR_WORKER_POD | grep RAY_gcs_rpc_server_reconnect_timeout_s
# RAY_gcs_rpc_server_reconnect_timeout_s:  600

# Kill the GCS server process on the head Pod
kubectl exec -it $YOUR_HEAD_POD -- pkill gcs_server

# Expected behavior: head Pod will crash after 60 seconds, and workers will not crash.
```

<img width="1303" alt="Screen Shot 2023-04-19 at 1 15 19 PM" src="https://user-images.githubusercontent.com/20109646/233200868-de548bb9-31a9-4176-952b-7994c8e9b959.png">

<img width="1412" alt="Screen Shot 2023-04-19 at 1 23 27 PM" src="https://user-images.githubusercontent.com/20109646/233200927-ee98c6a8-1053-40cf-87c4-f9d7ca1cb7f0.png">
