### PR TITLE
[Doc] Fix the order of comments in sample Job YAML file

### DIFF
--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -3,7 +3,7 @@ kind: RayJob
 metadata:
   name: rayjob-sample
 spec:
-  entrypoint: python /home/ray/samples/sample_code.pyyyy
+  entrypoint: python /home/ray/samples/sample_code.py
   # ShutdownAfterJobFinishes specifies whether the RayCluster should be deleted after the RayJob finishes. Default is false.
   shutdownAfterJobFinishes: true
   # runtimeEnv decoded to '{

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -3,7 +3,9 @@ kind: RayJob
 metadata:
   name: rayjob-sample
 spec:
-  entrypoint: python /home/ray/samples/sample_code.py
+  entrypoint: python /home/ray/samples/sample_code.pyyyy
+  # ShutdownAfterJobFinishes specifies whether the RayCluster should be deleted after the RayJob finishes. Default is false.
+  shutdownAfterJobFinishes: true
   # runtimeEnv decoded to '{
   #    "pip": [
   #        "requests==2.26.0",
@@ -13,8 +15,6 @@ spec:
   #        "counter_name": "test_counter"
   #    }
   #}'
-  # ShutdownAfterJobFinishes specifies whether the RayCluster should be deleted after the RayJob finishes. Default is false.
-  shutdownAfterJobFinishes: false
   runtimeEnv: ewogICAgInBpcCI6IFsKICAgICAgICAicmVxdWVzdHM9PTIuMjYuMCIsCiAgICAgICAgInBlbmR1bHVtPT0yLjEuMiIKICAgIF0sCiAgICAiZW52X3ZhcnMiOiB7ImNvdW50ZXJfbmFtZSI6ICJ0ZXN0X2NvdW50ZXIifQp9Cg==
   # Suspend specifies whether the RayJob controller should create a RayCluster instance.
   # If a job is applied with the suspend field set to true, the RayCluster will not be created and we will wait for the transition to false.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The docstring of `runtimeEnv` didn't appear right above the runtimeEnv field.  This PR fixes the issue.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
