### PR TITLE
[Bug][RayCluster] Fix RAY_REDIS_ADDRESS parsing with redis scheme and…

### DIFF
--- a/ray-operator/config/samples/ray-cluster.external-redis-uri.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-redis-uri.yaml
@@ -1,0 +1,198 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: redis-config
+  labels:
+    app: redis
+data:
+  redis.conf: |-
+    dir /data
+    port 6379
+    bind 0.0.0.0
+    appendonly yes
+    protected-mode no
+    requirepass 5241590000000000
+    pidfile /data/redis-6379.pid
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: 6379
+  selector:
+    app: redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:5.0.8
+          command:
+            - "sh"
+            - "-c"
+            - "redis-server /usr/local/etc/redis/redis.conf"
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/etc/redis/redis.conf
+              subPath: redis.conf
+      volumes:
+        - name: config
+          configMap:
+            name: redis-config
+---
+# Redis password
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-password-secret
+type: Opaque
+data:
+  # echo -n "5241590000000000" | base64
+  password: NTI0MTU5MDAwMDAwMDAwMA==
+---
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  annotations:
+    ray.io/ft-enabled: "true" # enable Ray GCS FT
+    # In most cases, you don't need to set `ray.io/external-storage-namespace` because KubeRay will
+    # automatically set it to the UID of RayCluster. Only modify this annotation if you fully understand
+    # the behaviors of the Ray GCS FT and RayService to avoid misconfiguration.
+    # [Example]:
+    # ray.io/external-storage-namespace: "my-raycluster-storage"
+  name: raycluster-external-redis-uri
+spec:
+  rayVersion: '2.7.0'
+  headGroupSpec:
+    # The `rayStartParams` are used to configure the `ray start` command.
+    # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+    # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+    rayStartParams:
+      # Setting "num-cpus: 0" to avoid any Ray actors or tasks being scheduled on the Ray head Pod.
+      num-cpus: "0"
+      # redis-password should match "requirepass" in redis.conf in the ConfigMap above.
+      # Ray 2.3.0 changes the default redis password from "5241590000000000" to "".
+      redis-password: $REDIS_PASSWORD
+    # Pod template
+    template:
+      spec:
+        containers:
+          - name: ray-head
+            image: rayproject/ray:2.7.0
+            resources:
+              limits:
+                cpu: "1"
+              requests:
+                cpu: "1"
+            env:
+              # Ray will read the RAY_REDIS_ADDRESS environment variable to establish
+              # a connection with the Redis server. In this instance, we use the "redis"
+              # Kubernetes ClusterIP service name, also created by this YAML, as the
+              # connection point to the Redis server.
+              - name: RAY_REDIS_ADDRESS
+                value: redis://redis:6379
+              # This environment variable is used in the `rayStartParams` above.
+              - name: REDIS_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: redis-password-secret
+                    key: password
+            ports:
+              - containerPort: 6379
+                name: redis
+              - containerPort: 8265
+                name: dashboard
+              - containerPort: 10001
+                name: client
+            volumeMounts:
+              - mountPath: /tmp/ray
+                name: ray-logs
+              - mountPath: /home/ray/samples
+                name: ray-example-uri-configmap
+        volumes:
+          - name: ray-logs
+            emptyDir: {}
+          - name: ray-example-uri-configmap
+            configMap:
+              name: ray-example-uri
+              defaultMode: 0777
+              items:
+                - key: detached_actor.py
+                  path: detached_actor.py
+                - key: increment_counter.py
+                  path: increment_counter.py
+  workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 1
+      maxReplicas: 10
+      groupName: small-group
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams: {}
+      # Pod template
+      template:
+        spec:
+          containers:
+            - name: ray-worker
+              image: rayproject/ray:2.7.0
+              volumeMounts:
+                - mountPath: /tmp/ray
+                  name: ray-logs
+              resources:
+                limits:
+                  cpu: "1"
+                requests:
+                  cpu: "1"
+          volumes:
+            - name: ray-logs
+              emptyDir: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ray-example-uri
+data:
+  detached_actor.py: |
+    import ray
+
+    @ray.remote(num_cpus=1)
+    class Counter:
+      def __init__(self):
+          self.value = 0
+
+      def increment(self):
+          self.value += 1
+          return self.value
+
+    ray.init(namespace="default_namespace")
+    Counter.options(name="counter_actor", lifetime="detached").remote()
+  increment_counter.py: |
+    import ray
+
+    ray.init(namespace="default_namespace")
+    counter = ray.get_actor("counter_actor")
+    print(ray.get(counter.increment.remote()))


### PR DESCRIPTION
## Why are these changes needed?

The current parsing of RAY_REDIS_ADDRESS in a redis cleanup job is not correct and may result in the error reported in the slack channel: https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1697556705340069

```python
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ValueError: too many values to unpack (expected 2)
```

This is because the current parsing:

```python
host, port = os.getenv('RAY_REDIS_ADDRESS').rsplit(':')
```

may result in more than two values in the following cases:

1. `RAY_REDIS_ADDRESS` contains multiple addresses.
2. `RAY_REDIS_ADDRESS` contains IPv6 addresses.
3. `RAY_REDIS_ADDRESS` contains a username and a password.

## Related issues 

#1557 

## A Potential Solution

We could use the private method [`get_address`](https://github.com/ray-project/ray/blob/b46c7ccd461e4ad2b4b5b4206ced4f1b7ba6bae2/python/ray/_private/services.py#L1402), which actually parses a redis address, from the upstream ray. This would let us stay consistent with the upstream. However, I think importing the `get_address` is not suitable right now for the following reasons:

1. The naming of `get_address` is too vague. I believe it will be changed to something like `get_redis_address` soon.
2. The `get_address` doesn't handle multiple addresses which are allowed in the `RAY_REDIS_ADDRESS` according to [here](https://github.com/ray-project/ray/blob/b46c7ccd461e4ad2b4b5b4206ced4f1b7ba6bae2/python/ray/scripts/scripts.py#L724).
5. The `get_address` implementation doesn't seem to be quite right to me. It doesn't consider most properties allowed in the [redis uri spec](https://www.iana.org/assignments/uri-schemes/prov/redis), such as password, and database number. A valid redis uri looks like this `redis://user:secret@localhost:6379/0` and it will not be parsed corrected by the `get_address`.
6. The `get_address` was introduced only 2 months ago. I am afraid that it doesn't exist in most ray releases.

## Proposed Solution

I propose using the standard `urlparse` to handle the parsing. It will help us extract the `scheme`, `hostname`, `port`, and even `username` and `password` more correctly. I also recommend contributing this method back to the upstream ray.

In this PR, I did the following

1. To handle multiple addresses according to [here](https://github.com/ray-project/ray/blob/b46c7ccd461e4ad2b4b5b4206ced4f1b7ba6bae2/python/ray/scripts/scripts.py#L724), I also use the `.split(',')` and only pick the first part.
2. If the address doesn't have a scheme, then I add a `redis://` scheme prefix to it. This is required by the `urlparse`.
3. Use the `urlparse` to extract scheme, hostname, port, and password from the address and ignore other properties that aren't supported by the `cleanup_redis_storage`. Note that I also enable the `use_ssl` flag if the scheme is `rediss`.

## Testing

To test this change, I added a new test, duplicated from the original `ray-operator/config/samples/ray-cluster.external-redis.yaml`, and added a redis scheme `redis://` to its `RAY_REDIS_ADDRESS`.

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
