### PR TITLE
[CI]: Kuberay operator e2e tests

### DIFF
--- a/.github/workflows/actions/kind/action.yml
+++ b/.github/workflows/actions/kind/action.yml
@@ -1,0 +1,58 @@
+name: "Set up KinD"
+description: "Step to start and configure KinD cluster"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Init directories
+      shell: bash
+      run: |
+        TEMP_DIR="$(pwd)/tmp"
+        mkdir -p "${TEMP_DIR}"
+        echo "TEMP_DIR=${TEMP_DIR}" >> $GITHUB_ENV
+
+        mkdir -p "$(pwd)/bin"
+        echo "$(pwd)/bin" >> $GITHUB_PATH
+
+    - name: Container image registry
+      shell: bash
+      run: |
+        podman run -d -p 5000:5000 --name registry registry:2.8.1
+
+        export REGISTRY_ADDRESS=$(hostname -i):5000
+        echo "REGISTRY_ADDRESS=${REGISTRY_ADDRESS}" >> $GITHUB_ENV
+        echo "Container image registry started at ${REGISTRY_ADDRESS}"
+
+        KIND_CONFIG_FILE=${{ env.TEMP_DIR }}/kind.yaml
+        echo "KIND_CONFIG_FILE=${KIND_CONFIG_FILE}" >> $GITHUB_ENV
+        envsubst < .github/workflows/actions/kind/kind.yaml > ${KIND_CONFIG_FILE}
+
+        sudo --preserve-env=REGISTRY_ADDRESS sh -c 'cat > /etc/containers/registries.conf.d/local.conf <<EOF
+        [[registry]]
+        prefix = "$REGISTRY_ADDRESS"
+        insecure = true
+        location = "$REGISTRY_ADDRESS"
+        EOF'
+
+    - name: Setup KinD cluster
+      uses: helm/kind-action@v1.8.0
+      with:
+        cluster_name: cluster
+        version: v0.17.0
+        config: ${{ env.KIND_CONFIG_FILE }}
+
+    - name: Print cluster info
+      shell: bash
+      run: |
+        echo "KinD cluster:"
+        kubectl cluster-info
+        kubectl describe nodes
+
+    - name: Install Ingress controller
+      shell: bash
+      run: |
+        VERSION=controller-v1.6.4
+        echo "Deploying Ingress controller into KinD cluster"
+        curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/"${VERSION}"/deploy/static/provider/kind/deploy.yaml | sed "s/--publish-status-address=localhost/--report-node-internal-ip-address\\n        - --status-update-interval=10/g" | kubectl apply -f -
+        kubectl annotate ingressclass nginx "ingressclass.kubernetes.io/is-default-class=true"
+        kubectl -n ingress-nginx wait --timeout=300s --for=condition=Available deployments --all

