### PR TITLE
[CI] [RayJob] Revert sample yamls to use `RuntimeEnv` field instead of `RuntimeEnvYAML`

### DIFF
--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -38,7 +38,7 @@
   commands:
     - ./.buildkite/setup-env.sh
     # Use KubeRay operator image from the latest release
-    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.6.3 OPERATOR_IMAGE=kuberay/operator:v0.6.2 python3 tests/test_sample_rayjob_yamls.py --latest
+    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.6.3 OPERATOR_IMAGE=kuberay/operator:v0.6.1 python3 tests/test_sample_rayjob_yamls.py --latest
 
 - label: 'Test RayService Sample YAMLs (nightly operator)'
   instance_size: large

--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -38,7 +38,7 @@
   commands:
     - ./.buildkite/setup-env.sh
     # Use KubeRay operator image from the latest release
-    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.6.3 OPERATOR_IMAGE=kuberay/operator:v0.6.0 python3 tests/test_sample_rayjob_yamls.py --latest
+    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.6.3 OPERATOR_IMAGE=kuberay/operator:v0.6.2 python3 tests/test_sample_rayjob_yamls.py --latest
 
 - label: 'Test RayService Sample YAMLs (nightly operator)'
   instance_size: large

--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -32,15 +32,13 @@
     # Use nightly KubeRay operator image
     - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.6.3 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayjob_yamls.py
 
-# Temporarily skip due to adding new `RuntimeEnvYAML` field in sample YAMLs.
-# TODO(architkulkarni): Reenable after 1.0 release
-# - label: 'Test RayJob Sample YAMLs (latest release)'
-#   instance_size: large
-#   image: golang:1.19
-#   commands:
-#     - ./.buildkite/setup-env.sh
-#     # Use KubeRay operator image from the latest release
-#     - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.6.3 OPERATOR_IMAGE=kuberay/operator:v0.6.0 python3 tests/test_sample_rayjob_yamls.py
+- label: 'Test RayJob Sample YAMLs (latest release)'
+  instance_size: large
+  image: golang:1.19
+  commands:
+    - ./.buildkite/setup-env.sh
+    # Use KubeRay operator image from the latest release
+    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.6.3 OPERATOR_IMAGE=kuberay/operator:v0.6.0 python3 tests/test_sample_rayjob_yamls.py --latest
 
 - label: 'Test RayService Sample YAMLs (nightly operator)'
   instance_size: large

--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -38,7 +38,7 @@
   commands:
     - ./.buildkite/setup-env.sh
     # Use KubeRay operator image from the latest release
-    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.6.3 OPERATOR_IMAGE=kuberay/operator:v0.6.1 python3 tests/test_sample_rayjob_yamls.py --latest
+    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.6.3 OPERATOR_IMAGE=kuberay/operator:v0.6.0 python3 tests/test_sample_rayjob_yamls.py --latest
 
 - label: 'Test RayService Sample YAMLs (nightly operator)'
   instance_size: large

--- a/ray-operator/config/samples/ray-job.custom-head-svc.yaml
+++ b/ray-operator/config/samples/ray-job.custom-head-svc.yaml
@@ -8,15 +8,27 @@ metadata:
 spec:
   entrypoint: python /home/ray/samples/sample_code.py
 
-  # RuntimeEnvYAML represents the runtime environment configuration provided as a multi-line YAML string.
-  # See https://docs.ray.io/en/latest/ray-core/handling-dependencies.html for details.
-  # (New in KubeRay version 1.0.)  
-  runtimeEnvYAML: |
-    pip:
-      - requests==2.26.0
-      - pendulum==2.1.2
-    env_vars:
-      counter_name: "test_counter"  
+  # runtimeEnv decoded to '{
+  #    "pip": [
+  #        "requests==2.26.0",
+  #        "pendulum==2.1.2"
+  #    ],
+  #    "env_vars": {
+  #        "counter_name": "test_counter"
+  #    }
+  #}'
+  # (deprecated in KubeRay version 1.0.)
+  runtimeEnv: ewogICAgInBpcCI6IFsKICAgICAgICAicmVxdWVzdHM9PTIuMjYuMCIsCiAgICAgICAgInBlbmR1bHVtPT0yLjEuMiIKICAgIF0sCiAgICAiZW52X3ZhcnMiOiB7ImNvdW50ZXJfbmFtZSI6ICJ0ZXN0X2NvdW50ZXIifQp9Cg==
+
+  # # RuntimeEnvYAML represents the runtime environment configuration provided as a multi-line YAML string.
+  # # See https://docs.ray.io/en/latest/ray-core/handling-dependencies.html for details.
+  # # (New in KubeRay version 1.0.)  
+  # runtimeEnvYAML: |
+  #   pip:
+  #     - requests==2.26.0
+  #     - pendulum==2.1.2
+  #   env_vars:
+  #     counter_name: "test_counter"
   
   # rayClusterSpec specifies the RayCluster instance to be created by the RayJob controller.
   rayClusterSpec:

