### PR TITLE
Update Dockerfiles to address CVE-2023-44487 (HTTP/2 Rapid Reset)

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -1,5 +1,5 @@
 # Build the backend service
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-10 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.13 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -1,5 +1,5 @@
 # Generate client code (go & json) from API protocol buffers
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-10 as generator
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.13 as generator
 
 ENV PROTOC_VERSION 3.17.3
 ENV GOLANG_PROTOBUF_VERSION v1.5.2

--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-16 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.13 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
This PR upgrades Dockerfiles to the latest version of the go-toolset:1.19 image that closes CVE-2023-44487.

https://bugzilla.redhat.com/show_bug.cgi?id=2242803

cc @kevin85421 @anishasthana @z103cb @tedhtchang @blublinsky
