### PR TITLE
Add field to expose entrypoint num cpus in rayjob

### DIFF
--- a/docs/guidance/rayjob.md
+++ b/docs/guidance/rayjob.md
@@ -59,7 +59,10 @@ $ kubectl get pod
 * `ttlSecondsAfterFinished` - _(Optional)_ TTL to clean up the cluster. This only works if `shutdownAfterJobFinishes` is set.
 * `submitterPodTemplate` - _(Optional)_ Pod template spec for the pod that runs `ray job submit` against the Ray cluster.
 * `runtimeEnv` - [DEPRECATED] _(Optional)_ base64-encoded string of the runtime env json string.
-
+* `entrypointNumCpus` - _(Optional)_ Specifies the quantity of CPU cores to reserve for the entrypoint command.
+* `entrypointNumGpus` - _(Optional)_ Specifies the number of GPUs to reserve for the entrypoint command.
+* `entrypointResources` - _(Optional)_ A json formatted dictionary to specify custom resources and their quantity.
+  
 ## RayJob Observability
 
 You can use `kubectl logs` to check the operator logs or the head/worker nodes logs.

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -12101,6 +12101,22 @@ spec:
                 description: ShutdownAfterJobFinishes will determine whether to delete
                   the ray cluster once rayJob succeed or fai
                 type: boolean
+              entrypointNumCpus:
+                description: EntrypointNumCpus specifies the number of cpus to reserve for
+                  the entrypoint command.
+                  oneOf:
+                    - type: integer
+                    - type: number
+              entrypointNumGpus:
+                description: EntrypointNumGpus specifies the number of gpus to reserve for
+                  the entrypoint command.
+                  oneOf:
+                    - type: integer
+                    - type: number
+              entrypointResources:
+                description: EntrypointResources specifies the custom resources and their
+                  quantities as a json formatted dictionary string.
+                type: string
               submitterPodTemplate:
                 description: SubmitterPodTemplate is the template for the pod that
                   will run `ray job submit`.

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -44,6 +44,18 @@ spec:
                 description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
                   Important: Run "make" to regenerate code af'
                 type: string
+              entrypointNumCpus:
+                description: EntrypointNumCpus specifies the number of cpus to reserve
+                  for the entrypoint command.
+                type: number
+              entrypointNumGpus:
+                description: EntrypointNumGpus specifies the number of gpus to reserve
+                  for the entrypoint command.
+                type: number
+              entrypointResources:
+                description: EntrypointResources specifies the custom resources and
+                  quantities to reserve for the entrypoint comm
+                type: string
               jobId:
                 description: If jobId is not set, a new jobId will be auto-generated.
                 type: string
@@ -12101,18 +12113,6 @@ spec:
                 description: ShutdownAfterJobFinishes will determine whether to delete
                   the ray cluster once rayJob succeed or fai
                 type: boolean
-              entrypointNumCpus:
-                description: EntrypointNumCpus specifies the number of cpus to reserve for
-                  the entrypoint command.
-                type: number
-              entrypointNumGpus:
-                description: EntrypointNumGpus specifies the number of gpus to reserve for
-                  the entrypoint command.
-                type: number
-              entrypointResources:
-                description: EntrypointResources specifies the custom resources and their
-                  quantities as a json formatted dictionary string.
-                type: string
               submitterPodTemplate:
                 description: SubmitterPodTemplate is the template for the pod that
                   will run `ray job submit`.
@@ -17428,4 +17428,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-  

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -12104,15 +12104,11 @@ spec:
               entrypointNumCpus:
                 description: EntrypointNumCpus specifies the number of cpus to reserve for
                   the entrypoint command.
-                  oneOf:
-                    - type: integer
-                    - type: number
+                type: number
               entrypointNumGpus:
                 description: EntrypointNumGpus specifies the number of gpus to reserve for
                   the entrypoint command.
-                  oneOf:
-                    - type: integer
-                    - type: number
+                type: number
               entrypointResources:
                 description: EntrypointResources specifies the custom resources and their
                   quantities as a json formatted dictionary string.
