### PR TITLE
[RayService][Observability] Add more loggings about networking issues

### DIFF
--- a/docs/guidance/rayservice-troubleshooting.md
+++ b/docs/guidance/rayservice-troubleshooting.md
@@ -160,7 +160,9 @@ and `app` is the name of the variable representing Ray Serve application within 
 
 ### Issue 5: Fail to create / update Serve applications.
 
-You may encounter the following error message when KubeRay tries to create / update Serve applications:
+You may encounter the following error messages when KubeRay tries to create / update Serve applications:
+
+#### Error message 1: `connect: connection refused`
 
 ```
 Put "http://${HEAD_SVC_FQDN}:52365/api/serve/applications/": dial tcp $HEAD_IP:52365: connect: connection refused
@@ -170,11 +172,16 @@ For RayService, the KubeRay operator submits a request to the RayCluster for cre
 It's important to note that the Dashboard, Dashboard Agent and GCS may take a few seconds to start up after the head Pod is ready.
 As a result, the request may fail a few times initially before the necessary components are fully operational.
 
-If you continue to encounter this issue after 1 minute, there are several possible causes:
+If you continue to encounter this issue after waiting for 1 minute, it's possible that the dashboard or dashboard agent may have failed to start.
+For more information, you can check the `dashboard.log` and `dashboard_agent.log` files located at `/tmp/ray/session_latest/logs/` on the head Pod.
 
-* The Dashboard and dashboard agent failed to start up due to some reasons. You can check the `dashboard.log` and `dashboard_agent.log` files located at `/tmp/ray/session_latest/logs/` on the head Pod for more information.
+#### Error message 2: `i/o timeout`
 
-* There is a Kubernetes NetworkPolicy blocking the traffic between the KubeRay operator and the dashboard agent port (i.e., 52365). Please review your NetworkPolicy configuration.
+```
+Put "http://${HEAD_SVC_FQDN}:52365/api/serve/applications/": dial tcp $HEAD_IP:52365: i/o timeout"
+```
+
+One possible cause of this issue could be a Kubernetes NetworkPolicy blocking the traffic between the Ray Pods and the dashboard agent's port (i.e., 52365).
 
 ### Issue 6: `runtime_env`
 

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -684,7 +684,11 @@ func (r *RayServiceReconciler) updateServeDeployment(ctx context.Context, raySer
 		}
 		r.Log.V(1).Info("updateServeDeployment", "SINGLE_APP json config", string(configJson))
 		if err := rayDashboardClient.UpdateDeployments(ctx, configJson, utils.SINGLE_APP); err != nil {
-			r.Log.Error(err, "fail to update deployment")
+			err = fmt.Errorf(
+				"Fail to create / update Serve deployments. If you observe this error consistently, "+
+					"please check \"Issue 5: Fail to create / update Serve applications.\" in "+
+					"https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayservice-troubleshooting.md for more details. "+
+					"err: %v", err)
 			return err
 		}
 
@@ -706,7 +710,11 @@ func (r *RayServiceReconciler) updateServeDeployment(ctx context.Context, raySer
 		}
 		r.Log.V(1).Info("updateServeDeployment", "MULTI_APP json config", string(configJson))
 		if err := rayDashboardClient.UpdateDeployments(ctx, configJson, serveConfigType); err != nil {
-			r.Log.Error(err, "fail to update deployment")
+			err = fmt.Errorf(
+				"Fail to create / update Serve applications. If you observe this error consistently, "+
+					"please check \"Issue 5: Fail to create / update Serve applications.\" in "+
+					"https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayservice-troubleshooting.md for more details. "+
+					"err: %v", err)
 			return err
 		}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Note that `NetworkPolicy` will not have any effect if you do not have CNI plugin installed in your Kubernetes cluster. Hence, I developed this PR on AWS EKS and installed the CNI plugin Calico.

* Step 1: Follow this [doc](https://docs.aws.amazon.com/eks/latest/userguide/calico.html) to install Calico in your EKS cluster.
* Step 2: Create a NetworkPolicy to block all incoming traffic to the Ray head Pod.
   ```yaml
    apiVersion: networking.k8s.io/v1
    kind: NetworkPolicy
    metadata:
      name: block-head-pod
    spec:
      podSelector:
        matchLabels:
          ray.io/node-type: head
      ingress: []
   ```
* Step 3: Install KubeRay operator with this PR.
  ```bash
  helm install kuberay-operator kuberay/kuberay-operator --version 0.6.1 --set image.repository=$YOUR_DOCKERHUB_REPO,image.tag=$YOUR_DOCKERHUB_TAG
  ``` 
* Step 4: Create a RayService with 1 head Pod and 0 worker Pods. Since incoming traffic is not allowed to reach the Ray head Pod, the init container in the worker Pods will indefinitely wait for GCS to become ready. For this reason, we opt to create 0 worker Pods here.

* Step 5: Check KubeRay operator's log
   ```bash
   kubectl logs $KUBERAY_OPERATOR_POD

   # [Example log]
   # 2023-08-01T00:37:37.818Z	ERROR	controllers.RayService	Fail to reconcileServe.	{"ServiceName": "default/rayservice-sample", "error": "Fail to create / update Serve applications. If you observe this error consistently, please check \"Issue 5: Fail to create / update Serve applications.\" in https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayservice-troubleshooting.md for more details.err: Put \"http://rayservice-sample-raycluster-8rshn-head-svc.default.svc.cluster.local:52365/api/serve/applications/\": dial tcp 10.100.192.179:52365: i/o timeout"}
   # sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
   #	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:114
   # sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
   #	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:311
   # sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
   #	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:266
   # sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
   #	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:227
   ```

## Related issue number

Closes #1279 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
