### PR TITLE
[Bug] Avoid assigning an entry to a map that is nil

### DIFF
--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -128,6 +128,9 @@ func main() {
 
 	// Manager options
 	options := ctrl.Options{
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{},
+		},
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,


### PR DESCRIPTION
## Why are these changes needed?

* Create a Kubernetes cluster, and create a namespace `n1`.
* Deploy the operator with the following changes in `values.yaml`.
  ```yaml
  # KubeRay operator values.yaml
  image:
    repository: kuberay/operator
    tag: nightly
  crNamespacedRbacEnable: true
  singleNamespaceInstall: true
  watchNamespace:
    - n1
  ```
* We will get the following error message by running `kubectl logs ${KUBERAY_POD}` caused by [this line](https://github.com/ray-project/kuberay/blob/1779fcdd13ab15fda8fc477c496a6e2f7f1e2605/ray-operator/main.go#L157).
  <img width="1135" alt="Screen Shot 2023-12-05 at 11 07 02 AM" src="https://github.com/ray-project/kuberay/assets/20109646/6b395ab8-53d2-4b03-a6a0-c16ce6a8043b"> 

* Solution: Initialize the map before the assignment.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* Create a Kubernetes cluster, and create a namespace `n1`.
* Build the image with this PR, and deploy the operator with the following changes in `values.yaml`.
  ```yaml
  # KubeRay operator values.yaml
  image:
    repository: controller
    tag: latest
  crNamespacedRbacEnable: true
  singleNamespaceInstall: true
  watchNamespace:
    - n1
  ```
* Check the operator's log
  <img width="1439" alt="Screen Shot 2023-12-05 at 2 25 48 PM" src="https://github.com/ray-project/kuberay/assets/20109646/a64d4d6a-edbc-47ae-9175-1c13c1ec51df">
