### PR TITLE
[Feature] Watch CR in multiple namespaces with namespaced RBAC resources

### DIFF
--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -42,10 +42,10 @@ spec:
             {{- $argList = append $argList "--enable-batch-scheduler" -}}
             {{- end -}}
             {{- $watchNamespace := "" -}}
-            {{- if .Values.singleNamespaceInstall -}}
+            {{- if and .Values.singleNamespaceInstall (not .Values.watchNamespace) -}}
             {{- $watchNamespace = .Release.Namespace -}}
             {{- else if .Values.watchNamespace -}}
-            {{- $watchNamespace = .Values.watchNamespace -}}
+            {{- $watchNamespace = join "," .Values.watchNamespace -}}
             {{- end -}}
             {{- if $watchNamespace -}}
             {{- $argList = append $argList "--watch-namespace" -}}

--- a/helm-chart/kuberay-operator/templates/leader_election_role.yaml
+++ b/helm-chart/kuberay-operator/templates/leader_election_role.yaml
@@ -2,8 +2,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
+  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
   name: {{ include "kuberay-operator.fullname" . }}-leader-election
 rules:
 - apiGroups:
@@ -32,4 +31,13 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/leader_election_role_binding.yaml
+++ b/helm-chart/kuberay-operator/templates/leader_election_role_binding.yaml
@@ -2,8 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
+  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
   name: {{ include "kuberay-operator.fullname" . }}-leader-election
 subjects:
 - kind: ServiceAccount

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
@@ -1,4 +1,5 @@
 # Install Role for namespaces listed in watchNamespace.
