### PR TITLE
[CI] Create release tag for ray-operator Go module

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -154,3 +154,14 @@ jobs:
         docker push quay.io/kuberay/operator:${{ steps.vars.outputs.sha_short }};
         docker image tag kuberay/operator:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/operator:${{ github.event.inputs.tag }};
         docker push quay.io/kuberay/operator:${{ github.event.inputs.tag }}
+
+    - name: Create tag
+      uses: actions/github-script@v6
+      with:
+        script: |
+          await github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: 'refs/tags/ray-operator/${{ github.event.inputs.tag }}',
+            sha: '${{ github.event.inputs.commit }}'
+          })

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -66,7 +66,7 @@ Manual testing can be time-consuming, and to relieve the workload, we plan to ad
 * Merge a PR into the release branch updating Helm chart versions, Helm chart image tags, and kustomize manifest image tags. For `v0.5.0-rc0`, we did this in [PR #1001](https://github.com/ray-project/kuberay/pull/1001)
 
 * Release `rc0` images using the [release-image-build](https://github.com/ray-project/kuberay/actions/workflows/image-release.yaml) workflow on GitHub actions.
-You will prompted for a commit reference and an image tag. The commit reference should be the SHA of the tip of the release branch. The image tag should be `vX.Y.Z-rc.0`.
+You will be prompted for a commit reference and an image tag. The commit reference should be the SHA of the tip of the release branch. The image tag should be `vX.Y.Z-rc.0`.
 
 * Tag the tip of release branch with `vX.Y.Z-rc.0`.
     ```
@@ -74,10 +74,7 @@ You will prompted for a commit reference and an image tag. The commit reference 
     git push upstream v0.5.0-rc.0
     ```
 
-* Tag the tip of the release branch as `ray-operator/vX.Y.Z-rc.0`. Without this tag, users won't be able to use `github.com/ray-project/kuberay/ray-operator@vX.Y.Z-rc.0` to install the Go module. KubeRay starts supporting Go modules from v0.6.0.
-    ```sh
-    git tag ray-operator/v0.5.0-rc.0
-    git push upstream ray-operator/v0.5.0-rc.0
+* Publish the `github.com/ray-project/kuberay/ray-operator@vX.Y.Z-rc.0` Go module. KubeRay starts supporting Go modules from v0.6.0.
 
     # Install the module. This step is highly possible to fail because the module is not available in the proxy server.
     go install github.com/ray-project/kuberay/ray-operator@v0.5.0-rc.0
@@ -103,7 +100,7 @@ You will prompted for a commit reference and an image tag. The commit reference 
 
 #### Step 4. Create more release candidates (`rc1`, `rc2`, ...) if necessary
 
-* Resolve issues with the release branch by cherry picking master commits into the release branch.
+* Resolve issues with the release branch by cherry-picking master commits into the release branch.
 * When cherry-picking changes, it is best to open a PR against the release branch -- don't push directly to the release branch.
 * Follow step 3 to create new Docker images and Helm charts for the new release candidate.
 


### PR DESCRIPTION
## Why are these changes needed?

Automate the creation of the release tags for the `ray-operator` Go module.

## Related issue number

Closes #1549

## Checks

I've tested it locally on my fork.

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
