### PR TITLE
[RayService][Health-Check][1/n] Offload the health check responsibilities to K8s and RayCluster

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -446,19 +446,25 @@ applications:
 			// Simulate autoscaler by updating the pending RayCluster directly. Note that the autoscaler
 			// will not update the RayService directly.
 
-			// ServiceUnhealthySecondThreshold is a global variable in rayservice_controller.go.
-			// If the time elapsed since the last update of the service HEALTHY status exceeds ServiceUnhealthySecondThreshold seconds,
-			// the RayService controller will consider the active RayCluster as unhealthy and prepare a new RayCluster.
-			orignalServeDeploymentUnhealthySecondThreshold := ServiceUnhealthySecondThreshold
-			ServiceUnhealthySecondThreshold = 5
-			fakeRayDashboardClient.SetSingleApplicationStatus(generateServeStatus(rayv1.DeploymentStatusEnum.UNHEALTHY, rayv1.ApplicationStatusEnum.UNHEALTHY))
+			// Trigger a new RayCluster preparation by updating the RayVersion.
+			oldRayVersion := myRayService.Spec.RayClusterSpec.RayVersion
+			newRayVersion := "2.200.0"
+			Expect(oldRayVersion).ShouldNot(Equal(newRayVersion))
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				Eventually(
+					getResourceFunc(ctx, client.ObjectKey{Name: myRayService.Name, Namespace: "default"}, myRayService),
+					time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayService  = %v", myRayService.Name)
+				myRayService.Spec.RayClusterSpec.RayVersion = newRayVersion
+				return k8sClient.Update(ctx, myRayService)
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to update test RayService resource")
 			Eventually(
 				getPreparingRayClusterNameFunc(ctx, myRayService),
 				time.Second*60, time.Millisecond*500).Should(Not(BeEmpty()), "New pending RayCluster name  = %v", myRayService.Status.PendingServiceStatus.RayClusterName)
 			initialPendingClusterName, _ := getPreparingRayClusterNameFunc(ctx, myRayService)()
 
 			// Simulate that the pending RayCluster is updated by the autoscaler.
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: initialPendingClusterName, Namespace: "default"}, myRayCluster),
 					time.Second*15, time.Millisecond*500).Should(BeNil(), "Pending RayCluster = %v", myRayCluster.Name)
@@ -478,7 +484,6 @@ applications:
 			// (1) The pending RayCluster's head Pod becomes Running and Ready
 			// (2) The pending RayCluster's Serve Deployments are HEALTHY.
 			updateHeadPodToRunningAndReady(ctx, initialPendingClusterName)
-			ServiceUnhealthySecondThreshold = orignalServeDeploymentUnhealthySecondThreshold
 			fakeRayDashboardClient.SetSingleApplicationStatus(generateServeStatus(rayv1.DeploymentStatusEnum.HEALTHY, rayv1.ApplicationStatusEnum.RUNNING))
 			Eventually(
 				getPreparingRayClusterNameFunc(ctx, myRayService),
@@ -596,29 +601,6 @@ applications:
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: myRayService.Status.ActiveServiceStatus.RayClusterName, Namespace: "default"}, myRayCluster),
 				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayCluster  = %v", myRayCluster.Name)
-		})
-
-		It("should detect unhealthy status and try to switch to new RayCluster.", func() {
-			// Set deployment statuses to UNHEALTHY
-			orignalServeDeploymentUnhealthySecondThreshold := ServiceUnhealthySecondThreshold
-			ServiceUnhealthySecondThreshold = 5
-			fakeRayDashboardClient.SetSingleApplicationStatus(generateServeStatus(rayv1.DeploymentStatusEnum.UNHEALTHY, rayv1.ApplicationStatusEnum.UNHEALTHY))
-
-			Eventually(
-				getPreparingRayClusterNameFunc(ctx, myRayService),
-				time.Second*60, time.Millisecond*500).Should(Not(BeEmpty()), "My new RayCluster name  = %v", myRayService.Status.PendingServiceStatus.RayClusterName)
-
-			ServiceUnhealthySecondThreshold = orignalServeDeploymentUnhealthySecondThreshold
-			pendingRayClusterName := myRayService.Status.PendingServiceStatus.RayClusterName
-			fakeRayDashboardClient.SetSingleApplicationStatus(generateServeStatus(rayv1.DeploymentStatusEnum.HEALTHY, rayv1.ApplicationStatusEnum.RUNNING))
-			updateHeadPodToRunningAndReady(ctx, pendingRayClusterName)
-
-			Eventually(
-				getPreparingRayClusterNameFunc(ctx, myRayService),
-				time.Second*15, time.Millisecond*500).Should(BeEmpty(), "My new RayCluster name  = %v", myRayService.Status.PendingServiceStatus.RayClusterName)
-			Eventually(
-				getRayClusterNameFunc(ctx, myRayService),
-				time.Second*15, time.Millisecond*500).Should(Equal(pendingRayClusterName), "My new RayCluster name  = %v", myRayService.Status.ActiveServiceStatus.RayClusterName)
 		})
 
 		It("should perform a zero-downtime update after a code change.", func() {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

RayService features a health check mechanism to monitor the status of the dashboard agent on the Ray head and the status of Ray Serve applications. It will trigger a new RayCluster preparation when the RayService controller thinks that the RayCluster is not healthy.

Almost no users benefit from this mechanism, and many have complained about why KubeRay created a new RayCluster automatically. Most users do not have enough computing resources to run two RayClusters simultaneously. In addition, maintaining the RayService health check mechanism is quite challenging due to the numerous interconnected health checks in KubeRay, including: (1) the RayCluster controller, (2) K8s readiness/liveness probes, (3) Raylet, (4) Ray Autoscaler, and (5) the RayService controller. That's why I decide to offload the health check responsibilities to K8s and RayCluster controller.

This PR avoids calling the function `markRestart` based on data plane status.

## Related issue number

* https://github.com/ray-project/kuberay/pull/1581
* https://github.com/ray-project/kuberay/pull/1293
* https://github.com/ray-project/kuberay/pull/1231
* https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1700143910045419?thread_ts=1699886904.977709&cid=C02GFQ82JPM 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
# Step 1: Create a RayService with (1) serviceUnhealthySecondThreshold: 90 and (2) deploymentUnhealthySecondThreshold: 30.
# https://gist.github.com/kevin85421/deba2e8c8e18455d6911cfe90a03e493

# Step 2: Delete the dashboard agent process after the Ray Serve applications are ready
export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -o custom-columns=POD:metadata.name --no-headers)
kubectl exec -it $HEAD_POD -- bash
kill $DASHBOARD_AGENT_PID

# Step 3: Wait for 3 mins, and no new RayCluster preparation should be triggered.
```

* Note that the dashboard agent status should be monitored by K8s Pod probes. However, KubeRay currently only injects probes to Pods when GCS FT is enabled. Hence, I will open a following PR to add probes to Ray Pods no matter whether GCS FT is enabled or not.