### PR TITLE
Make replicas optional for the worker spec

### DIFF
--- a/clients/python-client/python_client/utils/kuberay_cluster_builder.py
+++ b/clients/python-client/python_client/utils/kuberay_cluster_builder.py
@@ -125,7 +125,7 @@ class ClusterBuilder(IClusterBuilder):
         memory_requests: str = "1G",
         cpu_limits: str = "2",
         memory_limits: str = "2G",
-        replicas: int = 1,
+        replicas: int = 0,
         min_replicas: int = -1,
         max_replicas: int = -1,
         ray_start_params: dict = {},
@@ -143,7 +143,7 @@ class ClusterBuilder(IClusterBuilder):
         - memory_requests (str, optional): Memory requests for the worker pods. Default is "1G".
         - cpu_limits (str, optional): CPU limits for the worker pods. Default is "2".
         - memory_limits (str, optional): Memory limits for the worker pods. Default is "2G".
-        - replicas (int, optional): Number of worker pods to run. Default is 1.
+        - replicas (int, optional): Number of worker pods to run. Default is 0.
         - min_replicas (int, optional): Minimum number of worker pods to run. Default is -1.
         - max_replicas (int, optional): Maximum number of worker pods to run. Default is -1.
         - ray_start_params (dict, optional): Additional parameters to pass to the ray start command. Default is {}.

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -11568,7 +11568,6 @@ spec:
                   - maxReplicas
                   - minReplicas
                   - rayStartParams
-                  - replicas
                   - template
                   type: object
                 type: array

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -12082,7 +12082,6 @@ spec:
                       - maxReplicas
                       - minReplicas
                       - rayStartParams
-                      - replicas
                       - template
                       type: object
                     type: array

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -12068,7 +12068,6 @@ spec:
                       - maxReplicas
                       - minReplicas
                       - rayStartParams
-                      - replicas
                       - template
                       type: object
                     type: array

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -47,7 +47,7 @@ type WorkerGroupSpec struct {
 	GroupName string `json:"groupName"`
 	// Replicas Number of desired pods in this pod group. This is a pointer to distinguish between explicit
 	// zero and not specified. Defaults to 1.
-	Replicas *int32 `json:"replicas"`
+	Replicas *int32 `json:"replicas,omitempty"`
 	// MinReplicas defaults to 1
 	MinReplicas *int32 `json:"minReplicas"`
 	// MaxReplicas defaults to maxInt32

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -11568,7 +11568,6 @@ spec:
                   - maxReplicas
                   - minReplicas
                   - rayStartParams
-                  - replicas
                   - template
                   type: object
                 type: array

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -12082,7 +12082,6 @@ spec:
                       - maxReplicas
                       - minReplicas
                       - rayStartParams
-                      - replicas
                       - template
                       type: object
                     type: array

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -12068,7 +12068,6 @@ spec:
                       - maxReplicas
                       - minReplicas
                       - rayStartParams
-                      - replicas
                       - template
                       type: object
                     type: array

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -97,8 +97,7 @@ spec:
                 command: ["/bin/sh","-c","ray stop"]
   workerGroupSpecs:
   # the pod replicas in this group typed worker
-  - replicas: 1
-    minReplicas: 1
+  - minReplicas: 1
     maxReplicas: 10
     # logical group name, for this called large-group, also can be functional
     groupName: large-group

--- a/ray-operator/config/samples/ray-cluster.autoscaler.tls.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.tls.yaml
@@ -145,8 +145,7 @@ spec:
                 path: gencert_head.sh
   workerGroupSpecs:
   # the pod replicas in this group typed worker
-  - replicas: 1
-    minReplicas: 1
+  - minReplicas: 1
     maxReplicas: 10
     groupName: small-group
     # The `rayStartParams` are used to configure the `ray start` command.

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -98,8 +98,7 @@ spec:
               memory: "2G"
   workerGroupSpecs:
   # the pod replicas in this group typed worker
-  - replicas: 1
-    minReplicas: 1
+  - minReplicas: 1
     maxReplicas: 10
     # logical group name, for this called small-group, also can be functional
     groupName: small-group

--- a/ray-operator/config/samples/ray-service.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-service.autoscaler.yaml
@@ -83,8 +83,7 @@ spec:
                   name: serve
     workerGroupSpecs:
       # the pod replicas in this group typed worker
-      - replicas: 1
-        minReplicas: 1
+      - minReplicas: 1
         maxReplicas: 5
         # logical group name, for this called small-group, also can be functional
         groupName: small-group


### PR DESCRIPTION
## Why are these changes needed?

The replicas field must not be set when autoscaler is used because:
- Autoscaler updates the field.
- When GitOps systems such as FluxCD or ArgoCD are used, they keep reverting changes made by the autoscaler on every reconciliation.

## Related issue number

Closes #1120 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
