### PR TITLE
Helm chart ray-cluster template reference fix

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -129,8 +129,8 @@ spec:
             image: {{ $values.image.repository }}:{{ $values.image.tag }}
             imagePullPolicy: {{ $values.image.pullPolicy }}
             {{- else }}
-            image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
+            imagePullPolicy: {{ $.Values.image.pullPolicy }}
             {{- end }}
             resources: {{- toYaml $values.resources | nindent 14 }}
             securityContext:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes an issue where the raycluster-cluster template is not correctly referencing the root context's image field as it's intended.  So you get the following error when trying to install:

`
Error: INSTALLATION FAILED: template: ray-cluster/templates/raycluster-cluster.yaml:132:29: executing "ray-cluster/templates/raycluster-cluster.yaml" at <.Values.image.repository>: nil pointer evaluating interface {}.image
`

## Related issue number
N/A

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
