### PR TITLE
chore: Update K8s compatibility

### DIFF
--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -1,6 +1,6 @@
 ## Installation
 
-Make sure your Kubernetes cluster and Kubectl are both at version at least 1.19.
+Make sure your Kubernetes cluster and Kubectl are both at version at least 1.23.
 
 ### Nightly version
 

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This section walks through how to build and test the operator in a running Kuber
 
 | software | version  |                                                                link |
 |:---------|:--------:|--------------------------------------------------------------------:|
-| kubectl  | v1.21.0+ | [download](https://kubernetes.io/docs/tasks/tools/install-kubectl/) |
+| kubectl  | v1.23.0+ | [download](https://kubernetes.io/docs/tasks/tools/install-kubectl/) |
 | go       |  v1.20   |                                  [download](https://golang.org/dl/) |
 | docker   |  19.03+  |                        [download](https://docs.docker.com/install/) |
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* https://github.com/ray-project/kuberay/pull/1584#issuecomment-1828634414

#1584 implements a validation webhook, and best practices require users to install cert-manager concurrently. Currently, KubeRay uses cert-manager 1.13.2 which supports Kubernetes 1.23+. KubeRay currently supports Kubernetes 1.20 and above. However, it would be acceptable to only support versions 1.23 and higher, as the Kubernetes community has not supported version 1.23 since February 2023. (https://endoflife.date/kubernetes). In addition, KubeRay is still compatible with Kubernetes 1.20.7 if users decide to not use the webhook.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
