### PR TITLE
Remove miniReplicas in raycluster-cluster.yaml

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -110,8 +110,8 @@ spec:
       {{- end }}
     {{- end }}
     replicas: {{ $values.replicas }}
-    minReplicas: {{ $values.minReplicas | default (default 0 $values.miniReplicas) }}
-    maxReplicas: {{ $values.maxReplicas | default (default 2147483647 $values.maxiReplicas) }}
+    minReplicas: {{ $values.minReplicas | default 0 }}
+    maxReplicas: {{ $values.maxReplicas | default 2147483647 }}
     groupName: {{ $groupName }}
     template:
       spec:
@@ -185,8 +185,8 @@ spec:
       {{- end }}
     {{- end }}
     replicas: {{ .Values.worker.replicas }}
-    minReplicas: {{ .Values.worker.minReplicas | default (default 0 .Values.worker.miniReplicas) }}
-    maxReplicas: {{ .Values.worker.maxReplicas | default (default 2147483647 .Values.worker.maxiReplicas) }}
+    minReplicas: {{ .Values.worker.minReplicas | default 0 }}
+    maxReplicas: {{ .Values.worker.maxReplicas | default 2147483647 }}
     groupName: {{ .Values.worker.groupName }}
     template:
       spec:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Clean and high readability code is easier to maintain and less prone to introducing bugs. This enhances the long-term sustainability of the project.
This change is to cleanup the KubeRay helm chart and remove a typo.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#1472
https://github.com/ray-project/kuberay/pull/1106#issuecomment-1574164061
<!-- For example: "Closes #1234" -->

## Checks

```shell
$ git diff --cached | cat
diff --git a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
index 0c13e86..c080720 100644
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -110,8 +110,8 @@ spec:
       {{- end }}
     {{- end }}
     replicas: {{ $values.replicas }}
-    minReplicas: {{ $values.minReplicas | default (default 0 $values.miniReplicas) }}
-    maxReplicas: {{ $values.maxReplicas | default (default 2147483647 $values.maxiReplicas) }}
+    minReplicas: {{ $values.minReplicas | default 0 }}
+    maxReplicas: {{ $values.maxReplicas | default 2147483647 }}
     groupName: {{ $groupName }}
     template:
       spec:
@@ -185,8 +185,8 @@ spec:
       {{- end }}
     {{- end }}
     replicas: {{ .Values.worker.replicas }}
-    minReplicas: {{ .Values.worker.minReplicas | default (default 0 .Values.worker.miniReplicas) }}
-    maxReplicas: {{ .Values.worker.maxReplicas | default (default 2147483647 .Values.worker.maxiReplicas) }}
+    minReplicas: {{ .Values.worker.minReplicas | default 0 }}
+    maxReplicas: {{ .Values.worker.maxReplicas | default 2147483647 }}
     groupName: {{ .Values.worker.groupName }}
     template:
       spec:



$ helm lint
==> Linting .

1 chart(s) linted, 0 chart(s) failed
```

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
