### PR TITLE
[Bug] autoscaler not working properly in rayjob 

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -436,8 +436,7 @@ func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, ra
 		// This is because a user might set both RayClusterSpec and ClusterSelector. with rayJobInstance.Spec.RayClusterSpec == nil,
 		// though the RayJob controller will still use ClusterSelector, but it's now able to update the replica.
 		// this could result in a conflict as both the RayJob controller and the autoscaler in the existing RayCluster might try to update replicas simultaneously.
-		// if len(rayJobInstance.Spec.ClusterSelector) != 0 {
-		if rayJobInstance.Spec.RayClusterSpec == nil {
+		if len(rayJobInstance.Spec.ClusterSelector) != 0 {
 			r.Log.Info("ClusterSelector is being used to select an existing RayCluster", "raycluster", rayClusterNamespacedName)
 			return rayClusterInstance, nil
 		}

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -429,23 +429,58 @@ func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, ra
 	rayClusterInstance := &rayv1alpha1.RayCluster{}
 	err := r.Get(ctx, rayClusterNamespacedName, rayClusterInstance)
 	if err == nil {
-		r.Log.Info("RayJob associated rayCluster found", "rayjob", rayJobInstance.Name, "raycluster", rayClusterNamespacedName)
-		// just return the rayClusterInstance if cluster spec is nil
+		r.Log.Info("Found associated RayCluster for RayJob", "rayjob", rayJobInstance.Name, "raycluster", rayClusterNamespacedName)
+
+		// Case1: The job is submitted to an existing ray cluster, simply return the rayClusterInstance.
 		if rayJobInstance.Spec.RayClusterSpec == nil {
+			r.Log.Info("RayClusterSpec is empty. You are using ClusterSelector to select an existing RayCluster", "raycluster", rayClusterNamespacedName)
 			return rayClusterInstance, nil
 		}
 
-		if utils.CompareJsonStruct(rayClusterInstance.Spec, *rayJobInstance.Spec.RayClusterSpec) {
+		// Note, unlike the RayService, which creates new Ray clusters if any spec is changed,
+		// RayJob only supports changing the replicas. Changes to other specs may lead to
+		// unexpected behavior. Therefore, the following code focuses solely on updating replicas.
+
+		// Case2: In-tree autoscaling is enabled, only the autoscaler should update replicas to prevent race conditions
+		// between user updates and autoscaler decisions. RayJob controller should not modify the replica. Consider this scenario:
+		// 1. The autoscaler updates replicas to 10 based on the current workload.
+		// 2. The user updates replicas to 15 in the RayJob YAML file.
+		// 3. Both RayJob controller and the autoscaler attempt to update replicas, causing worker pods to be repeatedly created and terminated.
+		if rayJobInstance.Spec.RayClusterSpec.EnableInTreeAutoscaling != nil && *rayJobInstance.Spec.RayClusterSpec.EnableInTreeAutoscaling {
+			// Note, currently, there is no method to verify if the user has updated the RayJob since the last reconcile.
+			// In future, we could utilize annotation that stores the hash of the RayJob since last reconcile to compare.
+			// For now, we just log a warning message to remind the user regadless whether user has updated RayJob.
+			r.Log.Info("In-tree autoscaling is enabled, Adjustments made to RayJob will be disregarded")
 			return rayClusterInstance, nil
 		}
-		rayClusterInstance.Spec = *rayJobInstance.Spec.RayClusterSpec
 
-		r.Log.Info("Update ray cluster spec", "raycluster", rayClusterNamespacedName)
+		// Case3: In-tree autoscaling is disabled, respect the user's replicas setting.
+		// Loop over all worker groups and update replicas.
+		areReplicasIdentical := true
+		for i := range rayJobInstance.Spec.RayClusterSpec.WorkerGroupSpecs {
+			if *rayClusterInstance.Spec.WorkerGroupSpecs[i].Replicas != *rayJobInstance.Spec.RayClusterSpec.WorkerGroupSpecs[i].Replicas {
+				areReplicasIdentical = false
+				*rayClusterInstance.Spec.WorkerGroupSpecs[i].Replicas = *rayJobInstance.Spec.RayClusterSpec.WorkerGroupSpecs[i].Replicas
+			}
+		}
+
+		// Other specs rather than replicas are changed, warn the user that the RayJob supports replica changes only.
+		if !utils.CompareJsonStruct(rayClusterInstance.Spec, *rayJobInstance.Spec.RayClusterSpec) {
+			r.Log.Info("RayJob supports replica changes only. Adjustments made to other specs will be disregarded as they may cause unexpected behavior")
+		}
+
+		// Avoid updating the RayCluster's replicas if it's identical to the RayJob's replicas.
+		if areReplicasIdentical {
+			return rayClusterInstance, nil
+		}
+
+		r.Log.Info("Update ray cluster replica", "raycluster", rayClusterNamespacedName)
 		if err := r.Update(ctx, rayClusterInstance); err != nil {
-			r.Log.Error(err, "Fail to update ray cluster instance!", "rayCluster", rayClusterNamespacedName)
+			r.Log.Error(err, "Fail to update ray cluster replica!", "rayCluster", rayClusterNamespacedName)
 			// Error updating the RayCluster object.
 			return nil, client.IgnoreNotFound(err)
 		}
+
 	} else if errors.IsNotFound(err) {
 		if len(rayJobInstance.Spec.ClusterSelector) != 0 {
 			err := fmt.Errorf("we have choosed the cluster selector mode, failed to find the cluster named %v, err: %v", rayClusterInstanceName, err)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -437,7 +437,7 @@ func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, ra
 		// though the RayJob controller will still use ClusterSelector, but it's now able to update the replica.
 		// this could result in a conflict as both the RayJob controller and the autoscaler in the existing RayCluster might try to update replicas simultaneously.
 		if len(rayJobInstance.Spec.ClusterSelector) != 0 {
-			r.Log.Info("ClusterSelector is being used to select an existing RayCluster", "raycluster", rayClusterNamespacedName)
+			r.Log.Info("ClusterSelector is being used to select an existing RayCluster. RayClusterSpec will be disregarded", "raycluster", rayClusterNamespacedName)
 			return rayClusterInstance, nil
 		}
 
@@ -486,6 +486,8 @@ func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, ra
 		}
 
 	} else if errors.IsNotFound(err) {
+		// TODO: If both ClusterSelector and RayClusterSpec are not set, we avoid should attempting to retrieve a RayCluster instance.
+		// Consider moving this logic to a more appropriate location.
 		if len(rayJobInstance.Spec.ClusterSelector) == 0 && rayJobInstance.Spec.RayClusterSpec == nil {
 			err := fmt.Errorf("Both ClusterSelector and RayClusterSpec are undefined")
 			r.Log.Error(err, "Failed to configure RayCluster instance due to missing configuration")

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -436,7 +436,8 @@ func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, ra
 		// This is because a user might set both RayClusterSpec and ClusterSelector. with rayJobInstance.Spec.RayClusterSpec == nil,
 		// though the RayJob controller will still use ClusterSelector, but it's now able to update the replica.
 		// this could result in a conflict as both the RayJob controller and the autoscaler in the existing RayCluster might try to update replicas simultaneously.
-		if len(rayJobInstance.Spec.ClusterSelector) != 0 {
+		// if len(rayJobInstance.Spec.ClusterSelector) != 0 {
+		if rayJobInstance.Spec.RayClusterSpec == nil {
 			r.Log.Info("ClusterSelector is being used to select an existing RayCluster", "raycluster", rayClusterNamespacedName)
 			return rayClusterInstance, nil
 		}
@@ -486,6 +487,12 @@ func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, ra
 		}
 
 	} else if errors.IsNotFound(err) {
+		if len(rayJobInstance.Spec.ClusterSelector) == 0 && rayJobInstance.Spec.RayClusterSpec == nil {
+			err := fmt.Errorf("Both ClusterSelector and RayClusterSpec are undefined")
+			r.Log.Error(err, "Failed to configure RayCluster instance due to missing configuration")
+			return nil, err
+		}
+
 		if len(rayJobInstance.Spec.ClusterSelector) != 0 {
 			err := fmt.Errorf("we have choosed the cluster selector mode, failed to find the cluster named %v, err: %v", rayClusterInstanceName, err)
 			r.Log.Error(err, "Get rayCluster instance error!")

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -202,9 +202,6 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
 				time.Second*15, time.Millisecond*500).Should(Equal(int(*myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas)), fmt.Sprintf("workerGroup %v", workerPods.Items))
-			for _, workerPod := range workerPods.Items {
-				Expect(workerPod.Status.Phase).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))
-			}
 		})
 
 		// If in-tree autoscaling is disabled, the user should be able to update the replica settings.
