### PR TITLE
[RayService] Add e2e tests

### DIFF
--- a/ray-operator/config/samples/ray-service.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-service.autoscaler.yaml
@@ -21,7 +21,7 @@ spec:
             autoscaling_config:
               metrics_interval_s: 0.1
               min_replicas: 1
-              max_replicas: 10
+              max_replicas: 14
               look_back_period_s: 0.2
               downscale_delay_s: 0
               upscale_delay_s: 0
@@ -40,6 +40,13 @@ spec:
     enableInTreeAutoscaling: true
     autoscalerOptions:
       upscalingMode: Default
+      resources:
+        limits:
+          cpu: "1"
+          memory: "1000Mi"
+        requests:
+          cpu: "1"
+          memory: "1000Mi"
     ######################headGroupSpecs#################################
     headGroupSpec:
       # The `rayStartParams` are used to configure the `ray start` command.
@@ -95,5 +102,5 @@ spec:
                     cpu: "1"
                     memory: "2Gi"
                   requests:
-                    cpu: "500m"
+                    cpu: "1"
                     memory: "2Gi"

--- a/ray-operator/config/samples/ray-service.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-service.autoscaler.yaml
@@ -12,10 +12,10 @@ spec:
   serveConfigV2: |
     applications:
       - name: app1
-        import_path: blocked.app
+        import_path: autoscaling_test.blocked.app
         route_prefix: /
         runtime_env:
-          working_dir: "https://github.com/zcin/sample-serve-applications/archive/refs/heads/main.zip"
+          working_dir: "https://github.com/ray-project/serve_workloads/archive/7a0daafdb86b55118534b04d122b1b79c9ae99f5.zip"
         deployments:
           - name: Blocked
             autoscaling_config:
@@ -30,10 +30,10 @@ spec:
             ray_actor_options:
               num_cpus: 0.5
       - name: signal
-        import_path: signaling.app
+        import_path: autoscaling_test.signaling.app
         route_prefix: /signal
         runtime_env:
-          working_dir: "https://github.com/zcin/sample-serve-applications/archive/refs/heads/main.zip"
+          working_dir: "https://github.com/ray-project/serve_workloads/archive/7a0daafdb86b55118534b04d122b1b79c9ae99f5.zip"
   rayClusterConfig:
     rayVersion: '2.5.0' # should match the Ray version in the image of the containers
     ## raycluster autoscaling config

--- a/ray-operator/config/samples/ray-service.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-service.autoscaler.yaml
@@ -9,6 +9,11 @@ metadata:
 spec:
   serviceUnhealthySecondThreshold: 300 # Config for the health check threshold for service. Default value is 60.
   deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for deployments. Default value is 60.
+  # The workload consists of two applications. The first application checks on an event in the second application.
+  # If the event isn't set, the first application will block on requests until the event is set. So, to test upscaling
+  # we can first send a bunch of requests to the first application, which will trigger Serve autoscaling to bring up
+  # more replicas since the existing replicas are blocked on requests. Worker pods should scale up. To test downscaling,
+  # set the event in the second application, releasing all blocked requests, and worker pods should scale down.
   serveConfigV2: |
     applications:
       - name: app1

--- a/ray-operator/config/samples/ray-service.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-service.autoscaler.yaml
@@ -9,72 +9,56 @@ metadata:
 spec:
   serviceUnhealthySecondThreshold: 300 # Config for the health check threshold for service. Default value is 60.
   deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for deployments. Default value is 60.
