### PR TITLE
Add support for openshift routes

### DIFF
--- a/helm-chart/kuberay-apiserver/templates/route.yaml
+++ b/helm-chart/kuberay-apiserver/templates/route.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.route.enabled -}}
+{{- $fullName := include "kuberay-apiserver.fullname" . -}}
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "kuberay-apiserver.labels" . | nindent 4 }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  subdomain: api-server-kuberay
+  to:
+    kind: Service
+    name: {{ .Values.name }}-service
+    weight: 100
+  port:
+    targetPort: http
+  {{- if .Values.route.tls -}}
+  tls:
+    termination: edge
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -36,27 +36,27 @@ resources:
 # Only one service type needs to be picked
 service:
 # Nodeport service
-#  type: NodePort
-#  ports:
-#    - name: http
-#      port: 8888
-#      targetPort: 8888
-#      nodePort: 31888
-#    - name: rpc
-#      port: 8887
-#      targetPort: 8887
-#      nodePort: 31887
-# ClusterIP service
-  type: ClusterIP
+  type: NodePort
   ports:
     - name: http
-      protocol: TCP
       port: 8888
       targetPort: 8888
+      nodePort: 31888
     - name: rpc
-      protocol: TCP
       port: 8887
       targetPort: 8887
+      nodePort: 31887
+# ClusterIP service
+#  type: ClusterIP
+#  ports:
+#    - name: http
+#      protocol: TCP
+#      port: 8888
+#      targetPort: 8888
+#    - name: rpc
+#      protocol: TCP
+#      port: 8887
+#      targetPort: 8887
 
 # You can only enable an ingress or route, if you are using OpenShift cluster
 # Also note that in order to enable ingress or route you need to use ClusterIP service

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -33,21 +33,38 @@ resources:
   requests:
     cpu: 300m
     memory: 300Mi
-
+# Only one service type needs to be picked
 service:
-  type: NodePort
+# Nodeport service
+#  type: NodePort
+#  ports:
+#    - name: http
+#      port: 8888
+#      targetPort: 8888
+#      nodePort: 31888
+#    - name: rpc
+#      port: 8887
+#      targetPort: 8887
+#      nodePort: 31887
+# ClusterIP service
+  type: ClusterIP
   ports:
     - name: http
+      protocol: TCP
       port: 8888
       targetPort: 8888
-      nodePort: 31888
     - name: rpc
+      protocol: TCP
       port: 8887
       targetPort: 8887
-      nodePort: 31887
+
+# You can only enable an ingress or route, if you are using OpenShift cluster
+# Also note that in order to enable ingress or route you need to use ClusterIP service
 
 ingress:
   enabled: false
+route:
+  enabled: true
 
 rbacEnable: true
 

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -64,7 +64,7 @@ service:
 ingress:
   enabled: false
 route:
-  enabled: true
+  enabled: false
 
 rbacEnable: true
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
API server Helm chart allows creating an ingress, but for the OpenShift, the default way to expose services is the usage of Route. This PR adds support for Routes creation

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x ] Manual tests
   - [ ] This PR is not tested :(
