### PR TITLE
Fix in HeadPod Service Generation logic which was causing frequent reconciliation

### DIFF
--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"sort"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,6 +60,14 @@ func BuildServiceForHeadPod(cluster rayiov1alpha1.RayCluster, labels map[string]
 	for name, port := range ports {
 		svcPort := corev1.ServicePort{Name: name, Port: port, AppProtocol: &defaultAppProtocol}
 		service.Spec.Ports = append(service.Spec.Ports, svcPort)
+	}
+
+	// ensuring that ports order is maintained
+	// sorting the ports based on their name
+	if len(service.Spec.Ports) > 1 {
+		sort.SliceStable(service.Spec.Ports, func(i, j int) bool {
+			return service.Spec.Ports[i].Name < service.Spec.Ports[j].Name
+		})
 	}
 
 	return service, nil

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -62,8 +62,8 @@ func BuildServiceForHeadPod(cluster rayiov1alpha1.RayCluster, labels map[string]
 		service.Spec.Ports = append(service.Spec.Ports, svcPort)
 	}
 
-	// ensuring that ports order is maintained
-	// sorting the ports based on their name
+	// this change ensures that reconciliation in rayservice_controller will not update the Service spec due to change in ports order
+	// sorting the ServicePorts on their name
 	if len(service.Spec.Ports) > 1 {
 		sort.SliceStable(service.Spec.Ports, func(i, j int) bool {
 			return service.Spec.Ports[i].Name < service.Spec.Ports[j].Name

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -213,8 +213,10 @@ func TestBuildServiceForHeadPodPortsOrder(t *testing.T) {
 	ports1 := svc1.Spec.Ports
 	ports2 := svc2.Spec.Ports
 
+	// length should be same
 	assert.Equal(t, len(ports1), len(ports2))
 	for i := 0; i < len(ports1); i++ {
+		// name should be same
 		assert.Equal(t, ports1[i].Name, ports2[i].Name)
 	}
 }

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -203,3 +203,18 @@ func TestGetServicePortsWithMetricsPort(t *testing.T) {
 		t.Fatalf("Expected `%v` but got `%v`", customMetricsPort, ports[DefaultMetricsName])
 	}
 }
+
+func TestBuildServiceForHeadPodPortsOrder(t *testing.T) {
+	svc1, err1 := BuildServiceForHeadPod(*instanceWithWrongSvc, nil, nil)
+	svc2, err2 := BuildServiceForHeadPod(*instanceWithWrongSvc, nil, nil)
+	assert.Nil(t, err1)
+	assert.Nil(t, err2)
+
+	ports1 := svc1.Spec.Ports
+	ports2 := svc2.Spec.Ports
+
+	assert.Equal(t, len(ports1), len(ports2))
+	for i := 0; i < len(ports1); i++ {
+		assert.Equal(t, ports1[i].Name, ports2[i].Name)
+	}
+}


### PR DESCRIPTION
## Why are these changes needed?

`BuildServiceForHeadPod` method creates the `corev1.Service` object without ensuring the order of ports. When the  `rayservice_controller` reconciliation loop updates the Service Spec, K8s detects a change in the  and applies it. This will lead to a performance degradation.

## Related issue number

Closes [1044](https://github.com/ray-project/kuberay/issues/1044)

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
