### PR TITLE
[Refactor] Remove Dashboard Agent service

### DIFF
--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -126,6 +126,5 @@ type ServiceType string
 
 const (
 	HeadService    ServiceType = "headService"
-	AgentService   ServiceType = "agentService"
 	ServingService ServiceType = "serveService"
 )

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -104,8 +104,7 @@ func DefaultHeadPodTemplate(instance rayv1alpha1.RayCluster, headSpec rayv1alpha
 		podTemplate.Labels = make(map[string]string)
 	}
 	podTemplate.Labels = labelPod(rayv1alpha1.HeadNode, instance.Name, "headgroup", instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels)
-	headSpec.RayStartParams = setMissingRayStartParams(headSpec.RayStartParams, rayv1alpha1.HeadNode, headPort, "")
-	headSpec.RayStartParams = setAgentListPortStartParams(instance, headSpec.RayStartParams)
+	headSpec.RayStartParams = setMissingRayStartParams(headSpec.RayStartParams, rayv1alpha1.HeadNode, headPort, "", instance.Annotations)
 
 	initTemplateAnnotations(instance, &podTemplate)
 	rayContainerIndex := getRayContainerIndex(podTemplate.Spec)
@@ -230,8 +229,7 @@ func DefaultWorkerPodTemplate(instance rayv1alpha1.RayCluster, workerSpec rayv1a
 		podTemplate.Labels = make(map[string]string)
 	}
 	podTemplate.Labels = labelPod(rayv1alpha1.WorkerNode, instance.Name, workerSpec.GroupName, workerSpec.Template.ObjectMeta.Labels)
-	workerSpec.RayStartParams = setMissingRayStartParams(workerSpec.RayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP)
-	workerSpec.RayStartParams = setAgentListPortStartParams(instance, workerSpec.RayStartParams)
+	workerSpec.RayStartParams = setMissingRayStartParams(workerSpec.RayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP, instance.Annotations)
 
 	initTemplateAnnotations(instance, &podTemplate)
 
