### PR TITLE
Adding service account for pod's execution

### DIFF
--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -12,6 +12,8 @@ import (
 type RayClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	// ServiceAccount under which all of the cluster nodes run, if omitted, cluster name is used as service account name
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 	// HeadGroupSpecs are the spec for the head pod
 	HeadGroupSpec HeadGroupSpec `json:"headGroupSpec"`
 	// WorkerGroupSpecs are the specs for the worker pods

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types_test.go
@@ -15,7 +15,8 @@ var myRayCluster = &RayCluster{
 		Namespace: "default",
 	},
 	Spec: RayClusterSpec{
-		RayVersion: "1.0",
+		RayVersion:         "1.0",
+		ServiceAccountName: "foo",
 		HeadGroupSpec: HeadGroupSpec{
 			Replicas: pointer.Int32Ptr(1),
 			RayStartParams: map[string]string{

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -93,9 +93,9 @@ type RayJobStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+genclient
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +genclient
 // RayJob is the Schema for the rayjobs API
 type RayJob struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
@@ -23,7 +23,8 @@ var expectedRayJob = RayJob{
 			"owner": "userA",
 		},
 		RayClusterSpec: &RayClusterSpec{
-			RayVersion: "1.12.1",
+			RayVersion:         "1.12.1",
+			ServiceAccountName: "foo",
 			HeadGroupSpec: HeadGroupSpec{
 				Replicas: pointer.Int32Ptr(1),
 				RayStartParams: map[string]string{
@@ -145,6 +146,7 @@ var testRayJobJSON = `{
             "owner":"userA"
         },
         "rayClusterSpec": {
+			"serviceAccountName": "foo",
             "headGroupSpec": {
                 "replicas": 1,
                 "rayStartParams": {

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -142,9 +142,9 @@ type ServeDeploymentStatus struct {
 	HealthLastUpdateTime *metav1.Time `json:"healthLastUpdateTime,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+genclient
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +genclient
 // RayService is the Schema for the rayservices API
 type RayService struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -6,7 +6,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -685,10 +685,8 @@ func TestHeadPodTemplate_WithAutoscalingEnabled(t *testing.T) {
 // the head pod's service account should be an empty string.
 func TestHeadPodTemplate_WithNoServiceAccount(t *testing.T) {
 	cluster := instance.DeepCopy()
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
-	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 
-	actualResult := pod.Spec.ServiceAccountName
+	actualResult := cluster.Spec.ServiceAccountName
 	expectedResult := ""
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
@@ -700,11 +698,9 @@ func TestHeadPodTemplate_WithNoServiceAccount(t *testing.T) {
 func TestHeadPodTemplate_WithServiceAccountNoAutoscaling(t *testing.T) {
 	cluster := instance.DeepCopy()
 	serviceAccount := "head-service-account"
-	cluster.Spec.HeadGroupSpec.Template.Spec.ServiceAccountName = serviceAccount
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
-	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
+	cluster.Spec.ServiceAccountName = serviceAccount
 
-	actualResult := pod.Spec.ServiceAccountName
+	actualResult := cluster.Spec.ServiceAccountName
 	expectedResult := serviceAccount
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
@@ -716,12 +712,10 @@ func TestHeadPodTemplate_WithServiceAccountNoAutoscaling(t *testing.T) {
 func TestHeadPodTemplate_WithServiceAccount(t *testing.T) {
 	cluster := instance.DeepCopy()
 	serviceAccount := "head-service-account"
-	cluster.Spec.HeadGroupSpec.Template.Spec.ServiceAccountName = serviceAccount
+	cluster.Spec.ServiceAccountName = serviceAccount
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1alpha1.HeadNode) + DashSymbol + utils.FormatInt32(0))
-	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 
-	actualResult := pod.Spec.ServiceAccountName
+	actualResult := cluster.Spec.ServiceAccountName
 	expectedResult := serviceAccount
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)

--- a/ray-operator/controllers/ray/common/rbac.go
+++ b/ray-operator/controllers/ray/common/rbac.go
@@ -12,7 +12,7 @@ import (
 func BuildServiceAccount(cluster *rayv1alpha1.RayCluster) (*v1.ServiceAccount, error) {
 	sa := &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      utils.GetHeadGroupServiceAccountName(cluster),
+			Name:      utils.GetServiceAccountName(cluster),
 			Namespace: cluster.Namespace,
 			Labels: map[string]string{
 				RayClusterLabelKey:                cluster.Name,
@@ -56,7 +56,7 @@ func BuildRole(cluster *rayv1alpha1.RayCluster) (*rbacv1.Role, error) {
 
 // BuildRole
 func BuildRoleBinding(cluster *rayv1alpha1.RayCluster) (*rbacv1.RoleBinding, error) {
-	serviceAccountName := utils.GetHeadGroupServiceAccountName(cluster)
+	serviceAccountName := utils.GetServiceAccountName(cluster)
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name,

--- a/ray-operator/controllers/ray/common/rbac_test.go
+++ b/ray-operator/controllers/ray/common/rbac_test.go
@@ -18,25 +18,24 @@ func TestBuildRoleBindingSubjectAndRoleRefName(t *testing.T) {
 		input *rayv1alpha1.RayCluster
 		want  []string
 	}{
-		"Ray cluster with head group service account": {
+		"Ray cluster with service account": {
 			input: &rayv1alpha1.RayCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "raycluster-sample",
 					Namespace: "default",
 				},
 				Spec: rayv1alpha1.RayClusterSpec{
+					ServiceAccountName: "my-service-account",
 					HeadGroupSpec: rayv1alpha1.HeadGroupSpec{
 						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								ServiceAccountName: "my-service-account",
-							},
+							Spec: corev1.PodSpec{},
 						},
 					},
 				},
 			},
 			want: []string{"my-service-account", "raycluster-sample"},
 		},
-		"Ray cluster without head group service account": {
+		"Ray cluster without service account": {
 			input: &rayv1alpha1.RayCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "raycluster-sample",
@@ -52,7 +51,7 @@ func TestBuildRoleBindingSubjectAndRoleRefName(t *testing.T) {
 			},
 			want: []string{"raycluster-sample", "raycluster-sample"},
 		},
-		"Ray cluster with a long name and without head group service account": {
+		"Ray cluster with a long name and without service account": {
 			input: &rayv1alpha1.RayCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      longString(t), // 200 chars long

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -252,6 +252,7 @@ func setupTest(t *testing.T) {
 		},
 		Spec: rayv1alpha1.RayClusterSpec{
 			RayVersion:              "1.0",
+			ServiceAccountName:      headGroupServiceAccount,
 			EnableInTreeAutoscaling: &enableInTreeAutoscaling,
 			HeadGroupSpec: rayv1alpha1.HeadGroupSpec{
 				Replicas: pointer.Int32Ptr(1),
@@ -264,7 +265,6 @@ func setupTest(t *testing.T) {
 				},
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
-						ServiceAccountName: headGroupServiceAccount,
 						Containers: []corev1.Container{
 							{
 								Name:    "ray-head",
@@ -893,7 +893,7 @@ func TestReconcile_AutoscalerServiceAccount(t *testing.T) {
 		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
-	err = testRayClusterReconciler.reconcileAutoscalerServiceAccount(testRayCluster)
+	err = testRayClusterReconciler.reconcileServiceAccount(testRayCluster)
 	assert.Nil(t, err, "Fail to reconcile autoscaler ServiceAccount")
 
 	err = fakeClient.Get(context.Background(), saNamespacedName, &sa)

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -169,7 +169,7 @@ var _ = Context("Inside the default namespace", func() {
 		})
 
 		It("should create the head group's specified K8s ServiceAccount if it doesn't exist", func() {
-			saName := utils.GetHeadGroupServiceAccountName(myRayCluster)
+			saName := utils.GetServiceAccountName(myRayCluster)
 			sa := &corev1.ServiceAccount{}
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: saName, Namespace: "default"}, sa),

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -489,7 +489,7 @@ func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, ra
 		// TODO: If both ClusterSelector and RayClusterSpec are not set, we avoid should attempting to retrieve a RayCluster instance.
 		// Consider moving this logic to a more appropriate location.
 		if len(rayJobInstance.Spec.ClusterSelector) == 0 && rayJobInstance.Spec.RayClusterSpec == nil {
-			err := fmt.Errorf("Both ClusterSelector and RayClusterSpec are undefined")
+			err := fmt.Errorf("both ClusterSelector and RayClusterSpec are undefined")
 			r.Log.Error(err, "Failed to configure RayCluster instance due to missing configuration")
 			return nil, err
 		}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1070,7 +1070,7 @@ func (r *RayServiceReconciler) isHeadPodRunningAndReady(instance *rayv1alpha1.Ra
 	}
 
 	if len(podList.Items) != 1 {
-		return false, fmt.Errorf("Found %d head pods for RayCluster %s in the namespace %s", len(podList.Items), instance.Name, instance.Namespace)
+		return false, fmt.Errorf("found %d head pods for RayCluster %s in the namespace %s", len(podList.Items), instance.Name, instance.Namespace)
 	}
 
 	return utils.IsRunningAndReady(&podList.Items[0]), nil

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -328,10 +328,10 @@ func FilterContainerByName(containers []corev1.Container, name string) (corev1.C
 
 // GetHeadGroupServiceAccountName returns the head group service account if it exists.
 // Otherwise, it returns the name of the cluster itself.
-func GetHeadGroupServiceAccountName(cluster *rayv1alpha1.RayCluster) string {
-	headGroupServiceAccountName := cluster.Spec.HeadGroupSpec.Template.Spec.ServiceAccountName
-	if headGroupServiceAccountName != "" {
-		return headGroupServiceAccountName
+func GetServiceAccountName(cluster *rayv1alpha1.RayCluster) string {
+	serviceAccountName := cluster.Spec.ServiceAccountName
+	if serviceAccountName != "" {
+		return serviceAccountName
 	}
 	return cluster.Name
 }

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -120,25 +120,19 @@ func TestGetHeadGroupServiceAccountName(t *testing.T) {
 		input *rayv1alpha1.RayCluster
 		want  string
 	}{
-		"Ray cluster with head group service account": {
+		"Ray cluster with service account": {
 			input: &rayv1alpha1.RayCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "raycluster-sample",
 					Namespace: "default",
 				},
 				Spec: rayv1alpha1.RayClusterSpec{
-					HeadGroupSpec: rayv1alpha1.HeadGroupSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								ServiceAccountName: "my-service-account",
-							},
-						},
-					},
+					ServiceAccountName: "my-service-account",
 				},
 			},
 			want: "my-service-account",
 		},
-		"Ray cluster without head group service account": {
+		"Ray cluster without service account": {
 			input: &rayv1alpha1.RayCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "raycluster-sample",
@@ -158,7 +152,7 @@ func TestGetHeadGroupServiceAccountName(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := GetHeadGroupServiceAccountName(tc.input)
+			got := GetServiceAccountName(tc.input)
 			if got != tc.want {
 				t.Fatalf("got %s, want %s", got, tc.want)
 			}

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -16,7 +16,9 @@ require (
 	go.uber.org/zap v1.19.1
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	k8s.io/api v0.23.0
+	k8s.io/apiextensions-apiserver v0.23.0
 	k8s.io/apimachinery v0.23.0
+	k8s.io/apiserver v0.23.0
 	k8s.io/client-go v0.23.0
 	k8s.io/code-generator v0.23.0
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
@@ -75,8 +77,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.23.0 // indirect
-	k8s.io/apiserver v0.23.0 // indirect
 	k8s.io/component-base v0.23.0 // indirect
 	k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect

--- a/ray-operator/go.sum
+++ b/ray-operator/go.sum
@@ -46,6 +46,7 @@ github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSY
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -390,7 +391,6 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.11.1 h1:+4eQaD7vAZ6DsfsxB15hbE0odUjGI5ARs9yskGu1v4s=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=

--- a/ray-operator/pkg/client/clientset/versioned/fake/register.go
+++ b/ray-operator/pkg/client/clientset/versioned/fake/register.go
@@ -21,14 +21,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/ray-operator/pkg/client/clientset/versioned/scheme/register.go
+++ b/ray-operator/pkg/client/clientset/versioned/scheme/register.go
@@ -21,14 +21,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, both head (with the exception of autoscaling) and worker pods are running using the default server account. As explained here https://loft.sh/blog/kubernetes-service-account-what-it-is-and-how-to-use-it/, CI/CD access to the cluster, pods-to-pods communication, or pods to Kubernetes API authentication all typically require a service account. The service account is also quite important for security reasons.
In the case of autoscaling, this service account will have additional permissions, required for autoscaling 

## Related issue number

closes https://github.com/ray-project/kuberay/issues/1088

## Checks

- [ x] I've made sure the tests are passing. 
- Testing Strategy
   - [ x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
