### PR TITLE
[Feature] Allow RayCluster Helm chart to specify different images for different worker groups

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -48,8 +48,13 @@ spec:
         containers:
           - volumeMounts: {{- toYaml .Values.head.volumeMounts | nindent 12 }}
             name: ray-head
+            {{- if .Values.head.image.repository }}
+            image: {{ .Values.head.image.repository }}:{{ .Values.head.image.tag }}
+            imagePullPolicy: {{ .Values.head.image.pullPolicy }}
+            {{- else }}
             image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
             imagePullPolicy: {{ .Values.image.pullPolicy }}
+            {{- end }}
             resources: {{- toYaml .Values.head.resources | nindent 14 }}
             securityContext:
             {{- toYaml .Values.head.securityContext | nindent 14 }}
@@ -120,8 +125,13 @@ spec:
         containers:
           - volumeMounts: {{- toYaml $values.volumeMounts | nindent 12 }}
             name: ray-worker
-            image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
-            imagePullPolicy: {{ $.Values.image.pullPolicy }}
+            {{- if $values.image.repository }}
+            image: {{ $values.image.repository }}:{{ $values.image.tag }}
+            imagePullPolicy: {{ $values.image.pullPolicy }}
+            {{- else }}
+            image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            {{- end }}
             resources: {{- toYaml $values.resources | nindent 14 }}
             securityContext:
             {{- toYaml $values.securityContext | nindent 14 }}
@@ -190,8 +200,13 @@ spec:
         containers:
           - volumeMounts: {{- toYaml .Values.worker.volumeMounts | nindent 12 }}
             name: ray-worker
+            {{- if .Values.worker.image.repository }}
+            image: {{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}
+            imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+            {{- else }}
             image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
             imagePullPolicy: {{ .Values.image.pullPolicy }}
+            {{- end }}
             resources: {{- toYaml .Values.worker.resources | nindent 14 }}
             securityContext:
             {{- toYaml .Values.worker.securityContext | nindent 14 }}

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -48,7 +48,7 @@ spec:
         containers:
           - volumeMounts: {{- toYaml .Values.head.volumeMounts | nindent 12 }}
             name: ray-head
-            {{- if .Values.head.image.repository }}
+            {{- if .Values.head.image }}
             image: {{ .Values.head.image.repository }}:{{ .Values.head.image.tag }}
             imagePullPolicy: {{ .Values.head.image.pullPolicy }}
             {{- else }}
@@ -125,7 +125,7 @@ spec:
         containers:
           - volumeMounts: {{- toYaml $values.volumeMounts | nindent 12 }}
             name: ray-worker
-            {{- if $values.image.repository }}
+            {{- if $values.image }}
             image: {{ $values.image.repository }}:{{ $values.image.tag }}
             imagePullPolicy: {{ $values.image.pullPolicy }}
             {{- else }}
@@ -200,7 +200,7 @@ spec:
         containers:
           - volumeMounts: {{- toYaml .Values.worker.volumeMounts | nindent 12 }}
             name: ray-worker
-            {{- if .Values.worker.image.repository }}
+            {{- if .Values.worker.image }}
             image: {{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}
             imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
             {{- else }}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Prior to this pull request, the RayCluster Helm chart had uniform default images for various worker groups. This PR introduces a new feature that empowers users to designate distinct images for both worker groups and the head Pod. To ensure backward compatibility, the PR verifies if the "image" section is defined for each Pod. If an image isn't specified in values.yaml, the Pod's image defaults to the option provided at the outset of values.yaml.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #1291

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

## Test 1:
(Link to [values.yaml](https://gist.github.com/Darren221/471b253cf0297aa96340a94a306396d6) for test 1) 

```shell
helm install kuberay-operator kuberay/kuberay-operator --version 0.6.0

# Create a RayCluster with 1 head, 1 worker, and 2 worker groups (smallgroup 1 & 2)
# In values.yaml, specify the images for head, worker, and different worker groups
helm install ray-cluster kuberay/helm-chart/ray-cluster --version 0.6.0 -f kuberay/helm-chart/ray-cluster/values.yaml

# Describe the Pod to check its image
# [Expected result]: each Pod has the same image as what was specified (shown in the attached screenshots)
kubectl describe pod $PodName
```
<img width="1118" alt="head_Pod" src="https://github.com/ray-project/kuberay/assets/47858999/3334913e-bed0-4e01-a3ce-d52014d9838b">
<img width="972" alt="smallgroup1" src="https://github.com/ray-project/kuberay/assets/47858999/df5e40d9-b554-46df-b2d4-3e933ec9f02f">
<img width="968" alt="smallgroup2" src="https://github.com/ray-project/kuberay/assets/47858999/91f536b1-9df4-48bf-8891-4e79904191d8">
<img width="971" alt="worker" src="https://github.com/ray-project/kuberay/assets/47858999/5a75101c-76dc-4c4c-a61e-d6461031e183">

## Test 2:
(Link to [values.yaml](https://gist.github.com/Darren221/edbecbad98caece0a6deebf036b611d4) for test 2)

```shell
helm install kuberay-operator kuberay/kuberay-operator --version 0.6.0

# Create a RayCluster with 1 head, 1 worker, and 2 worker groups (smallgroup 1 & 2)
# In values.yaml, specify the images for worker, and different worker groups. 
# However, in Test 2, the image for head wasn't specified, and the image repository was missed when specifying the image for the worker Pod (to test backward compatibility and error handling).
helm install ray-cluster kuberay/helm-chart/ray-cluster --version 0.6.0 -f kuberay/helm-chart/ray-cluster/values.yaml

# Describe the Pod to check its image
# [Expected result]: 
# The image for the head was the same as the default option since it was not specified in values.yaml. 
# Additionally, an error (InvalidImageName) appeared in the worker Pod's description due to a missed image repository specification. This was done to alert the user. 
# Apart from these points, the images for other Pods matched those of Test 1, in line with what was defined in values.yaml.
kubectl describe pod $PodName
```
<img width="1119" alt="head_Pod(default)" src="https://github.com/ray-project/kuberay/assets/47858999/b2d45130-dd5f-46f3-a203-da30d9c9903d">
<img width="1460" alt="InvalidImageName" src="https://github.com/ray-project/kuberay/assets/47858999/7f256631-83ee-4dab-ada3-25ad19a52308">