@@ -531,14 +529,13 @@ func labelPod(rayNodeType rayv1alpha1.RayNodeType, rayClusterName string, groupN
 	}
 
 	ret = map[string]string{
-		RayNodeLabelKey:                    "yes",
-		RayClusterLabelKey:                 rayClusterName,
-		RayNodeTypeLabelKey:                string(rayNodeType),
-		RayNodeGroupLabelKey:               groupName,
-		RayIDLabelKey:                      utils.CheckLabel(utils.GenerateIdentifier(rayClusterName, rayNodeType)),
-		KubernetesApplicationNameLabelKey:  ApplicationName,
-		KubernetesCreatedByLabelKey:        ComponentName,
-		RayClusterDashboardServiceLabelKey: utils.GenerateDashboardAgentLabel(rayClusterName),
+		RayNodeLabelKey:                   "yes",
+		RayClusterLabelKey:                rayClusterName,
+		RayNodeTypeLabelKey:               string(rayNodeType),
+		RayNodeGroupLabelKey:              groupName,
+		RayIDLabelKey:                     utils.CheckLabel(utils.GenerateIdentifier(rayClusterName, rayNodeType)),
+		KubernetesApplicationNameLabelKey: ApplicationName,
+		KubernetesCreatedByLabelKey:       ComponentName,
 	}
 
 	for k, v := range ret {
@@ -684,8 +681,7 @@ func envVarExists(envName string, envVars []v1.EnvVar) bool {
 	return false
 }
 
-// TODO auto complete params
-func setMissingRayStartParams(rayStartParams map[string]string, nodeType rayv1alpha1.RayNodeType, headPort string, fqdnRayIP string) (completeStartParams map[string]string) {
+func setMissingRayStartParams(rayStartParams map[string]string, nodeType rayv1alpha1.RayNodeType, headPort string, fqdnRayIP string, annotations map[string]string) (completeStartParams map[string]string) {
 	// Note: The argument headPort is unused for nodeType == rayv1alpha1.HeadNode.
 	if nodeType == rayv1alpha1.WorkerNode {
 		if _, ok := rayStartParams["address"]; !ok {
@@ -711,23 +707,19 @@ func setMissingRayStartParams(rayStartParams map[string]string, nodeType rayv1al
 		}
 	}
 
-	// add metrics port for expose the metrics to the prometheus.
+	// Add a metrics port to expose the metrics to Prometheus.
 	if _, ok := rayStartParams["metrics-export-port"]; !ok {
 		rayStartParams["metrics-export-port"] = fmt.Sprint(DefaultMetricsPort)
 	}
 
-	// add --block option. See https://github.com/ray-project/kuberay/pull/675
+	// Add --block option. See https://github.com/ray-project/kuberay/pull/675
 	if _, ok := rayStartParams["block"]; !ok {
 		rayStartParams["block"] = "true"
 	}
 
-	return rayStartParams
-}
-
-func setAgentListPortStartParams(instance rayv1alpha1.RayCluster, rayStartParams map[string]string) (completeStartParams map[string]string) {
-	// add dashboard listen port for serve endpoints to RayService.
+	// Add dashboard listen port for RayService.
 	if _, ok := rayStartParams["dashboard-agent-listen-port"]; !ok {
-		if value, ok := instance.Annotations[EnableAgentServiceKey]; ok && value == EnableAgentServiceTrue {
+		if value, ok := annotations[EnableAgentServiceKey]; ok && value == EnableAgentServiceTrue {
 			rayStartParams["dashboard-agent-listen-port"] = strconv.Itoa(DefaultDashboardAgentListenPort)
 		}
 	}

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1066,6 +1066,44 @@ func TestSetMissingRayStartParamsDashboardHost(t *testing.T) {
 	assert.Equal(t, "localhost", rayStartParams["dashboard-host"], fmt.Sprintf("Expected `%v` but got `%v`", "localhost", rayStartParams["dashboard-host"]))
 }
 
+func TestSetMissingRayStartParamsAgentListenPort(t *testing.T) {
+	// The "dashboard-agent-listen-port" port will be automatically injected into RayStartParams with a default
+	// value of 52365 (i.e., DefaultDashboardAgentListenPort) when the annotation "ray.io/enableAgentService"
+	// is set to true. The behavior is the same for both head and workers.
+	headPort := "6379"
+	fqdnRayIP := "raycluster-kuberay-head-svc.default.svc.cluster.local"
+	rayStartParams := map[string]string{}
+	annotaions := map[string]string{}
+
+	// Case 1: Head node without "ray.io/enableAgentService=true".
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "", annotaions)
+	assert.NotContains(t, rayStartParams, "dashboard-agent-listen-port", "Head Pod should not have a dashboard-agent-listen-port option set by default.")
+
+	// Case 2: Worker node without "ray.io/enableAgentService=true".
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP, annotaions)
+	assert.NotContains(t, rayStartParams, "dashboard-agent-listen-port", "Worker Pod should not have a dashboard-agent-listen-port option set by default.")
+
+	// Case 3: Head node with "ray.io/enableAgentService=true" and users do not provide "dashboard-agent-listen-port".
+	annotaions = map[string]string{EnableAgentServiceKey: EnableAgentServiceTrue}
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "", annotaions)
+	assert.Equal(t, fmt.Sprint(DefaultDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(DefaultDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"]))
+
+	// Case 4: Worker node with "ray.io/enableAgentService=true" and users do not provide "dashboard-agent-listen-port".
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP, annotaions)
+	assert.Equal(t, fmt.Sprint(DefaultDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(DefaultDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"]))
+
+	// Case 5: Head node with "ray.io/enableAgentService=true" and users provide "dashboard-agent-listen-port".
+	customDashboardAgentListenPort := DefaultDashboardAgentListenPort + 1
+	rayStartParams = map[string]string{"dashboard-agent-listen-port": fmt.Sprint(customDashboardAgentListenPort)}
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "", annotaions)
+	assert.Equal(t, fmt.Sprint(customDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(customDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"]))
+
+	// Case 6: Worker node with "ray.io/enableAgentService=true" and users provide "dashboard-agent-listen-port".
+	rayStartParams = map[string]string{"dashboard-agent-listen-port": fmt.Sprint(customDashboardAgentListenPort)}
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP, annotaions)
+	assert.Equal(t, fmt.Sprint(customDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(customDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"]))
+}
+
 func TestGetCustomWorkerInitImage(t *testing.T) {
 	// cleanup
 	defer os.Unsetenv(EnableInitContainerInjectionEnvKey)

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -959,23 +959,23 @@ func TestSetMissingRayStartParamsAddress(t *testing.T) {
 
 	// Case 1: Head node with no address option set.
 	rayStartParams := map[string]string{}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "")
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "", nil)
 	assert.NotContains(t, rayStartParams, "address", "Head node should not have an address option set by default.")
 
 	// Case 2: Head node with custom address option set.
 	rayStartParams = map[string]string{"address": customAddress}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "")
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "", nil)
 	assert.Equal(t, customAddress, rayStartParams["address"], fmt.Sprintf("Expected `%v` but got `%v`", customAddress, rayStartParams["address"]))
 
 	// Case 3: Worker node with no address option set.
 	rayStartParams = map[string]string{}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP)
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP, nil)
 	expectedAddress := fmt.Sprintf("%s:%s", fqdnRayIP, headPort)
 	assert.Equal(t, expectedAddress, rayStartParams["address"], fmt.Sprintf("Expected `%v` but got `%v`", expectedAddress, rayStartParams["address"]))
 
 	// Case 4: Worker node with custom address option set.
 	rayStartParams = map[string]string{"address": customAddress}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP)
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP, nil)
 	assert.Equal(t, customAddress, rayStartParams["address"], fmt.Sprintf("Expected `%v` but got `%v`", customAddress, rayStartParams["address"]))
 }
 
@@ -990,22 +990,22 @@ func TestSetMissingRayStartParamsMetricsExportPort(t *testing.T) {
 
 	// Case 1: Head node with no metrics-export-port option set.
 	rayStartParams := map[string]string{}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "")
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "", nil)
 	assert.Equal(t, fmt.Sprint(DefaultMetricsPort), rayStartParams["metrics-export-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(DefaultMetricsPort), rayStartParams["metrics-export-port"]))
 
 	// Case 2: Head node with custom metrics-export-port option set.
 	rayStartParams = map[string]string{"metrics-export-port": fmt.Sprint(customMetricsPort)}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "")
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "", nil)
 	assert.Equal(t, fmt.Sprint(customMetricsPort), rayStartParams["metrics-export-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(customMetricsPort), rayStartParams["metrics-export-port"]))
 
 	// Case 3: Worker node with no metrics-export-port option set.
 	rayStartParams = map[string]string{}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP)
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP, nil)
 	assert.Equal(t, fmt.Sprint(DefaultMetricsPort), rayStartParams["metrics-export-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(DefaultMetricsPort), rayStartParams["metrics-export-port"]))
 
 	// Case 4: Worker node with custom metrics-export-port option set.
 	rayStartParams = map[string]string{"metrics-export-port": fmt.Sprint(customMetricsPort)}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP)
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP, nil)
 	assert.Equal(t, fmt.Sprint(customMetricsPort), rayStartParams["metrics-export-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(customMetricsPort), rayStartParams["metrics-export-port"]))
 }
 
@@ -1019,22 +1019,22 @@ func TestSetMissingRayStartParamsBlock(t *testing.T) {
 
 	// Case 1: Head node with no --block option set.
 	rayStartParams := map[string]string{}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "")
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "", nil)
 	assert.Equal(t, "true", rayStartParams["block"], fmt.Sprintf("Expected `%v` but got `%v`", "true", rayStartParams["block"]))
 
 	// Case 2: Head node with --block option set to false.
 	rayStartParams = map[string]string{"block": "false"}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "")
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "", nil)
 	assert.Equal(t, "false", rayStartParams["block"], fmt.Sprintf("Expected `%v` but got `%v`", "false", rayStartParams["block"]))
 
 	// Case 3: Worker node with no --block option set.
 	rayStartParams = map[string]string{}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP)
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP, nil)
 	assert.Equal(t, "true", rayStartParams["block"], fmt.Sprintf("Expected `%v` but got `%v`", "true", rayStartParams["block"]))
 
 	// Case 4: Worker node with --block option set to false.
 	rayStartParams = map[string]string{"block": "false"}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP)
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP, nil)
 	assert.Equal(t, "false", rayStartParams["block"], fmt.Sprintf("Expected `%v` but got `%v`", "false", rayStartParams["block"]))
 }
 