-  serveConfig:
-    importPath: fruit.deployment_graph
-    runtimeEnv: |
-      working_dir: "https://github.com/ray-project/test_dag/archive/41d09119cbdf8450599f993f51318e9e27c59098.zip"
-    deployments:
-      - name: MangoStand
-        numReplicas: 1
-        userConfig: |
-          price: 3
-        rayActorOptions:
-          numCpus: 1
-      - name: OrangeStand
-        numReplicas: 1
-        userConfig: |
-          price: 2
-        rayActorOptions:
-          numCpus: 0.1
-      - name: PearStand
-        numReplicas: 1
-        userConfig: |
-          price: 1
-        rayActorOptions:
-          numCpus: 0.1
-      - name: FruitMarket
-        numReplicas: 1
-        rayActorOptions:
-          numCpus: 0.1
-      - name: DAGDriver
-        numReplicas: 1
-        routePrefix: "/"
-        rayActorOptions:
-          numCpus: 0.1
+  serveConfigV2: |
+    applications:
+      - name: app1
+        import_path: blocked.app
+        route_prefix: /
+        runtime_env:
+          working_dir: "https://github.com/zcin/sample-serve-applications/archive/refs/heads/main.zip"
+        deployments:
+          - name: Blocked
+            autoscaling_config:
+              metrics_interval_s: 0.1
+              min_replicas: 1
+              max_replicas: 10
+              look_back_period_s: 0.2
+              downscale_delay_s: 0
+              upscale_delay_s: 0
+            graceful_shutdown_timeout_s: 1
+            max_concurrent_queries: 1000
+            ray_actor_options:
+              num_cpus: 0.5
+      - name: signal
+        import_path: signaling.app
+        route_prefix: /signal
+        runtime_env:
+          working_dir: "https://github.com/zcin/sample-serve-applications/archive/refs/heads/main.zip"
   rayClusterConfig:
     rayVersion: '2.5.0' # should match the Ray version in the image of the containers
     ## raycluster autoscaling config
     enableInTreeAutoscaling: true
     autoscalerOptions:
       upscalingMode: Default
-      resources:
-        limits:
-          cpu: "1"
-          memory: "1000Mi"
-        requests:
-          cpu: "1"
-          memory: "1000Mi"
     ######################headGroupSpecs#################################
     headGroupSpec:
       # The `rayStartParams` are used to configure the `ray start` command.
       # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
       # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
-      rayStartParams: {"num-cpus": "0"}
+      rayStartParams:
+        dashboard-host: '0.0.0.0'
       #pod template
       template:
         spec:
-          # Note: From KubeRay v0.6.0, users need to create the ServiceAccount by themselves if they specify the `serviceAccountName`
-          # in the headGroupSpec. See https://github.com/ray-project/kuberay/pull/1128 for more details.
-          # serviceAccountName: my-sa
           containers:
             - name: ray-head
               image: rayproject/ray:2.5.0
               resources:
                 limits:
-                  cpu: 200m
+                  cpu: 2
                   memory: 2Gi
                 requests:
-                  cpu: 200m
+                  cpu: 2
                   memory: 2Gi
               ports:
                 - containerPort: 6379
@@ -111,5 +95,5 @@ spec:
                     cpu: "1"
                     memory: "2Gi"
                   requests:
-                    cpu: "1"
+                    cpu: "500m"
                     memory: "2Gi"

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -232,7 +232,8 @@ class RayServiceTestCase(unittest.TestCase):
         # for serving requests. This `sleep` function is a workaround, and should be removed
         # when https://github.com/ray-project/kuberay/pull/730 is merged.
         time.sleep(60)
-        cr_event.rulesets = [RuleSet([CurlServiceRule()])]
+        query = {"path": "/", "json_args": ["MANGO", 2], "expected_output": "6"}
+        cr_event.rulesets = [RuleSet([CurlServiceRule([query])])]
         cr_event.check_rule_sets()
 
 def parse_environment():

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -245,7 +245,7 @@ class EasyJobRule(Rule):
             "python -c \"import ray; ray.init(); print(ray.cluster_resources())\"")
 
 class CurlServiceRule(Rule):
