### PR TITLE
[Bug][RayJob] Check dashboard readiness before creating job pod (#1381)

### DIFF
--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -36,6 +36,7 @@ const (
 	JobDeploymentStatusInitializing                  JobDeploymentStatus = "Initializing"
 	JobDeploymentStatusFailedToGetOrCreateRayCluster JobDeploymentStatus = "FailedToGetOrCreateRayCluster"
 	JobDeploymentStatusWaitForDashboard              JobDeploymentStatus = "WaitForDashboard"
+	JobDeploymentStatusWaitForDashboardReady         JobDeploymentStatus = "WaitForDashboardReady"
 	JobDeploymentStatusWaitForK8sJob                 JobDeploymentStatus = "WaitForK8sJob"
 	JobDeploymentStatusFailedJobDeploy               JobDeploymentStatus = "FailedJobDeploy"
 	JobDeploymentStatusRunning                       JobDeploymentStatus = "Running"

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -17,12 +17,14 @@ package ray
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -359,6 +361,51 @@ var _ = Context("Inside the default namespace with autoscaler", func() {
 		})
 	})
 })
+
+var _ = Context("With a delayed dashboard client", func() {
+	ctx := context.TODO()
+	myRayJob := myRayJob.DeepCopy()
+	myRayJob.Name = "rayjob-delayed-dashbaord"
+
+	mockedGetJobInfo := func(_ context.Context, jobId string) (*utils.RayJobInfo, error) {
+		return nil, errors.New("dashboard is not ready")
+	}
+
+	Describe("When creating a rayjob", func() {
+		It("should create a rayjob object", func() {
+			// setup mock first
+			utils.GetRayDashboardClientFunc().(*utils.FakeRayDashboardClient).GetJobInfoMock.Store(&mockedGetJobInfo)
+			err := k8sClient.Create(ctx, myRayJob)
+			Expect(err).NotTo(HaveOccurred(), "failed to create test RayJob resource")
+		})
+
+		It("should see a rayjob object with JobDeploymentStatusWaitForDashboardReady", func() {
+			Eventually(
+				getJobDeploymentStatusOfRayJob(ctx, myRayJob),
+				time.Second*3, time.Millisecond*500).Should(Equal(rayv1alpha1.JobDeploymentStatusWaitForDashboardReady), "My myRayJob  = %v", myRayJob.Name)
+		})
+
+		It("Dashboard URL should be set and deployment status should leave the JobDeploymentStatusWaitForDashboardReady", func() {
+			// clear mock to back to normal behavior
+			utils.GetRayDashboardClientFunc().(*utils.FakeRayDashboardClient).GetJobInfoMock.Store(nil)
+			Eventually(
+				getDashboardURLForRayJob(ctx, myRayJob),
+				time.Second*15, time.Millisecond*500).Should(HavePrefix(myRayJob.Name), "Dashboard URL = %v", myRayJob.Status.DashboardURL)
+			Eventually(
+				getJobDeploymentStatusOfRayJob(ctx, myRayJob),
+				time.Second*3, time.Millisecond*500).Should(Not(Equal(rayv1alpha1.JobDeploymentStatusWaitForDashboardReady)), "My myRayJob  = %v", myRayJob.Name)
+		})
+	})
+})
+
+func getJobDeploymentStatusOfRayJob(ctx context.Context, rayJob *rayv1alpha1.RayJob) func() (rayv1alpha1.JobDeploymentStatus, error) {
+	return func() (rayv1alpha1.JobDeploymentStatus, error) {
+		if err := k8sClient.Get(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: "default"}, rayJob); err != nil {
+			return "", err
+		}
+		return rayJob.Status.JobDeploymentStatus, nil
+	}
+}
 
 func getRayClusterNameForRayJob(ctx context.Context, rayJob *rayv1alpha1.RayJob) func() (string, error) {
 	return func() (string, error) {

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -258,7 +258,7 @@ applications:
 	fakeRayDashboardClient := prepareFakeRayDashboardClient()
 
 	utils.GetRayDashboardClientFunc = func() utils.RayDashboardClientInterface {
-		return &fakeRayDashboardClient
+		return fakeRayDashboardClient
 	}
 
 	utils.GetRayHttpProxyClientFunc = utils.GetFakeRayHttpProxyClient
@@ -648,8 +648,8 @@ applications:
 	})
 })
 
-func prepareFakeRayDashboardClient() utils.FakeRayDashboardClient {
-	client := utils.FakeRayDashboardClient{}
+func prepareFakeRayDashboardClient() *utils.FakeRayDashboardClient {
+	client := &utils.FakeRayDashboardClient{}
 
 	client.SetSingleApplicationStatus(generateServeStatus(rayv1alpha1.DeploymentStatusEnum.HEALTHY, rayv1alpha1.ApplicationStatusEnum.RUNNING))
 


### PR DESCRIPTION
## Why are these changes needed?

As discussed in the https://github.com/ray-project/kuberay/issues/1381#issuecomment-1720721651, I added a readiness check to the dashboard server as a workaround before the release of KubeRay 1.0.0.

I didn't add new tests for these changes because it was hard to mock the `rayDashboardClient` accordingly to simulate the target behavior. But I did make sure these changes can pass the current tests.

To further add tests for these, I would suggest adding mocking functionalities into the `FakeRayDashboardClient` first. For example:

```go
func (r *FakeRayDashboardClient) GetJobInfo(ctx context.Context, jobId string) (*RayJobInfo, error) {
	return r.GetJobInfoMock(ctx, jobId)
}

// setup mock
ts := time.Now()
r.GetJobInfoMock = func(ctx context.Context, jobId string) (*RayJobInfo, error) {
	if time.Since(ts) < time.Second*10 {
		return nil, errors.New("dashboard is not ready")
	}
	return nil, nil
}
```

## Related issue number

#1381

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
