### PR TITLE
Revert "[CI] Skip redis raycluster sample YAML test"

### DIFF
--- a/tests/test_sample_raycluster_yamls.py
+++ b/tests/test_sample_raycluster_yamls.py
@@ -52,7 +52,6 @@ if __name__ == '__main__':
             'Skip this test because it requires a lot of resources.',
         'ray-cluster-tpu.yaml': 'Skip this test because it requires TPU resources.',
         'ray-cluster.gke-bucket.yaml': 'Skip this test because it requires GKE and k8s service accounts.',
-        'ray-cluster.external-redis.yaml': 'Skip this test because it requires external Redis.',
     }
 
     rs = RuleSet([HeadPodNameRule(), EasyJobRule(), HeadSvcRule()])


### PR DESCRIPTION
Reverts ray-project/kuberay#1465

## Why are these changes needed?

Previously, we skipped the redis raycluster e2e test in https://github.com/ray-project/kuberay/pull/1465 due to the indefinite hanging it caused.

After the https://github.com/ray-project/kuberay/pull/1466 got merged, we can now safely perform the Redis cleanup e2e test without hanging. There is no need to skip the test anymore.

## Related issue number

#1465
#1422
#1459

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
