### PR TITLE
fix: expose prestop hook to values.yaml

### DIFF
--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -96,6 +96,10 @@ head:
   # container command for head Pod.
   command: []
   args: []
+  lifecycle:
+    preStop:
+      exec:
+        command: [ "/bin/sh","-c","ray stop" ]
 
 
 worker:
@@ -153,6 +157,10 @@ worker:
   # container command for worker Pod.
   command: []
   args: []
+  lifecycle:
+    preStop:
+      exec:
+        command: [ "/bin/sh","-c","ray stop" ]
 
 # The map's key is used as the groupName.
 # For example, key:small-group in the map below
@@ -211,6 +219,10 @@ additionalWorkerGroups:
     # container command for worker Pod.
     command: []
     args: []
+    lifecycle:
+      preStop:
+        exec:
+          command: [ "/bin/sh","-c","ray stop" ]
 
 # Configuration for Head's Kubernetes Service
 service:


### PR DESCRIPTION
ref: https://github.com/ray-project/kuberay/issues/1103

<!-- Thank you for your contribution! -->


## Why are these changes needed?

To make the field exposed when installing the chart by helm. Unfortunately the fix didn't work, and I don't understand why.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
