### PR TITLE
[RayService] Add RayService alb ingress CR

### DIFF
--- a/docs/guidance/ingress.md
+++ b/docs/guidance/ingress.md
@@ -39,6 +39,7 @@ eksctl get cluster ${YOUR_EKS_CLUSTER} # Check subnets on the EKS cluster
 
 # Step 4: Create an ALB ingress. When an ingress with proper annotations creates,
 #        AWS Load Balancer controller will reconcile a ALB (not in AWS EKS cluster).
+# For RayService, you can use ray-operator/config/samples/ray_v1alpha1_rayservice-alb-ingress.yaml
 kubectl apply -f ray-operator/config/samples/alb-ingress.yaml
 
 # Step 5: Check ingress created by Step 4.

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice-alb-ingress.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice-alb-ingress.yaml
@@ -8,7 +8,8 @@ metadata:
     # See `ingress.md` for more details about how to choose subnets.
     alb.ingress.kubernetes.io/subnets: subnet-d9d4ff92, subnet-0c0209db843c9fd72
     alb.ingress.kubernetes.io/target-type: ip
-    # Health Check Settings
+    # Health Check Settings. Health check is needed for
+    # ALB to route traffic to the healthy pod.
     alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
     alb.ingress.kubernetes.io/healthcheck-port: traffic-port
     alb.ingress.kubernetes.io/healthcheck-path: /-/routes

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice-alb-ingress.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice-alb-ingress.yaml
@@ -8,6 +8,10 @@ metadata:
     # See `ingress.md` for more details about how to choose subnets.
     alb.ingress.kubernetes.io/subnets: subnet-d9d4ff92, subnet-0c0209db843c9fd72
     alb.ingress.kubernetes.io/target-type: ip
+    # Health Check Settings
+    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
+    alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+    alb.ingress.kubernetes.io/healthcheck-path: /-/routes
 spec:
   ingressClassName: alb
   rules:

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice-alb-ingress.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice-alb-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ray-cluster-ingress
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/tags: Environment=dev,Team=test
+    # See `ingress.md` for more details about how to choose subnets.
+    alb.ingress.kubernetes.io/subnets: subnet-d9d4ff92, subnet-0c0209db843c9fd72
+    alb.ingress.kubernetes.io/target-type: ip
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: rayservice-sample-serve-svc # Serve service
+                port:
+                  number: 8000 # default HTTP port number for serving requests


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

three updates comparing with [this](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/alb-ingress.yaml)

- Update the service name to `rayservice-sample-serve-svc`
- Update the port to 8000.
- Health check.

With these two changes, customer will have workable CR out of the box for Ray Service.

Tested with eks.

<img width="1445" alt="image" src="https://github.com/ray-project/kuberay/assets/6515354/4e34e987-921f-4039-b78a-3347cbfefad3">

<img width="1073" alt="image" src="https://github.com/ray-project/kuberay/assets/6515354/f9b5e89a-3a52-4fa9-a9ca-1dbeb53c50fc">

I will put more details into the ray doc.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
