### PR TITLE
[CI] Downgrade `kind` from to `v0.20.0` to `v0.11.1`

### DIFF
--- a/.buildkite/kind-in-docker.yml
+++ b/.buildkite/kind-in-docker.yml
@@ -6,7 +6,7 @@
     - export PATH=$PATH:/usr/local/go/bin
 
     # Install kind
-    - curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+    - curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
     - chmod +x ./kind
     - mv ./kind /usr/local/bin/kind
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #1309.  I don't know why, after but downgrading the `kind` version to `0.11.1`, I never observed the issue again.  Whereas with `0.20.0`, the issue is consistently reproducible.

I haven't investigated which `kind` version between 0.11.1 and 0.20.0 is the first one that caused the issue.  

The reason for choosing 0.11.1 is that this is the version used in Ray CI, and we haven't observed the issue in Ray CI. https://github.com/architkulkarni/ray/blob/5cb837dbaf1e5875f4f365e67cec6b09d90bf710/ci/k8s/prep-k8s-environment.sh#L8

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [] Manual tests
   - [ ] This PR is not tested :(
