### PR TITLE
[RayOperator] Added Label/Annotation inheritance to ray jobs/pods

### DIFF
--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -148,7 +148,7 @@ func GetDefaultSubmitterTemplate(rayJobInstance *rayv1alpha1.RayJob) v1.PodTempl
 		// If we can't find the image of the Ray head, fall back to the latest stable release.
 		image = "rayproject/ray:latest"
 	}
-	return v1.PodTemplateSpec{
+	pts := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
@@ -159,4 +159,7 @@ func GetDefaultSubmitterTemplate(rayJobInstance *rayv1alpha1.RayJob) v1.PodTempl
 			RestartPolicy: v1.RestartPolicyNever,
 		},
 	}
+	pts.Labels = rayJobInstance.Labels
+	pts.Annotations = rayJobInstance.Annotations
+	return pts
 }

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -389,8 +389,10 @@ func (r *RayJobReconciler) getSubmitterTemplate(rayJobInstance *rayv1alpha1.RayJ
 func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *rayv1alpha1.RayJob, submitterTemplate v1.PodTemplateSpec, rayClusterInstance *rayv1alpha1.RayCluster) (string, bool, error) {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      rayJobInstance.Name,
-			Namespace: rayJobInstance.Namespace,
+			Name:        rayJobInstance.Name,
+			Namespace:   rayJobInstance.Namespace,
+			Labels:      rayJobInstance.Labels,
+			Annotations: rayJobInstance.Annotations,
 		},
 		Spec: batchv1.JobSpec{
 			Template: submitterTemplate,


### PR DESCRIPTION
Hello,

This PR is related to issue #1384, where we needed the worker pods/jobs to also include the same labels/annotations as the RayJob, as there was no obvious way to include them other that to pass the entire spec for the pods, although the jobs would still be unlabeled. If there is a more elegant solution to this problem, please let me know how.

All tests passed and was able to deploy in AWS EKS cluster and run a sample test.
Closes: #1384