-    """Using curl to access the deployed application(s) on Ray service"""
+    """Using curl to access the deployed application(s) on RayService"""
     CURL_CMD_FMT = (
         "kubectl exec curl -n {namespace} -- "
         "curl -X POST -H 'Content-Type: application/json' "
@@ -259,7 +259,7 @@ class CurlServiceRule(Rule):
     def assert_rule(self, custom_resource, cr_namespace):
         # If curl pod doesn't exist, create one
         if get_pod("default", "run=curl") is None:
-            start_curl_pod("curl", "default", timeout_s=30)
+            start_curl_pod("curl", cr_namespace, timeout_s=30)
         
         for query in self.queries:
             cmd = self.CURL_CMD_FMT.format(

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -86,6 +86,19 @@ def get_expected_worker_pods(custom_resource):
 
 def show_cluster_info(cr_namespace):
     """Show system information"""
+    k8s_v1_api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_V1_CLIENT_KEY]
+    head_pods = k8s_v1_api.list_namespaced_pod(
+        namespace=cr_namespace,
+        label_selector='ray.io/node-type=head'
+    )
+    worker_pods = k8s_v1_api.list_namespaced_pod(
+        namespace=cr_namespace,
+        label_selector='ray.io/node-type=worker'
+    )
+    logger.info(
+        f"Number of head pods: {len(head_pods.items)}, "
+        f"number of worker pods: {len(worker_pods.items)}"
+    )
     shell_subprocess_run(f'kubectl get all -n={cr_namespace}')
     shell_subprocess_run(f'kubectl describe pods -n={cr_namespace}')
     # With "--tail=-1", every line in the log will be printed. The default value of "tail" is not

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -21,8 +21,6 @@ from framework.utils import (
     OperatorManager
 )
 
-from kubernetes import client
-
 # Utility functions
 def search_path(yaml_object, steps, default_value = None):
     """
@@ -257,7 +255,10 @@ class CurlServiceRule(Rule):
                 json=json.dumps(query["json_args"]),
             )
             output = shell_subprocess_check_output(cmd)
-            assert output.decode('utf-8') == query["expected_output"]
+            if hasattr(query["expected_output"], "__iter__"):
+                assert output.decode('utf-8') in query["expected_output"]
+            else:
+                assert output.decode('utf-8') == query["expected_output"]
 
 class RayClusterAddCREvent(CREvent):
     """CREvent for RayCluster addition"""

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -1,5 +1,5 @@
 """Configuration test framework for KubeRay"""
-from typing import List
+from typing import Dict, List, Optional
 import unittest
 import time
 import jsonpatch
@@ -8,7 +8,9 @@ from framework.utils import (
     create_custom_object,
     delete_custom_object,
     get_custom_object,
+    get_pod,
     get_head_pod,
+    start_curl_pod,
     logger,
     pod_exec_command,
     shell_subprocess_run,
@@ -17,6 +19,8 @@ from framework.utils import (
     K8S_CLUSTER_MANAGER,
     OperatorManager
 )
+
+from kubernetes import client
 
 # Utility functions
 def search_path(yaml_object, steps, default_value = None):
@@ -145,8 +149,14 @@ class CREvent:
     CREvent: Custom Resource Event can be mainly divided into 3 categories.
     (1) Add (create) CR (2) Update CR (3) Delete CR
     """
-    def __init__(self, custom_resource_object,
-        rulesets: List[RuleSet], timeout, namespace, filepath = None):
+    def __init__(
+        self,
+        custom_resource_object,
+        rulesets: List[RuleSet] = [],
+        timeout: int = 90,
+        namespace: str = "default",
+        filepath: Optional[str] = None,
+    ):
         self.rulesets = rulesets
         self.timeout = timeout
         self.namespace = namespace
@@ -223,27 +233,26 @@ class EasyJobRule(Rule):
             "python -c \"import ray; ray.init(); print(ray.cluster_resources())\"")
 
 class CurlServiceRule(Rule):
-    """"Using curl to access the deployed application on Ray service"""
+    """"Using curl to access the deployed application(s) on Ray service"""
+
+    def __init__(self, queries: Dict[str, str]):
+        self.custom_resource = None
+        self.cr_namespace: Optional[str] = None
+        self.queries = queries
+
     def assert_rule(self, custom_resource=None, cr_namespace='default'):
-        # Create a pod for running curl command, because the service is not exposed.
-        shell_subprocess_run(f"kubectl run curl --image=radial/busyboxplus:curl -n {cr_namespace} "
-            "--command -- /bin/sh -c \"while true; do sleep 10;done\"")
-        success_create = False
-        k8s_v1_api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_V1_CLIENT_KEY]
-        for _ in range(30):
-            resp = k8s_v1_api.read_namespaced_pod(name="curl", namespace=cr_namespace)
-            if resp.status.phase != 'Pending':
-                success_create = True
-                break
-            time.sleep(1)
-        if not success_create:
-            raise Exception("CurlServiceRule create curl pod timeout")
-        output = shell_subprocess_check_output(f"kubectl exec curl -n {cr_namespace} "
-            "-- curl -X POST -H 'Content-Type: application/json' "
-            f"{custom_resource['metadata']['name']}-serve-svc.{cr_namespace}.svc.cluster.local:8000"
-            " -d '[\"MANGO\", 2]'")
-        assert output == b'6'
-        shell_subprocess_run(f"kubectl delete pod curl -n {cr_namespace}")
+        self.custom_resource = custom_resource
+        self.cr_namespace = cr_namespace
+
+        # If curl pod doesn't exist, create one
+        curl_pod = get_pod("default", "run=curl")
+        logger.info(f"curl pod: {curl_pod}")
+        if curl_pod is None:
+            start_curl_pod("curl", self.cr_namespace, timeout_s=30)
+        
+        for cmd, expected_output in self.queries.items():
+            output = shell_subprocess_check_output(cmd)
+            assert output.decode('utf-8') == expected_output
 
 class RayClusterAddCREvent(CREvent):
     """CREvent for RayCluster addition"""
