### PR TITLE
Update Dockerfile to address closed CVEs

### DIFF
--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-10 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
There's a number of CVEs that are closed in the latest versions of the go-1.19 toolset.

1. https://bugzilla.redhat.com/show_bug.cgi?id=2234712
2. https://bugzilla.redhat.com/show_bug.cgi?id=2234713
3. https://bugzilla.redhat.com/show_bug.cgi?id=2237782
4. https://bugzilla.redhat.com/show_bug.cgi?id=2237798
5. https://bugzilla.redhat.com/show_bug.cgi?id=2238352

cc @kevin85421 @z103cb @tedhtchang 