### PR TITLE
[Bug] KubeRay tries to create ClusterRoleBinding when singleNamespaceInstall and rbacEnable are set to true

### DIFF
--- a/.github/workflows/consistency-check.yaml
+++ b/.github/workflows/consistency-check.yaml
@@ -124,3 +124,8 @@ jobs:
       - name: Check rbac consistency
         run: |
           python3 scripts/rbac-check.py
+
+      - name: Check rbac configuration
+        run: |
+          cd helm-chart/script/
+          pytest -s

--- a/helm-chart/kuberay-operator/templates/rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnable }}
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/helm-chart/script/rbac_test.py
+++ b/helm-chart/script/rbac_test.py
@@ -15,26 +15,27 @@ def generate_config_patch(config):
     """
     Set `crNamespacedRbacEnable`, `singleNamespaceInstall`, and `watchNamespace` of the Helm chart.
     """
-    patch = jsonpatch.JsonPatch(
-        [
-            {
-                "op": "replace",
-                "path": "/crNamespacedRbacEnable",
-                "value": config["crNamespacedRbacEnable"],
-            },
-            {
-                "op": "replace",
-                "path": "/singleNamespaceInstall",
-                "value": config["singleNamespaceInstall"],
-            },
+    actions = [
+        {
+            "op": "replace",
+            "path": "/crNamespacedRbacEnable",
+            "value": config["crNamespacedRbacEnable"],
+        },
+        {
+            "op": "replace",
+            "path": "/singleNamespaceInstall",
+            "value": config["singleNamespaceInstall"],
+        },
+    ]
+    if "watchNamespace" in config:
+        actions.append(
             {
                 "op": "add",
                 "path": "/watchNamespace",
                 "value": config["watchNamespace"],
             },
-        ]
-    )
-    return patch
+        )
+    return jsonpatch.JsonPatch(actions)
 
 
 def helm_template_render(values_yaml):

--- a/helm-chart/script/rbac_test.py
+++ b/helm-chart/script/rbac_test.py
@@ -1,0 +1,82 @@
+"""
+Test `crNamespacedRbacEnable`, `singleNamespaceInstall`, and `watchNamespace` of the Helm chart.
+"""
+from pathlib import Path
+import subprocess
+import tempfile
+import yaml
+import jsonpatch
+
+
+REPO_ROOT = Path(__file__).absolute().parent.parent.parent
+
+
+def generate_config_patch(config):
+    """
+    Set `crNamespacedRbacEnable`, `singleNamespaceInstall`, and `watchNamespace` of the Helm chart.
+    """
+    patch = jsonpatch.JsonPatch(
+        [
+            {
+                "op": "replace",
+                "path": "/crNamespacedRbacEnable",
+                "value": config["crNamespacedRbacEnable"],
+            },
+            {
+                "op": "replace",
+                "path": "/singleNamespaceInstall",
+                "value": config["singleNamespaceInstall"],
+            },
+            {
+                "op": "add",
+                "path": "/watchNamespace",
+                "value": config["watchNamespace"],
+            },
+        ]
+    )
+    return patch
+
+
+def helm_template_render(values_yaml):
+    """
+    Render the Helm chart with the given values.yaml.
+    """
+    chart_path = REPO_ROOT.joinpath("helm-chart/kuberay-operator/")
+    with tempfile.NamedTemporaryFile("w", suffix="_values.yaml") as values_fd:
+        yaml.safe_dump(values_yaml, values_fd)
+        render_string = subprocess.run(
+            f"helm template kuberay-operator {chart_path} -f {values_fd.name}",
+            shell=True,
+            check=True,
+            capture_output=True,
+        ).stdout
+        return yaml.safe_load_all(render_string)
+
+
+class TestRbac:
+    base_values_yaml_path = REPO_ROOT.joinpath(
+        "helm-chart/kuberay-operator/values.yaml"
+    )
+    with open(base_values_yaml_path, encoding="utf-8") as fd:
+        base_values_yaml = yaml.safe_load(fd)
+
+    def test_rbac_1(self):
+        """
+        When singleNamespaceInstall is set to True, no cluster-scoped
+        RBAC resources should be created.
+        """
+        patch = generate_config_patch(
+            {
+                "singleNamespaceInstall": True,
+                "crNamespacedRbacEnable": False,
+                "watchNamespace": ["n1"],
+            }
+        )
+        render_output = helm_template_render(patch.apply(self.base_values_yaml))
+        for k8s_object in render_output:
+            if k8s_object is None:
+                continue
+            assert (
+                k8s_object["kind"] != "ClusterRole"
+                and k8s_object["kind"] != "ClusterRoleBinding"
+            )

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML==6.0
 deepdiff==5.8.1
 PyGithub==1.57
+pytest==7.0.1

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,3 +2,4 @@ PyYAML==6.0
 deepdiff==5.8.1
 PyGithub==1.57
 pytest==7.0.1
+jsonpatch==1.32


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* RBAC files
  * `leader_election_role.yaml` / `leader_election_rolebinding.yaml` => Role / RoleBinding for leader election
  * `role.yaml` / `rolebinding.yaml` => ClusterRole / ClusterRoleBinding for KubeRay operator to create Kubernetes resources for custom resources 
  * `multiple_namespaces_role.yaml` / `multiple_namespaces_rolebinding.yaml` => Role / RoleBinding in multiple namespaces for KubeRay operator to create Kubernetes resources for custom resources

* Test: Firstly, I wanted to try https://github.com/helm-unittest/helm-unittest, but it turned out to be not as versatile as expected.

## Related issue number

Closes #1186 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
