### PR TITLE
when running ray start, getting resources value from environment variables

### DIFF
--- a/ray-operator/controllers/ray/common/constant.go
+++ b/ray-operator/controllers/ray/common/constant.go
@@ -74,6 +74,9 @@ const (
 	// Use as container env variable
 	RAY_CLUSTER_NAME                        = "RAY_CLUSTER_NAME"
 	RAY_IP                                  = "RAY_IP"
+	RAY_NUM_CPUS                            = "RAY_NUM_CPUS"
+	RAY_MEMORY                              = "RAY_MEMORY"
+	RAY_NUM_GPUS                            = "RAY_NUM_GPUS"
 	FQ_RAY_IP                               = "FQ_RAY_IP"
 	RAY_PORT                                = "RAY_PORT"
 	RAY_ADDRESS                             = "RAY_ADDRESS"

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -390,8 +390,10 @@ func TestBuildPod(t *testing.T) {
 	checkContainerEnv(t, rayContainer, RAY_IP, "raycluster-sample-head-svc")
 	checkContainerEnv(t, rayContainer, RAY_CLUSTER_NAME, fmt.Sprintf("metadata.labels['%s']", RayClusterLabelKey))
 	checkContainerEnv(t, rayContainer, RAY_DASHBOARD_ENABLE_K8S_DISK_USAGE, "1")
+	checkContainerEnv(t, rayContainer, RAY_MEMORY, "1073741824")
+	checkContainerEnv(t, rayContainer, RAY_NUM_GPUS, "3")
 
-	expectedCommandArg := splitAndSort("ulimit -n 65536; ray start --block --memory=1073741824 --num-cpus=1 --num-gpus=3 --address=raycluster-sample-head-svc.default.svc.cluster.local:6379 --port=6379 --metrics-export-port=8080")
+	expectedCommandArg := splitAndSort("ulimit -n 65536; ray start --block --memory=$RAY_MEMORY --num-cpus=1 --num-gpus=$RAY_NUM_GPUS --address=raycluster-sample-head-svc.default.svc.cluster.local:6379 --port=6379 --metrics-export-port=8080")
 	actualCommandArg := splitAndSort(pod.Spec.Containers[0].Args[0])
 	if !reflect.DeepEqual(expectedCommandArg, actualCommandArg) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedCommandArg, actualCommandArg)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In a ray cluster, getting the resources value from the environment variable when launching a ray cluster. 

Currently the ray start command is as below, 
`ulimit -n 65536; ray start --head  --num-cpus=8  --memory=68719476736  --num-gpus=2 .....`
The number of resources (cpu/memory/gpu) are from the rayStartParams in the crd. If any of them is not specified, it will get the value from resources.limits[$resourceName] of the container. The "ray start ...." command is generated by the ray operator, which means we have to set the resources value of the ray cluster before the pods for raycluster are created. It is unable to update the resources dynamically.

The change of this PR is to get the resources from the environment variable if the resources in rayStartParams are not set so the value of the resources can be changed after the pod for the ray cluster are created. 
<!-- Please give a short summary of the change and the problem this solves. -->
This PR includes the following changes,
1. Creating environment variables RAY_NUM_CPUS, RAY_MEMORY, RAY_NUM_GPUS.
2. If any of the resources is not set in rayStartParams, the "ray start" cmd will get the value from environment variables, e.g. if we don't set the value of num_cpus in rayStartParams but set memory and num-gpus, the generated cmd will be like `ulimit -n 65536; ray start --head  --num-cpus=$RAY_NUM_CPUS  --memory=68719476736  --num-gpus=2 .....`
3.  To make it backward compatitble, the default value of these environment variable will be the resources.limit[$resourceName]  respectively.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