@@ -17432,3 +17428,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+  

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -76,6 +76,13 @@ type RayJobSpec struct {
 	Suspend bool `json:"suspend,omitempty"`
 	// SubmitterPodTemplate is the template for the pod that will run `ray job submit`.
 	SubmitterPodTemplate *v1.PodTemplateSpec `json:"submitterPodTemplate,omitempty"`
+	// EntrypointNumCpus specifies the number of cpus to reserve for the entrypoint command.
+	EntrypointNumCpus float32 `json:"entrypointNumCpus,omitempty"`
+	// EntrypointNumGpus specifies the number of gpus to reserve for the entrypoint command.
+	EntrypointNumGpus float32 `json:"entrypointNumGpus,omitempty"`
+	// EntrypointResources specifies the custom resources and quantities to reserve for the
+	// entrypoint command.
+	EntrypointResources string `json:"entrypointResources,omitempty"`
 }
 
 // RayJobStatus defines the observed state of RayJob

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -44,6 +44,18 @@ spec:
                 description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
                   Important: Run "make" to regenerate code af'
                 type: string
+              entrypointNumCpus:
+                description: EntrypointNumCpus specifies the number of cpus to reserve
+                  for the entrypoint command.
+                type: number
+              entrypointNumGpus:
+                description: EntrypointNumGpus specifies the number of gpus to reserve
+                  for the entrypoint command.
+                type: number
+              entrypointResources:
+                description: EntrypointResources specifies the custom resources and
+                  quantities to reserve for the entrypoint comm
+                type: string
               jobId:
                 description: If jobId is not set, a new jobId will be auto-generated.
                 type: string

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.resources.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.resources.yaml
@@ -41,6 +41,7 @@ spec:
         num-cpus: "3"
         num-gpus: "2"
         resources: '"{\"resource1\": 2, \"resource2\": 3}"'
+        
       #pod template
       template:
         spec:
@@ -55,8 +56,6 @@ spec:
                 - containerPort: 10001
                   name: client
               resources:
-                limits:
-                  cpu: "1"
                 requests:
                   cpu: "200m"
               volumeMounts:
@@ -94,8 +93,6 @@ spec:
                     exec:
                       command: [ "/bin/sh","-c","ray stop" ]
                 resources:
-                  limits:
-                    cpu: "1"
                   requests:
                     cpu: "200m"
   # SubmitterPodTemplate is the template for the pod that will run the `ray job submit` command against the RayCluster.
@@ -122,30 +119,17 @@ metadata:
 data:
   sample_code.py: |
     import ray
-    import os
-    import requests
 
     ray.init()
 
-    @ray.remote
-    class Counter:
-        def __init__(self):
-            # Used to verify runtimeEnv
-            self.name = os.getenv("counter_name")
-            assert self.name == "test_counter"
-            self.counter = 0
+    available = ray.available_resources()
+    total = ray.cluster_resources()
 
-        def inc(self):
-            self.counter += 1
+    assert total['CPU'] - available['CPU'] == 2, "Incorrect CPU assignment"
+    assert total['GPU'] - available['GPU'] == 0.5, "Incorrect GPU assignment"
+    assert total['resource1'] - available['resource1'] == 1.0, "Incorrect Resource1 assignment"
+    assert total['resource2'] - available['resource2'] == 2.0, "Incorrect Resource2 assignment"
+  
+    print(ray.cluster_resources())
 
-        def get_counter(self):
-            return "{} got {}".format(self.name, self.counter)
-
-    counter = Counter.remote()
-
-    for _ in range(5):
-        ray.get(counter.inc.remote())
-        print(ray.get(counter.get_counter.remote()))
-
-    # Verify that the correct runtime env was used for the job.
-    assert requests.__version__ == "2.26.0"
+     

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.resources.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.resources.yaml
@@ -129,7 +129,3 @@ data:
     assert total['GPU'] - available['GPU'] == 0.5, "Incorrect GPU assignment"
     assert total['resource1'] - available['resource1'] == 1.0, "Incorrect Resource1 assignment"
     assert total['resource2'] - available['resource2'] == 2.0, "Incorrect Resource2 assignment"
-  
-    print(ray.cluster_resources())
-
-     

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -19,9 +19,6 @@ spec:
       - pendulum==2.1.2
     env_vars:
       counter_name: "test_counter"
-  entrypointNumCpus: 2
-  entrypointNumGpus: 0.5
-  entrypointResources: "{\"resource1\": 1, \"resource2\": 2}"
 
   # Suspend specifies whether the RayJob controller should create a RayCluster instance.
   # If a job is applied with the suspend field set to true, the RayCluster will not be created and we will wait for the transition to false.
@@ -38,9 +35,6 @@ spec:
       # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
       rayStartParams:
         dashboard-host: '0.0.0.0'
