### PR TITLE
[Feature][Observability] Scrape Autoscaler and Dashboard metrics

### DIFF
--- a/config/prometheus/serviceMonitor.yaml
+++ b/config/prometheus/serviceMonitor.yaml
@@ -19,6 +19,8 @@ spec:
   # A list of endpoints allowed as part of this ServiceMonitor.
   endpoints:
     - port: metrics
+    - port: as-metrics # autoscaler metrics
+    - port: dash-metrics # dashboard metrics
   targetLabels:
   - ray.io/cluster
 

--- a/ray-operator/config/samples/ray-cluster.embed-grafana.yaml
+++ b/ray-operator/config/samples/ray-cluster.embed-grafana.yaml
@@ -1,4 +1,4 @@
-apiVersion: ray.io/v1alpha1
+apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
   name: raycluster-embed-grafana

--- a/ray-operator/config/samples/ray-cluster.embed-grafana.yaml
+++ b/ray-operator/config/samples/ray-cluster.embed-grafana.yaml
@@ -1,4 +1,4 @@
-apiVersion: ray.io/v1
+apiVersion: ray.io/v1alpha1
 kind: RayCluster
 metadata:
   name: raycluster-embed-grafana
@@ -26,6 +26,12 @@ spec:
             name: dashboard
           - containerPort: 10001
             name: client
+          # The name of a containerPort cannot be longer than 15 characters.
+          # Hence, we use the name "as-metrics" instead of "autoscaler-metrics".
+          - containerPort: 44217
+            name: as-metrics # autoscaler
+          - containerPort: 44227
+            name: dash-metrics # dashboard
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray exposes Prometheus metrics through three endpoints: 8080, 44217 (for autoscaler metrics), and 44227 (for dashboard metrics). See [/tmp/ray/prom_metrics_service_discovery.json](https://docs.ray.io/en/latest/cluster/metrics.html?highlight=prom_metrics_service_discovery.json#auto-discovering-metrics-endpoints) on the head Pod for more details. Some Grafana panels embedded in the Ray dashboard require metrics from Autoscaler. Hence, the panel may show "No data".

![image (3)](https://github.com/ray-project/kuberay/assets/20109646/167f2aa6-2a80-48e2-93b4-0bb3bb383feb)

This PR scrapes metrics from all 8080, 44217, and 44227, so the panel will not show "No data" anymore.

<img width="645" alt="Screen Shot 2023-10-13 at 1 17 43 PM" src="https://github.com/ray-project/kuberay/assets/20109646/cb749905-6ef1-45d1-a4a4-014ac045ebec">

## Related issue number

Closes #1487 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
