### PR TITLE
[Hotfix][Bug] Avoid unnecessary zero-downtime upgrade

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -889,11 +889,12 @@ func (r *RayServiceReconciler) generateConfigKeyPrefix(rayServiceInstance *rayv1
 }
 
 // Return true if healthy, otherwise false.
-func (r *RayServiceReconciler) updateAndCheckDashboardStatus(rayServiceClusterStatus *rayv1.RayServiceStatus, isHealthy bool, unhealthyThreshold *int32) bool {
+func updateAndCheckDashboardStatus(rayServiceClusterStatus *rayv1.RayServiceStatus, isHealthy bool, unhealthyThreshold *int32) bool {
 	timeNow := metav1.Now()
+	oldIsHealthy := rayServiceClusterStatus.DashboardStatus.IsHealthy
 	rayServiceClusterStatus.DashboardStatus.LastUpdateTime = &timeNow
 	rayServiceClusterStatus.DashboardStatus.IsHealthy = isHealthy
-	if rayServiceClusterStatus.DashboardStatus.HealthLastUpdateTime.IsZero() || isHealthy {
+	if rayServiceClusterStatus.DashboardStatus.HealthLastUpdateTime.IsZero() || oldIsHealthy {
 		rayServiceClusterStatus.DashboardStatus.HealthLastUpdateTime = &timeNow
 	}
 
@@ -1045,7 +1046,7 @@ func (r *RayServiceReconciler) updateStatusForActiveCluster(ctx context.Context,
 	rayServiceStatus := &rayServiceInstance.Status.ActiveServiceStatus
 
 	if clientURL, err = utils.FetchHeadServiceURL(ctx, &r.Log, r.Client, rayClusterInstance, common.DashboardAgentListenPortName); err != nil || clientURL == "" {
-		r.updateAndCheckDashboardStatus(rayServiceStatus, false, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold)
+		updateAndCheckDashboardStatus(rayServiceStatus, false, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold)
 		return err
 	}
 
@@ -1054,11 +1055,11 @@ func (r *RayServiceReconciler) updateStatusForActiveCluster(ctx context.Context,
 
 	var isHealthy, isReady bool
 	if isHealthy, isReady, err = r.getAndCheckServeStatus(ctx, rayDashboardClient, rayServiceStatus, r.determineServeConfigType(rayServiceInstance), rayServiceInstance.Spec.ServiceUnhealthySecondThreshold); err != nil {
-		r.updateAndCheckDashboardStatus(rayServiceStatus, false, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold)
+		updateAndCheckDashboardStatus(rayServiceStatus, false, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold)
 		return err
 	}
 
-	r.updateAndCheckDashboardStatus(rayServiceStatus, true, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold)
+	updateAndCheckDashboardStatus(rayServiceStatus, true, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold)
 
 	logger.Info("Check serve health", "isHealthy", isHealthy, "isReady", isReady)
 
@@ -1084,19 +1085,24 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 		rayServiceStatus = &rayServiceInstance.Status.PendingServiceStatus
 	}
 
-	// Check if head pod is running and ready. If not, requeue the resource event to avoid
-	// redundant custom resource status updates.
-	//
-	// TODO (kevin85421): Note that the Dashboard and GCS may take a few seconds to start up
-	// after the head pod is running and ready. Hence, some requests to the Dashboard (e.g. `UpdateDeployments`) may fail.
-	// This is not an issue since `UpdateDeployments` is an idempotent operation.
-	if isRunningAndReady, err := r.isHeadPodRunningAndReady(ctx, rayClusterInstance); err != nil || !isRunningAndReady {
-		if err != nil {
-			logger.Error(err, "Failed to check if head pod is running and ready!")
-		} else {
-			logger.Info("Skipping the update of Serve deployments because the Ray head pod is not ready.")
+	// TODO (kevin85421): This `if` block is a hotfix for the case that active RayCluster's dashboard agent process crashes.
+	// I will refactor the health checking logic in the future.
+	if !isActive {
+		// Check if head pod is running and ready. If not, requeue the resource event to avoid
+		// redundant custom resource status updates.
+		//
+		// TODO (kevin85421): Note that the Dashboard and GCS may take a few seconds to start up
+		// after the head pod is running and ready. Hence, some requests to the Dashboard (e.g. `UpdateDeployments`) may fail.
+		// This is not an issue since `UpdateDeployments` is an idempotent operation.
+		logger.Info("Check the head Pod status of the pending RayCluster", "RayCluster name", rayClusterInstance.Name)
+		if isRunningAndReady, err := r.isHeadPodRunningAndReady(ctx, rayClusterInstance); err != nil || !isRunningAndReady {
+			if err != nil {
+				logger.Error(err, "Failed to check if head Pod is running and ready!")
+			} else {
+				logger.Info("Skipping the update of Serve deployments because the Ray head Pod is not ready.")
+			}
+			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, false, false, err
 		}
-		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, false, false, err
 	}
 
 	if clientURL, err = utils.FetchHeadServiceURL(ctx, &r.Log, r.Client, rayClusterInstance, common.DashboardAgentListenPortName); err != nil || clientURL == "" {
@@ -1106,10 +1112,9 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 	rayDashboardClient.InitClient(clientURL)
 
 	shouldUpdate := r.checkIfNeedSubmitServeDeployment(rayServiceInstance, rayClusterInstance, rayServiceStatus)
-
 	if shouldUpdate {
 		if err = r.updateServeDeployment(ctx, rayServiceInstance, rayDashboardClient, rayClusterInstance.Name); err != nil {
-			if !r.updateAndCheckDashboardStatus(rayServiceStatus, false, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold) {
+			if !updateAndCheckDashboardStatus(rayServiceStatus, false, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold) {
 				logger.Info("Dashboard is unhealthy, restart the cluster.")
 				r.markRestart(rayServiceInstance)
 			}
@@ -1123,7 +1128,7 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 
 	var isHealthy, isReady bool
 	if isHealthy, isReady, err = r.getAndCheckServeStatus(ctx, rayDashboardClient, rayServiceStatus, r.determineServeConfigType(rayServiceInstance), rayServiceInstance.Spec.ServiceUnhealthySecondThreshold); err != nil {
-		if !r.updateAndCheckDashboardStatus(rayServiceStatus, false, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold) {
+		if !updateAndCheckDashboardStatus(rayServiceStatus, false, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold) {
 			logger.Info("Dashboard is unhealthy, restart the cluster.")
 			r.markRestart(rayServiceInstance)
 		}
@@ -1131,7 +1136,7 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, false, false, err
 	}
 
-	r.updateAndCheckDashboardStatus(rayServiceStatus, true, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold)
+	updateAndCheckDashboardStatus(rayServiceStatus, true, rayServiceInstance.Spec.DeploymentUnhealthySecondThreshold)
 
 	logger.Info("Check serve health", "isHealthy", isHealthy, "isReady", isReady, "isActive", isActive)
 

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -791,6 +791,43 @@ func TestReconcileRayCluster(t *testing.T) {
 	}
 }
 
+func TestUpdateAndCheckDashboardStatus(t *testing.T) {
+	now := metav1.Now()
+	rayServiceStatus := rayv1.RayServiceStatus{
+		DashboardStatus: rayv1.DashboardStatus{
+			IsHealthy:            true,
+			HealthLastUpdateTime: &now,
+			LastUpdateTime:       &now,
+		},
+	}
+	deploymentUnhealthySecondThreshold := int32(300)
+
+	// Test 1: The dashboard agent was healthy, and the dashboard agent is still healthy.
+	svcStatusCopy := rayServiceStatus.DeepCopy()
+	assert.True(t, updateAndCheckDashboardStatus(svcStatusCopy, true, &deploymentUnhealthySecondThreshold))
+	assert.NotEqual(t, svcStatusCopy.DashboardStatus.HealthLastUpdateTime, now)
+
+	// Test 2: The dashboard agent was healthy, and the dashboard agent becomes unhealthy.
+	svcStatusCopy = rayServiceStatus.DeepCopy()
+	assert.True(t, updateAndCheckDashboardStatus(svcStatusCopy, false, &deploymentUnhealthySecondThreshold))
+	assert.NotEqual(t, *svcStatusCopy.DashboardStatus.HealthLastUpdateTime, now)
+
+	// Test 3: The dashboard agent was unhealthy, and the dashboard agent is still unhealthy.
+	svcStatusCopy = rayServiceStatus.DeepCopy()
+	svcStatusCopy.DashboardStatus.IsHealthy = false
+	assert.True(t, updateAndCheckDashboardStatus(svcStatusCopy, false, &deploymentUnhealthySecondThreshold))
+	// The `HealthLastUpdateTime` should not be updated.
+	assert.Equal(t, *svcStatusCopy.DashboardStatus.HealthLastUpdateTime, now)
+
+	// Test 4: The dashboard agent was unhealthy, and the dashboard agent lasts unhealthy for more than `deploymentUnhealthySecondThreshold` seconds.
+	svcStatusCopy = rayServiceStatus.DeepCopy()
+	svcStatusCopy.DashboardStatus.IsHealthy = false
+	minus301Seconds := metav1.NewTime(now.Add(-time.Second * time.Duration(deploymentUnhealthySecondThreshold+1)))
+	svcStatusCopy.DashboardStatus.HealthLastUpdateTime = &minus301Seconds
+	assert.False(t, updateAndCheckDashboardStatus(svcStatusCopy, false, &deploymentUnhealthySecondThreshold))
+	assert.Equal(t, *svcStatusCopy.DashboardStatus.HealthLastUpdateTime, minus301Seconds)
+}
+
 func initFakeDashboardClient(appName string, deploymentStatus string, appStatus string) utils.RayDashboardClientInterface {
 	fakeDashboardClient := utils.FakeRayDashboardClient{}
 	status := generateServeStatus(deploymentStatus, appStatus)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The RayService's health check mechanism is not well-defined. This PR is a hotfix for v1.0.0, and I will revisit the mechanism after the release. Hence, I do not spend much time on writing tests for this PR.

* Change 1: `updateAndCheckDashboardStatus`
  * Question: KubeRay will not update the status of the RayService custom resource when the only changes are related to timestamps. Without this PR, deleting the head Pod of a GCS ft-enabled RayCluster could potentially trigger an unnecessary zero-downtime upgrade immediately after the head Pod restarts.
  
    ```sh
    # (without this PR)
    # Step 1: Create a GCS ft-enabled RayService
    kubectl apply -f ray-service.high-availability.yaml
    
    # Step 2: Check the RayService status
    kubectl describe rayservices.ray.io rayservice-ha
    # Dashboard Status:
    #   Health Last Update Time:  $t1
    #   Is Healthy:               true
    #   Last Update Time:         $t1
    
    # Step 3: Wait more than `deploymentUnhealthySecondThreshold` (300 here) seconds ($t2 >= $t1 + 300).
    # Delete the head Pod.
    export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -o custom-columns=POD:metadata.name --no-headers)
    kubectl delete pod $HEAD_POD

    # Step 4: `reconcileServe` will not send requests to the dashboard agent when the head Pod is not running and ready.

    # Step 5: When the new head Pod is ready and running again, KubeRay starts sending requests
    # to the dashboard agent and update the RayService CR status. In addition, the dashboard agent
    # still needs several seconds to be ready because the readiness probe only checks Raylet and GCS.

    # Step 6: $t3 is larger than $t1 + 300, so zero downtime upgrade is triggered accidentally.
    ```
   * With this PR, zero downtime upgrade will only be triggered when the dashboard agent has been unhealthy for more than `deploymentUnhealthySecondThreshold` seconds.

* Change 2: `reconcileServe`
  * Question: When we delete the dashboard agent process on the head Pod, the head Pod becomes not ready. Hence, the dashboard agent health check will be skipped. Hence, the zero-downtime upgrade will not be triggered after `deploymentUnhealthySecondThreshold` seconds. The Ray head will fail and restart after the liveness probes fail 120 times consecutively (~600 seconds).
  * This PR skips the active RayCluster's head Pod status check. KubeRay still sends requests to the dashboard agent, and triggers a zero-downtime upgrade after `deploymentUnhealthySecondThreshold` seconds.

## Related issue number

Closes #1565

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(


* Manual test
  * Create a GCS ft-enabled RayService
  * Kill the head Pod after `deploymentUnhealthySecondThreshold` seconds. => No zero-downtime upgrade should be triggered.
  * Kill the dashboard agent process on the head Pod. => Zero-downtime upgrade should be triggered after `deploymentUnhealthySecondThreshold` seconds.
