### PR TITLE
[Test][Bug] Update worker replias idempotently in rayjob autoscaler envtest (#1471)

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -310,7 +310,7 @@ var _ = Context("Inside the default namespace with autoscaler", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: myRayJob.Status.RayClusterName, Namespace: "default"}, myRayCluster),
 					time.Second*3, time.Millisecond*500).Should(BeNil(), "Active RayCluster = %v", myRayCluster.Name)
-				*myRayCluster.Spec.WorkerGroupSpecs[0].Replicas++
+				*myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = *myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas + 1
 				return k8sClient.Update(ctx, myRayCluster)
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to update RayCluster replica")


### PR DESCRIPTION
## Why are these changes needed?

Resolves https://github.com/ray-project/kuberay/issues/1471

As discussed in the issue, we should not use `++` in a `retry.RetryOnConflict` block because it is not idempotent.
We should use the following, which will guarantee the idempotency with retries, to remove the flaky mentioned in the issue:
```
*myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = *myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas + 1
```

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
