### PR TITLE
[Bug] Service (Serve) changing port from 8000 to 9000 doesn't work

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -11784,6 +11784,8 @@ spec:
                     type: array
                   importPath:
                     type: string
+                  port:
+                    type: integer
                   runtimeEnv:
                     type: string
                 required:

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -58,6 +58,7 @@ type ServeDeploymentGraphSpec struct {
 	ImportPath       string            `json:"importPath"`
 	RuntimeEnv       string            `json:"runtimeEnv,omitempty"`
 	ServeConfigSpecs []ServeConfigSpec `json:"deployments,omitempty"`
+	Port             int               `json:"port,omitempty"`
 }
 
 // ServeConfigSpec defines the desired state of RayService

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -11784,6 +11784,8 @@ spec:
                     type: array
                   importPath:
                     type: string
+                  port:
+                    type: integer
                   runtimeEnv:
                     type: string
                 required:

--- a/ray-operator/config/samples/ray-service.different-port.yaml
+++ b/ray-operator/config/samples/ray-service.different-port.yaml
@@ -1,0 +1,99 @@
+# ray-service.different-port.yaml: By default, RayService exposes port 8000 to serve requests. This sample YAML
+# file demonstrates how to change the port to 9000. To achieve this, follow these steps:
+# (1) Modify `spec.serveConfig.port` to 9000.
+# (2) Modify the container `ray-head`'s `serve` port to 9000.
+apiVersion: ray.io/v1alpha1
+kind: RayService
+metadata:
+  name: rayservice-sample
+spec:
+  serviceUnhealthySecondThreshold: 300 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for deployments. Default value is 60.
+  serveConfig:
+    importPath: fruit.deployment_graph
+    runtimeEnv: |
+      working_dir: "https://github.com/ray-project/test_dag/archive/41d09119cbdf8450599f993f51318e9e27c59098.zip"
+    deployments:
+      - name: MangoStand
+        numReplicas: 1
+        userConfig: |
+          price: 3
+        rayActorOptions:
+          numCpus: 0.1
+      - name: OrangeStand
+        numReplicas: 1
+        userConfig: |
+          price: 2
+        rayActorOptions:
+          numCpus: 0.1
+      - name: PearStand
+        numReplicas: 1
+        userConfig: |
+          price: 1
+        rayActorOptions:
+          numCpus: 0.1
+      - name: FruitMarket
+        numReplicas: 1
+        rayActorOptions:
+          numCpus: 0.1
+      - name: DAGDriver
+        numReplicas: 1
+        routePrefix: "/"
+        rayActorOptions:
+          numCpus: 0.1
+    port: 9000
+  rayClusterConfig:
+    rayVersion: '2.4.0' # should match the Ray version in the image of the containers
+    ######################headGroupSpecs#################################
+    # Ray head pod template.
+    headGroupSpec:
+      # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
+      rayStartParams:
+        dashboard-host: '0.0.0.0'
+      #pod template
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: rayproject/ray:2.4.0
+              resources:
+                limits:
+                  cpu: 2
+                  memory: 2Gi
+                requests:
+                  cpu: 2
+                  memory: 2Gi
+              ports:
+                - containerPort: 6379
+                  name: gcs-server
+                - containerPort: 8265
+                  name: dashboard
+                - containerPort: 10001
+                  name: client
+                - containerPort: 9000
+                  name: serve
+    workerGroupSpecs:
+      # the pod replicas in this group typed worker
+      - replicas: 1
+        minReplicas: 1
+        maxReplicas: 5
+        # logical group name, for this called small-group, also can be functional
+        groupName: small-group
+        rayStartParams: {}
+        # Pod template
+        template:
+          spec:
+            containers:
+              - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+                image: rayproject/ray:2.4.0
+                lifecycle:
+                  preStop:
+                    exec:
+                      command: ["/bin/sh","-c","ray stop"]
+                resources:
+                  limits:
+                    cpu: "1"
+                    memory: "2Gi"
+                  requests:
+                    cpu: "500m"
+                    memory: "2Gi"

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -216,7 +216,7 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	if r.inconsistentRayServiceStatuses(originalRayServiceInstance.Status, rayServiceInstance.Status) {
 		if errStatus := r.Status().Update(ctx, rayServiceInstance); errStatus != nil {
 			logger.Error(errStatus, "Failed to update RayService status", "rayServiceInstance", rayServiceInstance)
-			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
+			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, errStatus
 		}
 	}
 
