### PR TITLE
feat: add all three CRDs to the all category

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: ray.io
   names:
+    categories:
+    - all
     kind: RayCluster
     listKind: RayClusterList
     plural: rayclusters

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: ray.io
   names:
+    categories:
+    - all
     kind: RayJob
     listKind: RayJobList
     plural: rayjobs

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: ray.io
   names:
+    categories:
+    - all
     kind: RayService
     listKind: RayServiceList
     plural: rayservices

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -156,6 +156,7 @@ const (
 
 // RayCluster is the Schema for the RayClusters API
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="desired workers",type=integer,JSONPath=".status.desiredWorkerReplicas",priority=0

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -110,6 +110,7 @@ type RayJobStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +genclient

--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -153,6 +153,7 @@ type ServeDeploymentStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +genclient

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -156,6 +156,7 @@ const (
 
 // RayCluster is the Schema for the RayClusters API
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="desired workers",type=integer,JSONPath=".status.desiredWorkerReplicas",priority=0
 // +kubebuilder:printcolumn:name="available workers",type=integer,JSONPath=".status.availableWorkerReplicas",priority=0

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -110,6 +110,7 @@ type RayJobStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +genclient
 // RayJob is the Schema for the rayjobs API

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -153,6 +153,7 @@ type ServeDeploymentStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +genclient
 // RayService is the Schema for the rayservices API

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: ray.io
   names:
+    categories:
+    - all
     kind: RayCluster
     listKind: RayClusterList
     plural: rayclusters

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: ray.io
   names:
+    categories:
+    - all
     kind: RayJob
     listKind: RayJobList
     plural: rayjobs

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: ray.io
   names:
+    categories:
+    - all
     kind: RayService
     listKind: RayServiceList
     plural: rayservices


### PR DESCRIPTION
so they show up with `kubectl get all`.

## Example usage

```
❯ kubectl get all
NAME                                DESIRED WORKERS   AVAILABLE WORKERS   STATUS   AGE
raycluster.ray.io/raycluster-mini                                                  17s
```

[docs](https://book.kubebuilder.io/reference/markers/crd)


## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
