### PR TITLE
[CI] Publish KubeRay operator / apiserver images to Quay

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -58,7 +58,7 @@ jobs:
         docker save -o /tmp/apiserver.tar kuberay/apiserver:${{ steps.vars.outputs.sha_short }}
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -70,7 +70,7 @@ jobs:
         docker push kuberay/apiserver:${{ github.event.inputs.tag }}
 
     - name: Log in to Quay.io
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      uses: docker/login-action@v2
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
@@ -130,7 +130,7 @@ jobs:
       working-directory: ${{env.working-directory}}
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -142,7 +142,7 @@ jobs:
         docker push kuberay/operator:${{ github.event.inputs.tag }}
 
     - name: Log in to Quay.io
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      uses: docker/login-action@v2
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -69,6 +69,20 @@ jobs:
         docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:${{ github.event.inputs.tag }};
         docker push kuberay/apiserver:${{ github.event.inputs.tag }}
 
+    - name: Log in to Quay.io
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+    - name: Push Operator to Quay.io
+      run: |
+        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
+        docker push quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
+        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ github.event.inputs.tag }};
+        docker push quay.io/kuberay/apiserver:${{ github.event.inputs.tag }}
+
   release_operator_image:
     env:
       working-directory: ./ray-operator
@@ -126,3 +140,17 @@ jobs:
         docker push kuberay/operator:${{ steps.vars.outputs.sha_short }};
         docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} kuberay/operator:${{ github.event.inputs.tag }};
         docker push kuberay/operator:${{ github.event.inputs.tag }}
+
+    - name: Log in to Quay.io
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+    - name: Push Operator to Quay.io
+      run: |
+        docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/operator:${{ steps.vars.outputs.sha_short }};
+        docker push quay.io/kuberay/operator:${{ steps.vars.outputs.sha_short }};
+        docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/operator:${{ github.event.inputs.tag }};
+        docker push quay.io/kuberay/operator:${{ github.event.inputs.tag }}

--- a/.github/workflows/quay-test.yaml
+++ b/.github/workflows/quay-test.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Log in to Quay.io
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      uses: docker/login-action@v2
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -178,6 +178,20 @@ jobs:
         working-directory: ${{env.working-directory}}
         if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
+      - name: Log in to Quay.io
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Push Operator to Quay.io
+        run: |
+          docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
+          docker push quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
+          docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:nightly;
+          docker push quay.io/kuberay/apiserver:nightly
+
       - name: Build CLI
         run: go build -o kuberay -a main.go
         working-directory: ${{env.cli-working-directory}}
@@ -257,6 +271,22 @@ jobs:
         docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} kuberay/operator:nightly;
         docker push kuberay/operator:nightly
 
+      working-directory: ${{env.working-directory}}
+      if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
+
+    - name: Log in to Quay.io
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+    - name: Push Operator to Quay.io
+      run: |
+        docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/operator:${{ steps.vars.outputs.sha_short }};
+        docker push quay.io/kuberay/operator:${{ steps.vars.outputs.sha_short }};
+        docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/operator:nightly;
+        docker push quay.io/kuberay/operator:nightly
       working-directory: ${{env.working-directory}}
       if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -163,7 +163,7 @@ jobs:
           path: /tmp/apiserver.tar
 
       - name: Log in to Quay.io
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -177,7 +177,7 @@ jobs:
           docker push quay.io/kuberay/apiserver:nightly
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -255,7 +255,7 @@ jobs:
         path: /tmp/operator.tar
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -267,7 +267,7 @@ jobs:
         docker push kuberay/operator:nightly
 
     - name: Log in to Quay.io
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      uses: docker/login-action@v2
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -167,16 +167,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-        if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
       - name: Push Apiserver to DockerHub
         run: |
           docker push kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
           docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:nightly;
           docker push kuberay/apiserver:nightly
-
-        working-directory: ${{env.working-directory}}
-        if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
       - name: Log in to Quay.io
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -263,16 +259,12 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-      if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
     - name: Push Operator to DockerHub
       run: |
         docker push kuberay/operator:${{ steps.vars.outputs.sha_short }};
         docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} kuberay/operator:nightly;
         docker push kuberay/operator:nightly
-
-      working-directory: ${{env.working-directory}}
-      if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
     - name: Log in to Quay.io
       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -287,8 +279,6 @@ jobs:
         docker push quay.io/kuberay/operator:${{ steps.vars.outputs.sha_short }};
         docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/operator:nightly;
         docker push quay.io/kuberay/operator:nightly
-      working-directory: ${{env.working-directory}}
-      if: contains(fromJson('["refs/heads/master", "refs/heads/release-0.3"]'), github.ref)
 
   test-compatibility-1_13_0:
     needs:

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -101,9 +101,9 @@ jobs:
       if: failure()
 
   build_apiserver:
