### PR TITLE
Update ray operator Dockerfile

### DIFF
--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -18,9 +18,7 @@ COPY controllers/ controllers/
 USER root
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM scratch
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.12-11 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,6 +15,7 @@ COPY apis/ apis/
 COPY controllers/ controllers/
 
 # Build
+USER root
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary


### PR DESCRIPTION
## Why are these changes needed?

We are currently using generic golang and distroless images to build the ray-operator (and other images).
Using “ubi(universal base image)” and “scratch” will improve the security of our images. [UBI](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image) images are actively maintained, scanned, and updated by Red Hat productization and security teams. Using these images will improve user confidence in what is being provided by the KubeRay community.

`scratch` is similar to the distroless, but this will make the dockerfile more portable for build systems that are unable to access `gcr.io/distroless/static`

## Related issue number

Not directly related, but we should really update the Go version we are using: https://github.com/ray-project/kuberay/issues/518

<img width="639" alt="image" src="https://github.com/ray-project/kuberay/assets/6526150/3cda58d5-aa73-4705-9064-9f1ee5e3f5ad">

Go 1.17 seems to have a lot of vulnerabilities. I'll see if I have some time in the next couple weeks to update it.

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

I'm happy to create an issue if required. cc @kevin85421 