### PR TITLE
[Helm][RBAC] Introduce the option crNamespacedRbacEnable to enable or disable the creation of Role/RoleBinding for RayCluster preparation

### DIFF
--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
@@ -1,6 +1,6 @@
 # Install Role for namespaces listed in watchNamespace.
 # This should be consistent with `role.yaml`, except for the `kind` field.
-{{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
+{{- if and .Values.rbacEnable .Values.singleNamespaceInstall .Values.crNamespacedRbacEnable }}
 {{- $watchNamespaces := default (list .Release.Namespace) .Values.watchNamespace }}
 {{- range $namespace := $watchNamespaces }}
 ---

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
@@ -1,6 +1,6 @@
 # Install RoleBinding for namespaces listed in watchNamespace.
 # This should be consistent with `rolebinding.yaml`, except for the `kind` field.
-{{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
+{{- if and .Values.rbacEnable .Values.singleNamespaceInstall .Values.crNamespacedRbacEnable }}
 {{- $watchNamespaces := default (list .Release.Namespace) .Values.watchNamespace }}
 {{- range $namespace := $watchNamespaces }}
 ---

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -63,7 +63,7 @@ rbacEnable: true
 # Note:
 # (1) This variable is only effective when rbacEnable and singleNamespaceInstall are both set to true.
 # (2) In most cases, it should be set to true, unless you are using a Kubernetes cluster managed by GitOps tools such as ArgoCD.
-crNamespacedRbacEnable: false
+crNamespacedRbacEnable: true
 
 # When singleNamespaceInstall is true:
 # - Install namespaced RBAC resources such as Role and RoleBinding instead of cluster-scoped ones like ClusterRole and ClusterRoleBinding so that
@@ -71,7 +71,7 @@ crNamespacedRbacEnable: false
 #   (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
 # - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen
 #   to resource events within its own namespace.
-singleNamespaceInstall: true
+singleNamespaceInstall: false
 
 # The KubeRay operator will watch the custom resources in the namespaces listed in the "watchNamespace" parameter.
 # watchNamespace:

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -45,8 +45,6 @@ readinessProbe:
   periodSeconds: 5
   failureThreshold: 5
 
-rbacEnable: true
-
 batchScheduler:
   enabled: false
 
@@ -54,9 +52,20 @@ batchScheduler:
 # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md for further guidance.
 securityContext: {}
 
+
+# If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on.
+rbacEnable: true
+
+# When crNamespacedRbacEnable is set to true, the KubeRay operator will create a Role for RayCluster preparation (e.g., Pods, Services)
+# and a corresponding RoleBinding for each namespace listed in the "watchNamespace" parameter. Please note that even if crNamespacedRbacEnable
+# is set to false, the Role and RoleBinding for leader election will still be created. Note that this variable is only effective when rbacEnable
+# and singleNamespaceInstall are both set to true.
+crNamespacedRbacEnable: true
+
 # When singleNamespaceInstall is true:
-# - Install namespaced RBAC resources instead of cluster-scoped ones so that the chart can be installed by users
-#   with permissions restricted to a single namespace. (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
+# - Install namespaced RBAC resources such as Role and RoleBinding instead of cluster-scoped ones like ClusterRole and ClusterRoleBinding so that
+#   the chart can be installed by users with permissions restricted to a single namespace.
+#   (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
 # - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen
 #   to resource events within its own namespace.
 singleNamespaceInstall: false

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -59,11 +59,11 @@ rbacEnable: true
 # When crNamespacedRbacEnable is set to true, the KubeRay operator will create a Role for RayCluster preparation (e.g., Pods, Services)
 # and a corresponding RoleBinding for each namespace listed in the "watchNamespace" parameter. Please note that even if crNamespacedRbacEnable
 # is set to false, the Role and RoleBinding for leader election will still be created.
-# 
-# Note: 
+#
+# Note:
 # (1) This variable is only effective when rbacEnable and singleNamespaceInstall are both set to true.
 # (2) In most cases, it should be set to true, unless you are using a Kubernetes cluster managed by GitOps tools such as ArgoCD.
-crNamespacedRbacEnable: true
+crNamespacedRbacEnable: false
 
 # When singleNamespaceInstall is true:
 # - Install namespaced RBAC resources such as Role and RoleBinding instead of cluster-scoped ones like ClusterRole and ClusterRoleBinding so that
@@ -71,7 +71,7 @@ crNamespacedRbacEnable: true
 #   (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
 # - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen
 #   to resource events within its own namespace.
-singleNamespaceInstall: false
+singleNamespaceInstall: true
 
 # The KubeRay operator will watch the custom resources in the namespaces listed in the "watchNamespace" parameter.
 # watchNamespace:

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -58,8 +58,11 @@ rbacEnable: true
 
 # When crNamespacedRbacEnable is set to true, the KubeRay operator will create a Role for RayCluster preparation (e.g., Pods, Services)
 # and a corresponding RoleBinding for each namespace listed in the "watchNamespace" parameter. Please note that even if crNamespacedRbacEnable
-# is set to false, the Role and RoleBinding for leader election will still be created. Note that this variable is only effective when rbacEnable
-# and singleNamespaceInstall are both set to true.
+# is set to false, the Role and RoleBinding for leader election will still be created.
+# 
+# Note: 
+# (1) This variable is only effective when rbacEnable and singleNamespaceInstall are both set to true.
+# (2) In most cases, it should be set to true, unless you are using a Kubernetes cluster managed by GitOps tools such as ArgoCD.
 crNamespacedRbacEnable: true
 
 # When singleNamespaceInstall is true:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/kuberay/pull/1106#issuecomment-1578439022

### Without this PR, users have the following options to control the creation of RBAC resources:

(1) Users can set `rbacEnable`: false and `serviceAccount.create: false` to prevent the creation of any RBAC resources.

(2) Users can use the `singleNamespaceInstall` option to determine whether to create namespaced RBAC resources (e.g., Role and RoleBinding) or cluster-scoped RBAC resources (e.g., ClusterRole and ClusterRoleBinding).

(3) If `singleNamespaceInstall` is set to true, users can use the `watchNamespace` option to determine in which namespaces the Role and RoleBinding should be installed. If watchNamespace is not set, the Role and RoleBinding will be installed in the same namespace as the KubeRay operator.


### We can categorize Roles for KubeRay into three categories:
(A) Role for leader election
(B) Role for RayCluster preparation (e.g., Pods, Services) 
(C) ClusterRole for RayCluster preparation (e.g., Pods, Services) 

* If `rbacEnable` is set to false, (A)(B)(C) will not be created.
* The `singleNamespaceInstall` option is used to determine whether to create (B) or (C).

In conclusion, with these two options, users can choose to create nothing, (A)(B), or (A)(C). However, in ArgoCD, a project can only create resources within its associated namespace. Hence, users deploying KubeRay in a Kubernetes cluster managed by GitOps tools would like to only create (A) via Helm chart, and then the cluster admins create Role / RoleBinding for each namespace listed in `watchNamespace` manually later.

To achieve this goal, this PR introduces the option `crNamespacedRbacEnable` to enable or disable the creation of (B). Therefore, ArgoCD users can set `rbacEnable: true`, `singleNamespaceInstall: true`, and `crNamespacedRbacEnable: false` to install only (A).

## Related issue number

#1106 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* Gist1: [values.yaml](https://gist.github.com/kevin85421/493cb873bc1a53bb09352d8ab552ea85)
  * `rbacEnable: true`, `crNamespacedRbacEnable: false`, `singleNamespaceInstall: true`
* Gist2: [rbac.yaml
](https://gist.github.com/kevin85421/f0eabaf5e60ce44efeaf8d368af8fbea)
  * Role / RoleBinding (i.e. (B)) for `default` namespace

```sh
kind create cluster --image=kindest/node:v1.23.0

# Install the KubeRay operator with Gist1. (path: helm-chart/kuberay-operator)
helm install kuberay-operator .

# Verify that only (A) will be created.
kubectl get role
# NAME                               CREATED AT
# kuberay-operator-leader-election   2023-06-13T07:19:45Z

kubectl get rolebinding
# NAME                               CREATED AT
# kuberay-operator-leader-election   2023-06-13T07:19:45Z

# Check the KubeRay log
kubectl logs $YOUR_OPERATOR_POD

# W0613 07:23:19.622863       1 reflector.go:324] pkg/mod/k8s.io/client-go@v0.23.0/tools/cache/reflector.go:167: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:default:kuberay-operator" cannot list resource "pods" in API group "" in the namespace "default": RBAC: clusterrole.rbac.authorization.k8s.io "kuberay-operator" not found
# E0613 07:23:19.623053       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.23.0/tools/cache/reflector.go:167: Failed to watch *v1.Pod: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:default:kuberay-operator" cannot list resource "pods" in API group "" in the namespace "default": RBAC: clusterrole.rbac.authorization.k8s.io "kuberay-operator" not found

# Install Role/RoleBinding for `default` namespace by Gist2
kubectl apply -f rbac.yaml

# Install a RayCluster to verify that the KubeRay operator can create Pods after applying rbac.yaml.
helm install raycluster kuberay/ray-cluster --version 0.5.0
```
