### PR TITLE
[RayJob][Status][1/n] Redefine the definition of JobDeploymentStatusComplete

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -127,10 +127,10 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
-	// Mark the deployment status as Complete if RayJob is succeed or failed
-	// TODO: (jiaxin.shan) Double check raycluster status to make sure we don't have create duplicate clusters..
-	// But the code here is not elegant. We should spend some time to refactor the flow.
-	if isJobSucceedOrFailed(rayJobInstance.Status.JobStatus) && rayJobInstance.Status.JobDeploymentStatus != rayv1.JobDeploymentStatusComplete {
+	// If the JobStatus is in one of the terminal states, including STOPPED, SUCCEEDED, and FAILED,
+	// it is impossible for the Ray job to transition to any other status. Additionally, RayJob does
+	// not currently support retries. Hence, we can mark the RayJob as "Complete" to avoid unnecessary reconciliation.
+	if rayv1.IsJobTerminal(rayJobInstance.Status.JobStatus) {
 		// We need to make sure the cluster is deleted or in deletion, then update the status.
 		rayClusterInstance := &rayv1.RayCluster{}
 		rayClusterNamespacedName := types.NamespacedName{


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```go
if isJobSucceedOrFailed(rayJobInstance.Status.JobStatus) && rayJobInstance.Status.JobDeploymentStatus != rayv1.JobDeploymentStatusComplete {
  ...
}
```

The check of `JobDeploymentStatusComplete` is not necessary because there is a check to skip the reconciliation if the status is `rayv1.JobDeploymentStatusComplete`. 

* https://github.com/ray-project/kuberay/blob/b16c705c5e6fe194932301312ade7e1a87ec0ae2/ray-operator/controllers/ray/rayjob_controller.go#L124-L128

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
