### PR TITLE
[WIP] Multi-namespace cache

### DIFF
--- a/helm-chart/kuberay-operator/test.yaml
+++ b/helm-chart/kuberay-operator/test.yaml
@@ -1,0 +1,906 @@
+---
+# Source: kuberay-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuberay-operator
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: kuberay-operator/templates/leader_election_role.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  name: kuberay-operator-leader-election
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+---
+# Source: kuberay-operator/templates/ray_rayjob_editor_role.yaml
+# permissions for end users to edit rayjobs.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  name: rayjob-editor-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  verbs:
+  - get
+---
+# Source: kuberay-operator/templates/ray_rayjob_viewer_role.yaml
+# permissions for end users to view rayjobs.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  name: rayjob-viewer-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  verbs:
+  - get
+---
+# Source: kuberay-operator/templates/ray_rayservice_editor_role.yaml
+# permissions for end users to edit rayservices.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rayservice-editor-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/status
+  verbs:
+  - get
+---
+# Source: kuberay-operator/templates/ray_rayservice_viewer_role.yaml
+# permissions for end users to view rayservices.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rayservice-viewer-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/status
+  verbs:
+  - get
+---
+# Source: kuberay-operator/templates/role.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  name: kuberay-operator
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+---
+# Source: kuberay-operator/templates/leader_election_role_binding.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  name: kuberay-operator-leader-election
+subjects:
+- kind: ServiceAccount
+  name: kuberay-operator
+  namespace: default
+roleRef:
+  kind: Role
+  name: kuberay-operator-leader-election
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: kuberay-operator/templates/rolebinding.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  name: kuberay-operator
+subjects:
+- kind: ServiceAccount
+  name: kuberay-operator
+  namespace: default
+roleRef:
+  kind: Role
+  name: kuberay-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: kuberay-operator/templates/leader_election_role.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  name: kuberay-operator-leader-election
+  namespace: n1
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+---
+# Source: kuberay-operator/templates/ray_rayjob_editor_role.yaml
+# permissions for end users to edit rayjobs.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  name: rayjob-editor-role
+  namespace: n1
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  verbs:
+  - get
+---
+# Source: kuberay-operator/templates/ray_rayjob_viewer_role.yaml
+# permissions for end users to view rayjobs.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  name: rayjob-viewer-role
+  namespace: n1
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  verbs:
+  - get
+---
+# Source: kuberay-operator/templates/ray_rayservice_editor_role.yaml
+# permissions for end users to edit rayservices.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rayservice-editor-role
+  namespace: n1
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/status
+  verbs:
+  - get
+---
+# Source: kuberay-operator/templates/ray_rayservice_viewer_role.yaml
+# permissions for end users to view rayservices.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rayservice-viewer-role
+  namespace: n1
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/status
+  verbs:
+  - get
+---
+# Source: kuberay-operator/templates/role.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  name: kuberay-operator
+  namespace: n1
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+---
+# Source: kuberay-operator/templates/leader_election_role_binding.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  name: kuberay-operator-leader-election
+  namespace: n1
+subjects:
+- kind: ServiceAccount
+  name: kuberay-operator
+  namespace: default
+roleRef:
+  kind: Role
+  name: kuberay-operator-leader-election
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: kuberay-operator/templates/rolebinding.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  name: kuberay-operator
+  namespace: n1
+subjects:
+- kind: ServiceAccount
+  name: kuberay-operator
+  namespace: default
+roleRef:
+  kind: Role
+  name: kuberay-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: kuberay-operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kuberay-operator
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: kuberay-operator
+    app.kubernetes.io/instance: release-name
+---
+# Source: kuberay-operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuberay-operator
+  labels:
+    app.kubernetes.io/name: kuberay-operator
+    helm.sh/chart: kuberay-operator-0.5.0
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kuberay-operator
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kuberay-operator
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/component: kuberay-operator
+    spec:
+      serviceAccountName: kuberay-operator
+      volumes: []
+      securityContext:
+        null
+      containers:
+        - name: kuberay-operator
+          securityContext:
+            {}
+          # image: "kuberay/operator:nightly"
+          image: "controller:latest"
+          imagePullPolicy: IfNotPresent
+          volumeMounts: []
+          command:
+            - /manager
+          args:
+            []
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            null
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 5
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -125,7 +125,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "ray-operator-leader",
-		NewCache:               cache.MultiNamespacedCacheBuilder([]string{"default"}),
+		NewCache:               cache.MultiNamespacedCacheBuilder([]string{"default", "n1"}),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler"
 
 	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -124,7 +125,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "ray-operator-leader",
