### PR TITLE
use raycluster app's name as podgroup name key word

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -65,12 +65,12 @@ func (v *VolcanoBatchScheduler) DoBatchSchedulingOnSubmission(app *rayv1alpha1.R
 	return nil
 }
 
-func (v *VolcanoBatchScheduler) getAppPodGroupName(app *rayv1alpha1.RayCluster) string {
+func getAppPodGroupName(app *rayv1alpha1.RayCluster) string {
 	return fmt.Sprintf("ray-%s-pg", app.Name)
 }
 
 func (v *VolcanoBatchScheduler) syncPodGroup(app *rayv1alpha1.RayCluster, size int32, totalResource corev1.ResourceList) error {
-	podGroupName := v.getAppPodGroupName(app)
+	podGroupName := getAppPodGroupName(app)
 	if pg, err := v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Get(context.TODO(), podGroupName, metav1.GetOptions{}); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
@@ -138,7 +138,7 @@ func createPodGroup(
 }
 
 func (v *VolcanoBatchScheduler) AddMetadataToPod(app *rayv1alpha1.RayCluster, pod *corev1.Pod) {
-	pod.Annotations[v1beta1.KubeGroupNameAnnotationKey] = v.getAppPodGroupName(app)
+	pod.Annotations[v1beta1.KubeGroupNameAnnotationKey] = getAppPodGroupName(app)
 	if queue, ok := app.ObjectMeta.Labels[QueueNameLabelKey]; ok {
 		pod.Labels[QueueNameLabelKey] = queue
 	}

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
@@ -79,7 +79,7 @@ func TestCreatePodGroup(t *testing.T) {
 
 	minMember := utils.CalculateDesiredReplicas(&cluster) + *cluster.Spec.HeadGroupSpec.Replicas
 	totalResource := utils.CalculateDesiredResources(&cluster)
-	pg := createPodGroup(&cluster, cluster.ClusterName, minMember, totalResource)
+	pg := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource)
 
 	a.Equal(cluster.Namespace, pg.Namespace)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`ClusterName` has been removed in higher K8S version.
In order to be compatible with feature upgrade.

## Related issue number

Closes #1445

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
