### PR TITLE
Add instruction to skip unit tests in DEVELOPMENT.md

### DIFF
--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -52,6 +52,7 @@ kind create cluster --image=kindest/node:v1.24.0
 #         This command will copy the source code directory into the image, and build it.
 # Command: IMG={IMG_REPO}:{IMG_TAG} make docker-build
 IMG=kuberay/operator:nightly make docker-build
+
 # To skip running unit tests, run the following command instead:
 # IMG=kuberay/operator:nightly make docker-image
 

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -52,10 +52,13 @@ kind create cluster --image=kindest/node:v1.24.0
 #         This command will copy the source code directory into the image, and build it.
 # Command: IMG={IMG_REPO}:{IMG_TAG} make docker-build
 IMG=kuberay/operator:nightly make docker-build
+# To skip running unit tests, run the following command instead:
+# IMG=kuberay/operator:nightly make docker-image
 
 # Step 4: Load the custom KubeRay image into the Kind cluster.
 # Command: kind load docker-image {IMG_REPO}:{IMG_TAG}
 kind load docker-image kuberay/operator:nightly
+
 
 # Step 5: Keep consistency
 # If you update RBAC or CRD, you need to synchronize them.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In the development workflow, unit tests are automatically run when building the Docker image.  These can take 2+ minutes to complete.

This PR adds an instruction for skipping this step, which allows for faster iteration speed.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