--- a/.github/workflows/actions/kind/kind.yaml
+++ b/.github/workflows/actions/kind/kind.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."${REGISTRY_ADDRESS}"]
+      endpoint = ["http://${REGISTRY_ADDRESS}"]

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,0 +1,94 @@
+name: e2e
+
+on:
+  pull_request:
+    branches:
+      - master
+      - 'release-*'
+    paths-ignore:
+      - 'apiserver/**'
+      - 'cli/**'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - 'LICENSE'
+  push:
+    branches:
+      - master
+      - 'release-*'
+    paths-ignore:
+      - 'apiserver/**'
+      - 'cli/**'
+      - 'docs/**'
+      - '**.adoc'
+      - '**.md'
+      - 'LICENSE'
+
+concurrency:
+  group: ${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  ray-operator:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: v1.19
+
+      - name: Set up gotestfmt
+        uses: gotesttools/gotestfmt-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup and start KinD cluster
+        uses: ./.github/workflows/actions/kind
+
+      - name: Deploy Kuberay operator
+        id: deploy
+        run: |
+          echo Deploying Kuberay operator
+          cd ray-operator
+
+          IMG="${REGISTRY_ADDRESS}"/kuberay
+          make docker-build -e IMG="${IMG}" -e ENGINE=podman
+          make docker-push -e IMG="${IMG}" -e ENGINE=podman
+
+          make deploy -e IMG="${IMG}"
+          kubectl wait --timeout=90s --for=condition=Available=true deployment -n ray-system kuberay-operator
+
+      - name: Run e2e tests
+        run: |
+          export KUBERAY_TEST_TIMEOUT_SHORT=1m
+          export KUBERAY_TEST_TIMEOUT_MEDIUM=5m
+          export KUBERAY_TEST_TIMEOUT_LONG=10m
+
+          export KUBERAY_TEST_OUTPUT_DIR=${{ env.TEMP_DIR }}
+          echo "KUBERAY_TEST_OUTPUT_DIR=${KUBERAY_TEST_OUTPUT_DIR}" >> $GITHUB_ENV
+
+          set -euo pipefail
+          cd ray-operator
+          go test -timeout 30m -v ./test/e2e -json 2>&1 | tee ${KUBERAY_TEST_OUTPUT_DIR}/gotest.log | gotestfmt
+
+      - name: Print KubeRay operator logs
+        if: always() && steps.deploy.outcome == 'success'
+        run: |
+          echo "Printing KubeRay operator logs"
+          kubectl logs -n ray-system --tail -1 -l app.kubernetes.io/name=kuberay | tee ${KUBERAY_TEST_OUTPUT_DIR}/kuberay-operator.log
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        if: always() && steps.deploy.outcome == 'success'
+        with:
+          name: logs
+          retention-days: 10
+          path: |
+            ${{ env.KUBERAY_TEST_OUTPUT_DIR }}/**/*.log

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -32,6 +32,7 @@ export PATH="$GOROOT/bin:$PATH"
 ## Development
 
 ### IDE Setup (VS Code)
+
 * Step 1: Install the [VS Code Go extension](https://marketplace.visualstudio.com/items?itemName=golang.go).
 * Step 2: Import the KubeRay workspace configuration by using the file `kuberay.code-workspace` in the root of the KubeRay git repo:
   * "File" -> "Open Workspace from File" -> "kuberay.code-workspace"
@@ -59,7 +60,6 @@ IMG=kuberay/operator:nightly make docker-build
 # Command: kind load docker-image {IMG_REPO}:{IMG_TAG}
 kind load docker-image kuberay/operator:nightly
 
-
 # Step 5: Keep consistency
 # If you update RBAC or CRD, you need to synchronize them.
 # See the section "Consistency check" for more information.
@@ -81,11 +81,14 @@ kubectl logs {YOUR_OPERATOR_POD} | grep "Hello KubeRay"
 
 ### Running the tests
 
+The unit tests can be run by executing the following command:
+
 ```
 make test
 ```
 
-example results:
+Example output:
+
 ```
 ✗ make test
 ...
@@ -99,6 +102,49 @@ ok  	github.com/ray-project/kuberay/ray-operator/controllers	9.587s	coverage: 66
 ok  	github.com/ray-project/kuberay/ray-operator/controllers/common	0.016s	coverage: 75.6% of statements
 ok  	github.com/ray-project/kuberay/ray-operator/controllers/utils	0.015s	coverage: 31.4% of statements
 ```
+
+The e2e tests can be run by executing the following command:
+
+```
+make test-e2e
+```
+
+Example output:
+
+```asciidoc
+go test -timeout 30m -v ./test/e2e
+=== RUN   TestRayJobWithClusterSelector
+    rayjob_cluster_selector_test.go:41: Created ConfigMap test-ns-jtlbd/jobs successfully
+    rayjob_cluster_selector_test.go:159: Created RayCluster test-ns-jtlbd/raycluster successfully
+    rayjob_cluster_selector_test.go:161: Waiting for RayCluster test-ns-jtlbd/raycluster to become ready
+=== RUN   TestRayJobWithClusterSelector/Successful_RayJob
+=== PAUSE TestRayJobWithClusterSelector/Successful_RayJob
+=== RUN   TestRayJobWithClusterSelector/Failing_RayJob
+=== PAUSE TestRayJobWithClusterSelector/Failing_RayJob
+=== CONT  TestRayJobWithClusterSelector/Successful_RayJob
+=== CONT  TestRayJobWithClusterSelector/Failing_RayJob
+=== NAME  TestRayJobWithClusterSelector
+    rayjob_cluster_selector_test.go:213: Created RayJob test-ns-jtlbd/counter successfully
+    rayjob_cluster_selector_test.go:215: Waiting for RayJob test-ns-jtlbd/counter to complete
+    rayjob_cluster_selector_test.go:268: Created RayJob test-ns-jtlbd/fail successfully
+    rayjob_cluster_selector_test.go:270: Waiting for RayJob test-ns-jtlbd/fail to complete
+    test.go:118: Retrieving Pod Container test-ns-jtlbd/counter-zs9s8/ray-job-submitter logs
+    test.go:106: Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
+    test.go:109: Output directory has been created at: /var/folders/mx/kpgdgdqd5j56ynylglgn0nvh0000gn/T/TestRayJobWithClusterSelector2055000419/001
+    test.go:118: Retrieving Pod Container test-ns-jtlbd/fail-gdws6/ray-job-submitter logs
+    test.go:118: Retrieving Pod Container test-ns-jtlbd/raycluster-head-gnhlw/ray-head logs
+    test.go:118: Retrieving Pod Container test-ns-jtlbd/raycluster-worker-small-group-9dffx/ray-worker logs
+--- PASS: TestRayJobWithClusterSelector (12.19s)
+    --- PASS: TestRayJobWithClusterSelector/Failing_RayJob (16.11s)
+    --- PASS: TestRayJobWithClusterSelector/Successful_RayJob (19.14s)
+PASS
+ok      github.com/ray-project/kuberay/ray-operator/test/e2e    32.066s
+```
+
+Note you can set the `KUBERAY_TEST_OUTPUT_DIR` environment to specify the test output directory.
+If not set, it defaults to a temporary directory that's removed once the tests execution completes.
+
+Alternatively, You can run the e2e test(s) from your preferred IDE / debugger.
 
 ### Manually test new image in running cluster
 

--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -63,10 +63,15 @@ fumpt: gofumpt
 	$(GOFUMPT) -l -w ../
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
+test: WHAT ?= $(shell go list ./... | grep -v /test/)
 test: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
-	export ENVTEST_K8S_VERSION=1.24.2; source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -v -coverprofile cover.out
+	export ENVTEST_K8S_VERSION=1.24.2; source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test $(WHAT) -v -coverprofile cover.out
+
+test-e2e: WHAT ?= ./test/e2e
+test-e2e: manifests generate fmt vet ## Run e2e tests.
+	go test -timeout 30m -v $(WHAT)
 
 sync: helm
 	./hack/update-codegen.sh
@@ -90,7 +95,7 @@ build: generate fmt vet ## Build manager binary.
 docker-image: ## Build image only
 	${ENGINE} build -t ${IMG} .
 
-docker-build: test docker-image ## Build image with the manager.
+docker-build: build docker-image ## Build image with the manager.
 
 docker-push: ## Push image with the manager.
 	${ENGINE} push ${IMG}
@@ -107,8 +112,8 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image kuberay/operator=${IMG}
-	($(KUSTOMIZE) build config/default | kubectl create -f -) || ($(KUSTOMIZE) build config/default | kubectl replace -f -)
+	cd config/default && $(KUSTOMIZE) edit set image kuberay/operator=${IMG}
+	$(KUSTOMIZE) build config/default | kubectl apply --server-side=true -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
@@ -120,7 +125,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	test -s $(KUSTOMIZE) ||  GOBIN=$(KUSTOMIZE)/.. go install sigs.k8s.io/kustomize/kustomize/v5@latest
+	test -s $(KUSTOMIZE) || GOBIN=$(KUSTOMIZE)/.. go install sigs.k8s.io/kustomize/kustomize/v5@latest
 
 GOFUMPT = $(shell pwd)/bin/gofumpt
 gofumpt: ## Download gofumpt locally if necessary.

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -31,6 +31,13 @@ require (
 )
 
 require (
+	cloud.google.com/go v0.81.0 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.11.18 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.13 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.1 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -39,6 +46,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
+	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
@@ -65,6 +73,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect

--- a/ray-operator/go.sum
+++ b/ray-operator/go.sum
@@ -17,6 +17,7 @@ cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKP
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
 cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb8=
+cloud.google.com/go v0.81.0 h1:at8Tk2zUz63cLPR0JPWm5vp77pEZmzxEQBEfRKn1VV8=
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -39,12 +40,19 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/Azure/go-autorest/autorest v0.11.18 h1:90Y4srNYrwOtAgVo3ndrQkTYn6kf1Eg/AjTFJ8Is2aM=
 github.com/Azure/go-autorest/autorest v0.11.18/go.mod h1:dSiJPy22c3u0OtOKDNttNgqpNFY/GeWa7GH/Pz56QRA=
+github.com/Azure/go-autorest/autorest/adal v0.9.13 h1:Mp5hbtOePIzM8pJVRa3YLrWWmZtoxRXqUEzCfJt3+/Q=
 github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
+github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
+github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
+github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+ZtXWSmf4Tg=
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
+github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -139,6 +147,7 @@ github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQL
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
+github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNyAWIKUMIwqxEtgHOs5c=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -537,6 +546,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
+golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/ray-operator/test/e2e/counter.py
+++ b/ray-operator/test/e2e/counter.py
@@ -1,0 +1,24 @@
+import ray
+import os
+
+ray.init()
+
+@ray.remote
+class Counter:
+    def __init__(self):
+        # Used to verify runtimeEnv
+        self.name = os.getenv("counter_name")
+        assert self.name == "test_counter"
+        self.counter = 0
+
+    def inc(self):
+        self.counter += 1
+
+    def get_counter(self):
+        return "{} got {}".format(self.name, self.counter)
+
+counter = Counter.remote()
+
+for _ in range(5):
+    ray.get(counter.inc.remote())
+    print(ray.get(counter.get_counter.remote()))

--- a/ray-operator/test/e2e/fail.py
+++ b/ray-operator/test/e2e/fail.py
@@ -1,0 +1,4 @@
+import sys
+
+print("Something is seriously wrong.", file=sys.stderr)
+sys.exit(1)

--- a/ray-operator/test/e2e/rayjob_cluster_selector_test.go
+++ b/ray-operator/test/e2e/rayjob_cluster_selector_test.go
@@ -1,0 +1,278 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
+	. "github.com/ray-project/kuberay/ray-operator/test/support"
+)
+
+func TestRayJobWithClusterSelector(t *testing.T) {
+	test := With(t)
+
+	// Create a namespace
+	namespace := test.NewTestNamespace()
+
+	// Job scripts
+	jobs := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "jobs",
+			Namespace: namespace.Name,
+		},
+		BinaryData: map[string][]byte{
+			"counter.py": ReadFile(test, "counter.py"),
+			"fail.py":    ReadFile(test, "fail.py"),
+		},
+		Immutable: Ptr(true),
+	}
+	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Create(test.Ctx(), jobs, metav1.CreateOptions{})
+	test.Expect(err).NotTo(HaveOccurred())
+	test.T().Logf("Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
+
+	// RayCluster
+	rayCluster := &rayv1.RayCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: rayv1.GroupVersion.String(),
+			Kind:       "RayCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "raycluster",
+			Namespace: namespace.Name,
+		},
+		Spec: rayv1.RayClusterSpec{
+			RayVersion: GetRayVersion(),
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				RayStartParams: map[string]string{
+					"dashboard-host": "0.0.0.0",
+				},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "ray-head",
+								Image: GetRayImage(),
+								Ports: []corev1.ContainerPort{
+									{
+										ContainerPort: 6379,
+										Name:          "gcs",
+									},
+									{
+										ContainerPort: 8265,
+										Name:          "dashboard",
+									},
+									{
+										ContainerPort: 10001,
+										Name:          "client",
+									},
+								},
+								Lifecycle: &corev1.Lifecycle{
+									PreStop: &corev1.LifecycleHandler{
+										Exec: &corev1.ExecAction{
+											Command: []string{"/bin/sh", "-c", "ray stop"},
+										},
+									},
+								},
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("300m"),
+										corev1.ResourceMemory: resource.MustParse("1G"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("2G"),
+									},
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "jobs",
+										MountPath: "/home/ray/jobs",
+									},
+								},
+							},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "jobs",
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: jobs.Name,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+				{
+					Replicas:       Ptr(int32(1)),
+					MinReplicas:    Ptr(int32(1)),
+					MaxReplicas:    Ptr(int32(1)),
+					GroupName:      "small-group",
+					RayStartParams: map[string]string{},
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "ray-worker",
+									Image: GetRayImage(),
+									Lifecycle: &corev1.Lifecycle{
+										PreStop: &corev1.LifecycleHandler{
+											Exec: &corev1.ExecAction{
+												Command: []string{"/bin/sh", "-c", "ray stop"},
+											},
+										},
+									},
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("300m"),
+											corev1.ResourceMemory: resource.MustParse("1G"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+											corev1.ResourceMemory: resource.MustParse("1G"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Create(test.Ctx(), rayCluster, metav1.CreateOptions{})
+	test.Expect(err).NotTo(HaveOccurred())
+	test.T().Logf("Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+	test.T().Logf("Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+	test.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
+
+	test.T().Run("Successful RayJob", func(t *testing.T) {
+		t.Parallel()
+
+		// RayJob
+		rayJob := &rayv1.RayJob{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: rayv1.GroupVersion.String(),
+				Kind:       "RayJob",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "counter",
+				Namespace: namespace.Name,
+			},
+			Spec: rayv1.RayJobSpec{
+				ClusterSelector: map[string]string{
+					common.RayClusterLabelKey: rayCluster.Name,
+				},
+				Entrypoint: "python /home/ray/jobs/counter.py",
+				RuntimeEnvYAML: `
+env_vars:
+  counter_name: test_counter
+`,
+				ShutdownAfterJobFinishes: false,
+				SubmitterPodTemplate: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "ray-job-submitter",
+								Image: GetRayImage(),
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("200m"),
+										corev1.ResourceMemory: resource.MustParse("200Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("500Mi"),
+									},
+								},
+							},
+						},
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+				},
+			},
+		}
+		rayJob, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Create(test.Ctx(), rayJob, metav1.CreateOptions{})
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		test.T().Logf("Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+
+		// Assert the Ray job has completed successfully
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)))
+	})
+
+	test.T().Run("Failing RayJob", func(t *testing.T) {
+		t.Parallel()
+
+		// RayJob
+		rayJob := &rayv1.RayJob{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: rayv1.GroupVersion.String(),
+				Kind:       "RayJob",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fail",
+				Namespace: namespace.Name,
+			},
+			Spec: rayv1.RayJobSpec{
+				ClusterSelector: map[string]string{
+					common.RayClusterLabelKey: rayCluster.Name,
+				},
+				Entrypoint:               "python /home/ray/jobs/fail.py",
+				ShutdownAfterJobFinishes: false,
+				SubmitterPodTemplate: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "ray-job-submitter",
+								Image: GetRayImage(),
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("200m"),
+										corev1.ResourceMemory: resource.MustParse("200Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("500Mi"),
+									},
+								},
+							},
+						},
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+				},
+			},
+		}
+		rayJob, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Create(test.Ctx(), rayJob, metav1.CreateOptions{})
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		test.T().Logf("Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+
+		// Assert the Ray job has failed
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
+	})
+}

