### PR TITLE
[Bug] RayService with GCS FT HA issue

### DIFF
--- a/ray-operator/config/samples/ray-service.mobilenet.yaml
+++ b/ray-operator/config/samples/ray-service.mobilenet.yaml
@@ -12,6 +12,11 @@ spec:
         runtime_env:
           working_dir: "https://github.com/ray-project/serve_config_examples/archive/b393e77bbd6aba0881e3d94c05f968f05a387b96.zip"
           pip: ["python-multipart==0.0.6"]
+        deployments:
+          - name: ImageClassifier
+            num_replicas: 2
+            ray_actor_options:
+              num_cpus: 1
   rayClusterConfig:
     rayVersion: '2.7.0' # should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

According to the comment in [issue #1463](https://github.com/ray-project/kuberay/issues/1463#issuecomment-1771746578), only the Ray head and workers with Serve replicas will have an HTTPProxyActor in a stable state. Without this PR, if the replica is scheduled on the head, there will be only one replica in the cluster and the worker will not have an HTTPProxyActor. Hence, the K8s serve service has only one endpoint from the head, and this endpoint will be removed when the head Pod is terminated, and thus there will be no HTTPProxyActor & replica available.

This PR makes sure both the head Pod and worker Pod have 1 replica and 1 HTTPProxyActor. Hence, when the head Pod is deleted, the K8s serve service still has an endpoint from worker to achieve high-availability.

## Related issue number
Closes #1463

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

I made some changes based on @YQ-Wang's [reproduction script](https://github.com/YQ-Wang/ray-playground).

* Step 1: Create a GCS FT-enabled RayService with [this gist](https://gist.github.com/kevin85421/f4d2b945438ada1a47d59a3f150c65fe).
  * I changed the number of replica from 1 to 2, and each one requires 1 CPU.
    ```yaml
    deployments:
      - name: ImageClassifier
        num_replicas: 2
        ray_actor_options:
          num_cpus: 1
    ```

* Step 2: Create a Ray Pod by [this gist](https://gist.github.com/kevin85421/7015bcc1ebafbb695f0b13d64f9da804), and run the following script to send requests to the RayService.
  ```python
  import requests
  
  # TODO: Change this to your image path
  image_path = "./dog.png"
  
  url = "http://rayservice-mobilenet-serve-svc:8000"
  index = 0
  fail = 0
  
  while True:
      print(f"iter : {index}, fail: {fail}")
      files = {"image": open(image_path, "rb")}
      try:
          response = requests.post(url, files=files)
      except Exception as e:
          print(e)
          fail += 1
      print(response.text)
      index += 1
  ```

* Step 3: Kill the head Pod. Typically, only the 0 to 2 requests that were being processed by the Ray head at that moment will be dropped. Users should implement application-level retry to avoid failure.
   <img width="1439" alt="Screen Shot 2023-10-19 at 10 59 14 PM" src="https://github.com/ray-project/kuberay/assets/20109646/78202760-5161-4848-a9bc-faf9557fa0a1">

