### PR TITLE
fix: Issue #1391 - Custom labels not being pulled in

### DIFF
--- a/helm-chart/kuberay-apiserver/templates/deployment.yaml
+++ b/helm-chart/kuberay-apiserver/templates/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .Values.name }}
   labels:
 {{ include "kuberay-apiserver.labels" . | indent 4 }}
-{{ include "kuberay-apiserver.labels" . | indent 4 }}
 {{- if .Values.labels }}
 {{- toYaml .Values.labels | nindent 4 }}
 {{- end }}

--- a/helm-chart/kuberay-apiserver/templates/deployment.yaml
+++ b/helm-chart/kuberay-apiserver/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ .Values.name }}
   labels:
 {{ include "kuberay-apiserver.labels" . | indent 4 }}
+{{ include "kuberay-apiserver.labels" . | indent 4 }}
+{{- if .Values.labels }}
+{{- toYaml .Values.labels | nindent 4 }}
+{{- end }}
 spec:
   selector:
     matchLabels:
@@ -15,6 +19,13 @@ spec:
       labels:
         app.kubernetes.io/component: {{ include "kuberay-apiserver.name" . }}
         app.kubernetes.io/name: {{ .Release.Name }}
+        {{- if .Values.labels }}
+        {{- toYaml .Values.labels | nindent 8 }}
+        {{- end }}
+      {{- if .Values.annotations }}
+      annotations:
+        {{- toYaml .Values.annotations | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:

--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "kuberay-operator.fullname" . }}
   labels:
 {{ include "kuberay-operator.labels" . | indent 4 }}
+{{- if .Values.labels }}
+{{- toYaml .Values.labels | nindent 4 }}
+{{- end }}
 spec:
   replicas: 1
   strategy:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
fixes #1391 Some organizations have strict labeling requirements for their K8s objects, mainly deployments and pods. kuberay-operator was allowing to add custom labels via values.yaml to pods but not to deployments and kuberay-apiserver was not allowing to add custom labels to either. Added code to pull labels for deployment if present in values.yaml. Also, added code to pull annotations for apiserver as well as is the case with operator.  

## Related issue number
Closes #1391 

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
