### PR TITLE
[RayService][Health-Check][8/n] Add readiness / liveness probes

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -287,26 +287,6 @@ jobs:
         docker push quay.io/kuberay/operator:nightly
       if: contains(fromJson('["refs/heads/master"]'), github.ref)
 
-  test-compatibility-1_13_0:
-    needs:
-      - build_operator
-      - build_apiserver
-      - lint
-    runs-on: ubuntu-latest
-    name: Compatibility Test - 1.13.0
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-        with:
-          # When checking out the repository that
-          # triggered a workflow, this defaults to the reference or SHA for that event.
-          # Default value should work for both pull_request and merge(push) event.
-          ref: ${{github.event.pull_request.head.sha}}
-
-      - uses: ./.github/workflows/actions/compatibility
-        with:
-          ray_version: 1.13.0
-
   test-compatibility-2_5_0:
     needs:
       - build_operator

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -105,3 +105,8 @@ env:
 # Therefore, KubeRay offers ENABLE_ZERO_DOWNTIME as a feature flag for zero-downtime upgrades.
 # - name: ENABLE_ZERO_DOWNTIME
 #   value: "true"
+# This environment variable for the KubeRay operator is used to determine whether to enable
+# the injection of readiness and liveness probes into Ray head and worker containers.
+# Enabling this feature contributes to the robustness of Ray clusters.
+# - name: ENABLE_PROBES_INJECTION
+#   value: "true"

