### PR TITLE
[Enhancement] GPU RayCluster doesn't work on GKE Autopilot

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -185,8 +185,19 @@ func DefaultWorkerPodTemplate(instance rayv1alpha1.RayCluster, workerSpec rayv1a
 			// For more details, please refer to: https://docs.ray.io/en/latest/ray-core/configure.html#tls-authentication.
 			Env:          deepCopyRayContainer.Env,
 			VolumeMounts: deepCopyRayContainer.VolumeMounts,
-			// If users specify ResourceQuota for the namespace, the init container need to specify resource explicitly.
-			Resources: deepCopyRayContainer.Resources,
+			// If users specify a ResourceQuota for the namespace, the init container needs to specify resources explicitly.
+			// GKE's Autopilot does not support GPU-using init containers, so we explicitly specify the resources for the
+			// init container instead of reusing the resources of the Ray container.
+			Resources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("200m"),
+					v1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("200m"),
+					v1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
 		}
 		podTemplate.Spec.InitContainers = append(podTemplate.Spec.InitContainers, initContainer)
 	}

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -189,6 +189,8 @@ func DefaultWorkerPodTemplate(instance rayv1alpha1.RayCluster, workerSpec rayv1a
 			// GKE's Autopilot does not support GPU-using init containers, so we explicitly specify the resources for the
 			// init container instead of reusing the resources of the Ray container.
 			Resources: v1.ResourceRequirements{
+				// The init container's resource consumption remains constant, as it solely sends requests to check the GCS status at a fixed frequency.
+				// Therefore, hard-coding the resources is acceptable.
 				Limits: v1.ResourceList{
 					v1.ResourceCPU:    resource.MustParse("200m"),
 					v1.ResourceMemory: resource.MustParse("256Mi"),

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -903,9 +903,7 @@ func TestDefaultInitContainer(t *testing.T) {
 		}
 	}
 
-	// The values of `Resources` should be the same in both Ray container and health-check container.
 	assert.NotEmpty(t, rayContainer.Resources, "The test only makes sense if the Ray container has resource limit/request.")
-	assert.Equal(t, rayContainer.Resources, healthCheckContainer.Resources)
 }
 
 func TestDefaultInitContainerImagePullPolicy(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

GKE's Autopilot does not support GPU-using init containers, so we explicitly specify the resources for the init container instead of reusing the resources of the Ray container. The resource consumption of the init container should be constant. Hence, it is OK to hard-code the resources.

## Related issue number

Closes #1349 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

```sh
# Step 1: Create a GKE Autopilot cluster
gcloud container clusters create-auto kuberay-gpu-cluster --region=us-west1

# Step 2: Install a KubeRay operator with this PR
# Step 3: Install a RayCluster https://gist.github.com/kevin85421/ef4c3a0c7493e76edd3d2cab5cea33e4
# (Note that you need to add nodeSelector)

```
