### PR TITLE
Remove all namespace mentions from the cluster-scope-resources

### DIFF
--- a/manifests/cluster-scope-resources/kustomization.yaml
+++ b/manifests/cluster-scope-resources/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 namespace: ray-system
 
 resources:
-- namespace.yaml
 - ../../ray-operator/config/crd
 
 configurations:

--- a/manifests/cluster-scope-resources/namespace.yaml
+++ b/manifests/cluster-scope-resources/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ray-system

--- a/manifests/cluster-scope-resources/params.yaml
+++ b/manifests/cluster-scope-resources/params.yaml
@@ -1,4 +1,0 @@
-# Allow Kustomize var to replace following fields.
-varReference:
-- path: metadata/name
-  kind: Namespace


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, if one combines the `base` and `cluster-scope-resources` in one `kustomization.yaml` then the build will fail because both define the same Namespace.

Cluster scoped resources should be mostly if not _only_ the CRDs that are necessary. If you're only creating CRDs there is no need to create a Namespace.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

"Closes #1670"
<!-- For example: "Closes #1234" -->

## Checks
To test this manually, create this `kustomization.yaml` in the `manifests` directory:
```kustomization.yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

namespace: ray-system

resources:
  - ./base
  - ./cluster-scope-resources
```

Then run `kustomize build .`

If you run it outside of my branch, then you'll get the error mentioned in the issue. If you run it within my branch, it will build as expected.

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