@@ -1046,23 +1046,23 @@ func TestSetMissingRayStartParamsDashboardHost(t *testing.T) {
 
 	// Case 1: Head node with no dashboard-host option set.
 	rayStartParams := map[string]string{}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "")
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "", nil)
 	assert.Equal(t, "0.0.0.0", rayStartParams["dashboard-host"], fmt.Sprintf("Expected `%v` but got `%v`", "0.0.0.0", rayStartParams["dashboard-host"]))
 
 	// Case 2: Head node with dashboard-host option set.
 	rayStartParams = map[string]string{"dashboard-host": "localhost"}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "")
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.HeadNode, headPort, "", nil)
 	assert.Equal(t, "localhost", rayStartParams["dashboard-host"], fmt.Sprintf("Expected `%v` but got `%v`", "localhost", rayStartParams["dashboard-host"]))
 
 	// Case 3: Worker node with no dashboard-host option set.
 	rayStartParams = map[string]string{}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP)
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP, nil)
 	assert.NotContains(t, rayStartParams, "dashboard-host", "workers should not have an dashboard-host option set.")
 
 	// Case 4: Worker node with dashboard-host option set.
 	// To maximize user empowerment, this option can be enabled. However, it is important to note that the dashboard is not available on worker nodes.
 	rayStartParams = map[string]string{"dashboard-host": "localhost"}