--- a/ray-operator/config/samples/ray-job.runtimeenvyaml.yaml
+++ b/ray-operator/config/samples/ray-job.runtimeenvyaml.yaml
@@ -1,0 +1,145 @@
+apiVersion: ray.io/v1alpha1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  entrypoint: python /home/ray/samples/sample_code.py
+  # shutdownAfterJobFinishes specifies whether the RayCluster should be deleted after the RayJob finishes. Default is false.
+  # shutdownAfterJobFinishes: false
+
+  # ttlSecondsAfterFinished specifies the number of seconds after which the RayCluster will be deleted after the RayJob finishes.
+  # ttlSecondsAfterFinished: 10
+  
+  # RuntimeEnvYAML represents the runtime environment configuration provided as a multi-line YAML string.
+  # See https://docs.ray.io/en/latest/ray-core/handling-dependencies.html for details.
+  # (New in KubeRay version 1.0.)  
+  runtimeEnvYAML: |
+    pip:
+      - requests==2.26.0
+      - pendulum==2.1.2
+    env_vars:
+      counter_name: "test_counter"
+
+  # Suspend specifies whether the RayJob controller should create a RayCluster instance.
+  # If a job is applied with the suspend field set to true, the RayCluster will not be created and we will wait for the transition to false.
+  # If the RayCluster is already created, it will be deleted. In the case of transition to false, a new RayCluste rwill be created.
+  # suspend: false
+
+  # rayClusterSpec specifies the RayCluster instance to be created by the RayJob controller.
+  rayClusterSpec:
+    rayVersion: '2.6.3' # should match the Ray version in the image of the containers
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        dashboard-host: '0.0.0.0'
+      #pod template
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: rayproject/ray:2.6.3
+              ports:
+                - containerPort: 6379
+                  name: gcs-server
+                - containerPort: 8265 # Ray dashboard
+                  name: dashboard
+                - containerPort: 10001
+                  name: client
+              resources:
+                limits:
+                  cpu: "1"
+                requests:
+                  cpu: "200m"
+              volumeMounts:
+                - mountPath: /home/ray/samples
+                  name: code-sample
+          volumes:
+            # You set volumes at the Pod level, then mount them into containers inside that Pod
+            - name: code-sample
+              configMap:
+                # Provide the name of the ConfigMap you want to mount.
+                name: ray-job-code-sample
+                # An array of keys from the ConfigMap to create as files
+                items:
+                  - key: sample_code.py
+                    path: sample_code.py
+    workerGroupSpecs:
+      # the pod replicas in this group typed worker
+      - replicas: 1
+        minReplicas: 1
+        maxReplicas: 5
+        # logical group name, for this called small-group, also can be functional
+        groupName: small-group
+        # The `rayStartParams` are used to configure the `ray start` command.
+        # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+        # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+        rayStartParams: {}
+        #pod template
+        template:
+          spec:
+            containers:
+              - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+                image: rayproject/ray:2.6.3
+                lifecycle:
+                  preStop:
+                    exec:
+                      command: [ "/bin/sh","-c","ray stop" ]
+                resources:
+                  limits:
+                    cpu: "1"
+                  requests:
+                    cpu: "200m"
+  # SubmitterPodTemplate is the template for the pod that will run the `ray job submit` command against the RayCluster.
+  # If SubmitterPodTemplate is specified, the first container is assumed to be the submitter container.
+  # submitterPodTemplate:
+  #   spec:
+  #     restartPolicy: Never
+  #     containers:
+  #       - name: my-custom-rayjob-submitter-pod
+  #         image: rayproject/ray:2.6.3
+  #         # If Command is not specified, the correct command will be supplied at runtime using the RayJob spec `entrypoint` field.
+  #         # Specifying Command is not recommended.
+  #         # command: ["ray job submit --address=http://rayjob-sample-raycluster-v6qcq-head-svc.default.svc.cluster.local:8265 -- echo hello world"]
+      
+
+######################Ray code sample#################################
+# this sample is from https://docs.ray.io/en/latest/cluster/job-submission.html#quick-start-example
+# it is mounted into the container and executed to show the Ray job at work
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ray-job-code-sample
+data:
+  sample_code.py: |
+    import ray
+    import os
+    import requests
+
+    ray.init()
+
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            # Used to verify runtimeEnv
+            self.name = os.getenv("counter_name")
+            assert self.name == "test_counter"
+            self.counter = 0
+
+        def inc(self):
+            self.counter += 1
+
+        def get_counter(self):
+            return "{} got {}".format(self.name, self.counter)
+
+    counter = Counter.remote()
+
+    for _ in range(5):
+        ray.get(counter.inc.remote())
+        print(ray.get(counter.get_counter.remote()))
+
+    # Verify that the correct runtime env was used for the job.
+    assert requests.__version__ == "2.26.0"

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.resources.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.resources.yaml
@@ -10,15 +10,30 @@ spec:
   # ttlSecondsAfterFinished specifies the number of seconds after which the RayCluster will be deleted after the RayJob finishes.
   # ttlSecondsAfterFinished: 10
   
