### PR TITLE
[RayService][Health-Check][3/n] Update the definition of HealthLastUpdateTime for DashboardStatus

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -888,7 +888,7 @@ func (r *RayServiceReconciler) generateConfigKeyPrefix(rayServiceInstance *rayv1
 	return rayServiceInstance.Namespace + "/" + rayServiceInstance.Name + "/"
 }
 
-func updateAndCheckDashboardStatus(rayServiceClusterStatus *rayv1.RayServiceStatus, isHealthy bool) {
+func updateDashboardStatus(rayServiceClusterStatus *rayv1.RayServiceStatus, isHealthy bool) {
 	timeNow := metav1.Now()
 	rayServiceClusterStatus.DashboardStatus.LastUpdateTime = &timeNow
 	rayServiceClusterStatus.DashboardStatus.IsHealthy = isHealthy
@@ -1038,7 +1038,7 @@ func (r *RayServiceReconciler) updateStatusForActiveCluster(ctx context.Context,
 	rayServiceStatus := &rayServiceInstance.Status.ActiveServiceStatus
 
 	if clientURL, err = utils.FetchHeadServiceURL(ctx, &r.Log, r.Client, rayClusterInstance, common.DashboardAgentListenPortName); err != nil || clientURL == "" {
-		updateAndCheckDashboardStatus(rayServiceStatus, false)
+		updateDashboardStatus(rayServiceStatus, false)
 		return err
 	}
 
@@ -1047,11 +1047,11 @@ func (r *RayServiceReconciler) updateStatusForActiveCluster(ctx context.Context,
 
 	var isHealthy, isReady bool
 	if isHealthy, isReady, err = r.getAndCheckServeStatus(ctx, rayDashboardClient, rayServiceStatus, r.determineServeConfigType(rayServiceInstance), rayServiceInstance.Spec.ServiceUnhealthySecondThreshold); err != nil {
-		updateAndCheckDashboardStatus(rayServiceStatus, false)
+		updateDashboardStatus(rayServiceStatus, false)
 		return err
 	}
 
-	updateAndCheckDashboardStatus(rayServiceStatus, true)
+	updateDashboardStatus(rayServiceStatus, true)
 
 	logger.Info("Check serve health", "isHealthy", isHealthy, "isReady", isReady)
 
@@ -1116,7 +1116,7 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, false, false, err
 	}
 
-	updateAndCheckDashboardStatus(rayServiceStatus, true)
+	updateDashboardStatus(rayServiceStatus, true)
 
 	logger.Info("Check serve health", "isHealthy", isHealthy, "isReady", isReady, "isActive", isActive)
 

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -503,7 +503,7 @@ applications:
 			// ServiceUnhealthySecondThreshold is a global variable in rayservice_controller.go.
 			// If the time elapsed since the last update of the service HEALTHY status exceeds ServiceUnhealthySecondThreshold seconds,
 			// the RayService controller will consider the active RayCluster as unhealthy and prepare a new RayCluster.
-			orignalServeDeploymentUnhealthySecondThreshold := ServiceUnhealthySecondThreshold
+			originalServiceUnhealthySecondThreshold := ServiceUnhealthySecondThreshold
 			ServiceUnhealthySecondThreshold = 500
 
 			// Change serve status to be unhealthy
@@ -550,7 +550,7 @@ applications:
 			Eventually(
 				checkServiceHealth(ctx, myRayService),
 				time.Second*3, time.Millisecond*500).Should(BeTrue(), "myRayService status = %v", myRayService.Status)
-			ServiceUnhealthySecondThreshold = orignalServeDeploymentUnhealthySecondThreshold
+			ServiceUnhealthySecondThreshold = originalServiceUnhealthySecondThreshold
 		})
 
 		It("Status should not be updated if the only differences are the LastUpdateTime and HealthLastUpdateTime fields.", func() {

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -803,25 +803,25 @@ func TestUpdateAndCheckDashboardStatus(t *testing.T) {
 
 	// Test 1: The dashboard agent was healthy, and the dashboard agent is still healthy.
 	svcStatusCopy := rayServiceStatus.DeepCopy()
-	updateAndCheckDashboardStatus(svcStatusCopy, true)
+	updateDashboardStatus(svcStatusCopy, true)
 	assert.NotEqual(t, svcStatusCopy.DashboardStatus.HealthLastUpdateTime, timestamp)
 
 	// Test 2: The dashboard agent was healthy, and the dashboard agent becomes unhealthy.
 	svcStatusCopy = rayServiceStatus.DeepCopy()
-	updateAndCheckDashboardStatus(svcStatusCopy, false)
+	updateDashboardStatus(svcStatusCopy, false)
 	assert.Equal(t, *svcStatusCopy.DashboardStatus.HealthLastUpdateTime, timestamp)
 
 	// Test 3: The dashboard agent was unhealthy, and the dashboard agent is still unhealthy.
 	svcStatusCopy = rayServiceStatus.DeepCopy()
 	svcStatusCopy.DashboardStatus.IsHealthy = false
-	updateAndCheckDashboardStatus(svcStatusCopy, false)
+	updateDashboardStatus(svcStatusCopy, false)
 	// The `HealthLastUpdateTime` should not be updated.
 	assert.Equal(t, *svcStatusCopy.DashboardStatus.HealthLastUpdateTime, timestamp)
 
 	// Test 4: The dashboard agent was unhealthy, and the dashboard agent becomes healthy.
 	svcStatusCopy = rayServiceStatus.DeepCopy()
 	svcStatusCopy.DashboardStatus.IsHealthy = false
-	updateAndCheckDashboardStatus(svcStatusCopy, true)
+	updateDashboardStatus(svcStatusCopy, true)
 	assert.NotEqual(t, *svcStatusCopy.DashboardStatus.HealthLastUpdateTime, timestamp)
 }
 

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -804,7 +804,7 @@ func TestUpdateAndCheckDashboardStatus(t *testing.T) {
 	// Test 1: The dashboard agent was healthy, and the dashboard agent is still healthy.
 	svcStatusCopy := rayServiceStatus.DeepCopy()
 	updateDashboardStatus(svcStatusCopy, true)
-	assert.NotEqual(t, svcStatusCopy.DashboardStatus.HealthLastUpdateTime, timestamp)
+	assert.NotEqual(t, *svcStatusCopy.DashboardStatus.HealthLastUpdateTime, timestamp)
 
 	// Test 2: The dashboard agent was healthy, and the dashboard agent becomes unhealthy.
 	svcStatusCopy = rayServiceStatus.DeepCopy()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After PR #1656, the function `updateAndCheckDashboardStatus` no longer requires a check for its return value. Therefore, we can remove the function's return value. In addition, the value of `HealthLastUpdate` in the RayService CR status is totally for observability after PR #1656. Hence, we can change its definition to be more easy-to-understand. See [here](https://github.com/ray-project/kuberay/pull/1581/files#r1376729892) for more details about the old definition. 
 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
