### PR TITLE
[RayService] Revisit the conditions under which a RayService is considered unhealthy and the default threshold

### DIFF
--- a/docs/guidance/rayservice-troubleshooting.md
+++ b/docs/guidance/rayservice-troubleshooting.md
@@ -237,7 +237,7 @@ If you consistently encounter this issue, there are several possible causes:
   # Get \"http://rayservice-sample-raycluster-rqlsl-head-svc.default.svc.cluster.local:52365/api/serve/applications/\": dial tcp 10.96.7.154:52365: connect: connection refused
   ```
 
-### Issue 8: A loop of restarting the RayCluster occurs when the Kubernetes cluster runs out of resources.
+### Issue 8: A loop of restarting the RayCluster occurs when the Kubernetes cluster runs out of resources. (KubeRay v0.6.1 or earlier)
 
 > Note: Currently, the KubeRay operator does not have a clear plan to handle situations where the Kubernetes cluster runs out of resources.
 Therefore, we recommend ensuring that the Kubernetes cluster has sufficient resources to accommodate the serve application.

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -23,16 +23,21 @@ const (
 )
 
 // These statuses should match Ray Serve's application statuses
+// See `enum ApplicationStatus` in https://sourcegraph.com/github.com/ray-project/ray/-/blob/src/ray/protobuf/serve.proto for more details.
 var ApplicationStatusEnum = struct {
 	NOT_STARTED   string
 	DEPLOYING     string
 	RUNNING       string
 	DEPLOY_FAILED string
+	DELETING      string
+	UNHEALTHY     string
 }{
 	NOT_STARTED:   "NOT_STARTED",
 	DEPLOYING:     "DEPLOYING",
 	RUNNING:       "RUNNING",
 	DEPLOY_FAILED: "DEPLOY_FAILED",
+	DELETING:      "DELETING",
+	UNHEALTHY:     "UNHEALTHY",
 }
 
 // These statuses should match Ray Serve's deployment statuses

--- a/ray-operator/config/samples/ray-service.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-service.autoscaler.yaml
@@ -7,8 +7,8 @@ kind: RayService
 metadata:
   name: rayservice-sample
 spec:
-  serviceUnhealthySecondThreshold: 300 # Config for the health check threshold for service. Default value is 60.
-  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for deployments. Default value is 60.
+  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
+  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for Ray dashboard agent. Default value is 300.
   # The workload consists of two applications. The first application checks on an event in the second application.
   # If the event isn't set, the first application will block on requests until the event is set. So, to test upscaling
   # we can first send a bunch of requests to the first application, which will trigger Serve autoscaling to bring up

--- a/ray-operator/config/samples/ray-service.custom-serve-service.yaml
+++ b/ray-operator/config/samples/ray-service.custom-serve-service.yaml
@@ -7,8 +7,8 @@ kind: RayService
 metadata:
   name: rayservice-sample
 spec:
-  serviceUnhealthySecondThreshold: 300 # Config for the health check threshold for service. Default value is 60.
-  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for deployments. Default value is 60.
+  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
+  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for Ray dashboard agent. Default value is 300.
   serveService:
     metadata:
       name: custom-ray-serve-service-name

--- a/ray-operator/config/samples/ray-service.different-port.yaml
+++ b/ray-operator/config/samples/ray-service.different-port.yaml
@@ -7,8 +7,8 @@ kind: RayService
 metadata:
   name: rayservice-sample
 spec:
-  serviceUnhealthySecondThreshold: 300 # Config for the health check threshold for service. Default value is 60.
-  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for deployments. Default value is 60.
+  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
+  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for Ray dashboard agent. Default value is 300.
   serveConfig:
     importPath: fruit.deployment_graph
     runtimeEnv: |

--- a/ray-operator/config/samples/ray-service.mobilenet.yaml
+++ b/ray-operator/config/samples/ray-service.mobilenet.yaml
@@ -3,8 +3,8 @@ kind: RayService
 metadata:
   name: rayservice-mobilenet
 spec:
-  serviceUnhealthySecondThreshold: 300 # Config for the health check threshold for service. Default value is 60.
-  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for deployments. Default value is 60.
+  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
+  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for Ray dashboard agent. Default value is 300.
   serveConfigV2: |
     applications:
       - name: mobilenet

--- a/ray-operator/config/samples/ray-service.stable-diffusion.yaml
+++ b/ray-operator/config/samples/ray-service.stable-diffusion.yaml
@@ -3,8 +3,8 @@ kind: RayService
 metadata:
   name: stable-diffusion
 spec:
-  serviceUnhealthySecondThreshold: 300 # Config for the health check threshold for service. Default value is 60.
-  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for deployments. Default value is 60.
+  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
+  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for Ray dashboard agent. Default value is 300.
   serveConfigV2: |
     applications:
       - name: stable_diffusion

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -7,8 +7,8 @@ kind: RayService
 metadata:
   name: rayservice-sample
 spec:
-  serviceUnhealthySecondThreshold: 300 # Config for the health check threshold for service. Default value is 60.
-  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for deployments. Default value is 60.
+  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
+  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for Ray dashboard agent. Default value is 300.
   # serveConfigV2 takes a yaml multi-line scalar, which should be a Ray Serve multi-application config. See https://docs.ray.io/en/latest/serve/multi-app.html.
   # Only one of serveConfig and serveConfigV2 should be used.
   serveConfigV2: |

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -799,7 +799,7 @@ func (r *RayServiceReconciler) getAndCheckServeStatus(ctx context.Context, dashb
 				if prevApplicationStatus.HealthLastUpdateTime != nil {
 					applicationStatus.HealthLastUpdateTime = prevApplicationStatus.HealthLastUpdateTime
 					if time.Since(prevApplicationStatus.HealthLastUpdateTime.Time).Seconds() > serviceUnhealthySecondThreshold {
-						r.Log.Info("Restart RayCluster", "appName", appName, "restart reason",
+						r.Log.Info("Restart RayCluster", "appName", appName, "appStatus", app.Status, "restart reason",
 							fmt.Sprintf(
 								"The status of the serve application %s has been UNHEALTHY or DEPLOY_FAILED for more than %f seconds. "+
 									"Hence, KubeRay operator labels the RayCluster unhealthy and will prepare a new RayCluster. ",

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -835,7 +835,7 @@ func (r *RayServiceReconciler) getAndCheckServeStatus(ctx context.Context, dashb
 							r.Log.Info("Restart RayCluster", "deploymentName", deploymentName, "appName", appName, "restart reason",
 								fmt.Sprintf(
 									"The serve application %s has been UNHEALTHY or DEPLOY_FAILED for more than %f seconds. "+
-										"This may be caused by the serve deployment %s is UNHEALTHY. "+
+										"This may be caused by the serve deployment %s being UNHEALTHY. "+
 										"Hence, KubeRay operator labels the RayCluster unhealthy and will prepare a new RayCluster. "+
 										"The message of the serve deployment is: %s", appName, serviceUnhealthySecondThreshold, deploymentName, deploymentStatus.Message))
 						}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1094,7 +1094,7 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 	}
 
 	var isHealthy, isReady bool
-	if isHealthy, isReady, err = r.getAndCheckServeStatus(ctx, rayDashboardClient, rayServiceStatus, r.determineServeConfigType(rayServiceInstance), rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold); err != nil {
+	if isHealthy, isReady, err = r.getAndCheckServeStatus(ctx, rayDashboardClient, rayServiceStatus, r.determineServeConfigType(rayServiceInstance), rayServiceInstance.Spec.ServiceUnhealthySecondThreshold); err != nil {
 		if !r.updateAndCheckDashboardStatus(rayServiceStatus, false, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold) {
 			logger.Info("Dashboard is unhealthy, restart the cluster.")
 			r.markRestart(rayServiceInstance)

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -461,7 +461,7 @@ func TestGetAndCheckServeStatus(t *testing.T) {
 	dashboardClient = initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.UPDATING, rayv1alpha1.ApplicationStatusEnum.DEPLOYING)
 	prevRayServiceStatus = rayv1alpha1.RayServiceStatus{
 		Applications: map[string]rayv1alpha1.AppStatus{
-			serveAppName: rayv1alpha1.AppStatus{
+			serveAppName: {
 				Status:               rayv1alpha1.ApplicationStatusEnum.DEPLOYING,
 				HealthLastUpdateTime: &metav1.Time{Time: metav1.Now().Add(-time.Second * time.Duration(serviceUnhealthySecondThreshold+1))},
 			},
@@ -476,7 +476,7 @@ func TestGetAndCheckServeStatus(t *testing.T) {
 	dashboardClient = initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.HEALTHY, rayv1alpha1.ApplicationStatusEnum.RUNNING)
 	prevRayServiceStatus = rayv1alpha1.RayServiceStatus{
 		Applications: map[string]rayv1alpha1.AppStatus{
-			serveAppName: rayv1alpha1.AppStatus{
+			serveAppName: {
 				Status:               rayv1alpha1.ApplicationStatusEnum.DEPLOYING,
 				HealthLastUpdateTime: &metav1.Time{Time: metav1.Now().Time},
 			},
@@ -492,7 +492,7 @@ func TestGetAndCheckServeStatus(t *testing.T) {
 	dashboardClient = initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.UNHEALTHY, rayv1alpha1.ApplicationStatusEnum.UNHEALTHY)
 	prevRayServiceStatus = rayv1alpha1.RayServiceStatus{
 		Applications: map[string]rayv1alpha1.AppStatus{
-			serveAppName: rayv1alpha1.AppStatus{
+			serveAppName: {
 				Status:               rayv1alpha1.ApplicationStatusEnum.UNHEALTHY,
 				HealthLastUpdateTime: &metav1.Time{Time: metav1.Now().Add(-time.Second * time.Duration(serviceUnhealthySecondThreshold+1))},
 			},
@@ -508,7 +508,7 @@ func TestGetAndCheckServeStatus(t *testing.T) {
 	dashboardClient = initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.UNHEALTHY, rayv1alpha1.ApplicationStatusEnum.UNHEALTHY)
 	prevRayServiceStatus = rayv1alpha1.RayServiceStatus{
 		Applications: map[string]rayv1alpha1.AppStatus{
-			serveAppName: rayv1alpha1.AppStatus{
+			serveAppName: {
 				Status:               rayv1alpha1.ApplicationStatusEnum.UNHEALTHY,
 				HealthLastUpdateTime: &metav1.Time{Time: metav1.Now().Add(-time.Second * time.Duration(serviceUnhealthySecondThreshold-1))},
 			},
@@ -524,7 +524,7 @@ func TestGetAndCheckServeStatus(t *testing.T) {
 	dashboardClient = initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.UPDATING, rayv1alpha1.ApplicationStatusEnum.DEPLOY_FAILED)
 	prevRayServiceStatus = rayv1alpha1.RayServiceStatus{
 		Applications: map[string]rayv1alpha1.AppStatus{
-			serveAppName: rayv1alpha1.AppStatus{
+			serveAppName: {
 				Status:               rayv1alpha1.ApplicationStatusEnum.DEPLOY_FAILED,
 				HealthLastUpdateTime: &metav1.Time{Time: metav1.Now().Add(-time.Second * time.Duration(serviceUnhealthySecondThreshold+1))},
 			},
@@ -540,7 +540,7 @@ func TestGetAndCheckServeStatus(t *testing.T) {
 	dashboardClient = initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.UPDATING, rayv1alpha1.ApplicationStatusEnum.DEPLOY_FAILED)
 	prevRayServiceStatus = rayv1alpha1.RayServiceStatus{
 		Applications: map[string]rayv1alpha1.AppStatus{
-			serveAppName: rayv1alpha1.AppStatus{
+			serveAppName: {
 				Status:               rayv1alpha1.ApplicationStatusEnum.DEPLOY_FAILED,
 				HealthLastUpdateTime: &metav1.Time{Time: metav1.Now().Add(-time.Second * time.Duration(serviceUnhealthySecondThreshold-1))},
 			},

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	rayv1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
@@ -421,4 +422,139 @@ func TestFetchHeadServiceURL(t *testing.T) {
 	url, err := utils.FetchHeadServiceURL(ctx, &r.Log, r.Client, &cluster, common.DefaultDashboardName)
 	assert.Nil(t, err, "Fail to fetch head service url")
 	assert.Equal(t, fmt.Sprintf("test-cluster-head-svc.%s.svc.cluster.local:%d", namespace, dashboardPort), url, "Head service url is not correct")
+}
+
+func TestGetAndCheckServeStatus(t *testing.T) {
+	// Create a new scheme with CRDs, Pod, Service schemes.
+	newScheme := runtime.NewScheme()
+	_ = rayv1alpha1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	// Initialize a fake client with newScheme and runtimeObjects.
+	runtimeObjects := []runtime.Object{}
+	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
+
+	// Initialize RayService reconciler.
+	ctx := context.TODO()
+	r := RayServiceReconciler{
+		Client:   fakeClient,
+		Recorder: &record.FakeRecorder{},
+		Scheme:   scheme.Scheme,
+		Log:      ctrl.Log.WithName("controllers").WithName("RayService"),
+	}
+	serviceUnhealthySecondThreshold := int32(ServiceUnhealthySecondThreshold) // The threshold is 900 seconds by default.
+	serveAppName := "serve-app-1"
+
+	// Test 1: There is no pre-existing RayServiceStatus in the RayService CR. Create a new Ray Serve application, and the application is still deploying.
+	dashboardClient := initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.UPDATING, rayv1alpha1.ApplicationStatusEnum.DEPLOYING)
+	prevRayServiceStatus := rayv1alpha1.RayServiceStatus{
+		Applications: map[string]rayv1alpha1.AppStatus{},
+	}
+	isHealthy, isReady, err := r.getAndCheckServeStatus(ctx, dashboardClient, &prevRayServiceStatus, utils.MULTI_APP, &serviceUnhealthySecondThreshold)
+	assert.Nil(t, err)
+	assert.True(t, isHealthy)
+	assert.False(t, isReady)
+
+	// Test 2: The Ray Serve application takes more than `serviceUnhealthySecondThreshold` seconds to be "RUNNING".
+	// This may happen when `runtime_env` installation takes a long time or the cluster does not have enough resources
+	// for autoscaling. Note that the cluster will not be marked as unhealthy if the application is still deploying.
+	dashboardClient = initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.UPDATING, rayv1alpha1.ApplicationStatusEnum.DEPLOYING)
+	prevRayServiceStatus = rayv1alpha1.RayServiceStatus{
+		Applications: map[string]rayv1alpha1.AppStatus{
+			serveAppName: rayv1alpha1.AppStatus{
+				Status:               rayv1alpha1.ApplicationStatusEnum.DEPLOYING,
+				HealthLastUpdateTime: &metav1.Time{Time: metav1.Now().Add(-time.Second * time.Duration(serviceUnhealthySecondThreshold+1))},
+			},
+		},
+	}
+	isHealthy, isReady, err = r.getAndCheckServeStatus(ctx, dashboardClient, &prevRayServiceStatus, utils.MULTI_APP, &serviceUnhealthySecondThreshold)
+	assert.Nil(t, err)
+	assert.True(t, isHealthy)
+	assert.False(t, isReady)
+
+	// Test 3: The Ray Serve application finishes the deployment process and becomes "RUNNING".
+	dashboardClient = initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.HEALTHY, rayv1alpha1.ApplicationStatusEnum.RUNNING)
+	prevRayServiceStatus = rayv1alpha1.RayServiceStatus{
+		Applications: map[string]rayv1alpha1.AppStatus{
+			serveAppName: rayv1alpha1.AppStatus{
+				Status:               rayv1alpha1.ApplicationStatusEnum.DEPLOYING,
+				HealthLastUpdateTime: &metav1.Time{Time: metav1.Now().Time},
+			},
+		},
+	}
+	isHealthy, isReady, err = r.getAndCheckServeStatus(ctx, dashboardClient, &prevRayServiceStatus, utils.MULTI_APP, &serviceUnhealthySecondThreshold)
+	assert.Nil(t, err)
+	assert.True(t, isHealthy)
+	assert.True(t, isReady)
+
+	// Test 4: The Ray Serve application lasts "UNHEALTHY" for more than `serviceUnhealthySecondThreshold` seconds.
+	// The RayCluster will be marked as unhealthy.
+	dashboardClient = initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.UNHEALTHY, rayv1alpha1.ApplicationStatusEnum.UNHEALTHY)
+	prevRayServiceStatus = rayv1alpha1.RayServiceStatus{
+		Applications: map[string]rayv1alpha1.AppStatus{
+			serveAppName: rayv1alpha1.AppStatus{
+				Status:               rayv1alpha1.ApplicationStatusEnum.UNHEALTHY,
+				HealthLastUpdateTime: &metav1.Time{Time: metav1.Now().Add(-time.Second * time.Duration(serviceUnhealthySecondThreshold+1))},
+			},
+		},
+	}
+	isHealthy, isReady, err = r.getAndCheckServeStatus(ctx, dashboardClient, &prevRayServiceStatus, utils.MULTI_APP, &serviceUnhealthySecondThreshold)
+	assert.Nil(t, err)
+	assert.False(t, isHealthy)
+	assert.False(t, isReady)
+
+	// Test 5: The Ray Serve application lasts "UNHEALTHY" for less than `serviceUnhealthySecondThreshold` seconds.
+	// The RayCluster will not be marked as unhealthy.
+	dashboardClient = initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.UNHEALTHY, rayv1alpha1.ApplicationStatusEnum.UNHEALTHY)
+	prevRayServiceStatus = rayv1alpha1.RayServiceStatus{
+		Applications: map[string]rayv1alpha1.AppStatus{
+			serveAppName: rayv1alpha1.AppStatus{
+				Status:               rayv1alpha1.ApplicationStatusEnum.UNHEALTHY,
+				HealthLastUpdateTime: &metav1.Time{Time: metav1.Now().Add(-time.Second * time.Duration(serviceUnhealthySecondThreshold-1))},
+			},
+		},
+	}
+	isHealthy, isReady, err = r.getAndCheckServeStatus(ctx, dashboardClient, &prevRayServiceStatus, utils.MULTI_APP, &serviceUnhealthySecondThreshold)
+	assert.Nil(t, err)
+	assert.True(t, isHealthy)
+	assert.False(t, isReady)
+
+	// Test 6: The Ray Serve application lasts "DEPLOY_FAILED" for more than `serviceUnhealthySecondThreshold` seconds.
+	// The RayCluster will be marked as unhealthy.
+	dashboardClient = initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.UPDATING, rayv1alpha1.ApplicationStatusEnum.DEPLOY_FAILED)
+	prevRayServiceStatus = rayv1alpha1.RayServiceStatus{
+		Applications: map[string]rayv1alpha1.AppStatus{
+			serveAppName: rayv1alpha1.AppStatus{
+				Status:               rayv1alpha1.ApplicationStatusEnum.DEPLOY_FAILED,
+				HealthLastUpdateTime: &metav1.Time{Time: metav1.Now().Add(-time.Second * time.Duration(serviceUnhealthySecondThreshold+1))},
+			},
+		},
+	}
+	isHealthy, isReady, err = r.getAndCheckServeStatus(ctx, dashboardClient, &prevRayServiceStatus, utils.MULTI_APP, &serviceUnhealthySecondThreshold)
+	assert.Nil(t, err)
+	assert.False(t, isHealthy)
+	assert.False(t, isReady)
+
+	// Test 7: The Ray Serve application lasts "DEPLOY_FAILED" for less than `serviceUnhealthySecondThreshold` seconds.
+	// The RayCluster will not be marked as unhealthy.
+	dashboardClient = initFakeDashboardClient(serveAppName, rayv1alpha1.DeploymentStatusEnum.UPDATING, rayv1alpha1.ApplicationStatusEnum.DEPLOY_FAILED)
+	prevRayServiceStatus = rayv1alpha1.RayServiceStatus{
+		Applications: map[string]rayv1alpha1.AppStatus{
+			serveAppName: rayv1alpha1.AppStatus{
+				Status:               rayv1alpha1.ApplicationStatusEnum.DEPLOY_FAILED,
+				HealthLastUpdateTime: &metav1.Time{Time: metav1.Now().Add(-time.Second * time.Duration(serviceUnhealthySecondThreshold-1))},
+			},
+		},
+	}
+	isHealthy, isReady, err = r.getAndCheckServeStatus(ctx, dashboardClient, &prevRayServiceStatus, utils.MULTI_APP, &serviceUnhealthySecondThreshold)
+	assert.Nil(t, err)
+	assert.True(t, isHealthy)
+	assert.False(t, isReady)
+}
+
+func initFakeDashboardClient(appName string, deploymentStatus string, appStatus string) utils.RayDashboardClientInterface {
+	status := generateServeStatus(deploymentStatus, appStatus)
+	fakeDashboardClient := utils.FakeRayDashboardClient{}
+	fakeDashboardClient.SetMultiApplicationStatuses(map[string]*utils.ServeApplicationStatus{appName: &status})
+	return &fakeDashboardClient
 }

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -3,7 +3,7 @@ kind: RayService
 metadata:
   name: rayservice-sample
 spec:
-  serviceUnhealthySecondThreshold: 300
+  serviceUnhealthySecondThreshold: 900
   deploymentUnhealthySecondThreshold: 300
   serveConfig:
     importPath: fruit.deployment_graph


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Before Ray 2.6.0, the status of a Serve deployment would be `UPDATING` if it was attempting to scale up additional replicas. The Serve deployment could remain in the `UPDATING` status for longer than `serviceUnhealthySecondThreshold` seconds if the cluster lacked sufficient resources to accommodate the new replicas. In such cases, KubeRay would mark the RayCluster as unhealthy and proceed to prepare a new RayCluster instead. We should not trigger the new RayCluster preparation if it is in scaling process.

### Definition of "unhealthy" without this PR  

In the RayService, KubeRay can mark a RayCluster as unhealthy in two possible scenarios.

Case 1: The KubeRay operator cannot connect to the dashboard agent on the head Pod for more than the duration defined by the `deploymentUnhealthySecondThreshold` parameter.

* `deploymentUnhealthySecondThreshold`: If it is not set, the default value is 60 seconds. In sample YAML files, we typically set the value to 300 seconds. 

Case 2: The KubeRay operator will mark a RayCluster as unhealthy if the status of a serve application is not `RUNNING` or if a serve deployment isn't `HEALTHY` for a duration exceeding the `serviceUnhealthySecondThreshold` parameter.

* `serviceUnhealthySecondThreshold`: If it is not set, the default value is 60 seconds. In sample YAML files, we typically set the value to 300 seconds.

After KubeRay marks a RayCluster as unhealthy, it initiates the creation of a new RayCluster. Once the new RayCluster is ready, KubeRay redirects network traffic to it, and subsequently deletes the old RayCluster.

### Definition of "unhealthy" with this PR

In the RayService, KubeRay can mark a RayCluster as unhealthy in two possible scenarios.

Case 1: The KubeRay operator cannot connect to the dashboard agent on the head Pod for more than the duration defined by the `deploymentUnhealthySecondThreshold` parameter.

* `deploymentUnhealthySecondThreshold`: Both the default value and values in sample YAML files are 300 seconds.

Case 2: The KubeRay operator will mark a RayCluster as unhealthy if the status of a serve application is `DEPLOY_FAILED` or `UNHEALTHY` for a duration exceeding the `serviceUnhealthySecondThreshold` parameter.

* `serviceUnhealthySecondThreshold`: Both the default value and values in sample YAML files are 900 seconds.

After KubeRay marks a RayCluster as unhealthy, it initiates the creation of a new RayCluster. Once the new RayCluster is ready, KubeRay redirects network traffic to it, and subsequently deletes the old RayCluster.

To conclude, there are two main differences in this PR:

* Increase the default values of `deploymentUnhealthySecondThreshold` and `serviceUnhealthySecondThreshold` to decrease the possibility of triggering new cluster preparation.
* We only determine whether this RayCluster is unhealthy or not based on Serve applications. We will not take Serve deployments into consideration anymore. In addition, we also change the behavior for determining RayService health to not mark the cluster unhealthy if the Serve API returns `UPDATING`. Hence, the RayCluster will not be considered unhealthy when the Serve application tries to scale up more replicas.

## Related issue number

Closes #1277 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
RAY_IMAGE=rayproject/ray:2.5.0 OPERATOR_IMAGE=controller:latest pytest -vs tests/test_sample_rayservice_yamls.py --log-cli-level=INFO
```

<img width="1440" alt="Screen Shot 2023-08-06 at 12 19 12 AM" src="https://github.com/ray-project/kuberay/assets/20109646/89551bd1-e45a-4b05-99a7-32c4b999038d">
