### PR TITLE
[Bug][breaking change] Unauthorized 401 error on fetching Ray Custom Resources from K8s API server

### DIFF
--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -46,6 +46,8 @@ head:
     #     cpu: "500m"
     #     memory: "512Mi"
   labels: {}
+  # Note: From KubeRay v0.6.0, users need to create the ServiceAccount by themselves if they specify the `serviceAccountName`
+  # in the headGroupSpec. See https://github.com/ray-project/kuberay/pull/1128 for more details.
   serviceAccountName: ""
   rayStartParams:
     dashboard-host: '0.0.0.0'

--- a/ray-operator/config/samples/ray-service.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-service.autoscaler.yaml
@@ -63,6 +63,9 @@ spec:
       #pod template
       template:
         spec:
+          # Note: From KubeRay v0.6.0, users need to create the ServiceAccount by themselves if they specify the `serviceAccountName`
+          # in the headGroupSpec. See https://github.com/ray-project/kuberay/pull/1128 for more details.
+          # serviceAccountName: my-sa
           containers:
             - name: ray-head
               image: rayproject/ray:2.4.0

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1032,8 +1032,9 @@ func (r *RayClusterReconciler) reconcileAutoscalerServiceAccount(instance *rayio
 		// for more details.
 		if instance.Spec.HeadGroupSpec.Template.Spec.ServiceAccountName == namespacedName.Name {
 			r.Log.Error(err, fmt.Sprintf(
-				"If users specify ServiceAccountName for the head Pod, they need to create a ServiceAccount themselves."+
-					"However, ServiceAccount %s is not found. Please create one.", namespacedName.Name), "ServiceAccount", namespacedName)
+				"If users specify ServiceAccountName for the head Pod, they need to create a ServiceAccount themselves. "+
+					"However, ServiceAccount %s is not found. Please create one. "+
+					"See the PR description of https://github.com/ray-project/kuberay/pull/1128 for more details.", namespacedName.Name), "ServiceAccount", namespacedName)
 			return err
 		}
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1026,6 +1026,17 @@ func (r *RayClusterReconciler) reconcileAutoscalerServiceAccount(instance *rayio
 			return err
 		}
 
