### PR TITLE
[CI] Verify kubectl in kind-in-docker step

### DIFF
--- a/.buildkite/kind-in-docker.yml
+++ b/.buildkite/kind-in-docker.yml
@@ -1,4 +1,4 @@
-- label: kind in Docker
+- label: kind and kubectl
   instance_size: large
   image: golang:1.17
   commands:
@@ -13,6 +13,24 @@
     # Install Docker
     - bash scripts/install-docker.sh
 
-    # Delete cluster if it already exists
-    - kind delete cluster
-    - kind create cluster
+    # Delete dangling clusters
+    - kind delete clusters --all
+
+    # Create the cluster
+    - time kind create cluster --wait 120s --config tests/framework/config/kind-config-buildkite.yml
+    - docker ps
+
+    # Now the kind node is running, it exposes port 6443 in the dind-daemon network.
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+
+    # Install kubectl.
+    - curl -LO https://dl.k8s.io/release/v1.27.3/bin/linux/amd64/kubectl
+    - curl -LO "https://dl.k8s.io/release/v1.27.3/bin/linux/amd64/kubectl.sha256"
+    - echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
+    - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+    # Verify that kubectl works
+    - kubectl version
+    - kubectl cluster-info
+    - kubectl get nodes
+    - kubectl get pods --all-namespaces

--- a/.buildkite/kind-in-docker.yml
+++ b/.buildkite/kind-in-docker.yml
@@ -16,18 +16,18 @@
     # Delete dangling clusters
     - kind delete clusters --all
 
+    # Install kubectl.
+    - curl -LO https://dl.k8s.io/release/v1.27.3/bin/linux/amd64/kubectl
+    - curl -LO "https://dl.k8s.io/release/v1.27.3/bin/linux/amd64/kubectl.sha256"
+    - echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
+    - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
     # Create the cluster
     - time kind create cluster --wait 120s --config tests/framework/config/kind-config-buildkite.yml
     - docker ps
 
     # Now the kind node is running, it exposes port 6443 in the dind-daemon network.
     - kubectl config set clusters.kind-kind.server https://docker:6443
-
-    # Install kubectl.
-    - curl -LO https://dl.k8s.io/release/v1.27.3/bin/linux/amd64/kubectl
-    - curl -LO "https://dl.k8s.io/release/v1.27.3/bin/linux/amd64/kubectl.sha256"
-    - echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
-    - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
     # Verify that kubectl works
     - kubectl version

--- a/tests/framework/config/kind-config-buildkite.yml
+++ b/tests/framework/config/kind-config-buildkite.yml
@@ -1,0 +1,17 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  apiServerAddress: "0.0.0.0"
+  # Ensure stable port so we can rewrite the server address later
+  apiServerPort: 6443
+
+# Adding this so containers from the same docker network can access it
+# https://blog.scottlowe.org/2019/07/30/adding-a-name-to-kubernetes-api-server-certificate/
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      certSANs:
+        - "docker"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR configures `kind` to allow `kubectl` to connect to it. This is a prerequisite for testing sample YAML files end-to-end in Buildkite. The configuration is copied from @simon-mo's work in https://github.com/ray-project/ray/pull/22035.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
