### PR TITLE
Set imagePullPolicy in manager.yaml

### DIFF
--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -29,6 +29,7 @@ spec:
 #        args:
 #        - --enable-leader-election
         image: kuberay/operator
+        imagePullPolicy: IfNotPresent
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Noticed that using `make deploy` command to deploy kuberay operator, it will use the default image tag `:latest` to build the operator.
In [Kubernetes documentation](https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting), it said that

> If don't specify a registry hostname, Kubernetes assumes that you mean the Docker public registry.

> If omit the imagePullPolicy field, and the tag for the container image is :latest, imagePullPolicy is automatically set to Always.

To avoid the failure of pulling an image from a remote repository that does not exist, there should specify the imagePullPolicy.


Without this PR, there would be an error when deploying the kuberay operator.

![error_pull](https://github.com/ray-project/kuberay/assets/139951533/631cc873-84a4-4cb2-83d6-b31d2918a5e8)



With this PR, the process of deploying the kuberay operator is quick fast because can use the image which is already on the machine.

![describe pod](https://github.com/ray-project/kuberay/assets/139951533/65ab7730-9544-46b2-b08d-97bd74a06669)

![success](https://github.com/ray-project/kuberay/assets/139951533/6b814d49-d5ef-4103-b837-e6f05cd15ce0)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
