### PR TITLE
[Quay] Sanity check for KubeRay repository setup

### DIFF
--- a/.github/workflows/quay-test.yaml
+++ b/.github/workflows/quay-test.yaml
@@ -1,0 +1,13 @@
+name: test-quay
+
+jobs:
+  test_login_quay:
+    name: Test Quay
+    runs-on: ubuntu-latest
+    steps:
+    - name: Log in to Quay.io
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_ROBOT_TOKEN }}

--- a/.github/workflows/quay-test.yaml
+++ b/.github/workflows/quay-test.yaml
@@ -1,5 +1,8 @@
 name: test-quay
 
+on:
+  workflow_dispatch:
+
 jobs:
   test_login_quay:
     name: Test Quay


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I will have a sync with the repository admin to setup `QUAY_USERNAME` and `QUAY_ROBOT_TOKEN` tomorrow. I add a GitHub Action workflow that can only be triggered manually as a sanity check. This will be removed from the master branch if the `secrets` are set correctly. I have already tested this PR on my fork (https://github.com/kevin85421/kuberay/actions/runs/5790693022/job/15694229870).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
