### PR TITLE
Allow to install and remove operator via scripts

### DIFF
--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -30,11 +30,6 @@ logging.basicConfig(
 # Default Ray version
 ray_version = '2.7.0'
 
-# Default docker images
-ray_image = 'rayproject/ray:2.7.0'
-kuberay_operator_image = 'kuberay/operator:nightly'
-
-
 class BasicRayTestCase(unittest.TestCase):
     """Test the basic functionalities of RayCluster by executing simple jobs."""
     cluster_template = CONST.REPO_ROOT.joinpath("tests/config/ray-cluster.mini.yaml.template")
@@ -45,11 +40,7 @@ class BasicRayTestCase(unittest.TestCase):
         """Create a Kind cluster, a KubeRay operator, and a RayCluster."""
         K8S_CLUSTER_MANAGER.cleanup()
         K8S_CLUSTER_MANAGER.initialize_cluster()
-        image_dict = {
-            CONST.RAY_IMAGE_KEY: ray_image,
-            CONST.OPERATOR_IMAGE_KEY: kuberay_operator_image
-        }
-        operator_manager = OperatorManager(image_dict)
+        operator_manager = OperatorManager.instance()
         operator_manager.prepare_operator()
         utils.create_ray_cluster(BasicRayTestCase.cluster_template, ray_version, ray_image)
 
@@ -79,11 +70,7 @@ class RayFTTestCase(unittest.TestCase):
             raise unittest.SkipTest(f"{CONST.RAY_FT} is not supported")
         K8S_CLUSTER_MANAGER.cleanup()
         K8S_CLUSTER_MANAGER.initialize_cluster()
-        image_dict = {
-            CONST.RAY_IMAGE_KEY: ray_image,
-            CONST.OPERATOR_IMAGE_KEY: kuberay_operator_image
-        }
-        operator_manager = OperatorManager(image_dict)
+        operator_manager = OperatorManager.instance()
         operator_manager.prepare_operator()
         utils.create_ray_cluster(RayFTTestCase.cluster_template, ray_version, ray_image)
 
@@ -226,11 +213,7 @@ class KubeRayHealthCheckTestCase(unittest.TestCase):
     def setUpClass(cls):
         K8S_CLUSTER_MANAGER.cleanup()
         K8S_CLUSTER_MANAGER.initialize_cluster()
-        image_dict = {
-            CONST.RAY_IMAGE_KEY: ray_image,
-            CONST.OPERATOR_IMAGE_KEY: kuberay_operator_image
-        }
-        operator_manager = OperatorManager(image_dict)
+        operator_manager = OperatorManager.instance()
         operator_manager.prepare_operator()
         utils.create_ray_cluster(
             KubeRayHealthCheckTestCase.cluster_template, ray_version, ray_image)

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -166,7 +166,7 @@ class CREvent:
         self,
         custom_resource_object,
         rulesets: List[RuleSet] = [],
-        timeout: int = 90,
+        timeout: int = 300,
         namespace: str = "default",
         filepath: Optional[str] = None,
     ):
@@ -611,10 +611,10 @@ class RayJobAddCREvent(CREvent):
 
 class GeneralTestCase(unittest.TestCase):
     """TestSuite"""
-    def __init__(self, methodName, docker_image_dict, cr_event):
+    def __init__(self, methodName, cr_event):
         super().__init__(methodName)
         self.cr_event = cr_event
-        self.operator_manager = OperatorManager(docker_image_dict)
+        self.operator_manager = OperatorManager.instance()
 
     @classmethod
     def setUpClass(cls):

--- a/tests/test_sample_raycluster_yamls.py
+++ b/tests/test_sample_raycluster_yamls.py
@@ -55,11 +55,7 @@ if __name__ == '__main__':
     }
 
     rs = RuleSet([HeadPodNameRule(), EasyJobRule(), HeadSvcRule()])
-    image_dict = {
-        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.7.0'),
-        CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
-    }
-    logger.info(image_dict)
+    
     # Build a test plan
     logger.info("Build a test plan ...")
     test_cases = unittest.TestSuite()
@@ -69,7 +65,7 @@ if __name__ == '__main__':
             continue
         logger.info('[TEST %d]: %s', index, new_cr['name'])
         addEvent = RayClusterAddCREvent(new_cr['cr'], [rs], 90, NAMESPACE, new_cr['path'])
-        test_cases.addTest(GeneralTestCase('runtest', image_dict, addEvent))
+        test_cases.addTest(GeneralTestCase('runtest', addEvent))
 
     # Execute all tests
     runner = unittest.TextTestRunner()

--- a/tests/test_sample_rayjob_yamls.py
+++ b/tests/test_sample_rayjob_yamls.py
@@ -37,11 +37,6 @@ if __name__ == '__main__':
     # (The event is not considered "converged" until the job has succeeded.) The EasyJobRule
     # is only used to additionally check that the Ray Cluster remains alive and functional.
     rs = RuleSet([EasyJobRule(), ShutdownJobRule()])
-    image_dict = {
-        CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.7.0'),
-        CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
-    }
-    logger.info(image_dict)
 
     # Build a test plan
     logger.info("Building a test plan ...")
@@ -49,7 +44,7 @@ if __name__ == '__main__':
     for index, new_cr in enumerate(sample_yaml_files):
         logger.info('[TEST %d]: %s', index, new_cr['name'])
         addEvent = RayJobAddCREvent(new_cr['cr'], [rs], 300, NAMESPACE, new_cr['path'])
-        test_cases.addTest(GeneralTestCase('runtest', image_dict, addEvent))
+        test_cases.addTest(GeneralTestCase('runtest', addEvent))
 
     # Execute all testsCRs
     runner = unittest.TextTestRunner()

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -34,10 +34,6 @@ from framework.utils import (
 logger = logging.getLogger(__name__)
 
 NAMESPACE = 'default'
-DEFAULT_IMAGE_DICT = {
-    CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.7.0'),
-    CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
-}
 
 class RayServiceAddCREvent(CREvent):
     """CREvent for RayService addition"""
@@ -199,10 +195,9 @@ class TestRayService:
 
         K8S_CLUSTER_MANAGER.cleanup()
         K8S_CLUSTER_MANAGER.initialize_cluster()
-        operator_manager = OperatorManager(DEFAULT_IMAGE_DICT)
+        operator_manager = OperatorManager.instance()
         operator_manager.prepare_operator()
         start_curl_pod("curl", "default")
-        logger.info(DEFAULT_IMAGE_DICT)
 
         yield
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -69,7 +69,7 @@ class PodSecurityTestCase(unittest.TestCase):
                 'seccompProfile': {'type': 'RuntimeDefault'}
             }
         }])
-        operator_manager = OperatorManager(image_dict, PodSecurityTestCase.namespace, patch)
+        operator_manager = OperatorManager.instance(PodSecurityTestCase.namespace, patch)
         operator_manager.prepare_operator()
 
     def test_ray_cluster_with_security_context(self):


### PR DESCRIPTION
## Why are these changes needed?

It allows to install and uninstall Kuberay operator using scripts. It will be useful for environments where it is not possible to use Helm.

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
