### PR TITLE
[Doc] Add git fetch --tags command to release instructions

### DIFF
--- a/docs/release/changelog.md
+++ b/docs/release/changelog.md
@@ -16,6 +16,12 @@
     ```
     git log v0.3.0..v0.4.0 --oneline
     ```
+    
+    You may need to run the following command first:
+
+    ```
+    git fetch --tags
+    ```
 
 1. Copy the above commit history to `scripts/changelog-generator.py` and replace `<your_github_token>` with your Github token.
 Run the script to generate changelogs.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
I had to run an extra `git fetch` command to get the `git log` command to work.  This PR adds it to the instructions to make them more beginner-friendly.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