--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -99,6 +99,12 @@ const (
 	// cleanup Job should be enabled. This is a feature flag for v1.0.0.
 	ENABLE_GCS_FT_REDIS_CLEANUP = "ENABLE_GCS_FT_REDIS_CLEANUP"
 
+	// This environment variable for the KubeRay operator is used to determine whether to enable
+	// the injection of readiness and liveness probes into Ray head and worker containers.
+	// Enabling this feature contributes to the robustness of Ray clusters. It is currently a feature
+	// flag for v1.1.0 and will be removed if the behavior proves to be stable enough.
+	ENABLE_PROBES_INJECTION = "ENABLE_PROBES_INJECTION"
+
 	// Ray core default configurations
 	DefaultWorkerRayGcsReconnectTimeoutS = "600"
 

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -333,6 +333,7 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayv1.RayNodeType,
 	// Inject probes into the Ray containers if the user has not explicitly disabled them.
 	// The feature flag `ENABLE_PROBES_INJECTION` will be removed if this feature is stable enough.
 	enableProbesInjection := getEnableProbesInjection()
+	log.Info("Probes injection feature flag", "enabled", enableProbesInjection)
 	if enableProbesInjection {
 		// Configure the readiness and liveness probes for the Ray container. These probes
 		// play a crucial role in KubeRay health checks. Without them, certain failures,

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -137,6 +137,13 @@ func getEnableInitContainerInjection() bool {
 	return true
 }
 
+func getEnableProbesInjection() bool {
+	if s := os.Getenv(ENABLE_PROBES_INJECTION); strings.ToLower(s) == "false" {
+		return false
+	}
+	return true
+}
+
 // DefaultWorkerPodTemplate sets the config values
 func DefaultWorkerPodTemplate(instance rayv1.RayCluster, workerSpec rayv1.WorkerGroupSpec, podName string, fqdnRayIP string, headPort string) v1.PodTemplateSpec {
 	podTemplate := workerSpec.Template
@@ -323,32 +330,37 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayv1.RayNodeType,
 
 	setContainerEnvVars(&pod, rayNodeType, rayStartParams, fqdnRayIP, headPort, creator)
 
-	// Configure the readiness and liveness probes for the Ray container. These probes
-	// play a crucial role in KubeRay health checks. Without them, certain failures,
-	// such as the Raylet process crashing, may go undetected.
-	if pod.Spec.Containers[RayContainerIndex].ReadinessProbe == nil {
-		probe := &v1.Probe{
-			InitialDelaySeconds: DefaultReadinessProbeInitialDelaySeconds,
-			TimeoutSeconds:      DefaultReadinessProbeTimeoutSeconds,
-			PeriodSeconds:       DefaultReadinessProbePeriodSeconds,
-			SuccessThreshold:    DefaultReadinessProbeSuccessThreshold,
-			FailureThreshold:    DefaultReadinessProbeFailureThreshold,
+	// Inject probes into the Ray containers if the user has not explicitly disabled them.
+	// The feature flag `ENABLE_PROBES_INJECTION` will be removed if this feature is stable enough.
+	enableProbesInjection := getEnableProbesInjection()
+	if enableProbesInjection {
+		// Configure the readiness and liveness probes for the Ray container. These probes
+		// play a crucial role in KubeRay health checks. Without them, certain failures,
+		// such as the Raylet process crashing, may go undetected.
+		if pod.Spec.Containers[RayContainerIndex].ReadinessProbe == nil {
+			probe := &v1.Probe{
+				InitialDelaySeconds: DefaultReadinessProbeInitialDelaySeconds,
+				TimeoutSeconds:      DefaultReadinessProbeTimeoutSeconds,
+				PeriodSeconds:       DefaultReadinessProbePeriodSeconds,
+				SuccessThreshold:    DefaultReadinessProbeSuccessThreshold,
+				FailureThreshold:    DefaultReadinessProbeFailureThreshold,
+			}
+			pod.Spec.Containers[RayContainerIndex].ReadinessProbe = probe
 		}
-		pod.Spec.Containers[RayContainerIndex].ReadinessProbe = probe
-	}
-	initHealthProbe(pod.Spec.Containers[RayContainerIndex].ReadinessProbe, rayNodeType)
+		initHealthProbe(pod.Spec.Containers[RayContainerIndex].ReadinessProbe, rayNodeType)
 
-	if pod.Spec.Containers[RayContainerIndex].LivenessProbe == nil {
-		probe := &v1.Probe{
-			InitialDelaySeconds: DefaultLivenessProbeInitialDelaySeconds,
-			TimeoutSeconds:      DefaultLivenessProbeTimeoutSeconds,
-			PeriodSeconds:       DefaultLivenessProbePeriodSeconds,
-			SuccessThreshold:    DefaultLivenessProbeSuccessThreshold,
-			FailureThreshold:    DefaultLivenessProbeFailureThreshold,
+		if pod.Spec.Containers[RayContainerIndex].LivenessProbe == nil {
+			probe := &v1.Probe{
+				InitialDelaySeconds: DefaultLivenessProbeInitialDelaySeconds,
+				TimeoutSeconds:      DefaultLivenessProbeTimeoutSeconds,
+				PeriodSeconds:       DefaultLivenessProbePeriodSeconds,
+				SuccessThreshold:    DefaultLivenessProbeSuccessThreshold,
+				FailureThreshold:    DefaultLivenessProbeFailureThreshold,
+			}
+			pod.Spec.Containers[RayContainerIndex].LivenessProbe = probe
 		}
-		pod.Spec.Containers[RayContainerIndex].LivenessProbe = probe
+		initHealthProbe(pod.Spec.Containers[RayContainerIndex].LivenessProbe, rayNodeType)
 	}
-	initHealthProbe(pod.Spec.Containers[RayContainerIndex].LivenessProbe, rayNodeType)
 
 	return pod
 }

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1137,6 +1137,32 @@ func TestGetCustomWorkerInitImage(t *testing.T) {
 	assert.False(t, b)
 }
 
+func TestGetEnableProbesInjection(t *testing.T) {
+	// cleanup
+	defer os.Unsetenv(ENABLE_PROBES_INJECTION)
+
+	// not set the env
+	os.Unsetenv(ENABLE_PROBES_INJECTION)
+	b := getEnableProbesInjection()
+	assert.True(t, b)
+	// set the env with "true"
+	os.Setenv(ENABLE_PROBES_INJECTION, "true")
+	b = getEnableProbesInjection()
+	assert.True(t, b)
+	// set the env with "True"
+	os.Setenv(ENABLE_PROBES_INJECTION, "True")
+	b = getEnableProbesInjection()
+	assert.True(t, b)
+	// set the env with "false"
+	os.Setenv(ENABLE_PROBES_INJECTION, "false")
+	b = getEnableProbesInjection()
+	assert.False(t, b)
+	// set the env with "False"
+	os.Setenv(ENABLE_PROBES_INJECTION, "False")
+	b = getEnableProbesInjection()
+	assert.False(t, b)
+}
+
 func TestInitHealthProbe(t *testing.T) {
 	// Test 1: User defines a custom HTTPGet probe.
 	httpGetProbe := v1.Probe{

--- a/tests/config/ray-cluster.mini.yaml.template
+++ b/tests/config/ray-cluster.mini.yaml.template
@@ -1,9 +1,6 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
-    # An unique identifier for the head node and workers of this cluster.
   name: raycluster-mini
 spec:
   rayVersion: '$ray_version' # should match the Ray version in the image of the containers
@@ -12,7 +9,6 @@ spec:
   headGroupSpec:
     # the following params are used to complete the ray start: ray start --head --block ...
     rayStartParams:
-      dashboard-host: '0.0.0.0'
       num-cpus: '1'
     #pod template
     template:


### PR DESCRIPTION
## Why are these changes needed?

KubeRay only includes readiness/liveness probes when GCS is enabled. Therefore, if GCS is not enabled and the Raylet/dashboard agent processes crash, they will not be detected. Hence, we should inject the probes no matter whether the GCS is enabled or not.

In #1656, we decide to offload the health check responsibilities, including the dashboard agent on Ray head and Ray Serve applications, to K8s and Ray. With this PR, all RayCluster custom resources have probes to check the status of the Raylet which is fate-sharing with the Ray dashboard agent.

The compatibility test `KubeRayHealthCheckTestCase` for Ray 1.13.0 will fail because Ray 1.13.0 does not support the `/api/local_raylet_healthz` health-check endpoint. See here for the [evidence](https://sourcegraph.com/search?q=context%3Aglobal+repo%3A%5Egithub%5C.com%2Fray-project%2Fray%24%40ray-1.13.0+local_raylet_healthz&patternType=standard&sm=1&groupBy=path). It is acceptable to remove the compatibility test for Ray 1.13.0 because it lacks support for many KubeRay features, such as GCS FT, Autoscaler, and so on. Additionally, I have hardly heard of any users using versions older than Ray 2.4.0 in the past three months.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* I will add some compatibility tests in the follow-up PRs.
* Manual test: I follow #1656's PR description to create a RayService and kill the dashboard agent process in the head Pod.
  * The head Pod will become not ready after 50s (readiness probe fails 10 times).
  * The head Pod dies after 600s (liveness probe fails 120 times) and restarts because the Pod's `restartPolicy` is `Always`.