### PR TITLE
[Bug] Autoscaler doesn't support TLS

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -340,6 +340,42 @@ spec:
                     - Aggressive
                     - Conservative
                     type: string
+                  volumeMounts:
+                    description: Optional list of volumeMounts.  This is needed for
+                      enabling TLS for the autoscaler container.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            a
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted.
+                          type: string
+                        subPathExpr:
+                          description: Expanded path within the volume from which
+                            the container's volume should be mounted.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
                 type: object
               enableInTreeAutoscaling:
                 description: EnableInTreeAutoscaling indicates whether operator should

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -348,6 +348,42 @@ spec:
                         - Aggressive
                         - Conservative
                         type: string
+                      volumeMounts:
+                        description: Optional list of volumeMounts.  This is needed
+                          for enabling TLS for the autoscaler container.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way a
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted.
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
                     type: object
                   enableInTreeAutoscaling:
                     description: EnableInTreeAutoscaling indicates whether operator

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -334,6 +334,42 @@ spec:
                         - Aggressive
                         - Conservative
                         type: string
+                      volumeMounts:
+                        description: Optional list of volumeMounts.  This is needed
+                          for enabling TLS for the autoscaler container.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way a
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted.
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
                     type: object
                   enableInTreeAutoscaling:
                     description: EnableInTreeAutoscaling indicates whether operator

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -79,6 +79,8 @@ type AutoscalerOptions struct {
 	Env []v1.EnvVar `json:"env,omitempty"`
 	// Optional list of sources to populate environment variables in the autoscaler container.
 	EnvFrom []v1.EnvFromSource `json:"envFrom,omitempty"`
+	// Optional list of volumeMounts.  This is needed for enabling TLS for the autoscaler container.
+	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
 	// SecurityContext defines the security options the container should be run with.
 	// If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -151,15 +153,15 @@ const (
 )
 
 // RayCluster is the Schema for the RayClusters API
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="desired workers",type=integer,JSONPath=".status.desiredWorkerReplicas",priority=0
-//+kubebuilder:printcolumn:name="available workers",type=integer,JSONPath=".status.availableWorkerReplicas",priority=0
-//+kubebuilder:printcolumn:name="status",type="string",JSONPath=".status.state",priority=0
-//+kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp",priority=0
-//+kubebuilder:printcolumn:name="head pod IP",type="string",JSONPath=".status.head.podIP",priority=1
-//+kubebuilder:printcolumn:name="head service IP",type="string",JSONPath=".status.head.serviceIP",priority=1
-//+genclient
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="desired workers",type=integer,JSONPath=".status.desiredWorkerReplicas",priority=0
+// +kubebuilder:printcolumn:name="available workers",type=integer,JSONPath=".status.availableWorkerReplicas",priority=0
+// +kubebuilder:printcolumn:name="status",type="string",JSONPath=".status.state",priority=0
+// +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp",priority=0
+// +kubebuilder:printcolumn:name="head pod IP",type="string",JSONPath=".status.head.podIP",priority=1
+// +kubebuilder:printcolumn:name="head service IP",type="string",JSONPath=".status.head.serviceIP",priority=1
+// +genclient
 type RayCluster struct {
 	// Standard object metadata.
 	metav1.TypeMeta   `json:",inline"`

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -61,6 +61,13 @@ func (in *AutoscalerOptions) DeepCopyInto(out *AutoscalerOptions) {
 	if in.EnvFrom != nil {
 		in, out := &in.EnvFrom, &out.EnvFrom
 		*out = make([]v1.EnvFromSource, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -340,6 +340,42 @@ spec:
                     - Aggressive
                     - Conservative
                     type: string
+                  volumeMounts:
+                    description: Optional list of volumeMounts.  This is needed for
+                      enabling TLS for the autoscaler container.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            a
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted.
+                          type: string
+                        subPathExpr:
+                          description: Expanded path within the volume from which
+                            the container's volume should be mounted.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
                 type: object
               enableInTreeAutoscaling:
                 description: EnableInTreeAutoscaling indicates whether operator should

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -348,6 +348,42 @@ spec:
                         - Aggressive
                         - Conservative
                         type: string
+                      volumeMounts:
+                        description: Optional list of volumeMounts.  This is needed
+                          for enabling TLS for the autoscaler container.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way a
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted.
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
                     type: object
                   enableInTreeAutoscaling:
                     description: EnableInTreeAutoscaling indicates whether operator

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -334,6 +334,42 @@ spec:
                         - Aggressive
                         - Conservative
                         type: string
+                      volumeMounts:
+                        description: Optional list of volumeMounts.  This is needed
+                          for enabling TLS for the autoscaler container.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way a
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted.
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
                     type: object
                   enableInTreeAutoscaling:
                     description: EnableInTreeAutoscaling indicates whether operator

--- a/ray-operator/config/samples/ray-cluster.autoscaler.tls.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.tls.yaml
@@ -1,0 +1,414 @@
+apiVersion: ray.io/v1alpha1
+kind: RayCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: raycluster-autoscaler
+spec:
+  rayVersion: '2.4.0'
+  # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
+  # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
+  # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
+  enableInTreeAutoscaling: true
+  # autoscalerOptions is an OPTIONAL field specifying configuration overrides for the Ray autoscaler.
+  # The example configuration shown below below represents the DEFAULT values.
+  # (You may delete autoscalerOptions if the defaults are suitable.)
+  autoscalerOptions:
+    # upscalingMode is "Default" or "Aggressive."
+    # Conservative: Upscaling is rate-limited; the number of pending worker pods is at most the size of the Ray cluster.
+    # Default: Upscaling is not rate-limited.
+    # Aggressive: An alias for Default; upscaling is not rate-limited.
+    upscalingMode: Default
+    # idleTimeoutSeconds is the number of seconds to wait before scaling down a worker pod which is not using Ray resources.
+    idleTimeoutSeconds: 60
+    # image optionally overrides the autoscaler's container image.
+    # If instance.spec.rayVersion is at least "2.0.0", the autoscaler will default to the same image as
+    # the ray container. For older Ray versions, the autoscaler will default to using the Ray 2.0.0 image.
+    ## image: "my-repo/my-custom-autoscaler-image:tag"
+    # imagePullPolicy optionally overrides the autoscaler container's default image pull policy (IfNotPresent).
+    imagePullPolicy: IfNotPresent
+    # Optionally specify the autoscaler container's securityContext.
+    securityContext: {}
+    # Environment variables for Ray TLS authentication.
+    env:
+      - name: RAY_USE_TLS
+        value: "1"
+      - name: RAY_TLS_SERVER_CERT
+        value: "/etc/ray/tls/tls.crt"
+      - name: RAY_TLS_SERVER_KEY
+        value: "/etc/ray/tls/tls.key"
+      - name: RAY_TLS_CA_CERT
+        value: "/etc/ca/tls/ca.crt"
+    envFrom: []
+    # Use volumeMounts to mount the volumes where the TLS certs exist.
+    volumeMounts:
+      - mountPath: /etc/ca/tls
+        name: ca-tls
+      - mountPath: /etc/ray/tls
+        name: ray-tls
+    # resources specifies optional resource request and limit overrides for the autoscaler container.
+    # The default autoscaler resource limits and requests should be sufficient for production use-cases.
+    # However, for large Ray clusters, we recommend monitoring container resource usage to determine if overriding the defaults is required.
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+      requests:
+        cpu: "500m"
+        memory: "512Mi"
+  # Ray head pod configuration
+  headGroupSpec:
+    # The `rayStartParams` are used to configure the `ray start` command.
+    # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+    # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+    rayStartParams:
+      dashboard-host: '0.0.0.0'
+    # pod template
+    template:
+      metadata:
+        labels: {}
+      spec:
+        initContainers:
+          # Generate head's private key and certificate before `ray start`.
+          - name: ray-head-tls
+            image: rayproject/ray:2.4.0
+            command: ["/bin/sh", "-c", "cp -R /etc/ca/tls /etc/ray && /etc/gen/tls/gencert_head.sh"]
+            volumeMounts:
+              - mountPath: /etc/ca/tls
+                name: ca-tls
+                readOnly: true
+              - mountPath: /etc/ray/tls
+                name: ray-tls
+              - mountPath: /etc/gen/tls
+                name: gen-tls-script
+            env:
+              - name: POD_IP
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.podIP
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.4.0
+          ports:
+          - containerPort: 6379
+            name: gcs
+          - containerPort: 8265
+            name: dashboard
+          - containerPort: 10001
+            name: client
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+          volumeMounts:
+            - mountPath: /tmp/ray
+              name: ray-logs
+            - mountPath: /etc/ca/tls
+              name: ca-tls
+              readOnly: true
+            - mountPath: /etc/ray/tls
+              name: ray-tls
+          resources:
+            limits:
+              cpu: "1"
+              memory: "2G"
+            requests:
+              cpu: "500m"
+              memory: "2G"
+          env:
+            # Environment variables for Ray TLS authentication.
+            # See https://docs.ray.io/en/latest/ray-core/configure.html#tls-authentication for more details.
+            - name: RAY_USE_TLS
+              value: "1"
+            - name: RAY_TLS_SERVER_CERT
+              value: "/etc/ray/tls/tls.crt"
+            - name: RAY_TLS_SERVER_KEY
+              value: "/etc/ray/tls/tls.key"
+            - name: RAY_TLS_CA_CERT
+              value: "/etc/ca/tls/ca.crt"
+        volumes:
+          - name: ray-logs
+            emptyDir: {}
+          # Secret `ca-tls` has the information of CA's private key and certificate.
+          - name: ca-tls
+            secret:
+              secretName: ca-tls
+          - name: ray-tls
+            emptyDir: {}
+          # `gencert_head.sh` is a script to generate head Pod's private key and head's certificate.
+          - name: gen-tls-script
+            configMap:
+              name: tls
+              defaultMode: 0777
+              items:
+              - key: gencert_head.sh
+                path: gencert_head.sh
+  workerGroupSpecs:
+  # the pod replicas in this group typed worker
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 10
+    groupName: small-group
+    # The `rayStartParams` are used to configure the `ray start` command.
+    # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+    # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+    rayStartParams: {}
+    #pod template
+    template:
+      spec:
+        initContainers:
+          # Generate worker's private key and certificate before `ray start`.
+          - name: ray-worker-tls
+            image: rayproject/ray:2.4.0
+            command: ["/bin/sh", "-c", "cp -R /etc/ca/tls /etc/ray && /etc/gen/tls/gencert_worker.sh"]
+            volumeMounts:
+              - mountPath: /etc/ca/tls
+                name: ca-tls
+                readOnly: true
+              - mountPath: /etc/ray/tls
+                name: ray-tls
+              - mountPath: /etc/gen/tls
+                name: gen-tls-script
+            env:
+              - name: POD_IP
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.podIP
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:2.4.0
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+          # use volumeMounts.Optional.
+          # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
+          volumeMounts:
+            - mountPath: /tmp/ray
+              name: ray-logs
+            - mountPath: /etc/ca/tls
+              name: ca-tls
+              readOnly: true
+            - mountPath: /etc/ray/tls
+              name: ray-tls
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1G"
+            requests:
+              cpu: "500m"
+              memory: "1G"
+          env:
+            # Environment variables for Ray TLS authentication.
+            # See https://docs.ray.io/en/latest/ray-core/configure.html#tls-authentication for more details.
+            - name: RAY_USE_TLS
+              value: "1"
+            - name: RAY_TLS_SERVER_CERT
+              value: "/etc/ray/tls/tls.crt"
+            - name: RAY_TLS_SERVER_KEY
+              value: "/etc/ray/tls/tls.key"
+            - name: RAY_TLS_CA_CERT
+              value: "/etc/ca/tls/ca.crt"
+        volumes:
+          - name: ray-logs
+            emptyDir: {}
+          # Secret `ca-tls` has the information of CA's private key and certificate.
+          - name: ca-tls
+            secret:
+              secretName: ca-tls
+          - name: ray-tls
+            emptyDir: {}
+          # `gencert_worker.sh` is a script to generate worker Pod's private key and worker's certificate.
+          - name: gen-tls-script
+            configMap:
+              name: tls
+              defaultMode: 0777
+              # An array of keys from the ConfigMap to create as files
+              items:
+              - key: gencert_worker.sh
+                path: gencert_worker.sh
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ca-tls
+data:
+  # cat ca.crt | base64
+  ca.crt: |
+    LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURXekNDQWtPZ0F3SUJBZ0lVVzQyUDZxZVEr
+    MU54M2xzazFaY2hCTjhSUmhnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1BURVdNQlFHQTFVRUF3d05L
+    aTVyZFdKbGNtRjVMbU52YlRFTE1Ba0dBMVVFQmhNQ1ZWTXhGakFVQmdOVgpCQWNNRFZOaGJpQkdj
+    bUZ1WTJselkyOHdIaGNOTWpNd016STJNREUxT1RNeVdoY05Nek13TXpJek1ERTFPVE15CldqQTlN
+    Ull3RkFZRFZRUUREQTBxTG10MVltVnlZWGt1WTI5dE1Rc3dDUVlEVlFRR0V3SlZVekVXTUJRR0Ex
+    VUUKQnd3TlUyRnVJRVp5WVc1amFYTmpiekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFE
+    Q0NBUW9DZ2dFQgpBTkh5Yk1PWjNlZ2hZS0gzTVJlcVhqSU83QlRHUGk3NXJ0ekpsMjN5WVhRdEFP
+    Y050eVNxZUllVk43YnJIYzAyCkN1RXNocUNpSHBDeVdYcDlVMWRCYlZwYWU3OXc3R1AySHBJclBr
+    WXZITm5ZZEF3a0dnYkpTeTNPSkJOb2N0MUEKbVdwYWI5N243dGlFbkw1bFFsR01vejBwR0FYQ1BK
+    Q3lVTWtsbDE2eUlSVUtjdjZkZThBcWZMU0FPRmxIY1BHRQo1SnhpRlhJcWtzbStqN0txZDVqQk14
+    b1RCV0puVmk4MTRVZ3U4eEMxZkV2ZlRKM1hMeWZ6cmtIbkJHZGYyUG4wCkJHVWtobzB3dDNoSGVt
+    QUs4NXV2OWZIUUdNMlpZOTYxVzhFT2ZQL3pCT3FIODZZMG9hU0VUQlpiSm45WEg2Y2UKdnIvWW9z
+    OU1wQU52K3dpemhqZFVPUWNDQXdFQUFhTlRNRkV3SFFZRFZSME9CQllFRkh2bk81LzdjakVMVXpt
+    NwpiaUJSay9Qc2N5dDdNQjhHQTFVZEl3UVlNQmFBRkh2bk81LzdjakVMVXptN2JpQlJrL1BzY3l0
+    N01BOEdBMVVkCkV3RUIvd1FGTUFNQkFmOHdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBTHg1cXZW
+    VUQvNVMwUjE2UUpFTWRlS3IKQzhaazhPL2dMa3ZkTlNEeUVzam5zU1JKWFF5aW4zdEJXQjhLaSs3
+    VXBlQ3Y4TCtjOUdHM05oNzBUdGhxTmNrOApHT0ZHVHdYTi9XLy9MbTNIZEJVK2UzSkJkbElOTEo4
+    alRuRjFQUXJvS2ZacURCZnVlR0FwSDdPT0JKYWl2KzFtCjdxalNsbkovYS9rRlRaWXNsNVpZU204
+    dWI4Q3RGQnFwOFliM0xBcU5YUG9zL3QzVFBVbG1wRHpOK0lPTTBSb1IKKy9vS3A3TUpCNFFoeFQ2
+    T2RYVy9Iekw3bndmbnZ6QU12NXREKzdUamJuaDFrS0d2b0ZBUW5neXRMQnAzcllxcQpBRWFYck8x
+    OUFNKzdCMmpQcHB4RVM1Rm01K3FPdS9BUnBzVDdzbUJ0eitudnlwdEM3Y2J2QUZzZFAwRnhHWjA9
+    Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  # cat ca.key | base64
+  ca.key: |
+    LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV1d0lCQURBTkJna3Foa2lHOXcwQkFRRUZB
+    QVNDQktVd2dnU2hBZ0VBQW9JQkFRRFI4bXpEbWQzb0lXQ2gKOXpFWHFsNHlEdXdVeGo0dSthN2N5
+    WmR0OG1GMExRRG5EYmNrcW5pSGxUZTI2eDNOTmdyaExJYWdvaDZRc2xsNgpmVk5YUVcxYVdudS9j
+    T3hqOWg2U0t6NUdMeHpaMkhRTUpCb0d5VXN0emlRVGFITGRRSmxxV20vZTUrN1loSnkrClpVSlJq
+    S005S1JnRndqeVFzbERKSlpkZXNpRVZDbkwrblh2QUtueTBnRGhaUjNEeGhPU2NZaFZ5S3BMSnZv
+    K3kKcW5lWXdUTWFFd1ZpWjFZdk5lRklMdk1RdFh4TDMweWQxeThuODY1QjV3Um5YOWo1OUFSbEpJ
+    YU5NTGQ0UjNwZwpDdk9ici9YeDBCak5tV1BldFZ2QkRuei84d1RxaC9PbU5LR2toRXdXV3laL1Z4
+    K25IcjYvMktMUFRLUURiL3NJCnM0WTNWRGtIQWdNQkFBRUNnZ0VBQkx0RzhqMlVmN2ZJMnIyY2NL
+    RVpVRjEvdXBRaE1LUFY2Z250RE1CS3EvaWIKclpsa2lFSURSMkw0aDNuVENSM3ZydFYzRDBXNEZL
+    REFYWDlYa243Wi9SQk8rNmlLMjFIZnJJR20vS1B4TFlPdwpVZG02Y0c2MjhBaFdUYzJyMFFxMHFt
+    M3hXWCsycFZDUHk4YXljTzRQZThCaVZ6YmljSXhrUDdSR0xnOHJxYkt4CkhYM1pOUnhIUy9NOW9X
+    YzYyM2RTZEJwZGdxUitLYlVVM21aWjJXc3ZBSjZiME5sZ0U0Vkc4aTFqUFBLbDVFV2kKRmtnTkVG
+    N0pNZ0RHRDQvODEvMlErUnRCdmtpQTlmZkk0NER4Z04rbVJBZmVaRFQvZWtOTDROVlRUWm9SZkpk
+    YwpKcGtqMmppNE5NUENJTGNnazN5QVBuSXRTamlsWGkrMXFiTjNmZXQwV1FLQmdRRDRGOTBreWhy
+    K0p1cWRrMnIwCjZPTXVVSk9GM3k0UDA2OFFOTHF4blNPOERaMndKL2cwdGJhWk5Senp4anZwWHFZ
+    VVpIWGVhVHdNYkNreE55TnEKb0kvQmYwYTJoUGcyeE9iTm5HVUF6MEgzVGZ2Y0JvcVIvVXlOTFZr
+    d0dtUUx5WVZuNWdmSXdnN1lsS2x2emtsegp3aHUxNnNSVGNPNXpBUkpaTHV3dy9MSWFjd0tCZ1FE
+    WW8xV2Z3N1pWeUQrSSszRlRMbzhCeXJZd2F2S3FjY1dQCjM5T20wdzB2ckZTc0tHQVFnY0ZwR2NX
+    cG5FM0FMWnZ6eHAyU2lRTkc0RkhWTmNZblNqM0tKY2lGRC9vOHJRSTgKNjRxOE82MW9QL2lQOWNt
+    MzFpNjRCYmhsaFhqeUZPZGc4bU9LSWZnOHB2Y1AzeDBMKzdRMy9GbmIzWmxkd1lkdAo5SjhXbDR0
+    ZUhRS0JnUUN4czNZbENkWjN3S3hBSGYxNFd1K09sd3h6MFQ0Ty9CTGl5c0lHd29WOEIweXhobytV
+    ClFhdis1VHBOcWVuejZHV1JLYnY3aU9rSUJOa2tkVmdhNGRMV1NESUFQaElFT05rUTRUcS9iN1RT
+    VEx0Z0NCZHQKSmorVXg2eWdkZWEvUXFNWm5ueG80Z2I4UHM5MlZBM3NxbFpxNFRPcWlMTmpFSnR4
+    NGRndjVuQXozUUtCZ0dtSwphVlNFVEhoT0xtWFYyY2ZranRjWW90bkR3S1U0K0Q2M2xLMVpkTHNk
+    QWNNOWlFK0NaMitFbHIraTNsNFoyamhSCk1zTUk3UWZDa1J1R0x4dEZHQVU3a3cwQVU3RHJ1SU5s
+    WFJtSEdWd0lqbGZVTG9uWlZybGdVQTFsa1I2ZkFIcEMKbkN2WGtOQTdwM0djQ05LbHRZN3c2Zlly
+    WjJROXZIVGRFQVE1b0RRaEFuOCtwUFFySEZ1aHhWMnBGb0RjcFFCSApPR0NjbHZJUGxOZTZzWmFO
+    YXQwb0pjUDkxbkI3TFoxMnVhUG9wa3dZckxGZXBtQVRiOElDbU9LMGNCUWNIenljCm5tM3lWVEt1
+    LzA1NnMvdVQwSnY3dFA0clluR3c3WG5acWV1bVNzd2pqbTZIRHBRNG5Ia1JmWFZ5VkVBZFVONUsK
+    VVc3Q01ubkQ2OGsranZLc2lXbmYKLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQo=
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tls
+data:
+  gencert_head.sh: |
+    #!/bin/sh
+    ## Create tls.key
+    openssl genrsa -out /etc/ray/tls/tls.key 2048
+
+    ## Write CSR Config
+    cat > /etc/ray/tls/csr.conf <<EOF
+    [ req ]
+    default_bits = 2048
+    prompt = no
+    default_md = sha256
+    req_extensions = req_ext
+    distinguished_name = dn
+
+    [ dn ]
+    C = US
+    ST = California
+    L = San Fransisco
+    O = test
+    OU = test
+    CN = *.kuberay.com
+
+    [ req_ext ]
+    subjectAltName = @alt_names
+
+    [ alt_names ]
+    DNS.1 = localhost
+    DNS.2 = $FQ_RAY_IP
+    IP.1 = 127.0.0.1
+    IP.2 = $POD_IP
+
+    EOF
+
+    ## Create CSR using tls.key
+    openssl req -new -key /etc/ray/tls/tls.key -out /etc/ray/tls/ca.csr -config /etc/ray/tls/csr.conf
+
+    ## Write cert config
+    cat > /etc/ray/tls/cert.conf <<EOF
+
+    authorityKeyIdentifier=keyid,issuer
+    basicConstraints=CA:FALSE
+    keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+    subjectAltName = @alt_names
+
+    [alt_names]
+    DNS.1 = localhost
+    DNS.2 = $FQ_RAY_IP
+    IP.1 = 127.0.0.1
+    IP.2 = $POD_IP
+
+    EOF
+
+    ## Generate tls.cert
+    openssl x509 -req \
+        -in /etc/ray/tls/ca.csr \
+        -CA /etc/ray/tls/ca.crt -CAkey /etc/ray/tls/ca.key \
+        -CAcreateserial -out /etc/ray/tls/tls.crt \
+        -days 365 \
+        -sha256 -extfile /etc/ray/tls/cert.conf
+
+  gencert_worker.sh: |
+    #!/bin/sh
+    ## Create tls.key
+    openssl genrsa -out /etc/ray/tls/tls.key 2048
+
+    ## Write CSR Config
+    cat > /etc/ray/tls/csr.conf <<EOF
+    [ req ]
+    default_bits = 2048
+    prompt = no
+    default_md = sha256
+    req_extensions = req_ext
+    distinguished_name = dn
+
+    [ dn ]
+    C = US
+    ST = California
+    L = San Fransisco
+    O = test
+    OU = test
+    CN = *.kuberay.com
+
+    [ req_ext ]
+    subjectAltName = @alt_names
+
+    [ alt_names ]
+    DNS.1 = localhost
+    IP.1 = 127.0.0.1
+    IP.2 = $POD_IP
+
+    EOF
+
+    ## Create CSR using tls.key
+    openssl req -new -key /etc/ray/tls/tls.key -out /etc/ray/tls/ca.csr -config /etc/ray/tls/csr.conf
+
+    ## Write cert config
+    cat > /etc/ray/tls/cert.conf <<EOF
+
+    authorityKeyIdentifier=keyid,issuer
+    basicConstraints=CA:FALSE
+    keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+    subjectAltName = @alt_names
+
+    [alt_names]
+    DNS.1 = localhost
+    IP.1 = 127.0.0.1
+    IP.2 = $POD_IP
+
+    EOF
+
+    ## Generate tls.cert
+    openssl x509 -req \
+        -in /etc/ray/tls/ca.csr \
+        -CA /etc/ray/tls/ca.crt -CAkey /etc/ray/tls/ca.key \
+        -CAcreateserial -out /etc/ray/tls/tls.crt \
+        -days 365 \
+        -sha256 -extfile /etc/ray/tls/cert.conf

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -470,6 +470,9 @@ func mergeAutoscalerOverrides(autoscalerContainer *v1.Container, autoscalerOptio
 		if len(autoscalerOptions.EnvFrom) > 0 {
 			autoscalerContainer.EnvFrom = append(autoscalerContainer.EnvFrom, autoscalerOptions.EnvFrom...)
 		}
+		if len(autoscalerOptions.VolumeMounts) > 0 {
+			autoscalerContainer.VolumeMounts = append(autoscalerContainer.VolumeMounts, autoscalerOptions.VolumeMounts...)
+		}
 		if autoscalerOptions.SecurityContext != nil {
 			autoscalerContainer.SecurityContext = autoscalerOptions.SecurityContext.DeepCopy()
 		}

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -595,6 +595,17 @@ func TestBuildPodWithAutoscalerOptions(t *testing.T) {
 	}
 	customEnv := []v1.EnvVar{{Name: "fooEnv", Value: "fooValue"}}
 	customEnvFrom := []v1.EnvFromSource{{Prefix: "Pre"}}
+	customVolumeMounts := []v1.VolumeMount{
+		{
+			Name:      "ca-tls",
+			MountPath: "/etc/ca/tls",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "ray-tls",
+			MountPath: "/etc/ray/tls",
+		},
+	}
 
 	// Define a custom security profile.
 	allowPrivilegeEscalation := false
@@ -620,6 +631,7 @@ func TestBuildPodWithAutoscalerOptions(t *testing.T) {
 		Resources:          &customResources,
 		Env:                customEnv,
 		EnvFrom:            customEnvFrom,
+		VolumeMounts:       customVolumeMounts,
 		SecurityContext:    &customSecurityContext,
 	}
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
@@ -630,6 +642,7 @@ func TestBuildPodWithAutoscalerOptions(t *testing.T) {
 	expectedContainer.Resources = customResources
 	expectedContainer.EnvFrom = customEnvFrom
 	expectedContainer.Env = append(expectedContainer.Env, customEnv...)
+	expectedContainer.VolumeMounts = append(customVolumeMounts, expectedContainer.VolumeMounts...)
 	expectedContainer.SecurityContext = &customSecurityContext
 	index := getAutoscalerContainerIndex(pod)
 	actualContainer := pod.Spec.Containers[index]


### PR DESCRIPTION
## Why are these changes needed?

This PR adds the ability to mount volumes in AutoscalerOptions to enable TLS in Autoscaler.  At the moment, if you enable TLS and the autoscaler, the autoscaler is unable to connect to the Ray head because the certificates doesn't exist and there was no way to mount volumes where the certs reside like what you can do in the other containers [for example](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.tls.yaml#L56-L60)

This PR adds the ability to mount volumes in the AutoscalerOptions so we can mount the TLS volumes.

## Related issue number
No github issue but here's the Slack chat for more context - https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1684511397156609

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
