### PR TITLE
Do not update pod labels if they haven't changed

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1158,14 +1158,24 @@ func (r *RayServiceReconciler) labelHealthyServePods(ctx context.Context, rayClu
 		if pod.Labels == nil {
 			pod.Labels = make(map[string]string)
 		}
+
+		// Make a copy of the labels for comparison later, to decide whether we need to push an update.
+		originalLabels := make(map[string]string, len(pod.Labels))
+		for key, value := range pod.Labels {
+			originalLabels[key] = value
+		}
+
 		if httpProxyClient.CheckHealth() == nil {
 			pod.Labels[common.RayClusterServingServiceLabelKey] = common.EnableRayClusterServingServiceTrue
 		} else {
 			pod.Labels[common.RayClusterServingServiceLabelKey] = common.EnableRayClusterServingServiceFalse
 		}
-		if updateErr := r.Update(ctx, &pod); updateErr != nil {
-			r.Log.Error(updateErr, "Pod label Update error!", "Pod.Error", updateErr)
-			return updateErr
+
+		if !reflect.DeepEqual(originalLabels, pod.Labels) {
+			if updateErr := r.Update(ctx, &pod); updateErr != nil {
+				r.Log.Error(updateErr, "Pod label Update error!", "Pod.Error", updateErr)
+				return updateErr
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See #1303 for more context.

I decided on some light future-proofing by checking if *any* labels have changed before updating the pod (though there is only one label being changed right now).

## Related issue number

Closes #1303 

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

I followed `DEVELOPMENT.md` and was able to stand up a `RayService` in a local `kind` cluster using an operator image built from this PR:

```
❯ k get po -n default
NAME                                                      READY   STATUS    RESTARTS   AGE
ervice-sample-raycluster-pn4cd-worker-small-group-qfntp   1/1     Running   0          6m46s
kuberay-operator-5987588ffc-dg2mn                         1/1     Running   0          23m
rayservice-sample-raycluster-pn4cd-head-fnsl6             1/1     Running   0          6m46s
```

```
❯ k get svc -n default
NAME                                          TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                                                   AGE
custom-ray-serve-service-name                 LoadBalancer   10.96.163.198   <pending>     8000:30266/TCP                                            5m54s
kuberay-operator                              ClusterIP      10.96.30.152    <none>        8080/TCP                                                  23m
kubernetes                                    ClusterIP      10.96.0.1       <none>        443/TCP                                                   25m
rayservice-sample-head-svc                    ClusterIP      10.96.40.11     <none>        10001/TCP,8265/TCP,52365/TCP,6379/TCP,8080/TCP,8000/TCP   5m54s
rayservice-sample-raycluster-pn4cd-head-svc   ClusterIP      10.96.26.140    <none>        10001/TCP,8265/TCP,52365/TCP,6379/TCP,8080/TCP,8000/TCP   6m29s
```

```
❯ k describe pod/ervice-sample-raycluster-pn4cd-worker-small-group-qfntp
Name:         ervice-sample-raycluster-pn4cd-worker-small-group-qfntp
Namespace:    default
Priority:     0
Node:         kind-control-plane/172.19.0.2
Start Time:   Tue, 08 Aug 2023 15:06:05 -0500
Labels:       app.kubernetes.io/created-by=kuberay-operator
              app.kubernetes.io/name=kuberay
              ray.io/cluster=rayservice-sample-raycluster-pn4cd
              ray.io/group=small-group
              ray.io/identifier=rayservice-sample-raycluster-pn4cd-worker
              ray.io/is-ray-node=yes
              ray.io/node-type=worker
              ray.io/serve=true
Annotations:  ray.io/ft-enabled: false
              ray.io/health-state:
Status:       Running
IP:           10.244.0.12
IPs:
  IP:           10.244.0.12
Controlled By:  RayCluster/rayservice-sample-raycluster-pn4cd
Init Containers:
  wait-gcs-ready:
    Container ID:  containerd://ee18aa5754c97cf592f10a24fc04b712354b6577a0a778de47ec9c5aa04e74a9
    Image:         rayproject/ray:2.5.0
    Image ID:      docker.io/rayproject/ray@sha256:cb53dcc21af8f913978fd2a3fc57c812f87d99e0b40db6a42ccd6f43eca11281
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/bash
      -lc
      --
    Args:

                            SECONDS=0
                            while true; do
                              if (( SECONDS <= 120 )); then
                                if ray health-check --address rayservice-sample-raycluster-pn4cd-head-svc.default.svc.cluster.local:6379 > /dev/null 2>&1; then
                                  echo "GCS is ready."
                                  break
                                fi
                                echo "$SECONDS seconds elapsed: Waiting for GCS to be ready."
                              else
                                if ray health-check --address rayservice-sample-raycluster-pn4cd-head-svc.default.svc.cluster.local:6379; then
                                  echo "GCS is ready. Any error messages above can be safely ignored."
                                  break
                                fi
                                echo "$SECONDS seconds elapsed: Still waiting for GCS to be ready. For troubleshooting, refer to the FAQ at https://github.com/ray-project/kuberay/blob/master/docs/guidance/FAQ.md."
                              fi
                              sleep 5
                            done

    State:          Terminated
      Reason:       Completed
      Exit Code:    0
      Started:      Tue, 08 Aug 2023 15:06:06 -0500
      Finished:     Tue, 08 Aug 2023 15:06:17 -0500
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     1
      memory:  2Gi
    Requests:
      cpu:     500m
      memory:  2Gi
    Environment:
      FQ_RAY_IP:  rayservice-sample-raycluster-pn4cd-head-svc.default.svc.cluster.local
      RAY_IP:     rayservice-sample-raycluster-pn4cd-head-svc
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-fftq7 (ro)
Containers:
  ray-worker:
    Container ID:  containerd://ed185f50ffaf8a90922efa821d143969eec271740f4780877890f498596ca56d
    Image:         rayproject/ray:2.5.0
    Image ID:      docker.io/rayproject/ray@sha256:cb53dcc21af8f913978fd2a3fc57c812f87d99e0b40db6a42ccd6f43eca11281
    Port:          8080/TCP
    Host Port:     0/TCP
    Command:
      /bin/bash
      -lc
      --
    Args:
      ulimit -n 65536; ray start  --metrics-export-port=8080  --block  --dashboard-agent-listen-port=52365  --num-cpus=1  --memory=2147483648  --address=rayservice-sample-raycluster-pn4cd-head-svc.default.svc.cluster.local:6379
    State:          Running
      Started:      Tue, 08 Aug 2023 15:06:18 -0500
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     1
      memory:  2Gi
    Requests:
      cpu:     500m
      memory:  2Gi
    Environment:
      FQ_RAY_IP:                                  rayservice-sample-raycluster-pn4cd-head-svc.default.svc.cluster.local
      RAY_IP:                                     rayservice-sample-raycluster-pn4cd-head-svc
      RAY_CLUSTER_NAME:                            (v1:metadata.labels['ray.io/cluster'])
      RAY_PORT:                                   6379
      RAY_timeout_ms_task_wait_for_death_info:    0
      RAY_gcs_server_request_timeout_seconds:     5
      RAY_SERVE_KV_TIMEOUT_S:                     5
      RAY_INTERNAL_SERVE_CONTROLLER_PIN_ON_NODE:  0
      RAY_ADDRESS:                                rayservice-sample-raycluster-pn4cd-head-svc.default.svc.cluster.local:6379
      RAY_USAGE_STATS_KUBERAY_IN_USE:             1
      REDIS_PASSWORD:
      RAY_DASHBOARD_ENABLE_K8S_DISK_USAGE:        1
    Mounts:
      /dev/shm from shared-mem (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-fftq7 (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  shared-mem:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:     Memory
    SizeLimit:  2Gi
  kube-api-access-fftq7:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   Burstable
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason     Age    From               Message
  ----    ------     ----   ----               -------
  Normal  Scheduled  7m56s  default-scheduler  Successfully assigned default/ervice-sample-raycluster-pn4cd-worker-small-group-qfntp to kind-control-plane
  Normal  Pulled     7m55s  kubelet            Container image "rayproject/ray:2.5.0" already present on machine
  Normal  Created    7m55s  kubelet            Created container wait-gcs-ready
  Normal  Started    7m55s  kubelet            Started container wait-gcs-ready
  Normal  Pulled     7m44s  kubelet            Container image "rayproject/ray:2.5.0" already present on machine
  Normal  Created    7m43s  kubelet            Created container ray-worker
  Normal  Started    7m43s  kubelet            Started container ray-worker
```

```
❯ k describe svc/custom-ray-serve-service-name
Name:                     custom-ray-serve-service-name
Namespace:                default
Labels:                   custom-label=custom-ray-serve-service-label
                          ray.io/serve=rayservice-sample-serve
                          ray.io/service=rayservice-sample
Annotations:              custom-annotation: custom-ray-serve-service-annotation
Selector:                 ray.io/cluster=rayservice-sample-raycluster-pn4cd,ray.io/serve=true
Type:                     LoadBalancer
IP Family Policy:         SingleStack
IP Families:              IPv4
IP:                       10.96.163.198
IPs:                      10.96.163.198
Port:                     serve  8000/TCP
TargetPort:               8000/TCP
NodePort:                 serve  30266/TCP
Endpoints:                10.244.0.11:8000,10.244.0.12:8000
Session Affinity:         None
External Traffic Policy:  Cluster
Events:                   <none>
```

So cluster formation looks good, but I'm not really sure how to test the opposite case where the label should go from `true` to `false`. Open to suggestions!

Also I don't really know anything about go - please review carefully for style and correctness :) 