### PR TITLE
[CI] Skip redis raycluster sample YAML test

### DIFF
--- a/tests/test_sample_raycluster_yamls.py
+++ b/tests/test_sample_raycluster_yamls.py
@@ -52,6 +52,7 @@ if __name__ == '__main__':
             'Skip this test because it requires a lot of resources.',
         'ray-cluster-tpu.yaml': 'Skip this test because it requires TPU resources.',
         'ray-cluster.gke-bucket.yaml': 'Skip this test because it requires GKE and k8s service accounts.',
+        'ray-cluster.external-redis.yaml': 'Skip this test because it requires external Redis.',
     }
 
     rs = RuleSet([HeadPodNameRule(), EasyJobRule(), HeadSvcRule()])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
My understanding is that the RayCluster sample YAML test framework only adds RayCluster CRs, but doesn't add the other resources in the sample YAML file (for example the external redis deployment).  In the case of the external redis sample YAML, the sample YAML test started failing after https://github.com/ray-project/kuberay/pull/1412/ and my tentative hypothesis is that the cleanup job added by the PR hangs if there's no external redis.

For now, we should merge this PR to unbreak CI.  Later, we can decide whether to properly support an end-to-end external redis test.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #1459 
## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