@@ -306,7 +315,7 @@ class RayClusterAddCREvent(CREvent):
             show_cluster_info(self.namespace)
             raise Exception("RayClusterAddCREvent clean_up() timeout")
 
-class RayServiceAddCREvent(CREvent):
+class RayServiceFullCREvent(CREvent):
     """CREvent for RayService addition"""
     def wait(self):
         """Wait for RayService to converge"""""
@@ -495,3 +504,34 @@ class GeneralTestCase(unittest.TestCase):
         except Exception as ex:
             logger.error(str(ex))
             K8S_CLUSTER_MANAGER.delete_kind_cluster()
+
+class SeriesTestCase(unittest.TestCase):
+    """Test a series of cr events"""
+    def __init__(self, methodName, docker_image_dict: Dict, cr_events: List[CREvent], start_curl_pod: bool = False):
+        super().__init__(methodName)
+        self.cr_events = cr_events
+        self.operator_manager = OperatorManager(docker_image_dict)
+        self.start_curl_pod = start_curl_pod
+
+    @classmethod
+    def setUpClass(cls):
+        K8S_CLUSTER_MANAGER.delete_kind_cluster()
+
+    def setUp(self):
+        if not K8S_CLUSTER_MANAGER.check_cluster_exist():
+            K8S_CLUSTER_MANAGER.create_kind_cluster()
+            self.operator_manager.prepare_operator()
+        
+        if self.start_curl_pod:
+            start_curl_pod("curl", "default")
+
+    def runtest(self):
+        """Run a configuration test"""
+        for cr_event in self.cr_events:
+            cr_event.trigger()
+            cr_event.clean_up()
+
+    def tearDown(self) -> None:
+        print("teardown")
+        if self.start_curl_pod:
+            shell_subprocess_run(f"kubectl delete pod curl -n default")

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -195,7 +195,7 @@ class CREvent:
 
     def clean_up(self):
         """Cleanup the CR."""
-        pass
+        raise NotImplementedError
 
 # My implementations
 class HeadPodNameRule(Rule):

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -156,13 +156,27 @@ class OperatorManager:
                     f"--set image.repository={repo},image.tag={tag}"
                 )
 
-def shell_subprocess_run(command, check = True):
-    """
-    Command will be executed through the shell. If check=True, it will raise an error when
-    the returncode of the execution is not 0.
+def shell_subprocess_run(command, check=True, hide_output=False) -> int:
+    """Command will be executed through the shell.
+    
+    Args:
+        check: If true, an error will be raised if the returncode is nonzero
+        hide_output: If true, stdout and stderr of the command will be hidden
+    
+    Returns:
+        Return code of the subprocess.
     """
     logger.info("Execute command: %s", command)
-    return subprocess.run(command, shell = True, check = check).returncode
+    if hide_output:
+        return subprocess.run(
+            command,
+            shell=True,
+            check=check,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL
+        ).returncode
+    else:
+        return subprocess.run(command, shell=True, check=check).returncode
 
 def shell_subprocess_check_output(command):
     """
@@ -192,10 +206,6 @@ def get_pod(namespace, label_selector):
         )
         return None
     return pods.items[0]
-
-def get_pod_by_name(namespace, name):
-    k8s_v1_api: client.CoreV1Api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_V1_CLIENT_KEY]
-    k8s_v1_api.list_namespaced_pod
 
 def get_head_pod(namespace):
     """Gets a head pod in the `namespace`. Returns None if there are no matches."""

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -193,6 +193,10 @@ def get_pod(namespace, label_selector):
         return None
     return pods.items[0]
 
+def get_pod_by_name(namespace, name):
+    k8s_v1_api: client.CoreV1Api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_V1_CLIENT_KEY]
+    k8s_v1_api.list_namespaced_pod
+
 def get_head_pod(namespace):
     """Gets a head pod in the `namespace`. Returns None if there are no matches."""
     return get_pod(namespace, 'ray.io/node-type=head')

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -228,7 +228,7 @@ def start_curl_pod(name: str, namespace: str, timeout_s: int = -1):
     start_time = time.time()
     while time.time() - start_time < timeout_s or timeout_s < 0:
         resp = k8s_v1_api.read_namespaced_pod(name=name, namespace=namespace)
