### PR TITLE
[Bug][RayJob] RayJob with custom head service name

### DIFF
--- a/ray-operator/config/samples/ray-job.custom-head-svc.yaml
+++ b/ray-operator/config/samples/ray-job.custom-head-svc.yaml
@@ -1,0 +1,145 @@
+apiVersion: ray.io/v1alpha1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  entrypoint: python /home/ray/samples/sample_code.py
+  # shutdownAfterJobFinishes specifies whether the RayCluster should be deleted after the RayJob finishes. Default is false.
+  # shutdownAfterJobFinishes: false
+  # ttlSecondsAfterFinished specifies the number of seconds after which the RayCluster will be deleted after the RayJob finishes.
+  # ttlSecondsAfterFinished: 10
+  # runtimeEnv decoded to '{
+  #    "pip": [
+  #        "requests==2.26.0",
+  #        "pendulum==2.1.2"
+  #    ],
+  #    "env_vars": {
+  #        "counter_name": "test_counter"
+  #    }
+  #}'
+  runtimeEnv: ewogICAgInBpcCI6IFsKICAgICAgICAicmVxdWVzdHM9PTIuMjYuMCIsCiAgICAgICAgInBlbmR1bHVtPT0yLjEuMiIKICAgIF0sCiAgICAiZW52X3ZhcnMiOiB7ImNvdW50ZXJfbmFtZSI6ICJ0ZXN0X2NvdW50ZXIifQp9Cg==
+  # Suspend specifies whether the RayJob controller should create a RayCluster instance.
+  # If a job is applied with the suspend field set to true, the RayCluster will not be created and we will wait for the transition to false.
+  # If the RayCluster is already created, it will be deleted. In the case of transition to false, a new RayCluste rwill be created.
+  # suspend: false
+  # rayClusterSpec specifies the RayCluster instance to be created by the RayJob controller.
+  rayClusterSpec:
+    rayVersion: '2.5.0' # should match the Ray version in the image of the containers
+    # Ray head pod template
+    headGroupSpec:
+      headService:
+        metadata:
+          name: custom-ray-head-service-name
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        dashboard-host: '0.0.0.0'
+      #pod template
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: rayproject/ray:2.5.0
+              ports:
+                - containerPort: 6379
+                  name: gcs-server
+                - containerPort: 8265 # Ray dashboard
+                  name: dashboard
+                - containerPort: 10001
+                  name: client
+              resources:
+                limits:
+                  cpu: "1"
+                requests:
+                  cpu: "200m"
+              volumeMounts:
+                - mountPath: /home/ray/samples
+                  name: code-sample
+          volumes:
+            # You set volumes at the Pod level, then mount them into containers inside that Pod
+            - name: code-sample
+              configMap:
+                # Provide the name of the ConfigMap you want to mount.
+                name: ray-job-code-sample
+                # An array of keys from the ConfigMap to create as files
+                items:
+                  - key: sample_code.py
+                    path: sample_code.py
+    workerGroupSpecs:
+      # the pod replicas in this group typed worker
+      - replicas: 1
+        minReplicas: 1
+        maxReplicas: 5
+        # logical group name, for this called small-group, also can be functional
+        groupName: small-group
+        # The `rayStartParams` are used to configure the `ray start` command.
+        # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+        # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+        rayStartParams: {}
+        #pod template
+        template:
+          spec:
+            containers:
+              - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+                image: rayproject/ray:2.5.0
+                lifecycle:
+                  preStop:
+                    exec:
+                      command: [ "/bin/sh","-c","ray stop" ]
+                resources:
+                  limits:
+                    cpu: "1"
+                  requests:
+                    cpu: "200m"
+  # SubmitterPodTemplate is the template for the pod that will run the `ray job submit` command against the RayCluster.
+  # If SubmitterPodTemplate is specified, the first container is assumed to be the submitter container.
+  # submitterPodTemplate:
+  #   spec:
+  #     restartPolicy: Never
+  #     containers:
+  #       - name: my-custom-rayjob-submitter-pod
+  #         image: rayproject/ray:2.5.0
+  #         # If Command is not specified, the correct command will be supplied at runtime using the RayJob spec `entrypoint` field.
+  #         # Specifying Command is not recommended.
+  #         # command: ["ray job submit --address=http://rayjob-sample-raycluster-v6qcq-head-svc.default.svc.cluster.local:8265 -- echo hello world"]
+      
+
+######################Ray code sample#################################
+# this sample is from https://docs.ray.io/en/latest/cluster/job-submission.html#quick-start-example
+# it is mounted into the container and executed to show the Ray job at work
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ray-job-code-sample
+data:
+  sample_code.py: |
+    import ray
+    import os
+    import requests
+
+    ray.init()
+
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            # Used to verify runtimeEnv
+            self.name = os.getenv("counter_name")
+            assert self.name == "test_counter"
+            self.counter = 0
+
+        def inc(self):
+            self.counter += 1
+
+        def get_counter(self):
+            return "{} got {}".format(self.name, self.counter)
+
+    counter = Counter.remote()
+
+    for _ in range(5):
+        ray.get(counter.inc.remote())
+        print(ray.get(counter.get_counter.remote()))
+
+    # Verify that the correct runtime env was used for the job.
+    assert requests.__version__ == "2.26.0"

