### PR TITLE
[CI] Remove extraPortMappings from kind configurations

### DIFF
--- a/tests/framework/config/kind-config-buildkite.yml
+++ b/tests/framework/config/kind-config-buildkite.yml
@@ -15,25 +15,3 @@ nodes:
     apiServer:
       certSANs:
         - "docker"
-  - |
-    kind: InitConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        node-labels: "ingress-ready=true"
-  extraPortMappings:
-    - containerPort: 30265
-      hostPort: 8265
-      listenAddress: "0.0.0.0"
-      protocol: tcp
-    - containerPort: 30001
-      hostPort: 10001
-      listenAddress: "0.0.0.0"
-      protocol: tcp
-    - containerPort: 32365
-      hostPort: 52365
-      listenAddress: "0.0.0.0"
-      protocol: tcp
-    - containerPort: 30800
-      hostPort: 8000
-      listenAddress: "0.0.0.0"
-      protocol: tcp

--- a/tests/framework/config/kind-config.yaml
+++ b/tests/framework/config/kind-config.yaml
@@ -2,26 +2,3 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    kubeadmConfigPatches:
-      - |
-        kind: InitConfiguration
-        nodeRegistration:
-          kubeletExtraArgs:
-            node-labels: "ingress-ready=true"
-    extraPortMappings:
-      - containerPort: 30265
-        hostPort: 8265
-        listenAddress: "0.0.0.0"
-        protocol: tcp
-      - containerPort: 30001
-        hostPort: 10001
-        listenAddress: "0.0.0.0"
-        protocol: tcp
-      - containerPort: 32365
-        hostPort: 52365
-        listenAddress: "0.0.0.0"
-        protocol: tcp
-      - containerPort: 30800
-        hostPort: 8000
-        listenAddress: "0.0.0.0"
-        protocol: tcp


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?



Kind's [extraPortMappings configuration](https://kind.sigs.k8s.io/docs/user/configuration/#extra-port-mappings) is for NodePort or Ingress. However, we do not use these Kubernetes functionalities in CI tests. In addition, I cannot use `kubectl port-forward` to check Ray dashboard if the kind cluster is created by this Kind configurations.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