--- a/ray-operator/test/e2e/support.go
+++ b/ray-operator/test/e2e/support.go
@@ -1,0 +1,18 @@
+package e2e
+
+import (
+	"embed"
+
+	"github.com/onsi/gomega"
+	"github.com/ray-project/kuberay/ray-operator/test/support"
+)
+
+//go:embed *.py
+var files embed.FS
+
+func ReadFile(t support.Test, fileName string) []byte {
+	t.T().Helper()
+	file, err := files.ReadFile(fileName)
+	t.Expect(err).NotTo(gomega.HaveOccurred())
+	return file
+}

--- a/ray-operator/test/support/client.go
+++ b/ray-operator/test/support/client.go
@@ -1,0 +1,70 @@
+package support
+
+import (
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	rayclient "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned"
+)
+
+type Client interface {
+	Core() kubernetes.Interface
+	Ray() rayclient.Interface
+	Dynamic() dynamic.Interface
+}
+
+type testClient struct {
+	core    kubernetes.Interface
+	ray     rayclient.Interface
+	dynamic dynamic.Interface
+}
+
+var _ Client = (*testClient)(nil)
+
+func (t *testClient) Core() kubernetes.Interface {
+	return t.core
+}
+
+func (t *testClient) Ray() rayclient.Interface {
+	return t.ray
+}
+
+func (t *testClient) Dynamic() dynamic.Interface {
+	return t.dynamic
+}
+
+func newTestClient() (Client, error) {
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	rayClient, err := rayclient.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &testClient{
+		core:    kubeClient,
+		ray:     rayClient,
+		dynamic: dynamicClient,
+	}, nil
+}

