### PR TITLE
[RayService][Health-Check][6/n] Remove ServiceUnhealthySecondThreshold

### DIFF
--- a/ray-operator/config/samples/ray-service.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-service.autoscaler.yaml
@@ -7,7 +7,6 @@ kind: RayService
 metadata:
   name: rayservice-sample
 spec:
-  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
   # The workload consists of two applications. The first application checks on an event in the second application.
   # If the event isn't set, the first application will block on requests until the event is set. So, to test upscaling
   # we can first send a bunch of requests to the first application, which will trigger Serve autoscaling to bring up

--- a/ray-operator/config/samples/ray-service.custom-serve-service.yaml
+++ b/ray-operator/config/samples/ray-service.custom-serve-service.yaml
@@ -7,7 +7,6 @@ kind: RayService
 metadata:
   name: rayservice-sample
 spec:
-  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
   serveService:
     metadata:
       name: custom-ray-serve-service-name

--- a/ray-operator/config/samples/ray-service.different-port.yaml
+++ b/ray-operator/config/samples/ray-service.different-port.yaml
@@ -7,7 +7,6 @@ kind: RayService
 metadata:
   name: rayservice-sample
 spec:
-  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
   serveConfig:
     importPath: fruit.deployment_graph
     runtimeEnv: |

--- a/ray-operator/config/samples/ray-service.high-availability.yaml
+++ b/ray-operator/config/samples/ray-service.high-availability.yaml
@@ -79,7 +79,6 @@ metadata:
   annotations:
     ray.io/ft-enabled: "true"
 spec:
-  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
   serveConfigV2: |
     applications:
       - name: fruit_app

--- a/ray-operator/config/samples/ray-service.mobilenet.yaml
+++ b/ray-operator/config/samples/ray-service.mobilenet.yaml
@@ -3,7 +3,6 @@ kind: RayService
 metadata:
   name: rayservice-mobilenet
 spec:
-  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
   serveConfigV2: |
     applications:
       - name: mobilenet

--- a/ray-operator/config/samples/ray-service.stable-diffusion.yaml
+++ b/ray-operator/config/samples/ray-service.stable-diffusion.yaml
@@ -3,7 +3,6 @@ kind: RayService
 metadata:
   name: stable-diffusion
 spec:
-  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
   serveConfigV2: |
     applications:
       - name: stable_diffusion

--- a/ray-operator/config/samples/ray-service.text-ml.yaml
+++ b/ray-operator/config/samples/ray-service.text-ml.yaml
@@ -7,7 +7,6 @@ kind: RayService
 metadata:
   name: rayservice-sample
 spec:
-  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
   # serveConfigV2 takes a yaml multi-line scalar, which should be a Ray Serve multi-application config. See https://docs.ray.io/en/latest/serve/multi-app.html.
   # Only one of serveConfig and serveConfigV2 should be used.
   serveConfigV2: |

--- a/ray-operator/config/samples/ray-service.text-summarizer.yaml
+++ b/ray-operator/config/samples/ray-service.text-summarizer.yaml
@@ -3,7 +3,6 @@ kind: RayService
 metadata:
   name: text-summarizer
 spec:
-  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
   serveConfigV2: |
     applications:
       - name: text_summarizer

--- a/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
+++ b/ray-operator/config/samples/ray_v1alpha1_rayservice.yaml
@@ -7,7 +7,6 @@ kind: RayService
 metadata:
   name: rayservice-sample
 spec:
-  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
   # serveConfigV2 takes a yaml multi-line scalar, which should be a Ray Serve multi-application config. See https://docs.ray.io/en/latest/serve/multi-app.html.
   # Only one of serveConfig and serveConfigV2 should be used.
   serveConfigV2: |

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -800,7 +800,7 @@ func (r *RayServiceReconciler) getAndCheckServeStatus(ctx context.Context, dashb
 					applicationStatus.HealthLastUpdateTime = prevApplicationStatus.HealthLastUpdateTime
 					r.Log.Info("Ray Serve application is unhealthy", "appName", appName, "detail",
 						fmt.Sprintf(
-							"The status of the serve application %s has been UNHEALTHY or DEPLOY_FAILED sine %v. ",
+							"The status of the serve application %s has been UNHEALTHY or DEPLOY_FAILED since %v. ",
 							appName, prevApplicationStatus.HealthLastUpdateTime))
 				}
 			}

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -500,16 +500,10 @@ applications:
 				checkServiceHealth(ctx, myRayService),
 				time.Second*3, time.Millisecond*500).Should(BeTrue(), "myRayService status = %v", myRayService.Status)
 
-			// ServiceUnhealthySecondThreshold is a global variable in rayservice_controller.go.
-			// If the time elapsed since the last update of the service HEALTHY status exceeds ServiceUnhealthySecondThreshold seconds,
-			// the RayService controller will consider the active RayCluster as unhealthy and prepare a new RayCluster.
-			originalServiceUnhealthySecondThreshold := ServiceUnhealthySecondThreshold
-			ServiceUnhealthySecondThreshold = 500
-
 			// Change serve status to be unhealthy
 			fakeRayDashboardClient.SetSingleApplicationStatus(generateServeStatus(rayv1.DeploymentStatusEnum.UNHEALTHY, rayv1.ApplicationStatusEnum.UNHEALTHY))
 
-			// Confirm not switch to a new RayCluster because ServiceUnhealthySecondThreshold is 500 seconds.
+			// Confirm not switch to a new RayCluster.
 			Consistently(
 				getRayClusterNameFunc(ctx, myRayService),
 				time.Second*3, time.Millisecond*500).Should(Equal(initialClusterName), "Active RayCluster name = %v", myRayService.Status.ActiveServiceStatus.RayClusterName)
@@ -540,7 +534,7 @@ applications:
 
 			fakeRayDashboardClient.SetSingleApplicationStatus(generateServeStatus(rayv1.DeploymentStatusEnum.HEALTHY, rayv1.ApplicationStatusEnum.RUNNING))
 
-			// Confirm not switch to a new RayCluster because ServiceUnhealthySecondThreshold is 500 seconds.
+			// Confirm not switch to a new RayCluster.
 			Consistently(
 				getRayClusterNameFunc(ctx, myRayService),
 				time.Second*3, time.Millisecond*500).Should(Equal(initialClusterName), "Active RayCluster name = %v", myRayService.Status.ActiveServiceStatus.RayClusterName)
@@ -550,7 +544,6 @@ applications:
 			Eventually(
 				checkServiceHealth(ctx, myRayService),
 				time.Second*3, time.Millisecond*500).Should(BeTrue(), "myRayService status = %v", myRayService.Status)
-			ServiceUnhealthySecondThreshold = originalServiceUnhealthySecondThreshold
 		})
 
 		It("Status should not be updated if the only differences are the LastUpdateTime and HealthLastUpdateTime fields.", func() {

--- a/tests/config/ray-service.yaml.template
+++ b/tests/config/ray-service.yaml.template
@@ -3,7 +3,6 @@ kind: RayService
 metadata:
   name: rayservice-sample
 spec:
-  serviceUnhealthySecondThreshold: 900
   serveConfig:
     importPath: fruit.deployment_graph
     runtimeEnv: |


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

KubeRay operator will prepare a new RayCluster if the RayServe applications are unhealthy for more than `ServiceUnhealthySecondThreshold` seconds. However, we have already removed this behavior in #1656, so this PR removes the references of `ServiceUnhealthySecondThreshold` in the KubeRay codebase.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