@@ -234,9 +231,6 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
 				time.Second*15, time.Millisecond*500).Should(Equal(int(newReplicas)), fmt.Sprintf("workerGroup %v", workerPods.Items))
-			for _, workerPod := range workerPods.Items {
-				Expect(workerPod.Status.Phase).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))
-			}
 		})
 
 		It("Dashboard URL should be set", func() {
@@ -296,7 +290,7 @@ var _ = Context("Inside the default namespace with autoscaler", func() {
 				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayJob  = %v", myRayJob.Name)
 		})
 
-		// if In-tree autoscaling is enabled,  the autoscaler should adjust the number of replicas based on the workload.
+		// if In-tree autoscaling is enabled, the autoscaler should adjust the number of replicas based on the workload.
 		// This test emulates the behavior of the autoscaler by directly updating the RayCluster and verifying if the number of worker pods increases accordingly.
 		It("should create new worker since autoscaler increases the replica", func() {
 			Eventually(
@@ -325,9 +319,6 @@ var _ = Context("Inside the default namespace with autoscaler", func() {
 			Eventually(
 				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
 				time.Second*15, time.Millisecond*500).Should(Equal(int(*myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas)+1), fmt.Sprintf("workerGroup %v", workerPods.Items))
-			for _, workerPod := range workerPods.Items {
-				Expect(workerPod.Status.Phase).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))
-			}
 			// confirm RayJob controller does not revert the number of workers.
 			Consistently(
 				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
@@ -365,9 +356,6 @@ var _ = Context("Inside the default namespace with autoscaler", func() {
 			Consistently(
 				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
 				time.Second*5, time.Millisecond*500).Should(Equal(int(oldReplicas)), fmt.Sprintf("workerGroup %v", workerPods.Items))
-			for _, workerPod := range workerPods.Items {
-				Expect(workerPod.Status.Phase).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))
-			}
 		})
 	})
 })

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -33,45 +33,112 @@ import (
 	"k8s.io/utils/pointer"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	// +kubebuilder:scaffold:imports
 )
 
