### PR TITLE
chore: remove all deprecated `HeadGroupSpec.replicas`

### DIFF
--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -19,9 +19,6 @@ spec:
     # Kubernetes Service Type. This is an optional field, and the default value is ClusterIP.
     # Refer to https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types.
     serviceType: ClusterIP
-    # for the head group, replicas should always be 1.
-    # headGroupSpec.replicas is deprecated in KubeRay >= 0.3.0.
-    replicas: 1
     # The `rayStartParams` are used to configure the `ray start` command.
     # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
     # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.

--- a/ray-operator/config/samples/ray-cluster.separate-ingress.yaml
+++ b/ray-operator/config/samples/ray-cluster.separate-ingress.yaml
@@ -10,7 +10,6 @@ spec:
   rayVersion: '2.7.0' # should match the Ray version in the image of the containers
   headGroupSpec:
     serviceType: NodePort
-    replicas: 1
     # The `rayStartParams` are used to configure the `ray start` command.
     # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
     # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.

--- a/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
+++ b/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
@@ -9,7 +9,6 @@ spec:
   rayVersion: '2.7.0'
   headGroupSpec:
     rayStartParams: {}
-    replicas: 1
     template:
       spec:
         containers:

--- a/ray-operator/config/samples/ray-cluster.volcano-scheduler.yaml
+++ b/ray-operator/config/samples/ray-cluster.volcano-scheduler.yaml
@@ -8,7 +8,6 @@ spec:
   rayVersion: '2.7.0'
   headGroupSpec:
     rayStartParams: {}
-    replicas: 1
     template:
       spec:
         containers:

--- a/ray-operator/config/security/ray-cluster.pod-security.yaml
+++ b/ray-operator/config/security/ray-cluster.pod-security.yaml
@@ -13,9 +13,6 @@ spec:
   rayVersion: '2.4.0'
   # Ray head pod configuration
   headGroupSpec:
-    # for the head group, replicas should always be 1.
-    # headGroupSpec.replicas is deprecated in KubeRay >= 0.3.0.
-    replicas: 1
     # the following params are used to complete the ray start: ray start --head --block --dashboard-host: '0.0.0.0' ...
     rayStartParams:
       dashboard-host: '0.0.0.0'


### PR DESCRIPTION
in example YAMLs

## Why are these changes needed?

This field has been deprecated since 0.3.0.
[Related comment](https://github.com/ray-project/kuberay/issues/612#issuecomment-1266279244)

## Related issue number

#612

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