--- a/ray-operator/config/samples/ray-job.custom-head-svc.yaml
+++ b/ray-operator/config/samples/ray-job.custom-head-svc.yaml
@@ -1,30 +1,16 @@
+# This YAML file is primarily for testing purposes. It specifies a custom head service name for the 
+# RayCluster associated with the RayJob. The head service allows worker Pods to connect to the head 
+# Pod and enables the Kubernetes Job, owned by the RayJob, to submit tasks to the RayCluster.
 apiVersion: ray.io/v1alpha1
 kind: RayJob
 metadata:
   name: rayjob-sample
 spec:
   entrypoint: python /home/ray/samples/sample_code.py
-  # shutdownAfterJobFinishes specifies whether the RayCluster should be deleted after the RayJob finishes. Default is false.
-  # shutdownAfterJobFinishes: false
-  # ttlSecondsAfterFinished specifies the number of seconds after which the RayCluster will be deleted after the RayJob finishes.
-  # ttlSecondsAfterFinished: 10
-  # runtimeEnv decoded to '{
-  #    "pip": [
-  #        "requests==2.26.0",
-  #        "pendulum==2.1.2"
-  #    ],
-  #    "env_vars": {
-  #        "counter_name": "test_counter"
-  #    }
-  #}'
   runtimeEnv: ewogICAgInBpcCI6IFsKICAgICAgICAicmVxdWVzdHM9PTIuMjYuMCIsCiAgICAgICAgInBlbmR1bHVtPT0yLjEuMiIKICAgIF0sCiAgICAiZW52X3ZhcnMiOiB7ImNvdW50ZXJfbmFtZSI6ICJ0ZXN0X2NvdW50ZXIifQp9Cg==
-  # Suspend specifies whether the RayJob controller should create a RayCluster instance.
-  # If a job is applied with the suspend field set to true, the RayCluster will not be created and we will wait for the transition to false.
-  # If the RayCluster is already created, it will be deleted. In the case of transition to false, a new RayCluste rwill be created.
-  # suspend: false
   # rayClusterSpec specifies the RayCluster instance to be created by the RayJob controller.
   rayClusterSpec:
-    rayVersion: '2.5.0' # should match the Ray version in the image of the containers
+    rayVersion: '2.6.3' # should match the Ray version in the image of the containers
     # Ray head pod template
     headGroupSpec:
       headService:
@@ -40,7 +26,7 @@ spec:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.5.0
+              image: rayproject/ray:2.6.3
               ports:
                 - containerPort: 6379
                   name: gcs-server
@@ -52,17 +38,14 @@ spec:
                 limits:
                   cpu: "1"
                 requests:
-                  cpu: "200m"
+                  cpu: "1"
               volumeMounts:
                 - mountPath: /home/ray/samples
                   name: code-sample
           volumes:
-            # You set volumes at the Pod level, then mount them into containers inside that Pod
             - name: code-sample
               configMap:
-                # Provide the name of the ConfigMap you want to mount.
                 name: ray-job-code-sample
-                # An array of keys from the ConfigMap to create as files
                 items:
                   - key: sample_code.py
                     path: sample_code.py
@@ -82,7 +65,7 @@ spec:
           spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-                image: rayproject/ray:2.5.0
+                image: rayproject/ray:2.6.3
                 lifecycle:
                   preStop:
                     exec:
@@ -91,20 +74,7 @@ spec:
                   limits:
                     cpu: "1"
                   requests:
