### PR TITLE
[CI] Skip the flaky compatibility test `test_detached_actor` until https://github.com/ray-project/ray/issues/41343

### DIFF
--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -131,6 +131,11 @@ class RayFTTestCase(unittest.TestCase):
             show_cluster_info(RayFTTestCase.ray_cluster_ns)
             self.fail(f"Fail to execute test_ray_serve_2.py. The exit code is {exit_code}.")
 
+    @unittest.skipIf(
+        ray_version == '2.8.0' or ray_version == 'nightly',
+        'test_detached_actor is too flaky with Ray 2.8.0 and Ray nightly.'
+        'Therefore, skip it until https://github.com/ray-project/ray/issues/41343 is solved.'
+    )
     def test_detached_actor(self):
         """Kill GCS process on the head Pod and then test a detached actor."""
         headpod = get_head_pod(RayFTTestCase.ray_cluster_ns)


### PR DESCRIPTION
As discussed with @kevin85421 offline,

Because `test_detached_actor` is too flaky on the new Ray 2.8.0 and nightly, skipping the test until https://github.com/ray-project/ray/issues/41343 is solved can save us some time from reruning those failed github actions.