-		Namespace:              watchNamespace,
+		NewCache:               cache.MultiNamespacedCacheBuilder([]string{"default"}),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```sh
# Step 0: Build the KubeRay image (controller:latest) (path: ray-operator/)
make docker-image

# Step 1: Create a Kind cluster and load the image into the cluster
kind create cluster --image=kindest/node:v1.23.0
kind load docker-image controller:latest

# Step 2: Install CRD (path: kuberay/)
kubectl create -k manifests/cluster-scope-resources

# Step 3: Create namespace n1 and n2.
kubectl create ns n1
kubectl create ns n2

# Step 4: Install a KubeRay operator with the image `controller:latest` and RBAC for namespace `default` and `n1`.
kubectl apply -f test.yaml

# Step 5: Create a RayCluster in `default` namespace (1 head Pod and 1 worker Pod will be created.)
helm install raycluster kuberay/ray-cluster --version 0.5.1

# Step 6: Create a RayCluster in `n1` namespace (1 head Pod and 1 worker Pod will be created.)
helm install raycluster kuberay/ray-cluster --version 0.5.1 -n n1

# Step 7: Create a RayCluster in `n2` namespace (nothing will be created)
helm install raycluster kuberay/ray-cluster --version 0.5.1 -n n2
```



## main.go

```go
	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
		Scheme:                 scheme,
		MetricsBindAddress:     metricsAddr,
		Port:                   9443,
		HealthProbeBindAddress: probeAddr,
		LeaderElection:         enableLeaderElection,
		LeaderElectionID:       "ray-operator-leader",
		Namespace:              watchNamespace,
	})
```

Based on [this doc](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.6/pkg/manager#Options), if `Namespace` is specified, restricts the manager's cache to watch objects in the desired namespace. If the field is not specified, it defaults to all namespaces. However, we only have the permissions to watch the resources in namespace `default` and `n1`. To achieve that, we can use `MultiNamespacedCache`. See [this example](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.6/pkg/manager#example-New-MultinamespaceCache) and [this doc](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cache?utm_source=godoc#MultiNamespacedCacheBuilder) for more details. 

## Test RayService

```sh
# Step 0: Build the KubeRay image (controller:latest) (path: ray-operator/)
make docker-image

# Step 1: Create a Kind cluster and load the image into the cluster
kind create cluster --image=kindest/node:v1.23.0
kind load docker-image controller:latest

# Step 2: Install CRD (path: kuberay/)
kubectl create -k manifests/cluster-scope-resources

# Step 3: Create namespace n1 and n2.
kubectl create ns n1
kubectl create ns n2

# Step 4: Install a KubeRay operator with the image `controller:latest` and RBAC for namespace `default` and `n1`.
kubectl apply -f test.yaml

# Step 5: Create a RayService in `default` namespace (1 head Pod and 1 worker Pod will be created.)
# (path: ray-operator/config/samples)
kubectl apply -f ray_v1alpha1_rayservice.yaml

# Step 6: Create a RayCluster in `n1` namespace (1 head Pod and 1 worker Pod will be created.)
# (path: ray-operator/config/samples)
kubectl apply -f ray_v1alpha1_rayservice.yaml -n n1

# Step 7: Create a RayCluster in `n2` namespace (nothing will be created)
# (path: ray-operator/config/samples)
kubectl apply -f ray_v1alpha1_rayservice.yaml -n n2
```
<img width="1395" alt="Screen Shot 2023-05-17 at 10 06 00 AM" src="https://github.com/ray-project/kuberay/assets/20109646/80c3204a-8538-4ace-8e5c-ad7dcb9e073a">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
