### PR TITLE
fix: make `helm` and `make` usage compatible

### DIFF
--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -13,13 +13,12 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "kuberay-operator.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: kuberay
+      app.kubernetes.io/component: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "kuberay-operator.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/name: kuberay
         app.kubernetes.io/component: kuberay-operator
         {{- if .Values.labels }}
         {{- toYaml .Values.labels | nindent 8 }}


### PR DESCRIPTION
in local dev workflow by making helm chart's Deployment's Pod selectors and
labels compatible with the ones in `config/manager/manager.yaml` used by
`Makefile`.

Right now if one runs the following `helm` and `make` commands as instructed in `ray-operator/DEVELOPMENT.md`, one gets the following error.

## Before

```shell

helm install kuberay-operator --set image.repository=kuberay/operator --set image.tag=dxia-test4

NAME: kuberay-operator
LAST DEPLOYED: Mon Oct 30 17:16:31 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None

IMG=kuberay/operator:dxia-test4 make deploy

test -s /Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/controller-gen || GOBIN=/Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/controller-gen/.. go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0
/Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/controller-gen "crd:maxDescLen=0,trivialVersions=true,preserveUnknownFields=false,generateEmbeddedObjectMeta=true,allowDangerousTypes=true" rbac:roleName=kuberay-operator webhook paths="./..." output:crd:artifacts:config=config/crd/bases
test -s /Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/kustomize ||  GOBIN=/Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/kustomize/.. go install sigs.k8s.io/kustomize/kustomize/v5@latest
cd config/default && /Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/kustomize edit set image kuberay/operator=kuberay/operator:dxia-test4
(/Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/kustomize build config/default | grep -v 'creationTimestamp: "null"' | kubectl create -f -) || (/Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/kustomize build config/default | grep -v 'creationTimestamp: "null"' | kubectl replace -f -)
Error from server (AlreadyExists): error when creating "STDIN": namespaces "ray-system" already exists
Error from server (AlreadyExists): error when creating "STDIN": customresourcedefinitions.apiextensions.k8s.io "rayclusters.ray.io" already exists
Error from server (AlreadyExists): error when creating "STDIN": customresourcedefinitions.apiextensions.k8s.io "rayjobs.ray.io" already exists
Error from server (AlreadyExists): error when creating "STDIN": customresourcedefinitions.apiextensions.k8s.io "rayservices.ray.io" already exists
Error from server (AlreadyExists): error when creating "STDIN": serviceaccounts "kuberay-operator" already exists
Error from server (AlreadyExists): error when creating "STDIN": roles.rbac.authorization.k8s.io "kuberay-operator-leader-election" already exists
Error from server (AlreadyExists): error when creating "STDIN": clusterroles.rbac.authorization.k8s.io "kuberay-operator" already exists
Error from server (AlreadyExists): error when creating "STDIN": rolebindings.rbac.authorization.k8s.io "kuberay-operator-leader-election" already exists
Error from server (AlreadyExists): error when creating "STDIN": clusterrolebindings.rbac.authorization.k8s.io "kuberay-operator" already exists
Error from server (AlreadyExists): error when creating "STDIN": services "kuberay-operator" already exists
Error from server (AlreadyExists): error when creating "STDIN": deployments.apps "kuberay-operator" already exists
namespace/ray-system replaced
customresourcedefinition.apiextensions.k8s.io/rayclusters.ray.io replaced
customresourcedefinition.apiextensions.k8s.io/rayjobs.ray.io replaced
customresourcedefinition.apiextensions.k8s.io/rayservices.ray.io replaced
serviceaccount/kuberay-operator replaced
role.rbac.authorization.k8s.io/kuberay-operator-leader-election replaced
clusterrole.rbac.authorization.k8s.io/kuberay-operator replaced
rolebinding.rbac.authorization.k8s.io/kuberay-operator-leader-election replaced
clusterrolebinding.rbac.authorization.k8s.io/kuberay-operator replaced
service/kuberay-operator replaced
The Deployment "kuberay-operator" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/component":"kuberay-operator", "app.kubernetes.io/name":"kuberay"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
make: *** [deploy] Error 1
```

## After

```shell
helm install kuberay-operator --set image.repository=kuberay/operator --set image.tag=dxia-test4

NAME: kuberay-operator
LAST DEPLOYED: Mon Oct 30 17:16:31 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None

IMG=kuberay/operator:dxia-test4 make deploy

test -s /Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/controller-gen || GOBIN=/Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/controller-gen/.. go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0
/Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/controller-gen "crd:maxDescLen=0,trivialVersions=true,preserveUnknownFields=false,generateEmbeddedObjectMeta=true,allowDangerousTypes=true" rbac:roleName=kuberay-operator webhook paths="./..." output:crd:artifacts:config=config/crd/bases
test -s /Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/kustomize ||  GOBIN=/Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/kustomize/.. go install sigs.k8s.io/kustomize/kustomize/v5@latest
cd config/default && /Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/kustomize edit set image kuberay/operator=kuberay/operator:dxia-test4
(/Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/kustomize build config/default | grep -v 'creationTimestamp: "null"' | kubectl create -f -) || (/Users/dxia/src/github.com/ray-project/kuberay/ray-operator/bin/kustomize build config/default | grep -v 'creationTimestamp: "null"' | kubectl replace -f -)
Error from server (AlreadyExists): error when creating "STDIN": namespaces "ray-system" already exists
Error from server (AlreadyExists): error when creating "STDIN": customresourcedefinitions.apiextensions.k8s.io "rayclusters.ray.io" already exists
Error from server (AlreadyExists): error when creating "STDIN": customresourcedefinitions.apiextensions.k8s.io "rayjobs.ray.io" already exists
Error from server (AlreadyExists): error when creating "STDIN": customresourcedefinitions.apiextensions.k8s.io "rayservices.ray.io" already exists
Error from server (AlreadyExists): error when creating "STDIN": serviceaccounts "kuberay-operator" already exists
Error from server (AlreadyExists): error when creating "STDIN": roles.rbac.authorization.k8s.io "kuberay-operator-leader-election" already exists
Error from server (AlreadyExists): error when creating "STDIN": clusterroles.rbac.authorization.k8s.io "kuberay-operator" already exists
Error from server (AlreadyExists): error when creating "STDIN": rolebindings.rbac.authorization.k8s.io "kuberay-operator-leader-election" already exists
Error from server (AlreadyExists): error when creating "STDIN": clusterrolebindings.rbac.authorization.k8s.io "kuberay-operator" already exists
Error from server (AlreadyExists): error when creating "STDIN": services "kuberay-operator" already exists
Error from server (AlreadyExists): error when creating "STDIN": deployments.apps "kuberay-operator" already exists
namespace/ray-system replaced
customresourcedefinition.apiextensions.k8s.io/rayclusters.ray.io replaced
customresourcedefinition.apiextensions.k8s.io/rayjobs.ray.io replaced
customresourcedefinition.apiextensions.k8s.io/rayservices.ray.io replaced
serviceaccount/kuberay-operator replaced
role.rbac.authorization.k8s.io/kuberay-operator-leader-election replaced
clusterrole.rbac.authorization.k8s.io/kuberay-operator replaced
rolebinding.rbac.authorization.k8s.io/kuberay-operator-leader-election replaced
clusterrolebinding.rbac.authorization.k8s.io/kuberay-operator replaced
service/kuberay-operator replaced
deployment.apps/kuberay-operator replaced
```


## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
