### PR TITLE
[RayJob] Fix RayJob status reconciliation

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -343,7 +343,7 @@ func (r *RayJobReconciler) getOrCreateK8sJob(ctx context.Context, rayJobInstance
 				r.Log.Error(err, "failed to get submitter template")
 				return "", false, err
 			}
-			return r.createNewK8sJob(ctx, rayJobInstance, submitterTemplate, rayClusterInstance)
+			return r.createNewK8sJob(ctx, rayJobInstance, submitterTemplate)
 		}
 
 		// Some other error occurred while trying to get the Job
@@ -395,7 +395,7 @@ func (r *RayJobReconciler) getSubmitterTemplate(rayJobInstance *rayv1.RayJob, ra
 }
 
 // createNewK8sJob creates a new Kubernetes Job. It returns the Job's name and a boolean indicating whether a new Job was created.
-func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *rayv1.RayJob, submitterTemplate v1.PodTemplateSpec, rayClusterInstance *rayv1.RayCluster) (string, bool, error) {
+func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *rayv1.RayJob, submitterTemplate v1.PodTemplateSpec) (string, bool, error) {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rayJobInstance.Name,
@@ -407,7 +407,7 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 	}
 
 	// Set the ownership in order to do the garbage collection by k8s.
-	if err := ctrl.SetControllerReference(rayClusterInstance, job, r.Scheme); err != nil {
+	if err := ctrl.SetControllerReference(rayJobInstance, job, r.Scheme); err != nil {
 		r.Log.Error(err, "failed to set controller reference")
 		return "", false, err
 	}

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -489,7 +489,6 @@ func (r *RayJobReconciler) setRayJobIdAndRayClusterNameIfNeed(ctx context.Contex
 			}
 			rayJob.Status.RayClusterName = useValue
 			rayJob.Spec.ShutdownAfterJobFinishes = false
-			return nil
 		} else {
 			rayJob.Status.RayClusterName = utils.GenerateRayClusterName(rayJob.Name)
 		}


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes a number of issues related to the reconciliation of the RayJob status.

It also sets RayJob resources as owners of the Kubernetes Jobs that submit Ray jobs via the CLI.

It also addresses the issue of systematic failure upon retry of the job submission reported in #1480, by disabling submission retry altogether,  until a proper solution is found. 
The simplest solution would be to expose the job override option to the CLI, though this requires more thoughts and can be addressed in a separate PR:
https://github.com/ray-project/ray/blob/56affb7e4b5af8b1da7a322fdc6ecc7e2258d522/dashboard/modules/job/job_manager.py#L919

## Related issue numbers

Fixes #1478.
Fixes #1480.

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
