### PR TITLE
Remove GOARCH in ray-operator/Dockfile to support multi-arch images

### DIFF
--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -16,7 +16,7 @@ COPY controllers/ controllers/
 
 # Build
 USER root
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
 
 FROM scratch
 WORKDIR /

--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -92,6 +92,9 @@ docker-build: test docker-image ## Build image with the manager.
 docker-push: ## Push image with the manager.
 	${ENGINE} push ${IMG}
 
+docker-multi-arch-image: # Build and push multi arch image, amd64 and arm64 currently
+	${ENGINE} buildx build --push --platform linux/amd64,linux/arm64/v8 -t ${IMG} .
+
 ##@ Deployment
 
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
E.g. with docker buildx build --platform linux/amd64,linux/arm64/v8

## Why are these changes needed?

To support different architectures with multi-arch docker images with `docker buildx`, we should remove GOARCH=amd64 in Dockerfile.

## Related issue number

None.

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
