### PR TITLE
[Feature] Override the `block` option of `rayStartParams` to true

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -339,10 +339,6 @@ func BuildPod(podTemplateSpec v1.PodTemplateSpec, rayNodeType rayv1.RayNodeType,
 			args = generatedCmd
 		}
 
-		if !isRayStartWithBlock(rayStartParams) {
-			// sleep infinity is used to keep the pod `running` after the last command exits, and not go into `completed` state
-			args = args + " && sleep infinity"
-		}
 		pod.Spec.Containers[RayContainerIndex].Args = []string{args}
 	}
 
@@ -472,13 +468,6 @@ func mergeAutoscalerOverrides(autoscalerContainer *v1.Container, autoscalerOptio
 			autoscalerContainer.SecurityContext = autoscalerOptions.SecurityContext.DeepCopy()
 		}
 	}
-}
-
-func isRayStartWithBlock(rayStartParams map[string]string) bool {
-	if blockValue, exist := rayStartParams["block"]; exist {
-		return strings.ToLower(blockValue) == "true"
-	}
-	return false
 }
 
 func convertCmdToString(cmdArr []string) (cmd string) {
@@ -698,9 +687,7 @@ func setMissingRayStartParams(rayStartParams map[string]string, nodeType rayv1.R
 	}
 
 	// Add --block option. See https://github.com/ray-project/kuberay/pull/675
-	if _, ok := rayStartParams["block"]; !ok {
-		rayStartParams["block"] = "true"
-	}
+	rayStartParams["block"] = "true"
 
 	// Add dashboard listen port for RayService.
 	if _, ok := rayStartParams["dashboard-agent-listen-port"]; !ok {

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1069,7 +1069,7 @@ func TestSetMissingRayStartParamsBlock(t *testing.T) {
 	// Case 2: Head node with --block option set to false.
 	rayStartParams = map[string]string{"block": "false"}
 	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1.HeadNode, headPort, "", nil)
-	assert.Equal(t, "false", rayStartParams["block"], fmt.Sprintf("Expected `%v` but got `%v`", "false", rayStartParams["block"]))
+	assert.Equal(t, "true", rayStartParams["block"], fmt.Sprintf("Expected `%v` but got `%v`", "false", rayStartParams["block"]))
 
 	// Case 3: Worker node with no --block option set.
 	rayStartParams = map[string]string{}
@@ -1079,7 +1079,7 @@ func TestSetMissingRayStartParamsBlock(t *testing.T) {
 	// Case 4: Worker node with --block option set to false.
 	rayStartParams = map[string]string{"block": "false"}
 	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP, nil)
-	assert.Equal(t, "false", rayStartParams["block"], fmt.Sprintf("Expected `%v` but got `%v`", "false", rayStartParams["block"]))
+	assert.Equal(t, "true", rayStartParams["block"], fmt.Sprintf("Expected `%v` but got `%v`", "false", rayStartParams["block"]))
 }
 
 func TestSetMissingRayStartParamsDashboardHost(t *testing.T) {


### PR DESCRIPTION
Follow the https://github.com/ray-project/kuberay/pull/932, we continue to enforce the `--block` option in the ray start command. Previously, we only injected the `--block` option when it was missing in the `rayStartParams`. Now, we override it to be `true` anyway and we don't need to inject `sleep infinity` anymore.

@kevin85421, should we add a warning message in the validation webhook to inform users when their `block` value is overridden?

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