-        if resp.status.phase != 'Pending':
+        if resp.status.phase == 'Running':
             return
 
     raise TimeoutError(f"Curl pod wasn't started in {timeout_s}s.")

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -8,7 +8,7 @@ import yaml
 
 from framework.prototype import (
     RayClusterAddCREvent,
-    RayServiceAddCREvent
+    RayServiceFullCREvent
 )
 
 from framework.utils import (
@@ -81,7 +81,7 @@ def create_ray_service(template_name, ray_version, ray_image):
                 break
 
         # Create a RayService
-        ray_service_add_event = RayServiceAddCREvent(
+        ray_service_add_event = RayServiceFullCREvent(
             custom_resource_object = context['cr'],
             rulesets = [],
             timeout = 90,

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -302,6 +302,19 @@ class TestRayService:
                 cr_event.trigger()
 
     def test_service_autoscaling(self, set_up_cluster):
+        """This test uses a special workload that can allow us to
+        reliably test autoscaling.
+        
+        The workload consists of two applications. The first application
+        checks on an event in the second application. If the event isn't
+        set, the first application will block on requests until the
+        event is set. So, first we send a bunch of requests to the first
+        application, which will trigger Serve autoscaling to bring up
+        more replicas since the existing replicas are blocked on
+        requests. Worker pods should scale up. Then we set the event in
+        the second application, releasing all blocked requests. Worker
+        pods should scale down.
+        """
         filename = "ray-service.autoscaler.yaml"
         path = CONST.REPO_ROOT.joinpath("ray-operator/config/samples/").joinpath(filename)
 

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -316,14 +316,14 @@ class TestRayService:
             query={"path": "/signal", "json_args": {}},
             num_repeat=1,
             expected_worker_pods=1,
-            timeout=200,
+            timeout=300,
             message="Releasing all blocked requests. Worker pods should start scaling down..."
         )
         cr_events: List[CREvent] = [
             RayServiceAddCREvent(
                 custom_resource_object=self.cr,
                 rulesets=[RuleSet([scale_up_rule, scale_down_rule])],
-                timeout=1000,
+                timeout=600,
                 namespace=NAMESPACE,
                 filepath=path,
             ),

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -1,25 +1,319 @@
 ''' Test sample RayService YAML files to catch invalid and outdated ones. '''
-import unittest
-import os
+from kubernetes import client
 import logging
+import os
+from tempfile import NamedTemporaryFile
+import time
+from typing import Dict, List, Optional
+import unittest
 import yaml
 
 from framework.prototype import (
     RuleSet,
-    GeneralTestCase,
-    RayServiceAddCREvent,
+    SeriesTestCase,
+    CREvent,
     EasyJobRule,
-    CurlServiceRule
+    CurlServiceRule,
+    get_expected_head_pods,
+    get_expected_worker_pods,
+    show_cluster_info,
+    check_pod_running,
 )
 
 from framework.utils import (
-    CONST
+    logger,
+    shell_subprocess_run,
+    shell_subprocess_check_output,
+    CONST,
+    K8S_CLUSTER_MANAGER,
 )
 
 logger = logging.getLogger(__name__)
 
+CURL_CMD_TEMPLATE = (
+    "kubectl exec curl -n {namespace} -- "
+    "curl -X POST -H 'Content-Type: application/json' "
+    "{name}-serve-svc.{namespace}.svc.cluster.local:8000{path}/ -d '{json}'"
+)
+
+DEFAULT_IMAGE_DICT = {
+    CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.5.0'),
+    CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
+}
+
+NAMESPACE = 'default'
+
+
+class RayServiceAddCREvent(CREvent):
+    """CREvent for RayService addition"""
+    def exec(self):
+        shell_subprocess_run(f"kubectl apply -n {self.namespace} -f {self.filepath}")
+
+    def wait(self):
+        """Wait for RayService to converge"""""
+        start_time = time.time()
+        expected_head_pods = get_expected_head_pods(self.custom_resource_object)
+        expected_worker_pods = get_expected_worker_pods(self.custom_resource_object)
+        # Wait until:
+        #   (1) The number of head pods and worker pods are as expected.
+        #   (2) All head pods and worker pods are "Running".
+        #   (3) Service named "rayservice-sample-serve" presents
+        converge = False
+        k8s_v1_api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_V1_CLIENT_KEY]
+        for _ in range(self.timeout):
+            headpods = k8s_v1_api.list_namespaced_pod(
+                namespace = self.namespace, label_selector='ray.io/node-type=head')
+            workerpods = k8s_v1_api.list_namespaced_pod(
+                namespace = self.namespace, label_selector='ray.io/node-type=worker')
+            head_services = k8s_v1_api.list_namespaced_service(
+                namespace = self.namespace, label_selector =
+                f"ray.io/serve={self.custom_resource_object['metadata']['name']}-serve")
+            if (len(head_services.items) == 1 and len(headpods.items) == expected_head_pods
+                    and len(workerpods.items) == expected_worker_pods
+                    and check_pod_running(headpods.items) and check_pod_running(workerpods.items)):
+                converge = True
+                logger.info("--- RayServiceAddCREvent %s seconds ---", time.time() - start_time)
+                break
+            time.sleep(1)
+
+        if not converge:
+            logger.info("RayServiceAddCREvent wait() failed to converge in %d seconds.",
+                self.timeout)
+            logger.info("expected_head_pods: %d, expected_worker_pods: %d",
+                expected_head_pods, expected_worker_pods)
+            show_cluster_info(self.namespace)
+            raise Exception("RayServiceAddCREvent wait() timeout")
+
+    def clean_up(self):
+        pass
+
+class RayServiceUpdateCREvent(CREvent):
+    """CREvent for RayService update"""
+    def __init__(
+        self,
+        custom_resource_object,
+        rulesets: List[RuleSet] = [],
+        timeout: int = 90,
+        namespace: str = "default",
+        filepath: Optional[str] = None,
+        query_while_updating: Optional[Dict[str, str]] = None,
+    ):
+        super().__init__(custom_resource_object, rulesets, timeout, namespace, filepath)
+        self.name = self.custom_resource_object["metadata"]["name"]
+        self.query_while_updating = query_while_updating
+
+    def query(self):
+        if self.query_while_updating:
+            for cmd, expected_output in self.query_while_updating.items():
+                output = shell_subprocess_check_output(cmd)
+                assert output.decode('utf-8') == expected_output
+
+    def exec(self):
+        """Update a CR by a `kubectl apply` command."""
+        self.start = time.time()
+        shell_subprocess_run(f"kubectl apply -n {self.namespace} -f {self.filepath}")
+    
+    def wait_for_status(self, status: str):
+        """Helper function to check for service status."""
+        k8s_cr_api: client.CustomObjectsApi = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_CR_CLIENT_KEY]
+        while time.time() - self.start < self.timeout:
+            rayservice_info = k8s_cr_api.get_namespaced_custom_object_status(
+                group="ray.io",
+                namespace=self.namespace,
+                name=self.name,
+                version="v1alpha1",
+                plural="rayservices",
+            )
+            if rayservice_info["status"]["serviceStatus"] == status:
+                break
+
+            self.query()
+            time.sleep(0.1)
+        else:
+            raise TimeoutError(
+                f'Ray service "{self.name}" did not transition to status "{status}" '
+                f"after {self.timeout}s."
+            )
+
+    def wait(self):
+        """Wait for deployment to transition -> WaitForServeDeploymentReady -> Running"""
+
+        self.wait_for_status("WaitForServeDeploymentReady")
+        logger.info("Ray service transitioned to status WaitForServeDeploymentReady.")
+        self.wait_for_status("Running")
+        logger.info("Ray service transitioned to status Running.")
+
+    def clean_up(self):
+        pass
+
+class RayServiceDeleteCREvent(CREvent):
+    """CREvent for RayService deletion"""
+    def exec(self):
+        """Delete a CR by a `kubectl delete` command."""
+        shell_subprocess_run(f"kubectl delete -n {self.namespace} -f {self.filepath}")
+
+    def wait(self):
+        """Wait for pods to be deleted"""
+        converge = False
+        k8s_v1_api = K8S_CLUSTER_MANAGER.k8s_client_dict[CONST.K8S_V1_CLIENT_KEY]
+        start_time = time.time()
+        for _ in range(self.timeout):
+            headpods = k8s_v1_api.list_namespaced_pod(
+                namespace = self.namespace, label_selector = 'ray.io/node-type=head')
+            workerpods = k8s_v1_api.list_namespaced_pod(
+                namespace = self.namespace, label_selector = 'ray.io/node-type=worker')
+            if (len(headpods.items) == 0 and len(workerpods.items) == 0):
+                converge = True
+                logger.info("--- Cleanup RayService %s seconds ---", time.time() - start_time)
+                break
+            time.sleep(1)
+
+        if not converge:
+            logger.info("RayServiceAddCREvent clean_up() failed to converge in %d seconds.",
+                self.timeout)
+            logger.info("expected_head_pods: 0, expected_worker_pods: 0")
+            show_cluster_info(self.namespace)
+            raise Exception("RayServiceAddCREvent clean_up() timeout")
+
+    def clean_up(self):
+        pass
+
+
+def test_deploy_applications(namespace: str, sample_yaml_file: Dict):
+    rs = RuleSet([EasyJobRule(), CurlServiceRule()])
+    image_dict = {
+        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.5.0'),
+        CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
+    }
+    logger.info(image_dict)
+
+    # Build a test plan
+    logger.info("Build a test plan ...")
+    cr = sample_yaml_file['cr']
+    path = sample_yaml_file['path']
+
+    test_cases = unittest.TestSuite()
+    addEvent = RayServiceAddCREvent(cr, [rs], 90, namespace, path)
+    deleteEvent = RayServiceDeleteCREvent(cr, [], 90, namespace, path)
+    test_cases.addTest(SeriesTestCase('runtest', image_dict, [addEvent, deleteEvent]))
+
+    # Execute test
+    runner = unittest.TextTestRunner()
+    test_result = runner.run(test_cases)
+
+    # Without this line, the exit code will always be 0.
+    assert test_result.wasSuccessful()
+
+def test_deploy_and_in_place_update(namespace: str, sample_yaml_file: Dict):
+    image_dict = {
+        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.5.0'),
+        CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
+    }
+    logger.info(image_dict)
+    cr = sample_yaml_file['cr']
+    path = sample_yaml_file['path']
+
+    with open(path, 'r') as file:
+        yaml_lines = file.readlines()
+    
+    # Modify the MangoStand price and Multiplier factor
+    yaml_lines[24] = " " * 14 + "price: 4\n"
+    yaml_lines[62] = " " * 14 + "factor: 3\n"
+
+    with NamedTemporaryFile(mode="w+", suffix=".yaml") as yaml_copy:
+        logger.info(f"Writing modified RayService yaml to {yaml_copy.name}.")
+        yaml_copy.writelines(yaml_lines)
+        yaml_copy.flush()
+
+        # Build a test plan
+        logger.info("Build a test plan ...")
+        test_cases = unittest.TestSuite()
+        addEvent = RayServiceAddCREvent(
+            custom_resource_object=cr,
+            rulesets=[RuleSet([EasyJobRule(), CurlServiceRule()])],
+            timeout=90,
+            namespace=namespace,
+            filepath=path
+        )
+        updateEvent = RayServiceUpdateCREvent(
+            custom_resource_object=cr,
+            rulesets=[RuleSet([EasyJobRule(), CurlServiceRule(result1="8", result2='"9 pizzas please!"')])],
+            timeout=90,
+            namespace=namespace,
+            filepath=yaml_copy.name
+        )
+        deleteEvent = RayServiceDeleteCREvent(cr, [], 90, namespace, path)
+        test_cases.addTest(SeriesTestCase('runtest', image_dict, [addEvent, updateEvent, deleteEvent]))
+
+        # Execute test
+        runner = unittest.TextTestRunner()
+        test_result = runner.run(test_cases)
+
+        # Without this line, the exit code will always be 0.
+        assert test_result.wasSuccessful()
+
+def test_zero_downtime_rollout(cr: str, path: str):
+    logger.info(DEFAULT_IMAGE_DICT)
+
+    # Modify the cluster spec to trigger a rollout
+    with open(path, 'r') as file:
+        yaml_lines = file.readlines()
+        yaml_lines[103:103] = [
+            " " * 14 + "env:\n",
+            " " * 16 + "- name: SAMPLE_ENV_VAR\n",
+            " " * 18 + 'value: SAMPLE_VALUE\n',
+        ]
+
+    queries = {
+        CURL_CMD_TEMPLATE.format(
+            name=cr["metadata"]["name"],
+            namespace=NAMESPACE,
+            path="/fruit",
+            json='["MANGO", 2]'
+        ): "6",
+        CURL_CMD_TEMPLATE.format(
+            name=cr["metadata"]["name"],
+            namespace=NAMESPACE,
+            path="/calc",
+            json='["MUL", 3]'
+        ): '"15 pizzas please!"',
+    }
+
+    rs = RuleSet([EasyJobRule(), CurlServiceRule(queries=queries)])
+
+    with NamedTemporaryFile(mode="w+", suffix=".yaml") as yaml_copy:
+        logger.info(f"Writing modified RayService yaml to {yaml_copy.name}.")
+        yaml_copy.writelines(yaml_lines)
+        yaml_copy.flush()
+
+        # Build a test plan
+        logger.info("Build a test plan ...")
+        test_cases = unittest.TestSuite()
+        addEvent = RayServiceAddCREvent(custom_resource_object=cr, rulesets=[rs], filepath=path)
+        updateEvent = RayServiceUpdateCREvent(
+            custom_resource_object=cr,
+            rulesets=[rs],
+            filepath=yaml_copy.name,
+            query_while_updating=queries,
+        )
+        deleteEvent = RayServiceDeleteCREvent(custom_resource_object=cr, timeout=90, filepath=path)
+
+        test_case = SeriesTestCase(
+            methodName='runtest',
+            docker_image_dict=DEFAULT_IMAGE_DICT,
+            cr_events=[addEvent, updateEvent, deleteEvent],
+            start_curl_pod=True,
+        )
+        test_cases.addTest(test_case)
+
+        # Execute test
+        runner = unittest.TextTestRunner()
+        test_result = runner.run(test_cases)
+
+        # Without this line, the exit code will always be 0.
+        assert test_result.wasSuccessful()
+
 if __name__ == '__main__':
-    NAMESPACE = 'default'
     SAMPLE_PATH = CONST.REPO_ROOT.joinpath("ray-operator/config/samples/")
     YAMLs = ['ray_v1alpha1_rayservice.yaml']
 
@@ -32,24 +326,6 @@ if __name__ == '__main__':
                     {'path': filepath, 'name': filename, 'cr': k8s_object}
                 )
 
