### PR TITLE
[GCS FT] Enhance observability of redis cleanup job

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1093,7 +1093,8 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(instance rayv1.RayCluster) b
 	pod.Spec.Containers = []corev1.Container{pod.Spec.Containers[common.RayContainerIndex]}
 	pod.Spec.Containers[common.RayContainerIndex].Command = []string{"/bin/bash", "-lc", "--"}
 	pod.Spec.Containers[common.RayContainerIndex].Args = []string{
-		"python -c " +
+		"echo \"To get more information about manually delete the storage namespace in Redis and remove the RayCluster's finalizer, please check https://docs.ray.io/en/master/cluster/kubernetes/user-guides/kuberay-gcs-ft.html for more details.\" && " +
+			"python -c " +
 			"\"from ray._private.gcs_utils import cleanup_redis_storage; " +
 			"from urllib.parse import urlparse; " +
 			"import os; " +


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There are two situations that the K8s Job fails to clean up the Redis key.
1. K8s Job cannot connect to the Redis. If the redis have been deleted, the K8s Job cannot connect to redis, it will retry 120 attempts to connect.
2. Redis key have been deleted. If the redis key is empty, the K8s cleanup Job would fail.

To enhance the user experience, display the link to [the KubeRay GCS FT doc](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/kuberay-gcs-ft.html#kuberay-gcs-ft) on the Ray website in the K8s Job. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
#1557 

## Checks
Following are the screenshot of the K8s Job logs:
1. K8s Job cannot connect to the Redis.
![scenario1-1](https://github.com/ray-project/kuberay/assets/139951533/ae46abb6-24b6-4305-bbc5-6347be361969)
![scenario1-2](https://github.com/ray-project/kuberay/assets/139951533/6132b25f-e409-4c38-9497-92e72ee23495)

2. Redis key have been deleted.
![scenario2](https://github.com/ray-project/kuberay/assets/139951533/fd3e9a92-af32-40ea-b6df-7eb135c934c5)
As the above shown,  users who encounter the K8s Job fails to clean up the Redis key, can find the solution in the document.




- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
