### PR TITLE
RayService object's Status is being updated due to frequent reconciliation

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -266,12 +266,12 @@ func (r *RayServiceReconciler) inconsistentRayServiceStatuses(oldStatus rayv1alp
 	}
 
 	if r.inconsistentRayServiceStatus(oldStatus.ActiveServiceStatus, newStatus.ActiveServiceStatus) {
-		r.Log.Info(fmt.Sprintf("inconsistentRayServiceStatus RayService ActiveServiceStatus changed"))
+		r.Log.Info("inconsistentRayServiceStatus RayService ActiveServiceStatus changed")
 		return true
 	}
 
 	if r.inconsistentRayServiceStatus(oldStatus.PendingServiceStatus, newStatus.PendingServiceStatus) {
-		r.Log.Info(fmt.Sprintf("inconsistentRayServiceStatus RayService PendingServiceStatus changed"))
+		r.Log.Info("inconsistentRayServiceStatus RayService PendingServiceStatus changed")
 		return true
 	}
 

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -223,6 +223,10 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
 }
 
+// Checks whether the old and new RayServiceStatus are inconsistent by comparing different fields.
+// If the only differences between the old and new status are the LastUpdateTime and HealthLastUpdateTime fields,
+// the status update will not be triggered.
+// The RayClusterStatus field is only for observability in RayService CR, and changes to it will not trigger the status update.
 func (r *RayServiceReconciler) inconsistentRayServiceStatus(oldStatus rayv1alpha1.RayServiceStatus, newStatus rayv1alpha1.RayServiceStatus) bool {
 	if oldStatus.RayClusterName != newStatus.RayClusterName {
 		r.Log.Info(fmt.Sprintf("inconsistentRayServiceStatus RayService RayClusterName changed from %s to %s", oldStatus.RayClusterName, newStatus.RayClusterName))

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -215,7 +215,7 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	// Final status update for any CR modification.
 	if r.inconsistentRayServiceStatuses(originalRayServiceInstance.Status, rayServiceInstance.Status) {
 		if errStatus := r.Status().Update(ctx, rayServiceInstance); errStatus != nil {
-			logger.Error(errStatus, "Fail to update status of RayService", "rayServiceInstance", rayServiceInstance)
+			logger.Error(errStatus, "Failed to update RayService status", "rayServiceInstance", rayServiceInstance)
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
 		}
 	}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -125,7 +125,6 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	// Check if we need to create pending RayCluster.
 	if rayServiceInstance.Status.PendingServiceStatus.RayClusterName != "" && pendingRayClusterInstance == nil {
 		// Update RayService Status since reconcileRayCluster may mark RayCluster restart.
-		r.Log.Info("r.Status().Update() Update RayService Status since reconcileRayCluster may mark RayCluster restart.")
 		if errStatus := r.Status().Update(ctx, rayServiceInstance); errStatus != nil {
 			logger.Error(errStatus, "Fail to update status of RayService after RayCluster changes", "rayServiceInstance", rayServiceInstance)
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
@@ -215,7 +214,6 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 
 	// Final status update for any CR modification.
 	if r.inconsistentRayServiceStatuses(originalRayServiceInstance.Status, rayServiceInstance.Status) {
-		r.Log.Info("r.Status().Update() Final status update for any CR modification.")
 		if errStatus := r.Status().Update(ctx, rayServiceInstance); errStatus != nil {
 			logger.Error(errStatus, "Fail to update status of RayService", "rayServiceInstance", rayServiceInstance)
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
@@ -259,6 +257,7 @@ func (r *RayServiceReconciler) inconsistentRayServiceStatus(oldStatus rayv1alpha
 	return false
 }
 
+// Determine whether to update the status of the RayService instance.
 func (r *RayServiceReconciler) inconsistentRayServiceStatuses(oldStatus rayv1alpha1.RayServiceStatuses, newStatus rayv1alpha1.RayServiceStatuses) bool {
 	if oldStatus.ServiceStatus != newStatus.ServiceStatus {
 		r.Log.Info(fmt.Sprintf("inconsistentRayServiceStatus RayService ServiceStatus changed from %s to %s", oldStatus.ServiceStatus, newStatus.ServiceStatus))
@@ -307,7 +306,6 @@ func (r *RayServiceReconciler) getRayServiceInstance(ctx context.Context, reques
 
 func (r *RayServiceReconciler) updateState(ctx context.Context, rayServiceInstance *rayv1alpha1.RayService, status rayv1alpha1.ServiceStatus, err error) error {
 	rayServiceInstance.Status.ServiceStatus = status
-	r.Log.Info("r.Status().Update() updateState", "error", err)
 	if errStatus := r.Status().Update(ctx, rayServiceInstance); errStatus != nil {
 		return fmtErrors.Errorf("combined error: %v %v", err, errStatus)
 	}
@@ -941,7 +939,6 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 		r.Recorder.Event(rayServiceInstance, "Normal", "Running", "The Serve applicaton is now running and healthy.")
 	} else if isHealthy && !isReady {
 		rayServiceInstance.Status.ServiceStatus = rayv1alpha1.WaitForServeDeploymentReady
-		r.Log.Info("r.Status().Update() isHealthy && !isReady")
 		if err := r.Status().Update(ctx, rayServiceInstance); err != nil {
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, true, false, err
 		}
@@ -950,7 +947,6 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 		// NOTE: When isHealthy is false, isReady is guaranteed to be false.
 		r.markRestart(rayServiceInstance)
 		rayServiceInstance.Status.ServiceStatus = rayv1alpha1.Restarting
-		r.Log.Info("r.Status().Update() !isHealthy")
 		if err := r.Status().Update(ctx, rayServiceInstance); err != nil {
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, false, false, err
 		}

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -398,7 +398,6 @@ var _ = Context("Inside the default namespace", func() {
 			// Only update the LastUpdateTime and HealthLastUpdateTime fields in the active RayCluster.
 			oldTime := myRayService.Status.ActiveServiceStatus.ServeStatuses[0].HealthLastUpdateTime.DeepCopy()
 			newTime := oldTime.Add(time.Duration(5) * time.Minute) // 300 seconds
-			fmt.Printf("!!!!!!oldTime = %v, newTime = %v\n", oldTime, newTime)
 			fakeRayDashboardClient.SetServeStatus(generateServeStatus(metav1.NewTime(newTime), "UNHEALTHY"))
 
 			// Confirm not switch to a new RayCluster because ServiceUnhealthySecondThreshold is 500 seconds.

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -382,6 +382,95 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*15, time.Millisecond*500).Should(Equal(initialPendingClusterName), "New active RayCluster name = %v", myRayService.Status.ActiveServiceStatus.RayClusterName)
 		})
 
+		It("Status should be updated if the differences are not only LastUpdateTime and HealthLastUpdateTime fields.", func() {
+			// Make sure (1) Dashboard client is healthy (2) All the three Ray Serve deployments in the active RayCluster are HEALTHY.
+			initialClusterName, _ := getRayClusterNameFunc(ctx, myRayService)()
+			Eventually(
+				checkServiceHealth(ctx, myRayService),
+				time.Second*3, time.Millisecond*500).Should(BeTrue(), "myRayService status = %v", myRayService.Status)
+
+			// ServiceUnhealthySecondThreshold is a global variable in rayservice_controller.go.
+			// If the time elapsed since the last update of the service HEALTHY status exceeds ServiceUnhealthySecondThreshold seconds,
+			// the RayService controller will consider the active RayCluster as unhealthy and prepare a new RayCluster.
+			orignalServeDeploymentUnhealthySecondThreshold := ServiceUnhealthySecondThreshold
+			ServiceUnhealthySecondThreshold = 500
+
+			// Only update the LastUpdateTime and HealthLastUpdateTime fields in the active RayCluster.
+			oldTime := myRayService.Status.ActiveServiceStatus.ServeStatuses[0].HealthLastUpdateTime.DeepCopy()
+			newTime := oldTime.Add(time.Duration(5) * time.Minute) // 300 seconds
+			fmt.Printf("!!!!!!oldTime = %v, newTime = %v\n", oldTime, newTime)
+			fakeRayDashboardClient.SetServeStatus(generateServeStatus(metav1.NewTime(newTime), "UNHEALTHY"))
+
+			// Confirm not switch to a new RayCluster because ServiceUnhealthySecondThreshold is 500 seconds.
+			Consistently(
+				getRayClusterNameFunc(ctx, myRayService),
+				time.Second*3, time.Millisecond*500).Should(Equal(initialClusterName), "Active RayCluster name = %v", myRayService.Status.ActiveServiceStatus.RayClusterName)
+
+			// Check if all the ServeStatuses[i].Status are UNHEALTHY.
+			checkAllServeStatusesUnhealthy := func(ctx context.Context, rayService *rayiov1alpha1.RayService) bool {
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: rayService.Name, Namespace: rayService.Namespace}, rayService); err != nil {
+					return false
+				}
+				for _, serveStatus := range rayService.Status.ActiveServiceStatus.ServeStatuses {
+					if serveStatus.Status != "UNHEALTHY" {
+						return false
+					}
+				}
+				return true
+			}
+
+			// The status update not only includes the LastUpdateTime and HealthLastUpdateTime fields, but also the ServeStatuses[i].Status field.
+			// Hence, all the ServeStatuses[i].Status should be updated to UNHEALTHY.
+			//
+			// Note: LastUpdateTime/HealthLastUpdateTime will be overwritten via metav1.Now() in rayservice_controller.go.
+			// Hence, we cannot use `newTime`` to check whether the status is updated or not.
+			Eventually(
+				checkAllServeStatusesUnhealthy(ctx, myRayService),
+				time.Second*3, time.Millisecond*500).Should(BeTrue(), "myRayService status = %v", myRayService.Status)
+
+			fakeRayDashboardClient.SetServeStatus(generateServeStatus(metav1.NewTime(newTime), "HEALTHY"))
+
+			// Confirm not switch to a new RayCluster because ServiceUnhealthySecondThreshold is 500 seconds.
+			Consistently(
+				getRayClusterNameFunc(ctx, myRayService),
+				time.Second*3, time.Millisecond*500).Should(Equal(initialClusterName), "Active RayCluster name = %v", myRayService.Status.ActiveServiceStatus.RayClusterName)
+
+			// The status update not only includes the LastUpdateTime and HealthLastUpdateTime fields, but also the ServeStatuses[i].Status field.
+			// Hence, the status should be updated.
+			Eventually(
+				checkServiceHealth(ctx, myRayService),
+				time.Second*3, time.Millisecond*500).Should(BeTrue(), "myRayService status = %v", myRayService.Status)
+			ServiceUnhealthySecondThreshold = orignalServeDeploymentUnhealthySecondThreshold
+		})
+
+		It("Status should not be updated if the only differences are the LastUpdateTime and HealthLastUpdateTime fields.", func() {
+			// Make sure (1) Dashboard client is healthy (2) All the three Ray Serve deployments in the active RayCluster are HEALTHY.
+			initialClusterName, _ := getRayClusterNameFunc(ctx, myRayService)()
+			Eventually(
+				checkServiceHealth(ctx, myRayService),
+				time.Second*3, time.Millisecond*500).Should(BeTrue(), "myRayService status = %v", myRayService.Status)
+
+			// Only update the LastUpdateTime and HealthLastUpdateTime fields in the active RayCluster.
+			oldTime := myRayService.Status.ActiveServiceStatus.ServeStatuses[0].HealthLastUpdateTime.DeepCopy()
+			newTime := oldTime.Add(time.Duration(5) * time.Minute) // 300 seconds
+			fakeRayDashboardClient.SetServeStatus(generateServeStatus(metav1.NewTime(newTime), "HEALTHY"))
+
+			// Confirm not switch to a new RayCluster
+			Consistently(
+				getRayClusterNameFunc(ctx, myRayService),
+				time.Second*3, time.Millisecond*500).Should(Equal(initialClusterName), "Active RayCluster name = %v", myRayService.Status.ActiveServiceStatus.RayClusterName)
+
+			// The status is still the same as before.
+			Eventually(
+				checkServiceHealth(ctx, myRayService),
+				time.Second*3, time.Millisecond*500).Should(BeTrue(), "myRayService status = %v", myRayService.Status)
+
+			// Status should not be updated if the only differences are the LastUpdateTime and HealthLastUpdateTime fields.
+			// Unlike the test "Status should be updated if the differences are not only LastUpdateTime and HealthLastUpdateTime fields.",
+			// the status update will not be triggered, so we can check whether the LastUpdateTime/HealthLastUpdateTime fields are updated or not by `oldTime`.
+			Expect(myRayService.Status.ActiveServiceStatus.ServeStatuses[0].HealthLastUpdateTime).Should(Equal(oldTime), "myRayService status = %v", myRayService.Status)
+		})
+
 		It("Update workerGroup.replicas in RayService and should not switch to new Ray Cluster", func() {
 			// Certain field updates should not trigger new RayCluster preparation, such as updates
 			// to `Replicas` and `WorkersToDelete` triggered by the autoscaler during scaling up/down.

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -6,7 +6,9 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func TestGenerateRayClusterJsonHash(t *testing.T) {
@@ -59,4 +61,116 @@ func TestCompareRayClusterJsonHash(t *testing.T) {
 	equal, err = compareRayClusterJsonHash(cluster1.Spec, cluster1.Spec)
 	assert.Nil(t, err)
 	assert.True(t, equal)
+}
+
+func TestInconsistentRayServiceStatuses(t *testing.T) {
+	r := &RayServiceReconciler{
+		Log: ctrl.Log.WithName("controllers").WithName("RayService"),
+	}
+
+	timeNow := metav1.Now()
+	oldStatus := v1alpha1.RayServiceStatuses{
+		ActiveServiceStatus: v1alpha1.RayServiceStatus{
+			RayClusterName: "new-cluster",
+			DashboardStatus: v1alpha1.DashboardStatus{
+				IsHealthy:            true,
+				LastUpdateTime:       &timeNow,
+				HealthLastUpdateTime: &timeNow,
+			},
+			ApplicationStatus: v1alpha1.AppStatus{
+				Status:               "running",
+				Message:              "OK",
+				LastUpdateTime:       &timeNow,
+				HealthLastUpdateTime: &timeNow,
+			},
+			ServeStatuses: []v1alpha1.ServeDeploymentStatus{
+				{
+					Name:                 "serve-1",
+					Status:               "unhealthy",
+					Message:              "error",
+					LastUpdateTime:       &timeNow,
+					HealthLastUpdateTime: &timeNow,
+				},
+			},
+		},
+		PendingServiceStatus: v1alpha1.RayServiceStatus{
+			RayClusterName: "old-cluster",
+			DashboardStatus: v1alpha1.DashboardStatus{
+				IsHealthy:            true,
+				LastUpdateTime:       &timeNow,
+				HealthLastUpdateTime: &timeNow,
+			},
+			ApplicationStatus: v1alpha1.AppStatus{
+				Status:               "stopped",
+				Message:              "stopped",
+				LastUpdateTime:       &timeNow,
+				HealthLastUpdateTime: &timeNow,
+			},
+			ServeStatuses: []v1alpha1.ServeDeploymentStatus{
+				{
+					Name:                 "serve-1",
+					Status:               "healthy",
+					Message:              "Serve is healthy",
+					LastUpdateTime:       &timeNow,
+					HealthLastUpdateTime: &timeNow,
+				},
+			},
+		},
+		ServiceStatus: v1alpha1.WaitForDashboard,
+	}
+
+	// Test 1: Update ServiceStatus only.
+	newStatus := oldStatus.DeepCopy()
+	newStatus.ServiceStatus = v1alpha1.WaitForServeDeploymentReady
+	assert.True(t, r.inconsistentRayServiceStatuses(oldStatus, *newStatus))
+
+	// Test 2: Test RayServiceStatus
+	newStatus = oldStatus.DeepCopy()
+	newStatus.ActiveServiceStatus.DashboardStatus.LastUpdateTime = &metav1.Time{Time: timeNow.Add(1)}
+	assert.False(t, r.inconsistentRayServiceStatuses(oldStatus, *newStatus))
+
+	newStatus.ActiveServiceStatus.DashboardStatus.IsHealthy = !oldStatus.ActiveServiceStatus.DashboardStatus.IsHealthy
+	assert.True(t, r.inconsistentRayServiceStatuses(oldStatus, *newStatus))
+}
+
+func TestInconsistentRayServiceStatus(t *testing.T) {
+	timeNow := metav1.Now()
+	oldStatus := v1alpha1.RayServiceStatus{
+		RayClusterName: "cluster-1",
+		DashboardStatus: v1alpha1.DashboardStatus{
+			IsHealthy:            true,
+			LastUpdateTime:       &timeNow,
+			HealthLastUpdateTime: &timeNow,
+		},
+		ApplicationStatus: v1alpha1.AppStatus{
+			Status:               "running",
+			Message:              "Application is running",
+			LastUpdateTime:       &timeNow,
+			HealthLastUpdateTime: &timeNow,
+		},
+		ServeStatuses: []v1alpha1.ServeDeploymentStatus{
+			{
+				Name:                 "serve-1",
+				Status:               "healthy",
+				Message:              "Serve is healthy",
+				LastUpdateTime:       &timeNow,
+				HealthLastUpdateTime: &timeNow,
+			},
+		},
+	}
+
+	r := &RayServiceReconciler{
+		Log: ctrl.Log.WithName("controllers").WithName("RayService"),
+	}
+
+	// Test 1: Only LastUpdateTime and HealthLastUpdateTime are updated.
+	newStatus := oldStatus.DeepCopy()
+	newStatus.DashboardStatus.LastUpdateTime = &metav1.Time{Time: timeNow.Add(1)}
+	assert.False(t, r.inconsistentRayServiceStatus(oldStatus, *newStatus))
+
+	// Test 2: Not only LastUpdateTime and HealthLastUpdateTime are updated.
+	newStatus = oldStatus.DeepCopy()
+	newStatus.DashboardStatus.LastUpdateTime = &metav1.Time{Time: timeNow.Add(1)}
+	newStatus.DashboardStatus.IsHealthy = !oldStatus.DashboardStatus.IsHealthy
+	assert.True(t, r.inconsistentRayServiceStatus(oldStatus, *newStatus))
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The experiment result in #1062 shows that `r.Status().Update()` occurred 48 times during the RayCluster initialization phase and 239 times after the RayCluster completed the initialization process within 10 minutes. Hence, this PR mainly focuses on relieving the frequent status update caused by `r.Status().Update() Final status update for any CR modification.`.

The root cause is that `r.Status().Update()` is called at the end of the function `Reconcile` no matter whether it should be updated or not. The frequent status update will hurt the performance of the Kubernetes cluster. 

Refer to the source code of [ReplicaSet](https://sourcegraph.com/github.com/kubernetes/kubernetes@9e622d23648f4af4a12835de97484dc0e4859269/-/blob/pkg/controller/replicaset/replica_set_utils.go?L41-L48) and [StatefulSet](https://sourcegraph.com/github.com/kubernetes/kubernetes@9e622d2/-/blob/pkg/controller/statefulset/stateful_set_utils.go?L577-L586). They will check the difference between the original status and the new status to determine whether update the status or not. Hence, this PR implements a similar function `inconsistentRayServiceStatuses` to determine whether update status or not.

### Implementation of `inconsistentRayServiceStatuses`

* `inconsistentRayServiceStatuses` does not check `LastUpdateTime` and `HealthLastUpdateTime`: 
  * If the only differences between the old and new status are the LastUpdateTime and HealthLastUpdateTime fields, the status update will not be triggered. 
  * RayService controller will use  `HealthLastUpdateTime` to determine whether the RayService is healthy or not ([example](https://github.com/ray-project/kuberay/blob/974bedf4fba32ca38d025c44304b2ef7abb22500/ray-operator/controllers/ray/rayservice_controller.go#L619)). If the RayService is unhealthy, the controller will trigger a new RayCluster preparation. The controller only uses `HealthLastUpdateTime` when the status is not `HEALTHY`. Hence, it is fine to ignore the status update of `HealthLastUpdateTime`.

* `inconsistentRayServiceStatuses` ignores `RayClusterStatus`. 
  * `rayservice_controller.go` does not use any information in RayClusterStatus. It is totally for observability. 

This solution is not good enough because the status is too complicated, so I list some items in the follow-up section.

## Related issue number

Closes #1061 
#1062 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(


I performed an experiment similar to #1062, and the only difference is this experiment is 15 mins and #1062 is 10 mins. The result is (see this [gist](https://gist.github.com/kevin85421/59995d8b62516252778d6905d1b0ab1f) for more details):

Let the number of reconciliations be ***N***.

* 47 times status updates in the RayCluster initialization. => ***O(1)*** -> ***O(1)*** 
* 2 times status updates after the initialization finishes. => ***O(N)*** -> ***O(1)***
  * The second one is caused by the inconsistency between the stale informer cache and Kubernetes API Server. This is common and protected by Kubernetes OCC.

## Follow-up

* The status of RayService is too complicated. We should revisit the status design based on the principle of [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md).
* Add `observedGeneration` to the logic of `inconsistentRayServiceStatuses`.
* "47 times status updates in the RayCluster initialization." => This is definitely not good enough. I will optimize it.
* Currently, RayService determines whether to trigger a new RayCluster preparation or not based on data plane logic (i.e. Ray). This is pretty weird and makes everything very complex because Ray has already had similar functionalities. For me, the better solution will be:
  * Use readiness probe/healthiness probe on the Ray head Pod to monitor the data plane.
  * RayCluster will handle the control plane logic (i.e. unhealthy Pods)
  * GCS fault tolerance will handle the data plane logic after the Pod is up again.

* The key of the cache may not be unique in some special cases. In addition, Kubernetes operator should be stateless, but the cache means that the operator is stateful.