### PR TITLE
[2.5.0 Release] Change version numbers 2.4.0 -> 2.5.0

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -360,6 +360,26 @@ jobs:
         with:
           ray_version: 2.4.0
 
+  test-compatibility-2_5_0:
+    needs:
+      - build_operator
+      - build_apiserver
+      - lint
+    runs-on: ubuntu-latest
+    name: Compatibility Test - 2.5.0
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          # When checking out the repository that
+          # triggered a workflow, this defaults to the reference or SHA for that event.
+          # Default value should work for both pull_request and merge(push) event.
+          ref: ${{github.event.pull_request.head.sha}}
+
+      - uses: ./.github/workflows/actions/compatibility
+        with:
+          ray_version: 2.5.0
+
   test-compatibility-nightly:
     needs:
       - build_operator
@@ -380,13 +400,13 @@ jobs:
         with:
           ray_version: nightly
 
-  sample-yaml-config-test-2_3_0:
+  sample-yaml-config-test-2_5_0:
     needs:
       - build_operator
       - build_apiserver
       - lint
     runs-on: ubuntu-latest
-    name: Sample YAML Config Test - 2.4.0
+    name: Sample YAML Config Test - 2.5.0
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -397,7 +417,7 @@ jobs:
           ref: ${{github.event.pull_request.head.sha}}
       - uses: ./.github/workflows/actions/configuration
         with:
