### PR TITLE
[CI] Only run test_ray_serve for Ray 2.6.0 and later

### DIFF
--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -112,6 +112,10 @@ class RayFTTestCase(unittest.TestCase):
 
     def test_ray_serve(self):
         """Kill GCS process on the head Pod and then test a deployed Ray Serve model."""
+        if not utils.is_feature_supported(ray_version, CONST.RAY_SERVE_FT):
+            raise unittest.SkipTest(
+                "This test is flaky before Ray 2.6.0, so we only run it for 2.6.0 and later."
+            )
         headpod = get_head_pod(RayFTTestCase.ray_cluster_ns)
         headpod_name = headpod.metadata.name
 

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -39,6 +39,7 @@ class CONST:
     # Ray features
     RAY_FT = "RAY_FT"
     RAY_SERVICE = "RAY_SERVICE"
+    RAY_SERVE_FT = "RAY_SERVE_FT"
 
     # Custom Resource Definitions
     RAY_CLUSTER_CRD = "RayCluster"

--- a/tests/kuberay_utils/utils.py
+++ b/tests/kuberay_utils/utils.py
@@ -31,6 +31,11 @@ def is_feature_supported(ray_version, feature):
     major, minor, _ = [int(s) for s in ray_version.split('.')]
     if feature in [CONST.RAY_FT, CONST.RAY_SERVICE]:
         return major * 100 + minor > 113
+    # Before Ray 2.6.0, there was a bug in Ray Serve that caused the
+    # test_ray_serve to be quite unstable. Therefore, we only run
+    # `test_ray_serve` for Ray versions 2.6.0 and later.
+    if feature == CONST.RAY_SERVE_FT:
+        return major * 100 + minor >= 206
     return False
 
 def create_ray_cluster(template_name, ray_version, ray_image):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Before Ray 2.6.0, there was a bug in Ray Serve that caused the `test_ray_serve` to be quite unstable (See #1058 for more details). Therefore, we only run `test_ray_serve` for Ray versions 2.6.0 and later. Currently, Ray 2.6.0 is not included in the KubeRay CI pipeline. However, I believe the release manager for Ray 2.6.0 will open a PR to update the version from 2.5.0 to 2.6.0 (or 2.6.2) in the next few days.

## Related issue number

Closes #1058 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
RAY_IMAGE=rayproject/ray:2.5.0 python3 tests/compatibility-test.py RayFTTestCase.test_ray_serve 2>&1 | tee log
```

<img width="1440" alt="Screen Shot 2023-08-02 at 1 31 22 PM" src="https://github.com/ray-project/kuberay/assets/20109646/2466f5ca-1f1a-4c2b-96b9-af1c6deb825e">

* `test_ray_serve` is executed in [Compatibility Test - Nightly](https://github.com/ray-project/kuberay/actions/runs/5743528549/job/15568228623?pr=1288#step:3:1406).
* `test_ray_serve` is skipped in [Compatibility Test - 2.5.0](https://github.com/ray-project/kuberay/actions/runs/5743528549/job/15568228500?pr=1288#step:3:1417)