### PR TITLE
Allow E2E tests to run with arbitrary k8s cluster

### DIFF
--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -43,8 +43,8 @@ class BasicRayTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create a Kind cluster, a KubeRay operator, and a RayCluster."""
-        K8S_CLUSTER_MANAGER.delete_kind_cluster()
-        K8S_CLUSTER_MANAGER.create_kind_cluster()
+        K8S_CLUSTER_MANAGER.cleanup()
+        K8S_CLUSTER_MANAGER.initialize_cluster()
         image_dict = {
             CONST.RAY_IMAGE_KEY: ray_image,
             CONST.OPERATOR_IMAGE_KEY: kuberay_operator_image
@@ -77,8 +77,8 @@ class RayFTTestCase(unittest.TestCase):
     def setUpClass(cls):
         if not utils.is_feature_supported(ray_version, CONST.RAY_FT):
             raise unittest.SkipTest(f"{CONST.RAY_FT} is not supported")
-        K8S_CLUSTER_MANAGER.delete_kind_cluster()
-        K8S_CLUSTER_MANAGER.create_kind_cluster()
+        K8S_CLUSTER_MANAGER.cleanup()
+        K8S_CLUSTER_MANAGER.initialize_cluster()
         image_dict = {
             CONST.RAY_IMAGE_KEY: ray_image,
             CONST.OPERATOR_IMAGE_KEY: kuberay_operator_image
@@ -224,8 +224,8 @@ class KubeRayHealthCheckTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        K8S_CLUSTER_MANAGER.delete_kind_cluster()
-        K8S_CLUSTER_MANAGER.create_kind_cluster()
+        K8S_CLUSTER_MANAGER.cleanup()
+        K8S_CLUSTER_MANAGER.initialize_cluster()
         image_dict = {
             CONST.RAY_IMAGE_KEY: ray_image,
             CONST.OPERATOR_IMAGE_KEY: kuberay_operator_image

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -599,11 +599,11 @@ class GeneralTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        K8S_CLUSTER_MANAGER.delete_kind_cluster()
+        K8S_CLUSTER_MANAGER.cleanup()
 
     def setUp(self):
         if not K8S_CLUSTER_MANAGER.check_cluster_exist():
-            K8S_CLUSTER_MANAGER.create_kind_cluster()
+            K8S_CLUSTER_MANAGER.initialize_cluster()
             self.operator_manager.prepare_operator()
 
     def runtest(self):
@@ -615,4 +615,4 @@ class GeneralTestCase(unittest.TestCase):
             self.cr_event.clean_up()
         except Exception as ex:
             logger.error(str(ex))
-            K8S_CLUSTER_MANAGER.delete_kind_cluster()
+            K8S_CLUSTER_MANAGER.cleanup()

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -197,8 +197,8 @@ class TestRayService:
             {"path": "/calc", "json_args": ["MUL", 3], "expected_output": '"15 pizzas please!"'},
         ]
 
-        K8S_CLUSTER_MANAGER.delete_kind_cluster()
-        K8S_CLUSTER_MANAGER.create_kind_cluster()
+        K8S_CLUSTER_MANAGER.cleanup()
+        K8S_CLUSTER_MANAGER.initialize_cluster()
         operator_manager = OperatorManager(DEFAULT_IMAGE_DICT)
         operator_manager.prepare_operator()
         start_curl_pod("curl", "default")
@@ -206,7 +206,7 @@ class TestRayService:
 
         yield
 
-        K8S_CLUSTER_MANAGER.delete_kind_cluster()
+        K8S_CLUSTER_MANAGER.cleanup()
 
     def test_deploy_applications(self, set_up_cluster):
         rs = RuleSet([EasyJobRule(), CurlServiceRule(queries=self.default_queries)])

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -39,9 +39,9 @@ class PodSecurityTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        K8S_CLUSTER_MANAGER.delete_kind_cluster()
+        K8S_CLUSTER_MANAGER.cleanup()
         kind_config = CONST.REPO_ROOT.joinpath("ray-operator/config/security/kind-config.yaml")
-        K8S_CLUSTER_MANAGER.create_kind_cluster(kind_config = kind_config)
+        K8S_CLUSTER_MANAGER.initialize_cluster(kind_config = kind_config)
         # Apply the restricted Pod security standard to all Pods in the namespace pod-security.
         # The label pod-security.kubernetes.io/enforce=restricted means that the Pod that violates
         # the policies will be rejected.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently E2E tests run only with Kind cluster. The goal of this PR is to make these tests more configurable and allow it to run with any Kubernetes cluster. It is now possible to login to arbitrary cluster using kubectl/oc command and run tests with arbitrary cluster. For example:
```
oc login ...
EXTERNAL_CLUSTER=true RAY_IMAGE=rayproject/ray:2.5.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/compatibility-test.py
```
## Related issue number

<!-- For example: "Closes #1234" -->
Closes #1284

## Checks

- [] I've made sure the tests are passing. 
- Testing Strategy
   - [] Unit tests
   - [] Manual tests
   - [*] This PR is not tested :(
