### PR TITLE
[Bug][RayJob] Fix FailedToGetJobStatus by allowing transition to Running

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -311,10 +311,8 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		}
 	}
 
-	deployStatus := rayJobInstance.Status.JobDeploymentStatus
-	isDeployStatusRunningOrFailedToGetStatus := deployStatus == rayv1.JobDeploymentStatusRunning || deployStatus == rayv1.JobDeploymentStatusFailedToGetJobStatus
 	// Let's use rayJobInstance.Status.JobStatus to make sure we only delete cluster after the CR is updated.
-	if isJobSucceedOrFailed(rayJobInstance.Status.JobStatus) && isDeployStatusRunningOrFailedToGetStatus {
+	if isJobSucceedOrFailed(rayJobInstance.Status.JobStatus) && rayJobInstance.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusRunning {
 		if rayJobInstance.Spec.ShutdownAfterJobFinishes && len(rayJobInstance.Spec.ClusterSelector) == 0 {
 			// the RayJob is submitted against the RayCluster created by THIS job, so we can tear that
 			// RayCluster down.

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -526,7 +526,7 @@ func (r *RayJobReconciler) initRayJobStatusIfNeed(ctx context.Context, rayJob *r
 
 func (r *RayJobReconciler) shouldUpdateJobStatus(oldJobStatus rayv1.JobStatus, oldJobDeploymentStatus rayv1.JobDeploymentStatus, jobInfo *utils.RayJobInfo) bool {
 	if jobInfo != nil {
-		jobStatusChanged := (oldJobStatus != jobInfo.JobStatus)	
+		jobStatusChanged := (oldJobStatus != jobInfo.JobStatus)
 		// If the status changed, or if we didn't have the status before and now we have it, update the status and deployment status.
 		if jobStatusChanged || oldJobDeploymentStatus == rayv1.JobDeploymentStatusFailedToGetJobStatus {
 			return true

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -259,7 +259,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	if jobInfo != nil {
 		jobStatusChanged := (rayJobInstance.Status.JobStatus != jobInfo.JobStatus)
 		// If the status changed, or if we didn't have the status before and now we have it, update the status and deployment status.
-		if (jobStatusChanged || rayJobInstance.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailedToGetJobStatus) {
+		if jobStatusChanged || rayJobInstance.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailedToGetJobStatus {
 			r.Log.Info(fmt.Sprintf("Update jobStatus from %s to %s", rayJobInstance.Status.JobStatus, jobInfo.JobStatus), "rayjob", rayJobInstance.Status.JobId)
 			r.Log.Info(fmt.Sprintf("Update jobDeploymentStatus from %s to %s", rayJobInstance.Status.JobDeploymentStatus, rayv1.JobDeploymentStatusRunning), "rayjob", rayJobInstance.Status.JobId)
 			err = r.updateState(ctx, rayJobInstance, jobInfo, jobInfo.JobStatus, rayv1.JobDeploymentStatusRunning, nil)

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -182,22 +182,22 @@ func TestShouldUpdateJobStatus(t *testing.T) {
 	r := &RayJobReconciler{}
 
 	tests := []struct {
-		name                     string
-		oldJobStatus             rayv1.JobStatus
-		oldJobDeploymentStatus   rayv1.JobDeploymentStatus
-		jobInfo                  *utils.RayJobInfo
-		expectedShouldUpdate     bool
+		name                   string
+		oldJobStatus           rayv1.JobStatus
+		oldJobDeploymentStatus rayv1.JobDeploymentStatus
+		jobInfo                *utils.RayJobInfo
+		expectedShouldUpdate   bool
 	}{
 		{
-			name: "jobInfo is nil",
-			oldJobStatus: rayv1.JobStatusPending,
+			name:                   "jobInfo is nil",
+			oldJobStatus:           rayv1.JobStatusPending,
 			oldJobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
-			jobInfo: nil,
-			expectedShouldUpdate: false,
+			jobInfo:                nil,
+			expectedShouldUpdate:   false,
 		},
 		{
-			name: "job status changed",
-			oldJobStatus: rayv1.JobStatusRunning,
+			name:                   "job status changed",
+			oldJobStatus:           rayv1.JobStatusRunning,
 			oldJobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
 			jobInfo: &utils.RayJobInfo{
 				JobStatus: rayv1.JobStatusStopped,
@@ -205,8 +205,8 @@ func TestShouldUpdateJobStatus(t *testing.T) {
 			expectedShouldUpdate: true,
 		},
 		{
-			name: "job status same but JobDeploymentStatus failed",
-			oldJobStatus: rayv1.JobStatusRunning,
+			name:                   "job status same but JobDeploymentStatus failed",
+			oldJobStatus:           rayv1.JobStatusRunning,
 			oldJobDeploymentStatus: rayv1.JobDeploymentStatusFailedToGetJobStatus,
 			jobInfo: &utils.RayJobInfo{
 				JobStatus: rayv1.JobStatusRunning,
@@ -214,8 +214,8 @@ func TestShouldUpdateJobStatus(t *testing.T) {
 			expectedShouldUpdate: true,
 		},
 		{
-			name: "job status same and JobDeploymentStatus not failed",
-			oldJobStatus: rayv1.JobStatusRunning,
+			name:                   "job status same and JobDeploymentStatus not failed",
+			oldJobStatus:           rayv1.JobStatusRunning,
 			oldJobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
 			jobInfo: &utils.RayJobInfo{
 				JobStatus: rayv1.JobStatusRunning,

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -205,7 +205,7 @@ func TestShouldUpdateJobStatus(t *testing.T) {
 			expectedShouldUpdate: true,
 		},
 		{
-			name:                   "job status same but JobDeploymentStatus failed",
+			name:                   "job status same but JobDeploymentStatus failed to get status",
 			oldJobStatus:           rayv1.JobStatusRunning,
 			oldJobDeploymentStatus: rayv1.JobDeploymentStatusFailedToGetJobStatus,
 			jobInfo: &utils.RayJobInfo{
@@ -214,7 +214,7 @@ func TestShouldUpdateJobStatus(t *testing.T) {
 			expectedShouldUpdate: true,
 		},
 		{
-			name:                   "job status same and JobDeploymentStatus not failed",
+			name:                   "job status same and JobDeploymentStatus not failed to get status",
 			oldJobStatus:           rayv1.JobStatusRunning,
 			oldJobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
 			jobInfo: &utils.RayJobInfo{


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
The job reconciler pings the job status endpoint every 3 seconds. Previously, if this failed at any time during the job execution, the job deployment status would be set to FailedToGetJobStatus, and it would never be updated back to JobDeploymentStatusRunning because due to an oversight, the existing code only updates the JobDeploymentStatus if the JobStatus changed. Thus in the case where the JobStatus doesn't change (e.g. "RUNNING" -> "RUNNING"), but there is an intermittent failure to get the job status, the JobDeploymentStatus is never updated from JobDeploymentStatusFailedToGetJobStatus to JobDeploymentStatusRunning.

This PR fixes this bug by explicitly updating the status back to JobDeploymentStatusRunning if the reconcile loop gets a JobStatus when the previous status is FailedToGetJobStatus.

Testing: unit test

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/kuberay/issues/1489
## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