--- a/ray-operator/test/support/core.go
+++ b/ray-operator/test/support/core.go
@@ -1,0 +1,46 @@
+package support
+
+import (
+	"io"
+
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func storeAllPodLogs(t Test, namespace *corev1.Namespace) {
+	t.T().Helper()
+
+	pods, err := t.Client().Core().CoreV1().Pods(namespace.Name).List(t.Ctx(), metav1.ListOptions{})
+	t.Expect(err).NotTo(gomega.HaveOccurred())
+
+	for _, pod := range pods.Items {
+		for _, container := range pod.Spec.Containers {
+			t.T().Logf("Retrieving Pod Container %s/%s/%s logs", pod.Namespace, pod.Name, container.Name)
+			storeContainerLog(t, namespace, pod.Name, container.Name)
+		}
+	}
+}
+
+func storeContainerLog(t Test, namespace *corev1.Namespace, podName, containerName string) {
+	t.T().Helper()
+
+	options := corev1.PodLogOptions{Container: containerName}
+	stream, err := t.Client().Core().CoreV1().Pods(namespace.Name).GetLogs(podName, &options).Stream(t.Ctx())
+	if err != nil {
+		t.T().Logf("Error getting logs from container %s/%s/%s", namespace.Name, podName, containerName)
+		return
+	}
+	t.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer func() {
+		t.Expect(stream.Close()).To(gomega.Succeed())
+	}()
+
+	bytes, err := io.ReadAll(stream)
+	t.Expect(err).NotTo(gomega.HaveOccurred())
+
+	containerLogFileName := "pod-" + podName + "-" + containerName
+	WriteToOutputDir(t, containerLogFileName, Log, bytes)
+}

--- a/ray-operator/test/support/defaults.go
+++ b/ray-operator/test/support/defaults.go
@@ -1,0 +1,6 @@
+package support
+
+const (
+	RayVersion = "2.7.0"
+	RayImage   = "rayproject/ray:2.7.0"
+)

--- a/ray-operator/test/support/environment.go
+++ b/ray-operator/test/support/environment.go
@@ -1,0 +1,31 @@
+package support
+
+import (
+	"os"
+)
+
+const (
+	// KuberayTestOutputDir is the testing output directory, to write output files into.
+	KuberayTestOutputDir = "KUBERAY_TEST_OUTPUT_DIR"
+
+	// KuberayTestRayVersion is the version of Ray to use for testing.
+	KuberayTestRayVersion = "KUBERAY_TEST_RAY_VERSION"
+
+	// KuberayTestRayImage is the Ray image to use for testing.
+	KuberayTestRayImage = "KUBERAY_TEST_RAY_IMAGE"
+)
+
+func GetRayVersion() string {
+	return lookupEnvOrDefault(KuberayTestRayVersion, RayVersion)
+}
+
+func GetRayImage() string {
+	return lookupEnvOrDefault(KuberayTestRayImage, RayImage)
+}
+
+func lookupEnvOrDefault(key, value string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return value
+}

--- a/ray-operator/test/support/events.go
+++ b/ray-operator/test/support/events.go
@@ -1,0 +1,131 @@
+package support
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Based on https://github.com/apache/incubator-kie-kogito-operator/blob/28b2d3dc945e48659b199cca33723568b848f72e/test/pkg/framework/logging.go
+
+const (
+	eventLastSeenKey  = "LAST_SEEN"
+	eventFirstSeenKey = "FIRST_SEEN"
+	eventNameKey      = "NAME"
+	eventSubObjectKey = "SUBOBJECT"
+	eventTypeKey      = "TYPE"
+	eventReasonKey    = "REASON"
+	eventMessageKey   = "MESSAGE"
+
+	eventLogFileName = "events"
+)
+
+var eventKeys = []string{
+	eventLastSeenKey,
+	eventFirstSeenKey,
+	eventNameKey,
+	eventSubObjectKey,
+	eventTypeKey,
+	eventReasonKey,
+	eventMessageKey,
+}
+
+func storeEvents(t Test, namespace *corev1.Namespace) {
+	t.T().Helper()
+
+	events, err := t.Client().Core().EventsV1().Events(namespace.Name).List(t.Ctx(), metav1.ListOptions{})
+	t.Expect(err).NotTo(gomega.HaveOccurred())
+
+	bytes, err := renderEventContent(eventKeys, mapEventsToKeys(events))
+	t.Expect(err).NotTo(gomega.HaveOccurred())
+
+	WriteToOutputDir(t, eventLogFileName, Log, bytes)
+}
+
+func mapEventsToKeys(eventList *eventsv1.EventList) []map[string]string {
+	eventMaps := []map[string]string{}
+
+	for _, event := range eventList.Items {
+		eventMap := make(map[string]string)
+		eventMap[eventLastSeenKey] = getDefaultEventValueIfNull(event.DeprecatedLastTimestamp.Format("2006-01-02 15:04:05"))
+		eventMap[eventFirstSeenKey] = getDefaultEventValueIfNull(event.DeprecatedFirstTimestamp.Format("2006-01-02 15:04:05"))
+		eventMap[eventNameKey] = getDefaultEventValueIfNull(event.GetName())
+		eventMap[eventSubObjectKey] = getDefaultEventValueIfNull(event.Regarding.FieldPath)
+		eventMap[eventTypeKey] = getDefaultEventValueIfNull(event.Type)
+		eventMap[eventReasonKey] = getDefaultEventValueIfNull(event.Reason)
+		eventMap[eventMessageKey] = getDefaultEventValueIfNull(event.Note)
+
+		eventMaps = append(eventMaps, eventMap)
+	}
+	return eventMaps
+}
+
+func getDefaultEventValueIfNull(value string) string {
+	if len(value) <= 0 {
+		return "-"
+	}
+	return value
+}
+
+func renderEventContent(keys []string, dataMaps []map[string]string) ([]byte, error) {
+	var content bytes.Buffer
+	// Get size of strings to be written, to be able to format correctly
+	maxStringSizeMap := make(map[string]int)
+	for _, key := range keys {
+		maxSize := len(key)
+		for _, dataMap := range dataMaps {
+			if len(dataMap[key]) > maxSize {
+				maxSize = len(dataMap[key])
+			}
+		}
+		maxStringSizeMap[key] = maxSize
+	}
+
+	// Write headers
+	for _, header := range keys {
+		if _, err := content.WriteString(header); err != nil {
+			return nil, fmt.Errorf("error in writing the header: %v", err)
+		}
+		if _, err := content.WriteString(getWhitespaceStr(maxStringSizeMap[header] - len(header) + 1)); err != nil {
+			return nil, fmt.Errorf("error in writing headers: %v", err)
+		}
+		if _, err := content.WriteString(" | "); err != nil {
+			return nil, fmt.Errorf("error in writing headers : %v", err)
+		}
+	}
+	if _, err := content.WriteString("\n"); err != nil {
+		return nil, fmt.Errorf("error in writing headers '|': %v", err)
+	}
+
+	// Write events
+	for _, dataMap := range dataMaps {
+		for _, key := range keys {
+			if _, err := content.WriteString(dataMap[key]); err != nil {
+				return nil, fmt.Errorf("error in writing events: %v", err)
+			}
+			if _, err := content.WriteString(getWhitespaceStr(maxStringSizeMap[key] - len(dataMap[key]) + 1)); err != nil {
+				return nil, fmt.Errorf("error in writing events: %v", err)
+			}
+			if _, err := content.WriteString(" | "); err != nil {
+				return nil, fmt.Errorf("error in writing events: %v", err)
+			}
+		}
+		if _, err := content.WriteString("\n"); err != nil {
+			return nil, fmt.Errorf("error in writing events: %v", err)
+		}
+	}
+	return content.Bytes(), nil
+}
+
+func getWhitespaceStr(size int) string {
+	whiteSpaceStr := ""
+	for i := 0; i < size; i++ {
+		whiteSpaceStr += " "
+	}
+	return whiteSpaceStr
+}

--- a/ray-operator/test/support/namespace.go
+++ b/ray-operator/test/support/namespace.go
@@ -1,0 +1,39 @@
+package support
+
+import (
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func createTestNamespace(t Test, options ...Option[*corev1.Namespace]) *corev1.Namespace {
+	t.T().Helper()
+	namespace := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-ns-",
+		},
+	}
+
+	for _, option := range options {
+		t.Expect(option.applyTo(namespace)).To(gomega.Succeed())
+	}
+
+	namespace, err := t.Client().Core().CoreV1().Namespaces().Create(t.Ctx(), namespace, metav1.CreateOptions{})
+	t.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return namespace
+}
+
+func deleteTestNamespace(t Test, namespace *corev1.Namespace) {
+	t.T().Helper()
+	propagationPolicy := metav1.DeletePropagationBackground
+	err := t.Client().Core().CoreV1().Namespaces().Delete(t.Ctx(), namespace.Name, metav1.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	})
+	t.Expect(err).NotTo(gomega.HaveOccurred())
+}

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -1,0 +1,48 @@
+package support
+
+import (
+	"github.com/onsi/gomega"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func RayJob(t Test, namespace, name string) func(g gomega.Gomega) *rayv1.RayJob {
+	return func(g gomega.Gomega) *rayv1.RayJob {
+		job, err := t.Client().Ray().RayV1().RayJobs(namespace).Get(t.Ctx(), name, metav1.GetOptions{})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		return job
+	}
+}
+
+func GetRayJob(t Test, namespace, name string) *rayv1.RayJob {
+	t.T().Helper()
+	return RayJob(t, namespace, name)(t)
+}
+
+func RayJobStatus(job *rayv1.RayJob) rayv1.JobStatus {
+	return job.Status.JobStatus
+}
+
+func GetRayJobId(t Test, namespace, name string) string {
+	t.T().Helper()
+	job := RayJob(t, namespace, name)(t)
+	return job.Status.JobId
+}
+
+func RayCluster(t Test, namespace, name string) func(g gomega.Gomega) *rayv1.RayCluster {
+	return func(g gomega.Gomega) *rayv1.RayCluster {
+		cluster, err := t.Client().Ray().RayV1().RayClusters(namespace).Get(t.Ctx(), name, metav1.GetOptions{})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		return cluster
+	}
+}
+
+func GetRayCluster(t Test, namespace, name string) *rayv1.RayCluster {
+	t.T().Helper()
+	return RayCluster(t, namespace, name)(t)
+}
+
+func RayClusterState(cluster *rayv1.RayCluster) rayv1.ClusterState {
+	return cluster.Status.State
+}

--- a/ray-operator/test/support/support.go
+++ b/ray-operator/test/support/support.go
@@ -1,0 +1,48 @@
+package support
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+)
+
+var (
+	TestTimeoutShort  = 1 * time.Minute
+	TestTimeoutMedium = 2 * time.Minute
+	TestTimeoutLong   = 5 * time.Minute
+)
+
+func init() {
+	if value, ok := os.LookupEnv("KUBERAY_TEST_TIMEOUT_SHORT"); ok {
+		if duration, err := time.ParseDuration(value); err == nil {
+			TestTimeoutShort = duration
+		} else {
+			fmt.Printf("Error parsing KUBERAY_TEST_TIMEOUT_SHORT. Using default value: %s", TestTimeoutShort)
+		}
+	}
+	if value, ok := os.LookupEnv("KUBERAY_TEST_TIMEOUT_MEDIUM"); ok {
+		if duration, err := time.ParseDuration(value); err == nil {
+			TestTimeoutMedium = duration
+		} else {
+			fmt.Printf("Error parsing KUBERAY_TEST_TIMEOUT_MEDIUM. Using default value: %s", TestTimeoutMedium)
+		}
+	}
+	if value, ok := os.LookupEnv("KUBERAY_TEST_TIMEOUT_LONG"); ok {
+		if duration, err := time.ParseDuration(value); err == nil {
+			TestTimeoutLong = duration
+		} else {
+			fmt.Printf("Error parsing KUBERAY_TEST_TIMEOUT_LONG. Using default value: %s", TestTimeoutLong)
+		}
+	}
+
+	// Gomega settings
+	gomega.SetDefaultEventuallyTimeout(TestTimeoutShort)
+	gomega.SetDefaultEventuallyPollingInterval(1 * time.Second)
+	gomega.SetDefaultConsistentlyDuration(30 * time.Second)
+	gomega.SetDefaultConsistentlyPollingInterval(1 * time.Second)
+	// Disable object truncation on test results
+	format.MaxLength = 0
+}