+		// If users specify ServiceAccountName for the head Pod, they need to create a ServiceAccount themselves.
+		// However, if KubeRay creates a ServiceAccount for users, the autoscaler may encounter permission issues during
+		// zero-downtime rolling updates when RayService is performed. See https://github.com/ray-project/kuberay/issues/1123
+		// for more details.
+		if instance.Spec.HeadGroupSpec.Template.Spec.ServiceAccountName == namespacedName.Name {
+			r.Log.Error(err, fmt.Sprintf(
+				"If users specify ServiceAccountName for the head Pod, they need to create a ServiceAccount themselves."+
+					"However, ServiceAccount %s is not found. Please create one.", namespacedName.Name), "ServiceAccount", namespacedName)
+			return err
+		}
+
 		// Create service account for autoscaler if there's no existing one in the cluster.
 		serviceAccount, err := common.BuildServiceAccount(instance)
 		if err != nil {
@@ -1034,6 +1045,7 @@ func (r *RayClusterReconciler) reconcileAutoscalerServiceAccount(instance *rayio
 
 		// making sure the name is valid
 		serviceAccount.Name = utils.CheckName(serviceAccount.Name)
+
 		// Set controller reference
 		if err := controllerutil.SetControllerReference(instance, serviceAccount, r.Scheme); err != nil {
 			return err

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -62,7 +62,6 @@ var _ = Context("Inside the default namespace", func() {
 				},
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
-						ServiceAccountName: "head-service-account",
 						Containers: []corev1.Container{
 							{
 								Name:    "ray-head",
@@ -166,14 +165,6 @@ var _ = Context("Inside the default namespace", func() {
 				getResourceFunc(ctx, client.ObjectKey{Name: pod.Name, Namespace: "default"}, pod),
 				time.Second*3, time.Millisecond*500).Should(BeNil(), "My head pod = %v", pod)
 			Expect(pod.Status.Phase).Should(Or(Equal(corev1.PodPending), Equal(corev1.PodRunning)))
-		})
-
-		It("should create the head group's specified K8s ServiceAccount if it doesn't exist", func() {
-			saName := utils.GetHeadGroupServiceAccountName(myRayCluster)
-			sa := &corev1.ServiceAccount{}
-			Eventually(
-				getResourceFunc(ctx, client.ObjectKey{Name: saName, Namespace: "default"}, sa),
-				time.Second*15, time.Millisecond*500).Should(BeNil(), "My head group ServiceAccount = %v", saName)
 		})
 
 		It("should create the autoscaler K8s RoleBinding if it doesn't exist", func() {

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -441,7 +441,7 @@ var _ = Context("Inside the default namespace", func() {
 			// Hence, all the ServeStatuses[i].Status should be updated to UNHEALTHY.
 			//
 			// Note: LastUpdateTime/HealthLastUpdateTime will be overwritten via metav1.Now() in rayservice_controller.go.
-			// Hence, we cannot use `newTime`` to check whether the status is updated or not.
+			// Hence, we cannot use `newTime` to check whether the status is updated or not.
 			Eventually(
 				checkAllServeStatusesUnhealthy(ctx, myRayService),
 				time.Second*3, time.Millisecond*500).Should(BeTrue(), "myRayService status = %v", myRayService.Status)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In #1123, the autoscaler container fails to GET the RayCluster from the Kubernetes API Server and receives error code 401 after a zero-downtime upgrade. If you are interested in the root cause, you can read the "debug process" section.

We have two solutions for this issue:

* Solution 1: Still create a ServiceAccount for users if the specified `ServiceAccountName` does not exist. The only difference is that we do not set the ControllerReference for the ServiceAccount to avoid it being deleted by the Kubernetes garbage collector. (Step 5 in the section **"3. Root cause of this issue"**)
  * (+) More backward-compatible
  * (-) Users need to delete the ServiceAccount themselves, which may introduce "unknown unknowns" for users.

* Solution 2 (this PR): If users specify ServiceAccountName, they need to create the ServiceAccount by themselves.
  * (-) Break the backward compatibility for users who specify the `ServiceAccountName` without creating a ServiceAccount manually.
  * (+) It can avoid "unknown unknowns" and makes it easier to identify and fix any issues. Although it breaks backward compatibility, it provides clarity and transparency in troubleshooting.
 

## Debug process (optional)

### 1. Understand ServiceAccount

In the head Pod, we can get three files, `ca.crt`, `namespace`, `token`, related to the ServiceAccount. You can check this [article](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-bound-service-account-tokens) for the descriptions about these 3 files.

```sh
ls /var/run/secrets/kubernetes.io/serviceaccount/
# example output: ca.crt  namespace  token
```

#### [Experiment for `ca.crt` and `token`]:

You can execute the following commands in the head Pod of an autoscaling RayCluster. The ServiceAccount should have sufficient permissions to perform a `GET` operation on the RayCluster.

```sh
# Typically, the Kubernetes APIServer will be in the default namespace, so you can use 
export APISERVER=https://kubernetes.default:443
export TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
curl -X GET $APISERVER/apis/ray.io/v1alpha1/namespaces/$RAYCLUSTER_NAMESPACE/rayclusters/$RAYCLUSTER_CR_NAME --header "Authorization: Bearer $TOKEN" --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
```

* [Case 1] Only use `ca.crt`: Use the anonymous ServiceAccount "system:anonymous" which does not have the permission to GET RayCluster => 403 Forbidden
* [Case 2] Only use `token`: Use the ServiceAccount that associated with this Pod which has the permission to GET RayCluster => Succeed
* [Case 3] Use `ca.crt` and `token` at the same time => Succeed (same as Case 2)

The result is same as the result in this [article](https://itnext.io/k8s-tips-accessing-the-api-server-from-a-pod-f6f72bc847de). I am not sure the purpose of ca.crt. It may only be used when some Kubernetes API Server configurations are set.

### 2. 401 Unauthorized vs 403 Forbidden

* **401 Unauthorized definition**:
  * https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests (Kubernetes) => “For example, on a server with token authentication configured, and anonymous access enabled, a request providing an invalid bearer token would receive a 401 Unauthorized error.” => Focus on this.
  * https://docs.aws.amazon.com/eks/latest/userguide/troubleshooting.html (EKS) => “Your Amazon EKS version 1.21 or later cluster’s Kubernetes API server rejects requests with tokens older than 90 days.” => This seems to be impossible in our case.

Based on this [Kubernetes link](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests),

* When we did not configure `token` and Kubernetes API Server enables anonymous access (it is enabled by default after Kubernetes 1.6+, and you can check whether it is disabled or not by this [link](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests).) => It will use the anonymous ServiceAccount `"system:anonymous"`. If the ServiceAccount does not have enough permissions to perform the operation. The error code will be `403 Forbidden`.

* If we specify an invalid token in the request, we will get a 401 Unauthorized error. For example, we can get 401 by changing 
  ```sh
  # Typically, the Kubernetes APIServer will be in the default namespace, so you can use 
  export APISERVER=https://kubernetes.default:443
  export TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
  curl -X GET $APISERVER/apis/ray.io/v1alpha1/namespaces/$RAYCLUSTER_NAMESPACE/rayclusters/$RAYCLUSTER_CR_NAME --header "Authorization: Bearer $TOKEN" --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
  ```
  
  to 

  ```sh
  # Typically, the Kubernetes APIServer will be in the default namespace, so you can use 
  export APISERVER=https://kubernetes.default:443
  export TOKEN=WRONG_TOKEN
  curl -X GET $APISERVER/apis/ray.io/v1alpha1/namespaces/$RAYCLUSTER_NAMESPACE/rayclusters/$RAYCLUSTER_CR_NAME --header "Authorization: Bearer $TOKEN" --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
  ```

#### TL;DR
* `401 Unauthorized`: `token` is invalid.
* `403 Forbidden`: Kubernetes API Server can associate the ServiceAccount, but the account does not enough permission to perform the operation.

### 3. Root cause of this issue

Because we received a 401 error instead of a 403 error, our focus should be on why the `token` is invalid rather than whether the ServiceAccount has sufficient permissions or not.

* Step 1: When users specify `ServiceAccountName` (e.g., `my-sa`) for the head Pod without manually creating the ServiceAccount, KubeRay will create a ServiceAccount for them.
* Step 2: Users trigger a new RayCluster preparation by updating the RayService CR.
* Step 3: The new RayCluster will use the same `my-sa` ServiceAccount as the old RayCluster.
* Step 4: When the Serve deployments on the new RayCluster are ready and healthy, traffic will be redirected to the new RayCluster. Then, the old RayCluster will be deleted.
* Step 5: Because the old RayCluster and the `my-sa` ServiceAccount have an owner/dependent relationship, the `my-sa` ServiceAccount will be deleted when the old RayCluster is deleted.
* Step 6: Although KubeRay will create a new ServiceAccount called `my-sa` (referred to as new `my-sa` below), the new RayCluster has already mounted the old `my-sa` ServiceAccount in Step 3.
* Step 7: The autoscaler of the new RayCluster will attempt to use the token of the old my-sa ServiceAccount to make a GET request to the Kubernetes API Server for the RayCluster information. However, since the ServiceAccount has been deleted, the token is no longer valid. This is why we receive a `401 Unauthorized` error.

## Related issue number

Closes #1123 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
# Step 0: Create a Kind cluster
kind create cluster --image=kindest/node:v1.23.0

# Step 1: Build docker image for this PR (path: ray-operator/) and load into the Kind cluster
make docker-image
kind load docker-image controller:latest

# Step 2: Install a KubeRay operator
# path: helm-chart/kuberay-operator
helm install kuberay-operator . --set image.repository=controller,image.tag=latest

# Step 3: Create a ServiceAccount `my-sa` with the following YAML file
apiVersion: v1
kind: ServiceAccount
metadata:
  name: my-sa
  namespace: default

# Step 3: Create a RayService
# Use this gist: https://gist.github.com/kevin85421/b2f2af680aff2562c540cef1f138b4b9
kubectl apply -f ray-service.autoscaler-with-ServiceAccountName.yaml

# Step 4: Edit `spec.rayClusterConfig.rayVersion` from 2.4.0 to 2.100.0.
kubectl edit rayservices.ray.io rayservice-sample

# Step 5: Check the log of the new RayCluster to ensure that no 401 error is present, as the expected behavior is to have no occurrences of the 401 error.
```
