### PR TITLE
Highlight Redis HA Cluster Limitations for GCS Fault Tolerance

### DIFF
--- a/docs/guidance/gcs-ft.md
+++ b/docs/guidance/gcs-ft.md
@@ -8,8 +8,7 @@ without affecting important services such as detached Actors & RayServe deployme
 ### Prerequisite
 
 * Ray 2.0 is required.
-* You need to support external Redis server for Ray. (Redis HA cluster is highly recommended.)
-
+* You need to support external Redis server for Ray. Redis HA cluster is highly recommended. Please note: While a Redis cluster with a single shard and multiple replicas is supported, clusters with multiple shards are not supported. For further details about limitations of using a Redis cluster, refer to this [issue](https://github.com/ray-project/ray/issues/34015).
 ### Enable Ray GCS FT
 
 To enable Ray GCS FT in your newly KubeRay-managed Ray cluster, you need to enable it by adding an annotation to the

--- a/docs/guidance/gcs-ft.md
+++ b/docs/guidance/gcs-ft.md
@@ -8,7 +8,7 @@ without affecting important services such as detached Actors & RayServe deployme
 ### Prerequisite
 
 * Ray 2.0 is required.
-* You need to support external Redis server for Ray. Redis HA cluster is highly recommended. Please note: While a Redis cluster with a single shard and multiple replicas is supported, clusters with multiple shards are not supported. For further details about limitations of using a Redis cluster, refer to this [issue](https://github.com/ray-project/ray/issues/34015).
+* You need to support external Redis server for Ray. (Redis HA cluster is highly recommended.) Please note: While a Redis cluster with a single shard and multiple replicas is supported, clusters with multiple shards are not supported. For further details about limitations of using a Redis cluster, refer to this [issue](https://github.com/ray-project/ray/issues/34015).
 ### Enable Ray GCS FT
 
 To enable Ray GCS FT in your newly KubeRay-managed Ray cluster, you need to enable it by adding an annotation to the


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As mentioned in the slack channel, https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1683214062234029, users might attempt to use a sharded HA Redis Cluster when employing GCS Fault Tolerance. However, only Redis clusters with a single shard are supported, though they may contain multiple replicas.

In GCS Fault Tolerance doc, `Redis HA cluster is highly recommended.` might cause this misunderstanding. To prevent potential issues, this PR adds detailed notes regarding these limitations to the GCS Fault Tolerance documentation. 



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