+# This should be consistent with `role.yaml`, except for the `kind` field.
 {{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
 {{- $watchNamespaces := default .Values.watchNamespace (list .Release.Namespace) }}
 {{- range $namespace := $watchNamespaces }}

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
@@ -1,11 +1,14 @@
-{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
+# Install Role for namespaces listed in watchNamespace.
+{{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
 
-kind: ClusterRole
+{{- range $namespace := .Values.watchNamespace }}
+---
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
-  name: {{ include "kuberay-operator.fullname" . }}
+  labels: {{ include "kuberay-operator.labels" $ | nindent 4 }}
+  name: {{ include "kuberay-operator.fullname" $ }}
+  namespace: {{ $namespace }}
 rules:
 - apiGroups:
   - coordination.k8s.io
@@ -213,7 +216,7 @@ rules:
   - list
   - update
   - watch
-{{- if .Values.batchScheduler.enabled }}
+{{- if $.Values.batchScheduler.enabled }}
 - apiGroups:
   - scheduling.volcano.sh
   resources:
@@ -231,5 +234,6 @@ rules:
   - customresourcedefinitions
   verbs:
   - get
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
@@ -1,7 +1,7 @@
 # Install Role for namespaces listed in watchNamespace.
 # This should be consistent with `role.yaml`, except for the `kind` field.
 {{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
-{{- $watchNamespaces := default .Values.watchNamespace (list .Release.Namespace) }}
+{{- $watchNamespaces := default (list .Release.Namespace) .Values.watchNamespace }}
 {{- range $namespace := $watchNamespaces }}
 ---
 kind: Role

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
@@ -1,7 +1,7 @@
 # Install Role for namespaces listed in watchNamespace.
 {{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
-
-{{- range $namespace := .Values.watchNamespace }}
+{{- $watchNamespaces := default .Values.watchNamespace (list .Release.Namespace) }}
+{{- range $namespace := $watchNamespaces }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
@@ -1,6 +1,8 @@
+# Install RoleBinding for namespaces listed in watchNamespace.
 {{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
 
 {{- range $namespace := .Values.watchNamespace }}
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
@@ -1,7 +1,7 @@
 # Install RoleBinding for namespaces listed in watchNamespace.
 # This should be consistent with `rolebinding.yaml`, except for the `kind` field.
 {{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
-{{- $watchNamespaces := default .Values.watchNamespace (list .Release.Namespace) }}
+{{- $watchNamespaces := default (list .Release.Namespace) .Values.watchNamespace }}
 {{- range $namespace := $watchNamespaces }}
 ---
 kind: RoleBinding

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
@@ -1,7 +1,7 @@
 # Install RoleBinding for namespaces listed in watchNamespace.
 {{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
-
-{{- range $namespace := .Values.watchNamespace }}
+{{- $watchNamespaces := default .Values.watchNamespace (list .Release.Namespace) }}
+{{- range $namespace := $watchNamespaces }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
@@ -1,4 +1,5 @@
 # Install RoleBinding for namespaces listed in watchNamespace.
+# This should be consistent with `rolebinding.yaml`, except for the `kind` field.
 {{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
 {{- $watchNamespaces := default .Values.watchNamespace (list .Release.Namespace) }}
 {{- range $namespace := $watchNamespaces }}

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
+
+{{- range $namespace := .Values.watchNamespace }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels: {{ include "kuberay-operator.labels" $ | nindent 4 }}
+  name: {{ include "kuberay-operator.fullname" $ }}
+  namespace: {{ $namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.serviceAccount.name  }}
+  namespace: {{ $.Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "kuberay-operator.fullname" $ }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/helm-chart/kuberay-operator/templates/ray_rayjob_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayjob_editor_role.yaml
@@ -1,15 +1,10 @@
 # permissions for end users to edit rayjobs.
-{{- if .Values.rbacEnable }}
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
 
-{{- if .Values.singleNamespaceInstall }}
-kind: Role
-{{- else }}
 kind: ClusterRole
-{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
+  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
   name: rayjob-editor-role
 rules:
 - apiGroups:

--- a/helm-chart/kuberay-operator/templates/ray_rayjob_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayjob_viewer_role.yaml
@@ -1,15 +1,10 @@
 # permissions for end users to view rayjobs.
-{{- if .Values.rbacEnable }}
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
 
-{{- if .Values.singleNamespaceInstall }}
-kind: Role
-{{- else }}
 kind: ClusterRole
-{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
+  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
   name: rayjob-viewer-role
 rules:
 - apiGroups:

--- a/helm-chart/kuberay-operator/templates/ray_rayservice_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayservice_editor_role.yaml
@@ -1,12 +1,7 @@
 # permissions for end users to edit rayservices.
-{{- if .Values.rbacEnable }}
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
 apiVersion: rbac.authorization.k8s.io/v1
-
-{{- if .Values.singleNamespaceInstall }}
-kind: Role
-{{- else }}
 kind: ClusterRole
-{{- end }}
 metadata:
   name: rayservice-editor-role
 rules:

--- a/helm-chart/kuberay-operator/templates/ray_rayservice_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayservice_viewer_role.yaml
@@ -1,12 +1,7 @@
 # permissions for end users to view rayservices.
-{{- if .Values.rbacEnable }}
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
 apiVersion: rbac.authorization.k8s.io/v1
-
-{{- if .Values.singleNamespaceInstall }}
-kind: Role
-{{- else }}
 kind: ClusterRole
-{{- end }}
 metadata:
   name: rayservice-viewer-role
 rules:

--- a/helm-chart/kuberay-operator/templates/rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/rolebinding.yaml
@@ -1,9 +1,5 @@
 {{- if .Values.rbacEnable }}
-{{- if .Values.singleNamespaceInstall }}
-kind: RoleBinding
-{{- else }}
 kind: ClusterRoleBinding
-{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
@@ -14,11 +10,7 @@ subjects:
   name: {{ .Values.serviceAccount.name  }}
   namespace: {{ .Release.Namespace }}
 roleRef:
-{{- if .Values.singleNamespaceInstall }}
-  kind: Role
-{{- else }}
   kind: ClusterRole
-{{- end }}
   name: {{ include "kuberay-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -55,16 +55,16 @@ batchScheduler:
 securityContext: {}
 
 # When singleNamespaceInstall is true:
-# - the chart can be installed by users with permissions to a single namespace only
-#   (this excludes the CRDs which can only be installed at cluster-scope)
-# - the KubeRay operator will only listen to the resource
-#   events from the operator's namespace by default
+# - Install namespaced RBAC resources instead of cluster-scoped ones so that the chart can be installed by users
+#   with permissions restricted to a single namespace. (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
+# - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen
+#   to resource events within its own namespace.
 singleNamespaceInstall: false
 
-# kuberay operator will only watch the resource events from the "watchNamespace" namespace.
-# this option has no effect if singleNamespaceInstall is true, because we assume there are no
-# permissions outside of the current namespace
-# watchNamespace: ray-user-namespace
+# The KubeRay operator will watch the custom resources in the namespaces listed in the "watchNamespace" parameter.
+# watchNamespace:
+#   - n1
+#   - n2
 
 # Environment variables
 env:

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -132,6 +132,7 @@ We have several [consistency checks](https://github.com/ray-project/kuberay/blob
 3. CRD YAML files in `ray-operator/config/crd/bases/` and `helm-chart/kuberay-operator/crds/` should be the same.
 4. Kubebuilder markers in `ray-operator/controllers/ray/*_controller.go` should be synchronized with RBAC YAML files in `ray-operator/config/rbac`.
 5. RBAC YAML files in `helm-chart/kuberay-operator/templates` and `ray-operator/config/rbac` should be synchronized. **Currently, we need to synchronize this manually.** See [#631](https://github.com/ray-project/kuberay/pull/631) as an example.
+6. `multiple_namespaces_role.yaml` and `multiple_namespaces_rolebinding.yaml` should be synchronized with `role.yaml` and `rolebinding.yaml` in the `helm-chart/kuberay-operator/templates` directory. The only difference is that the former creates namespaced RBAC resources, while the latter creates cluster-scoped RBAC resources.
 
 ```bash
 # Synchronize consistency 1 and 4:
@@ -144,7 +145,7 @@ make manifests
 make helm
 
 # Synchronize 1, 2, 3, and 4 in one command
-# [Note]: Currently, we need to synchronize consistency 5 manually.
+# [Note]: Currently, we need to synchronize consistency 5 and 6 manually.
 make sync
 
 # Reproduce CI error for job "helm-chart-verify-rbac" (consistency 5)

--- a/ray-operator/config/rbac/leader_election_role.yaml
+++ b/ray-operator/config/rbac/leader_election_role.yaml
@@ -30,3 +30,12 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -142,7 +142,6 @@ func main() {
 	}
 	setupLog.Info("Setup manager")
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
-
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -129,7 +129,7 @@ func main() {
 		LeaderElectionID:       "ray-operator-leader",
 	}
 
-	if len(watchNamespaces) == 1 {
+	if len(watchNamespaces) == 1 { // It is not possible for len(watchNamespaces) == 0 to be true. The length of `strings.Split("", ",")`` is still 1.
 		options.Namespace = watchNamespaces[0]
 		if watchNamespaces[0] == "" {
 			setupLog.Info("Flag watchNamespace is not set. Watch custom resources in all namespaces.")

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
@@ -13,6 +14,7 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler"
 
 	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,7 +60,7 @@ func main() {
 		&watchNamespace,
 		"watch-namespace",
 		"",
-		"Watch custom resources in the namespace, ignore other namespaces. If empty, all namespaces will be watched.")
+		"Specify a list of namespaces to watch for custom resources, separated by commas. If left empty, all namespaces will be watched.")
 	flag.BoolVar(&ray.PrioritizeWorkersToDelete, "prioritize-workers-to-delete", true,
 		"Temporary feature flag - to be deleted after testing")
 	flag.BoolVar(&ray.ForcedClusterUpgrade, "forced-cluster-upgrade", false,
@@ -117,15 +119,30 @@ func main() {
 		setupLog.Info("Feature flag enable-batch-scheduler is enabled.")
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	watchNamespaces := strings.Split(watchNamespace, ",")
+	options := ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "ray-operator-leader",
-		Namespace:              watchNamespace,
-	})
+	}
+
+	if len(watchNamespaces) == 1 {
+		options.Namespace = watchNamespaces[0]
+		if watchNamespaces[0] == "" {
+			setupLog.Info("Flag watchNamespace is not set. Watch custom resources in all namespaces.")
+		} else {
+			setupLog.Info(fmt.Sprintf("Only watch custom resources in the namespace: %s", watchNamespaces[0]))
+		}
+	} else {
+		options.NewCache = cache.MultiNamespacedCacheBuilder(watchNamespaces)
+		setupLog.Info(fmt.Sprintf("Only watch custom resources in multiple namespaces: %v", watchNamespaces))
+	}
+	setupLog.Info("Setup manager")
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
+
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, KubeRay supports the following options:

* Watching all custom resources in the Kubernetes cluster: This is the default setting, which installs cluster-scoped RBAC resources (i.e., ClusterRole and ClusterRoleBinding).
* Watching only the namespace where the operator is deployed: This is achieved by setting `singleNamespaceInstall` to true, which installs namespaced RBAC resources (i.e., Role and RoleBinding).

However, for users who only have namespaced access, they would need to deploy one KubeRay operator for each namespace. This can increase the maintenance overhead, such as upgrading the version of KubeRay for each deployed instance.

This PR implements a feature that supports users to deploy a KubeRay operator to watch multiple namespaces without installing ClusterRole and ClusterRoleBinding as proposal in #1084.

There are two fields available to configure the KubeRay operator to achieve this:

* `singleNamespaceInstall`: 
  * Case 1: If set to false, the KubeRay operator will create ClusterRole and ClusterRoleBinding.
  * Case 2: If set to true and `watchNamespace` is set, it will create Role and RoleBinding for all namespaces listed in `watchNamespace`.
  * Case 3: If set to true and `watchNamespace` is not set, it will create Role and RoleBinding for the namespace where the operator is deployed.
  * Case 4: If `singleNamespaceInstall` is not set, the KubeRay operator will create ClusterRole and ClusterRoleBinding.

* `watchNamespace`: A list of namespaces that the KubeRay operator will watch. In addition, it will be passed to KubeRay binary as the `--watch-namespace` flag.

## Related issue number

Closes #1084 
Closes #1083
<!-- For example: "Closes #1234" -->
#1094

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* [gist1](https://gist.github.com/kevin85421/54978483b9002eef0c0edb90c7749015)
* [gist2](https://gist.github.com/kevin85421/417297e9563d84be5b29937ea46233d5)
* [gist3](https://gist.github.com/kevin85421/c2005b43eb29271ebbd0da9e08ab1cd0)
* [gist4](https://gist.github.com/kevin85421/a7fb98f360d4549b10c4e294a6d5e403)

### Case 1: If `singleNamespaceInstall` is set to false, the KubeRay operator will create ClusterRole and ClusterRoleBinding.

```sh
kind create cluster --image=kindest/node:v1.23.0
kind load docker-image controller:latest

# Create namespaces
kubectl create ns n1
kubectl create ns n2

# Install a KubeRay operator (use gist1 to replace values.yaml)
# (path: helm-chart/kuberay-operator)
helm install kuberay-operator . --set image.repository=controller,image.tag=latest

# Check ClusterRole
kubectl get clusterrole | grep kuberay
# kuberay-operator                                                       2023-05-23T22:02:31Z

# Check Role 
kubectl get role
# NAME                               CREATED AT
# kuberay-operator-leader-election   2023-05-23T22:02:31Z


# Install RayCluster in `default`, `n1`, `n2`
helm install raycluster kuberay/ray-cluster --version 0.5.0
helm install raycluster kuberay/ray-cluster --version 0.5.0 -n n1
helm install raycluster kuberay/ray-cluster --version 0.5.0 -n n2

# RayCluster in these 3 namespaces should be created.
```
<img width="1439" alt="Screen Shot 2023-05-23 at 3 08 44 PM" src="https://github.com/ray-project/kuberay/assets/20109646/346b3c60-5531-4cd1-ac23-7f03cbcd15a0">

### Case 2: If `singleNamespaceInstall` is set to true and watchNamespace is set, it will create Role and RoleBinding for all namespaces listed in watchNamespace.

* `watchNamespace`: `n1`, `n2`


```sh
kind create cluster --image=kindest/node:v1.23.0
kind load docker-image controller:latest

# Create namespaces
kubectl create ns n1
kubectl create ns n2

# Install a KubeRay operator (use gist2 to replace values.yaml)
# (path: helm-chart/kuberay-operator)
helm install kuberay-operator . --set image.repository=controller,image.tag=latest

# Check ClusterRole
kubectl get clusterrole | grep kuberay
# (nothing found)

# Check Role 
kubectl get role --all-namespaces | grep kuberay
# default       kuberay-operator-leader-election                 2023-05-23T22:27:37Z
# n1            kuberay-operator                                 2023-05-23T22:27:37Z
# n2            kuberay-operator                                 2023-05-23T22:27:37Z


# Install RayCluster in `default`, `n1`, `n2`
helm install raycluster kuberay/ray-cluster --version 0.5.0
helm install raycluster kuberay/ray-cluster --version 0.5.0 -n n1
helm install raycluster kuberay/ray-cluster --version 0.5.0 -n n2

# Only RayCluster in n1 and n2 will be created.
```
<img width="1440" alt="Screen Shot 2023-05-23 at 3 31 02 PM" src="https://github.com/ray-project/kuberay/assets/20109646/703482aa-9dba-4414-bf3c-00b0fe23d858">

### Case 3: If `singleNamespaceInstall` is set to true and `watchNamespace` is not set, it will create Role and RoleBinding for the namespace where the operator is deployed.

```sh
kind create cluster --image=kindest/node:v1.23.0
kind load docker-image controller:latest

# Create namespaces
kubectl create ns n1
kubectl create ns n2

# Install a KubeRay operator (use gist3 to replace values.yaml)
# (path: helm-chart/kuberay-operator)
helm install kuberay-operator . --set image.repository=controller,image.tag=latest

# Check ClusterRole
kubectl get clusterrole | grep kuberay
# (nothing found)

# Check Role 
kubectl get role --all-namespaces | grep kuberay
# default       kuberay-operator                                 2023-05-23T22:35:15Z
# default       kuberay-operator-leader-election                 2023-05-23T22:35:15Z


# Install RayCluster in `default`, `n1`, `n2`
helm install raycluster kuberay/ray-cluster --version 0.5.0
helm install raycluster kuberay/ray-cluster --version 0.5.0 -n n1
helm install raycluster kuberay/ray-cluster --version 0.5.0 -n n2

# Only RayCluster in `default` will be created.
```
<img width="1437" alt="Screen Shot 2023-05-23 at 3 36 15 PM" src="https://github.com/ray-project/kuberay/assets/20109646/0979c7d9-7a86-4dfd-b535-2b323f34093f">

### Case 4: If `singleNamespaceInstall` is not set, the KubeRay operator will create ClusterRole and ClusterRoleBinding.

```sh
kind create cluster --image=kindest/node:v1.23.0
kind load docker-image controller:latest

# Create namespaces
kubectl create ns n1
kubectl create ns n2

# Install a KubeRay operator (use gist3 to replace values.yaml)
# (path: helm-chart/kuberay-operator)
helm install kuberay-operator . --set image.repository=controller,image.tag=latest

# Check ClusterRole
kubectl get clusterrole | grep kuberay
# kuberay-operator                                                       2023-05-23T22:40:18Z

# Check Role 
kubectl get role --all-namespaces | grep kuberay
# default       kuberay-operator-leader-election                 2023-05-23T22:40:18Z


# Install RayCluster in `default`, `n1`, `n2`
helm install raycluster kuberay/ray-cluster --version 0.5.0
helm install raycluster kuberay/ray-cluster --version 0.5.0 -n n1
helm install raycluster kuberay/ray-cluster --version 0.5.0 -n n2

# RayCluster in `default`, `n1`, and `n2` will be created.
```
<img width="1434" alt="Screen Shot 2023-05-23 at 3 41 11 PM" src="https://github.com/ray-project/kuberay/assets/20109646/919fc490-e508-45e4-a521-9daa06d89307">
