### PR TITLE
[Bug] Enable ResourceQuota by adding Resources for the health-check init container

### DIFF
--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -827,6 +827,8 @@ func TestDefaultInitContainer(t *testing.T) {
 	// Ray container to the init container. This may be changed in the future.
 	healthCheckContainer := podTemplateSpec.Spec.InitContainers[numInitContainers-1]
 	rayContainer := worker.Template.Spec.Containers[getRayContainerIndex(worker.Template.Spec)]
+
+	assert.NotEqual(t, len(rayContainer.Env), 0, "The test only makes sense if the Ray container has environment variables.")
 	assert.Equal(t, len(rayContainer.Env), len(healthCheckContainer.Env))
 	for _, env := range rayContainer.Env {
 		// env.ValueFrom is the source for the environment variable's value. Cannot be used if value is not empty.
@@ -836,4 +838,8 @@ func TestDefaultInitContainer(t *testing.T) {
 			checkContainerEnv(t, healthCheckContainer, env.Name, env.ValueFrom.FieldRef.FieldPath)
 		}
 	}
+
+	// The values of `Resources` should be the same in both Ray container and health-check container.
+	assert.NotEmpty(t, rayContainer.Resources, "The test only makes sense if the Ray container has resource limit/request.")
+	assert.Equal(t, rayContainer.Resources, healthCheckContainer.Resources)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Flyte will create `ResourceQuota` for each Kubernetes namespace. To support `ResourceQuota`, each container in the namespace requires setting resource limits. However, the injected health-check init container does not specify the resource limits.

**Why am I using the same resource configurations for the init container as those used in the Ray container?**

In Kubernetes Pod, all init containers will be executed in a sequence, one by one, and each init container must complete successfully before the next one starts. On the other hands, when all init containers complete successfully, all application containers will start in parallel, and the startup order is arbitrary.

For example, we have 3 init containers and 3 application containers. The execution order will be:

init1 -> init2 -> init3 -> app1, app2, app3

The Pod's effective request/limit for a resource is the higher of:

* the sum of all app containers request/limit for a resource
* the effective init request/limit for a resource

Example: `max(max(init1, init2, init3), sum(app1, app2, app3))`

Hence, using the same resource configurations for the init container as those used in the Ray container will not waste resources.






<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Slack thread: https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1681294121762329

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(


```sh
# Step 0: Build the Docker image for this PR
# Step 1: Install the KubeRay operator with this new Docker image
helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0 --set image.repository=controller,image.tag=latest

# Step 2: Create a namespace flyte and ResourceQuota.
kubectl create ns flyte
kubectl apply -f resource_quota.yaml

# resource_quota.yaml
apiVersion: v1
kind: List
items:
- apiVersion: v1
  kind: ResourceQuota
  metadata:
    name: project-quota
    namespace: flyte
  spec:
    hard:
      limits.cpu: "8"
      limits.memory: 3000Mi

# Step 3: Install a RayCluster with resource limit/request for both head & worker groups in the `flyte` namespace.
# => Expected behavior: Both head & worker Pods should be created successfully.
helm install raycluster kuberay/ray-cluster --version 0.5.1 -n flyte
```
* If you use `helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0` in Step 1, only the head Pod will be created in Step 3.