-var _ = Context("Inside the default namespace", func() {
-	ctx := context.TODO()
-	myRayJob := &rayiov1alpha1.RayJob{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rayjob-test",
-			Namespace: "default",
-		},
-		Spec: rayiov1alpha1.RayJobSpec{
-			Entrypoint: "sleep 999",
-			RayClusterSpec: &rayiov1alpha1.RayClusterSpec{
-				RayVersion: "1.12.1",
-				HeadGroupSpec: rayiov1alpha1.HeadGroupSpec{
-					Replicas: pointer.Int32(1),
+var myRayJob = &rayiov1alpha1.RayJob{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "rayjob-test",
+		Namespace: "default",
+	},
+	Spec: rayiov1alpha1.RayJobSpec{
+		Entrypoint: "sleep 999",
+		RayClusterSpec: &rayiov1alpha1.RayClusterSpec{
+			RayVersion: "1.12.1",
+			HeadGroupSpec: rayiov1alpha1.HeadGroupSpec{
+				Replicas: pointer.Int32(1),
+				RayStartParams: map[string]string{
+					"port":                        "6379",
+					"object-store-memory":         "100000000",
+					"dashboard-host":              "0.0.0.0",
+					"num-cpus":                    "1",
+					"node-ip-address":             "127.0.0.1",
+					"dashboard-agent-listen-port": "52365",
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"groupName": "headgroup",
+						},
+						Annotations: map[string]string{
+							"key": "value",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "ray-head",
+								Image: "rayproject/ray:2.4.0",
+								Env: []corev1.EnvVar{
+									{
+										Name: "MY_POD_IP",
+										ValueFrom: &corev1.EnvVarSource{
+											FieldRef: &corev1.ObjectFieldSelector{
+												FieldPath: "status.podIP",
+											},
+										},
+									},
+								},
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("2Gi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("2Gi"),
+									},
+								},
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "gcs-server",
+										ContainerPort: 6379,
+									},
+									{
+										Name:          "dashboard",
+										ContainerPort: 8265,
+									},
+									{
+										Name:          "head",
+										ContainerPort: 10001,
+									},
+									{
+										Name:          "dashboard-agent",
+										ContainerPort: 52365,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WorkerGroupSpecs: []rayiov1alpha1.WorkerGroupSpec{
+				{
+					Replicas:    pointer.Int32(3),
+					MinReplicas: pointer.Int32(0),
+					MaxReplicas: pointer.Int32(10000),
+					GroupName:   "small-group",
 					RayStartParams: map[string]string{
 						"port":                        "6379",
-						"object-store-memory":         "100000000",
-						"dashboard-host":              "0.0.0.0",
 						"num-cpus":                    "1",
-						"node-ip-address":             "127.0.0.1",
 						"dashboard-agent-listen-port": "52365",
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
 							Labels: map[string]string{
-								"groupName": "headgroup",
-							},
-							Annotations: map[string]string{
-								"key": "value",
+								"groupName": "small-group",
 							},
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Name:  "ray-head",
-									Image: "rayproject/ray:2.4.0",
+									Name:    "ray-worker",
+									Image:   "rayproject/ray:2.4.0",
+									Command: []string{"echo"},
+									Args:    []string{"Hello Ray"},
 									Env: []corev1.EnvVar{
 										{
 											Name: "MY_POD_IP",
@@ -82,28 +149,10 @@ var _ = Context("Inside the default namespace", func() {
 											},
 										},
 									},
-									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("2Gi"),
-										},
-										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
-											corev1.ResourceMemory: resource.MustParse("2Gi"),
-										},
-									},
 									Ports: []corev1.ContainerPort{
 										{
-											Name:          "gcs-server",
-											ContainerPort: 6379,
-										},
-										{
-											Name:          "dashboard",
-											ContainerPort: 8265,
-										},
-										{
-											Name:          "head",
-											ContainerPort: 10001,
+											Name:          "client",
+											ContainerPort: 80,
 										},
 										{
 											Name:          "dashboard-agent",
@@ -115,60 +164,15 @@ var _ = Context("Inside the default namespace", func() {
 						},
 					},
 				},
-				WorkerGroupSpecs: []rayiov1alpha1.WorkerGroupSpec{
-					{
-						Replicas:    pointer.Int32(3),
-						MinReplicas: pointer.Int32(0),
-						MaxReplicas: pointer.Int32(10000),
-						GroupName:   "small-group",
-						RayStartParams: map[string]string{
-							"port":                        "6379",
-							"num-cpus":                    "1",
-							"dashboard-agent-listen-port": "52365",
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "default",
-								Labels: map[string]string{
-									"groupName": "small-group",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name:    "ray-worker",
-										Image:   "rayproject/ray:2.4.0",
-										Command: []string{"echo"},
-										Args:    []string{"Hello Ray"},
-										Env: []corev1.EnvVar{
-											{
-												Name: "MY_POD_IP",
-												ValueFrom: &corev1.EnvVarSource{
-													FieldRef: &corev1.ObjectFieldSelector{
-														FieldPath: "status.podIP",
-													},
-												},
-											},
-										},
-										Ports: []corev1.ContainerPort{
-											{
-												Name:          "client",
-												ContainerPort: 80,
-											},
-											{
-												Name:          "dashboard-agent",
-												ContainerPort: 52365,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 		},
-	}
+	},
+}
+
+var _ = Context("Inside the default namespace", func() {
+	ctx := context.TODO()
+	myRayJob := myRayJob.DeepCopy()
+	myRayJob.Name = "rayjob-test-default"
 
 	Describe("When creating a rayjob", func() {
 		It("should create a rayjob object", func() {
@@ -192,14 +196,46 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayCluster  = %v", myRayCluster.Name)
 		})
 
-		It("should create more than 1 worker", func() {
-			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayJob.Status.RayClusterName, common.RayNodeGroupLabelKey: "small-group"}
+		It("Should create a number of workers equal to the replica setting", func() {
+			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayJob.Status.RayClusterName, common.RayNodeGroupLabelKey: myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName}
 			workerPods := corev1.PodList{}
 			Eventually(
 				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
-				time.Second*15, time.Millisecond*500).Should(Equal(3), fmt.Sprintf("workerGroup %v", workerPods.Items))
-			if len(workerPods.Items) > 0 {
-				Expect(workerPods.Items[0].Status.Phase).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))
+				time.Second*15, time.Millisecond*500).Should(Equal(int(*myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas)), fmt.Sprintf("workerGroup %v", workerPods.Items))
+			for _, workerPod := range workerPods.Items {
+				Expect(workerPod.Status.Phase).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))
+			}
+		})
+
+		// If in-tree autoscaling is disabled, the user should be able to update the replica settings.
+		// This test verifies that the RayJob controller correctly updates the replica settings and increases the number of workers in this scenario.
+		It("should increase number of worker pods by updating RayJob", func() {
+			Eventually(
+				getRayClusterNameForRayJob(ctx, myRayJob),
+				time.Second*15, time.Millisecond*500).Should(Not(BeEmpty()), "My RayCluster name  = %v", myRayJob.Status.RayClusterName)
+
+			myRayCluster := &rayiov1alpha1.RayCluster{}
+			Eventually(
+				getResourceFunc(ctx, client.ObjectKey{Name: myRayJob.Status.RayClusterName, Namespace: "default"}, myRayCluster),
+				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayCluster  = %v", myRayCluster.Name)
+
+			newReplicas := *myRayCluster.Spec.WorkerGroupSpecs[0].Replicas + 1
+
+			// simulate updating the RayJob directly.
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				*myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas = newReplicas
+				return k8sClient.Update(ctx, myRayJob)
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to update RayJob")
+
+			// confirm the number of worker pods increased.
+			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayJob.Status.RayClusterName, common.RayNodeGroupLabelKey: myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName}
+			workerPods := corev1.PodList{}
+			Eventually(
+				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
+				time.Second*15, time.Millisecond*500).Should(Equal(int(newReplicas)), fmt.Sprintf("workerGroup %v", workerPods.Items))
+			for _, workerPod := range workerPods.Items {
+				Expect(workerPod.Status.Phase).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))
 			}
 		})
 
@@ -215,7 +251,7 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*15, time.Millisecond*500).Should(Not(BeEmpty()), "My RayCluster name  = %v", myRayJob.Status.RayClusterName)
 			myRayJobWithClusterSelector := &rayiov1alpha1.RayJob{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "rayjob-test-2",
+					Name:      "rayjob-test-default-2",
 					Namespace: "default",
 				},
 				Spec: rayiov1alpha1.RayJobSpec{
@@ -231,6 +267,107 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				getRayClusterNameForRayJob(ctx, myRayJobWithClusterSelector),
 				time.Second*15, time.Millisecond*500).Should(Equal(myRayJob.Status.RayClusterName))
+		})
+	})
+})
+
+var _ = Context("Inside the default namespace with autoscaler", func() {
+	ctx := context.TODO()
+	myRayJob := myRayJob.DeepCopy()
+	myRayJob.Name = "rayjob-test-with-autoscaler"
+	upscalingMode := rayiov1alpha1.UpscalingMode("Default")
+	imagePullPolicy := corev1.PullPolicy("IfNotPresent")
+	myRayJob.Spec.RayClusterSpec.EnableInTreeAutoscaling = pointer.BoolPtr(true)
+	myRayJob.Spec.RayClusterSpec.AutoscalerOptions = &rayiov1alpha1.AutoscalerOptions{
+		UpscalingMode:      &upscalingMode,
+		IdleTimeoutSeconds: pointer.Int32(1),
+		ImagePullPolicy:    &imagePullPolicy,
+	}
+
+	Describe("When creating a rayjob", func() {
+		It("should create a rayjob object", func() {
+			err := k8sClient.Create(ctx, myRayJob)
+			Expect(err).NotTo(HaveOccurred(), "failed to create test RayJob resource")
+		})
+
+		It("should see a rayjob object", func() {
+			Eventually(
+				getResourceFunc(ctx, client.ObjectKey{Name: myRayJob.Name, Namespace: "default"}, myRayJob),
+				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayJob  = %v", myRayJob.Name)
+		})
+
+		// if In-tree autoscaling is enabled,  the autoscaler should adjust the number of replicas based on the workload.
+		// This test emulates the behavior of the autoscaler by directly updating the RayCluster and verifying if the number of worker pods increases accordingly.
+		It("should create new worker since autoscaler increases the replica", func() {
+			Eventually(
+				getRayClusterNameForRayJob(ctx, myRayJob),
+				time.Second*15, time.Millisecond*500).Should(Not(BeEmpty()), "My RayCluster name  = %v", myRayJob.Status.RayClusterName)
+
+			myRayCluster := &rayiov1alpha1.RayCluster{}
+			Eventually(
+				getResourceFunc(ctx, client.ObjectKey{Name: myRayJob.Status.RayClusterName, Namespace: "default"}, myRayCluster),
+				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayCluster  = %v", myRayCluster.Name)
+
+			// simulate autoscaler by updating the RayCluster directly. Note that the autoscaler
+			// will not update the RayJob directly.
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				Eventually(
+					getResourceFunc(ctx, client.ObjectKey{Name: myRayJob.Status.RayClusterName, Namespace: "default"}, myRayCluster),
+					time.Second*3, time.Millisecond*500).Should(BeNil(), "Active RayCluster = %v", myRayCluster.Name)
+				*myRayCluster.Spec.WorkerGroupSpecs[0].Replicas++
+				return k8sClient.Update(ctx, myRayCluster)
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to update RayCluster replica")
+
+			// confirm a new worker pod is created.
+			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayJob.Status.RayClusterName, common.RayNodeGroupLabelKey: myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName}
+			workerPods := corev1.PodList{}
+			Eventually(
+				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
+				time.Second*15, time.Millisecond*500).Should(Equal(int(*myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas)+1), fmt.Sprintf("workerGroup %v", workerPods.Items))
+			for _, workerPod := range workerPods.Items {
+				Expect(workerPod.Status.Phase).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))
+			}
+			// confirm RayJob controller does not revert the number of workers.
+			Consistently(
+				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
+				time.Second*5, time.Millisecond*500).Should(Equal(int(*myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas)+1), fmt.Sprintf("workerGroup %v", workerPods.Items))
+		})
+
+		// if In-tree autoscaling is enabled, only the autoscaler should update replicas to prevent race conditions
+		// between user updates and autoscaler decisions. RayJob controller should not modify the replica. Consider this scenario:
+		// 1. The autoscaler updates replicas to 10 based on the current workload.
+		// 2. The user updates replicas to 15 in the RayJob YAML file.
+		// 3. Both RayJob controller and the autoscaler attempt to update replicas, causing worker pods to be repeatedly created and terminated.
+		// This test emulates a user attempting to update the replica and verifies that the number of worker pods remains unaffected by this change.
+		It("should not increase number of workers by updating RayJob", func() {
+			Eventually(
+				getRayClusterNameForRayJob(ctx, myRayJob),
+				time.Second*15, time.Millisecond*500).Should(Not(BeEmpty()), "My RayCluster name  = %v", myRayJob.Status.RayClusterName)
+
+			myRayCluster := &rayiov1alpha1.RayCluster{}
+			Eventually(
+				getResourceFunc(ctx, client.ObjectKey{Name: myRayJob.Status.RayClusterName, Namespace: "default"}, myRayCluster),
+				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayCluster  = %v", myRayCluster.Name)
+
+			oldReplicas := *myRayCluster.Spec.WorkerGroupSpecs[0].Replicas
+
+			// simulate updating the RayJob directly.
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				*myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas = *myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas + 1
+				return k8sClient.Update(ctx, myRayJob)
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to update RayJob")
+
+			// confirm the number of worker pods is not changed.
+			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayJob.Status.RayClusterName, common.RayNodeGroupLabelKey: myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName}
+			workerPods := corev1.PodList{}
+			Consistently(
+				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
+				time.Second*5, time.Millisecond*500).Should(Equal(int(oldReplicas)), fmt.Sprintf("workerGroup %v", workerPods.Items))
+			for _, workerPod := range workerPods.Items {
+				Expect(workerPod.Status.Phase).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))
+			}
 		})
 	})
 })


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