-                    cpu: "200m"
-  # SubmitterPodTemplate is the template for the pod that will run the `ray job submit` command against the RayCluster.
-  # If SubmitterPodTemplate is specified, the first container is assumed to be the submitter container.
-  # submitterPodTemplate:
-  #   spec:
-  #     restartPolicy: Never
-  #     containers:
-  #       - name: my-custom-rayjob-submitter-pod
-  #         image: rayproject/ray:2.5.0
-  #         # If Command is not specified, the correct command will be supplied at runtime using the RayJob spec `entrypoint` field.
-  #         # Specifying Command is not recommended.
-  #         # command: ["ray job submit --address=http://rayjob-sample-raycluster-v6qcq-head-svc.default.svc.cluster.local:8265 -- echo hello world"]
-      
-
+                    cpu: "1"
 ######################Ray code sample#################################
 # this sample is from https://docs.ray.io/en/latest/cluster/job-submission.html#quick-start-example
 # it is mounted into the container and executed to show the Ray job at work

--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -44,13 +44,18 @@ func BuildIngressForHeadService(cluster rayv1alpha1.RayCluster) (*networkingv1.I
 	if port, ok := servicePorts["dashboard"]; ok {
 		dashboardPort = port
 	}
+
+	headSvcName, err := utils.GenerateHeadServiceName(utils.RayClusterCRD, cluster.Spec, cluster.Name)
+	if err != nil {
+		return nil, err
+	}
 	paths = []networkingv1.HTTPIngressPath{
 		{
 			Path:     "/" + cluster.Name + "/(.*)",
 			PathType: &pathType,
 			Backend: networkingv1.IngressBackend{
 				Service: &networkingv1.IngressServiceBackend{
-					Name: utils.GenerateServiceName(cluster.Name),
+					Name: headSvcName,
 					Port: networkingv1.ServiceBackendPort{
 						Number: dashboardPort,
 					},
@@ -100,7 +105,12 @@ func BuildIngressForRayService(service rayv1alpha1.RayService, cluster rayv1alph
 		return nil, err
 	}
 
-	ingress.ObjectMeta.Name = utils.GenerateServiceName(service.Name)
+	headSvcName, err := utils.GenerateHeadServiceName(utils.RayServiceCRD, service.Spec.RayClusterSpec, service.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	ingress.ObjectMeta.Name = headSvcName
 	ingress.ObjectMeta.Namespace = service.Namespace
 	ingress.ObjectMeta.Labels = map[string]string{
 		RayServiceLabelKey: service.Name,

--- a/ray-operator/controllers/ray/common/ingress_test.go
+++ b/ray-operator/controllers/ray/common/ingress_test.go
@@ -124,9 +124,11 @@ func TestBuildIngressForHeadService(t *testing.T) {
 
 	// path names
 	paths := ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths
+	headSvcName, err := utils.GenerateHeadServiceName(utils.RayClusterCRD, instanceWithIngressEnabled.Spec, instanceWithIngressEnabled.Name)
+	assert.Nil(t, err)
 	for _, path := range paths {
 		actualResult = path.Backend.Service.Name
-		expectedResult = utils.GenerateServiceName(instanceWithIngressEnabled.Name)
+		expectedResult = headSvcName
 
 		if !reflect.DeepEqual(expectedResult, actualResult) {
 			t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -401,7 +401,7 @@ func TestBuildPod(t *testing.T) {
 	// testing worker pod
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	podName = cluster.Name + DashSymbol + string(rayv1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
-	fqdnRayIP := utils.GenerateFQDNServiceName(cluster.Name, cluster.Namespace)
+	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	pod = BuildPod(podTemplateSpec, rayv1alpha1.WorkerNode, worker.RayStartParams, "6379", nil, "", fqdnRayIP)
 
@@ -549,7 +549,7 @@ func TestBuildPod_WithGcsFtEnabled(t *testing.T) {
 	// Build a worker pod
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	podName = cluster.Name + DashSymbol + string(rayv1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
-	fqdnRayIP := utils.GenerateFQDNServiceName(cluster.Name, cluster.Namespace)
+	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	pod = BuildPod(podTemplateSpec, rayv1alpha1.WorkerNode, worker.RayStartParams, "6379", nil, "", fqdnRayIP)
 
@@ -799,7 +799,7 @@ func TestCleanupInvalidVolumeMounts(t *testing.T) {
 
 func TestDefaultWorkerPodTemplateWithName(t *testing.T) {
 	cluster := instance.DeepCopy()
-	fqdnRayIP := utils.GenerateFQDNServiceName(cluster.Name, cluster.Namespace)
+	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	worker.Template.ObjectMeta.Name = "ray-worker-test"
 	podName := cluster.Name + DashSymbol + string(rayv1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
@@ -851,7 +851,7 @@ func TestDefaultWorkerPodTemplateWithConfigurablePorts(t *testing.T) {
 	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Ports = []v1.ContainerPort{}
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	podName := cluster.Name + DashSymbol + string(rayv1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
-	fqdnRayIP := utils.GenerateFQDNServiceName(cluster.Name, cluster.Namespace)
+	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	podTemplateSpec := DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	// DefaultWorkerPodTemplate will add the default metrics port if user doesn't specify it.
 	// Verify the default metrics port exists.
@@ -874,7 +874,7 @@ func TestDefaultWorkerPodTemplateWithConfigurablePorts(t *testing.T) {
 func TestDefaultInitContainer(t *testing.T) {
 	// A default init container to check the health of GCS is expected to be added.
 	cluster := instance.DeepCopy()
-	fqdnRayIP := utils.GenerateFQDNServiceName(cluster.Name, cluster.Namespace)
+	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	podName := cluster.Name + DashSymbol + string(rayv1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
 	expectedResult := len(cluster.Spec.WorkerGroupSpecs[0].Template.Spec.InitContainers) + 1
@@ -908,7 +908,7 @@ func TestDefaultInitContainer(t *testing.T) {
 
 func TestDefaultInitContainerImagePullPolicy(t *testing.T) {
 	cluster := instance.DeepCopy()
-	fqdnRayIP := utils.GenerateFQDNServiceName(cluster.Name, cluster.Namespace)
+	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	podName := cluster.Name + DashSymbol + string(rayv1alpha1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
 

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -51,7 +51,10 @@ func BuildServiceForHeadPod(cluster rayv1alpha1.RayCluster, labels map[string]st
 		annotations = make(map[string]string)
 	}
 
-	default_name := utils.GenerateServiceName(cluster.Name)
+	default_name, err := utils.GenerateHeadServiceName(utils.RayClusterCRD, cluster.Spec, cluster.Name)
+	if err != nil {
+		return nil, err
+	}
 	default_namespace := cluster.Namespace
 	default_type := cluster.Spec.HeadGroupSpec.ServiceType
 
@@ -132,7 +135,12 @@ func BuildHeadServiceForRayService(rayService rayv1alpha1.RayService, rayCluster
 		return nil, err
 	}
 
-	service.ObjectMeta.Name = utils.GenerateServiceName(rayService.Name)
+	headSvcName, err := utils.GenerateHeadServiceName(utils.RayServiceCRD, rayService.Spec.RayClusterSpec, rayService.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	service.ObjectMeta.Name = headSvcName
 	service.ObjectMeta.Namespace = rayService.Namespace
 	service.ObjectMeta.Labels = map[string]string{
 		RayServiceLabelKey:  rayService.Name,

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -754,8 +754,8 @@ func (r *RayClusterReconciler) createWorkerPod(ctx context.Context, instance ray
 // Build head instance pod(s).
 func (r *RayClusterReconciler) buildHeadPod(instance rayv1alpha1.RayCluster) corev1.Pod {
 	podName := strings.ToLower(instance.Name + common.DashSymbol + string(rayv1alpha1.HeadNode) + common.DashSymbol)
-	podName = utils.CheckName(podName)                                            // making sure the name is valid
-	fqdnRayIP := utils.GenerateFQDNServiceName(instance.Name, instance.Namespace) // Fully Qualified Domain Name
+	podName = utils.CheckName(podName)                                       // making sure the name is valid
+	fqdnRayIP := utils.GenerateFQDNServiceName(instance, instance.Namespace) // Fully Qualified Domain Name
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
 	autoscalingEnabled := instance.Spec.EnableInTreeAutoscaling
@@ -787,8 +787,8 @@ func getCreator(instance rayv1alpha1.RayCluster) string {
 // Build worker instance pods.
 func (r *RayClusterReconciler) buildWorkerPod(instance rayv1alpha1.RayCluster, worker rayv1alpha1.WorkerGroupSpec) corev1.Pod {
 	podName := strings.ToLower(instance.Name + common.DashSymbol + string(rayv1alpha1.WorkerNode) + common.DashSymbol + worker.GroupName + common.DashSymbol)
-	podName = utils.CheckName(podName)                                            // making sure the name is valid
-	fqdnRayIP := utils.GenerateFQDNServiceName(instance.Name, instance.Namespace) // Fully Qualified Domain Name
+	podName = utils.CheckName(podName)                                       // making sure the name is valid
+	fqdnRayIP := utils.GenerateFQDNServiceName(instance, instance.Namespace) // Fully Qualified Domain Name
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
 	autoscalingEnabled := instance.Spec.EnableInTreeAutoscaling

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -789,6 +789,7 @@ func (r *RayClusterReconciler) buildWorkerPod(instance rayv1alpha1.RayCluster, w
 	podName := strings.ToLower(instance.Name + common.DashSymbol + string(rayv1alpha1.WorkerNode) + common.DashSymbol + worker.GroupName + common.DashSymbol)
 	podName = utils.CheckName(podName)                                       // making sure the name is valid
 	fqdnRayIP := utils.GenerateFQDNServiceName(instance, instance.Namespace) // Fully Qualified Domain Name
+
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
 	autoscalingEnabled := instance.Spec.EnableInTreeAutoscaling

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -331,8 +331,10 @@ applications:
 
 		It("should create a new head service resource", func() {
 			svc := &corev1.Service{}
+			headSvcName, err := utils.GenerateHeadServiceName(utils.RayServiceCRD, myRayService.Spec.RayClusterSpec, myRayService.Name)
+			Expect(err).To(BeNil(), "failed to generate head service name")
 			Eventually(
-				getResourceFunc(ctx, client.ObjectKey{Name: utils.GenerateServiceName(myRayService.Name), Namespace: "default"}, svc),
+				getResourceFunc(ctx, client.ObjectKey{Name: headSvcName, Namespace: "default"}, svc),
 				time.Second*15, time.Millisecond*500).Should(BeNil(), "My head service = %v", svc)
 			Expect(svc.Spec.Selector[common.RayIDLabelKey]).Should(Equal(utils.GenerateIdentifier(myRayCluster.Name, rayv1alpha1.HeadNode)))
 		})

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -391,9 +391,12 @@ func TestFetchHeadServiceURL(t *testing.T) {
 			Namespace: namespace,
 		},
 	}
+
+	headSvcName, err := utils.GenerateHeadServiceName(utils.RayClusterCRD, cluster.Spec, cluster.Name)
+	assert.Nil(t, err, "Fail to generate head service name")
 	headSvc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      utils.GenerateServiceName(cluster.Name),
+			Name:      headSvcName,
 			Namespace: cluster.ObjectMeta.Namespace,
 		},
 		Spec: corev1.ServiceSpec{

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -69,6 +69,9 @@ type RayDashboardClient struct {
 func FetchHeadServiceURL(ctx context.Context, log *logr.Logger, cli client.Client, rayCluster *rayv1alpha1.RayCluster, defaultPortName string) (string, error) {
 	headSvc := &corev1.Service{}
 	headSvcName := GenerateServiceName(rayCluster.Name)
+	if rayCluster.Spec.HeadGroupSpec.HeadService != nil && rayCluster.Spec.HeadGroupSpec.HeadService.Name != "" {
+		headSvcName = rayCluster.Spec.HeadGroupSpec.HeadService.Name
+	}
 	if err := cli.Get(ctx, client.ObjectKey{Name: headSvcName, Namespace: rayCluster.Namespace}, headSvc); err != nil {
 		if errors.IsNotFound(err) {
 			log.Error(err, "Head service is not found", "head service name", headSvcName, "namespace", rayCluster.Namespace)

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -68,11 +68,13 @@ type RayDashboardClient struct {
 // and the port with the given port name (defaultPortName).
 func FetchHeadServiceURL(ctx context.Context, log *logr.Logger, cli client.Client, rayCluster *rayv1alpha1.RayCluster, defaultPortName string) (string, error) {
 	headSvc := &corev1.Service{}
-	headSvcName := GenerateServiceName(rayCluster.Name)
-	if rayCluster.Spec.HeadGroupSpec.HeadService != nil && rayCluster.Spec.HeadGroupSpec.HeadService.Name != "" {
-		headSvcName = rayCluster.Spec.HeadGroupSpec.HeadService.Name
+	headSvcName, err := GenerateHeadServiceName(RayClusterCRD, rayCluster.Spec, rayCluster.Name)
+	if err != nil {
+		log.Error(err, "Failed to generate head service name", "RayCluster name", rayCluster.Name, "RayCluster spec", rayCluster.Spec)
+		return "", err
 	}
-	if err := cli.Get(ctx, client.ObjectKey{Name: headSvcName, Namespace: rayCluster.Namespace}, headSvc); err != nil {
+
+	if err = cli.Get(ctx, client.ObjectKey{Name: headSvcName, Namespace: rayCluster.Namespace}, headSvc); err != nil {
 		if errors.IsNotFound(err) {
 			log.Error(err, "Head service is not found", "head service name", headSvcName, "namespace", rayCluster.Namespace)
 		}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -135,8 +135,12 @@ func GenerateServiceName(clusterName string) string {
 }
 
 // GenerateFQDNServiceName generates a Fully Qualified Domain Name.
-func GenerateFQDNServiceName(clusterName string, namespace string) string {
-	return fmt.Sprintf("%s.%s.svc.%s", GenerateServiceName(clusterName), namespace, GetClusterDomainName())
+func GenerateFQDNServiceName(cluster rayv1alpha1.RayCluster, namespace string) string {
+	headSvcName := GenerateServiceName(cluster.Name)
+	if cluster.Spec.HeadGroupSpec.HeadService != nil && cluster.Spec.HeadGroupSpec.HeadService.Name != "" {
+		headSvcName = cluster.Spec.HeadGroupSpec.HeadService.Name
+	}
+	return fmt.Sprintf("%s.%s.svc.%s", headSvcName, namespace, GetClusterDomainName())
 }
 
 // ExtractRayIPFromFQDN extracts the head service name (i.e., RAY_IP, deprecated) from a fully qualified

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -171,9 +171,6 @@ func GenerateFQDNServiceName(cluster rayv1alpha1.RayCluster, namespace string) s
 		logrus.Errorf("Failed to generate head service name: %v", err)
 		return ""
 	}
-	if cluster.Spec.HeadGroupSpec.HeadService != nil && cluster.Spec.HeadGroupSpec.HeadService.Name != "" {
-		headSvcName = cluster.Spec.HeadGroupSpec.HeadService.Name
-	}
 	return fmt.Sprintf("%s.%s.svc.%s", headSvcName, namespace, GetClusterDomainName())
 }
 

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -32,6 +32,7 @@ const (
 	DefaultDomainName   = "cluster.local"
 )
 
+// TODO (kevin85421): Define CRDType here rather than constant.go to avoid circular dependency.
 type CRDType string
 
 const (
@@ -137,7 +138,17 @@ func GetNamespace(metaData metav1.ObjectMeta) string {
 	return metaData.Namespace
 }
 
-// GenerateHeadServiceName generates a Ray head service name for both RayCluster and RayService.
+// GenerateHeadServiceName generates a Ray head service name. Note that there are two types of head services:
+//
+// (1) For RayCluster: If `HeadService.Name` in the cluster spec is not empty, it will be used as the head service name.
+// Otherwise, the name is generated based on the RayCluster CR's name.
+// (2) For RayService: It's important to note that the RayService CR not only possesses a head service owned by its RayCluster CR
+// but also maintains a separate head service for itself to facilitate zero-downtime upgrades. The name of the head service owned
+// by the RayService CR is generated based on the RayService CR's name.
+//
+// @param crdType: The type of the CRD that owns the head service.
+// @param clusterSpec: `RayClusterSpec`
+// @param ownerName: The name of the CR that owns the head service.
 func GenerateHeadServiceName(crdType CRDType, clusterSpec rayv1alpha1.RayClusterSpec, ownerName string) (string, error) {
 	switch crdType {
 	case RayServiceCRD:

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -459,4 +459,8 @@ func TestGenerateHeadServiceName(t *testing.T) {
 	headSvcName, err = GenerateHeadServiceName(RayServiceCRD, *clusterSpecWithHeadService.DeepCopy(), "rayservice-sample")
 	assert.Nil(t, err)
 	assert.Equal(t, headSvcName, expectedGeneratedSvcName)
+
+	// Invalid CRD type
+	_, err = GenerateHeadServiceName(RayJobCRD, rayv1alpha1.RayClusterSpec{}, "rayjob-sample")
+	assert.NotNil(t, err)
 }

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -9,6 +9,7 @@ import (
 
 	rayv1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestGetClusterDomainName(t *testing.T) {
@@ -414,4 +415,48 @@ func TestFindContainerPort(t *testing.T) {
 	assert.NotEqual(t, port, -1, "expect port2 found")
 	port = FindContainerPort(&container, "port3", -1)
 	assert.Equal(t, port, -1, "expect port3 not found")
+}
+
+func TestGenerateHeadServiceName(t *testing.T) {
+	// GenerateHeadServiceName generates a Ray head service name. Note that there are two types of head services:
+	//
+	// (1) For RayCluster: If `HeadService.Name` in the cluster spec is not empty, it will be used as the head service name.
+	// Otherwise, the name is generated based on the RayCluster CR's name.
+	// (2) For RayService: It's important to note that the RayService CR not only possesses a head service owned by its RayCluster CR
+	// but also maintains a separate head service for itself to facilitate zero-downtime upgrades. The name of the head service owned
+	// by the RayService CR is generated based on the RayService CR's name.
+
+	// [RayCluster]
+	// Test 1: `HeadService.Name` is empty.
+	headSvcName, err := GenerateHeadServiceName(RayClusterCRD, rayv1alpha1.RayClusterSpec{}, "raycluster-sample")
+	expectedGeneratedSvcName := "raycluster-sample-head-svc"
+	assert.Nil(t, err)
+	assert.Equal(t, headSvcName, expectedGeneratedSvcName)
+
+	// Test 2: `HeadService.Name` is not empty.
+	clusterSpecWithHeadService := rayv1alpha1.RayClusterSpec{
+		HeadGroupSpec: rayv1alpha1.HeadGroupSpec{
+			HeadService: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-head-svc",
+				},
+			},
+		},
+	}
+
+	headSvcName, err = GenerateHeadServiceName(RayClusterCRD, *clusterSpecWithHeadService.DeepCopy(), "raycluster-sample")
+	assert.Nil(t, err)
+	assert.Equal(t, headSvcName, "my-head-svc")
+
+	// [RayService]
+	// Test 3: `HeadService.Name` is empty.
+	headSvcName, err = GenerateHeadServiceName(RayServiceCRD, rayv1alpha1.RayClusterSpec{}, "rayservice-sample")
+	expectedGeneratedSvcName = "rayservice-sample-head-svc"
+	assert.Nil(t, err)
+	assert.Equal(t, headSvcName, expectedGeneratedSvcName)
+
+	// Test 4: `HeadService.Name` is not empty.
+	headSvcName, err = GenerateHeadServiceName(RayServiceCRD, *clusterSpecWithHeadService.DeepCopy(), "rayservice-sample")
+	assert.Nil(t, err)
+	assert.Equal(t, headSvcName, expectedGeneratedSvcName)
 }

--- a/tests/test_sample_rayjob_yamls.py
+++ b/tests/test_sample_rayjob_yamls.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 if __name__ == '__main__':
     NAMESPACE = 'default'
     SAMPLE_PATH = CONST.REPO_ROOT.joinpath("ray-operator/config/samples/")
-    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml']
+    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml', 'ray-job.custom-head-svc.yaml']
 
     sample_yaml_files = []
     for filename in YAMLs:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As @mmourafiq pointed out in https://github.com/ray-project/kuberay/pull/1326#issuecomment-1678476425, some users prefer a deterministic head service name for RayJob in order to set up a reverse proxy. Although we've made the entire head service configurable, there are some issues that arise when we set the name of the head service:

* Kubernetes Jobs cannot communicate with the Ray head because of an incorrect service name.
* Ray workers fail to connect to the Ray head due to the same naming issue.

## Related issue number

Closes #1294 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
# Step 0: Build a KubeRay operator image
# Step 1: Install a KubeRay operator
helm install kuberay-operator kuberay/kuberay-operator --version 0.6.0 --set image.repository=controller,image.tag=latest

# Step 2: Create a RayJob with custom head service
# https://gist.github.com/kevin85421/b8e0259467ffdb1b000c4177159f57e9#file-ray-job-custom-head-svc-name-yaml
kubectl apply -f ray-job-custom-head-svc-name.yaml

# Step 3: Check RayJob's status
kubectl get rayjobs.ray.io rayjob-sample -o=jsonpath='{.status.jobStatus}'
# [expected output]: "SUCCEEDED"
```