-  # RuntimeEnvYAML represents the runtime environment configuration provided as a multi-line YAML string.
-  # See https://docs.ray.io/en/latest/ray-core/handling-dependencies.html for details.
-  # (New in KubeRay version 1.0.)  
-  runtimeEnvYAML: |
-    pip:
-      - requests==2.26.0
-      - pendulum==2.1.2
-    env_vars:
-      counter_name: "test_counter"
+  # runtimeEnv decoded to '{
+  #    "pip": [
+  #        "requests==2.26.0",
+  #        "pendulum==2.1.2"
+  #    ],
+  #    "env_vars": {
+  #        "counter_name": "test_counter"
+  #    }
+  #}'
+  # (deprecated in KubeRay version 1.0.)
+  runtimeEnv: ewogICAgInBpcCI6IFsKICAgICAgICAicmVxdWVzdHM9PTIuMjYuMCIsCiAgICAgICAgInBlbmR1bHVtPT0yLjEuMiIKICAgIF0sCiAgICAiZW52X3ZhcnMiOiB7ImNvdW50ZXJfbmFtZSI6ICJ0ZXN0X2NvdW50ZXIifQp9Cg==
+
+  # # RuntimeEnvYAML represents the runtime environment configuration provided as a multi-line YAML string.
+  # # See https://docs.ray.io/en/latest/ray-core/handling-dependencies.html for details.
+  # # (New in KubeRay version 1.0.)  
+  # runtimeEnvYAML: |
+  #   pip:
+  #     - requests==2.26.0
+  #     - pendulum==2.1.2
+  #   env_vars:
+  #     counter_name: "test_counter"
+
+  # Specifies the number of resources for the Ray scheduler to reserve for the execution of the Ray Job entrypoint script. 
+  # (New in KubeRay version 1.0.)
   entrypointNumCpus: 2
   entrypointNumGpus: 0.5
   entrypointResources: "{\"resource1\": 1, \"resource2\": 2}"

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.shutdown.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.shutdown.yaml
@@ -11,15 +11,27 @@ spec:
   # ttlSecondsAfterFinished specifies the number of seconds after which the RayCluster will be deleted after the RayJob finishes.
   ttlSecondsAfterFinished: 10
 