-        num-cpus: "3"
-        num-gpus: "2"
-        resources: '"{\"resource1\": 2, \"resource2\": 3}"'
       #pod template
       template:
         spec:

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -18,7 +18,8 @@ spec:
       - requests==2.26.0
       - pendulum==2.1.2
     env_vars:
-      counter_name: "test_counter"  
+      counter_name: "test_counter" 
+  entrypointNumCpus: 1 
       
   # Suspend specifies whether the RayJob controller should create a RayCluster instance.
   # If a job is applied with the suspend field set to true, the RayCluster will not be created and we will wait for the transition to false.

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -19,7 +19,6 @@ spec:
       - pendulum==2.1.2
     env_vars:
       counter_name: "test_counter" 
-  entrypointNumCpus: 1 
       
   # Suspend specifies whether the RayJob controller should create a RayCluster instance.
   # If a job is applied with the suspend field set to true, the RayCluster will not be created and we will wait for the transition to false.

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -18,9 +18,9 @@ spec:
       - requests==2.26.0
       - pendulum==2.1.2
     env_vars:
-      counter_name: "test_counter" 
-         
-  # Suspend specifies whether the RayJob coSntroller should create a RayCluster instance.
+      counter_name: "test_counter"
+
+  # Suspend specifies whether the RayJob controller should create a RayCluster instance.
   # If a job is applied with the suspend field set to true, the RayCluster will not be created and we will wait for the transition to false.
   # If the RayCluster is already created, it will be deleted. In the case of transition to false, a new RayCluste rwill be created.
   # suspend: false

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -85,6 +85,9 @@ func GetK8sJobCommand(rayJobInstance *rayv1alpha1.RayJob) ([]string, error) {
 	metadata := rayJobInstance.Spec.Metadata
 	jobId := rayJobInstance.Status.JobId
 	entrypoint := rayJobInstance.Spec.Entrypoint
+	entrypointNumCpus := rayJobInstance.Spec.EntrypointNumCpus
+	entrypointNumGpus := rayJobInstance.Spec.EntrypointNumGpus
+	entrypointResources := rayJobInstance.Spec.EntrypointResources
 
 	k8sJobCommand := GetBaseRayJobCommand(address)
 
@@ -106,6 +109,18 @@ func GetK8sJobCommand(rayJobInstance *rayv1alpha1.RayJob) ([]string, error) {
 
 	if len(jobId) > 0 {
 		k8sJobCommand = append(k8sJobCommand, "--submission-id", jobId)
+	}
+
+	if entrypointNumCpus > 0 {
+		k8sJobCommand = append(k8sJobCommand, "--entrypoint_num_cpus", fmt.Sprintf("%f", entrypointNumCpus))
+	}
+
+	if entrypointNumGpus > 0 {
+		k8sJobCommand = append(k8sJobCommand, "--entrypoint_num_gpus", fmt.Sprintf("%f", entrypointNumGpus))
+	}
+
+	if len(entrypointResources) > 0 {
+		k8sJobCommand = append(k8sJobCommand, "--entrypoint_resources", entrypointResources)
 	}
 
 	// "--" is used to separate the entrypoint from the Ray Job CLI command and its arguments.

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -112,15 +112,15 @@ func GetK8sJobCommand(rayJobInstance *rayv1alpha1.RayJob) ([]string, error) {
 	}
 
 	if entrypointNumCpus > 0 {
-		k8sJobCommand = append(k8sJobCommand, "--entrypoint_num_cpus", fmt.Sprintf("%f", entrypointNumCpus))
+		k8sJobCommand = append(k8sJobCommand, "--entrypoint-num-cpus", fmt.Sprintf("%f", entrypointNumCpus))
 	}
 
 	if entrypointNumGpus > 0 {
-		k8sJobCommand = append(k8sJobCommand, "--entrypoint_num_gpus", fmt.Sprintf("%f", entrypointNumGpus))
+		k8sJobCommand = append(k8sJobCommand, "--entrypoint-num-gpus", fmt.Sprintf("%f", entrypointNumGpus))
 	}
 
 	if len(entrypointResources) > 0 {
-		k8sJobCommand = append(k8sJobCommand, "--entrypoint_resources", entrypointResources)
+		k8sJobCommand = append(k8sJobCommand, "--entrypoint-resources", entrypointResources)
 	}
 
 	// "--" is used to separate the entrypoint from the Ray Job CLI command and its arguments.

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -96,9 +96,9 @@ func TestGetK8sJobCommand(t *testing.T) {
 		"--runtime-env-json", `{"test":"test"}`,
 		"--metadata-json", `{"testKey":"testValue"}`,
 		"--submission-id", "testJobId",
-		"--entrypoint_num_cpus", "1.000000",
-		"--entrypoint_num_gpus", "0.500000",
-		"--entrypoint_resources", `{"Custom_1": 1, "Custom_2": 5.5}`,
+		"--entrypoint-num-cpus", "1.000000",
+		"--entrypoint-num-gpus", "0.500000",
+		"--entrypoint-resources", `{"Custom_1": 1, "Custom_2": 5.5}`,
 		"--",
 		"echo", "hello",
 	}

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -17,7 +17,10 @@ var testRayJob = &rayv1alpha1.RayJob{
 		RayClusterSpec: &rayv1alpha1.RayClusterSpec{
 			RayVersion: "2.6.0",
 		},
-		Entrypoint: "echo hello",
+		Entrypoint:          "echo hello",
+		EntrypointNumCpus:   1,
+		EntrypointNumGpus:   0.5,
+		EntrypointResources: `{"Custom_1": 1, "Custom_2": 5.5}`,
 	},
 	Status: rayv1alpha1.RayJobStatus{
 		DashboardURL: "http://127.0.0.1:8265",
@@ -93,6 +96,9 @@ func TestGetK8sJobCommand(t *testing.T) {
 		"--runtime-env-json", `{"test":"test"}`,
 		"--metadata-json", `{"testKey":"testValue"}`,
 		"--submission-id", "testJobId",
+		"--entrypoint_num_cpus", "1.000000",
+		"--entrypoint_num_gpus", "0.500000",
+		"--entrypoint_resources", `{"Custom_1": 1, "Custom_2": 5.5}`,
 		"--",
 		"echo", "hello",
 	}

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -71,7 +71,7 @@ func NewRayJobReconciler(mgr manager.Manager) *RayJobReconciler {
 // Automatically generate RBAC rules to allow the Controller to read and write workloads
 // Reconcile used to bridge the desired state with the current state
 func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	r.Log.Info("reconciling RayJob World", "NamespacedName", request.NamespacedName)
+	r.Log.Info("reconciling RayJob", "NamespacedName", request.NamespacedName)
 
 	// Get RayJob instance
 	var err error
@@ -86,8 +86,6 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		r.Log.Error(err, "Failed to get RayJob")
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 	}
-
-	fmt.Printf("Hello : %v", rayJobInstance)
 
 	if rayJobInstance.ObjectMeta.DeletionTimestamp.IsZero() {
 		// The object is not being deleted, so if it does not have our finalizer,

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -71,7 +71,7 @@ func NewRayJobReconciler(mgr manager.Manager) *RayJobReconciler {
 // Automatically generate RBAC rules to allow the Controller to read and write workloads
 // Reconcile used to bridge the desired state with the current state
 func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	r.Log.Info("reconciling RayJob", "NamespacedName", request.NamespacedName)
+	r.Log.Info("reconciling RayJob World", "NamespacedName", request.NamespacedName)
 
 	// Get RayJob instance
 	var err error
@@ -86,6 +86,8 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		r.Log.Error(err, "Failed to get RayJob")
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 	}
+
+	fmt.Printf("Hello : %v", rayJobInstance)
 
 	if rayJobInstance.ObjectMeta.DeletionTimestamp.IsZero() {
 		// The object is not being deleted, so if it does not have our finalizer,

--- a/tests/test_sample_rayjob_yamls.py
+++ b/tests/test_sample_rayjob_yamls.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 if __name__ == '__main__':
     NAMESPACE = 'default'
     SAMPLE_PATH = CONST.REPO_ROOT.joinpath("ray-operator/config/samples/")
-    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml', 'ray-job.custom-head-svc.yaml']
+    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml', 'ray-job.custom-head-svc.yaml', 'ray_v1alpha1_rayjob.resources.yaml']
 
     sample_yaml_files = []
     for filename in YAMLs:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds the fields entrypoint_num_cpus, gpus, resources in Kuberay Rayjob spec. Ray Job API supports specification of these resources, but before this code change the Kuberay Job Spec did not expose these fields  

## Related issue number

Closes #1266

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