-    rs = RuleSet([EasyJobRule(), CurlServiceRule()])
-    image_dict = {
-        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.5.0'),
-        CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
-    }
-    logger.info(image_dict)
-
-    # Build a test plan
-    logger.info("Build a test plan ...")
-    test_cases = unittest.TestSuite()
-    for index, new_cr in enumerate(sample_yaml_files):
-        logger.info('[TEST %d]: %s', index, new_cr['name'])
-        addEvent = RayServiceAddCREvent(new_cr['cr'], [rs], 90, NAMESPACE, new_cr['path'])
-        test_cases.addTest(GeneralTestCase('runtest', image_dict, addEvent))
-
-    # Execute all tests
-    runner = unittest.TextTestRunner()
-    test_result = runner.run(test_cases)
-
-    # Without this line, the exit code will always be 0.
-    assert test_result.wasSuccessful()
+    # test_deploy_applications(NAMESPACE, sample_yaml_files[0])
+    # test_deploy_and_in_place_update(NAMESPACE, sample_yaml_files[0])
+    test_zero_downtime_rollout(sample_yaml_files[0]['cr'], sample_yaml_files[0]['path'])

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -316,7 +316,7 @@ class TestRayService:
             query={"path": "/signal", "json_args": {}},
             num_repeat=1,
             expected_worker_pods=1,
-            timeout=300,
+            timeout=400,
             message="Releasing all blocked requests. Worker pods should start scaling down..."
         )
         cr_events: List[CREvent] = [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

4 e2e tests for RayService:
- deploy 2 applications
- deploy then execute in place update
- deploy then execute zero downtime rollout
- autoscaling

The e2e tests should be run with the following command:
```
RAY_IMAGE=rayproject/ray:2.5.0 OPERATOR_IMAGE=controller:latest pytest -vs tests/test_sample_rayservice_yamls.py --log-cli-level=INFO
```

To run a specific test in `test_sample_rayservice_yamls.py`, specify the test name with `-k`, e.g:
```
RAY_IMAGE=rayproject/ray:2.5.0 OPERATOR_IMAGE=controller:latest pytest -vs tests/test_sample_rayservice_yamls.py -k test_service_autoscaling --log-cli-level=INFO
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
