### PR TITLE
[Feature] Allow custom labels&annotations for kuberay operator (#1275)

### DIFF
--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -18,6 +18,13 @@ spec:
         app.kubernetes.io/name: {{ include "kuberay-operator.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: kuberay-operator
+        {{- if .Values.labels }}
+        {{- toYaml .Values.labels | nindent 8 }}
+        {{- end }}
+      {{- if .Values.annotations }}
+      annotations:
+        {{- toYaml .Values.annotations | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
## Why are these changes needed?

Some custom Kubernetes clusters require special labels and annotations for pods, which currently can not be set.
This PR allows setting custom labels on the kuberay operator. 
(https://github.com/ray-project/kuberay/issues/1275)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
