### PR TITLE
[Bug] compatibility test for the nightly Ray image fails

### DIFF
--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -115,13 +115,9 @@ class RayFTTestCase(unittest.TestCase):
         headpod = get_head_pod(RayFTTestCase.ray_cluster_ns)
         headpod_name = headpod.metadata.name
 
-        # RAY_NAMESPACE is an abstraction in Ray. It is not a Kubernetes namespace.
-        ray_namespace = ''.join(random.choices(string.ascii_lowercase, k=10))
-        logger.info('Ray namespace: %s', ray_namespace)
-
         # Deploy a Ray Serve model.
         exit_code = pod_exec_command(headpod_name, RayFTTestCase.ray_cluster_ns,
-            f" python samples/test_ray_serve_1.py {ray_namespace}",
+            "python samples/test_ray_serve_1.py",
             check = False
         )
 

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -148,7 +148,7 @@ class RayFTTestCase(unittest.TestCase):
         headpod = get_head_pod(RayFTTestCase.ray_cluster_ns)
         headpod_name = headpod.metadata.name
         exit_code = pod_exec_command(headpod_name, RayFTTestCase.ray_cluster_ns,
-            f" python samples/test_ray_serve_2.py {ray_namespace}",
+            "python samples/test_ray_serve_2.py",
             check = False
         )
 

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -183,7 +183,7 @@ data:
         def __call__(self):
             return self._msg
 
-    ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1])
+    ray.init(namespace=sys.argv[1])
     # 2: Deploy the model.
     handle = serve.run(MyModelDeployment.bind(msg="Hello world!"))
     # 3: Query the deployment and print the result.
@@ -214,13 +214,13 @@ data:
         print('Response content:', response.text)
         assert(response.text == "Hello world!")
 
-    retry_with_timeout(send_req)
+    retry_with_timeout(send_req, 180)
 
   test_detached_actor_1.py: |
     import ray
     import sys
 
-    ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1])
+    ray.init(namespace=sys.argv[1])
 
     @ray.remote
     class TestCounter:
@@ -261,7 +261,7 @@ data:
 
     # Try to connect to Ray cluster.
     print("Try to connect to Ray cluster.")
-    retry_with_timeout(lambda: ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1]), timeout = 180)
+    retry_with_timeout(lambda: ray.init(namespace=sys.argv[1]), timeout = 180)
 
     # Get TestCounter actor
     print("Get TestCounter actor.")

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -167,12 +167,8 @@ metadata:
   name: test-script
 data:
   test_ray_serve_1.py: |
-    import requests
-    from starlette.requests import Request
     import ray
     from ray import serve
-    import time
-    import sys
 
     # 1: Define a Ray Serve model.
     @serve.deployment(route_prefix="/")
@@ -183,7 +179,7 @@ data:
         def __call__(self):
             return self._msg
 
-    ray.init(namespace=sys.argv[1])
+    ray.init()
     # 2: Deploy the model.
     handle = serve.run(MyModelDeployment.bind(msg="Hello world!"))
     # 3: Query the deployment and print the result.
@@ -194,6 +190,7 @@ data:
   test_ray_serve_2.py: |
     import requests
     import time
+    import json
 
     def retry_with_timeout(func, timeout=90):
         err = None
@@ -214,7 +211,19 @@ data:
         print('Response content:', response.text)
         assert(response.text == "Hello world!")
 
-    retry_with_timeout(send_req, 180)
+    def check_status():
+        headers = {
+            'Accept': 'application/json',
+        }
+        url = 'http://localhost:52365/api/serve/deployments/status'
+        response = requests.get(url, headers=headers)
+        status_json = json.loads(response.text)
+        print("Serve status:", status_json)
+        # Application "RUNNING": all deployments are healthy.
+        assert(status_json['app_status']['status'] == 'RUNNING')
+
+    retry_with_timeout(check_status, 240)
+    retry_with_timeout(send_req, 5)
 
   test_detached_actor_1.py: |
     import ray

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -75,7 +75,7 @@ spec:
   headGroupSpec:
     rayStartParams:
       dashboard-host: "0.0.0.0"
-      num-cpus: "1"
+      num-cpus: "0"
       redis-password: "5241590000000000"
     #pod template
     template:

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -130,7 +130,7 @@ spec:
                   path: test_detached_actor_2.py
   workerGroupSpecs:
     # the pod replicas in this group typed worker
-    - replicas: 2
+    - replicas: 1
       minReplicas: 1
       maxReplicas: 2
       # logical group name, for this called small-group, also can be functional
