### PR TITLE
RayCluster updates status frequently

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -264,7 +264,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 	// Check if need to update the status.
 	if r.inconsistentRayClusterStatus(originalRayClusterInstance.Status, *newStatus) {
 		instance.Status = *newStatus
-		r.Log.Info("rayClusterReconcile", "r.Status().Update()", request.Name, "status", instance.Status)
+		r.Log.Info("rayClusterReconcile", "Update CR status", request.Name, "status", instance.Status)
 		if err := r.Status().Update(ctx, instance); err != nil {
 			r.Log.Info("Got error when updating status", "cluster name", request.Name, "error", err, "RayCluster", instance)
 			return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
@@ -1162,7 +1162,7 @@ func (r *RayClusterReconciler) updateClusterState(ctx context.Context, instance 
 		return nil
 	}
 	instance.Status.State = clusterState
-	r.Log.Info("updateClusterState", "r.Status().Update()", clusterState)
+	r.Log.Info("updateClusterState", "Update CR Status.State", clusterState)
 	return r.Status().Update(ctx, instance)
 }
 
@@ -1171,6 +1171,6 @@ func (r *RayClusterReconciler) updateClusterReason(ctx context.Context, instance
 		return nil
 	}
 	instance.Status.Reason = clusterReason
-	r.Log.Info("updateClusterReason", "r.Status().Update()", clusterReason)
+	r.Log.Info("updateClusterReason", "Update CR Status.Reason", clusterReason)
 	return r.Status().Update(ctx, instance)
 }

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
@@ -1354,4 +1355,127 @@ func TestUpdateStatusObservedGeneration(t *testing.T) {
 	err = fakeClient.Get(ctx, namespacedName, &cluster)
 	assert.Nil(t, err)
 	assert.Equal(t, cluster.ObjectMeta.Generation, newStatus.ObservedGeneration)
+}
+
+func TestReconcile_UpdateClusterState(t *testing.T) {
+	setupTest(t)
+	defer tearDown(t)
+	newScheme := runtime.NewScheme()
+	_ = rayv1alpha1.AddToScheme(newScheme)
+
+	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(testRayCluster).Build()
+	ctx := context.Background()
+
+	namespacedName := types.NamespacedName{
+		Name:      instanceName,
+		Namespace: namespaceStr,
+	}
+	cluster := rayv1alpha1.RayCluster{}
+	err := fakeClient.Get(ctx, namespacedName, &cluster)
+	assert.Nil(t, err, "Fail to get RayCluster")
+	assert.Empty(t, cluster.Status.State, "Cluster state should be empty")
+
+	testRayClusterReconciler := &RayClusterReconciler{
+		Client:   fakeClient,
+		Recorder: &record.FakeRecorder{},
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
+	}
+
+	state := rayv1alpha1.Ready
+	err = testRayClusterReconciler.updateClusterState(ctx, testRayCluster, state)
+	assert.Nil(t, err, "Fail to update cluster state")
+
+	err = fakeClient.Get(ctx, namespacedName, &cluster)
+	assert.Nil(t, err, "Fail to get RayCluster after updating state")
+	assert.Equal(t, cluster.Status.State, state, "Cluster state should be updated")
+}
+
+func TestInconsistentRayClusterStatus(t *testing.T) {
+	newScheme := runtime.NewScheme()
+	_ = rayv1alpha1.AddToScheme(newScheme)
+	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects().Build()
+	r := &RayClusterReconciler{
+		Client:   fakeClient,
+		Recorder: &record.FakeRecorder{},
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
+	}
+
+	// Mock data
+	timeNow := metav1.Now()
+	oldStatus := rayv1alpha1.RayClusterStatus{
+		State:                   rayv1alpha1.Ready,
+		AvailableWorkerReplicas: 1,
+		DesiredWorkerReplicas:   1,
+		MinWorkerReplicas:       1,
+		MaxWorkerReplicas:       10,
+		LastUpdateTime:          &timeNow,
+		Endpoints: map[string]string{
+			"client":    "10001",
+			"dashboard": "8265",
+			"gcs":       "6379",
+			"metrics":   "8080",
+		},
+		Head: rayv1alpha1.HeadInfo{
+			PodIP:     "10.244.0.6",
+			ServiceIP: "10.96.140.249",
+		},
+		ObservedGeneration: 1,
+		Reason:             "test reason",
+	}
+
+	// `inconsistentRayClusterStatus` is used to check whether the old and new RayClusterStatus are inconsistent
+	// by comparing different fields. If the only differences between the old and new status are the `LastUpdateTime`
+	// and `ObservedGeneration` fields (Case 9 and Case 10), the status update will not be triggered.
+
+	// Case 1: `State` is different => return true
+	newStatus := oldStatus.DeepCopy()
+	newStatus.State = rayv1alpha1.Failed
+	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+
+	// Case 2: `Reason` is different => return true
+	newStatus = oldStatus.DeepCopy()
+	newStatus.Reason = "new reason"
+	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+
+	// Case 3: `AvailableWorkerReplicas` is different => return true
+	newStatus = oldStatus.DeepCopy()
+	newStatus.AvailableWorkerReplicas = oldStatus.AvailableWorkerReplicas + 1
+	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+
+	// Case 4: `DesiredWorkerReplicas` is different => return true
+	newStatus = oldStatus.DeepCopy()
+	newStatus.DesiredWorkerReplicas = oldStatus.DesiredWorkerReplicas + 1
+	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+
+	// Case 5: `MinWorkerReplicas` is different => return true
+	newStatus = oldStatus.DeepCopy()
+	newStatus.MinWorkerReplicas = oldStatus.MinWorkerReplicas + 1
+	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+
+	// Case 6: `MaxWorkerReplicas` is different => return true
+	newStatus = oldStatus.DeepCopy()
+	newStatus.MaxWorkerReplicas = oldStatus.MaxWorkerReplicas + 1
+	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+
+	// Case 7: `Endpoints` is different => return true
+	newStatus = oldStatus.DeepCopy()
+	newStatus.Endpoints["fakeEndpoint"] = "10009"
+	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+
+	// Case 8: `Head` is different => return true
+	newStatus = oldStatus.DeepCopy()
+	newStatus.Head.PodIP = "test head pod ip"
+	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+
+	// Case 9: `LastUpdateTime` is different => return false
+	newStatus = oldStatus.DeepCopy()
+	newStatus.LastUpdateTime = &metav1.Time{Time: timeNow.Add(time.Hour)}
+	assert.False(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+
+	// Case 10: `ObservedGeneration` is different => return false
+	newStatus = oldStatus.DeepCopy()
+	newStatus.ObservedGeneration = oldStatus.ObservedGeneration + 1
+	assert.False(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
 }

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -1350,11 +1350,11 @@ func TestUpdateStatusObservedGeneration(t *testing.T) {
 	}
 
 	// Compare the values of `Generation` and `ObservedGeneration` to check if they match.
-	newStatus, err := testRayClusterReconciler.calculateStatus(ctx, testRayCluster)
+	newInstance, err := testRayClusterReconciler.calculateStatus(ctx, testRayCluster)
 	assert.Nil(t, err)
 	err = fakeClient.Get(ctx, namespacedName, &cluster)
 	assert.Nil(t, err)
-	assert.Equal(t, cluster.ObjectMeta.Generation, newStatus.ObservedGeneration)
+	assert.Equal(t, cluster.ObjectMeta.Generation, newInstance.Status.ObservedGeneration)
 }
 
 func TestReconcile_UpdateClusterState(t *testing.T) {

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -1349,9 +1349,9 @@ func TestUpdateStatusObservedGeneration(t *testing.T) {
 	}
 
 	// Compare the values of `Generation` and `ObservedGeneration` to check if they match.
-	err = testRayClusterReconciler.updateStatus(ctx, testRayCluster)
+	newStatus, err := testRayClusterReconciler.calculateStatus(ctx, testRayCluster)
 	assert.Nil(t, err)
 	err = fakeClient.Get(ctx, namespacedName, &cluster)
 	assert.Nil(t, err)
-	assert.Equal(t, cluster.ObjectMeta.Generation, cluster.Status.ObservedGeneration)
+	assert.Equal(t, cluster.ObjectMeta.Generation, newStatus.ObservedGeneration)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR is similar to #1065. Without this PR, the RayCluster reconciler will update the CR's status in every reconciliation. Refer to the source code of [ReplicaSet](https://sourcegraph.com/github.com/kubernetes/kubernetes@9e622d23648f4af4a12835de97484dc0e4859269/-/blob/pkg/controller/replicaset/replica_set_utils.go?L41-L48) and [StatefulSet](https://sourcegraph.com/github.com/kubernetes/kubernetes@9e622d2/-/blob/pkg/controller/statefulset/stateful_set_utils.go?L577-L586). They will check the difference between the original status and the new status to determine whether update the status or not. Hence, this PR implements a similar function `inconsistentRayClusterStatus` to determine whether update status or not.

## Related issue number

#1182

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* I conducted an experiment similar to #1214. In #1214, the status update is called 8 times in 10 minutes. Let the number of reconciliations be ***N***.
    * 6 => RayCluster initialization phase => ***O(1)***
    * 2 => The reconciler will be triggered every 5 minutes because the operator will unconditionally requeue the resource event using `ctrl.Result{RequeueAfter: time.Duration(requeueAfterSeconds) * time.Second}` (with a default of 300 seconds). => ***O(N)***

* The CR status update is called 3 times in 10 minutes. 
  * 3 =>  RayCluster initialization phase => ***O(1)***
  * 0 => After RayCluster finishes initialization.
  ```
  2023-06-30T18:15:46.246Z	INFO	controllers.RayCluster	rayClusterReconcile	{"r.Status().Update()": "raycluster-complete", "status": {"desiredWorkerReplicas":1,"minWorkerReplicas":1,"maxWorkerReplicas":10,"lastUpdateTime":"2023-06-30T18:15:46Z","head":{},"observedGeneration":1}}
  2023-06-30T18:15:46.345Z	INFO	controllers.RayCluster	rayClusterReconcile	{"r.Status().Update()": "raycluster-complete", "status": {"desiredWorkerReplicas":1,"minWorkerReplicas":1,"maxWorkerReplicas":10,"lastUpdateTime":"2023-06-30T18:15:46Z","head":{},"observedGeneration":1}}
  2023-06-30T18:16:51.042Z	INFO	controllers.RayCluster	rayClusterReconcile	{"r.Status().Update()": "raycluster-complete", "status": {"state":"ready","availableWorkerReplicas":1,"desiredWorkerReplicas":1,"minWorkerReplicas":1,"maxWorkerReplicas":10,"lastUpdateTime":"2023-06-30T18:16:51Z","head":{},"observedGeneration":1}}
  ```

<img width="794" alt="Screen Shot 2023-06-30 at 5 24 06 PM" src="https://github.com/ray-project/kuberay/assets/20109646/b7e715e3-daef-4433-a25d-8e80df0f422e">
