### PR TITLE
[Bug] Fix null map handling in `BuildServiceForHeadPod` function

### DIFF
--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -70,6 +70,9 @@ func BuildServiceForHeadPod(cluster rayiov1alpha1.RayCluster, labels map[string]
 
 		// For the Labels field, merge labels_for_service with custom HeadService labels.
 		// If there are overlaps, ignore the custom HeadService labels.
+		if headService.ObjectMeta.Labels == nil {
+			headService.ObjectMeta.Labels = make(map[string]string)
+		}
 		for k, v := range labels_for_service {
 			headService.ObjectMeta.Labels[k] = v
 		}
@@ -79,6 +82,9 @@ func BuildServiceForHeadPod(cluster rayiov1alpha1.RayCluster, labels map[string]
 
 		// Merge annotations with custom HeadService annotations. If there are overlaps,
 		// ignore the custom HeadService annotations.
+		if headService.ObjectMeta.Annotations == nil {
+			headService.ObjectMeta.Annotations = make(map[string]string)
+		}
 		for k, v := range annotations {
 			// if the key is present, log a warning message
 			if _, ok := headService.ObjectMeta.Annotations[k]; ok {

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -374,6 +374,21 @@ func TestUserSpecifiedHeadService(t *testing.T) {
 	}
 }
 
+func TestNilMapDoesntErrorInUserSpecifiedHeadService(t *testing.T) {
+	// Use any RayCluster instance as a base for the test.
+	testRayClusterWithHeadService := instanceWithWrongSvc.DeepCopy()
+
+	// Set user-specified head service with many nil fields.
+	testRayClusterWithHeadService.Spec.HeadGroupSpec.HeadService = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{},
+	}
+
+	_, err := BuildServiceForHeadPod(*testRayClusterWithHeadService, nil, nil)
+	if err != nil {
+		t.Errorf("failed to build head service: %v", err)
+	}
+}
+
 func TestBuildServiceForHeadPodPortsOrder(t *testing.T) {
 	svc1, err1 := BuildServiceForHeadPod(*instanceWithWrongSvc, nil, nil)
 	svc2, err2 := BuildServiceForHeadPod(*instanceWithWrongSvc, nil, nil)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR addresses a bug in the `BuildServiceForHeadPod` function where a nil map was not properly handled when building the head service for a Ray cluster. This caused a panic when attempting to add labels and annotations to uninitialized maps.

Changes include:
1. A fix in the `BuildServiceForHeadPod` function to correctly initialize the `Labels` and `Annotations` maps if they are nil. 
2. A unit test that specifically tests the scenario of nil maps in the input `HeadService`. 

With this fix, the function can safely handle nil maps and ensures that the `Labels` and `Annotations` of the head service are always properly initialized, which prevents runtime errors when attempting to modify these maps.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