-	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP)
+	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1alpha1.WorkerNode, headPort, fqdnRayIP, nil)
 	assert.Equal(t, "localhost", rayStartParams["dashboard-host"], fmt.Sprintf("Expected `%v` but got `%v`", "localhost", rayStartParams["dashboard-host"]))
 }
 

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -222,40 +222,6 @@ func BuildServeServiceForRayService(rayService rayv1alpha1.RayService, rayCluste
 	return serveService, nil
 }
 
-// BuildDashboardService Builds the service for dashboard agent and head node.
-func BuildDashboardService(cluster rayv1alpha1.RayCluster) (*corev1.Service, error) {
-	labels := map[string]string{
-		RayClusterDashboardServiceLabelKey: utils.GenerateDashboardAgentLabel(cluster.Name),
-	}
-	selectorLabels := map[string]string{
-		RayClusterDashboardServiceLabelKey: utils.GenerateDashboardAgentLabel(cluster.Name),
-	}
-
-	service := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      utils.GenerateDashboardServiceName(cluster.Name),
-			Namespace: cluster.Namespace,
-			Labels:    labels,
-		},
-		Spec: corev1.ServiceSpec{
-			Selector: selectorLabels,
-			Ports:    []corev1.ServicePort{},
-			Type:     cluster.Spec.HeadGroupSpec.ServiceType,
-		},
-	}
-
-	ports := getServicePorts(cluster)
-	for name, port := range ports {
-		if name == DefaultDashboardAgentListenPortName {
-			svcPort := corev1.ServicePort{Name: name, Port: port}
-			service.Spec.Ports = append(service.Spec.Ports, svcPort)
-			break
-		}
-	}
-
-	return service, nil
-}
-
 func setServiceTypeForUserProvidedService(service *corev1.Service, default_type corev1.ServiceType) {
 	// If the user has not specified a service type, use the default service type
 	if service.Spec.Type == "" {
@@ -358,13 +324,4 @@ func getDefaultPorts() map[string]int32 {
 		DefaultMetricsName:     DefaultMetricsPort,
 		DefaultServingPortName: DefaultServingPort,
 	}
-}
-
-// IsAgentServiceEnabled check if the agent service is enabled for RayCluster.
-func IsAgentServiceEnabled(instance *rayv1alpha1.RayCluster) bool {
-	enableAgentServiceValue, exist := instance.Annotations[EnableAgentServiceKey]
-	if exist && enableAgentServiceValue == EnableAgentServiceTrue {
-		return true
-	}
-	return false
 }

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -334,16 +334,8 @@ func setupTest(t *testing.T) {
 	for i, port := range headService.Spec.Ports {
 		headService.Spec.Ports[i].TargetPort = intstr.IntOrString{IntVal: port.Port}
 	}
-	dashboardService, err := common.BuildDashboardService(*testRayCluster)
-	if err != nil {
-		t.Errorf("failed to build dashboard service: %v", err)
-	}
-	for i, port := range dashboardService.Spec.Ports {
-		headService.Spec.Ports[i].TargetPort = intstr.IntOrString{IntVal: port.Port}
-	}
 	testServices = []runtime.Object{
 		headService,
-		dashboardService,
 	}
 
 	instanceReqValue := []string{instanceName}

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -886,6 +886,90 @@ func TestReconcile_PodEvicted_DiffLess0_OK(t *testing.T) {
 		"Evicted head should be deleted after reconcile expect %d actual %d", 0, len(podList.Items))
 }
 
+func TestReconcileHeadService(t *testing.T) {
+	setupTest(t)
+	defer tearDown(t)
+
+	// Create a new scheme with CRDs, Pod, Service schemes.
+	newScheme := runtime.NewScheme()
+	_ = rayv1alpha1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	// Mock data
+	cluster := testRayCluster.DeepCopy()
+	headService1 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "head-svc-1",
+			Namespace: cluster.Namespace,
+			Labels: map[string]string{
+				common.RayClusterLabelKey:  cluster.Name,
+				common.RayNodeTypeLabelKey: string(rayv1alpha1.HeadNode),
+			},
+		},
+	}
+	headService2 := headService1.DeepCopy()
+	headService2.Name = "head-svc-2"
+
+	// Initialize a fake client with newScheme and runtimeObjects.
+	runtimeObjects := []runtime.Object{cluster}
+	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
+	ctx := context.TODO()
+	headServiceSelector := labels.SelectorFromSet(map[string]string{
+		common.RayClusterLabelKey:  cluster.Name,
+		common.RayNodeTypeLabelKey: string(rayv1alpha1.HeadNode),
+	})
+
+	// Initialize RayCluster reconciler.
+	r := &RayClusterReconciler{
+		Client:   fakeClient,
+		Recorder: &record.FakeRecorder{},
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
+	}
+
+	// Case 1: Head service does not exist.
+	err := r.reconcileHeadService(ctx, cluster)
+	assert.Nil(t, err, "Fail to reconcile head service")
+
+	// One head service should be created.
+	serviceList := corev1.ServiceList{}
+	err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
+		LabelSelector: headServiceSelector,
+		Namespace:     cluster.Namespace,
+	})
+	assert.Nil(t, err, "Fail to get service list")
+	assert.Equal(t, 1, len(serviceList.Items), "Service list len is wrong")
+
+	// Case 2: One head service exists.
+	err = r.reconcileHeadService(ctx, cluster)
+	assert.Nil(t, err, "Fail to reconcile head service")
+
+	// The namespace should still have only one head service.
+	serviceList = corev1.ServiceList{}
+	err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
+		LabelSelector: headServiceSelector,
+		Namespace:     cluster.Namespace,
+	})
+	assert.Nil(t, err, "Fail to get service list")
+	assert.Equal(t, 1, len(serviceList.Items), "Service list len is wrong")
+
+	// Case 3: Two head services exist. This case only happens when users manually create a head service.
+	runtimeObjects = []runtime.Object{headService1, headService2}
+	fakeClient = clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
+	serviceList = corev1.ServiceList{}
+	err = fakeClient.List(ctx, &serviceList, &client.ListOptions{
+		LabelSelector: headServiceSelector,
+		Namespace:     cluster.Namespace,
+	})
+	assert.Nil(t, err, "Fail to get service list")
+	assert.Equal(t, 2, len(serviceList.Items), "Service list len is wrong")
+	r.Client = fakeClient
+
+	// When there are two head services, the reconciler should report an error.
+	err = r.reconcileHeadService(ctx, cluster)
+	assert.NotNil(t, err, "Reconciler should report an error when there are two head services")
+}
+
 func contains(slice []string, item string) bool {
 	set := make(map[string]struct{}, len(slice))
 	for _, s := range slice {

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -304,6 +304,22 @@ applications:
 				time.Second*15, time.Millisecond*500).Should(Equal(3), fmt.Sprintf("workerGroup %v", workerPods.Items))
 			if len(workerPods.Items) > 0 {
 				Expect(workerPods.Items[0].Status.Phase).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))
