### PR TITLE
Fix for Sample YAML Config Test - 2.4.0 Failure due to 'suspend' Field 

### DIFF
--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -3,7 +3,6 @@ kind: RayJob
 metadata:
   name: rayjob-sample
 spec:
-  suspend: false
   entrypoint: python /home/ray/samples/sample_code.py
   # runtimeEnv decoded to '{
   #    "pip": [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed? 
https://github.com/ray-project/kuberay/pull/926 adds the `suspend: false` field to `ray_v1alpha1_rayjob.yaml`. However, since this field is new and not present in the CRD of kuberay/operator:v0.5.0, it would compromise backwards compatibility.

We need to ensure that sample files function with both the 0.5.0 and nightly versions, so we shouldn't add `suspend: false `now, but only after the 0.6.0 release.


The failure can  be reproduced:
1. introducing `suspend: false` will cause the Sample YAML Config Test - 2.4.0 to consistently fail :
```
error: error validating "/home/runner/work/kuberay/kuberay/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml": error validating data: ValidationError(RayJob.spec): unknown field "suspend" in io.ray.v1alpha1.RayJob.spec; if you choose to ignore these errors, turn validation off with --validate=false
```

https://github.com/ray-project/kuberay/actions/runs/4995614782/jobs/8947869834
https://github.com/ray-project/kuberay/actions/runs/5008264539/jobs/8976078708

2.  current `ray_v1alpha1_rayjob.yaml` is not compatible with `kuberay/operator:v0.5.0`. 
```shell
kind delete cluster
kind create cluster --image=kindest/node:v1.24.0
helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0
kubectl apply -f kuberay/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
```
```
error: error validating "/home/ubuntu/workspace/kuberay/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml": error validating data: ValidationError(RayJob.spec): unknown field "suspend" in io.ray.v1alpha1.RayJob.spec; if you choose to ignore these errors, turn validation off with --validate=false
```

This PR removes `suspend: false`, so that:
1. `ray_v1alpha1_rayjob.yaml ` compatible  with `kuberay/operator:v0.5.0`. 
2. `ray_v1alpha1_rayjob.yaml` compatible with `nightly kuberay`.  This is becasue `suspend`  field is optional and if not set, it will be `false` by default.

## TODO
Add `suspend: false` back after 0.6.0 release.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
