### PR TITLE
[RayService] Change runtime env for e2e autoscaling test

### DIFF
--- a/ray-operator/config/samples/ray-service.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-service.autoscaler.yaml
@@ -17,10 +17,10 @@ spec:
   serveConfigV2: |
     applications:
       - name: app1
-        import_path: autoscaling_test.blocked.app
+        import_path: autoscaling.blocked.app
         route_prefix: /
         runtime_env:
-          working_dir: "https://github.com/ray-project/serve_workloads/archive/7a0daafdb86b55118534b04d122b1b79c9ae99f5.zip"
+          working_dir: "https://github.com/ray-project/test_dag/archive/7a0daafdb86b55118534b04d122b1b79c9ae99f5.zip"
         deployments:
           - name: Blocked
             autoscaling_config:
@@ -35,10 +35,10 @@ spec:
             ray_actor_options:
               num_cpus: 0.5
       - name: signal
-        import_path: autoscaling_test.signaling.app
+        import_path: autoscaling.signaling.app
         route_prefix: /signal
         runtime_env:
-          working_dir: "https://github.com/ray-project/serve_workloads/archive/7a0daafdb86b55118534b04d122b1b79c9ae99f5.zip"
+          working_dir: "https://github.com/ray-project/test_dag/archive/7a0daafdb86b55118534b04d122b1b79c9ae99f5.zip"
   rayClusterConfig:
     rayVersion: '2.5.0' # should match the Ray version in the image of the containers
     ## raycluster autoscaling config

--- a/ray-operator/config/samples/ray-service.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-service.autoscaler.yaml
@@ -17,10 +17,10 @@ spec:
   serveConfigV2: |
     applications:
       - name: app1
-        import_path: autoscaling.blocked.app
+        import_path: autoscaling.blocked:app
         route_prefix: /
         runtime_env:
-          working_dir: "https://github.com/ray-project/test_dag/archive/7a0daafdb86b55118534b04d122b1b79c9ae99f5.zip"
+          working_dir: "https://github.com/ray-project/test_dag/archive/041ac908e5a04ab50cb23d5939e53bd05a03e1ae.zip"
         deployments:
           - name: Blocked
             autoscaling_config:
@@ -35,10 +35,10 @@ spec:
             ray_actor_options:
               num_cpus: 0.5
       - name: signal
-        import_path: autoscaling.signaling.app
+        import_path: autoscaling.signaling:app
         route_prefix: /signal
         runtime_env:
-          working_dir: "https://github.com/ray-project/test_dag/archive/7a0daafdb86b55118534b04d122b1b79c9ae99f5.zip"
+          working_dir: "https://github.com/ray-project/test_dag/archive/041ac908e5a04ab50cb23d5939e53bd05a03e1ae.zip"
   rayClusterConfig:
     rayVersion: '2.5.0' # should match the Ray version in the image of the containers
     ## raycluster autoscaling config


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Change the repo used for the runtime env for the autoscaling e2e test to [ray-project/test_dag](https://github.com/ray-project/test_dag/tree/master).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
