### PR TITLE
[Sample YAML] Bump ray version in pod security YAML to 2.4.0

### DIFF
--- a/ray-operator/config/security/ray-cluster.pod-security.yaml
+++ b/ray-operator/config/security/ray-cluster.pod-security.yaml
@@ -10,7 +10,7 @@ metadata:
     # A unique identifier for the head node and workers of this cluster.
   name: raycluster-pod-security
 spec:
-  rayVersion: '2.2.0'
+  rayVersion: '2.4.0'
   # Ray head pod configuration
   headGroupSpec:
     # for the head group, replicas should always be 1.
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray-ml:2.2.0
+          image: rayproject/ray-ml:2.4.0
           ports:
           - containerPort: 6379
             name: gcs
@@ -88,7 +88,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray-ml:2.2.0
+          image: rayproject/ray-ml:2.4.0
           # environment variables to set in the container.Optional.
           # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
           lifecycle:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The existing sample YAML was pinned to Ray 2.2.0.  Running the test locally failed with 

```
2023-06-12:14:21:56,768 INFO     [utils.py:163] Execute command: kubectl logs -n=pod-security -l ray.io/node-type=head --tail=-1
Error from server (BadRequest): container "ray-head" in pod "raycluster-pod-security-head-hg67c" is waiting to start: ContainerCreating
ERROR

======================================================================
ERROR: test_ray_cluster_with_security_context (__main__.PodSecurityTestCase)
Create a RayCluster with securityContext config under restricted mode.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_security.py", line 98, in test_ray_cluster_with_security_context
    ray_cluster_add_event.trigger()
  File "/Users/archit/kuberay/tests/framework/prototype.py", line 165, in trigger
    self.wait()
  File "/Users/archit/kuberay/tests/framework/prototype.py", line 277, in wait
    show_cluster_info(self.namespace)
  File "/Users/archit/kuberay/tests/framework/prototype.py", line 90, in show_cluster_info
    shell_subprocess_run(f'kubectl logs -n={cr_namespace} -l ray.io/node-type=head --tail=-1')
  File "/Users/archit/kuberay/tests/framework/utils.py", line 164, in shell_subprocess_run
    return subprocess.run(command, shell = True, check = check).returncode
  File "/Users/archit/anaconda3/envs/ray-py38/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'kubectl logs -n=pod-security -l ray.io/node-type=head --tail=-1' returned non-zero exit status 1.

----------------------------------------------------------------------
Ran 2 tests in 1189.059s

FAILED (errors=1)
```

It's possible this is just a race condition in the test, but it should be updated to Ray 2.4.0 regardless. I tested it locally with Ray 2.4.0 and it passes.

```
----------------------------------------------------------------------
Ran 2 tests in 900.921s

OK
```

This PR will also be cherry-picked to the 0.5.2 release branch.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