@@ -992,7 +992,8 @@ func (r *RayServiceReconciler) labelHealthyServePods(ctx context.Context, rayClu
 	httpProxyClient := utils.GetRayHttpProxyClientFunc()
 	httpProxyClient.InitClient()
 	for _, pod := range allPods.Items {
-		httpProxyClient.SetHostIp(pod.Status.PodIP)
+		servingPort := utils.FindRayContainerPort(&pod, common.DefaultServingPortName, common.DefaultServingPort)
+		httpProxyClient.SetHostIp(pod.Status.PodIP, servingPort)
 		if pod.Labels == nil {
 			pod.Labels = make(map[string]string)
 		}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -992,7 +992,8 @@ func (r *RayServiceReconciler) labelHealthyServePods(ctx context.Context, rayClu
 	httpProxyClient := utils.GetRayHttpProxyClientFunc()
 	httpProxyClient.InitClient()
 	for _, pod := range allPods.Items {
-		servingPort := utils.FindRayContainerPort(&pod, common.DefaultServingPortName, common.DefaultServingPort)
+		rayContainer := pod.Spec.Containers[utils.FindRayContainerIndex(pod.Spec)]
+		servingPort := utils.FindContainerPort(&rayContainer, common.DefaultServingPortName, common.DefaultServingPort)
 		httpProxyClient.SetHostIp(pod.Status.PodIP, servingPort)
 		if pod.Labels == nil {
 			pod.Labels = make(map[string]string)

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -67,10 +67,12 @@ type ServeDeploymentStatuses struct {
 }
 
 // ServingClusterDeployments defines the request sent to the dashboard api server.
+// See https://docs.ray.io/en/master/_modules/ray/serve/schema.html#ServeApplicationSchema for more details.
 type ServingClusterDeployments struct {
 	ImportPath  string                 `json:"import_path"`
 	RuntimeEnv  map[string]interface{} `json:"runtime_env,omitempty"`
 	Deployments []ServeConfigSpec      `json:"deployments,omitempty"`
+	Port        int                    `json:"port,omitempty"`
 }
 
 type RayDashboardClientInterface interface {
@@ -191,14 +193,15 @@ func (r *RayDashboardClient) GetDeployments() (string, error) {
 }
 
 // UpdateDeployments update the deployments in the Ray cluster.
-func (r *RayDashboardClient) UpdateDeployments(specs rayv1alpha1.ServeDeploymentGraphSpec) error {
+func (r *RayDashboardClient) UpdateDeployments(spec rayv1alpha1.ServeDeploymentGraphSpec) error {
 	runtimeEnv := make(map[string]interface{})
-	_ = yaml.Unmarshal([]byte(specs.RuntimeEnv), &runtimeEnv)
+	_ = yaml.Unmarshal([]byte(spec.RuntimeEnv), &runtimeEnv)
 
 	servingClusterDeployments := ServingClusterDeployments{
-		ImportPath:  specs.ImportPath,
+		ImportPath:  spec.ImportPath,
 		RuntimeEnv:  runtimeEnv,
-		Deployments: r.ConvertServeConfig(specs.ServeConfigSpecs),
+		Deployments: r.ConvertServeConfig(spec.ServeConfigSpecs),
+		Port:        spec.Port,
 	}
 
 	deploymentJson, err := json.Marshal(servingClusterDeployments)

--- a/ray-operator/controllers/ray/utils/fake_httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/fake_httpproxy_httpclient.go
@@ -21,8 +21,8 @@ func (r *FakeRayHttpProxyClient) InitClient() {
 	}
 }
 
-func (r *FakeRayHttpProxyClient) SetHostIp(hostIp string) {
-	r.httpProxyURL = fmt.Sprint("http://", hostIp, ":", DefaultHttpProxyPort)
+func (r *FakeRayHttpProxyClient) SetHostIp(hostIp string, port int) {
+	r.httpProxyURL = fmt.Sprintf("http://%s:%d", hostIp, port)
 }
 
 func (r *FakeRayHttpProxyClient) CheckHealth() error {

--- a/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
@@ -8,8 +8,7 @@ import (
 )
 
 var (
-	DefaultHttpProxyPort = 8000
-	HealthCheckPath      = "/-/healthz"
+	HealthCheckPath = "/-/healthz"
 )
 
 type RayHttpProxyClientInterface interface {

--- a/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
@@ -7,9 +7,7 @@ import (
 	"time"
 )
 
-var (
-	HealthCheckPath = "/-/healthz"
-)
+const HealthCheckPath = "/-/healthz"
 
 type RayHttpProxyClientInterface interface {
 	InitClient()

--- a/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
@@ -15,7 +15,7 @@ var (
 type RayHttpProxyClientInterface interface {
 	InitClient()
 	CheckHealth() error
-	SetHostIp(hostIp string)
+	SetHostIp(hostIp string, port int)
 }
 
 // GetRayHttpProxyClientFunc Used for unit tests.
@@ -36,8 +36,8 @@ func (r *RayHttpProxyClient) InitClient() {
 	}
 }
 
-func (r *RayHttpProxyClient) SetHostIp(hostIp string) {
-	r.httpProxyURL = fmt.Sprint("http://", hostIp, ":", DefaultHttpProxyPort)
+func (r *RayHttpProxyClient) SetHostIp(hostIp string, port int) {
+	r.httpProxyURL = fmt.Sprintf("http://%s:%d", hostIp, port)
 }
 
 func (r *RayHttpProxyClient) CheckHealth() error {

--- a/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const HealthCheckPath = "/-/healthz"
+const healthCheckPath = "/-/healthz"
 
 type RayHttpProxyClientInterface interface {
 	InitClient()
@@ -38,7 +38,7 @@ func (r *RayHttpProxyClient) SetHostIp(hostIp string, port int) {
 }
 
 func (r *RayHttpProxyClient) CheckHealth() error {
-	req, err := http.NewRequest("GET", r.httpProxyURL+HealthCheckPath, nil)
+	req, err := http.NewRequest("GET", r.httpProxyURL+healthCheckPath, nil)
 	if err != nil {
 		return err
 	}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -454,12 +454,11 @@ func GenerateJsonHash(obj interface{}) (string, error) {
 	return hashStr, nil
 }
 
-// FindRayContainerPort searches for a specific port $portName in the Ray container of a given pod.
-// If the port is found in the Ray container, the corresponding port is returned.
+// FindContainerPort searches for a specific port $portName in the container.
+// If the port is found in the container, the corresponding port is returned.
 // If the port is not found, the $defaultPort is returned instead.
-func FindRayContainerPort(pod *corev1.Pod, portName string, defaultPort int) int {
-	rayContainerIndex := FindRayContainerIndex(pod.Spec)
-	for _, port := range pod.Spec.Containers[rayContainerIndex].Ports {
+func FindContainerPort(container *corev1.Container, portName string, defaultPort int) int {
+	for _, port := range container.Ports {
 		if port.Name == portName {
 			return int(port.ContainerPort)
 		}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -453,3 +453,16 @@ func GenerateJsonHash(obj interface{}) (string, error) {
 
 	return hashStr, nil
 }
+
+// FindRayContainerPort searches for a specific port $portName in the Ray container of a given pod.
+// If the port is found in the Ray container, the corresponding port is returned.
+// If the port is not found, the $defaultPort is returned instead.
+func FindRayContainerPort(pod *corev1.Pod, portName string, defaultPort int) int {
+	rayContainerIndex := FindRayContainerIndex(pod.Spec)
+	for _, port := range pod.Spec.Containers[rayContainerIndex].Ports {
+		if port.Name == portName {
+			return int(port.ContainerPort)
+		}
+	}
+	return defaultPort
+}

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -393,3 +393,25 @@ func TestCalculateAvailableReplicas(t *testing.T) {
 	count := CalculateAvailableReplicas(podList)
 	assert.Equal(t, count, int32(1), "expect 1 available replica")
 }
+
+func TestFindContainerPort(t *testing.T) {
+	container := corev1.Container{
+		Name: "ray-head",
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "port1",
+				ContainerPort: 10001,
+			},
+			{
+				Name:          "port2",
+				ContainerPort: 10002,
+			},
+		},
+	}
+	port := FindContainerPort(&container, "port1", -1)
+	assert.NotEqual(t, port, -1, "expect port1 found")
+	port = FindContainerPort(&container, "port2", -1)
+	assert.NotEqual(t, port, -1, "expect port2 found")
+	port = FindContainerPort(&container, "port3", -1)
+	assert.Equal(t, port, -1, "expect port3 not found")
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Without this PR, users can only serve requests via port 8000.

To serve requests via another port (e.g. 9000), user needs to specify `spec.serveConfig.port` and the head Pod's `serve` port to 9000. See [RESTful API](https://docs.ray.io/en/master/serve/api/index.html#put-api-serve-deployments) and [single-application config schema](https://docs.ray.io/en/master/serve/api/doc/ray.serve.schema.ServeApplicationSchema.html#ray.serve.schema.ServeApplicationSchema) for more details.

The HTTPProxy is used to check the health condition ([code](https://sourcegraph.com/github.com/ray-project/ray@d5b470140b4d7dc5724f69d12551c42f4a4957c4/-/blob/python/ray/serve/_private/http_proxy.py?L385-L395)) of Serve deployments. If the Serve deployments are healthy, the HTTPProxy will add the label `"ray.io/serve=true"` to the Pod. Note that the selector of Kubernetes Serve service also includes `"ray.io/serve=true"`. That is, the traffic will be redirected to the Serve deployments after HTTPProxy believes that the deployments are healthy.

### Others

* Convert `HealthCheckPath` (public) into `healthCheckPath` (private) because the variable is only used by the function `CheckHealth()`.

* The [single-application config schema](https://docs.ray.io/en/master/serve/api/doc/ray.serve.schema.ServeApplicationSchema.html#ray.serve.schema.ServeApplicationSchema) indicates that `port` is an `int` in Python. However, the size of `int` type in Python depends on the underlying platform and implementation. Hence, I am unsure about which integer type to use in Golang (e.g. `int`, `int32`, `int64`). I conducted the following experiment and found that there is no difference between `int`, `int32`, and `int64` after serializing. Hence, I declare `Port` as an `int` in this PR.
  ```go
  package main
  
  import (
	  "bytes"
	  "encoding/json"
	  "fmt"
  )
  
  func main() {
	  // Define sample integer values
	  valueInt := 42
	  valueInt32 := int32(42)
	  valueInt64 := int64(42)
  
	  // Serialize int to JSON
	  jsonInt, _ := json.Marshal(valueInt)
	  fmt.Println("Serialized int:", jsonInt, string(jsonInt))
  
	  // Serialize int32 to JSON
	  jsonInt32, _ := json.Marshal(valueInt32)
	  fmt.Println("Serialized int32:", jsonInt32, string(jsonInt32))
  
	  // Serialize int64 to JSON
	  jsonInt64, _ := json.Marshal(valueInt64)
	  fmt.Println("Serialized int64:", jsonInt64, string(jsonInt64))
  
	  // Compare the byte slices
	  equal := bytes.Equal(jsonInt, jsonInt32) && bytes.Equal(jsonInt32, jsonInt64)
	  fmt.Println("Are the byte slices equal?", equal)
  }

  # STDOUT
  Serialized int: [52 50] 42
  Serialized int32: [52 50] 42
  Serialized int64: [52 50] 42
  Are the byte slices equal? true
  ```

## Related issue number
Closes #570 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
# Step 0: Build the KubeRay operator
# Step 1: Install the KubeRay operator. Note that we need to use the local Helm chart because this PR includes CRD 
changes.
# (path: helm-chart/kuberay-operator)
helm install kuberay-operator . --set image.repository=controller,image.tag=latest

# Step 2: Create a RayService (path: ray-operator/config/samples)
kubectl apply -f ray-service.different-port.yaml

# Step 3: Wait until the service `rayservice-sample-serve-svc` is created and forward the port 9000
kubectl port-forward svc/rayservice-sample-serve-svc 9000

# Step 4: Test it
curl -X POST -H 'Content-Type: application/json' localhost:9000 -d '["PEAR", 12]'
```
<img width="1178" alt="Screen Shot 2023-05-12 at 11 18 21 AM" src="https://github.com/ray-project/kuberay/assets/20109646/c906e31a-59a6-4c1c-b777-f59d251db38f">