-  # RuntimeEnvYAML represents the runtime environment configuration provided as a multi-line YAML string.
-  # See https://docs.ray.io/en/latest/ray-core/handling-dependencies.html for details.  
-  # (New in KubeRay version 1.0.)
-  runtimeEnvYAML: |
-    pip:
-      - requests==2.26.0
-      - pendulum==2.1.2
-    env_vars:
-      counter_name: "test_counter"
+  # runtimeEnv decoded to '{
+  #    "pip": [
+  #        "requests==2.26.0",
+  #        "pendulum==2.1.2"
+  #    ],
+  #    "env_vars": {
+  #        "counter_name": "test_counter"
+  #    }
+  #}'
+  # (deprecated in KubeRay version 1.0.)
+  runtimeEnv: ewogICAgInBpcCI6IFsKICAgICAgICAicmVxdWVzdHM9PTIuMjYuMCIsCiAgICAgICAgInBlbmR1bHVtPT0yLjEuMiIKICAgIF0sCiAgICAiZW52X3ZhcnMiOiB7ImNvdW50ZXJfbmFtZSI6ICJ0ZXN0X2NvdW50ZXIifQp9Cg==
+
+  # # RuntimeEnvYAML represents the runtime environment configuration provided as a multi-line YAML string.
+  # # See https://docs.ray.io/en/latest/ray-core/handling-dependencies.html for details.
+  # # (New in KubeRay version 1.0.)  
+  # runtimeEnvYAML: |
+  #   pip:
+  #     - requests==2.26.0
+  #     - pendulum==2.1.2
+  #   env_vars:
+  #     counter_name: "test_counter"
       
   # Suspend specifies whether the RayJob controller should create a RayCluster instance.
   # If a job is applied with the suspend field set to true, the RayCluster will not be created and we will wait for the transition to false.

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -10,15 +10,27 @@ spec:
   # ttlSecondsAfterFinished specifies the number of seconds after which the RayCluster will be deleted after the RayJob finishes.
   # ttlSecondsAfterFinished: 10
   
-  # RuntimeEnvYAML represents the runtime environment configuration provided as a multi-line YAML string.
-  # See https://docs.ray.io/en/latest/ray-core/handling-dependencies.html for details.
-  # (New in KubeRay version 1.0.)  
-  runtimeEnvYAML: |
-    pip:
-      - requests==2.26.0
-      - pendulum==2.1.2
-    env_vars:
-      counter_name: "test_counter"
+  # runtimeEnv decoded to '{
+  #    "pip": [
+  #        "requests==2.26.0",
+  #        "pendulum==2.1.2"
+  #    ],
+  #    "env_vars": {
+  #        "counter_name": "test_counter"
+  #    }
+  #}'
+  # (deprecated in KubeRay version 1.0.)
+  runtimeEnv: ewogICAgInBpcCI6IFsKICAgICAgICAicmVxdWVzdHM9PTIuMjYuMCIsCiAgICAgICAgInBlbmR1bHVtPT0yLjEuMiIKICAgIF0sCiAgICAiZW52X3ZhcnMiOiB7ImNvdW50ZXJfbmFtZSI6ICJ0ZXN0X2NvdW50ZXIifQp9Cg==
+
+  # # RuntimeEnvYAML represents the runtime environment configuration provided as a multi-line YAML string.
+  # # See https://docs.ray.io/en/latest/ray-core/handling-dependencies.html for details.
+  # # (New in KubeRay version 1.0.)  
+  # runtimeEnvYAML: |
+  #   pip:
+  #     - requests==2.26.0
+  #     - pendulum==2.1.2
+  #   env_vars:
+  #     counter_name: "test_counter"
 
   # Suspend specifies whether the RayJob controller should create a RayCluster instance.
   # If a job is applied with the suspend field set to true, the RayCluster will not be created and we will wait for the transition to false.

--- a/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayjob.yaml
@@ -118,8 +118,10 @@ spec:
       
 
 ######################Ray code sample#################################
-# this sample is from https://docs.ray.io/en/latest/cluster/job-submission.html#quick-start-example
-# it is mounted into the container and executed to show the Ray job at work
+# This sample is from https://docs.ray.io/en/latest/cluster/job-submission.html#quick-start-example.
+# It is mounted into the container and executed to show the Ray job at work.
+# Note that the job entrypoint script can also reside in a remote cloud bucket, and the bucket can be specified in the
+# working_dir field of runtimeEnvYAML; see https://docs.ray.io/en/latest/ray-core/handling-dependencies.html#remote-uris.
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/tests/test_sample_rayjob_yamls.py
+++ b/tests/test_sample_rayjob_yamls.py
@@ -3,6 +3,7 @@ import unittest
 import os
 import logging
 import yaml
