### PR TITLE
[Feature] Make replicas optional for WorkerGroupSpec

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -6088,8 +6088,8 @@ spec:
                       type: string
                     maxReplicas:
                       default: 2147483647
-                      description: MaxReplicas denotes the maximum number of desired
-                        Pods for this worker group.
+                      description: 'MaxReplicas denotes the maximum number of desired
+                        Pods for this worker group, and the default value '
                       format: int32
                       type: integer
                     minReplicas:
@@ -6107,7 +6107,7 @@ spec:
                     replicas:
                       default: 0
                       description: Replicas is the number of desired Pods for this
-                        worker group.
+                        worker group. See https://github.
                       format: int32
                       type: integer
                     scaleStrategy:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -6089,13 +6089,13 @@ spec:
                     maxReplicas:
                       default: 2147483647
                       description: MaxReplicas denotes the maximum number of desired
-                        Pods for this worker group and is used by the Auto
+                        Pods for this worker group.
                       format: int32
                       type: integer
                     minReplicas:
                       default: 0
                       description: MinReplicas denotes the minimum number of desired
-                        Pods for this worker group and is used by the Auto
+                        Pods for this worker group.
                       format: int32
                       type: integer
                     rayStartParams:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -6087,11 +6087,15 @@ spec:
                         them by name
                       type: string
                     maxReplicas:
-                      description: MaxReplicas defaults to maxInt32
+                      default: 2147483647
+                      description: MaxReplicas denotes the maximum number of desired
+                        Pods for this worker group and is used by the Auto
                       format: int32
                       type: integer
                     minReplicas:
-                      description: MinReplicas defaults to 1
+                      default: 0
+                      description: MinReplicas denotes the minimum number of desired
+                        Pods for this worker group and is used by the Auto
                       format: int32
                       type: integer
                     rayStartParams:
@@ -6101,7 +6105,9 @@ spec:
                         address, object-store-memory, ...'
                       type: object
                     replicas:
-                      description: Replicas Number of desired pods in this pod group.
+                      default: 0
+                      description: Replicas is the number of desired Pods for this
+                        worker group.
                       format: int32
                       type: integer
                     scaleStrategy:
@@ -11568,7 +11574,6 @@ spec:
                   - maxReplicas
                   - minReplicas
                   - rayStartParams
-                  - replicas
                   - template
                   type: object
                 type: array

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -6357,13 +6357,13 @@ spec:
                         maxReplicas:
                           default: 2147483647
                           description: MaxReplicas denotes the maximum number of desired
-                            Pods for this worker group and is used by the Auto
+                            Pods for this worker group.
                           format: int32
                           type: integer
                         minReplicas:
                           default: 0
                           description: MinReplicas denotes the minimum number of desired
-                            Pods for this worker group and is used by the Auto
+                            Pods for this worker group.
                           format: int32
                           type: integer
                         rayStartParams:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -6355,11 +6355,15 @@ spec:
                             them by name
                           type: string
                         maxReplicas:
-                          description: MaxReplicas defaults to maxInt32
+                          default: 2147483647
+                          description: MaxReplicas denotes the maximum number of desired
+                            Pods for this worker group and is used by the Auto
                           format: int32
                           type: integer
                         minReplicas:
-                          description: MinReplicas defaults to 1
+                          default: 0
+                          description: MinReplicas denotes the minimum number of desired
+                            Pods for this worker group and is used by the Auto
                           format: int32
                           type: integer
                         rayStartParams:
@@ -6369,8 +6373,9 @@ spec:
                             command: address, object-store-memory, ...'
                           type: object
                         replicas:
-                          description: Replicas Number of desired pods in this pod
-                            group.
+                          default: 0
+                          description: Replicas is the number of desired Pods for
+                            this worker group.
                           format: int32
                           type: integer
                         scaleStrategy:
@@ -12094,7 +12099,6 @@ spec:
                       - maxReplicas
                       - minReplicas
                       - rayStartParams
