### PR TITLE
[GCS FT] Give readiness / liveness probes good default values

### DIFF
--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -5,15 +5,14 @@ const (
 	// Default application name
 	DefaultServeAppName = "default"
 	// Belows used as label key
-	RayServiceLabelKey                 = "ray.io/service"
-	RayClusterLabelKey                 = "ray.io/cluster"
-	RayNodeTypeLabelKey                = "ray.io/node-type"
-	RayNodeGroupLabelKey               = "ray.io/group"
-	RayNodeLabelKey                    = "ray.io/is-ray-node"
-	RayIDLabelKey                      = "ray.io/identifier"
-	RayClusterDashboardServiceLabelKey = "ray.io/cluster-dashboard"
-	RayClusterServingServiceLabelKey   = "ray.io/serve"
-	RayServiceClusterHashKey           = "ray.io/cluster-hash"
+	RayServiceLabelKey               = "ray.io/service"
+	RayClusterLabelKey               = "ray.io/cluster"
+	RayNodeTypeLabelKey              = "ray.io/node-type"
+	RayNodeGroupLabelKey             = "ray.io/group"
+	RayNodeLabelKey                  = "ray.io/is-ray-node"
+	RayIDLabelKey                    = "ray.io/identifier"
+	RayClusterServingServiceLabelKey = "ray.io/serve"
+	RayServiceClusterHashKey         = "ray.io/cluster-hash"
 
 	// Batch scheduling labels
 	// TODO(tgaddair): consider making these part of the CRD
@@ -23,7 +22,6 @@ const (
 	// Ray GCS FT related annotations
 	RayFTEnabledAnnotationKey         = "ray.io/ft-enabled"
 	RayExternalStorageNSAnnotationKey = "ray.io/external-storage-namespace"
-	RayNodeHealthStateAnnotationKey   = "ray.io/health-state"
 
 	// Pod health state values
 	PodUnhealthy = "Unhealthy"
@@ -74,7 +72,6 @@ const (
 	PodReadyFilepath = "POD_READY_FILEPATH"
 
 	// Use as container env variable
-	NAMESPACE                               = "NAMESPACE"
 	RAY_CLUSTER_NAME                        = "RAY_CLUSTER_NAME"
 	RAY_IP                                  = "RAY_IP"
 	FQ_RAY_IP                               = "FQ_RAY_IP"
@@ -99,23 +96,22 @@ const (
 	ENABLE_RANDOM_POD_DELETE = "ENABLE_RANDOM_POD_DELETE"
 
 	// Ray core default configurations
-	DefaultRedisPassword                 = "5241590000000000"
 	DefaultWorkerRayGcsReconnectTimeoutS = "600"
 
 	LOCAL_HOST = "127.0.0.1"
 	// Ray FT default readiness probe values
 	DefaultReadinessProbeInitialDelaySeconds = 10
 	DefaultReadinessProbeTimeoutSeconds      = 1
-	DefaultReadinessProbePeriodSeconds       = 3
-	DefaultReadinessProbeSuccessThreshold    = 0
-	DefaultReadinessProbeFailureThreshold    = 20
+	DefaultReadinessProbePeriodSeconds       = 5
+	DefaultReadinessProbeSuccessThreshold    = 1
+	DefaultReadinessProbeFailureThreshold    = 10
 
 	// Ray FT default liveness probe values
-	DefaultLivenessProbeInitialDelaySeconds = 10
+	DefaultLivenessProbeInitialDelaySeconds = 30
 	DefaultLivenessProbeTimeoutSeconds      = 1
-	DefaultLivenessProbePeriodSeconds       = 3
-	DefaultLivenessProbeSuccessThreshold    = 0
-	DefaultLivenessProbeFailureThreshold    = 40
+	DefaultLivenessProbePeriodSeconds       = 5
+	DefaultLivenessProbeSuccessThreshold    = 1
+	DefaultLivenessProbeFailureThreshold    = 120
 
 	// Ray health check related configurations
 	RayAgentRayletHealthPath  = "api/local_raylet_healthz"

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -100,14 +100,14 @@ const (
 
 	LOCAL_HOST = "127.0.0.1"
 	// Ray FT default readiness probe values
-	DefaultReadinessProbeInitialDelaySeconds = 10
+	DefaultReadinessProbeInitialDelaySeconds = 60
 	DefaultReadinessProbeTimeoutSeconds      = 1
 	DefaultReadinessProbePeriodSeconds       = 5
 	DefaultReadinessProbeSuccessThreshold    = 1
 	DefaultReadinessProbeFailureThreshold    = 10
 
 	// Ray FT default liveness probe values
-	DefaultLivenessProbeInitialDelaySeconds = 30
+	DefaultLivenessProbeInitialDelaySeconds = 60
 	DefaultLivenessProbeTimeoutSeconds      = 1
 	DefaultLivenessProbePeriodSeconds       = 5
 	DefaultLivenessProbeSuccessThreshold    = 1

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -100,14 +100,14 @@ const (
 
 	LOCAL_HOST = "127.0.0.1"
 	// Ray FT default readiness probe values
-	DefaultReadinessProbeInitialDelaySeconds = 60
+	DefaultReadinessProbeInitialDelaySeconds = 10
 	DefaultReadinessProbeTimeoutSeconds      = 1
 	DefaultReadinessProbePeriodSeconds       = 5
 	DefaultReadinessProbeSuccessThreshold    = 1
 	DefaultReadinessProbeFailureThreshold    = 10
 
 	// Ray FT default liveness probe values
-	DefaultLivenessProbeInitialDelaySeconds = 60
+	DefaultLivenessProbeInitialDelaySeconds = 30
 	DefaultLivenessProbeTimeoutSeconds      = 1
 	DefaultLivenessProbePeriodSeconds       = 5
 	DefaultLivenessProbeSuccessThreshold    = 1

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -266,6 +266,8 @@ func DefaultWorkerPodTemplate(instance rayv1alpha1.RayCluster, workerSpec rayv1a
 // For KubeRay, the liveness and readiness probes perform the same checks.
 // Hence, we use the same function to initialize both probes.
 func initHealthProbe(probe *v1.Probe, rayNodeType rayv1alpha1.RayNodeType) {
+	// TODO (kevin85421): This function assumes that user-defined probes will always be `Exec`.
+	// If users want to use `HTTPGet`, we currently do not support it.
 	if probe.Exec == nil {
 		// Case 1: head node => Check GCS and Raylet status.
 		// Case 2: worker node => Check Raylet status.
@@ -365,9 +367,9 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayv1alpha1.RayNod
 						SuccessThreshold:    DefaultReadinessProbeSuccessThreshold,
 						FailureThreshold:    DefaultReadinessProbeFailureThreshold,
 					}
-					initHealthProbe(probe, rayNodeType)
 					pod.Spec.Containers[rayContainerIndex].ReadinessProbe = probe
 				}
+				initHealthProbe(pod.Spec.Containers[rayContainerIndex].ReadinessProbe, rayNodeType)
 
 				if pod.Spec.Containers[rayContainerIndex].LivenessProbe == nil {
 					probe := &v1.Probe{
@@ -377,9 +379,9 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayv1alpha1.RayNod
 						SuccessThreshold:    DefaultLivenessProbeSuccessThreshold,
 						FailureThreshold:    DefaultLivenessProbeFailureThreshold,
 					}
-					initHealthProbe(probe, rayNodeType)
 					pod.Spec.Containers[rayContainerIndex].LivenessProbe = probe
 				}
+				initHealthProbe(pod.Spec.Containers[rayContainerIndex].LivenessProbe, rayNodeType)
 			}
 		}
 	}

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -78,7 +78,6 @@ func initTemplateAnnotations(instance rayv1alpha1.RayCluster, podTemplate *v1.Po
 	} else {
 		podTemplate.Annotations[RayFTEnabledAnnotationKey] = "false"
 	}
-	podTemplate.Annotations[RayNodeHealthStateAnnotationKey] = ""
 
 	// set ray external storage namespace if user specified one.
 	if instance.Annotations != nil {
@@ -264,11 +263,17 @@ func DefaultWorkerPodTemplate(instance rayv1alpha1.RayCluster, workerSpec rayv1a
 	return podTemplate
 }
 
-func initLivenessProbeHandler(probe *v1.Probe, rayNodeType rayv1alpha1.RayNodeType) {
+// For KubeRay, the liveness and readiness probes perform the same checks.
+// Hence, we use the same function to initialize both probes.
+func initHealthProbe(probe *v1.Probe, rayNodeType rayv1alpha1.RayNodeType) {
 	if probe.Exec == nil {
-		// we only create the probe if user did not specify any.
+		// Case 1: head node => Check GCS and Raylet status.
+		// Case 2: worker node => Check Raylet status.
+		//
+		// Note: Since the Raylet process and the dashboard agent process are fate-sharing,
+		// we only need to check one of them.
+		// TODO (kevin85421): Should we take the dashboard process into account?
 		if rayNodeType == rayv1alpha1.HeadNode {
-			// head node liveness probe
 			cmd := []string{
 				"bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
 					DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
@@ -277,30 +282,6 @@ func initLivenessProbeHandler(probe *v1.Probe, rayNodeType rayv1alpha1.RayNodeTy
 			}
 			probe.Exec = &v1.ExecAction{Command: cmd}
 		} else {
-			// worker node liveness probe
-			cmd := []string{
-				"bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
-					DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
-			}
-			probe.Exec = &v1.ExecAction{Command: cmd}
-		}
-	}
-}
-
-func initReadinessProbeHandler(probe *v1.Probe, rayNodeType rayv1alpha1.RayNodeType) {
-	if probe.Exec == nil {
-		// we only create the probe if user did not specify any.
-		if rayNodeType == rayv1alpha1.HeadNode {
-			// head node readiness probe
-			cmd := []string{
-				"bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
-					DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
-				"&&", "bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
-					DefaultDashboardPort, RayDashboardGCSHealthPath),
-			}
-			probe.Exec = &v1.ExecAction{Command: cmd}
-		} else {
-			// worker node readiness probe
 			cmd := []string{
 				"bash", "-c", fmt.Sprintf("wget -T 2 -q -O- http://localhost:%d/%s | grep success",
 					DefaultDashboardAgentListenPort, RayAgentRayletHealthPath),
@@ -375,10 +356,8 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayv1alpha1.RayNod
 	if podTemplateSpec.Annotations != nil {
 		if enabledString, ok := podTemplateSpec.Annotations[RayFTEnabledAnnotationKey]; ok {
 			if strings.ToLower(enabledString) == "true" {
-				// Ray FT is enabled and we need to add health checks
+				// If users do not specify probes, we will set the default probes.
 				if pod.Spec.Containers[rayContainerIndex].ReadinessProbe == nil {
-					// it is possible that some user have the probe parameters to override the default,
-					// in this case, this if condition is skipped
 					probe := &v1.Probe{
 						InitialDelaySeconds: DefaultReadinessProbeInitialDelaySeconds,
 						TimeoutSeconds:      DefaultReadinessProbeTimeoutSeconds,
@@ -386,14 +365,11 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayv1alpha1.RayNod
 						SuccessThreshold:    DefaultReadinessProbeSuccessThreshold,
 						FailureThreshold:    DefaultReadinessProbeFailureThreshold,
 					}
+					initHealthProbe(probe, rayNodeType)
 					pod.Spec.Containers[rayContainerIndex].ReadinessProbe = probe
 				}
-				// add readiness probe exec command in case missing.
-				initReadinessProbeHandler(pod.Spec.Containers[rayContainerIndex].ReadinessProbe, rayNodeType)
 
 				if pod.Spec.Containers[rayContainerIndex].LivenessProbe == nil {
-					// it is possible that some user have the probe parameters to override the default,
-					// in this case, this if condition is skipped
 					probe := &v1.Probe{
 						InitialDelaySeconds: DefaultLivenessProbeInitialDelaySeconds,
 						TimeoutSeconds:      DefaultLivenessProbeTimeoutSeconds,
@@ -401,10 +377,9 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayv1alpha1.RayNod
 						SuccessThreshold:    DefaultLivenessProbeSuccessThreshold,
 						FailureThreshold:    DefaultLivenessProbeFailureThreshold,
 					}
+					initHealthProbe(probe, rayNodeType)
 					pod.Spec.Containers[rayContainerIndex].LivenessProbe = probe
 				}
-				// add liveness probe exec command in case missing
-				initLivenessProbeHandler(pod.Spec.Containers[rayContainerIndex].LivenessProbe, rayNodeType)
 			}
 		}
 	}

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -266,9 +266,7 @@ func DefaultWorkerPodTemplate(instance rayv1alpha1.RayCluster, workerSpec rayv1a
 // For KubeRay, the liveness and readiness probes perform the same checks.
 // Hence, we use the same function to initialize both probes.
 func initHealthProbe(probe *v1.Probe, rayNodeType rayv1alpha1.RayNodeType) {
-	// TODO (kevin85421): This function assumes that user-defined probes will always be `Exec`.
-	// If users want to use `HTTPGet`, we currently do not support it.
-	if probe.Exec == nil {
+	if probe.Exec == nil && probe.HTTPGet == nil && probe.TCPSocket == nil && probe.GRPC == nil {
 		// Case 1: head node => Check GCS and Raylet status.
 		// Case 2: worker node => Check Raylet status.
 		//

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -266,12 +266,14 @@ func DefaultWorkerPodTemplate(instance rayv1alpha1.RayCluster, workerSpec rayv1a
 // For KubeRay, the liveness and readiness probes perform the same checks.
 // Hence, we use the same function to initialize both probes.
 func initHealthProbe(probe *v1.Probe, rayNodeType rayv1alpha1.RayNodeType) {
+	// If users do not specify probe handlers, we will set `Exec` as the default probe handler.
 	if probe.Exec == nil && probe.HTTPGet == nil && probe.TCPSocket == nil && probe.GRPC == nil {
 		// Case 1: head node => Check GCS and Raylet status.
 		// Case 2: worker node => Check Raylet status.
 		//
 		// Note: Since the Raylet process and the dashboard agent process are fate-sharing,
-		// we only need to check one of them.
+		// we only need to check one of them. The probes use the dashboard agent's API endpoint
+		// to check the health of the Raylet process.
 		// TODO (kevin85421): Should we take the dashboard process into account?
 		if rayNodeType == rayv1alpha1.HeadNode {
 			cmd := []string{

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -101,7 +101,7 @@ class RayFTTestCase(unittest.TestCase):
 
         # Deploy a Ray Serve model.
         exit_code = pod_exec_command(headpod_name, RayFTTestCase.ray_cluster_ns,
-            "python samples/test_ray_serve_1.py",
+            "ray list nodes; python samples/test_ray_serve_1.py",
             check = False
         )
 

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -100,8 +100,13 @@ class RayFTTestCase(unittest.TestCase):
         headpod_name = headpod.metadata.name
 
         # Deploy a Ray Serve model.
+        pod_exec_command(headpod_name, RayFTTestCase.ray_cluster_ns,
+            "ray list nodes",
+            check = False
+        )
+
         exit_code = pod_exec_command(headpod_name, RayFTTestCase.ray_cluster_ns,
-            "ray list nodes; python samples/test_ray_serve_1.py",
+            "python samples/test_ray_serve_1.py",
             check = False
         )
 

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -99,12 +99,20 @@ class RayFTTestCase(unittest.TestCase):
         headpod = get_head_pod(RayFTTestCase.ray_cluster_ns)
         headpod_name = headpod.metadata.name
 
-        # Deploy a Ray Serve model.
+        # In `test_detached_actor`, we create 1 head Pod and 1 worker Pod. Afterward, we kill the
+        # GCS process of the head Pod to trigger its restart. Next, we terminate the head Pod,
+        # and KubeRay will create a new one in its place. However, Ray may take several seconds to
+        # realize that the old head Pod is gone. Therefore, using `ray list nodes` might show more
+        # than 1 "ALIVE" head nodes in the cluster temporarily. This may lead to an issue where the
+        # Serve controller believes it hasn't been scheduled to the head node, and as a result, it
+        # raises an exception. To avoid this issue, we will add a retry logic in `test_ray_serve_1`
+        # to wait until only 1 head node is alive. `ray list nodes` is for debugging purpose only.
         pod_exec_command(headpod_name, RayFTTestCase.ray_cluster_ns,
             "ray list nodes",
             check = False
         )
 
+        # Deploy a Ray Serve model.
         exit_code = pod_exec_command(headpod_name, RayFTTestCase.ray_cluster_ns,
             "python samples/test_ray_serve_1.py",
             check = False

--- a/tests/config/ray-cluster.mini.yaml.template
+++ b/tests/config/ray-cluster.mini.yaml.template
@@ -16,11 +16,6 @@ spec:
       num-cpus: '1'
     #pod template
     template:
-      metadata:
-        labels:
-          # Enables Ray client command execution via the NodePort service
-          # configured in tests/config/raycluster-service.yaml.
-          ray.io/test: compatibility-test-label
       spec:
         containers:
         - name: ray-head

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -99,16 +99,6 @@ spec:
             volumeMounts:
               - mountPath: /home/ray/samples
                 name: test-script-configmap
-            livenessProbe:
-              initialDelaySeconds: 1
-              periodSeconds: 3
-              timeoutSeconds: 1
-              failureThreshold: 400
-            readinessProbe:
-              initialDelaySeconds: 1
-              periodSeconds: 3
-              timeoutSeconds: 1
-              failureThreshold: 300
         volumes:
           - name: test-script-configmap
             configMap:
@@ -145,16 +135,6 @@ spec:
                   cpu: "1"
                 requests:
                   cpu: "200m"
-              livenessProbe:
-                initialDelaySeconds: 1
-                periodSeconds: 3
-                timeoutSeconds: 1
-                failureThreshold: 400
-              readinessProbe:
-                initialDelaySeconds: 1
-                periodSeconds: 3
-                timeoutSeconds: 1
-                failureThreshold: 300
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -104,6 +104,16 @@ spec:
             volumeMounts:
               - mountPath: /home/ray/samples
                 name: test-script-configmap
+            livenessProbe:
+              initialDelaySeconds: 30
+              periodSeconds: 3
+              timeoutSeconds: 1
+              failureThreshold: 400
+            readinessProbe:
+              initialDelaySeconds: 30
+              periodSeconds: 3
+              timeoutSeconds: 1
+              failureThreshold: 300
         volumes:
           - name: test-script-configmap
             configMap:
@@ -140,6 +150,16 @@ spec:
                   cpu: "1"
                 requests:
                   cpu: "200m"
+              livenessProbe:
+                initialDelaySeconds: 30
+                periodSeconds: 3
+                timeoutSeconds: 1
+                failureThreshold: 400
+              readinessProbe:
+                initialDelaySeconds: 30
+                periodSeconds: 3
+                timeoutSeconds: 1
+                failureThreshold: 300
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -101,16 +101,6 @@ spec:
                 name: dashboard
               - containerPort: 10001
                 name: client
-            livenessProbe:
-              initialDelaySeconds: 30
-              periodSeconds: 3
-              timeoutSeconds: 1
-              failureThreshold: 400
-            readinessProbe:
-              initialDelaySeconds: 30
-              periodSeconds: 3
-              timeoutSeconds: 1
-              failureThreshold: 300
             volumeMounts:
               - mountPath: /home/ray/samples
                 name: test-script-configmap
@@ -150,16 +140,6 @@ spec:
                   cpu: "1"
                 requests:
                   cpu: "200m"
-              livenessProbe:
-                initialDelaySeconds: 30
-                periodSeconds: 3
-                timeoutSeconds: 1
-                failureThreshold: 400
-              readinessProbe:
-                initialDelaySeconds: 30
-                periodSeconds: 3
-                timeoutSeconds: 1
-                failureThreshold: 300
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -214,7 +214,7 @@ data:
     import ray
     import sys
 
-    ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1])
+    ray.init(namespace=sys.argv[1])
 
     @ray.remote
     class TestCounter:
@@ -255,7 +255,7 @@ data:
 
     # Try to connect to Ray cluster.
     print("Try to connect to Ray cluster.")
-    retry_with_timeout(lambda: ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1]), timeout = 180)
+    retry_with_timeout(lambda: ray.init(namespace=sys.argv[1]), timeout = 180)
 
     # Get TestCounter actor
     print("Get TestCounter actor.")

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -79,11 +79,6 @@ spec:
       redis-password: "5241590000000000"
     #pod template
     template:
-      metadata:
-        labels:
-          # Enables Ray client command execution via the NodePort service
-          # configured in tests/config/raycluster-service.yaml.
-          ray.io/test: compatibility-test-label
       spec:
         containers:
           - name: ray-head
@@ -101,9 +96,6 @@ spec:
                 name: dashboard
               - containerPort: 10001
                 name: client
-            volumeMounts:
-              - mountPath: /home/ray/samples
-                name: test-script-configmap
             livenessProbe:
               initialDelaySeconds: 30
               periodSeconds: 3
@@ -114,6 +106,9 @@ spec:
               periodSeconds: 3
               timeoutSeconds: 1
               failureThreshold: 300
+            volumeMounts:
+              - mountPath: /home/ray/samples
+                name: test-script-configmap
         volumes:
           - name: test-script-configmap
             configMap:
@@ -169,6 +164,7 @@ data:
   test_ray_serve_1.py: |
     import ray
     from ray import serve
+    import requests
 
     # 1: Define a Ray Serve model.
     @serve.deployment(route_prefix="/")
@@ -178,14 +174,16 @@ data:
 
         def __call__(self):
             return self._msg
+    app = MyModelDeployment.bind(msg="Hello world!")
 
-    ray.init(address='ray://127.0.0.1:10001')
     # 2: Deploy the model.
-    handle = serve.run(MyModelDeployment.bind(msg="Hello world!"))
+    serve.run(app)
     # 3: Query the deployment and print the result.
-    val = ray.get(handle.remote())
-    print(val)
-    assert(val == "Hello world!")
+    resp = requests.get("http://localhost:8000/")
+    assert(resp.status_code == 200)
+    print(resp.status_code)
+    print(resp.text)
+    assert(resp.text == "Hello world!")
 
   test_ray_serve_2.py: |
     import requests

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -164,10 +164,26 @@ data:
   test_ray_serve_1.py: |
     import ray
     from ray import serve
+    from ray.util.state import list_nodes
     import requests
+    import time
+
+    # 0: Wait until only 1 head Pod is alive
+    print("Wait until only 1 head Pod is alive", flush=True)
+    for i in range(90): 
+      nodes = list_nodes()
+      num_alive_heads = 0
+      for node in nodes:
+          if node.is_head_node and node.state == "ALIVE":
+              num_alive_heads += 1
+      print(f"iter {i}: {num_alive_heads} head nodes are alive.")
+      if num_alive_heads == 1:
+          break
+      time.sleep(1)
+
 
     # 1: Define a Ray Serve model.
-    @serve.deployment(route_prefix="/")
+    @serve.deployment
     class MyModelDeployment:
         def __init__(self, msg: str):
             self._msg = msg

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -156,7 +156,7 @@ data:
       for node in nodes:
           if node.is_head_node and node.state == "ALIVE":
               num_alive_heads += 1
-      print(f"iter {i}: {num_alive_heads} head nodes are alive.")
+      print(f"iter {i}: {num_alive_heads} head nodes are alive.", flush=True)
       if num_alive_heads == 1:
           break
       time.sleep(1)

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -96,16 +96,6 @@ spec:
                 name: dashboard
               - containerPort: 10001
                 name: client
-            livenessProbe:
-              initialDelaySeconds: 30
-              periodSeconds: 3
-              timeoutSeconds: 1
-              failureThreshold: 400
-            readinessProbe:
-              initialDelaySeconds: 30
-              periodSeconds: 3
-              timeoutSeconds: 1
-              failureThreshold: 300
             volumeMounts:
               - mountPath: /home/ray/samples
                 name: test-script-configmap
@@ -145,16 +135,6 @@ spec:
                   cpu: "1"
                 requests:
                   cpu: "200m"
-              livenessProbe:
-                initialDelaySeconds: 30
-                periodSeconds: 3
-                timeoutSeconds: 1
-                failureThreshold: 400
-              readinessProbe:
-                initialDelaySeconds: 30
-                periodSeconds: 3
-                timeoutSeconds: 1
-                failureThreshold: 300
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/tests/config/ray-cluster.ray-ft.yaml.template
+++ b/tests/config/ray-cluster.ray-ft.yaml.template
@@ -99,6 +99,16 @@ spec:
             volumeMounts:
               - mountPath: /home/ray/samples
                 name: test-script-configmap
+            livenessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 3
+              timeoutSeconds: 1
+              failureThreshold: 400
+            readinessProbe:
+              initialDelaySeconds: 1
+              periodSeconds: 3
+              timeoutSeconds: 1
+              failureThreshold: 300
         volumes:
           - name: test-script-configmap
             configMap:
@@ -135,6 +145,16 @@ spec:
                   cpu: "1"
                 requests:
                   cpu: "200m"
+              livenessProbe:
+                initialDelaySeconds: 1
+                periodSeconds: 3
+                timeoutSeconds: 1
+                failureThreshold: 400
+              readinessProbe:
+                initialDelaySeconds: 1
+                periodSeconds: 3
+                timeoutSeconds: 1
+                failureThreshold: 300
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -221,8 +241,11 @@ data:
     def retry_with_timeout(func, timeout=90):
         err = None
         start = time.time()
+        i = 0
         while time.time() - start <= timeout:
             try:
+                print(f"retry iter: {i}", flush=True)
+                i += 1
                 return func()
             except BaseException as e:
                 err = e
@@ -234,15 +257,15 @@ data:
         return ray.get_actor("testCounter")
 
     # Try to connect to Ray cluster.
-    print("Try to connect to Ray cluster.")
-    retry_with_timeout(lambda: ray.init(namespace=sys.argv[1]), timeout = 180)
+    print("Try to connect to Ray cluster.", flush=True)
+    retry_with_timeout(lambda: ray.init(address='ray://127.0.0.1:10001', namespace=sys.argv[1]), timeout = 180)
 
     # Get TestCounter actor
-    print("Get TestCounter actor.")
+    print("Get TestCounter actor.", flush=True)
     tc = retry_with_timeout(get_detached_actor)
 
-    print("Try to call remote function \'increment\'.")
+    print("Try to call remote function \'increment\'.", flush=True)
     val = retry_with_timeout(lambda: ray.get(tc.increment.remote()))
-    print(f"val: {val}")
+    print(f"val: {val}", flush=True)
 
     assert(val == int(sys.argv[2]))

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -65,16 +65,6 @@ spec:
                   name: client
                 - containerPort: 8000
                   name: serve
-              livenessProbe:
-                initialDelaySeconds: 30
-                periodSeconds: 3
-                timeoutSeconds: 1
-                failureThreshold: 400
-              readinessProbe:
-                initialDelaySeconds: 30
-                periodSeconds: 3
-                timeoutSeconds: 1
-                failureThreshold: 300
     workerGroupSpecs:
       # the pod replicas in this group typed worker
       - replicas: 1
@@ -103,13 +93,3 @@ spec:
                   preStop:
                     exec:
                       command: ["/bin/sh","-c","ray stop"]
-                livenessProbe:
-                  initialDelaySeconds: 30
-                  periodSeconds: 3
-                  timeoutSeconds: 1
-                  failureThreshold: 400
-                readinessProbe:
-                  initialDelaySeconds: 30
-                  periodSeconds: 3
-                  timeoutSeconds: 1
-                  failureThreshold: 300

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -65,6 +65,16 @@ spec:
                   name: client
                 - containerPort: 8000
                   name: serve
+              livenessProbe:
+                initialDelaySeconds: 30
+                periodSeconds: 3
+                timeoutSeconds: 1
+                failureThreshold: 400
+              readinessProbe:
+                initialDelaySeconds: 30
+                periodSeconds: 3
+                timeoutSeconds: 1
+                failureThreshold: 300
     workerGroupSpecs:
       # the pod replicas in this group typed worker
       - replicas: 1
@@ -93,3 +103,13 @@ spec:
                   preStop:
                     exec:
                       command: ["/bin/sh","-c","ray stop"]
+                livenessProbe:
+                  initialDelaySeconds: 30
+                  periodSeconds: 3
+                  timeoutSeconds: 1
+                  failureThreshold: 400
+                readinessProbe:
+                  initialDelaySeconds: 30
+                  periodSeconds: 3
+                  timeoutSeconds: 1
+                  failureThreshold: 300

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -47,11 +47,6 @@ spec:
         dashboard-host: '0.0.0.0'
       #pod template
       template:
-        metadata:
-          labels:
-            # Enables Ray client command execution via the NodePort service
-            # configured in tests/config/raycluster-service.yaml.
-            ray.io/test: compatibility-test-label
         spec:
           containers:
             - name: ray-head


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Remove unused constant variables: `ray.io/cluster-dashboard`, `ray.io/health-state`, `NAMESPACE`, and `DefaultRedisPassword`.

* Merge `initLivenessProbeHandler` and `initReadinessProbeHandler` into 1 function. Both readiness and liveness probes perform the same checks for most Kubernetes use cases.

* Kubernetes probe supports several handlers, including `exec`, `httpGet`, `GRPC`, and `tcpSocket`. However, the previous implementation assumes that users will always use `exec`.

* The minimum value of `probe.SuccessThreshold` is 1, but the default value (`DefaultReadinessProbeSuccessThreshold` & `DefaultLivenessProbeSuccessThreshold`) in KubeRay is 0. Although Kubernetes will override 0 with 1, it would be better to set it to 1 explicitly to avoid some potential K8s compatibility issues.

* Increase probe failure thresholds. I observe a situation occasionally in Kubernetes services provided by public cloud vendors. Some Kubernetes nodes lost connections with the Kubernetes API Server for several minutes, so I increased the failure threshold to reduce the number of restarts.

* `ray-cluster.ray-ft.yaml.template`: Replace Ray Serve API V1 with API V2.

* `ray-cluster.*****.yaml.template`: Remove unused label `ray.io/test`.

* ~~Eliminate the reliance on the Ray client in compatibility tests.~~ => I decided not to replace `ray.init()` with Ray client. See #848 for more details.

* The probe's `initialDelaySeconds` seem to be important for compatibility test stability. 
  * Update:  In `test_detached_actor`, we create 1 head Pod and 1 worker Pod. Afterward, we kill the GCS process of the head Pod to trigger its restart. Next, we terminate the head Pod, and KubeRay will create a new one in its place. However, Ray may take several seconds to realize that the old head Pod is gone. Therefore, using `ray list nodes` might show more than 1 "ALIVE" head nodes in the cluster temporarily. This may lead to an issue where the Serve controller believes it hasn't been scheduled to the head node, and as a result, it raises an exception. To avoid this issue, we will add a workaround retry logic in `test_ray_serve_1` to wait until only 1 head node is alive.



## Related issue number

Closes #1354 
#848 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
