### PR TITLE
[Feature][GCS FT] Clean up Redis once a GCS FT-Enabled RayCluster is deleted

### DIFF
--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -98,3 +98,6 @@ env:
 # environment variable is not set, requeue after the default value (300).
 # - name: RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV
 #   value: 300
+# If not set or set to "true", KubeRay will clean up the Redis storage namespace when a GCS FT-enabled RayCluster is deleted.
+# - name: ENABLE_GCS_FT_REDIS_CLEANUP
+#   value: "true"

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -147,10 +147,11 @@ type HeadInfo struct {
 type RayNodeType string
 
 const (
-	// HeadNode means that this pod will be ray cluster head
-	HeadNode RayNodeType = "head"
-	// WorkerNode means that this pod will be ray cluster worker
+	HeadNode   RayNodeType = "head"
 	WorkerNode RayNodeType = "worker"
+	// RedisCleanupNode is a Pod managed by a Kubernetes Job that cleans up Redis data after
+	// a RayCluster with GCS fault tolerance enabled is deleted.
+	RedisCleanupNode RayNodeType = "redis-cleanup"
 )
 
 // RayCluster is the Schema for the RayClusters API

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -26,6 +26,9 @@ const (
 	RayFTEnabledAnnotationKey         = "ray.io/ft-enabled"
 	RayExternalStorageNSAnnotationKey = "ray.io/external-storage-namespace"
 
+	// Finalizers for GCS fault tolerance
+	GCSFaultToleranceRedisCleanupFinalizer = "ray.io/gcs-ft-redis-cleanup-finalizer"
+
 	// Pod health state values
 	PodUnhealthy = "Unhealthy"
 

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -101,6 +101,10 @@ const (
 	// removed if the default behavior is stable enoguh.
 	ENABLE_RANDOM_POD_DELETE = "ENABLE_RANDOM_POD_DELETE"
 
+	// This KubeRay operator environment variable is used to determine if the Redis
+	// cleanup Job should be enabled. This is a feature flag for v1.0.0.
+	ENABLE_GCS_FT_REDIS_CLEANUP = "ENABLE_GCS_FT_REDIS_CLEANUP"
+
 	// Ray core default configurations
 	DefaultWorkerRayGcsReconnectTimeoutS = "600"
 

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -51,17 +51,10 @@ func GetHeadPort(headStartParams map[string]string) string {
 	return headPort
 }
 
-// rayClusterHAEnabled check if RayCluster enabled FT in annotations
-func rayClusterHAEnabled(instance rayv1alpha1.RayCluster) bool {
-	if instance.Annotations == nil {
-		return false
-	}
-	if v, ok := instance.Annotations[RayFTEnabledAnnotationKey]; ok {
-		if strings.ToLower(v) == "true" {
-			return true
-		}
-	}
-	return false
+// Check if the RayCluster has GCS fault tolerance enabled.
+func IsGCSFaultToleranceEnabled(instance rayv1alpha1.RayCluster) bool {
+	v, ok := instance.Annotations[RayFTEnabledAnnotationKey]
+	return ok && strings.ToLower(v) == "true"
 }
 
 func initTemplateAnnotations(instance rayv1alpha1.RayCluster, podTemplate *v1.PodTemplateSpec) {
@@ -71,7 +64,7 @@ func initTemplateAnnotations(instance rayv1alpha1.RayCluster, podTemplate *v1.Po
 
 	// For now, we just set ray external storage enabled/disabled by checking if FT is enabled/disabled.
 	// This may need to be updated in the future.
-	if rayClusterHAEnabled(instance) {
+	if IsGCSFaultToleranceEnabled(instance) {
 		podTemplate.Annotations[RayFTEnabledAnnotationKey] = "true"
 		// if we have FT enabled, we need to set up a default external storage namespace.
 		podTemplate.Annotations[RayExternalStorageNSAnnotationKey] = string(instance.UID)

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -185,7 +185,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 		if instance.DeletionTimestamp.IsZero() {
 			if !controllerutil.ContainsFinalizer(instance, common.GCSFaultToleranceRedisCleanupFinalizer) {
 				r.Log.Info(
-					"GCS fault tolerance has been enabled. Implement a finalizer to ensure that Redis is properly cleaned up once the RayCluster custom resource (CR) is deleted.",
+					"GCS fault tolerance has been enabled. Implementing a finalizer to ensure that Redis is properly cleaned up once the RayCluster custom resource (CR) is deleted.",
 					"finalizer", common.GCSFaultToleranceRedisCleanupFinalizer)
 				controllerutil.AddFinalizer(instance, common.GCSFaultToleranceRedisCleanupFinalizer)
 				if err := r.Update(ctx, instance); err != nil {

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 
+	batchv1 "k8s.io/api/batch/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	rayv1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
@@ -56,7 +57,7 @@ func getDiscoveryClient(config *rest.Config) (*discovery.DiscoveryClient, error)
 }
 
 // Check where we are running. We are trying to distinguish here whether
-// this is vanilla kubernetes cluster or OPenshift
+// this is vanilla kubernetes cluster or Openshift
 func getClusterType(logger logr.Logger) bool {
 	if os.Getenv("USE_INGRESS_ON_OPENSHIFT") == "true" {
 		// Environment is set to treat OpenShift cluster as Vanilla Kubernetes
@@ -173,6 +174,111 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 
 	_ = r.Log.WithValues("raycluster", request.NamespacedName)
 	r.Log.Info("reconciling RayCluster", "cluster name", request.Name)
+
+	if common.IsGCSFaultToleranceEnabled(*instance) {
+		if instance.DeletionTimestamp.IsZero() {
+			if !controllerutil.ContainsFinalizer(instance, common.GCSFaultToleranceRedisCleanupFinalizer) {
+				r.Log.Info(
+					"GCS fault tolerance has been enabled. Implement a finalizer to ensure that Redis is properly cleaned up once the RayCluster custom resource (CR) is deleted.",
+					"finalizer", common.GCSFaultToleranceRedisCleanupFinalizer)
+				controllerutil.AddFinalizer(instance, common.GCSFaultToleranceRedisCleanupFinalizer)
+				if err := r.Update(ctx, instance); err != nil {
+					r.Log.Error(err, fmt.Sprintf("Failed to add the finalizer %s to the RayCluster.", common.GCSFaultToleranceRedisCleanupFinalizer))
+					return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+				}
+				// Only start the RayCluster reconciliation after the finalizer is added.
+				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
+			}
+		} else {
+			r.Log.Info(
+				fmt.Sprintf("The RayCluster with GCS enabled, %s, is being deleted. Start to handle the Redis cleanup finalizer %s.",
+					instance.Name, common.GCSFaultToleranceRedisCleanupFinalizer),
+				"DeletionTimestamp", instance.ObjectMeta.DeletionTimestamp)
+
+			// Delete the head Pod if it exists.
+			headPods := corev1.PodList{}
+			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeTypeLabelKey: string(rayv1alpha1.HeadNode)}
+			if err := r.List(ctx, &headPods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
+				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+			}
+
+			for _, headPod := range headPods.Items {
+				r.Log.Info(fmt.Sprintf(
+					"Delete the head Pod %s before the Redis cleanup. "+
+						"The storage namespace %s in Redis cannot be fully deleted if the GCS process on the head Pod is still writing to it.",
+					headPod.Name, headPod.Annotations[common.RayExternalStorageNSAnnotationKey]))
+				if err := r.Delete(ctx, &headPod); err != nil {
+					return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+				}
+			}
+
+			// Delete all worker Pods if they exist.
+			for _, workerGroup := range instance.Spec.WorkerGroupSpecs {
+				workerPods := corev1.PodList{}
+				filterLabels = client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeGroupLabelKey: workerGroup.GroupName}
+				if err := r.List(ctx, &workerPods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
+					return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+				}
+
+				for _, workerPod := range workerPods.Items {
+					r.Log.Info(fmt.Sprintf(
+						"Delete the worker Pod %s. This step isn't necessary for initiating the Redis cleanup process.", workerPod.Name))
+					if err := r.Delete(ctx, &workerPod); err != nil {
+						return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+					}
+				}
+			}
+
+			// If the number of head Pods is not 0, wait for it to be terminated before initiating the Redis cleanup process.
+			if len(headPods.Items) != 0 {
+				r.Log.Info(fmt.Sprintf(
+					"Wait for the head Pod %s to be terminated before initiating the Redis cleanup process. "+
+						"The storage namespace %s in Redis cannot be fully deleted if the GCS process on the head Pod is still writing to it.",
+					headPods.Items[0].Name, headPods.Items[0].Annotations[common.RayExternalStorageNSAnnotationKey]))
+				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
+			}
+
+			// We can start the Redis cleanup process now because the head Pod has been terminated.
+			filterLabels = client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeTypeLabelKey: string(rayv1alpha1.RedisCleanupNode)}
+			redisCleanupJobs := batchv1.JobList{}
+			if err := r.List(ctx, &redisCleanupJobs, client.InNamespace(instance.Namespace), filterLabels); err != nil {
+				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+			}
+
+			if len(redisCleanupJobs.Items) != 0 {
+				// Check whether the Redis cleanup Job has been completed.
+				redisCleanupJob := redisCleanupJobs.Items[0]
+				if redisCleanupJob.Status.Succeeded > 0 {
+					r.Log.Info(fmt.Sprintf(
+						"The Redis cleanup Job %s has been completed. "+
+							"The storage namespace %s in Redis has been fully deleted.",
+						redisCleanupJob.Name, redisCleanupJob.Annotations[common.RayExternalStorageNSAnnotationKey]))
+					// Remove the finalizer from the RayCluster CR.
+					controllerutil.RemoveFinalizer(instance, common.GCSFaultToleranceRedisCleanupFinalizer)
+					if err := r.Update(ctx, instance); err != nil {
+						r.Log.Error(err, "Failed to remove finalizer for RayCluster")
+						return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+					}
+					r.Log.Info(fmt.Sprintf(
+						"The Redis cleanup finalizer has been successfully removed from the RayCluster CR %s. "+
+							"We do not need to requeue the RayCluster CR anymore.", instance.Name))
+					return ctrl.Result{}, nil
+				}
+			} else {
+				redisCleanupJob := r.buildRedisCleanupJob(*instance)
+				if err := r.Create(ctx, &redisCleanupJob); err != nil {
+					if errors.IsAlreadyExists(err) {
+						r.Log.Info(fmt.Sprintf("Redis cleanup Job already exists. Requeue the RayCluster CR %s.", instance.Name))
+						return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
+					}
+					r.Log.Error(err, "Failed to create Redis cleanup Job")
+					return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+				}
+				r.Log.Info("Successfully created Redis cleanup Job", "Job name", redisCleanupJob.Name)
+			}
+			return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
+		}
+	}
 
 	if instance.DeletionTimestamp != nil && !instance.DeletionTimestamp.IsZero() {
 		r.Log.Info("RayCluster is being deleted, just ignore", "cluster name", request.Name)
@@ -915,6 +1021,43 @@ func (r *RayClusterReconciler) buildWorkerPod(instance rayv1alpha1.RayCluster, w
 	}
 
 	return pod
+}
+
+func (r *RayClusterReconciler) buildRedisCleanupJob(instance rayv1alpha1.RayCluster) batchv1.Job {
+	pod := r.buildHeadPod(instance)
+	pod.Labels[common.RayNodeTypeLabelKey] = string(rayv1alpha1.RedisCleanupNode)
+	// Only keep the Ray container in the Redis cleanup Job.
+	pod.Spec.Containers = []corev1.Container{pod.Spec.Containers[common.RayContainerIndex]}
+	pod.Spec.Containers[common.RayContainerIndex].Command = []string{"/bin/bash", "-lc", "--"}
+	pod.Spec.Containers[common.RayContainerIndex].Args = []string{
+		"python -c " +
+			"\"from ray._private.gcs_utils import cleanup_redis_storage; " +
+			"import os; " +
+			"host, port = os.getenv('RAY_REDIS_ADDRESS').rsplit(':'); " +
+			"cleanup_redis_storage(host=host, port=int(port), password=os.getenv('REDIS_PASSWORD'), use_ssl=False, storage_namespace=os.getenv('RAY_external_storage_namespace'))\""}
+	// For Kubernetes Job, the valid values for Pod's `RestartPolicy` are `Never` and `OnFailure`.
+	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
+
+	redisCleanupJob := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        fmt.Sprintf("%s-%s", instance.Name, "redis-cleanup"),
+			Namespace:   instance.Namespace,
+			Labels:      pod.Labels,
+			Annotations: pod.Annotations,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: pod.ObjectMeta,
+				Spec:       pod.Spec,
+			},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(&instance, &redisCleanupJob, r.Scheme); err != nil {
+		r.Log.Error(err, "Failed to set controller reference for the Redis cleanup Job.")
+	}
+
+	return redisCleanupJob
 }
 
 // SetupWithManager builds the reconciler.

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -37,9 +37,11 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/utils/pointer"
@@ -1947,4 +1949,250 @@ func Test_ShouldDeletePod(t *testing.T) {
 	}
 	shouldDelete, _ = shouldDeletePod(pod, rayv1alpha1.HeadNode)
 	assert.True(t, shouldDelete)
+}
+
+func Test_RedisCleanupFeatureFlag(t *testing.T) {
+	setupTest(t)
+
+	defer os.Unsetenv(common.ENABLE_GCS_FT_REDIS_CLEANUP)
+
+	newScheme := runtime.NewScheme()
+	_ = rayv1alpha1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	// Prepare a RayCluster with the GCS FT enabled and Autoscaling disabled.
+	gcsFTEnabledcluster := testRayCluster.DeepCopy()
+	if gcsFTEnabledcluster.Annotations == nil {
+		gcsFTEnabledcluster.Annotations = make(map[string]string)
+	}
+	gcsFTEnabledcluster.Annotations[common.RayFTEnabledAnnotationKey] = "true"
+	gcsFTEnabledcluster.Spec.EnableInTreeAutoscaling = nil
+	ctx := context.Background()
+
+	// The KubeRay operator environment variable `ENABLE_GCS_FT_REDIS_CLEANUP` is used to enable/disable
+	// the GCS FT Redis cleanup feature. If the feature flag is not set, the GCS FT Redis cleanup feature
+	// is enabled by default.
+	tests := map[string]struct {
+		enableGCSFTRedisCleanup string
+		expectedNumFinalizers   int
+	}{
+		"Enable GCS FT Redis cleanup": {
+			enableGCSFTRedisCleanup: "true",
+			expectedNumFinalizers:   1,
+		},
+		"Disable GCS FT Redis cleanup": {
+			enableGCSFTRedisCleanup: "false",
+			expectedNumFinalizers:   0,
+		},
+		"Feature flag is not set": {
+			enableGCSFTRedisCleanup: "unset",
+			expectedNumFinalizers:   1,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.enableGCSFTRedisCleanup == "unset" {
+				os.Unsetenv(common.ENABLE_GCS_FT_REDIS_CLEANUP)
+			} else {
+				os.Setenv(common.ENABLE_GCS_FT_REDIS_CLEANUP, tc.enableGCSFTRedisCleanup)
+			}
+
+			cluster := gcsFTEnabledcluster.DeepCopy()
+			runtimeObjects := []runtime.Object{cluster}
+			fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
+
+			// Initialize the reconciler
+			testRayClusterReconciler := &RayClusterReconciler{
+				Client:   fakeClient,
+				Recorder: &record.FakeRecorder{},
+				Scheme:   newScheme,
+				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
+			}
+
+			rayClusterList := rayv1alpha1.RayClusterList{}
+			err := fakeClient.List(ctx, &rayClusterList, client.InNamespace(namespaceStr))
+			assert.Nil(t, err, "Fail to get RayCluster list")
+			assert.Equal(t, 1, len(rayClusterList.Items))
+			assert.Equal(t, 0, len(rayClusterList.Items[0].Finalizers))
+
+			request := ctrl.Request{NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}}
+			testRayClusterReconciler.rayClusterReconcile(ctx, request, cluster)
+
+			// Check the RayCluster's finalizer
+			rayClusterList = rayv1alpha1.RayClusterList{}
+			err = fakeClient.List(ctx, &rayClusterList, client.InNamespace(namespaceStr))
+			assert.Nil(t, err, "Fail to get RayCluster list")
+			assert.Equal(t, 1, len(rayClusterList.Items))
+			assert.Equal(t, tc.expectedNumFinalizers, len(rayClusterList.Items[0].Finalizers))
+			if tc.expectedNumFinalizers > 0 {
+				assert.True(t, controllerutil.ContainsFinalizer(&rayClusterList.Items[0], common.GCSFaultToleranceRedisCleanupFinalizer))
+
+				// No Pod should be created before adding the GCS FT Redis cleanup finalizer.
+				podList := corev1.PodList{}
+				err = fakeClient.List(ctx, &podList, client.InNamespace(namespaceStr))
+				assert.Nil(t, err, "Fail to get Pod list")
+				assert.Equal(t, 0, len(podList.Items))
+
+				// Reconcile the RayCluster again. The controller should create Pods.
+				testRayClusterReconciler.rayClusterReconcile(ctx, request, cluster)
+				err = fakeClient.List(ctx, &podList, client.InNamespace(namespaceStr))
+				assert.Nil(t, err, "Fail to get Pod list")
+				assert.NotEqual(t, 0, len(podList.Items))
+			}
+		})
+	}
+}
+
+func Test_RedisCleanup(t *testing.T) {
+	setupTest(t)
+	newScheme := runtime.NewScheme()
+	_ = rayv1alpha1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+	_ = batchv1.AddToScheme(newScheme)
+
+	// Prepare a RayCluster with the GCS FT enabled and Autoscaling disabled.
+	gcsFTEnabledcluster := testRayCluster.DeepCopy()
+	if gcsFTEnabledcluster.Annotations == nil {
+		gcsFTEnabledcluster.Annotations = make(map[string]string)
+	}
+	gcsFTEnabledcluster.Annotations[common.RayFTEnabledAnnotationKey] = "true"
+	gcsFTEnabledcluster.Spec.EnableInTreeAutoscaling = nil
+
+	// Add the Redis cleanup finalizer to the RayCluster and modify the RayCluster's DeleteTimestamp to trigger the Redis cleanup.
+	controllerutil.AddFinalizer(gcsFTEnabledcluster, common.GCSFaultToleranceRedisCleanupFinalizer)
+	now := metav1.Now()
+	gcsFTEnabledcluster.DeletionTimestamp = &now
+
+	// TODO (kevin85421): Create a constant variable in constant.go for the head group name.
+	const headGroupName = "headgroup"
+
+	headPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "headNode",
+			Namespace: gcsFTEnabledcluster.Namespace,
+			Labels: map[string]string{
+				common.RayClusterLabelKey:   gcsFTEnabledcluster.Name,
+				common.RayNodeTypeLabelKey:  string(rayv1alpha1.HeadNode),
+				common.RayNodeGroupLabelKey: headGroupName,
+			},
+		},
+	}
+	workerPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "workerNode",
+			Namespace: gcsFTEnabledcluster.Namespace,
+			Labels: map[string]string{
+				common.RayClusterLabelKey:   gcsFTEnabledcluster.Name,
+				common.RayNodeTypeLabelKey:  string(rayv1alpha1.WorkerNode),
+				common.RayNodeGroupLabelKey: gcsFTEnabledcluster.Spec.WorkerGroupSpecs[0].GroupName,
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		hasHeadPod      bool
+		hasWorkerPod    bool
+		expectedNumJobs int
+	}{
+		"Both head and worker Pods are not terminated": {
+			hasHeadPod:      true,
+			hasWorkerPod:    true,
+			expectedNumJobs: 0,
+		},
+		"Only head Pod is terminated": {
+			hasHeadPod:      false,
+			hasWorkerPod:    true,
+			expectedNumJobs: 1,
+		},
+		"Only worker Pod is terminated": {
+			hasHeadPod:      true,
+			hasWorkerPod:    false,
+			expectedNumJobs: 0,
+		},
+		"Both head and worker Pods are terminated": {
+			hasHeadPod:      false,
+			hasWorkerPod:    false,
+			expectedNumJobs: 1,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cluster := gcsFTEnabledcluster.DeepCopy()
+			runtimeObjects := []runtime.Object{cluster}
+			if tc.hasHeadPod {
+				runtimeObjects = append(runtimeObjects, headPod.DeepCopy())
+			}
+			if tc.hasWorkerPod {
+				runtimeObjects = append(runtimeObjects, workerPod.DeepCopy())
+			}
+			ctx := context.Background()
+
+			fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
+			if tc.hasHeadPod {
+				headPods := corev1.PodList{}
+				fakeClient.List(ctx, &headPods, client.InNamespace(namespaceStr),
+					client.MatchingLabels{
+						common.RayClusterLabelKey:   cluster.Name,
+						common.RayNodeGroupLabelKey: headGroupName,
+						common.RayNodeTypeLabelKey:  string(rayv1alpha1.HeadNode),
+					})
+				assert.Equal(t, 1, len(headPods.Items))
+			}
+			if tc.hasWorkerPod {
+				workerPods := corev1.PodList{}
+				fakeClient.List(ctx, &workerPods, client.InNamespace(namespaceStr),
+					client.MatchingLabels{
+						common.RayClusterLabelKey:   cluster.Name,
+						common.RayNodeGroupLabelKey: cluster.Spec.WorkerGroupSpecs[0].GroupName,
+						common.RayNodeTypeLabelKey:  string(rayv1alpha1.WorkerNode),
+					})
+				assert.Equal(t, 1, len(workerPods.Items))
+			}
+
+			testRayClusterReconciler := &RayClusterReconciler{
+				Client:   fakeClient,
+				Recorder: &record.FakeRecorder{},
+				Scheme:   newScheme,
+				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
+			}
+
+			// Check Job
+			jobList := batchv1.JobList{}
+			err := fakeClient.List(ctx, &jobList, client.InNamespace(namespaceStr))
+			assert.Nil(t, err, "Fail to get Job list")
+			assert.Equal(t, 0, len(jobList.Items))
+
+			request := ctrl.Request{NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}}
+			testRayClusterReconciler.rayClusterReconcile(ctx, request, cluster)
+
+			// Check Job
+			jobList = batchv1.JobList{}
+			err = fakeClient.List(ctx, &jobList, client.InNamespace(namespaceStr))
+			assert.Nil(t, err, "Fail to get Job list")
+			assert.Equal(t, tc.expectedNumJobs, len(jobList.Items))
+
+			if tc.expectedNumJobs > 0 {
+				// Check RayCluster's finalizer
+				rayClusterList := rayv1alpha1.RayClusterList{}
+				err = fakeClient.List(ctx, &rayClusterList, client.InNamespace(namespaceStr))
+				assert.Nil(t, err, "Fail to get RayCluster list")
+				assert.Equal(t, 1, len(rayClusterList.Items))
+				assert.True(t, controllerutil.ContainsFinalizer(&rayClusterList.Items[0], common.GCSFaultToleranceRedisCleanupFinalizer))
+
+				// Simulate the Job succeeded.
+				job := jobList.Items[0]
+				job.Status.Succeeded = 1
+				fakeClient.Update(ctx, &job)
+
+				// Reconcile the RayCluster again. The controller should remove the finalizer and the RayCluster will be deleted.
+				// See https://github.com/kubernetes-sigs/controller-runtime/blob/release-0.11/pkg/client/fake/client.go#L308-L310 for more details.
+				testRayClusterReconciler.rayClusterReconcile(ctx, request, cluster)
+				err = fakeClient.List(ctx, &rayClusterList, client.InNamespace(namespaceStr))
+				assert.Nil(t, err, "Fail to get RayCluster list")
+				assert.Equal(t, 0, len(rayClusterList.Items))
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Implement Method 5 in https://github.com/ray-project/kuberay/issues/1286#issuecomment-1699968632.
* Add a feature gate.

## TODO

* Kubernetes Job configurations, e.g. `backoffLimit`, `completions`, ... etc.
* Documentations (including how to delete it if it fails)
* E2E tests
* Improve observability
* Test if the Job fails to connect to Redis.

## Related issue number

Closes #1286 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
# Step 0: Create a Kubernetes cluster
# Step 1: Install a KubeRay operator with this PR
# Step 2: Create a GCS FT-enabled 
# (path: ray-operator/config/samples)
kubectl apply -f ray-cluster.external-redis.yaml

# Step 3: Wait until head Pod is running and ready.

# Step 4: Log in to the Redis Pod
kubectl exec -it $REDIS_POD -- bash

# Step 5: Check Redis data (in the Redis Pod)
redis-cli -a "5241590000000000"
KEYS *
# [Example output]: 1) "4c31680c-2a27-4788-92d8-6867188ecdd8"
HGETALL  "4c31680c-2a27-4788-92d8-6867188ecdd8"

# [Example output]
# 57) "4c31680c-2a27-4788-92d8-6867188ecdd8@KV:@namespace_dashboard:DASHBOARD_AGENT_PORT_PREFIX:19ca12675b387fb9e69ba6613b6c47ebc38ce441176b931fb052e09e"
# 58) "[52365, 43258]"
# 59) "4c31680c-2a27-4788-92d8-6867188ecdd8@KV:@namespace_usage_stats:extra_usage_tag_dashboard_used"
# 60) "False"

# Step 6: Delete the RayCluster
kubectl delete rayclusters.ray.io raycluster-external-redis 

# Step 7: Repeat Step 4 and Step 5
KEYS *
# [Expected output]: (empty list or set)

```