-                      - replicas
                       - template
                       type: object
                     type: array

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -6356,8 +6356,8 @@ spec:
                           type: string
                         maxReplicas:
                           default: 2147483647
-                          description: MaxReplicas denotes the maximum number of desired
-                            Pods for this worker group.
+                          description: 'MaxReplicas denotes the maximum number of
+                            desired Pods for this worker group, and the default value '
                           format: int32
                           type: integer
                         minReplicas:
@@ -6375,7 +6375,7 @@ spec:
                         replicas:
                           default: 0
                           description: Replicas is the number of desired Pods for
-                            this worker group.
+                            this worker group. See https://github.
                           format: int32
                           type: integer
                         scaleStrategy:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -6330,8 +6330,8 @@ spec:
                           type: string
                         maxReplicas:
                           default: 2147483647
-                          description: MaxReplicas denotes the maximum number of desired
-                            Pods for this worker group.
+                          description: 'MaxReplicas denotes the maximum number of
+                            desired Pods for this worker group, and the default value '
                           format: int32
                           type: integer
                         minReplicas:
@@ -6349,7 +6349,7 @@ spec:
                         replicas:
                           default: 0
                           description: Replicas is the number of desired Pods for
-                            this worker group.
+                            this worker group. See https://github.
                           format: int32
                           type: integer
                         scaleStrategy:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -6331,13 +6331,13 @@ spec:
                         maxReplicas:
                           default: 2147483647
                           description: MaxReplicas denotes the maximum number of desired
-                            Pods for this worker group and is used by the Auto
+                            Pods for this worker group.
                           format: int32
                           type: integer
                         minReplicas:
                           default: 0
                           description: MinReplicas denotes the minimum number of desired
-                            Pods for this worker group and is used by the Auto
+                            Pods for this worker group.
                           format: int32
                           type: integer
                         rayStartParams:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -6329,11 +6329,15 @@ spec:
                             them by name
                           type: string
                         maxReplicas:
-                          description: MaxReplicas defaults to maxInt32
+                          default: 2147483647
+                          description: MaxReplicas denotes the maximum number of desired
+                            Pods for this worker group and is used by the Auto
                           format: int32
                           type: integer
                         minReplicas:
-                          description: MinReplicas defaults to 1
+                          default: 0
+                          description: MinReplicas denotes the minimum number of desired
+                            Pods for this worker group and is used by the Auto
                           format: int32
                           type: integer
                         rayStartParams:
@@ -6343,8 +6347,9 @@ spec:
                             command: address, object-store-memory, ...'
                           type: object
                         replicas:
-                          description: Replicas Number of desired pods in this pod
-                            group.
+                          default: 0
+                          description: Replicas is the number of desired Pods for
+                            this worker group.
                           format: int32
                           type: integer
                         scaleStrategy:
@@ -12068,7 +12073,6 @@ spec:
                       - maxReplicas
                       - minReplicas
                       - rayStartParams
