### PR TITLE
[Bug][RayService] KubeRay does not recreate Serve applications if a head Pod without GCS FT recovers from a failure.

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -596,7 +596,7 @@ func TestCheckIfNeedSubmitServeDeployment(t *testing.T) {
 			Namespace: cluster.ObjectMeta.Namespace,
 		},
 		Spec: rayv1alpha1.RayServiceSpec{
-			ServeConfigV2: fmt.Sprintf(`
+			ServeConfigV2: `
 applications:
 - name: myapp
   import_path: fruit.deployment_graph
@@ -608,7 +608,7 @@ applications:
 	user_config:
 	price: 3
 	ray_actor_options:
-	num_cpus: 0.1`),
+	num_cpus: 0.1`,
 		},
 	}
 
@@ -643,10 +643,10 @@ applications:
 
 	// Test 4: The Serve application has been created, but the Serve config has been updated.
 	// Therefore, the Serve in-place update should be triggered.
-	rayService.Spec.ServeConfigV2 = fmt.Sprintf(`
+	rayService.Spec.ServeConfigV2 = `
 applications:
 - name: new_app_name
-  import_path: fruit.deployment_graph`)
+  import_path: fruit.deployment_graph`
 	shouldCreate = r.checkIfNeedSubmitServeDeployment(&rayService, &cluster, &serveStatus)
 	assert.True(t, shouldCreate)
 }


### PR DESCRIPTION
## Why are these changes needed?

The function `checkIfNeedSubmitServeDeployment` is used to determine whether to update or create Ray Serve applications. Without this PR, this function returns true in the following two conditions:

(1) When there is no Serve config cache in the KubeRay operator, indicating that either a new RayCluster has just become ready or the KubeRay operator has crashed.

(2) When the Serve config in the cache differs from the RayService CR's ServeConfigV2, indicating an in-place Serve config update.

However, in the case of a head Pod crash and restart without GCS FT, the KubeRay operator will not send a request to create new Ray Serve applications because the Serve config cache remains the same as the RayService CR's ServeConfigV2.

Furthermore, the RayCluster will not be labeled as unhealthy because the function `getAndCheckServeStatus` does not handle the edge case when the number of Ray Serve applications is 0.

## TODO

e2e test

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
# Step 1: Install a KubeRay operator with an image built by this PR
# Step 2: Create a RayService (path: ray-operator/config/samples)
kubectl apply -f ray_v1alpha1_rayservice.yaml

# Step 3: Forward the dashboard
kubectl port-forward --address 0.0.0.0 svc/rayservice-sample-head-svc 8265

# Step 4: Check http://127.0.0.1:8265/#/serve

# Step 5: Delete the head Pod
export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -o custom-columns=POD:metadata.name --no-headers)
kubectl delete pod $HEAD_POD

# Step 6: Check the dashboard again after the head Pod restarts
```

* Step 4 screenshot
   <img width="1918" alt="Screen Shot 2023-09-14 at 3 28 54 PM" src="https://github.com/ray-project/kuberay/assets/20109646/695d1e50-12b5-4b07-865e-1a1942aba5d4">
* Step 6 screenshot
   <img width="1918" alt="Screen Shot 2023-09-14 at 3 29 49 PM" src="https://github.com/ray-project/kuberay/assets/20109646/945081c2-d165-470a-84a3-48c2237c424a">

Without this PR, you cannot see any Serve application in Step 6.
* Example:
  <img width="1917" alt="Screen Shot 2023-09-14 at 3 37 25 PM" src="https://github.com/ray-project/kuberay/assets/20109646/96d72f47-b7d3-4e0f-89da-28763ce8bfd3">