@@ -179,7 +179,7 @@ data:
         def __call__(self):
             return self._msg
 
-    ray.init()
+    ray.init(address='ray://127.0.0.1:10001')
     # 2: Deploy the model.
     handle = serve.run(MyModelDeployment.bind(msg="Hello world!"))
     # 3: Query the deployment and print the result.
@@ -190,7 +190,6 @@ data:
   test_ray_serve_2.py: |
     import requests
     import time
-    import json
 
     def retry_with_timeout(func, timeout=90):
         err = None
@@ -205,31 +204,19 @@ data:
         raise err
 
     def send_req():
-        response = requests.get('http://127.0.0.1:8000', timeout=60)
+        response = requests.get('http://127.0.0.1:8000', timeout=10)
         print('Response status code:', response.status_code)
         print('Response headers:', response.headers)
         print('Response content:', response.text)
         assert(response.text == "Hello world!")
 
-    def check_status():
-        headers = {
-            'Accept': 'application/json',
-        }
-        url = 'http://localhost:52365/api/serve/deployments/status'
-        response = requests.get(url, headers=headers)
-        status_json = json.loads(response.text)
-        print("Serve status:", status_json)
-        # Application "RUNNING": all deployments are healthy.
-        assert(status_json['app_status']['status'] == 'RUNNING')
-
-    retry_with_timeout(check_status, 240)
-    retry_with_timeout(send_req, 5)
+    retry_with_timeout(send_req, 180)
 
   test_detached_actor_1.py: |
     import ray
     import sys
 
-    ray.init(namespace=sys.argv[1])
+    ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1])
 
     @ray.remote
     class TestCounter:
@@ -270,7 +257,7 @@ data:
 
     # Try to connect to Ray cluster.
     print("Try to connect to Ray cluster.")
-    retry_with_timeout(lambda: ray.init(namespace=sys.argv[1]), timeout = 180)
+    retry_with_timeout(lambda: ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1]), timeout = 180)
 
     # Get TestCounter actor
     print("Get TestCounter actor.")

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -192,33 +192,16 @@ data:
     assert(val == "Hello world!")
 
   test_ray_serve_2.py: |
-    import ray
-    import time
-    import sys
-    from ray import serve
+    import requests
 
-    def retry_with_timeout(func, timeout=90):
-        err = None
-        for i in range(timeout):
-            try:
-                print(f"retry iter: {i}")
-                return func()
-            except BaseException as e:
-                err = e
-            finally:
-                time.sleep(1)
-        raise err
-
-    print("Execute ray.init()")
-    retry_with_timeout(lambda: ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1]))
-
-    print("Execute serve.start()")
-    retry_with_timeout(lambda:serve.start(detached=True))
-
-    print("Execute ray.get()")
-    val = retry_with_timeout(lambda: ray.get(serve.get_deployment("MyModelDeployment").get_handle().remote()))
-    print(val)
-    assert(val == "Hello world!")
+    try:
+        response = requests.get('http://127.0.0.1:8000', timeout=90)
+        print('Response status code:', response.status_code)
+        print('Response headers:', response.headers)
+        print('Response content:', response.text)
+        assert(response.text == 'Hello world!')
+    except requests.exceptions.RequestException as e:
+        raise SystemExit(e)
 
   test_detached_actor_1.py: |
     import ray

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -193,15 +193,28 @@ data:
 
   test_ray_serve_2.py: |
     import requests
+    import time
 
-    try:
-        response = requests.get('http://127.0.0.1:8000', timeout=90)
+    def retry_with_timeout(func, timeout=90):
+        err = None
+        for i in range(timeout):
+            try:
+                print(f"retry iter: {i}")
+                return func()
+            except BaseException as e:
+                err = e
+            finally:
+                time.sleep(1)
+        raise err
+
+    def send_req():
+        response = requests.get('http://127.0.0.1:8000', timeout=60)
         print('Response status code:', response.status_code)
         print('Response headers:', response.headers)
         print('Response content:', response.text)
-        assert(response.text == 'Hello world!')
-    except requests.exceptions.RequestException as e:
-        raise SystemExit(e)
+        assert(response.text == "Hello world!")
+
+    retry_with_timeout(send_req)
 
   test_detached_actor_1.py: |
     import ray

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -273,4 +273,4 @@ data:
 
     # The actual value should be 1 rather than 2. Ray will launch all registered actors when
     # the ray cluster restarts, but the internal state of the state will not be restored.
