### PR TITLE
Make KubeRay Operator Image FIPS compliant

### DIFF
--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -16,9 +16,9 @@ COPY controllers/ controllers/
 
 # Build
 USER root
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=1 GOOS=linux go build -tags strictfipsruntime -a -o manager main.go
 
-FROM scratch
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
cc @kevin85421  @tedhtchang @jbusche 

Closes #1632

Test image that I built and pushed:  quay.io/anishasthana/kuberay-operator:ubiminimaltest

Output of payload checker:
```
---- Successful run
```