-          ray_version: 2.4.0
+          ray_version: 2.5.0
 
   python-client-test:
     runs-on: ubuntu-latest

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -194,7 +194,7 @@ curl -X POST 'localhost:31888/apis/v1alpha2/namespaces/ray-system/services' \
   "clusterSpec": {
     "headGroupSpec": {
       "computeTemplate": "default-template",
-      "image": "rayproject/ray:2.4.0",
+      "image": "rayproject/ray:2.5.0",
       "serviceType": "NodePort",
       "rayStartParams": {
             "dashboard-host": "0.0.0.0",
@@ -206,7 +206,7 @@ curl -X POST 'localhost:31888/apis/v1alpha2/namespaces/ray-system/services' \
       {
         "groupName": "small-wg",
         "computeTemplate": "default-template",
-        "image": "rayproject/ray:2.4.0",
+        "image": "rayproject/ray:2.5.0",
         "replicas": 1,
         "minReplicas": 0,
         "maxReplicas": 5,

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -58,7 +58,7 @@ var headSpecTest = v1alpha1.HeadGroupSpec{
 			Containers: []v1.Container{
 				{
 					Name:  "ray-head",
-					Image: "blublinsky1/ray310:2.4.0",
+					Image: "blublinsky1/ray310:2.5.0",
 					Env: []v1.EnvVar{
 						{
 							Name:  "AWS_KEY",
@@ -154,7 +154,7 @@ var workerSpecTest = v1alpha1.WorkerGroupSpec{
 			Containers: []v1.Container{
 				{
 					Name:  "ray-worker",
-					Image: "blublinsky1/ray310:2.4.0",
+					Image: "blublinsky1/ray310:2.5.0",
 					Env: []v1.EnvVar{
 						{
 							Name:  "AWS_KEY",

--- a/clients/python-client/examples/use-raw-config_map_with-api.py
+++ b/clients/python-client/examples/use-raw-config_map_with-api.py
@@ -47,7 +47,7 @@ cluster_body: dict = {
     "name": "raycluster-getting-started"
   },
   "spec": {
-    "rayVersion": "2.4.0",
+    "rayVersion": "2.5.0",
     "headGroupSpec": {
       "rayStartParams": {
         "dashboard-host": "0.0.0.0",
@@ -58,7 +58,7 @@ cluster_body: dict = {
           "containers": [
             {
               "name": "ray-head",
-              "image": "rayproject/ray:2.4.0",
+              "image": "rayproject/ray:2.5.0",
               "volumeMounts": [
                 {
                   "mountPath": "/opt",

--- a/clients/python-client/examples/use-raw-with-api.py
+++ b/clients/python-client/examples/use-raw-with-api.py
@@ -28,7 +28,7 @@ cluster_body: dict = {
         "name": "raycluster-mini-raw",
     },
     "spec": {
-        "rayVersion": "2.4.0",
+        "rayVersion": "2.5.0",
         "headGroupSpec": {
             "rayStartParams": {
                 "dashboard-host": "0.0.0.0",
@@ -39,7 +39,7 @@ cluster_body: dict = {
                     "containers": [
                         {
                             "name": "ray-head",
-                            "image": "rayproject/ray:2.4.0",
+                            "image": "rayproject/ray:2.5.0",
                             "resources": {
                                 "limits": {"cpu": 1, "memory": "2Gi"},
                                 "requests": {"cpu": "500m", "memory": "2Gi"},
@@ -66,7 +66,7 @@ cluster_body2: dict = {
         "name": "raycluster-complete-raw",
     },
     "spec": {
-        "rayVersion": "2.4.0",
+        "rayVersion": "2.5.0",
         "headGroupSpec": {
             "rayStartParams": {"dashboard-host": "0.0.0.0"},
             "template": {
@@ -75,7 +75,7 @@ cluster_body2: dict = {
                     "containers": [
                         {
                             "name": "ray-head",
-                            "image": "rayproject/ray:2.4.0",
+                            "image": "rayproject/ray:2.5.0",
                             "ports": [
                                 {"containerPort": 6379, "name": "gcs"},
                                 {"containerPort": 8265, "name": "dashboard"},
@@ -111,7 +111,7 @@ cluster_body2: dict = {
                         "containers": [
                             {
                                 "name": "ray-worker",
-                                "image": "rayproject/ray:2.4.0",
+                                "image": "rayproject/ray:2.5.0",
                                 "lifecycle": {
                                     "preStop": {
                                         "exec": {

--- a/clients/python-client/python_client/utils/kuberay_cluster_builder.py
+++ b/clients/python-client/python_client/utils/kuberay_cluster_builder.py
@@ -60,7 +60,7 @@ class ClusterBuilder(IClusterBuilder):
         name: str,
         k8s_namespace: str = "default",
         labels: dict = None,
-        ray_version: str = "2.4.0",
+        ray_version: str = "2.5.0",
     ):
         """Builds the metadata and ray version of the cluster.
 
@@ -68,7 +68,7 @@ class ClusterBuilder(IClusterBuilder):
         - name (str): The name of the cluster.
         - k8s_namespace (str, optional): The namespace in which the Ray cluster exists. Defaults to "default".
         - labels (dict, optional): A dictionary of key-value pairs to add as labels to the cluster. Defaults to None.
-        - ray_version (str, optional): The version of Ray to use for the cluster. Defaults to "2.4.0".
+        - ray_version (str, optional): The version of Ray to use for the cluster. Defaults to "2.5.0".
         """
         self.cluster = self.cluster_utils.populate_meta(
             cluster=self.cluster,
@@ -81,7 +81,7 @@ class ClusterBuilder(IClusterBuilder):
 
     def build_head(
         self,
-        ray_image: str = "rayproject/ray:2.4.0",
+        ray_image: str = "rayproject/ray:2.5.0",
         service_type: str = "ClusterIP",
         cpu_requests: str = "2",
         memory_requests: str = "3G",
@@ -94,7 +94,7 @@ class ClusterBuilder(IClusterBuilder):
         """Build head node of the ray cluster.
 
         Parameters:
-        - ray_image (str): Docker image for the head node. Default value is "rayproject/ray:2.4.0".
+        - ray_image (str): Docker image for the head node. Default value is "rayproject/ray:2.5.0".
         - service_type (str): Service type of the head node. Default value is "ClusterIP".
         - cpu_requests (str): CPU requests for the head node. Default value is "2".
         - memory_requests (str): Memory requests for the head node. Default value is "3G".
@@ -118,7 +118,7 @@ class ClusterBuilder(IClusterBuilder):
     def build_worker(
         self,
         group_name: str,
-        ray_image: str = "rayproject/ray:2.4.0",
+        ray_image: str = "rayproject/ray:2.5.0",
         ray_command: Any = ["/bin/bash", "-lc"],
         init_image: str = "busybox:1.28",
         cpu_requests: str = "1",
@@ -136,7 +136,7 @@ class ClusterBuilder(IClusterBuilder):
 
         Parameters:
         - group_name (str): name of the worker group.
-        - ray_image (str, optional): Docker image for the Ray process. Default is "rayproject/ray:2.4.0".
+        - ray_image (str, optional): Docker image for the Ray process. Default is "rayproject/ray:2.5.0".
         - ray_command (Any, optional): Command to run in the Docker container. Default is ["/bin/bash", "-lc"].
         - init_image (str, optional): Docker image for the init container. Default is "busybox:1.28".
         - cpu_requests (str, optional): CPU requests for the worker pods. Default is "1".

--- a/clients/python-client/python_client_test/test_api.py
+++ b/clients/python-client/python_client_test/test_api.py
@@ -14,7 +14,7 @@ test_cluster_body: dict = {
         "name": "raycluster-complete-raw",
     },
     "spec": {
-        "rayVersion": "2.4.0",
+        "rayVersion": "2.5.0",
         "headGroupSpec": {
             "rayStartParams": {"dashboard-host": "0.0.0.0"},
             "template": {
@@ -23,7 +23,7 @@ test_cluster_body: dict = {
                     "containers": [
                         {
                             "name": "ray-head",
-                            "image": "rayproject/ray:2.4.0",
+                            "image": "rayproject/ray:2.5.0",
                             "ports": [
                                 {"containerPort": 6379, "name": "gcs"},
                                 {"containerPort": 8265, "name": "dashboard"},
@@ -59,7 +59,7 @@ test_cluster_body: dict = {
                         "containers": [
                             {
                                 "name": "ray-worker",
-                                "image": "rayproject/ray:2.4.0",
+                                "image": "rayproject/ray:2.5.0",
                                 "lifecycle": {
                                     "preStop": {
                                         "exec": {
@@ -77,7 +77,7 @@ test_cluster_body: dict = {
                             },
                             {
                                 "name": "side-car",
-                                "image": "rayproject/ray:2.4.0",
+                                "image": "rayproject/ray:2.5.0",
                                 "resources": {
                                     "limits": {"cpu": "1", "memory": "1G"},
                                     "requests": {"cpu": "500m", "memory": "1G"},

--- a/clients/python-client/python_client_test/test_utils.py
+++ b/clients/python-client/python_client_test/test_utils.py
@@ -13,7 +13,7 @@ test_cluster_body: dict = {
         "name": "raycluster-complete-raw",
     },
     "spec": {
-        "rayVersion": "2.4.0",
+        "rayVersion": "2.5.0",
         "headGroupSpec": {
             "rayStartParams": {"dashboard-host": "0.0.0.0"},
             "template": {
@@ -22,7 +22,7 @@ test_cluster_body: dict = {
                     "containers": [
                         {
                             "name": "ray-head",
-                            "image": "rayproject/ray:2.4.0",
+                            "image": "rayproject/ray:2.5.0",
                             "ports": [
                                 {"containerPort": 6379, "name": "gcs"},
                                 {"containerPort": 8265, "name": "dashboard"},
@@ -58,7 +58,7 @@ test_cluster_body: dict = {
                         "containers": [
                             {
                                 "name": "ray-worker",
-                                "image": "rayproject/ray:2.4.0",
+                                "image": "rayproject/ray:2.5.0",
                                 "lifecycle": {
                                     "preStop": {
                                         "exec": {
@@ -76,7 +76,7 @@ test_cluster_body: dict = {
                             },
                             {
                                 "name": "side-car",
-                                "image": "rayproject/ray:2.4.0",
+                                "image": "rayproject/ray:2.5.0",
                                 "resources": {
                                     "limits": {"cpu": "1", "memory": "1G"},
                                     "requests": {"cpu": "500m", "memory": "1G"},
@@ -115,7 +115,7 @@ class TestUtils(unittest.TestCase):
     def test_populate_worker_group(self):
         worker_group, succeeded = self.utils.populate_worker_group(
             group_name="small-group",
-            ray_image="rayproject/ray:2.4.0",
+            ray_image="rayproject/ray:2.5.0",
             ray_command=["/bin/bash", "-lc"],
             init_image="busybox:1.28",
             cpu_requests="3",
@@ -137,7 +137,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(worker_group["replicas"], 1)
 
         container = worker_group["template"]["spec"]["containers"][0]
-        self.assertEqual(container["image"], "rayproject/ray:2.4.0")
+        self.assertEqual(container["image"], "rayproject/ray:2.5.0")
         self.assertEqual(container["command"], ["/bin/bash", "-lc"])
 
         resources = container["resources"]

--- a/docs/guidance/aws-eks-iam.md
+++ b/docs/guidance/aws-eks-iam.md
@@ -27,7 +27,7 @@ The root cause is that the version of `boto3` in the Ray image is too old. To el
 a more recent version (1.26) is currently available as per https://pypi.org/project/boto3/#history. The `boto3` 1.4.8 does not support to initialize the security credentials automatically in some cases (e.g. `AssumeRoleWithWebIdentity`).
 
 ```shell
-# image: rayproject/ray:2.4.0
+# image: rayproject/ray:2.5.0
 pip freeze | grep boto
 # boto3==1.4.8
 # botocore==1.8.50

--- a/docs/guidance/pod-command.md
+++ b/docs/guidance/pod-command.md
@@ -21,7 +21,7 @@ Currently, for timing (1), we can set the container's `Command` and `Args` in Ra
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           resources:
             ...
           ports:

--- a/docs/guidance/volcano-integration.md
+++ b/docs/guidance/volcano-integration.md
@@ -42,7 +42,7 @@ metadata:
     ray.io/scheduler-name: volcano
     volcano.sh/queue-name: kuberay-test-queue
 spec:
-  rayVersion: '2.4.0'
+  rayVersion: '2.5.0'
   headGroupSpec:
     rayStartParams: {}
     replicas: 1
@@ -50,7 +50,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           resources:
             limits:
               cpu: "1"
@@ -104,7 +104,7 @@ metadata:
     ray.io/scheduler-name: volcano
     volcano.sh/queue-name: kuberay-test-queue
 spec:
-  rayVersion: '2.4.0'
+  rayVersion: '2.5.0'
   headGroupSpec:
     rayStartParams: {}
     replicas: 1
@@ -112,7 +112,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           resources:
             limits:
               cpu: "1"
@@ -130,7 +130,7 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray:2.4.0
+            image: rayproject/ray:2.5.0
             resources:
               limits:
                 cpu: "1"
@@ -215,7 +215,7 @@ metadata:
     ray.io/scheduler-name: volcano
     volcano.sh/queue-name: kuberay-test-queue
 spec:
-  rayVersion: '2.4.0'
+  rayVersion: '2.5.0'
   headGroupSpec:
     rayStartParams: {}
     replicas: 1
@@ -223,7 +223,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           resources:
             limits:
               cpu: "1"
@@ -241,7 +241,7 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray:2.4.0
+            image: rayproject/ray:2.5.0
             resources:
               limits:
                 cpu: "1"

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -7,7 +7,7 @@
 
 image:
   repository: rayproject/ray
-  tag: 2.4.0
+  tag: 2.5.0
   pullPolicy: IfNotPresent
 
 nameOverride: "kuberay"
@@ -19,7 +19,7 @@ imagePullSecrets: []
 head:
   # rayVersion determines the autoscaler's image version.
   # It should match the Ray version in the image of the containers.
-  # rayVersion: 2.4.0
+  # rayVersion: 2.5.0
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -166,7 +166,7 @@ These tests operate small Ray clusters running within a [kind](https://kind.sigs
   # [Usage]: RAY_IMAGE=$RAY_IMAGE OPERATOR_IMAGE=$OPERATOR_IMAGE python3 tests/compatibility-test.py
   #          These 3 environment variables are optional.
   # [Example]:
-  RAY_IMAGE=rayproject/ray:2.4.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/compatibility-test.py
+  RAY_IMAGE=rayproject/ray:2.5.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/compatibility-test.py
   ```
 ### Running configuration tests locally.
 
@@ -176,9 +176,9 @@ and `tests/test_sample_rayservice_yamls.py`. Currently, only a few of these samp
 
 ```bash
 # Test RayCluster doc examples.
-RAY_IMAGE=rayproject/ray:2.4.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_raycluster_yamls.py
+RAY_IMAGE=rayproject/ray:2.5.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_raycluster_yamls.py
 # Test RayService doc examples.
-RAY_IMAGE=rayproject/ray:2.4.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
+RAY_IMAGE=rayproject/ray:2.5.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
 ```
 
 See [KubeRay PR #605](https://github.com/ray-project/kuberay/pull/605) for more details about the test framework.

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
@@ -46,7 +46,7 @@ var expectedRayJob = RayJob{
 						Containers: []corev1.Container{
 							{
 								Name:  "ray-head",
-								Image: "rayproject/ray:2.4.0",
+								Image: "rayproject/ray:2.5.0",
 								Env: []corev1.EnvVar{
 									{
 										Name: "MY_POD_IP",
@@ -107,7 +107,7 @@ var expectedRayJob = RayJob{
 							Containers: []corev1.Container{
 								{
 									Name:    "ray-worker",
-									Image:   "rayproject/ray:2.4.0",
+									Image:   "rayproject/ray:2.5.0",
 									Command: []string{"echo"},
 									Args:    []string{"Hello Ray"},
 									Env: []corev1.EnvVar{
@@ -168,7 +168,7 @@ var testRayJobJSON = `{
                         "containers": [
                             {
                                 "name": "ray-head",
-                                "image": "rayproject/ray:2.4.0",
+                                "image": "rayproject/ray:2.5.0",
                                 "ports": [
                                     {
                                         "name": "gcs-server",
@@ -230,7 +230,7 @@ var testRayJobJSON = `{
                             "containers": [
                                 {
                                     "name": "ray-worker",
-                                    "image": "rayproject/ray:2.4.0",
+                                    "image": "rayproject/ray:2.5.0",
                                     "command": [
                                         "echo"
                                     ],

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
@@ -94,7 +94,7 @@ var myRayService = &RayService{
 						Containers: []corev1.Container{
 							{
 								Name:  "ray-head",
-								Image: "rayproject/ray:2.4.0",
+								Image: "rayproject/ray:2.5.0",
 								Env: []corev1.EnvVar{
 									{
 										Name: "MY_POD_IP",
@@ -160,7 +160,7 @@ var myRayService = &RayService{
 							Containers: []corev1.Container{
 								{
 									Name:    "ray-worker",
-									Image:   "rayproject/ray:2.4.0",
+									Image:   "rayproject/ray:2.5.0",
 									Command: []string{"echo"},
 									Args:    []string{"Hello Ray"},
 									Env: []corev1.EnvVar{
@@ -260,7 +260,7 @@ var expected = `{
                   "containers":[
                      {
                         "name":"ray-head",
-                        "image":"rayproject/ray:2.4.0",
+                        "image":"rayproject/ray:2.5.0",
                         "ports":[
                            {
                               "name":"gcs-server",
@@ -327,7 +327,7 @@ var expected = `{
                      "containers":[
                         {
                            "name":"ray-worker",
-                           "image":"rayproject/ray:2.4.0",
+                           "image":"rayproject/ray:2.5.0",
                            "command":[
                               "echo"
                            ],

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -20,7 +20,7 @@ metadata:
   name: raycluster-autoscaler
 spec:
   # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
-  rayVersion: '2.4.0'
+  rayVersion: '2.5.0'
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
@@ -72,7 +72,7 @@ spec:
         containers:
         # The Ray head container
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
           # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal
@@ -127,7 +127,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
           # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal

--- a/ray-operator/config/samples/ray-cluster.autoscaler.tls.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.tls.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: raycluster-autoscaler
 spec:
-  rayVersion: '2.4.0'
+  rayVersion: '2.5.0'
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
@@ -71,7 +71,7 @@ spec:
         initContainers:
           # Generate head's private key and certificate before `ray start`.
           - name: ray-head-tls
-            image: rayproject/ray:2.4.0
+            image: rayproject/ray:2.5.0
             command: ["/bin/sh", "-c", "cp -R /etc/ca/tls /etc/ray && /etc/gen/tls/gencert_head.sh"]
             volumeMounts:
               - mountPath: /etc/ca/tls
@@ -88,7 +88,7 @@ spec:
                     fieldPath: status.podIP
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           ports:
           - containerPort: 6379
             name: gcs
@@ -159,7 +159,7 @@ spec:
         initContainers:
           # Generate worker's private key and certificate before `ray start`.
           - name: ray-worker-tls
-            image: rayproject/ray:2.4.0
+            image: rayproject/ray:2.5.0
             command: ["/bin/sh", "-c", "cp -R /etc/ca/tls /etc/ray && /etc/gen/tls/gencert_worker.sh"]
             volumeMounts:
               - mountPath: /etc/ca/tls
@@ -176,7 +176,7 @@ spec:
                     fieldPath: status.podIP
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           lifecycle:
             preStop:
               exec:

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -11,7 +11,7 @@ metadata:
   name: raycluster-autoscaler
 spec:
   # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
-  rayVersion: '2.4.0'
+  rayVersion: '2.5.0'
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
@@ -64,7 +64,7 @@ spec:
         containers:
         # The Ray head container
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           ports:
           - containerPort: 6379
             name: gcs
@@ -122,7 +122,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           lifecycle:
             preStop:
               exec:

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -13,7 +13,7 @@ metadata:
     # A unique identifier for the head node and workers of this cluster.
   name: raycluster-complete
 spec:
-  rayVersion: '2.4.0'
+  rayVersion: '2.5.0'
   # Ray head pod template
   headGroupSpec:
     # Kubernetes Service Type. This is an optional field, and the default value is ClusterIP.
@@ -36,7 +36,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
           # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal
@@ -91,7 +91,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           # Optimal resource allocation will depend on your Kubernetes infrastructure and might
           # require some experimentation.
           # Setting requests=limits is recommended with Ray. K8s limits are used for Ray-internal

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -10,7 +10,7 @@ metadata:
     # A unique identifier for the head node and workers of this cluster.
   name: raycluster-complete
 spec:
-  rayVersion: '2.4.0'
+  rayVersion: '2.5.0'
   # Ray head pod configuration
   headGroupSpec:
     # Kubernetes Service Type. This is an optional field, and the default value is ClusterIP.
@@ -30,7 +30,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           ports:
           - containerPort: 6379
             name: gcs
@@ -91,7 +91,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           lifecycle:
             preStop:
               exec:

--- a/ray-operator/config/samples/ray-cluster.custom-head-service.yaml
+++ b/ray-operator/config/samples/ray-cluster.custom-head-service.yaml
@@ -11,7 +11,7 @@ metadata:
     # An unique identifier for the head node and workers of this cluster.
   name: raycluster-custom-head-service.yaml
 spec:
-  rayVersion: '2.4.0' # should match the Ray version in the image of the containers
+  rayVersion: '2.5.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
     # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...
@@ -36,7 +36,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           resources:
             limits:
               cpu: 1

--- a/ray-operator/config/samples/ray-cluster.external-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis.yaml
@@ -87,7 +87,7 @@ metadata:
   # An unique identifier for the head node and workers of this cluster.
   name: raycluster-external-redis
 spec:
-  rayVersion: '2.4.0'
+  rayVersion: '2.5.0'
   headGroupSpec:
     replicas: 1
     # The `rayStartParams` are used to configure the `ray start` command.
@@ -103,7 +103,7 @@ spec:
       spec:
         containers:
           - name: ray-head
-            image: rayproject/ray:2.4.0
+            image: rayproject/ray:2.5.0
             resources:
               limits:
                 cpu: "1"
@@ -147,7 +147,7 @@ spec:
         spec:
           containers:
             - name: ray-worker
-              image: rayproject/ray:2.4.0
+              image: rayproject/ray:2.5.0
               volumeMounts:
                 - mountPath: /tmp/ray
                   name: ray-logs

--- a/ray-operator/config/samples/ray-cluster.head-command.yaml
+++ b/ray-operator/config/samples/ray-cluster.head-command.yaml
@@ -8,7 +8,7 @@ metadata:
     # An unique identifier for the head node and workers of this cluster.
   name: raycluster-mini
 spec:
-  rayVersion: '2.4.0' # should match the Ray version in the image of the containers
+  rayVersion: '2.5.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
     # The `rayStartParams` are used to configure the `ray start` command.
@@ -21,7 +21,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           resources:
             limits:
               cpu: 1

--- a/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
+++ b/ray-operator/config/samples/ray-cluster.heterogeneous.yaml
@@ -34,7 +34,7 @@ metadata:
     # An unique identifier for the head node and workers of this cluster.
   name: raycluster-heterogeneous
 spec:
-  rayVersion: '2.4.0'
+  rayVersion: '2.5.0'
   ######################headGroupSpecs#################################
   # Ray head pod template
   headGroupSpec:
@@ -48,7 +48,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           resources:
             limits:
               cpu: "1"
@@ -87,7 +87,7 @@ spec:
       spec:
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           volumeMounts:
             - mountPath: /tmp/ray
               name: ray-logs
@@ -123,7 +123,7 @@ spec:
       spec:
         containers:
         - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           # use volumeMounts.Optional.
           # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
           volumeMounts:

--- a/ray-operator/config/samples/ray-cluster.mini.yaml
+++ b/ray-operator/config/samples/ray-cluster.mini.yaml
@@ -10,7 +10,7 @@ metadata:
     # An unique identifier for the head node and workers of this cluster.
   name: raycluster-mini
 spec:
-  rayVersion: '2.4.0' # should match the Ray version in the image of the containers
+  rayVersion: '2.5.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
     # The `rayStartParams` are used to configure the `ray start` command.
@@ -23,7 +23,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           resources:
             limits:
               cpu: 1

--- a/ray-operator/config/samples/ray-cluster.separate-ingress.yaml
+++ b/ray-operator/config/samples/ray-cluster.separate-ingress.yaml
@@ -7,7 +7,7 @@ kind: RayCluster
 metadata:
   name: raycluster-ingress
 spec:
-  rayVersion: '2.4.0' # should match the Ray version in the image of the containers
+  rayVersion: '2.5.0' # should match the Ray version in the image of the containers
   headGroupSpec:
     serviceType: NodePort
     replicas: 1
@@ -21,7 +21,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           resources:
             limits:
               cpu: "1"

--- a/ray-operator/config/samples/ray-cluster.tls.yaml
+++ b/ray-operator/config/samples/ray-cluster.tls.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: raycluster-tls
 spec:
-  rayVersion: '2.4.0'
+  rayVersion: '2.5.0'
   # Ray head pod configuration
   headGroupSpec:
     # The `rayStartParams` are used to configure the `ray start` command.
@@ -21,7 +21,7 @@ spec:
         initContainers:
           # Generate head's private key and certificate before `ray start`.
           - name: ray-head-tls
-            image: rayproject/ray:2.4.0
+            image: rayproject/ray:2.5.0
             command: ["/bin/sh", "-c", "cp -R /etc/ca/tls /etc/ray && /etc/gen/tls/gencert_head.sh"]
             volumeMounts:
               - mountPath: /etc/ca/tls
@@ -38,7 +38,7 @@ spec:
                     fieldPath: status.podIP
         containers:
         - name: ray-head
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           ports:
           - containerPort: 6379
             name: gcs
@@ -109,7 +109,7 @@ spec:
         initContainers:
           # Generate worker's private key and certificate before `ray start`.
           - name: ray-worker-tls
-            image: rayproject/ray:2.4.0
+            image: rayproject/ray:2.5.0
             command: ["/bin/sh", "-c", "cp -R /etc/ca/tls /etc/ray && /etc/gen/tls/gencert_worker.sh"]
             volumeMounts:
               - mountPath: /etc/ca/tls
@@ -126,7 +126,7 @@ spec:
                     fieldPath: status.podIP
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.4.0
+          image: rayproject/ray:2.5.0
           lifecycle:
             preStop:
               exec:

--- a/ray-operator/config/samples/ray-pod.tls.yaml
+++ b/ray-operator/config/samples/ray-pod.tls.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: client
-    image: rayproject/ray:2.4.0
+    image: rayproject/ray:2.5.0
     args: [/bin/sh, -c, 'python -c "import ray; ray.init(\"ray://$FQ_RAY_IP:10001\"); print(ray.cluster_resources())" && sleep infinity']
     env:
     - name: RAY_USE_TLS
@@ -30,7 +30,7 @@ spec:
         name: gen-tls-script
   initContainers:
   - name: gen-cert
-    image: rayproject/ray:2.4.0
+    image: rayproject/ray:2.5.0
     args: ["/bin/sh", "-c", "cp -R /etc/ca/tls /etc/ray && /etc/gen/tls/gencert_worker.sh"]
     volumeMounts:
       - mountPath: /etc/ca/tls

--- a/ray-operator/config/samples/ray-service.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-service.autoscaler.yaml
@@ -42,7 +42,7 @@ spec:
         rayActorOptions:
           numCpus: 0.1
   rayClusterConfig:
-    rayVersion: '2.4.0' # should match the Ray version in the image of the containers
+    rayVersion: '2.5.0' # should match the Ray version in the image of the containers
     ## raycluster autoscaling config
     enableInTreeAutoscaling: true
     autoscalerOptions:
@@ -68,7 +68,7 @@ spec:
           # serviceAccountName: my-sa
           containers:
             - name: ray-head
-              image: rayproject/ray:2.4.0
+              image: rayproject/ray:2.5.0
               resources:
                 limits:
                   cpu: 200m
@@ -101,7 +101,7 @@ spec:
           spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-                image: rayproject/ray:2.4.0
+                image: rayproject/ray:2.5.0
                 lifecycle:
                   preStop:
                     exec:

--- a/ray-operator/config/samples/ray-service.custom-serve-service.yaml
+++ b/ray-operator/config/samples/ray-service.custom-serve-service.yaml
@@ -55,7 +55,7 @@ spec:
         rayActorOptions:
           numCpus: 0.1
   rayClusterConfig:
-    rayVersion: '2.4.0' # should match the Ray version in the image of the containers
+    rayVersion: '2.5.0' # should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
@@ -69,7 +69,7 @@ spec:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.4.0
+              image: rayproject/ray:2.5.0
               resources:
                 limits:
                   cpu: 2
@@ -102,7 +102,7 @@ spec:
           spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-                image: rayproject/ray:2.4.0
+                image: rayproject/ray:2.5.0
                 lifecycle:
                   preStop:
                     exec:

--- a/ray-operator/config/samples/ray-service.different-port.yaml
+++ b/ray-operator/config/samples/ray-service.different-port.yaml
@@ -43,7 +43,7 @@ spec:
           numCpus: 0.1
     port: 9000
   rayClusterConfig:
-    rayVersion: '2.4.0' # should match the Ray version in the image of the containers
+    rayVersion: '2.5.0' # should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
@@ -55,7 +55,7 @@ spec:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.4.0
+              image: rayproject/ray:2.5.0
               resources:
                 limits:
                   cpu: 2
@@ -85,7 +85,7 @@ spec:
           spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-                image: rayproject/ray:2.4.0
+                image: rayproject/ray:2.5.0
                 lifecycle:
                   preStop:
                     exec:

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -15,7 +15,7 @@ spec:
   #}'
   runtimeEnv: ewogICAgInBpcCI6IFsKICAgICAgICAicmVxdWVzdHM9PTIuMjYuMCIsCiAgICAgICAgInBlbmR1bHVtPT0yLjEuMiIKICAgIF0sCiAgICAiZW52X3ZhcnMiOiB7ImNvdW50ZXJfbmFtZSI6ICJ0ZXN0X2NvdW50ZXIifQp9Cg==
   rayClusterSpec:
-    rayVersion: '2.4.0' # should match the Ray version in the image of the containers
+    rayVersion: '2.5.0' # should match the Ray version in the image of the containers
     # Ray head pod template
     headGroupSpec:
       # The `rayStartParams` are used to configure the `ray start` command.
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.4.0
+              image: rayproject/ray:2.5.0
               ports:
                 - containerPort: 6379
                   name: gcs-server
@@ -72,7 +72,7 @@ spec:
           spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-                image: rayproject/ray:2.4.0
+                image: rayproject/ray:2.5.0
                 lifecycle:
                   preStop:
                     exec:

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -42,7 +42,7 @@ spec:
         rayActorOptions:
           numCpus: 0.1
   rayClusterConfig:
-    rayVersion: '2.4.0' # should match the Ray version in the image of the containers
+    rayVersion: '2.5.0' # should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
@@ -56,7 +56,7 @@ spec:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.4.0
+              image: rayproject/ray:2.5.0
               resources:
                 limits:
                   cpu: 2
@@ -89,7 +89,7 @@ spec:
           spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-                image: rayproject/ray:2.4.0
+                image: rayproject/ray:2.5.0
                 lifecycle:
                   preStop:
                     exec:

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -193,7 +193,7 @@ func setupTest(t *testing.T) {
 				Containers: []corev1.Container{
 					{
 						Name:    "ray-worker",
-						Image:   "rayproject/ray:2.4.0",
+						Image:   "rayproject/ray:2.5.0",
 						Command: []string{"echo"},
 						Args:    []string{"Hello Ray"},
 					},
@@ -217,7 +217,7 @@ func setupTest(t *testing.T) {
 				Containers: []corev1.Container{
 					{
 						Name:    "ray-worker",
-						Image:   "rayproject/ray:2.4.0",
+						Image:   "rayproject/ray:2.5.0",
 						Command: []string{"echo"},
 						Args:    []string{"Hello Ray"},
 					},
@@ -268,7 +268,7 @@ func setupTest(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name:    "ray-head",
-								Image:   "rayproject/ray:2.4.0",
+								Image:   "rayproject/ray:2.5.0",
 								Command: []string{"python"},
 								Args:    []string{"/opt/code.py"},
 								Env: []corev1.EnvVar{
@@ -301,7 +301,7 @@ func setupTest(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:    "ray-worker",
-									Image:   "rayproject/ray:2.4.0",
+									Image:   "rayproject/ray:2.5.0",
 									Command: []string{"echo"},
 									Args:    []string{"Hello Ray"},
 									Env: []corev1.EnvVar{

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -65,7 +65,7 @@ var _ = Context("Inside the default namespace", func() {
 						Containers: []corev1.Container{
 							{
 								Name:    "ray-head",
-								Image:   "rayproject/ray:2.4.0",
+								Image:   "rayproject/ray:2.5.0",
 								Command: []string{"python"},
 								Args:    []string{"/opt/code.py"},
 								Env: []corev1.EnvVar{
@@ -98,7 +98,7 @@ var _ = Context("Inside the default namespace", func() {
 							Containers: []corev1.Container{
 								{
 									Name:    "ray-worker",
-									Image:   "rayproject/ray:2.4.0",
+									Image:   "rayproject/ray:2.5.0",
 									Command: []string{"echo"},
 									Args:    []string{"Hello Ray"},
 									Env: []corev1.EnvVar{

--- a/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
@@ -52,7 +52,7 @@ var _ = Context("Inside the default namespace", func() {
 			Suspend:    true,
 			Entrypoint: "sleep 999",
 			RayClusterSpec: &rayv1alpha1.RayClusterSpec{
-				RayVersion: "2.4.0",
+				RayVersion: "2.5.0",
 				HeadGroupSpec: rayv1alpha1.HeadGroupSpec{
 					ServiceType: corev1.ServiceTypeClusterIP,
 					Replicas:    pointer.Int32(1),

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -70,7 +70,7 @@ var myRayJob = &rayv1alpha1.RayJob{
 						Containers: []corev1.Container{
 							{
 								Name:  "ray-head",
-								Image: "rayproject/ray:2.4.0",
+								Image: "rayproject/ray:2.5.0",
 								Env: []corev1.EnvVar{
 									{
 										Name: "MY_POD_IP",
@@ -136,7 +136,7 @@ var myRayJob = &rayv1alpha1.RayJob{
 							Containers: []corev1.Container{
 								{
 									Name:    "ray-worker",
-									Image:   "rayproject/ray:2.4.0",
+									Image:   "rayproject/ray:2.5.0",
 									Command: []string{"echo"},
 									Args:    []string{"Hello Ray"},
 									Env: []corev1.EnvVar{

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -108,7 +108,7 @@ var _ = Context("Inside the default namespace", func() {
 							Containers: []corev1.Container{
 								{
 									Name:  "ray-head",
-									Image: "rayproject/ray:2.4.0",
+									Image: "rayproject/ray:2.5.0",
 									Env: []corev1.EnvVar{
 										{
 											Name: "MY_POD_IP",
@@ -182,7 +182,7 @@ var _ = Context("Inside the default namespace", func() {
 								Containers: []corev1.Container{
 									{
 										Name:    "ray-worker",
-										Image:   "rayproject/ray:2.4.0",
+										Image:   "rayproject/ray:2.5.0",
 										Command: []string{"echo"},
 										Args:    []string{"Hello Ray"},
 										Env: []corev1.EnvVar{

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -25,7 +25,7 @@ func TestGenerateRayClusterJsonHash(t *testing.T) {
 	// `hash2` in this case.
 	cluster := rayv1alpha1.RayCluster{
 		Spec: rayv1alpha1.RayClusterSpec{
-			RayVersion: "2.4.0",
+			RayVersion: "2.5.0",
 			WorkerGroupSpecs: []rayv1alpha1.WorkerGroupSpec{
 				{
 					Template: corev1.PodTemplateSpec{
@@ -57,7 +57,7 @@ func TestGenerateRayClusterJsonHash(t *testing.T) {
 func TestCompareRayClusterJsonHash(t *testing.T) {
 	cluster1 := rayv1alpha1.RayCluster{
 		Spec: rayv1alpha1.RayClusterSpec{
-			RayVersion: "2.4.0",
+			RayVersion: "2.5.0",
 		},
 	}
 	cluster2 := cluster1.DeepCopy()

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -31,10 +31,10 @@ logging.basicConfig(
 )
 
 # Default Ray version
-ray_version = '2.4.0'
+ray_version = '2.5.0'
 
 # Default docker images
-ray_image = 'rayproject/ray:2.4.0'
+ray_image = 'rayproject/ray:2.5.0'
 kuberay_operator_image = 'kuberay/operator:nightly'
 
 

--- a/tests/test_sample_raycluster_yamls.py
+++ b/tests/test_sample_raycluster_yamls.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
 
     rs = RuleSet([HeadPodNameRule(), EasyJobRule(), HeadSvcRule()])
     image_dict = {
-        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.4.0'),
+        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.5.0'),
         CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
     }
     logger.info(image_dict)

--- a/tests/test_sample_rayjob_yamls.py
+++ b/tests/test_sample_rayjob_yamls.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     # (namespace=SUPERVISOR_ACTOR_RAY_NAMESPACE) is already taken.
     rs = RuleSet([EasyJobRule()])
     image_dict = {
-        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.4.0'),
+        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.5.0'),
         CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
     }
     logger.info(image_dict)

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
 
     rs = RuleSet([EasyJobRule(), CurlServiceRule()])
     image_dict = {
-        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.4.0'),
+        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.5.0'),
         CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
     }
     logger.info(image_dict)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -55,7 +55,7 @@ class PodSecurityTestCase(unittest.TestCase):
                              {PodSecurityTestCase.namespace}.kubernetes.io/enforce-version=latest")
         # Install the KubeRay operator in the namespace pod-security.
         image_dict = {
-            CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.4.0',
+            CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.5.0',
             CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly'),
         }
         logger.info(image_dict)


### PR DESCRIPTION
## Why are these changes needed?

For every Ray release, we need to update version numbers in KubeRay.
(see https://github.com/ray-project/kuberay/pull/1049 and go/release)