-    assert(val == 1)
+    assert(val == 3)

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -44,13 +44,7 @@ spec:
     headGroupSpec:
       # the following params are used to complete the ray start: ray start --head --block ...
       rayStartParams:
-        port: '6379' # should match container port named gcs-server
-        #include_webui: 'true'
-        object-store-memory: '100000000'
-        # webui_host: "10.1.2.60"
         dashboard-host: '0.0.0.0'
-        num-cpus: '2' # can be auto-completed from the limits
-        num-cpus: "1000"
       #pod template
       template:
         metadata:
@@ -88,9 +82,7 @@ spec:
         #  - raycluster-complete-worker-small-group-hv457
         #  - raycluster-complete-worker-small-group-k8tj7
         # the following params are used to complete the ray start: ray start --block --node-ip-address= ...
-        rayStartParams:
-          node-ip-address: $$MY_POD_IP
-          num-cpus: "1000"
+        rayStartParams: {}
         #pod template
         template:
           spec:

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -46,6 +46,9 @@ def check_pod_running(pods) -> bool:
     for pod in pods:
         if pod.status.phase != 'Running':
             return False
+        for container in pod.status.container_statuses:
+            if not container.ready:
+                return False
     return True
 
 def get_expected_head_pods(custom_resource):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Use HTTP request to verify serve deployment after the cluster recovers from a failure to fix https://github.com/ray-project/ray/issues/34799.
* For Ray 2.1.0, containers require tens of seconds to become "READY" after the Pod is running. In addition, the serve deployment takes few seconds to be ready to serve requests after all containers are "READY".

* With #1036, the worker Pods will not crash after the GCS server process is killed. Hence, the output of `test_detached_actor_2.py` may be different based on the actor is assigned to the head or a worker. `test_detached_actor_1.py` calls `increment()` twice, and `test_detached_actor_2.py` calls `increment()` once. Hence, if the actor is scheduled on a worker, the output of `test_detached_actor_2.py` should be 3. On the other hand, the output should be 1 if it is scheduled on the head Pod.
  * Set `num-cpus: 0` to prevent the actor from scheduling on the head.
  * Update the assert function in `test_detached_actor_2.py` (`assert(val == 3)`).
  * Delete `ray_namespace`.