-    env:
-      working-directory: ./apiserver
-      cli-working-directory: ./cli
+    # env:
+    #   working-directory: ./apiserver
+    #   cli-working-directory: ./cli
     name: Build Apiserver, CLI Binaries and Docker Images
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -107,6 +107,12 @@ jobs:
     name: Build Apiserver, CLI Binaries and Docker Images
     runs-on: ubuntu-latest
     steps:
+      - name: Log in to Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
       - name: Set up Go 1.17.x
         uses: actions/setup-go@v2

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -8,16 +8,6 @@ on:
     branches: [ master ]
 
 jobs:
-  test_login_quay:
-    name: Test Quay
-    runs-on: ubuntu-latest
-    steps:
-    - name: Log in to Quay.io
-      uses: docker/login-action@v2
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_ROBOT_TOKEN }}
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -117,13 +107,6 @@ jobs:
     name: Build Apiserver, CLI Binaries and Docker Images
     runs-on: ubuntu-latest
     steps:
-      - name: Log in to Quay.io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
-
       - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
@@ -178,12 +161,27 @@ jobs:
           name: apiserver_img
           path: /tmp/apiserver.tar
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: contains(fromJson('["refs/heads/master"]'), github.ref)
+
+      - name: Push Apiserver to DockerHub
+        run: |
+          docker push kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
+          docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:nightly;
+          docker push kuberay/apiserver:nightly
+        if: contains(fromJson('["refs/heads/master"]'), github.ref)
+
       - name: Log in to Quay.io
         uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+        if: contains(fromJson('["refs/heads/master"]'), github.ref)
 
       - name: Push Operator to Quay.io
         run: |
@@ -191,18 +189,7 @@ jobs:
           docker push quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
           docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:nightly;
           docker push quay.io/kuberay/apiserver:nightly
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Push Apiserver to DockerHub
-        run: |
-          docker push kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-          docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:nightly;
-          docker push kuberay/apiserver:nightly
+        if: contains(fromJson('["refs/heads/master"]'), github.ref)
 
       - name: Build CLI
         run: go build -o kuberay -a main.go
@@ -275,12 +262,14 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+      if: contains(fromJson('["refs/heads/master"]'), github.ref)
 
     - name: Push Operator to DockerHub
       run: |
         docker push kuberay/operator:${{ steps.vars.outputs.sha_short }};
         docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} kuberay/operator:nightly;
         docker push kuberay/operator:nightly
+      if: contains(fromJson('["refs/heads/master"]'), github.ref)
 
     - name: Log in to Quay.io
       uses: docker/login-action@v2
@@ -288,6 +277,7 @@ jobs:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+      if: contains(fromJson('["refs/heads/master"]'), github.ref)
 
     - name: Push Operator to Quay.io
       run: |
@@ -295,6 +285,7 @@ jobs:
         docker push quay.io/kuberay/operator:${{ steps.vars.outputs.sha_short }};
         docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/operator:nightly;
         docker push quay.io/kuberay/operator:nightly
+      if: contains(fromJson('["refs/heads/master"]'), github.ref)
 
   test-compatibility-1_13_0:
     needs:

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -8,6 +8,16 @@ on:
     branches: [ master ]
 
 jobs:
+  test_login_quay:
+    name: Test Quay
+    runs-on: ubuntu-latest
+    steps:
+    - name: Log in to Quay.io
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_ROBOT_TOKEN }}
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -101,9 +111,9 @@ jobs:
       if: failure()
 
   build_apiserver:
-    # env:
-    #   working-directory: ./apiserver
-    #   cli-working-directory: ./cli
+    env:
+      working-directory: ./apiserver
+      cli-working-directory: ./cli
     name: Build Apiserver, CLI Binaries and Docker Images
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -162,18 +162,6 @@ jobs:
           name: apiserver_img
           path: /tmp/apiserver.tar
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Push Apiserver to DockerHub
-        run: |
-          docker push kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-          docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:nightly;
-          docker push kuberay/apiserver:nightly
-
       - name: Log in to Quay.io
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -187,6 +175,18 @@ jobs:
           docker push quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
           docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:nightly;
           docker push quay.io/kuberay/apiserver:nightly
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push Apiserver to DockerHub
+        run: |
+          docker push kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
+          docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:nightly;
+          docker push kuberay/apiserver:nightly
 
       - name: Build CLI
         run: go build -o kuberay -a main.go


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```yaml
if: contains(fromJson('["refs/heads/master"]'), github.ref)
```

Because I am not a collaborator of this GitHub repo, I cannot read the `secrets` of this repo. Hence, we will not log in to either DockerHub or Quay for PR. We will only log in to the image registries after the PR is merged into the master branch.

## Related issue number

#1133: We can close the issue if the PR works well after merge.
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

We can only verify this PR after it is merged.
