### PR TITLE
[Bug] KubeRay operator fails to get serve deployment status due to 500 Internal Server Error

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -172,7 +172,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	clientURL := rayJobInstance.Status.DashboardURL
 	if clientURL == "" {
 		// TODO: dashboard service may be changed. Check it instead of using the same URL always
-		if clientURL, err = utils.FetchDashboardURL(ctx, &r.Log, r.Client, rayClusterInstance); err != nil || clientURL == "" {
+		if clientURL, err = utils.FetchHeadServiceURL(ctx, &r.Log, r.Client, rayClusterInstance, common.DefaultDashboardName); err != nil || clientURL == "" {
 			if clientURL == "" {
 				err = fmt.Errorf("empty dashboardURL")
 			}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -985,7 +985,7 @@ func (r *RayServiceReconciler) updateStatusForActiveCluster(ctx context.Context,
 	var clientURL string
 	rayServiceStatus := &rayServiceInstance.Status.ActiveServiceStatus
 
-	if clientURL, err = utils.FetchDashboardAgentURL(ctx, &r.Log, r.Client, rayClusterInstance); err != nil || clientURL == "" {
+	if clientURL, err = utils.FetchHeadServiceURL(ctx, &r.Log, r.Client, rayClusterInstance, common.DefaultDashboardAgentListenPortName); err != nil || clientURL == "" {
 		r.updateAndCheckDashboardStatus(rayServiceStatus, false, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold)
 		return err
 	}
@@ -1025,7 +1025,7 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 		rayServiceStatus = &rayServiceInstance.Status.PendingServiceStatus
 	}
 
-	if clientURL, err = utils.FetchDashboardAgentURL(ctx, &r.Log, r.Client, rayClusterInstance); err != nil || clientURL == "" {
+	if clientURL, err = utils.FetchHeadServiceURL(ctx, &r.Log, r.Client, rayClusterInstance, common.DefaultDashboardAgentListenPortName); err != nil || clientURL == "" {
 		if !r.updateAndCheckDashboardStatus(rayServiceStatus, false, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold) {
 			logger.Info("Dashboard is unhealthy, restart the cluster.")
 			r.markRestart(rayServiceInstance)

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -389,28 +389,7 @@ func TestFetchHeadServiceURL(t *testing.T) {
 			Name:      "test-cluster",
 			Namespace: namespace,
 		},
-		Spec: rayv1alpha1.RayClusterSpec{
-			HeadGroupSpec: rayv1alpha1.HeadGroupSpec{
-				Template: corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name: "ray-head",
-								Ports: []corev1.ContainerPort{
-									{
-										Name:          common.DefaultDashboardName,
-										ContainerPort: dashboardPort,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
 	}
-
-	// A head service for the RayCluster.
 	headSvc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.GenerateServiceName(cluster.Name),
@@ -430,7 +409,7 @@ func TestFetchHeadServiceURL(t *testing.T) {
 	runtimeObjects := []runtime.Object{&headSvc}
 	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
 
-	// Initialize RayCluster reconciler.
+	// Initialize RayService reconciler.
 	ctx := context.TODO()
 	r := RayServiceReconciler{
 		Client:   fakeClient,

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -72,7 +72,7 @@ func FetchHeadServiceURL(ctx context.Context, log *logr.Logger, cli client.Clien
 		return "", err
 	}
 
-	log.V(3).Info("FetchHeadServiceURL", "head service name", headSvc.Name, "namespace", headSvc.Namespace)
+	log.Info("FetchHeadServiceURL", "head service name", headSvc.Name, "namespace", headSvc.Namespace)
 	servicePorts := headSvc.Spec.Ports
 	port := int32(-1)
 
@@ -93,7 +93,7 @@ func FetchHeadServiceURL(ctx context.Context, log *logr.Logger, cli client.Clien
 		headSvc.Namespace,
 		domainName,
 		port)
-	log.V(1).Info("FetchHeadServiceURL", "head service URL", headServiceURL, "port", defaultPortName)
+	log.Info("FetchHeadServiceURL", "head service URL", headServiceURL, "port", defaultPortName)
 	return headServiceURL, nil
 }
 

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -129,7 +129,7 @@ func GetNamespace(metaData metav1.ObjectMeta) string {
 	return metaData.Namespace
 }
 
-// GenerateServiceName generates a ray head service name from cluster name
+// GenerateServiceName generates a Ray head service name from cluster name
 func GenerateServiceName(clusterName string) string {
 	return CheckName(fmt.Sprintf("%s-%s-%s", clusterName, rayv1alpha1.HeadNode, "svc"))
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

### Trace code

```
500 Internal Server Error Traceback (most recent call last):
 File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/optional_utils.py", line 279, in decorator
 raise e from None
 File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/optional_utils.py", line 271, in decorator
 ray.init(
 File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/client_mode_hook.py", line 105, in wrapper
 return func(*args, **kwargs)
 File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/worker.py", line 1509, in init
 _global_node = ray._private.node.Node(
 File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/node.py", line 244, in __init__
 node_info = ray._private.services.get_node_to_connect_for_driver(
 File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/services.py", line 444, in get_node_to_connect_for_driver
 return global_state.get_node_to_connect_for_driver(node_ip_address)
 File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/state.py", line 752, in get_node_to_connect_for_driver
 node_info_str = self.global_state_accessor.get_node_to_connect_for_driver(
 File "python/ray/includes/global_state_accessor.pxi", line 156, in ray._raylet.GlobalStateAccessor.get_node_to_connect_for_driver
RuntimeError: b"This node has an IP address of 100.64.101.199, and Ray expects this IP address to be either the GCS address or one of the Raylet addresses. Connected to GCS at rayservice-raycluster-4tcq6-head-svc.ns-team-colligo-rayservice.svc.cluster.local and found raylets at 100.64.55.99 but none of these match this node's IP 100.64.101.199. Are any of these actually a different IP address for the same node?You might need to provide --node-ip-address to specify the IP address that the head should use when sending to this node."
```

#1125 provides the aforementioned error message. This user is using Ray 2.3.0, so I traced the code of Ray 2.3.0 instead of 2.5.0.

* Step 1: KubeRay uses an HTTP client to send a `GET $DASHBOARD_AGENT_SERVICE:52365/api/serve/deployments/status` request to retrieve Serve status.
* Step 2: The request in Step 1 will be received and processed by the `get_all_deployment_statuses` function in the Serve agent. You can find the code for this function [here](https://sourcegraph.com/github.com/ray-project/ray@ray-2.3.0/-/blob/dashboard/modules/serve/serve_agent.py?L77-L101).
* Step 3: The function `get_all_deployment_statuses` uses `@optional_utils.init_ray_and_catch_exceptions()` as a decorator. This decorator checks whether Ray is initialized or not. If Ray is not initialized, the decorator will call `ray.init()`.
* Step 4: The function `ray.init()` in [worker.py](https://sourcegraph.com/github.com/ray-project/ray@ray-2.3.0/-/blob/python/ray/_private/worker.py?L1509-L1515) invokes the following function to initialize a Ray node. In addition, we can determine that this node is a worker node based on the `head=False` parameter.
   ```python
            _global_node = ray._private.node.Node(
                ray_params,
                head=False,
                shutdown_at_exit=False,
                spawn_reaper=False,
                connect_only=True,
            )
   ```
* Step 5: The constructor of `class Node` ([node.py](https://sourcegraph.com/github.com/ray-project/ray@ray-2.3.0/-/blob/python/ray/_private/node.py?L244-L247)) calls the function `ray._private.services.get_node_to_connect_for_driver` to retrieve address information from GCS.
* Step 6: [services.py](https://sourcegraph.com/github.com/ray-project/ray@ray-2.3.0/-/blob/python/ray/_private/services.py?L439-L444) `global_state.get_node_to_connect_for_driver(node_ip_address)`.
* Step 7: [state.py](https://sourcegraph.com/github.com/ray-project/ray@ray-2.3.0/-/blob/python/ray/_private/state.py?L749) `get_node_to_connect_for_driver(self, node_ip_address)`
* Step 8: [global_state_accessor.pxi](https://sourcegraph.com/github.com/ray-project/ray@ray-2.3.0/-/blob/python/ray/includes/global_state_accessor.pxi?L148) (Cython wrapper) `get_node_to_connect_for_driver`
* Step 9: [global_state_accessor.cc](https://sourcegraph.com/github.com/ray-project/ray@ray-2.3.0/-/blob/src/ray/gcs/gcs_client/global_state_accessor.cc?L301) `GetNodeToConnectForDriver` => The error message is reported by this function
   ```
    RuntimeError: b"This node has an IP address of 100.64.101.199, and Ray expects this IP address to be either the GCS address or one of the Raylet addresses. Connected to GCS at rayservice-raycluster-4tcq6-head-svc.ns-team-colligo-rayservice.svc.cluster.local and found raylets at 100.64.55.99 but none of these match this node's IP 100.64.101.199. Are any of these actually a different IP address for the same node?You might need to provide --node-ip-address to specify the IP address that the head should use when sending to this node."
   ```

### Root cause of #1125 

To summarize, the root cause is that KubeRay sends a request to the dashboard agent process on a worker node, but GCS does not have the address information for this Raylet. This means that the dashboard agent process starts serving requests before the node registration process with GCS finishes. See the "Node management" section in the [Ray architecture whitepaper](https://docs.google.com/document/d/1tBw9A4j62ruI5omIJbMxly-la5w4q_TjyJgJL_jN2fI/preview#heading=h.p0swli9tlu72) for more details.

KubeRay will start sending requests to the dashboard agent processes once the head Pod is running and ready. In other words, KubeRay does not check the status of workers, so it is possible for the dashboard agent processes on workers to receive requests at any moment. See #1074 for more details.

### Solution

Without this PR, the Kubernetes service for the dashboard agent uses a round-robin algorithm to evenly distribute traffic among the available Pods, including the head Pod and worker Pods. You can refer to [this link](https://kodekloud.com/blog/clusterip-nodeport-loadbalancer/) for more details. Hence, this PR decides to only send requests to the head Pod by changing from the dashboard agent service to the head service.

### Something needs to be verified.

1. Is it possible for the dashboard agent process starts serving requests before the node registration process with GCS finishes?
2. Does it make sense to restrict the sending of only GET and PUT requests to the head Pod? In my understanding, requests will typically be forwarded to the ServeController actor, which is expected to be running on the head Pod.

## Related issue number

Closes #1125 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

The following experiment is used to verify the statement "KubeRay will start sending requests to the dashboard agent processes once the head Pod is running and ready. In other words, KubeRay does not check the status of workers, so it is possible for the dashboard agent processes on workers to receive requests at any moment.".

```sh
# Step 1: Create a Kind cluster
kind create cluster --image=kindest/node:v1.23.0

# Step 2: Install a KubeRay operator
helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0

# Step 3: Load the Ray image into the Kind cluster
docker pull rayproject/ray:2.4.0
kind load docker-image rayproject/ray:2.4.0

# Step 4: Install gist https://gist.github.com/kevin85421/d64e730acc2e1e3b5223610e450e4478
# In this gist, the worker Pod will sleep for 60 seconds before executing the `ray start` command.
kubectl apply -f rayservice.yaml

# Step 5: Run the following commands and the script `loop_curl.sh` immediately after the head Pod is ready
export DASHBOARD_AGENT_SVC=$(kubectl get svc -l=ray.io/cluster-dashboard  -o custom-columns=SERVICE:metadata.name --no-headers)
kubectl port-forward svc/$DASHBOARD_AGENT_SVC 52365
./loop_curl.sh 2>&1 | tee log

"""loop_curl.sh
#!/bin/bash

kubectl run curl --image=radial/busyboxplus:curl --command -- /bin/sh -c "while true; do sleep 10;done"
export DASHBOARD_AGENT_SVC=$(kubectl get svc -l=ray.io/cluster-dashboard  -o custom-columns=SERVICE:metadata.name --no-headers)
ITERATIONS=120

# Run the loop
for ((i=1; i<=$ITERATIONS; i++)); do
    echo -e "Iteration: $i\n"
    kubectl exec -it curl -- curl -X GET $DASHBOARD_AGENT_SVC:52365/api/serve/deployments/status
    echo -e "\n"
    sleep 1
done
"""

# You will observe some requests fail because they are forwarded to the worker Pod before it is ready.

# Step 6: Update the loop_curl script to send the request to the head service. No request should fail after the head Pod is ready and running.
```
