### PR TITLE
Align Init Container's ImagePullPolicy with Ray Container's ImagePullPolicy

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -212,7 +212,7 @@ func DefaultWorkerPodTemplate(instance rayiov1alpha1.RayCluster, workerSpec rayi
 		initContainer := v1.Container{
 			Name:            "wait-gcs-ready",
 			Image:           podTemplate.Spec.Containers[rayContainerIndex].Image,
-			ImagePullPolicy: v1.PullIfNotPresent,
+			ImagePullPolicy: podTemplate.Spec.Containers[rayContainerIndex].ImagePullPolicy,
 			Command:         []string{"/bin/bash", "-lc", "--"},
 			Args: []string{
 				fmt.Sprintf("until ray health-check --address %s:%s > /dev/null 2>&1; do echo wait for GCS to be ready; sleep 5; done", fqdnRayIP, headPort),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

According to [this discussion](https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1683240364495989), users may need to adjust the ImagePullPolicy of the init container, which is currently set to `PullIfNotPresent`.

This PR aligns the init container's ImagePullPolicy with the ImagePullPolicy of the ray container.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
None
<!-- For example: "Closes #1234" -->

## Checks

### Manual Testing Procedure:

1. Add the line `imagePullPolicy: Always` to the `workerGroupSpecs[0].template.spec.containers[0]` in the `ray-cluster.complete.yaml` file(can be found [here](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.complete.yaml))
2. 
```shell
kubectl apply -f /home/ubuntu/workspace/kuberay/ray-operator/config/samples/ray-cluster.complete.yaml
```
4. 
```shell
kubectl get pod raycluster-complete-worker-small-group-pfzbm -o yaml
```

Here is an image showing the expected output:

![Expected Output](https://github.com/ray-project/kuberay/assets/51814063/66233102-c64a-4d68-8692-1db597498c5a)