+import argparse
 
 from framework.prototype import (
     RuleSet,
@@ -19,9 +20,20 @@ from framework.utils import (
 logger = logging.getLogger(__name__)
 
 if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--latest', action='store_true', help='Only test YAMLs compatible with the latest Kuberay version.')
+    args = parser.parse_args()
+    latest = args.latest
+
+
     NAMESPACE = 'default'
     SAMPLE_PATH = CONST.REPO_ROOT.joinpath("ray-operator/config/samples/")
-    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml', 'ray-job.custom-head-svc.yaml', 'ray_v1alpha1_rayjob.resources.yaml']
+    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml', 'ray-job.custom-head-svc.yaml']
+    if not latest:
+        # Test new backwards-incompatible fields.
+        # TODO: Move these to "latest" after KubeRay v1.0 is released.
+        YAMLs.extend(['ray_v1alpha1_rayjob.resources.yaml', 'ray-job.runtimeenvyaml.yaml'])
 
     sample_yaml_files = []
     for filename in YAMLs:

--- a/tests/test_sample_rayjob_yamls.py
+++ b/tests/test_sample_rayjob_yamls.py
@@ -29,11 +29,13 @@ if __name__ == '__main__':
 
     NAMESPACE = 'default'
     SAMPLE_PATH = CONST.REPO_ROOT.joinpath("ray-operator/config/samples/")
-    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml', 'ray-job.custom-head-svc.yaml']
+    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml']
     if not latest:
         # Test new backwards-incompatible fields.
         # TODO: Move these to "latest" after KubeRay v1.0 is released.
-        YAMLs.extend(['ray_v1alpha1_rayjob.resources.yaml', 'ray-job.runtimeenvyaml.yaml'])
+        # Note: ray-job.custom-head-svc.yaml is included here because the fix it depends on,
+        # https://github.com/ray-project/kuberay/pull/1332, was merged after the latest release 0.6.0.
+        YAMLs.extend(['ray_v1alpha1_rayjob.resources.yaml', 'ray-job.runtimeenvyaml.yaml', 'ray-job.custom-head-svc.yaml'])
 
     sample_yaml_files = []
     for filename in YAMLs:

--- a/tests/test_sample_rayjob_yamls.py
+++ b/tests/test_sample_rayjob_yamls.py
@@ -29,11 +29,11 @@ if __name__ == '__main__':
 
     NAMESPACE = 'default'
     SAMPLE_PATH = CONST.REPO_ROOT.joinpath("ray-operator/config/samples/")
-    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml']
+    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml', 'ray-job.custom-head-svc.yaml']
     if not latest:
         # Test new backwards-incompatible fields.
         # TODO: Move these to "latest" after KubeRay v1.0 is released.
-        YAMLs.extend(['ray_v1alpha1_rayjob.resources.yaml', 'ray-job.runtimeenvyaml.yaml', 'ray-job.custom-head-svc.yaml'])
+        YAMLs.extend(['ray_v1alpha1_rayjob.resources.yaml', 'ray-job.runtimeenvyaml.yaml'])
 
     sample_yaml_files = []
     for filename in YAMLs:

--- a/tests/test_sample_rayjob_yamls.py
+++ b/tests/test_sample_rayjob_yamls.py
@@ -29,11 +29,11 @@ if __name__ == '__main__':
 
     NAMESPACE = 'default'
     SAMPLE_PATH = CONST.REPO_ROOT.joinpath("ray-operator/config/samples/")
-    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml', 'ray-job.custom-head-svc.yaml']
+    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml']
     if not latest:
         # Test new backwards-incompatible fields.
         # TODO: Move these to "latest" after KubeRay v1.0 is released.
-        YAMLs.extend(['ray_v1alpha1_rayjob.resources.yaml', 'ray-job.runtimeenvyaml.yaml'])
+        YAMLs.extend(['ray_v1alpha1_rayjob.resources.yaml', 'ray-job.runtimeenvyaml.yaml', 'ray-job.custom-head-svc.yaml'])
 
     sample_yaml_files = []
     for filename in YAMLs:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The KubeRay documentation resides in the Ray repository.  However, these docs link to sample YAML files from the KubeRay repo's master branch.  Since these YAML files include new fields such as `EntrypointNumCPUs` and `RuntimeEnvYAML` that are not yet available in a released KubeRay version, these files will only work if the user installs the nightly KubeRay version.  However, the default Ray documentation tells users to use the latest released KubeRay version (as it should), not the nightly.

This PR reverts the default sample YAML files to only use fields that are compatible with the latest released KubeRay version.    

For the new field `RuntimeEnvYAML`, this PR adds a separate new sample YAML file `rayjob-runtimeenvyaml.yaml`.

Finally, this PR adds a new flag `--latest` for the sample YAML test script that allows CI to test different sets of YAML files depending on whether it's running the latest or the nightly KubeRay.   This allows the new fields to be tested, while still allowing the old sample YAML files to be tested.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
