### PR TITLE
[Doc] Support consistency check for API reference in CI

### DIFF
--- a/.github/workflows/consistency-check.yaml
+++ b/.github/workflows/consistency-check.yaml
@@ -34,6 +34,30 @@ jobs:
       - name: Verify Generated Files
         working-directory: ./ray-operator
         run: ./hack/verify-generated-files.sh
+
+  # Check consistency between types.go and generated API reference.
+  ray-operator-verify-api-docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go 1.19.x
+        uses: actions/setup-go@v2
+        with:
+          # Use the same go version with build job
+          go-version: '1.19'
+
+      - name: Check golang version
+        working-directory: ./ray-operator
+        run: go version
+
+      - name: Verify API reference
+        working-directory: ./ray-operator
+        run: ./hack/verify-api-docs.sh
+
   # 1. Check consistency between types.go and CRD YAML files.
   # 2. Check consistency between kubebuilder markers and RBAC.
   ray-operator-verify-crd-rbac:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -38,17 +38,6 @@ _Appears in:_
 | `upscalingMode` _[UpscalingMode](#upscalingmode)_ | UpscalingMode is "Conservative", "Default", or "Aggressive." Conservative: Upscaling is rate-limited; the number of pending worker pods is at most the size of the Ray cluster. Default: Upscaling is not rate-limited. Aggressive: An alias for Default; upscaling is not rate-limited. It is not read by the KubeRay operator but by the Ray autoscaler. |
 
 
-#### ClusterState
-
-_Underlying type:_ _string_
-
-The overall state of the Ray cluster.
-
-_Appears in:_
-- [RayClusterStatus](#rayclusterstatus)
-
-
-
 
 
 #### HeadGroupSpec
@@ -65,24 +54,8 @@ _Appears in:_
 | `serviceType` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#servicetype-v1-core)_ | ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod |
 | `headService` _[Service](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#service-v1-core)_ | HeadService is the Kubernetes service of the head pod. |
 | `enableIngress` _boolean_ | EnableIngress indicates whether operator should create ingress object for head service or not. |
-| `replicas` _integer_ | HeadGroupSpec.Replicas is deprecated and ignored; there can only be one head pod per Ray cluster. |
 | `rayStartParams` _object (keys:string, values:string)_ | RayStartParams are the params of the start command: node-manager-port, object-store-memory, ... |
 | `template` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | Template is the exact pod template used in K8s depoyments, statefulsets, etc. |
-
-
-#### HeadInfo
-
-
-
-HeadInfo gives info about head
-
-_Appears in:_
-- [RayClusterStatus](#rayclusterstatus)
-
-| Field | Description |
-| --- | --- |
-| `podIP` _string_ |  |
-| `serviceIP` _string_ |  |
 
 
 #### RayActorOptionSpec
@@ -345,17 +318,6 @@ _Appears in:_
 | `upscalingMode` _[UpscalingMode](#upscalingmode)_ | UpscalingMode is "Conservative", "Default", or "Aggressive." Conservative: Upscaling is rate-limited; the number of pending worker pods is at most the size of the Ray cluster. Default: Upscaling is not rate-limited. Aggressive: An alias for Default; upscaling is not rate-limited. It is not read by the KubeRay operator but by the Ray autoscaler. |
 
 
-#### ClusterState
-
-_Underlying type:_ _string_
-
-The overall state of the Ray cluster.
-
-_Appears in:_
-- [RayClusterStatus](#rayclusterstatus)
-
-
-
 
 
 #### HeadGroupSpec
@@ -372,24 +334,8 @@ _Appears in:_
 | `serviceType` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#servicetype-v1-core)_ | ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod |
 | `headService` _[Service](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#service-v1-core)_ | HeadService is the Kubernetes service of the head pod. |
 | `enableIngress` _boolean_ | EnableIngress indicates whether operator should create ingress object for head service or not. |
-| `replicas` _integer_ | HeadGroupSpec.Replicas is deprecated and ignored; there can only be one head pod per Ray cluster. |
 | `rayStartParams` _object (keys:string, values:string)_ | RayStartParams are the params of the start command: node-manager-port, object-store-memory, ... |
 | `template` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | Template is the exact pod template used in K8s depoyments, statefulsets, etc. |
-
-
-#### HeadInfo
-
-
-
-HeadInfo gives info about head
-
-_Appears in:_
-- [RayClusterStatus](#rayclusterstatus)
-
-| Field | Description |
-| --- | --- |
-| `podIP` _string_ |  |
-| `serviceIP` _string_ |  |
 
 
 #### RayActorOptionSpec

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -228,22 +228,26 @@ We have several [consistency checks](https://github.com/ray-project/kuberay/blob
 
 1. `ray-operator/apis/ray/v1alpha1/*_types.go` should be synchronized with the CRD YAML files (`ray-operator/config/crd/bases/`)
 2. `ray-operator/apis/ray/v1alpha1/*_types.go` should be synchronized with generated API (`ray-operator/pkg/client`)
-3. CRD YAML files in `ray-operator/config/crd/bases/` and `helm-chart/kuberay-operator/crds/` should be the same.
-4. Kubebuilder markers in `ray-operator/controllers/ray/*_controller.go` should be synchronized with RBAC YAML files in `ray-operator/config/rbac`.
-5. RBAC YAML files in `helm-chart/kuberay-operator/templates` and `ray-operator/config/rbac` should be synchronized. **Currently, we need to synchronize this manually.** See [#631](https://github.com/ray-project/kuberay/pull/631) as an example.
-6. `multiple_namespaces_role.yaml` and `multiple_namespaces_rolebinding.yaml` should be synchronized with `role.yaml` and `rolebinding.yaml` in the `helm-chart/kuberay-operator/templates` directory. The only difference is that the former creates namespaced RBAC resources, while the latter creates cluster-scoped RBAC resources.
+3. `ray-operator/apis/ray/v1alpha1/*_types.go` should be synchronized with generated API reference (`docs/reference/api.md`)
+4. CRD YAML files in `ray-operator/config/crd/bases/` and `helm-chart/kuberay-operator/crds/` should be the same.
+5. Kubebuilder markers in `ray-operator/controllers/ray/*_controller.go` should be synchronized with RBAC YAML files in `ray-operator/config/rbac`.
+6. RBAC YAML files in `helm-chart/kuberay-operator/templates` and `ray-operator/config/rbac` should be synchronized. **Currently, we need to synchronize this manually.** See [#631](https://github.com/ray-project/kuberay/pull/631) as an example.
+7. `multiple_namespaces_role.yaml` and `multiple_namespaces_rolebinding.yaml` should be synchronized with `role.yaml` and `rolebinding.yaml` in the `helm-chart/kuberay-operator/templates` directory. The only difference is that the former creates namespaced RBAC resources, while the latter creates cluster-scoped RBAC resources.
 
 ```bash
-# Synchronize consistency 1 and 4:
+# Synchronize consistency 1 and 5:
 make manifests
 
 # Synchronize consistency 2:
 ./hack/update-codegen.sh
 
 # Synchronize consistency 3:
+make api-docs
+
+# Synchronize consistency 4:
 make helm
 
-# Synchronize 1, 2, 3, and 4 in one command
+# Synchronize 1, 2, 3, 4 and 5 in one command
 # [Note]: Currently, we need to synchronize consistency 5 and 6 manually.
 make sync
 

--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -73,8 +73,9 @@ test-e2e: WHAT ?= ./test/e2e
 test-e2e: manifests generate fmt vet ## Run e2e tests.
 	go test -timeout 30m -v $(WHAT)
 
-sync: helm
+sync: helm api-docs
 	./hack/update-codegen.sh
+
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.

--- a/ray-operator/hack/config.yaml
+++ b/ray-operator/hack/config.yaml
@@ -2,6 +2,8 @@ processor:
   ignoreTypes:
     - "List$"
     - "Status$"
+    - "HeadInfo$"
+    - "ClusterState$"
   ignoreFields:
     - "status$"
     - "TypeMeta$"

--- a/ray-operator/hack/verify-api-docs.sh
+++ b/ray-operator/hack/verify-api-docs.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+DIFFROOT="${SCRIPT_ROOT}/../docs/reference"
+TMP_DIFFROOT="${SCRIPT_ROOT}/_tmp/pkg"
+_tmp="${SCRIPT_ROOT}/_tmp"
+
+cleanup() {
+  rm -rf "${_tmp}"
+}
+trap "cleanup" EXIT SIGINT
+
+cleanup
+
+mkdir -p "${TMP_DIFFROOT}"
+cp -a "${DIFFROOT}"/api.md "${TMP_DIFFROOT}"
+
+make api-docs
+echo "diffing ${DIFFROOT} against freshly generated API reference"
+ret=0
+diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
+cp -a "${TMP_DIFFROOT}"/* "${DIFFROOT}"
+if [[ $ret -eq 0 ]]
+then
+  echo "${DIFFROOT} up to date."
+else
+  echo "${DIFFROOT} is out of date. Please run 'make api-docs'"
+  exit 1
+fi


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This pull request adds support for consistency check of API reference in CI.

Besides, it ignores additional types related to `RayClusterStatus` in `hack/config.yaml`.

/cc @kevin85421

## Related issue number

<!-- For example: "Closes #1234" -->

It's a subsequent pull request of #1625.

## Checks

1. This pull request should [pass](https://github.com/ray-project/kuberay/actions/runs/6905995210/job/18790000256?pr=1655).
2. #1661 I used the commit version at 3754d34ef61734b569d235f5512c27c3f40d82df as the base since `docs/reference/api.md` is outdated with the current config. The workflow is expected to fail. Here is the [result](https://github.com/ray-project/kuberay/actions/runs/6911466506/job/18806035717?pr=1661).

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
