### PR TITLE
Add support for pvcs to apiserver

### DIFF
--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -494,7 +494,18 @@ func buildVols(apiVolumes []*api.Volume) []v1.Volume {
 			}
 			vols = append(vols, vol)
 		}
-		// TODO(Jeffwan@): handle PVC in the future
+		if rayVol.VolumeType == api.Volume_PERSISTENT_VOLUME_CLAIM {
+			vol := v1.Volume{
+				Name: rayVol.Name,
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						ClaimName: rayVol.Name,
+						ReadOnly:  rayVol.ReadOnly,
+					},
+				},
+			}
+			vols = append(vols, vol)
+		}
 	}
 
 	return vols

--- a/apiserver/pkg/util/cluster_test.go
+++ b/apiserver/pkg/util/cluster_test.go
@@ -28,6 +28,13 @@ var testFileVolume = &api.Volume{
 	ReadOnly:             true,
 }
 
+var testPVCVolume = &api.Volume{
+	Name:       "test-pvc",
+	VolumeType: api.Volume_PERSISTENT_VOLUME_CLAIM,
+	MountPath:  "/pvc/dir",
+	ReadOnly:   true,
+}
+
 // Spec for testing
 var headGroup = api.HeadGroupSpec{
 	ComputeTemplate: "foo",
@@ -113,6 +120,16 @@ func TestBuildVolumes(t *testing.T) {
 			},
 		},
 	}
+
+	targetPVCVolume := v1.Volume{
+		Name: testPVCVolume.Name,
+		VolumeSource: v1.VolumeSource{
+			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+				ClaimName: testPVCVolume.Name,
+				ReadOnly:  testPVCVolume.ReadOnly,
+			},
+		},
+	}
 	tests := []struct {
 		name      string
 		apiVolume []*api.Volume
@@ -124,6 +141,11 @@ func TestBuildVolumes(t *testing.T) {
 				testVolume, testFileVolume,
 			},
 			[]v1.Volume{targetVolume, targetFileVolume},
+		},
+		{
+			"pvc test",
+			[]*api.Volume{testPVCVolume},
+			[]v1.Volume{targetPVCVolume},
 		},
 	}
 	for _, tt := range tests {
@@ -149,6 +171,11 @@ func TestBuildVolumeMounts(t *testing.T) {
 		MountPath:        testFileVolume.MountPath,
 		MountPropagation: &hostToContainer,
 	}
+	targetPVCVolumeMount := v1.VolumeMount{
+		Name:      testPVCVolume.Name,
+		ReadOnly:  testPVCVolume.ReadOnly,
+		MountPath: testPVCVolume.MountPath,
+	}
 	tests := []struct {
 		name      string
 		apiVolume []*api.Volume
@@ -164,6 +191,11 @@ func TestBuildVolumeMounts(t *testing.T) {
 				targetVolumeMount,
 				targetFileVolumeMount,
 			},
+		},
+		{
+			"pvc test",
+			[]*api.Volume{testPVCVolume},
+			[]v1.VolumeMount{targetPVCVolumeMount},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Users may wish to add PVC volumes to Ray pods instead of hostPath volumes as its [recommended](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) to avoid hostPath volumes when possible due to security risks. Plus, it was something [already marked](https://github.com/ray-project/kuberay/blob/f6a172f3d7e44d4ee22bd058f2c33a69601c39c2/apiserver/pkg/util/cluster.go#L387) to be implemented.

## Related issue number

#1087 

<!-- For example: "Closes #1234" -->

## Checks

- [ X ] I've made sure the tests are passing. 
- Testing Strategy
   - [ X ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