--- a/ray-operator/test/support/test.go
+++ b/ray-operator/test/support/test.go
@@ -1,0 +1,123 @@
+package support
+
+import (
+	"context"
+	"os"
+	"path"
+	"sync"
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Test interface {
+	T() *testing.T
+	Ctx() context.Context
+	Client() Client
+	OutputDir() string
+
+	gomega.Gomega
+
+	NewTestNamespace(...Option[*corev1.Namespace]) *corev1.Namespace
+}
+
+type Option[T any] interface {
+	applyTo(to T) error
+}
+
+type errorOption[T any] func(to T) error
+
+// nolint: unused
+// To be removed when the false-positivity is fixed.
+func (o errorOption[T]) applyTo(to T) error {
+	return o(to)
+}
+
+var _ Option[any] = errorOption[any](nil)
+
+func With(t *testing.T) Test {
+	t.Helper()
+	ctx := context.Background()
+	if deadline, ok := t.Deadline(); ok {
+		withDeadline, cancel := context.WithDeadline(ctx, deadline)
+		t.Cleanup(cancel)
+		ctx = withDeadline
+	}
+
+	return &T{
+		WithT: gomega.NewWithT(t),
+		t:     t,
+		ctx:   ctx,
+	}
+}
+
+type T struct {
+	*gomega.WithT
+	t *testing.T
+	// nolint: containedctx
+	ctx       context.Context
+	client    Client
+	outputDir string
+	once      struct {
+		client    sync.Once
+		outputDir sync.Once
+	}
+}
+
+func (t *T) T() *testing.T {
+	return t.t
+}
+
+func (t *T) Ctx() context.Context {
+	return t.ctx
+}
+
+func (t *T) Client() Client {
+	t.T().Helper()
+	t.once.client.Do(func() {
+		c, err := newTestClient()
+		if err != nil {
+			t.T().Fatalf("Error creating client: %v", err)
+		}
+		t.client = c
+	})
+	return t.client
+}
+
+func (t *T) OutputDir() string {
+	t.T().Helper()
+	t.once.outputDir.Do(func() {
+		if parent, ok := os.LookupEnv(KuberayTestOutputDir); ok {
+			if !path.IsAbs(parent) {
+				if cwd, err := os.Getwd(); err == nil {
+					// best effort to output the parent absolute path
+					parent = path.Join(cwd, parent)
+				}
+			}
+			t.T().Logf("Creating output directory in parent directory: %s", parent)
+			dir, err := os.MkdirTemp(parent, t.T().Name())
+			if err != nil {
+				t.T().Fatalf("Error creating output directory: %v", err)
+			}
+			t.outputDir = dir
+		} else {
+			t.T().Logf("Creating ephemeral output directory as %s env variable is unset", KuberayTestOutputDir)
+			t.outputDir = t.T().TempDir()
+		}
+		t.T().Logf("Output directory has been created at: %s", t.outputDir)
+	})
+	return t.outputDir
+}
+
+func (t *T) NewTestNamespace(options ...Option[*corev1.Namespace]) *corev1.Namespace {
+	t.T().Helper()
+	namespace := createTestNamespace(t, options...)
+	t.T().Cleanup(func() {
+		storeAllPodLogs(t, namespace)
+		storeEvents(t, namespace)
+		deleteTestNamespace(t, namespace)
+	})
+	return namespace
+}

--- a/ray-operator/test/support/utils.go
+++ b/ray-operator/test/support/utils.go
@@ -1,0 +1,25 @@
+package support
+
+import (
+	"io/fs"
+	"os"
+	"path"
+
+	"github.com/onsi/gomega"
+)
+
+func Ptr[T any](v T) *T {
+	return &v
+}
+
+type OutputType string
+
+const (
+	Log OutputType = "log"
+)
+
+func WriteToOutputDir(t Test, fileName string, fileType OutputType, data []byte) {
+	t.T().Helper()
+	t.Expect(os.WriteFile(path.Join(t.OutputDir(), fileName+"."+string(fileType)), data, fs.ModePerm)).
+		To(gomega.Succeed())
+}


### PR DESCRIPTION
## Why are these changes needed?

This PR adds e2e tests for the operator, following up https://github.com/ray-project/kuberay/pull/1539#issuecomment-1778717122.

This e2e testing enables to assert Kuberay resources, in a way that cannot be achieved with existing tests (envtest).

The e2e tests execution output is post-processed using gotestfmt:

![image](https://github.com/ray-project/kuberay/assets/366207/ef4fcff8-a0a4-48d5-b836-5b45370ce82f)

The logs and events are gathered and uploaded are part of the workflow run:

![image](https://github.com/ray-project/kuberay/assets/366207/0f8990f1-d045-4a4d-bf33-1b0e1715210f)
