### PR TITLE
[BugFix]RayCluster enable ingress dashboard ingress return 404

### DIFF
--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -23,6 +23,11 @@ func BuildIngressForHeadService(cluster rayv1.RayCluster) (*networkingv1.Ingress
 		KubernetesCreatedByLabelKey:       ComponentName,
 	}
 
+	// https://github.com/ray-project/kuberay/pull/1312#issuecomment-1712451301
+	annotation := map[string]string{
+		"nginx.ingress.kubernetes.io/rewrite-target": "/$1\\",
+	}
+
 	// Copy other ingress configurations from cluster annotations to provide a generic way
 	// for user to customize their ingress settings. The `exclude_set` is used to avoid setting
 	// both IngressClassAnnotationKey annotation which is deprecated and `Spec.IngressClassName`
@@ -30,7 +35,6 @@ func BuildIngressForHeadService(cluster rayv1.RayCluster) (*networkingv1.Ingress
 	exclude_set := map[string]struct{}{
 		IngressClassAnnotationKey: {},
 	}
-	annotation := map[string]string{}
 	for key, value := range cluster.Annotations {
 		if _, ok := exclude_set[key]; !ok {
 			annotation[key] = value


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When deployed Raycluster with `enableIngress: true`, the dashboard ingress always return 404.

## Related issue number

https://github.com/ray-project/kuberay/pull/1312#issuecomment-1712451301

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
