### PR TITLE
[release blocker][Feature] Only Autoscaler can make decisions to delete Pods

### DIFF
--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -92,6 +92,12 @@ const (
 	RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV  = "RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV"
 	RAYCLUSTER_DEFAULT_REQUEUE_SECONDS      = 300
 
+	// This KubeRay operator environment variable is used to determine if random Pod
+	// deletion should be enabled. Note that this only takes effect when autoscaling
+	// is enabled for the RayCluster. This is a feature flag for v0.6.0, and will be
+	// removed if the default behavior is stable enoguh.
+	ENABLE_RANDOM_POD_DELETE = "ENABLE_RANDOM_POD_DELETE"
+
 	// Ray core default configurations
 	DefaultRedisPassword                 = "5241590000000000"
 	DefaultWorkerRayGcsReconnectTimeoutS = "600"

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -627,7 +627,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 					r.Recorder.Eventf(instance, corev1.EventTypeNormal, "Deleted", "Deleted Pod %s", randomPodToDelete.Name)
 				}
 			} else {
-				r.Log.Info(fmt.Sprintf("Random Pod deletion is disabled for cluster %s. The only decision-maker decision-maker for Pod deletions is Autoscaler.", instance.Name))
+				r.Log.Info(fmt.Sprintf("Random Pod deletion is disabled for cluster %s. The only decision-maker for Pod deletions is Autoscaler.", instance.Name))
 			}
 		}
 	}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -416,7 +416,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	// Reconcile head Pod
 	if len(headPods.Items) == 1 {
 		headPod := headPods.Items[0]
-		r.Log.Info("reconcilePods ", "head pod found", headPod.Name)
+		r.Log.Info("reconcilePods", "head pod found", headPod.Name)
 		if headPod.Status.Phase == corev1.PodRunning || headPod.Status.Phase == corev1.PodPending {
 			r.Log.Info("reconcilePods", "head pod is up and running... checking workers", headPod.Name)
 		} else if headPod.Status.Phase == corev1.PodFailed && strings.Contains(headPod.Status.Reason, "Evicted") {
@@ -431,7 +431,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	}
 	if len(headPods.Items) == 0 || headPods.Items == nil {
 		// create head pod
-		r.Log.Info("reconcilePods ", "creating head pod for cluster", instance.Name)
+		r.Log.Info("reconcilePods", "creating head pod for cluster", instance.Name)
 		common.CreatedClustersCounterInc(instance.Namespace)
 		if err := r.createHeadPod(ctx, *instance); err != nil {
 			common.FailedClustersCounterInc(instance.Namespace)
@@ -439,7 +439,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		}
 		common.SuccessfulClustersCounterInc(instance.Namespace)
 	} else if len(headPods.Items) > 1 {
-		r.Log.Info("reconcilePods ", "more than 1 head pod found for cluster", instance.Name)
+		r.Log.Info("reconcilePods", "more than 1 head pod found for cluster", instance.Name)
 		itemLength := len(headPods.Items)
 		for index := 0; index < itemLength; index++ {
 			if headPods.Items[index].Status.Phase == corev1.PodRunning || headPods.Items[index].Status.Phase == corev1.PodPending {
@@ -594,19 +594,40 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 			r.Log.Info("reconcilePods", "all workers already exist for group", worker.GroupName)
 			continue
 		} else {
-			// diff < 0 means that we need to delete some Pods to meet the desired number of replicas.
-			randomlyRemovedWorkers := -diff
-			r.Log.Info("reconcilePods", "Number workers to delete randomly", randomlyRemovedWorkers, "Worker group", worker.GroupName)
-			for i := 0; i < int(randomlyRemovedWorkers); i++ {
-				randomPodToDelete := runningPods.Items[i]
-				r.Log.Info("Randomly deleting Pod", "progress", fmt.Sprintf("%d / %d", i+1, randomlyRemovedWorkers), "with name", randomPodToDelete.Name)
-				if err := r.Delete(ctx, &randomPodToDelete); err != nil {
-					if !errors.IsNotFound(err) {
-						return err
-					}
-					r.Log.Info("reconcilePods", "The worker Pod has already been deleted", randomPodToDelete.Name)
+			// diff < 0 indicates the need to delete some Pods to match the desired number of replicas. However,
+			// randomly deleting Pods is certainly not ideal. So, if autoscaling is enabled for the cluster, we
+			// will disable random Pod deletion, making Autoscaler the sole decision-maker for Pod deletions.
+			enableInTreeAutoscaling := (instance.Spec.EnableInTreeAutoscaling != nil) && (*instance.Spec.EnableInTreeAutoscaling)
+
+			// TODO (kevin85421): `enableRandomPodDelete` is a feature flag for KubeRay v0.6.0. If users want to use
+			// the old behavior, they can set the environment variable `ENABLE_RANDOM_POD_DELETE` to `true`. When the
+			// default behavior is stable enough, we can remove this feature flag.
+			enableRandomPodDelete := false
+			if enableInTreeAutoscaling {
+				if s := os.Getenv(common.ENABLE_RANDOM_POD_DELETE); strings.ToLower(s) == "true" {
+					enableRandomPodDelete = true
 				}
-				r.Recorder.Eventf(instance, corev1.EventTypeNormal, "Deleted", "Deleted Pod %s", randomPodToDelete.Name)
+			}
+			// Case 1: If Autoscaler is disabled, we will always enable random Pod deletion no matter the value of the feature flag.
+			// Case 2: If Autoscaler is enabled, we will respect the value of the feature flag. If the feature flag environment variable
+			// is not set, we will disable random Pod deletion by default.
+			if !enableInTreeAutoscaling || enableRandomPodDelete {
+				// diff < 0 means that we need to delete some Pods to meet the desired number of replicas.
+				randomlyRemovedWorkers := -diff
+				r.Log.Info("reconcilePods", "Number workers to delete randomly", randomlyRemovedWorkers, "Worker group", worker.GroupName)
+				for i := 0; i < int(randomlyRemovedWorkers); i++ {
+					randomPodToDelete := runningPods.Items[i]
+					r.Log.Info("Randomly deleting Pod", "progress", fmt.Sprintf("%d / %d", i+1, randomlyRemovedWorkers), "with name", randomPodToDelete.Name)
+					if err := r.Delete(ctx, &randomPodToDelete); err != nil {
+						if !errors.IsNotFound(err) {
+							return err
+						}
+						r.Log.Info("reconcilePods", "The worker Pod has already been deleted", randomPodToDelete.Name)
+					}
+					r.Recorder.Eventf(instance, corev1.EventTypeNormal, "Deleted", "Deleted Pod %s", randomPodToDelete.Name)
+				}
+			} else {
+				r.Log.Info(fmt.Sprintf("Random Pod deletion is disabled for cluster %s. The only decision-maker decision-maker for Pod deletions is Autoscaler.", instance.Name))
 			}
 		}
 	}

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -720,7 +720,6 @@ func TestReconcile_RemoveWorkersToDelete_NoRandomDelete(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestReconcile_RandomDelete_OK(t *testing.T) {

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -240,13 +240,6 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to update test RayCluster resource")
 		})
 
-		It("should have only 2 running worker", func() {
-			// retry listing pods, given that last update may not immediately happen.
-			Eventually(
-				listResourceFunc(ctx, &workerPods, workerFilterLabels, &client.ListOptions{Namespace: "default"}),
-				time.Second*15, time.Millisecond*500).Should(Equal(2), fmt.Sprintf("workerGroup %v", workerPods.Items))
-		})
-
 		It("should update a raycluster object", func() {
 			// adding a scale strategy
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -254,18 +247,18 @@ var _ = Context("Inside the default namespace", func() {
 					getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),
 					time.Second*9, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
 				podToDelete := workerPods.Items[0]
-				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = pointer.Int32(1)
+				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = pointer.Int32(2)
 				myRayCluster.Spec.WorkerGroupSpecs[0].ScaleStrategy.WorkersToDelete = []string{podToDelete.Name}
 				return k8sClient.Update(ctx, myRayCluster)
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to update test RayCluster resource")
 		})
 
-		It("should have only 1 running worker", func() {
+		It("should have only 2 running workers", func() {
 			// retry listing pods, given that last update may not immediately happen.
 			Eventually(
 				listResourceFunc(ctx, &workerPods, workerFilterLabels, &client.ListOptions{Namespace: "default"}),
-				time.Second*15, time.Millisecond*500).Should(Equal(1), fmt.Sprintf("workerGroup %v", workerPods.Items))
+				time.Second*15, time.Millisecond*500).Should(Equal(2), fmt.Sprintf("workerGroup %v", workerPods.Items))
 		})
 
 		It("should increase replicas past maxReplicas", func() {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Without this PR, there are two mechanisms to delete Pods.

1. Autoscaler: When Autoscaler wants to scale down the cluster, it will send a patch to update `replicas` and `workersToDelete` fields in RayCluster CR. Then, KubeRay operator will delete all Pods in `workersToDelete`.
2. Random Pod deletion: If all Pods in `workersToDelete` have been deleted, and additional deletions are still required to reach the target state, the KubeRay operator will proceed to delete worker Pods randomly.

This PR provides a new behavior for Pod deletion:

* Case 1: If Autoscaler is disabled, we will always enable random Pod deletion.
* Case 2: If Autoscaler is enabled, the default behavior is disabling random Pod deletion. We also provide a feature flag `ENABLE_RANDOM_POD_DELETE` for users to go back to the old behavior if we ignore some edge cases.

Random Pod deletion is undesirable for numerous reasons. We should try to avoid it as much as possible. In addition, this behavior can avoid Case 4 mentioned in https://github.com/ray-project/kuberay/issues/1238#issuecomment-1642858026.

## Related issue number

#1238

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

## Test 1: No Autoscaler

```sh
helm install kuberay-operator kuberay/kuberay-operator --version 0.6.0-rc.0 --set image.repository=controller,image.tag=latest

# Create a RayCluster with 1 head and 1 worker
helm install raycluster kuberay/ray-cluster --version 0.6.0-rc.0

# Edit the worker's `replicas` to 2
# [Expected result]: 1 new worker will be created
kubectl edit rayclusters.ray.io raycluster-kuberay

# Edit the worker's `replicas` to 1
# [Expected result]: 1 random worker Pod will be deleted => random Pod deletion is enabled.
kubectl edit rayclusters.ray.io raycluster-kuberay
```

## Test 2: Autoscaler

```sh
helm install kuberay-operator kuberay/kuberay-operator --version 0.6.0-rc.0 --set image.repository=controller,image.tag=latest

# Create an autoscaling-enabled RayCluster with 1 head and 1 worker
kubectl apply -f ray-cluster.autoscaler.yaml

# Execute a script in the head Pod.
export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -o custom-columns=POD:metadata.name --no-headers)
kubectl exec -it $HEAD_POD -- bash

# https://gist.github.com/kevin85421/c35b69ff99cd30c55abbe4d5ccf2a18e
# Create 3 actors and each one requires a CPU, so Autoscaler scales up to 2 workers. (1 head = 1 CPU, 2 workers = 2 * 1 CPU)
python script.py 

# After `script.py` finishes, it will scale down to 1 worker because `minReplicas` is 1.
```