* Update `rayStartParams` in `ray-service.yaml.template`. Worker Pod with `node-ip-address: $$MY_POD_IP` cannot connect to the head (See https://github.com/ray-project/kuberay/issues/805 for more details.)

* Connect to GCS (`ray.init()`) rather than Ray client (10001) (#848).
  * [Update] When I use `ray.init()` instead of Ray client, the tests become very unstable. 

<!-- Please give a short summary of the change and the problem this solves. -->

(Bug? Ray 2.1.0) In some cases, HTTPProxy will not be created on the head Pod after the cluster recovers from a failure.

## Experiments for 73b37b159c749377550775114b171a946734ece4

```sh
#!/bin/bash
for i in {1..25}
do
  RAY_IMAGE=rayproject/ray:2.1.0 python3 tests/compatibility-test.py RayFTTestCase 2>&1 | tee log_$i.txt
done
```
* Run `RayFTTestCase` 25 times on my devbox.
  * `test_detached_actor` never fails.
  * `test_ray_serve` fails 6 times.
      <details>
      <summary>test_ray_serve_1.py * 5</summary>
      
      ```
      ^[[2m^[[36m(ServeController pid=643)^[[0m INFO 2023-04-28 01:32:33,683 controller 643 http_state.py:132 - Starting HTTP proxy with name 'SERVE_CONTROLLER_ACTOR:SERVE_PROXY_ACTOR-c82ea22161ab30914ebd453cc3bd00e7e2088203b1506c26dc98116c' on node 'c82ea22161ab30914ebd453cc3bd00e7e2088203b1506c26dc98116c' listening on '127.0.0.1:8000'
      ^[[2m^[[36m(ServeController pid=643)^[[0m INFO 2023-04-28 01:32:33,716 controller 643 http_state.py:132 - Starting HTTP proxy with name 'SERVE_CONTROLLER_ACTOR:SERVE_PROXY_ACTOR-cc6e7b1793a1f6e801f67f310ef39428d54e15c3ca140fcc193795fd' on node 'cc6e7b1793a1f6e801f67f310ef39428d54e15c3ca140fcc193795fd' listening on '127.0.0.1:8000'
      ^[[2m^[[36m(ServeController pid=643)^[[0m INFO 2023-04-28 01:32:33,725 controller 643 http_state.py:132 - Starting HTTP proxy with name 'SERVE_CONTROLLER_ACTOR:SERVE_PROXY_ACTOR-438634dbcfb7ea6edd2cc3fef2feaf02ae2df4c6198e7a17a3155f72' on node '438634dbcfb7ea6edd2cc3fef2feaf02ae2df4c6198e7a17a3155f72' listening on '127.0.0.1:8000'
      ^[[2m^[[36m(HTTPProxyActor pid=700)^[[0m INFO:     Started server process [700]
      Traceback (most recent call last):
        File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/serve/_private/api.py", line 241, in serve_start
          timeout=HTTP_PROXY_TIMEOUT,
        File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
          return getattr(ray, func.__name__)(*args, **kwargs)
        File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/util/client/api.py", line 42, in get
          return self.worker.get(vals, timeout=timeout)
        File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/util/client/worker.py", line 434, in get
          res = self._get(to_get, op_timeout)
        File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/util/client/worker.py", line 462, in _get
          raise err
      ray.exceptions.GetTimeoutError: Get timed out: some object(s) not ready.
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "samples/test_ray_serve_1.py", line 15, in <module>
          handle = serve.run(MyModelDeployment.bind(msg="Hello world!"))
        File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/serve/api.py", line 483, in run
          http_options={"host": host, "port": port, "location": "EveryNode"},
        File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/serve/_private/api.py", line 245, in serve_start
          f"HTTP proxies not available after {HTTP_PROXY_TIMEOUT}s."
      TimeoutError: HTTP proxies not available after 60s.
      command terminated with exit code 1
      ```
      </details>
      <details>
      <summary>test_ray_serve_2.py * 1 </summary>
      
      ```
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "/home/ray/anaconda3/lib/python3.7/site-packages/requests/adapters.py", line 449, in send
          timeout=timeout
        File "/home/ray/anaconda3/lib/python3.7/site-packages/urllib3/connectionpool.py", line 786, in urlopen
          method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
        File "/home/ray/anaconda3/lib/python3.7/site-packages/urllib3/util/retry.py", line 592, in increment
          raise MaxRetryError(_pool, url, error or ResponseError(cause))
      urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='127.0.0.1', port=8000): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fcabbf355d0>: Failed to establish a new connection: [Errno 111] Connection refused'))
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "samples/test_ray_serve_2.py", line 23, in <module>
          retry_with_timeout(send_req, 180)
        File "samples/test_ray_serve_2.py", line 14, in retry_with_timeout
          raise err
        File "samples/test_ray_serve_2.py", line 9, in retry_with_timeout
          return func()
        File "samples/test_ray_serve_2.py", line 17, in send_req
          response = requests.get('http://127.0.0.1:8000', timeout=10)
        File "/home/ray/anaconda3/lib/python3.7/site-packages/requests/api.py", line 76, in get
          return request('get', url, params=params, **kwargs)
        File "/home/ray/anaconda3/lib/python3.7/site-packages/requests/api.py", line 61, in request
          return session.request(method=method, url=url, **kwargs)
        File "/home/ray/anaconda3/lib/python3.7/site-packages/requests/sessions.py", line 542, in request
          resp = self.send(prep, **send_kwargs)
        File "/home/ray/anaconda3/lib/python3.7/site-packages/requests/sessions.py", line 655, in send
          r = adapter.send(request, **kwargs)
        File "/home/ray/anaconda3/lib/python3.7/site-packages/requests/adapters.py", line 516, in send
          raise ConnectionError(e, request=request)
      requests.exceptions.ConnectionError: HTTPConnectionPool(host='127.0.0.1', port=8000): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fcabbf355d0>: Failed to establish a new connection: [Errno 111] Connection refused'))
      command terminated with exit code 1
      ```
      </details>

The `test_ray_serve_1.py`'s error message is from the [link](https://sourcegraph.com/github.com/ray-project/ray@0d59be7f27454200c9a2c153ad14b0ad00d541e5/-/blob/python/ray/serve/_private/api.py?L169-L209). The reason seems to be failing to get HTTPProxy actors which is similar to my observation above "(Bug? Ray 2.1.0) In some cases, HTTPProxy will not be created on the head Pod after the cluster recovers from a failure.". I will file an issue later, but the check seems to be legacy code.




## Related issue number
Closes #1053 
#848 
Closes https://github.com/ray-project/ray/issues/34799



## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