## In short:
When submitting a Ray job to Kubernetes with the autoscaler, the following behaviors can be observed:

1. A new worker pod is created as the autoscaler increases the number of replicas.
2. An existing worker is terminated simultaneously.
3. The total number of worker pods remains equal to the original replica count.


The root cause is that both the autoscaler and the RayJob controller are trying to update the replicas, causing worker pods to be repeatedly created and terminated.

So, This PR:

1. Preventing Ray job controllers from updating the RayCluster when the autoscaler is enabled.
2.  Even when the autoscaler is not enabled, Ray job controller only modifies the replica, rather than the entire RayClusterSpec.

## Reproduce
The reproduction file can be found here: [ray_v1alpha1_rayjob.yaml](https://github.com/Yicheng-Lu-llll/kuberay/blob/tmp/ray_v1alpha1_rayjob.yaml).



I believe the root cause of the problem lies in this section of the code:

https://github.com/ray-project/kuberay/blob/3571d52d723de7135338b6d5f9a41fb9b2e972f0/ray-operator/controllers/ray/rayjob_controller.go#L379-L382




##  The sequence of events is as follows:
After `kubectl apply -f ray_v1alpha1_rayjob.yaml`:
1. RayJob operator creates a Ray cluster with 1 head pod and 1 worker pod.

2. Based on the workload (placement group in this case), the autoscaler adjusts the RayCluster replica count to 2.
3. The RayCluster operator creates a new worker pod.
4. During the reconciliation of the RayJob operator, it executes the above-mentioned code, overwriting `RayClusterInstance.Spec` with `RayJobInstance.Spec.RayClusterSpec`（The goal here is to reflect the user's update to the ray job yaml file）. As a result, the replica count reverts to its original value of 1(Replicas's type is *int32).
5. The RayCluster operator deletes an existing worker pod based on the updated replica count.
6. So, we can see "New pod did created but another pod terminated suddenly."


