### PR TITLE
RayCluster Helm: Make volumeMounts and volumes optional for workers

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -46,7 +46,9 @@ spec:
         initContainers: {{- toYaml .Values.head.initContainers | nindent 10 }}
         {{- end }}
         containers:
-          - volumeMounts: {{- toYaml .Values.head.volumeMounts | nindent 12 }}
+          - {{ if .Values.head.volumeMounts }}
+            volumeMounts: {{- toYaml .Values.head.volumeMounts | nindent 12 }}
+            {{- end }}
             name: ray-head
             {{- if .Values.head.image }}
             image: {{ .Values.head.image.repository }}:{{ .Values.head.image.tag }}
@@ -79,7 +81,9 @@ spec:
           {{- if .Values.head.sidecarContainers }}
           {{- toYaml .Values.head.sidecarContainers | nindent 10 }}
           {{- end }}
+        {{ if .Values.head.volumes }}
         volumes: {{- toYaml .Values.head.volumes | nindent 10 }}
+        {{- end }}
         affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.head.tolerations | nindent 10 }}
         nodeSelector: {{- toYaml .Values.head.nodeSelector | nindent 10 }}
@@ -123,7 +127,9 @@ spec:
         initContainers: {{- toYaml $values.initContainers | nindent 10 }}
         {{- end }}
         containers:
-          - volumeMounts: {{- toYaml $values.volumeMounts | nindent 12 }}
+          - {{ if $values.volumeMounts }}
+            volumeMounts: {{- toYaml $values.volumeMounts | nindent 12 }}
+            {{- end }}
             name: ray-worker
             {{- if $values.image }}
             image: {{ $values.image.repository }}:{{ $values.image.tag }}
@@ -154,7 +160,9 @@ spec:
           {{- if $values.sidecarContainers }}
           {{- toYaml $values.sidecarContainers | nindent 10 }}
           {{- end }}
+        {{ if $values.volumes }}
         volumes: {{- toYaml $values.volumes | nindent 10 }}
+        {{- end }}
         affinity: {{- toYaml $values.affinity | nindent 10 }}
         tolerations: {{- toYaml $values.tolerations | nindent 10 }}
         nodeSelector: {{- toYaml $values.nodeSelector | nindent 10 }}
@@ -198,7 +206,9 @@ spec:
         initContainers: {{- toYaml .Values.worker.initContainers | nindent 10 }}
         {{- end }}
         containers:
-          - volumeMounts: {{- toYaml .Values.worker.volumeMounts | nindent 12 }}
+          - {{ if .Values.worker.volumeMounts }}
+            volumeMounts: {{- toYaml .Values.worker.volumeMounts | nindent 12 }}
+            {{- end }}
             name: ray-worker
             {{- if .Values.worker.image }}
             image: {{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}
@@ -229,7 +239,9 @@ spec:
           {{- if .Values.worker.sidecarContainers }}
           {{- toYaml .Values.worker.sidecarContainers | nindent 10 }}
           {{- end }}
+        {{ if .Values.worker.volumes }}
         volumes: {{- toYaml .Values.worker.volumes | nindent 10 }}
+        {{- end }}
         affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.worker.tolerations | nindent 10 }}
         nodeSelector: {{- toYaml .Values.worker.nodeSelector | nindent 10 }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -7,7 +7,7 @@
 
 image:
   repository: rayproject/ray
-  tag: 2.7.0
+  tag: 2.8.0
   pullPolicy: IfNotPresent
 
 nameOverride: "kuberay"
@@ -19,7 +19,7 @@ imagePullSecrets: []
 head:
   # rayVersion determines the autoscaler's image version.
   # It should match the Ray version in the image of the containers.
-  # rayVersion: 2.7.0
+  # rayVersion: 2.8.0
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
@@ -84,10 +84,11 @@ head:
   affinity: {}
   # Ray container security context.
   securityContext: {}
+  # Optional: The following volumes/volumeMounts configurations are optional but recommended because
+  # Ray writes logs to /tmp/ray/session_latests/logs instead of stdout/stderr.
   volumes:
     - name: log-volume
       emptyDir: {}
-  # Ray writes logs to /tmp/ray/session_latests/logs
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
@@ -141,10 +142,11 @@ worker:
   affinity: {}
   # Ray container security context.
   securityContext: {}
+  # Optional: The following volumes/volumeMounts configurations are optional but recommended because
+  # Ray writes logs to /tmp/ray/session_latests/logs instead of stdout/stderr.
   volumes:
     - name: log-volume
       emptyDir: {}
-  # Ray writes logs to /tmp/ray/session_latests/logs
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
@@ -169,8 +171,8 @@ additionalWorkerGroups:
     labels: {}
     serviceAccountName: ""
     rayStartParams: {}
-  # containerEnv specifies environment variables for the Ray container,
-  # Follows standard K8s container env schema.
+    # containerEnv specifies environment variables for the Ray container,
+    # Follows standard K8s container env schema.
     containerEnv: []
       # - name: EXAMPLE_ENV
       #   value: "1"
@@ -179,15 +181,15 @@ additionalWorkerGroups:
         #     name: my-env-secret
     # ports optionally allows specifying ports for the Ray container.
     # ports: []
-  # resource requests and limits for the Ray head container.
-  # Modify as needed for your application.
-  # Note that the resources in this example are much too small for production;
-  # we don't recommend allocating less than 8G memory for a Ray pod in production.
-  # Ray pods should be sized to take up entire K8s nodes when possible.
-  # Always set CPU and memory limits for Ray pods.
-  # It is usually best to set requests equal to limits.
-  # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#resources
-  # for further guidance.
+    # resource requests and limits for the Ray head container.
+    # Modify as needed for your application.
+    # Note that the resources in this example are much too small for production;
+    # we don't recommend allocating less than 8G memory for a Ray pod in production.
+    # Ray pods should be sized to take up entire K8s nodes when possible.
+    # Always set CPU and memory limits for Ray pods.
+    # It is usually best to set requests equal to limits.
+    # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#resources
+    # for further guidance.
     resources:
       limits:
         cpu: 1
@@ -201,10 +203,11 @@ additionalWorkerGroups:
     affinity: {}
     # Ray container security context.
     securityContext: {}
+    # Optional: The following volumes/volumeMounts configurations are optional but recommended because
+    # Ray writes logs to /tmp/ray/session_latests/logs instead of stdout/stderr.
     volumes:
       - name: log-volume
         emptyDir: {}
-  # Ray writes logs to /tmp/ray/session_latests/logs
     volumeMounts:
       - mountPath: /tmp/ray
         name: log-volume


### PR DESCRIPTION
Add defaults to the above and merge otherwise

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current Helm chart errors out inscrutably as described [here](https://github.com/ray-project/kuberay/issues/1668)
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #1668
<!-- For example: "Closes #1234" -->

## Checks

It's a Helm chart so I did manual testing on outputs etc.

To test, create the below file as `extra-values.yaml` and pass it as an argument to helm via `-f`:
```extra-values.yaml
additionalWorkerGroups:
  testGroup:
    disabled: false
    minReplicas: 0
    maxReplicas: 1
    replicas: 1
```

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(