### PR TITLE
[Feature] Ray container must be the first application container

### DIFF
--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -14,6 +14,9 @@ const (
 	RayClusterServingServiceLabelKey = "ray.io/serve"
 	RayServiceClusterHashKey         = "ray.io/cluster-hash"
 
+	// In KubeRay, the Ray container must be the first application container in a head or worker Pod.
+	RayContainerIndex = 0
+
 	// Batch scheduling labels
 	// TODO(tgaddair): consider making these part of the CRD
 	RaySchedulerName     = "ray.io/scheduler-name"

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -317,8 +317,7 @@ func getServicePorts(cluster rayv1alpha1.RayCluster) map[string]int32 {
 func getPortsFromCluster(cluster rayv1alpha1.RayCluster) (map[string]int32, error) {
 	svcPorts := map[string]int32{}
 
-	index := utils.FindRayContainerIndex(cluster.Spec.HeadGroupSpec.Template.Spec)
-	cPorts := cluster.Spec.HeadGroupSpec.Template.Spec.Containers[index].Ports
+	cPorts := cluster.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Ports
 	for _, port := range cPorts {
 		if port.Name == "" {
 			port.Name = fmt.Sprint(port.ContainerPort) + "-port"

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	rayv1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 
 	"github.com/stretchr/testify/assert"
 
@@ -182,8 +181,7 @@ func TestGetPortsFromCluster(t *testing.T) {
 		svcNames[port] = name
 	}
 
-	index := utils.FindRayContainerIndex(instanceWithWrongSvc.Spec.HeadGroupSpec.Template.Spec)
-	cPorts := instanceWithWrongSvc.Spec.HeadGroupSpec.Template.Spec.Containers[index].Ports
+	cPorts := instanceWithWrongSvc.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Ports
 
 	for _, cPort := range cPorts {
 		expectedResult := cPort.Name

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1156,7 +1156,7 @@ func (r *RayServiceReconciler) labelHealthyServePods(ctx context.Context, rayClu
 	httpProxyClient := utils.GetRayHttpProxyClientFunc()
 	httpProxyClient.InitClient()
 	for _, pod := range allPods.Items {
-		rayContainer := pod.Spec.Containers[utils.FindRayContainerIndex(pod.Spec)]
+		rayContainer := pod.Spec.Containers[common.RayContainerIndex]
 		servingPort := utils.FindContainerPort(&rayContainer, common.DefaultServingPortName, common.DefaultServingPort)
 		httpProxyClient.SetHostIp(pod.Status.PodIP, servingPort)
 		if pod.Labels == nil {

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -215,16 +215,6 @@ func GenerateIdentifier(clusterName string, nodeType rayv1alpha1.RayNodeType) st
 	return fmt.Sprintf("%s-%s", clusterName, nodeType)
 }
 
-// TODO: find target container through name instead of using index 0.
-// FindRayContainerIndex finds the ray head/worker container's index in the pod
-func FindRayContainerIndex(spec corev1.PodSpec) (index int) {
-	// We only support one container at this moment. We definitely need a better way to filter out sidecar containers.
-	if len(spec.Containers) > 1 {
-		logrus.Warnf("Pod has multiple containers, we choose index=0 as Ray container")
-	}
-	return 0
-}
-
 // CalculateDesiredReplicas calculate desired worker replicas at the cluster level
 func CalculateDesiredReplicas(cluster *rayv1alpha1.RayCluster) int32 {
 	count := int32(0)

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -338,6 +338,7 @@ class AutoscaleRule(Rule):
             pods = k8s_v1_api.list_namespaced_pod(
                 namespace=cr_namespace, label_selector='ray.io/node-type=worker'
             )
+            logger.info("Number of worker pods: %d", len(pods.items))
             if len(pods.items) == self.expected_worker_pods:
                 logger.info(
                     "Cluster has successfully scaled to the expected number of "
@@ -345,9 +346,9 @@ class AutoscaleRule(Rule):
                     f"{time.time() - start_time} seconds."
                 )
                 break
-            
-            time.sleep(0.1)
+            time.sleep(2)
         else:
+            show_cluster_info(cr_namespace)
             raise TimeoutError(
                 "Cluster did not scale to the expected number of "
                 f"{self.expected_worker_pods} worker pod(s) within {self.timeout} "


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Unlike init containers, which start one by one in a sequence, all application containers in the same Pod can start simultaneously. Therefore, it is fine to enforce the Ray container to be the first application container.

**Backward compatibility** (v0.6.0):

**[Case 1]**:
* Add an Nginx sidecar container as the first application container, and the Ray container as the second.
* [Gist](https://gist.github.com/kevin85421/969599a7dcbf28fe4a99e2576b6be599)
  
The head Pod crashes repeatedly because KubeRay identifies the first app container (i.e., Nginx container) as the Ray container and injects `ray start ...` command into the Nginx container.

**[Case 2]**:
* Add an Nginx sidecar container as the first application container, and the Ray container as the second.
* Add an env with name `ray` and value `"true"` in both head and workers.
   ```yaml
   env:
   - name: ray
     value: "true"
   ```
* [Gist](https://gist.github.com/kevin85421/6f421eb3e1f622243f0bdfc31c4f292a)

The function `getRayContainerIndex` identifies the Ray container as the second app container. While the head Pod starts successfully, the worker's init container hangs indefinitely. This happens because `FindRayContainerIndex` always recognizes the first app container as the Ray container, and this function helps generate the spec for the head service. As a result, the head service exposes the Nginx port instead of the ports defined in the Ray container. Hence, the worker Pods cannot connect with the Ray head Pod successfully.

In conclusion, KubeRay has never supported a Ray container with an index other than 0.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
