### PR TITLE
chore: remove `HeadGroupSpec.Replicas` from `raycluster_types.go`

### DIFF
--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -17,7 +17,6 @@ import (
 var (
 	enableIngress                    = true
 	deploymentReplicas       int32   = 1
-	headNodeReplicas         int32   = 1
 	workerReplicas           int32   = 5
 	unhealthySecondThreshold int32   = 900
 	floatNumber              float64 = 1
@@ -27,7 +26,6 @@ var (
 var headSpecTest = rayv1api.HeadGroupSpec{
 	ServiceType:   "ClusterIP",
 	EnableIngress: &enableIngress,
-	Replicas:      &headNodeReplicas,
 	RayStartParams: map[string]string{
 		"dashboard-host":      "0.0.0.0",
 		"metrics-export-port": "8080",

--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -70,13 +70,11 @@ func buildRayClusterSpec(imageVersion string, envs *api.EnvironmentVariables, cl
 	if err != nil {
 		return nil, err
 	}
-	headReplicas := int32(1)
 	rayClusterSpec := &rayv1api.RayClusterSpec{
 		RayVersion: imageVersion,
 		HeadGroupSpec: rayv1api.HeadGroupSpec{
 			ServiceType:    v1.ServiceType(clusterSpec.HeadGroupSpec.ServiceType),
 			Template:       *headPodTemplate,
-			Replicas:       &headReplicas,
 			RayStartParams: clusterSpec.HeadGroupSpec.RayStartParams,
 		},
 		WorkerGroupSpecs: []rayv1api.WorkerGroupSpec{},

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -444,9 +444,6 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
-                  replicas:
-                    format: int32
-                    type: integer
                   serviceType:
                     type: string
                   template:
@@ -7120,9 +7117,6 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
-                  replicas:
-                    format: int32
-                    type: integer
                   serviceType:
                     type: string
                   template:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -443,9 +443,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      replicas:
-                        format: int32
-                        type: integer
                       serviceType:
                         type: string
                       template:
@@ -10232,9 +10229,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      replicas:
-                        format: int32
-                        type: integer
                       serviceType:
                         type: string
                       template:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -428,9 +428,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      replicas:
-                        format: int32
-                        type: integer
                       serviceType:
                         type: string
                       template:
@@ -7482,9 +7479,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      replicas:
-                        format: int32
-                        type: integer
                       serviceType:
                         type: string
                       template:

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -33,8 +33,6 @@ type HeadGroupSpec struct {
 	HeadService *v1.Service `json:"headService,omitempty"`
 	// EnableIngress indicates whether operator should create ingress object for head service or not.
 	EnableIngress *bool `json:"enableIngress,omitempty"`
-	// HeadGroupSpec.Replicas is deprecated and ignored; there can only be one head pod per Ray cluster.
-	Replicas *int32 `json:"replicas,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template is the exact pod template used in K8s depoyments, statefulsets, etc.

--- a/ray-operator/apis/ray/v1/raycluster_types_test.go
+++ b/ray-operator/apis/ray/v1/raycluster_types_test.go
@@ -16,7 +16,6 @@ var myRayCluster = &RayCluster{
 	},
 	Spec: RayClusterSpec{
 		HeadGroupSpec: HeadGroupSpec{
-			Replicas: pointer.Int32Ptr(1),
 			RayStartParams: map[string]string{
 				"port":                        "6379",
 				"object-manager-port":         "12345",

--- a/ray-operator/apis/ray/v1/rayjob_types_test.go
+++ b/ray-operator/apis/ray/v1/rayjob_types_test.go
@@ -25,7 +25,6 @@ var expectedRayJob = RayJob{
 		RayClusterSpec: &RayClusterSpec{
 			RayVersion: "1.12.1",
 			HeadGroupSpec: HeadGroupSpec{
-				Replicas: pointer.Int32Ptr(1),
 				RayStartParams: map[string]string{
 					"port":                "6379",
 					"object-store-memory": "100000000",

--- a/ray-operator/apis/ray/v1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1/rayservice_types_test.go
@@ -71,7 +71,6 @@ var myRayService = &RayService{
 		},
 		RayClusterSpec: RayClusterSpec{
 			HeadGroupSpec: HeadGroupSpec{
-				Replicas: pointer.Int32Ptr(1),
 				RayStartParams: map[string]string{
 					"port":                        "6379",
 					"object-store-memory":         "100000000",
@@ -236,7 +235,6 @@ var expected = `{
       },
       "rayClusterConfig":{
          "headGroupSpec":{
-            "replicas":1,
             "rayStartParams":{
                "dashboard-agent-listen-port":"52365",
                "dashboard-host":"0.0.0.0",

--- a/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
@@ -142,11 +142,6 @@ func (in *HeadGroupSpec) DeepCopyInto(out *HeadGroupSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.Replicas != nil {
-		in, out := &in.Replicas, &out.Replicas
-		*out = new(int32)
-		**out = **in
-	}
 	if in.RayStartParams != nil {
 		in, out := &in.RayStartParams, &out.RayStartParams
 		*out = make(map[string]string, len(*in))

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -33,8 +33,6 @@ type HeadGroupSpec struct {
 	HeadService *v1.Service `json:"headService,omitempty"`
 	// EnableIngress indicates whether operator should create ingress object for head service or not.
 	EnableIngress *bool `json:"enableIngress,omitempty"`
-	// HeadGroupSpec.Replicas is deprecated and ignored; there can only be one head pod per Ray cluster.
-	Replicas *int32 `json:"replicas,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template is the exact pod template used in K8s depoyments, statefulsets, etc.

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types_test.go
@@ -16,7 +16,6 @@ var myRayCluster = &RayCluster{
 	},
 	Spec: RayClusterSpec{
 		HeadGroupSpec: HeadGroupSpec{
-			Replicas: pointer.Int32Ptr(1),
 			RayStartParams: map[string]string{
 				"port":                        "6379",
 				"object-manager-port":         "12345",

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
@@ -25,7 +25,6 @@ var expectedRayJob = RayJob{
 		RayClusterSpec: &RayClusterSpec{
 			RayVersion: "1.12.1",
 			HeadGroupSpec: HeadGroupSpec{
-				Replicas: pointer.Int32Ptr(1),
 				RayStartParams: map[string]string{
 					"port":                "6379",
 					"object-store-memory": "100000000",

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
@@ -71,7 +71,6 @@ var myRayService = &RayService{
 		},
 		RayClusterSpec: RayClusterSpec{
 			HeadGroupSpec: HeadGroupSpec{
-				Replicas: pointer.Int32Ptr(1),
 				RayStartParams: map[string]string{
 					"port":                        "6379",
 					"object-store-memory":         "100000000",
@@ -236,7 +235,6 @@ var expected = `{
       },
       "rayClusterConfig":{
          "headGroupSpec":{
-            "replicas":1,
             "rayStartParams":{
                "dashboard-agent-listen-port":"52365",
                "dashboard-host":"0.0.0.0",

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -142,11 +142,6 @@ func (in *HeadGroupSpec) DeepCopyInto(out *HeadGroupSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.Replicas != nil {
-		in, out := &in.Replicas, &out.Replicas
-		*out = new(int32)
-		**out = **in
-	}
 	if in.RayStartParams != nil {
 		in, out := &in.RayStartParams, &out.RayStartParams
 		*out = make(map[string]string, len(*in))

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -444,9 +444,6 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
-                  replicas:
-                    format: int32
-                    type: integer
                   serviceType:
                     type: string
                   template:
@@ -7120,9 +7117,6 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
-                  replicas:
-                    format: int32
-                    type: integer
                   serviceType:
                     type: string
                   template:

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -443,9 +443,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      replicas:
-                        format: int32
-                        type: integer
                       serviceType:
                         type: string
                       template:
@@ -10232,9 +10229,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      replicas:
-                        format: int32
-                        type: integer
                       serviceType:
                         type: string
                       template:

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -428,9 +428,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      replicas:
-                        format: int32
-                        type: integer
                       serviceType:
                         type: string
                       template:
@@ -7482,9 +7479,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      replicas:
-                        format: int32
-                        type: integer
                       serviceType:
                         type: string
                       template:

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -52,10 +52,10 @@ func (v *VolcanoBatchScheduler) DoBatchSchedulingOnSubmission(app *rayv1.RayClus
 	var minMember int32
 	var totalResource corev1.ResourceList
 	if app.Spec.EnableInTreeAutoscaling == nil || !*app.Spec.EnableInTreeAutoscaling {
-		minMember = utils.CalculateDesiredReplicas(app) + *app.Spec.HeadGroupSpec.Replicas
+		minMember = utils.CalculateDesiredReplicas(app) + 1
 		totalResource = utils.CalculateDesiredResources(app)
 	} else {
-		minMember = utils.CalculateMinReplicas(app) + *app.Spec.HeadGroupSpec.Replicas
+		minMember = utils.CalculateMinReplicas(app) + 1
 		totalResource = utils.CalculateMinResources(app)
 	}
 

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
@@ -62,7 +62,6 @@ func TestCreatePodGroup(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: headSpec,
 				},
-				Replicas: pointer.Int32Ptr(1),
 			},
 			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 				{
@@ -77,7 +76,7 @@ func TestCreatePodGroup(t *testing.T) {
 		},
 	}
 
-	minMember := utils.CalculateDesiredReplicas(&cluster) + *cluster.Spec.HeadGroupSpec.Replicas
+	minMember := utils.CalculateDesiredReplicas(&cluster) + 1
 	totalResource := utils.CalculateDesiredResources(&cluster)
 	pg := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource)
 

--- a/ray-operator/controllers/ray/common/ingress_test.go
+++ b/ray-operator/controllers/ray/common/ingress_test.go
@@ -12,7 +12,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 var instanceWithIngressEnabled = &rayv1.RayCluster{
@@ -25,7 +24,6 @@ var instanceWithIngressEnabled = &rayv1.RayCluster{
 	},
 	Spec: rayv1.RayClusterSpec{
 		HeadGroupSpec: rayv1.HeadGroupSpec{
-			Replicas: pointer.Int32Ptr(1),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -49,7 +47,6 @@ var instanceWithIngressEnabledWithoutIngressClass = &rayv1.RayCluster{
 	},
 	Spec: rayv1.RayClusterSpec{
 		HeadGroupSpec: rayv1.HeadGroupSpec{
-			Replicas: pointer.Int32Ptr(1),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -30,7 +30,6 @@ var instance = rayv1.RayCluster{
 	},
 	Spec: rayv1.RayClusterSpec{
 		HeadGroupSpec: rayv1.HeadGroupSpec{
-			Replicas: pointer.Int32Ptr(1),
 			RayStartParams: map[string]string{
 				"port":                "6379",
 				"object-manager-port": "12345",

--- a/ray-operator/controllers/ray/common/route_test.go
+++ b/ray-operator/controllers/ray/common/route_test.go
@@ -22,7 +22,6 @@ var instanceWithRouteEnabled = &rayv1.RayCluster{
 	},
 	Spec: rayv1.RayClusterSpec{
 		HeadGroupSpec: rayv1.HeadGroupSpec{
-			Replicas:      pointer.Int32Ptr(1),
 			EnableIngress: pointer.BoolPtr(true),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -12,7 +12,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 var (
@@ -44,7 +43,6 @@ var (
 				headServiceAnnotationKey2: headServiceAnnotationValue2,
 			},
 			HeadGroupSpec: rayv1.HeadGroupSpec{
-				Replicas: pointer.Int32Ptr(1),
 				RayStartParams: map[string]string{
 					"port":                "6379",
 					"object-manager-port": "12345",

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -290,7 +290,6 @@ func setupTest(t *testing.T) {
 		Spec: rayv1.RayClusterSpec{
 			EnableInTreeAutoscaling: &enableInTreeAutoscaling,
 			HeadGroupSpec: rayv1.HeadGroupSpec{
-				Replicas: pointer.Int32Ptr(1),
 				RayStartParams: map[string]string{
 					"port":                "6379",
 					"object-manager-port": "12345",

--- a/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
@@ -58,7 +58,6 @@ var _ = Context("Inside the default namespace", func() {
 				RayVersion: "2.7.0",
 				HeadGroupSpec: rayv1.HeadGroupSpec{
 					ServiceType: corev1.ServiceTypeClusterIP,
-					Replicas:    pointer.Int32(1),
 					RayStartParams: map[string]string{
 						"port":                        "6379",
 						"object-store-memory":         "100000000",

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -50,7 +50,6 @@ var myRayJob = &rayv1.RayJob{
 		RayClusterSpec: &rayv1.RayClusterSpec{
 			RayVersion: "1.12.1",
 			HeadGroupSpec: rayv1.HeadGroupSpec{
-				Replicas: pointer.Int32(1),
 				RayStartParams: map[string]string{
 					"port":                        "6379",
 					"object-store-memory":         "100000000",

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -123,7 +123,6 @@ applications:
 			RayClusterSpec: rayv1.RayClusterSpec{
 				RayVersion: "1.12.1",
 				HeadGroupSpec: rayv1.HeadGroupSpec{
-					Replicas: pointer.Int32(1),
 					RayStartParams: map[string]string{
 						"port":                        "6379",
 						"object-store-memory":         "100000000",

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -284,9 +284,7 @@ func CalculateAvailableReplicas(pods corev1.PodList) int32 {
 func CalculateDesiredResources(cluster *rayv1.RayCluster) corev1.ResourceList {
 	desiredResourcesList := []corev1.ResourceList{{}}
 	headPodResource := calculatePodResource(cluster.Spec.HeadGroupSpec.Template.Spec)
-	for i := int32(0); i < *cluster.Spec.HeadGroupSpec.Replicas; i++ {
-		desiredResourcesList = append(desiredResourcesList, headPodResource)
-	}
+	desiredResourcesList = append(desiredResourcesList, headPodResource)
 	for _, nodeGroup := range cluster.Spec.WorkerGroupSpecs {
 		podResource := calculatePodResource(nodeGroup.Template.Spec)
 		for i := int32(0); i < *nodeGroup.Replicas; i++ {
@@ -299,9 +297,7 @@ func CalculateDesiredResources(cluster *rayv1.RayCluster) corev1.ResourceList {
 func CalculateMinResources(cluster *rayv1.RayCluster) corev1.ResourceList {
 	minResourcesList := []corev1.ResourceList{{}}
 	headPodResource := calculatePodResource(cluster.Spec.HeadGroupSpec.Template.Spec)
-	for i := int32(0); i < *cluster.Spec.HeadGroupSpec.Replicas; i++ {
-		minResourcesList = append(minResourcesList, headPodResource)
-	}
+	minResourcesList = append(minResourcesList, headPodResource)
 	for _, nodeGroup := range cluster.Spec.WorkerGroupSpecs {
 		podResource := calculatePodResource(nodeGroup.Template.Spec)
 		for i := int32(0); i < *nodeGroup.MinReplicas; i++ {


### PR DESCRIPTION
## Why are these changes needed?

It has been deprecated since 0.3.0.

Changes to generated files made by running `cd ray-operator && make sync generate manifests`.

## Related issue number

closes #612

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