+				// All the worker Pods should have a port with the name "dashboard-agent"
+				for _, pod := range workerPods.Items {
+					// Worker Pod should have only one container.
+					Expect(len(pod.Spec.Containers)).Should(Equal(1))
+					// Each worker Pod should have a container port with the name "dashboard-agent"
+					exist := false
+					for _, port := range pod.Spec.Containers[0].Ports {
+						if port.Name == common.DefaultDashboardAgentListenPortName {
+							exist = true
+							break
+						}
+					}
+					if !exist {
+						Fail(fmt.Sprintf("Worker Pod %v should have a container port with the name %v", pod.Name, common.DefaultDashboardAgentListenPortName))
+					}
+				}
 			}
 		})
 

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -321,14 +321,6 @@ applications:
 			Expect(svc.Spec.Selector[common.RayIDLabelKey]).Should(Equal(utils.GenerateIdentifier(myRayCluster.Name, rayv1alpha1.HeadNode)))
 		})
 
-		It("should create a new agent service resource", func() {
-			svc := &corev1.Service{}
-			Eventually(
-				getResourceFunc(ctx, client.ObjectKey{Name: utils.GenerateDashboardServiceName(myRayCluster.Name), Namespace: "default"}, svc),
-				time.Second*15, time.Millisecond*500).Should(BeNil(), "My agent service = %v", svc)
-			Expect(svc.Spec.Selector[common.RayClusterDashboardServiceLabelKey]).Should(Equal(utils.GenerateDashboardAgentLabel(myRayCluster.Name)))
-		})
-
 		It("should create a new serve service resource", func() {
 			svc := &corev1.Service{}
 			Eventually(

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -246,7 +246,7 @@ func TestIsHeadPodRunningAndReady(t *testing.T) {
 	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
 	ctx := context.TODO()
 
-	// Initialize RayCluster reconciler.
+	// Initialize RayService reconciler.
 	r := &RayServiceReconciler{
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -150,11 +150,6 @@ func GenerateDashboardServiceName(clusterName string) string {
 	return fmt.Sprintf("%s-%s-%s", clusterName, DashboardName, "svc")
 }
 
-// GenerateDashboardAgentLabel generates label value for agent service selector.
-func GenerateDashboardAgentLabel(clusterName string) string {
-	return fmt.Sprintf("%s-%s", clusterName, DashboardName)
-}
-
 // GenerateServeServiceName generates name for serve service.
 func GenerateServeServiceName(serviceName string) string {
 	return CheckName(fmt.Sprintf("%s-%s-%s", serviceName, ServeName, "svc"))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Without #1173, the Kubernetes service for the dashboard agent uses a round-robin algorithm to evenly distribute traffic among the available Pods, including the head Pod and worker Pods. This may cause stability issues. Hence, #1173 decides to only send the requests to the head service's 52365 (dashboard agent port). The dashboard agent service is no longer used after #1173, so this PR aims to remove the service.

### pod.go

1. Merge `setAgentListPortStartParams` into `setMissingRayStartParams`: The function `setAgentListPortStartParams` will always be called after `setMissingRayStartParams` and both have very similar functionalities. Hence, there is no reason to keep them as two separate functions.

2. Remove `RayClusterDashboardServiceLabelKey: utils.GenerateDashboardAgentLabel(rayClusterName)` from Pod labels. The label is for the dashboard agent service's selector.

## Related issue number
#1173 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
RAY_IMAGE=rayproject/ray:2.5.0 OPERATOR_IMAGE=controller:latest pytest -vs tests/test_sample_rayservice_yamls.py --log-cli-level=INFO
```

<img width="1440" alt="Screen Shot 2023-06-29 at 8 23 10 AM" src="https://github.com/ray-project/kuberay/assets/20109646/0494e64c-d82c-434e-afff-6c3c3d3faf60">
