### PR TITLE
Bump the golangci-lint version in the api server makefile

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -122,7 +122,7 @@ KIND ?= $(REPO_ROOT_BIN)/kind
 KUSTOMIZE_VERSION ?= v3.8.7
 GOFUMPT_VERSION ?= v0.3.1
 GOIMPORTS_VERSION ?= latest
-GOLANGCI_LINT_VERSION ?= v1.50.1
+GOLANGCI_LINT_VERSION ?= v1.54.1
 KIND_VERSION ?= v0.19.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -597,8 +597,8 @@ func NewComputeTemplate(runtime *api.ComputeTemplate) (*v1.ConfigMap, error) {
 func GetNodeHostIP(node *v1.Node) (net.IP, error) {
 	addresses := node.Status.Addresses
 	addressMap := make(map[v1.NodeAddressType][]v1.NodeAddress)
-	for i := range addresses {
-		addressMap[addresses[i].Type] = append(addressMap[addresses[i].Type], addresses[i])
+	for _, nodeAddress := range addresses {
+		addressMap[nodeAddress.Type] = append(addressMap[nodeAddress.Type], nodeAddress)
 	}
 	if addresses, ok := addressMap[v1.NodeInternalIP]; ok {
 		return net.ParseIP(addresses[0].Address), nil


### PR DESCRIPTION
## Why are these changes needed?
The version of `golangci-lint` used in the KubeRay api server hangs when used with higher versions of golang (1.20+). This is related [to this issue](https://github.com/golangci/golangci-lint/issues/3420)

## Related issue number
Closes #1334

## Checks

- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
