### PR TITLE
Fix: odd number of arguments

### DIFF
--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -190,7 +190,7 @@ func cacheSelectors() (cache.SelectorsByObject, error) {
 
 func exitOnError(err error, msg string, keysAndValues ...interface{}) {
 	if err != nil {
-		setupLog.Error(err, msg, keysAndValues)
+		setupLog.Error(err, msg, keysAndValues...)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For now, `exitOnError` without keysAndValues, will cause panic: odd number of arguments passed as key-value pairs for logging.  It is noisily.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
