### PR TITLE
Remove unnecessary kustomize in make helm

### DIFF
--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -49,7 +49,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-helm: manifests kustomize ## Sync the CRDs into the Helm chart
+helm: manifests ## Sync the CRDs into the Helm chart
 	rm -r ../helm-chart/kuberay-operator/crds/
 	cp -r config/crd/bases/ ../helm-chart/kuberay-operator/crds/
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We first make kustomize as part of make helm (and hence make sync). But this is not required. This was realized while running make sync. This code change simply removes kustomize from make helm.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #1368 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