## Fix


From my understanding, the need to overwrite `RayClusterInstance.Spec` with` RayJobInstance.Spec.RayClusterSpec` (when a RayCluster is found) arises when users update the replicas in the Ray job YAML file, prompting the Ray job controller to adjust the replica count on their behalf.


So, the root cause stems from both the autoscaler (based on the workload) and Ray job controllers (based on the Ray job YAML file) attempting to update the replica count simultaneously. Consider these points:

1. RayCluster currently only permits replica updates; modifying other specs may cause errors.
2. When the autoscaler is enabled, users are less likely to manually adjust the replica count, as the autoscaler should adapt the replica based on workload.

So, a potential solution to address this issue is:

1. Preventing Ray job controllers from updating the RayCluster when the autoscaler is enabled.
2.  Even when the autoscaler is not enabled, Ray job controllers should only modify the replica, rather than the entire RayClusterSpec.





<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #532
<!-- For example: "Closes #1234" -->

## Checks
Most tests are incorporated in the CI. Additionally, I've conducted manual testing for the following cases.

**_I can confirm all the below cases will work._**

- [x] Case1: With in-tree autoscaling is disabled, user(RayJob controller) should be able to update the replica.

- [x] Case2: With in-tree autoscaling disabled, if users update specs other than the replica, The following log message should be displayed:

