### PR TITLE
[Refactor] Rename EnableAgentService to EnableServeService

### DIFF
--- a/apiserver/CreatingServe.md
+++ b/apiserver/CreatingServe.md
@@ -4,7 +4,7 @@ Up until rescently the only way to create a Ray cluster supporting RayServe was 
 
 ```json
 "annotations" : {
-    "ray.io/enableAgentService": "true"
+    "ray.io/enable-serve-service": "true"
   },
 ```
 
@@ -18,7 +18,7 @@ curl -X POST 'localhost:31888/apis/v1/namespaces/default/clusters' \
   "namespace": "default",
   "user": "boris",
   "annotations" : {
-    "ray.io/enableAgentService": "true"
+    "ray.io/enable-serve-service": "true"
   },
   "clusterSpec": {
     "headGroupSpec": {

--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -23,14 +23,14 @@ type RayCluster struct {
 // NewRayCluster creates a RayCluster.
 // func NewRayCluster(apiCluster *api.Cluster, clusterRuntime *api.ClusterRuntime, computeRuntime *api.ComputeRuntime) *RayCluster {
 func NewRayCluster(apiCluster *api.Cluster, computeTemplateMap map[string]*api.ComputeTemplate) (*RayCluster, error) {
-	// Check for "ray.io/enableAgentService"
-	enableAgentService := false
-	if enableAgentServiceValue, exist := apiCluster.Annotations["ray.io/enableAgentService"]; exist && enableAgentServiceValue == "true" {
-		enableAgentService = true
+	// Check for "ray.io/enable-serve-service=true"
+	enableServeService := false
+	if enableServeServiceValue, exist := apiCluster.Annotations["ray.io/enable-serve-service"]; exist && enableServeServiceValue == "true" {
+		enableServeService = true
 	}
 
 	// Build cluster spec
-	spec, err := buildRayClusterSpec(apiCluster.Version, apiCluster.Envs, apiCluster.ClusterSpec, computeTemplateMap, enableAgentService)
+	spec, err := buildRayClusterSpec(apiCluster.Version, apiCluster.Envs, apiCluster.ClusterSpec, computeTemplateMap, enableServeService)
 	if err != nil {
 		return nil, err
 	}
@@ -70,9 +70,9 @@ func buildRayClusterAnnotations(cluster *api.Cluster) map[string]string {
 
 // TODO(Basasuya & MissionToMars): The job spec depends on ClusterSpec which not all cluster-related configs are included,
 // such as `metadata` and `envs`. We just put `imageVersion` and `envs` in the arguments list, and should be refactored later.
-func buildRayClusterSpec(imageVersion string, envs *api.EnvironmentVariables, clusterSpec *api.ClusterSpec, computeTemplateMap map[string]*api.ComputeTemplate, enableAgentService bool) (*rayv1api.RayClusterSpec, error) {
+func buildRayClusterSpec(imageVersion string, envs *api.EnvironmentVariables, clusterSpec *api.ClusterSpec, computeTemplateMap map[string]*api.ComputeTemplate, enableServeService bool) (*rayv1api.RayClusterSpec, error) {
 	computeTemplate := computeTemplateMap[clusterSpec.HeadGroupSpec.ComputeTemplate]
-	headPodTemplate, err := buildHeadPodTemplate(imageVersion, envs, clusterSpec.HeadGroupSpec, computeTemplate, enableAgentService)
+	headPodTemplate, err := buildHeadPodTemplate(imageVersion, envs, clusterSpec.HeadGroupSpec, computeTemplate, enableServeService)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func buildNodeGroupAnnotations(computeTemplate *api.ComputeTemplate, image strin
 }
 
 // Build head node template
-func buildHeadPodTemplate(imageVersion string, envs *api.EnvironmentVariables, spec *api.HeadGroupSpec, computeRuntime *api.ComputeTemplate, enableAgentService bool) (*v1.PodTemplateSpec, error) {
+func buildHeadPodTemplate(imageVersion string, envs *api.EnvironmentVariables, spec *api.HeadGroupSpec, computeRuntime *api.ComputeTemplate, enableServeService bool) (*v1.PodTemplateSpec, error) {
 	image := constructRayImage(RayClusterDefaultImageRepository, imageVersion)
 	if len(spec.Image) != 0 {
 		image = spec.Image
@@ -230,8 +230,8 @@ func buildHeadPodTemplate(imageVersion string, envs *api.EnvironmentVariables, s
 			container.Env = append(container.Env, specEnv...)
 		}
 
-		// If enableAgentService add port
-		if enableAgentService {
+		// If enableServeService add port
+		if enableServeService {
 			container.Ports = append(container.Ports, v1.ContainerPort{Name: "dashboard-agent", ContainerPort: 52365})
 			container.Ports = append(container.Ports, v1.ContainerPort{Name: "serve", ContainerPort: 8000})
 		}

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -29,8 +29,8 @@ const (
 	// Finalizers for GCS fault tolerance
 	GCSFaultToleranceRedisCleanupFinalizer = "ray.io/gcs-ft-redis-cleanup-finalizer"
 
-	EnableAgentServiceKey  = "ray.io/enableAgentService"
-	EnableAgentServiceTrue = "true"
+	EnableServeServiceKey  = "ray.io/enable-serve-service"
+	EnableServeServiceTrue = "true"
 
 	EnableRayClusterServingServiceTrue  = "true"
 	EnableRayClusterServingServiceFalse = "false"

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -258,8 +258,11 @@ func initHealthProbe(probe *v1.Probe, rayNodeType rayv1.RayNodeType) {
 }
 
 // BuildPod a pod config
-func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayv1.RayNodeType, rayStartParams map[string]string, headPort string, enableRayAutoscaler *bool, creator string, fqdnRayIP string, enableAgentService bool) (aPod v1.Pod) {
-	if enableAgentService {
+func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayv1.RayNodeType, rayStartParams map[string]string, headPort string, enableRayAutoscaler *bool, creator string, fqdnRayIP string, enableServeService bool) (aPod v1.Pod) {
+	if enableServeService {
+		// TODO (kevin85421): In the current RayService implementation, we only add this label to a Pod after
+		// it passes the health check. The other option is to use the readiness probe to control it. This
+		// logic always add the label to the Pod no matter whether it is ready or not.
 		podTemplateSpec.Labels[RayClusterServingServiceLabelKey] = EnableRayClusterServingServiceTrue
 	}
 	pod := v1.Pod{
@@ -667,7 +670,7 @@ func setMissingRayStartParams(rayStartParams map[string]string, nodeType rayv1.R
 
 	// Add dashboard listen port for RayService.
 	if _, ok := rayStartParams["dashboard-agent-listen-port"]; !ok {
-		if value, ok := annotations[EnableAgentServiceKey]; ok && value == EnableAgentServiceTrue {
+		if value, ok := annotations[EnableServeServiceKey]; ok && value == EnableServeServiceTrue {
 			rayStartParams["dashboard-agent-listen-port"] = strconv.Itoa(DefaultDashboardAgentListenPort)
 		}
 	}

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -105,14 +105,19 @@ var (
 				headServiceAnnotationKey2: headServiceAnnotationValue2,
 			},
 			HeadGroupSpec: rayv1.HeadGroupSpec{
-				RayStartParams: map[string]string{
-					"port":                "6379",
-					"object-manager-port": "12345",
-					"node-manager-port":   "12346",
-					"object-store-memory": "100000000",
-					"num-cpus":            "1",
-				},
 				ServiceType: corev1.ServiceTypeClusterIP,
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "ray-head",
+								Ports: []corev1.ContainerPort{
+									{ContainerPort: 8000, Name: "serve"},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -344,8 +344,8 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 		}
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
-	// only reconcile serve service is "ray.io/enableAgentService" annotation is set to true
-	if enableAgentServiceValue, exist := instance.Annotations[common.EnableAgentServiceKey]; exist && enableAgentServiceValue == common.EnableAgentServiceTrue {
+	// Only reconcile the K8s service for Ray Serve when the "ray.io/enable-serve-service" annotation is set to true.
+	if enableServeServiceValue, exist := instance.Annotations[common.EnableServeServiceKey]; exist && enableServeServiceValue == common.EnableServeServiceTrue {
 		if err := r.reconcileServeService(ctx, instance); err != nil {
 			if updateErr := r.updateClusterState(ctx, instance, rayv1.Failed); updateErr != nil {
 				r.Log.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
@@ -1031,7 +1031,7 @@ func (r *RayClusterReconciler) buildHeadPod(instance rayv1.RayCluster) corev1.Po
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
 	// Check whether serve is enabled and add serve label
 	serveLabel := false
-	if enableAgentServiceValue, exist := instance.Annotations[common.EnableAgentServiceKey]; exist && enableAgentServiceValue == common.EnableAgentServiceTrue {
+	if enableServeServiceValue, exist := instance.Annotations[common.EnableServeServiceKey]; exist && enableServeServiceValue == common.EnableServeServiceTrue {
 		serveLabel = true
 	}
 	autoscalingEnabled := instance.Spec.EnableInTreeAutoscaling
@@ -1073,7 +1073,7 @@ func (r *RayClusterReconciler) buildWorkerPod(instance rayv1.RayCluster, worker 
 	creatorName := getCreator(instance)
 	// Check whether serve is enabled and add serve label
 	serveLabel := false
-	if enableAgentServiceValue, exist := instance.Annotations[common.EnableAgentServiceKey]; exist && enableAgentServiceValue == common.EnableAgentServiceTrue {
+	if enableServeServiceValue, exist := instance.Annotations[common.EnableServeServiceKey]; exist && enableServeServiceValue == common.EnableServeServiceTrue {
 		serveLabel = true
 	}
 	pod := common.BuildPod(podTemplateSpec, rayv1.WorkerNode, worker.RayStartParams, headPort, autoscalingEnabled, creatorName, fqdnRayIP, serveLabel)

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -584,7 +584,7 @@ func (r *RayServiceReconciler) constructRayClusterForRayService(rayService *rayv
 	for k, v := range rayService.Annotations {
 		rayClusterAnnotations[k] = v
 	}
-	rayClusterAnnotations[common.EnableAgentServiceKey] = common.EnableAgentServiceTrue
+	rayClusterAnnotations[common.EnableServeServiceKey] = common.EnableServeServiceTrue
 	rayClusterAnnotations[common.RayServiceClusterHashKey], err = generateRayClusterJsonHash(rayService.Spec.RayClusterSpec)
 	if err != nil {
 		errContext := "Failed to serialize RayCluster config. " +


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#1207 removed the K8s service for the dashboard agent, but there are still some variables with "AgentService" in their names. This may cause misleading, so this PR changes `EnableAgentService` to `EnableServeService`. In fact, the K8s service introduced by #1672 is designed for serving purposes. It is used to expose HTTP Proxy actors on each Ray node.

## Related issue number

Follow up for https://github.com/ray-project/kuberay/pull/1672#issuecomment-1821898634

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
