### PR TITLE
[Feature] Add API to execute python file in ray cluster for python client

### DIFF
--- a/clients/python-client/examples/script/test.py
+++ b/clients/python-client/examples/script/test.py
@@ -1,0 +1,4 @@
+import ray
+
+ray.init()
+print(ray.cluster_resources())

--- a/clients/python-client/examples/simple-example.py
+++ b/clients/python-client/examples/simple-example.py
@@ -1,0 +1,32 @@
+from python_client import kuberay_cluster_api
+from python_client.utils import kuberay_cluster_utils, kuberay_cluster_builder
+
+def main():
+    print("starting cluster handler...")
+    cluster_name = "new-cluster0"
+    cluster_namespace = "default"
+    my_kuberay_api = kuberay_cluster_api.RayClusterApi() # this is the main api object
+    my_cluster_director = kuberay_cluster_builder.Director()
+    my_cluster_util = kuberay_cluster_utils.ClusterUtils()
+    cluster0 = my_cluster_director.build_small_cluster(name="new-cluster0")
+
+    if cluster0:
+        my_kuberay_api.create_ray_cluster(body=cluster0)
+        is_running = my_kuberay_api.wait_until_ray_cluster_running(
+            name=cluster_name,
+            k8s_namespace=cluster_namespace,
+        )
+        if not is_running:
+            print("cluster do not start well")
+        output, success = my_cluster_util.exec_file("script/test.py", cluster_name, cluster_namespace)
+        if success:
+            print(output)
+        else:
+            print("Error in exec python file")
+        my_kuberay_api.delete_ray_cluster(cluster_name, cluster_namespace)
+    else:
+        print("Error in build small cluster")
+    
+
+if __name__ == "__main__":
+    main()

--- a/clients/python-client/python_client/kuberay_cluster_api.py
+++ b/clients/python-client/python_client/kuberay_cluster_api.py
@@ -177,8 +177,7 @@ class RayClusterApi:
                 else:
                     log.error("error fetching custom resource: {}".format(e))
                     return None
-            
-            if resource["status"]:
+            if "status" in resource and resource["status"]:
                     return resource["status"]
             else:
                 log.info("raycluster {} status not set yet, waiting...".format(name))

--- a/clients/python-client/python_client/utils/kuberay_cluster_utils.py
+++ b/clients/python-client/python_client/utils/kuberay_cluster_utils.py
@@ -37,12 +37,7 @@ class ClusterUtils:
     def __init__(self):
         # loading the config
         self.kube_config = config.load_kube_config()
-        self.api = client.CustomObjectsApi()
         self.core_v1_api = client.CoreV1Api()
-
-    def __del__(self):
-        self.api = None
-        self.kube_config = None
 
     def populate_meta(
         self,

--- a/clients/python-client/python_client/utils/kuberay_cluster_utils.py
+++ b/clients/python-client/python_client/utils/kuberay_cluster_utils.py
@@ -474,34 +474,6 @@ class ClusterUtils:
         )
         return cluster, False
 
-    def exec_command(
-        self,
-        command,
-        cluster_name,
-        cluster_namespace = "default", 
-    ) -> str:
-        """Execute command in the cluster
-
-        Parameters:
-        - command (str): The command which will be executed in the head pod of the ray cluster.
-        - cluster_name (str): The name of the ray cluster where the python file will be executed.
-        - cluster_name (str): The name of the namespace which the ray cluster is in.
-
-        Returns:
-        - Tuple (str, bool): execution ouput of the python file, and a boolean indicating whether the update was successful.
-        """
-        head_pod = self.get_head_pod(cluster_name, cluster_namespace)
-        if head_pod == "":
-            return "", False
-        exec_command = f"kubectl exec {head_pod} -- {command} 2>&1"
-        result = subprocess.run(exec_command, shell=True, stdout=subprocess.PIPE, text=True)
-        if result.returncode != 0:
-            log.error(
-                f"error while exec command {exec_command} in {cluster_name}:\n {result.stdout}"
-            )
-            return "", False       
-        return result.stdout, True
-
     def exec_file(
         self,
         file_path,

--- a/clients/python-client/python_client_test/test_api.py
+++ b/clients/python-client/python_client_test/test_api.py
@@ -102,7 +102,8 @@ test_cluster_body: dict = {
             "serviceIP": "10.152.183.194"
         },
         "lastUpdateTime": "2023-02-16T05:15:17Z",
-        "maxWorkerReplicas": 2
+        "maxWorkerReplicas": 2,
+        "state": "ready"
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Originally, users will need to port-forward and utilize the terminal to submit Python files for execution.([reference](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started.html#kuberay-quickstart))
```
kubectl port-forward --address 0.0.0.0 service/raycluster-kuberay-head-svc 8265:8265
ray job submit --address http://localhost:8265 -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
```
The `exec_file` function enables users to submit a Python file to get executed in the ray cluster easily([example](https://github.com/jasoonn/kuberay/blob/ea67213867e6b5038156f584a1757a62f918ac9d/clients/python-client/examples/simple-example.py#L21)).

`output, success = my_cluster_util.exec_file("script/test.py", cluster_name, cluster_namespace)`

## Why modify `wait_until_ray_cluster_running()`
In the original implementation, it will return `True` when the ray cluster is not fully ready. Right now, it will return `True` only when the status.state of the raycluster is equal to `ready`.
<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
#### Under /home/ubuntu/kuberay/clients/python-client
```
pip3 install -e .
python3 -m unittest discover './python_client_test/'

for file in ./examples/*.py
do
    echo "Running $file"
    python3 "$file"
done
```