```log
2023-05-19T01:05:10.326Z        INFO    controllers.RayJob      RayJob supports replica changes only. Adjustments made to other specs will be disregarded as they may cause unexpected behavior
```


- [x] Case3: With in-tree autoscaling is enabled, the autoscaler should be able to adjust the number of workers based on the workload. The RayJob controller should not be able to change RayJob and  propagate to the RayCluster. The following log message should be displayed:

```log
2023-05-19T01:08:28.652Z        INFO    controllers.RayJob      Since in-tree autoscaling is enabled, any adjustments made to the RayJob will be disregarded and will not be propagated to the RayCluster.
```

- [x] Case4: With RayClusterSpec empty and ClusterSelector set, an existing Ray cluster should be used. The following log message should be displayed:

```log
2023-05-19T01:14:23.429Z        INFO    controllers.RayJob      ClusterSelector is being used to select an existing RayCluster. RayClusterSpec will be disregarded      {"raycluster": "default/raycluster-autoscaler"}
```

- [x] Case5: With both RayClusterSpec and ClusterSelector are set, an existing Ray cluster should be used RayClusterSpec should be ignored. The RayJob controller should not be able to change RayJob and  propagate to the **existing** RayCluster.  The following log message should be displayed:

```log
2023-05-19T01:19:05.363Z        INFO    controllers.RayJob      ClusterSelector is being used to select an existing RayCluster. RayClusterSpec will be disregarded      {"raycluster": "default/raycluster-autoscaler"}
```

- [x] Case6: With both RayClusterSpec and ClusterSelector are unset, The following error message should be displayed:

```log
2023-05-19T01:22:12.162Z        ERROR   controllers.RayJob      Failed to configure RayCluster instance due to missing configuration    {"error": "Both ClusterSelector and RayClusterSpec are undefined"}
```