-                      - replicas
                       - template
                       type: object
                     type: array

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -45,12 +45,14 @@ type HeadGroupSpec struct {
 type WorkerGroupSpec struct {
 	// we can have multiple worker groups, we distinguish them by name
 	GroupName string `json:"groupName"`
-	// Replicas Number of desired pods in this pod group. This is a pointer to distinguish between explicit
-	// zero and not specified. Defaults to 1.
-	Replicas *int32 `json:"replicas"`
-	// MinReplicas defaults to 1
+	// Replicas is the number of desired Pods for this worker group.
+	// +kubebuilder:default:=0
+	Replicas *int32 `json:"replicas,omitempty"`
+	// MinReplicas denotes the minimum number of desired Pods for this worker group and is used by the Autoscaler.
+	// +kubebuilder:default:=0
 	MinReplicas *int32 `json:"minReplicas"`
-	// MaxReplicas defaults to maxInt32
+	// MaxReplicas denotes the maximum number of desired Pods for this worker group and is used by the Autoscaler.
+	// +kubebuilder:default:=2147483647
 	MaxReplicas *int32 `json:"maxReplicas"`
 	// RayStartParams are the params of the start command: address, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -45,7 +45,7 @@ type HeadGroupSpec struct {
 type WorkerGroupSpec struct {
 	// we can have multiple worker groups, we distinguish them by name
 	GroupName string `json:"groupName"`
-	// Replicas is the number of desired Pods for this worker group.
+	// Replicas is the number of desired Pods for this worker group. See https://github.com/ray-project/kuberay/pull/1443 for more details about the reason for making this field optional.
 	// +kubebuilder:default:=0
 	Replicas *int32 `json:"replicas,omitempty"`
 	// MinReplicas denotes the minimum number of desired Pods for this worker group.

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -51,7 +51,7 @@ type WorkerGroupSpec struct {
 	// MinReplicas denotes the minimum number of desired Pods for this worker group.
 	// +kubebuilder:default:=0
 	MinReplicas *int32 `json:"minReplicas"`
-	// MaxReplicas denotes the maximum number of desired Pods for this worker group.
+	// MaxReplicas denotes the maximum number of desired Pods for this worker group, and the default value is maxInt32.
 	// +kubebuilder:default:=2147483647
 	MaxReplicas *int32 `json:"maxReplicas"`
 	// RayStartParams are the params of the start command: address, object-store-memory, ...

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -48,10 +48,10 @@ type WorkerGroupSpec struct {
 	// Replicas is the number of desired Pods for this worker group.
 	// +kubebuilder:default:=0
 	Replicas *int32 `json:"replicas,omitempty"`
-	// MinReplicas denotes the minimum number of desired Pods for this worker group and is used by the Autoscaler.
+	// MinReplicas denotes the minimum number of desired Pods for this worker group.
 	// +kubebuilder:default:=0
 	MinReplicas *int32 `json:"minReplicas"`
-	// MaxReplicas denotes the maximum number of desired Pods for this worker group and is used by the Autoscaler.
+	// MaxReplicas denotes the maximum number of desired Pods for this worker group.
 	// +kubebuilder:default:=2147483647
 	MaxReplicas *int32 `json:"maxReplicas"`
 	// RayStartParams are the params of the start command: address, object-store-memory, ...

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -6088,8 +6088,8 @@ spec:
                       type: string
                     maxReplicas:
                       default: 2147483647
-                      description: MaxReplicas denotes the maximum number of desired
-                        Pods for this worker group.
+                      description: 'MaxReplicas denotes the maximum number of desired
+                        Pods for this worker group, and the default value '
                       format: int32
                       type: integer
                     minReplicas:

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -6107,7 +6107,7 @@ spec:
                     replicas:
                       default: 0
                       description: Replicas is the number of desired Pods for this
-                        worker group.
+                        worker group. See https://github.
                       format: int32
                       type: integer
                     scaleStrategy:

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -6089,13 +6089,13 @@ spec:
                     maxReplicas:
                       default: 2147483647
                       description: MaxReplicas denotes the maximum number of desired
-                        Pods for this worker group and is used by the Auto
+                        Pods for this worker group.
                       format: int32
                       type: integer
                     minReplicas:
                       default: 0
                       description: MinReplicas denotes the minimum number of desired
-                        Pods for this worker group and is used by the Auto
+                        Pods for this worker group.
                       format: int32
                       type: integer
                     rayStartParams:

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -6087,11 +6087,15 @@ spec:
                         them by name
                       type: string
                     maxReplicas:
-                      description: MaxReplicas defaults to maxInt32
+                      default: 2147483647
+                      description: MaxReplicas denotes the maximum number of desired
+                        Pods for this worker group and is used by the Auto
                       format: int32
                       type: integer
                     minReplicas:
-                      description: MinReplicas defaults to 1
+                      default: 0
+                      description: MinReplicas denotes the minimum number of desired
+                        Pods for this worker group and is used by the Auto
                       format: int32
                       type: integer
                     rayStartParams:
@@ -6101,7 +6105,9 @@ spec:
                         address, object-store-memory, ...'
                       type: object
                     replicas:
-                      description: Replicas Number of desired pods in this pod group.
+                      default: 0
+                      description: Replicas is the number of desired Pods for this
+                        worker group.
                       format: int32
                       type: integer
                     scaleStrategy:
@@ -11568,7 +11574,6 @@ spec:
                   - maxReplicas
                   - minReplicas
                   - rayStartParams
-                  - replicas
                   - template
                   type: object
                 type: array

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -6357,13 +6357,13 @@ spec:
                         maxReplicas:
                           default: 2147483647
                           description: MaxReplicas denotes the maximum number of desired
-                            Pods for this worker group and is used by the Auto
+                            Pods for this worker group.
                           format: int32
                           type: integer
                         minReplicas:
                           default: 0
                           description: MinReplicas denotes the minimum number of desired
-                            Pods for this worker group and is used by the Auto
+                            Pods for this worker group.
                           format: int32
                           type: integer
                         rayStartParams:

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -6375,7 +6375,7 @@ spec:
                         replicas:
                           default: 0
                           description: Replicas is the number of desired Pods for
-                            this worker group.
+                            this worker group. See https://github.
                           format: int32
                           type: integer
                         scaleStrategy:

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -6355,11 +6355,15 @@ spec:
                             them by name
                           type: string
                         maxReplicas:
-                          description: MaxReplicas defaults to maxInt32
+                          default: 2147483647
+                          description: MaxReplicas denotes the maximum number of desired
+                            Pods for this worker group and is used by the Auto
                           format: int32
                           type: integer
                         minReplicas:
-                          description: MinReplicas defaults to 1
+                          default: 0
+                          description: MinReplicas denotes the minimum number of desired
+                            Pods for this worker group and is used by the Auto
                           format: int32
                           type: integer
                         rayStartParams:
@@ -6369,8 +6373,9 @@ spec:
                             command: address, object-store-memory, ...'
                           type: object
                         replicas:
-                          description: Replicas Number of desired pods in this pod
-                            group.
+                          default: 0
+                          description: Replicas is the number of desired Pods for
+                            this worker group.
                           format: int32
                           type: integer
                         scaleStrategy:
@@ -12094,7 +12099,6 @@ spec:
                       - maxReplicas
                       - minReplicas
                       - rayStartParams
-                      - replicas
                       - template
                       type: object
                     type: array

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -6356,8 +6356,8 @@ spec:
                           type: string
                         maxReplicas:
                           default: 2147483647
-                          description: MaxReplicas denotes the maximum number of desired
-                            Pods for this worker group.
+                          description: 'MaxReplicas denotes the maximum number of
+                            desired Pods for this worker group, and the default value '
                           format: int32
                           type: integer
                         minReplicas:

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -6330,8 +6330,8 @@ spec:
                           type: string
                         maxReplicas:
                           default: 2147483647
-                          description: MaxReplicas denotes the maximum number of desired
-                            Pods for this worker group.
+                          description: 'MaxReplicas denotes the maximum number of
+                            desired Pods for this worker group, and the default value '
                           format: int32
                           type: integer
                         minReplicas:

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -6349,7 +6349,7 @@ spec:
                         replicas:
                           default: 0
                           description: Replicas is the number of desired Pods for
-                            this worker group.
+                            this worker group. See https://github.
                           format: int32
                           type: integer
                         scaleStrategy:

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -6331,13 +6331,13 @@ spec:
                         maxReplicas:
                           default: 2147483647
                           description: MaxReplicas denotes the maximum number of desired
-                            Pods for this worker group and is used by the Auto
+                            Pods for this worker group.
                           format: int32
                           type: integer
                         minReplicas:
                           default: 0
                           description: MinReplicas denotes the minimum number of desired
-                            Pods for this worker group and is used by the Auto
+                            Pods for this worker group.
                           format: int32
                           type: integer
                         rayStartParams:

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -6329,11 +6329,15 @@ spec:
                             them by name
                           type: string
                         maxReplicas:
-                          description: MaxReplicas defaults to maxInt32
+                          default: 2147483647
+                          description: MaxReplicas denotes the maximum number of desired
+                            Pods for this worker group and is used by the Auto
                           format: int32
                           type: integer
                         minReplicas:
-                          description: MinReplicas defaults to 1
+                          default: 0
+                          description: MinReplicas denotes the minimum number of desired
+                            Pods for this worker group and is used by the Auto
                           format: int32
                           type: integer
                         rayStartParams:
@@ -6343,8 +6347,9 @@ spec:
                             command: address, object-store-memory, ...'
                           type: object
                         replicas:
-                          description: Replicas Number of desired pods in this pod
-                            group.
+                          default: 0
+                          description: Replicas is the number of desired Pods for
+                            this worker group.
                           format: int32
                           type: integer
                         scaleStrategy:
@@ -12068,7 +12073,6 @@ spec:
                       - maxReplicas
                       - minReplicas
                       - rayStartParams
-                      - replicas
                       - template
                       type: object
                     type: array

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -643,7 +643,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	for _, worker := range instance.Spec.WorkerGroupSpecs {
 		// workerReplicas will store the target number of pods for this worker group.
 		var workerReplicas int32 = utils.GetWorkerGroupDesiredReplicas(worker)
-		r.Log.Info("reconcilePods", "desired workerReplicas", workerReplicas, "worker group", worker.GroupName, "maxReplicas", *worker.MaxReplicas, "minReplicas", *worker.MinReplicas, "replicas", *worker.Replicas)
+		r.Log.Info("reconcilePods", "desired workerReplicas (always adhering to minReplicas/maxReplica)", workerReplicas, "worker group", worker.GroupName, "maxReplicas", *worker.MaxReplicas, "minReplicas", *worker.MinReplicas, "replicas", *worker.Replicas)
 
 		workerPods := corev1.PodList{}
 		filterLabels = client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeGroupLabelKey: worker.GroupName}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -642,22 +642,9 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	// Reconcile worker pods now
 	for _, worker := range instance.Spec.WorkerGroupSpecs {
 		// workerReplicas will store the target number of pods for this worker group.
-		var workerReplicas int32
-		// Always honor MaxReplicas if it is set:
-		// If MaxReplicas is set and Replicas > MaxReplicas, use MaxReplicas as the
-		// effective target replica count and log the discrepancy.
-		// See https://github.com/ray-project/kuberay/issues/560.
-		if worker.MaxReplicas != nil && *worker.MaxReplicas < *worker.Replicas {
-			workerReplicas = *worker.MaxReplicas
-			r.Log.Info(
-				fmt.Sprintf(
-					"Replicas for worker group %s (%d) is greater than maxReplicas (%d). Using maxReplicas (%d) as the target replica count.",
-					worker.GroupName, *worker.Replicas, *worker.MaxReplicas, *worker.MaxReplicas,
-				),
-			)
-		} else {
-			workerReplicas = *worker.Replicas
-		}
+		var workerReplicas int32 = utils.GetWorkerGroupDesiredReplicas(worker)
+		r.Log.Info("reconcilePods", "desired workerReplicas", workerReplicas, "worker group", worker.GroupName, "maxReplicas", *worker.MaxReplicas, "minReplicas", *worker.MinReplicas, "replicas", *worker.Replicas)
+
 		workerPods := corev1.PodList{}
 		filterLabels = client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeGroupLabelKey: worker.GroupName}
 		if err := r.List(ctx, &workerPods, client.InNamespace(instance.Namespace), filterLabels); err != nil {

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -643,7 +643,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	for _, worker := range instance.Spec.WorkerGroupSpecs {
 		// workerReplicas will store the target number of pods for this worker group.
 		var workerReplicas int32 = utils.GetWorkerGroupDesiredReplicas(worker)
-		r.Log.Info("reconcilePods", "desired workerReplicas (always adhering to minReplicas/maxReplica)", workerReplicas, "worker group", worker.GroupName, "maxReplicas", *worker.MaxReplicas, "minReplicas", *worker.MinReplicas, "replicas", *worker.Replicas)
+		r.Log.Info("reconcilePods", "desired workerReplicas (always adhering to minReplicas/maxReplica)", workerReplicas, "worker group", worker.GroupName, "maxReplicas", worker.MaxReplicas, "minReplicas", worker.MinReplicas, "replicas", worker.Replicas)
 
 		workerPods := corev1.PodList{}
 		filterLabels = client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeGroupLabelKey: worker.GroupName}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -217,9 +217,10 @@ func GenerateIdentifier(clusterName string, nodeType rayv1alpha1.RayNodeType) st
 
 func GetWorkerGroupDesiredReplicas(workerGroupSpec rayv1alpha1.WorkerGroupSpec) int32 {
 	// Always adhere to min/max replicas constraints. If minReplicas > maxReplicas, minReplicas will be used.
-	// The values for Replicas, MinReplicas, and MaxReplicas cannot be nil as they have default values assigned in the CRD.
 	var workerReplicas int32
-	if *workerGroupSpec.Replicas < *workerGroupSpec.MinReplicas {
+	if workerGroupSpec.Replicas == nil || *workerGroupSpec.Replicas < *workerGroupSpec.MinReplicas {
+		// Replicas is impossible to be nil as it has a default value assigned in the CRD.
+		// Add this check to make testing easier.
 		workerReplicas = *workerGroupSpec.MinReplicas
 	} else if *workerGroupSpec.Replicas > *workerGroupSpec.MaxReplicas {
 		workerReplicas = *workerGroupSpec.MaxReplicas

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -216,9 +216,14 @@ func GenerateIdentifier(clusterName string, nodeType rayv1alpha1.RayNodeType) st
 }
 
 func GetWorkerGroupDesiredReplicas(workerGroupSpec rayv1alpha1.WorkerGroupSpec) int32 {
-	// Always adhere to min/max replicas constraints. If minReplicas > maxReplicas, minReplicas will be used.
+	// Always adhere to min/max replicas constraints.
 	var workerReplicas int32
-	if workerGroupSpec.Replicas == nil || *workerGroupSpec.Replicas < *workerGroupSpec.MinReplicas {
+	if *workerGroupSpec.MinReplicas > *workerGroupSpec.MaxReplicas {
+		logrus.Warn(
+			fmt.Sprintf("minReplicas (%v) is greater than maxReplicas (%v), using maxReplicas as desired replicas. "+
+				"Please fix this to avoid any unexpected behaviors.", *workerGroupSpec.MinReplicas, *workerGroupSpec.MaxReplicas))
+		workerReplicas = *workerGroupSpec.MaxReplicas
+	} else if workerGroupSpec.Replicas == nil || *workerGroupSpec.Replicas < *workerGroupSpec.MinReplicas {
 		// Replicas is impossible to be nil as it has a default value assigned in the CRD.
 		// Add this check to make testing easier.
 		workerReplicas = *workerGroupSpec.MinReplicas

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -218,7 +218,7 @@ func GenerateIdentifier(clusterName string, nodeType rayv1alpha1.RayNodeType) st
 func GetWorkerGroupDesiredReplicas(workerGroupSpec rayv1alpha1.WorkerGroupSpec) int32 {
 	// Always adhere to min/max replicas constraints. If minReplicas > maxReplicas, minReplicas will be used.
 	// The values for Replicas, MinReplicas, and MaxReplicas cannot be nil as they have default values assigned in the CRD.
-	var workerReplicas int32 = 0
+	var workerReplicas int32
 	if *workerGroupSpec.Replicas < *workerGroupSpec.MinReplicas {
 		workerReplicas = *workerGroupSpec.MinReplicas
 	} else if *workerGroupSpec.Replicas > *workerGroupSpec.MaxReplicas {

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -491,6 +491,12 @@ func TestGetWorkerGroupDesiredReplicas(t *testing.T) {
 	replicas = int32(0)
 	workerGroupSpec.Replicas = &replicas
 	assert.Equal(t, GetWorkerGroupDesiredReplicas(workerGroupSpec), minReplicas)
+
+	// Test 5: `WorkerGroupSpec.Replicas` is nil and minReplicas is less than maxReplicas.
+	workerGroupSpec.Replicas = nil
+	workerGroupSpec.MinReplicas = &maxReplicas
+	workerGroupSpec.MaxReplicas = &minReplicas
+	assert.Equal(t, GetWorkerGroupDesiredReplicas(workerGroupSpec), *workerGroupSpec.MaxReplicas)
 }
 
 func TestCalculateDesiredReplicas(t *testing.T) {

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -463,3 +463,31 @@ func TestGenerateHeadServiceName(t *testing.T) {
 	_, err = GenerateHeadServiceName(RayJobCRD, rayv1alpha1.RayClusterSpec{}, "rayjob-sample")
 	assert.NotNil(t, err)
 }
+
+func TestGetWorkerGroupDesiredReplicas(t *testing.T) {
+	// Test 1: `WorkerGroupSpec.Replicas` is nil.
+	// `Replicas` is impossible to be nil in a real RayCluster CR as it has a default value assigned in the CRD.
+	minReplicas := int32(1)
+	maxReplicas := int32(5)
+
+	workerGroupSpec := rayv1alpha1.WorkerGroupSpec{
+		MinReplicas: &minReplicas,
+		MaxReplicas: &maxReplicas,
+	}
+	assert.Equal(t, GetWorkerGroupDesiredReplicas(workerGroupSpec), minReplicas)
+
+	// Test 2: `WorkerGroupSpec.Replicas` is not nil and is within the range.
+	replicas := int32(3)
+	workerGroupSpec.Replicas = &replicas
+	assert.Equal(t, GetWorkerGroupDesiredReplicas(workerGroupSpec), replicas)
+
+	// Test 3: `WorkerGroupSpec.Replicas` is not nil but is more than maxReplicas.
+	replicas = int32(6)
+	workerGroupSpec.Replicas = &replicas
+	assert.Equal(t, GetWorkerGroupDesiredReplicas(workerGroupSpec), maxReplicas)
+
+	// Test 4: `WorkerGroupSpec.Replicas` is not nil but is less than minReplicas.
+	replicas = int32(0)
+	workerGroupSpec.Replicas = &replicas
+	assert.Equal(t, GetWorkerGroupDesiredReplicas(workerGroupSpec), minReplicas)
+}


### PR DESCRIPTION
## Why are these changes needed?

Some GitOps systems, like Flux, will revert changes that are not initiated by the system itself. The Ray Autoscaler modifies the `Replicas` field to scale the Ray cluster up or down. Consequently, a conflict arises where the Autoscaler makes updates to the field, and Flux continuously reverts them. To address this issue, this PR makes the `Replicas` field optional. If the field is optional, Flux will not have the reverting behavior.

* Similar issue: https://github.com/fluxcd/flux/issues/1686
* Related discussions:
  * https://ray-distributed.slack.com/archives/C01CKH05XBN/p1685123816833509
  * #1120 

## Related issue number

Closes #1154 
Closes #1120 
Closes #265 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
