### PR TITLE
[Post v1.0.0-rc.1] Reenable sample YAML tests for latest release and update some docs

### DIFF
--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -12,13 +12,13 @@
     # Use nightly KubeRay operator image
     - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.7.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_raycluster_yamls.py
 
-# - label: 'Test RayCluster Sample YAMLs (latest release)'
-#   instance_size: large
-#   image: golang:1.19
-#   commands:
-#     - ./.buildkite/setup-env.sh
-#     # Use KubeRay operator image from the latest release
-#     - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.7.0 OPERATOR_IMAGE=kuberay/operator:v1.0.0-rc.0 python3 tests/test_sample_raycluster_yamls.py
+- label: 'Test RayCluster Sample YAMLs (latest release)'
+  instance_size: large
+  image: golang:1.19
+  commands:
+    - ./.buildkite/setup-env.sh
+    # Use KubeRay operator image from the latest release
+    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.7.0 OPERATOR_IMAGE=kuberay/operator:v1.0.0-rc.1 python3 tests/test_sample_raycluster_yamls.py
 
 - label: 'Test RayJob Sample YAMLs (nightly operator)'
   instance_size: large
@@ -32,13 +32,13 @@
     # Use nightly KubeRay operator image
     - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.7.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayjob_yamls.py
 
-# - label: 'Test RayJob Sample YAMLs (latest release)'
-#   instance_size: large
-#   image: golang:1.19
-#   commands:
-#     - ./.buildkite/setup-env.sh
-#     # Use KubeRay operator image from the latest release
-#     - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.7.0 OPERATOR_IMAGE=kuberay/operator:v1.0.0-rc.0 python3 tests/test_sample_rayjob_yamls.py
+- label: 'Test RayJob Sample YAMLs (latest release)'
+  instance_size: large
+  image: golang:1.19
+  commands:
+    - ./.buildkite/setup-env.sh
+    # Use KubeRay operator image from the latest release
+    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.7.0 OPERATOR_IMAGE=kuberay/operator:v1.0.0-rc.1 python3 tests/test_sample_rayjob_yamls.py
 
 - label: 'Test RayService Sample YAMLs (nightly operator)'
   instance_size: large
@@ -52,10 +52,10 @@
     # Use nightly KubeRay operator image
     - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.7.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
 
-# - label: 'Test RayService Sample YAMLs (latest release)'
-#   instance_size: large
-#   image: golang:1.19
-#   commands:
-#     - ./.buildkite/setup-env.sh
-#     # Use KubeRay operator image from the latest release
-#     - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.7.0 OPERATOR_IMAGE=kuberay/operator:v1.0.0-rc.0 python3 tests/test_sample_rayservice_yamls.py
+- label: 'Test RayService Sample YAMLs (latest release)'
+  instance_size: large
+  image: golang:1.19
+  commands:
+    - ./.buildkite/setup-env.sh
+    # Use KubeRay operator image from the latest release
+    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.7.0 OPERATOR_IMAGE=kuberay/operator:v1.0.0-rc.1 python3 tests/test_sample_rayservice_yamls.py

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -7,7 +7,7 @@ on:
         description: 'Commit reference (branch or SHA) from which to build the images.'
         required: true
       tag:
-        description: 'Desired release version tag (e.g. v1.0.0-rc.0).'
+        description: 'Desired release version tag (e.g. v1.0.0-rc.1).'
         required: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ helm repo update
 helm search repo kuberay --devel
 
 # Install both CRDs and KubeRay operator v1.0.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 1.0.0-rc.0
+helm install kuberay-operator kuberay/kuberay-operator --version 1.0.0-rc.1
 
 # Check the KubeRay operator Pod in `default` namespace
 kubectl get pods

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -35,8 +35,8 @@ helm version
     # Install the KubeRay helm repo
     helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-    # Install KubeRay Operator v1.0.0-rc.0.
-    helm install kuberay-operator kuberay/kuberay-operator --version v1.0.0-rc.0
+    # Install KubeRay Operator v1.0.0-rc.1.
+    helm install kuberay-operator kuberay/kuberay-operator --version v1.0.0-rc.1
 
     # Check the KubeRay Operator Pod in `default` namespace
     kubectl get pods
@@ -47,7 +47,7 @@ helm version
 ### Install KubeRay APIServer
 
 ```text
-Please note that examples show here will only work with the nightly builds of the api-server. `v1.0.0-rc.0` does not yet contain critical fixes
+Please note that examples show here will only work with the nightly builds of the api-server. `v1.0.0-rc.1` does not yet contain critical fixes
 to the api server that would allow Kuberay Serve endpoints to work properly
 ```
 
@@ -98,8 +98,8 @@ To list the deployments:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
-# kuberay-apiserver       default         1               2023-09-25 10:42:34.267328 +0300 EEST   deployed        kuberay-apiserver-1.0.0-rc.0               
-# kuberay-operator        default         1               2023-09-25 10:41:48.355831 +0300 EEST   deployed        kuberay-operator-1.0.0-rc.0                
+# kuberay-apiserver       default         1               2023-09-25 10:42:34.267328 +0300 EEST   deployed        kuberay-apiserver-1.0.0-rc.1               
+# kuberay-operator        default         1               2023-09-25 10:41:48.355831 +0300 EEST   deployed        kuberay-operator-1.0.0-rc.1                
 ```
 
 ### Uninstall the Chart

--- a/docs/deploy/images.md
+++ b/docs/deploy/images.md
@@ -9,7 +9,7 @@ We recommend using Quay.io as the primary source for images as there are image-p
 
 ## Stable versions
 
-For stable releases, use version tags (e.g. `quay.io/kuberay/operator:v1.0.0-rc.0`).
+For stable releases, use version tags (e.g. `quay.io/kuberay/operator:v1.0.0-rc.1`).
 
 ## Master commits
 

--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -26,10 +26,10 @@ helm install kuberay-operator kuberay/kuberay-operator
 #### Method 2: Kustomize
 ```sh
 # Install CRDs
-kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v1.0.0-rc.0&timeout=90s"
+kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v1.0.0-rc.1&timeout=90s"
 
 # Install KubeRay operator
-kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=v1.0.0-rc.0"
+kubectl apply -k "github.com/ray-project/kuberay/manifests/base?ref=v1.0.0-rc.1"
 ```
 
 > Observe that we must use `kubectl create` to install cluster-scoped resources.
@@ -43,8 +43,8 @@ Users can use the following commands to deploy KubeRay operator in a specific na
 export KUBERAY_NAMESPACE=<my-awesome-namespace>
 
 # Install CRDs (Executed by cluster admin)
-kustomize build "github.com/ray-project/kuberay/manifests/overlays/single-namespace-resources?ref=v1.0.0-rc.0" | envsubst | kubectl create -f -
+kustomize build "github.com/ray-project/kuberay/manifests/overlays/single-namespace-resources?ref=v1.0.0-rc.1" | envsubst | kubectl create -f -
 
 # Install KubeRay operator (Executed by user)
-kustomize build "github.com/ray-project/kuberay/manifests/overlays/single-namespace?ref=v1.0.0-rc.0" | envsubst | kubectl apply -f -
+kustomize build "github.com/ray-project/kuberay/manifests/overlays/single-namespace?ref=v1.0.0-rc.1" | envsubst | kubectl apply -f -
 ```

--- a/helm-chart/kuberay-operator/Chart.yaml
+++ b/helm-chart/kuberay-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: kuberay-operator
-version: 1.0.0-rc.0
+version: 1.0.0-rc.1
 icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png
 type: application

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -16,8 +16,8 @@ helm version
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-  # Install both CRDs and KubeRay operator v1.0.0-rc.0.
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.0.0-rc.0
+  # Install both CRDs and KubeRay operator v1.0.0-rc.1.
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.0.0-rc.1
 
   # Check the KubeRay operator Pod in `default` namespace
   kubectl get pods
@@ -40,10 +40,10 @@ helm version
   * Use Helm's built-in `--skip-crds` flag to install the operator only. See [this document](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) for more details.
   ```sh
   # Step 1: Install CRDs only (for cluster admin)
-  kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v1.0.0-rc.0&timeout=90s"
+  kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v1.0.0-rc.1&timeout=90s"
 
   # Step 2: Install KubeRay operator only. (for developer)
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.0.0-rc.0 --skip-crds
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.0.0-rc.1 --skip-crds
   ``` 
 
 ## List the chart
@@ -53,7 +53,7 @@ To list the `my-release` deployment:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
-# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.0.0-rc.0
+# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.0.0-rc.1
 ```
 
 ## Uninstall the Chart

--- a/helm-chart/ray-cluster/Chart.yaml
+++ b/helm-chart/ray-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: ray-cluster
-version: 1.0.0-rc.0
+version: 1.0.0-rc.1
 icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -16,15 +16,15 @@ kind create cluster
 # Step 2: Register a Helm chart repo
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Step 3: Install both CRDs and KubeRay operator v1.0.0-rc.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 1.0.0-rc.0
+# Step 3: Install both CRDs and KubeRay operator v1.0.0-rc.1.
+helm install kuberay-operator kuberay/kuberay-operator --version 1.0.0-rc.1
 
 # Step 4: Install a RayCluster custom resource
 # (For x86_64 users)
-helm install raycluster kuberay/ray-cluster --version 1.0.0-rc.0
+helm install raycluster kuberay/ray-cluster --version 1.0.0-rc.1
 # (For arm64 users, e.g. Mac M1)
 # See here for all available arm64 images: https://hub.docker.com/r/rayproject/ray/tags?page=1&name=aarch64
-helm install raycluster kuberay/ray-cluster --version 1.0.0-rc.0 --set image.tag=nightly-aarch64
+helm install raycluster kuberay/ray-cluster --version 1.0.0-rc.1 --set image.tag=nightly-aarch64
 
 # Step 5: Verify the installation of KubeRay operator and RayCluster 
 kubectl get pods

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -27,7 +27,7 @@ class CONST:
     # Docker images
     OPERATOR_IMAGE_KEY = "kuberay-operator-image"
     RAY_IMAGE_KEY = "ray-image"
-    KUBERAY_LATEST_RELEASE = "kuberay/operator:v1.0.0-rc.0"
+    KUBERAY_LATEST_RELEASE = "kuberay/operator:v1.0.0-rc.1"
 
     # Kubernetes API clients
     K8S_CR_CLIENT_KEY = "k8s-cr-api-client"


### PR DESCRIPTION
## Why are these changes needed?

* v1.0.0-rc.0 does not support CRD v1, so the sample YAML tests fail consistently. #1482 comments the tests out, and this PR uncomments them.
* Update some docs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #1491

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
