### PR TITLE
[Refactor] Standardize all `k8s.io/api/core/v1` imports as `corev1`

### DIFF
--- a/apiserver/pkg/model/converter.go
+++ b/apiserver/pkg/model/converter.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ray-project/kuberay/apiserver/pkg/util"
 	api "github.com/ray-project/kuberay/proto/go_client"
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Default annotations used by Ray nodes
@@ -87,7 +87,7 @@ func contains(s []string, str string) bool {
 	return false
 }
 
-func FromCrdToApiClusters(clusters []*rayv1api.RayCluster, clusterEventsMap map[string][]v1.Event) []*api.Cluster {
+func FromCrdToApiClusters(clusters []*rayv1api.RayCluster, clusterEventsMap map[string][]corev1.Event) []*api.Cluster {
 	apiClusters := make([]*api.Cluster, 0)
 	for _, cluster := range clusters {
 		apiClusters = append(apiClusters, FromCrdToApiCluster(cluster, clusterEventsMap[cluster.Name]))
@@ -95,7 +95,7 @@ func FromCrdToApiClusters(clusters []*rayv1api.RayCluster, clusterEventsMap map[
 	return apiClusters
 }
 
-func FromCrdToApiCluster(cluster *rayv1api.RayCluster, events []v1.Event) *api.Cluster {
+func FromCrdToApiCluster(cluster *rayv1api.RayCluster, events []corev1.Event) *api.Cluster {
 	pbCluster := &api.Cluster{
 		Name:         cluster.Name,
 		Namespace:    cluster.Namespace,
@@ -307,7 +307,7 @@ func PopulateWorkerNodeSpec(specs []rayv1api.WorkerGroupSpec) []*api.WorkerGroup
 	return workerNodeSpecs
 }
 
-func convert_env_variables(cenv []v1.EnvVar, header bool) *api.EnvironmentVariables {
+func convert_env_variables(cenv []corev1.EnvVar, header bool) *api.EnvironmentVariables {
 	env := api.EnvironmentVariables{
 		Values:     make(map[string]string),
 		ValuesFrom: make(map[string]*api.EnvValueFrom),
@@ -368,7 +368,7 @@ func convert_env_variables(cenv []v1.EnvVar, header bool) *api.EnvironmentVariab
 	return &env
 }
 
-func FromKubeToAPIComputeTemplate(configMap *v1.ConfigMap) *api.ComputeTemplate {
+func FromKubeToAPIComputeTemplate(configMap *corev1.ConfigMap) *api.ComputeTemplate {
 	cpu, _ := strconv.ParseUint(configMap.Data["cpu"], 10, 32)
 	memory, _ := strconv.ParseUint(configMap.Data["memory"], 10, 32)
 	gpu, _ := strconv.ParseUint(configMap.Data["gpu"], 10, 32)
@@ -391,7 +391,7 @@ func FromKubeToAPIComputeTemplate(configMap *v1.ConfigMap) *api.ComputeTemplate 
 	return runtime
 }
 
-func FromKubeToAPIComputeTemplates(configMaps []*v1.ConfigMap) []*api.ComputeTemplate {
+func FromKubeToAPIComputeTemplates(configMaps []*corev1.ConfigMap) []*api.ComputeTemplate {
 	apiComputeTemplates := make([]*api.ComputeTemplate, 0)
 	for _, configMap := range configMaps {
 		apiComputeTemplates = append(apiComputeTemplates, FromKubeToAPIComputeTemplate(configMap))
@@ -471,7 +471,7 @@ func FromCrdToApiJob(job *rayv1api.RayJob) (pbJob *api.RayJob) {
 	return pbJob
 }
 
-func FromCrdToApiServices(services []*rayv1api.RayService, serviceEventsMap map[string][]v1.Event) []*api.RayService {
+func FromCrdToApiServices(services []*rayv1api.RayService, serviceEventsMap map[string][]corev1.Event) []*api.RayService {
 	apiServices := make([]*api.RayService, 0)
 	for _, service := range services {
 		apiServices = append(apiServices, FromCrdToApiService(service, serviceEventsMap[service.Name]))
@@ -479,7 +479,7 @@ func FromCrdToApiServices(services []*rayv1api.RayService, serviceEventsMap map[
 	return apiServices
 }
 
-func FromCrdToApiService(service *rayv1api.RayService, events []v1.Event) *api.RayService {
+func FromCrdToApiService(service *rayv1api.RayService, events []corev1.Event) *api.RayService {
 	defer func() {
 		err := recover()
 		if err != nil {
@@ -569,7 +569,7 @@ func PoplulateUnhealthySecondThreshold(value *int32) int32 {
 	return *value
 }
 
-func PoplulateRayServiceStatus(serviceName string, serviceStatus rayv1api.RayServiceStatuses, events []v1.Event) *api.RayServiceStatus {
+func PoplulateRayServiceStatus(serviceName string, serviceStatus rayv1api.RayServiceStatuses, events []corev1.Event) *api.RayServiceStatus {
 	status := &api.RayServiceStatus{
 		RayServiceEvents:       PopulateRayServiceEvent(serviceName, events),
 		RayClusterName:         serviceStatus.ActiveServiceStatus.RayClusterName,
@@ -610,7 +610,7 @@ func PopulateServeDeploymentStatus(serveDeploymentStatuses map[string]rayv1api.S
 	return deploymentStatuses
 }
 
-func PopulateRayServiceEvent(serviceName string, events []v1.Event) []*api.RayServiceEvent {
+func PopulateRayServiceEvent(serviceName string, events []corev1.Event) []*api.RayServiceEvent {
 	serviceEvents := make([]*api.RayServiceEvent, 0)
 	for _, event := range events {
 		serviceEvent := &api.RayServiceEvent{

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -9,7 +9,7 @@ import (
 	api "github.com/ray-project/kuberay/proto/go_client"
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -34,7 +34,7 @@ var headSpecTest = rayv1api.HeadGroupSpec{
 		"metrics-export-port": "8080",
 		"num-cpus":            "0",
 	},
-	Template: v1.PodTemplateSpec{
+	Template: corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"openshift.io/scc":    "restricted",
@@ -56,32 +56,32 @@ var headSpecTest = rayv1api.HeadGroupSpec{
 			Name:      "boris-cluster-head-f7zx2",
 			Namespace: "max",
 		},
-		Spec: v1.PodSpec{
+		Spec: corev1.PodSpec{
 			ServiceAccountName: "account",
-			ImagePullSecrets: []v1.LocalObjectReference{
+			ImagePullSecrets: []corev1.LocalObjectReference{
 				{Name: "foo"},
 			},
-			Tolerations: []v1.Toleration{
+			Tolerations: []corev1.Toleration{
 				{
 					Key:      "blah1",
 					Operator: "Exists",
 					Effect:   "NoExecute",
 				},
 			},
-			Containers: []v1.Container{
+			Containers: []corev1.Container{
 				{
 					Name:  "ray-head",
 					Image: "blublinsky1/ray310:2.5.0",
-					Env: []v1.EnvVar{
+					Env: []corev1.EnvVar{
 						{
 							Name:  "AWS_KEY",
 							Value: "123",
 						},
 						{
 							Name: "REDIS_PASSWORD",
-							ValueFrom: &v1.EnvVarSource{
-								SecretKeyRef: &v1.SecretKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+							ValueFrom: &corev1.EnvVarSource{
+								SecretKeyRef: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "redis-password-secret",
 									},
 									Key: "password",
@@ -90,9 +90,9 @@ var headSpecTest = rayv1api.HeadGroupSpec{
 						},
 						{
 							Name: "CONFIGMAP",
-							ValueFrom: &v1.EnvVarSource{
-								ConfigMapKeyRef: &v1.ConfigMapKeySelector{
-									LocalObjectReference: v1.LocalObjectReference{
+							ValueFrom: &corev1.EnvVarSource{
+								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "special-config",
 									},
 									Key: "special.how",
@@ -101,8 +101,8 @@ var headSpecTest = rayv1api.HeadGroupSpec{
 						},
 						{
 							Name: "ResourceFieldRef",
-							ValueFrom: &v1.EnvVarSource{
-								ResourceFieldRef: &v1.ResourceFieldSelector{
+							ValueFrom: &corev1.EnvVarSource{
+								ResourceFieldRef: &corev1.ResourceFieldSelector{
 									ContainerName: "my-container",
 									Resource:      "resource",
 								},
@@ -110,8 +110,8 @@ var headSpecTest = rayv1api.HeadGroupSpec{
 						},
 						{
 							Name: "FieldRef",
-							ValueFrom: &v1.EnvVarSource{
-								FieldRef: &v1.ObjectFieldSelector{
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
 									FieldPath: "path",
 								},
 							},
@@ -123,7 +123,7 @@ var headSpecTest = rayv1api.HeadGroupSpec{
 	},
 }
 
-var configMapWithoutTolerations = v1.ConfigMap{
+var configMapWithoutTolerations = corev1.ConfigMap{
 	Data: map[string]string{
 		"cpu":             "4",
 		"gpu":             "0",
@@ -134,7 +134,7 @@ var configMapWithoutTolerations = v1.ConfigMap{
 	},
 }
 
-var configMapWithTolerations = v1.ConfigMap{
+var configMapWithTolerations = corev1.ConfigMap{
 	Data: map[string]string{
 		"cpu":             "4",
 		"gpu":             "0",
@@ -154,7 +154,7 @@ var workerSpecTest = rayv1api.WorkerGroupSpec{
 	RayStartParams: map[string]string{
 		"node-ip-address": "$MY_POD_IP",
 	},
-	Template: v1.PodTemplateSpec{
+	Template: corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"cni.projectcalico.org/containerID": "cce862a899455385e98e3453ba9ef5a376e85ad45c3e95b18e04e001204af728",
@@ -179,23 +179,23 @@ var workerSpecTest = rayv1api.WorkerGroupSpec{
 			Name:      "boris-cluster-worker-8-cpus-4dp9v",
 			Namespace: "max",
 		},
-		Spec: v1.PodSpec{
+		Spec: corev1.PodSpec{
 			ServiceAccountName: "account",
-			ImagePullSecrets: []v1.LocalObjectReference{
+			ImagePullSecrets: []corev1.LocalObjectReference{
 				{Name: "foo"},
 			},
-			Tolerations: []v1.Toleration{
+			Tolerations: []corev1.Toleration{
 				{
 					Key:      "blah1",
 					Operator: "Exists",
 					Effect:   "NoExecute",
 				},
 			},
-			Containers: []v1.Container{
+			Containers: []corev1.Container{
 				{
 					Name:  "ray-worker",
 					Image: "blublinsky1/ray310:2.5.0",
-					Env: []v1.EnvVar{
+					Env: []corev1.EnvVar{
 						{
 							Name:  "AWS_KEY",
 							Value: "123",
@@ -260,11 +260,11 @@ var ClusterSpecAutoscalerTest = rayv1api.RayCluster{
 		AutoscalerOptions: &rayv1api.AutoscalerOptions{
 			IdleTimeoutSeconds: pointer.Int32(int32(60)),
 			UpscalingMode:      (*rayv1api.UpscalingMode)(pointer.String("Default")),
-			ImagePullPolicy:    (*v1.PullPolicy)(pointer.String("Always")),
-			Resources: &v1.ResourceRequirements{
-				Requests: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("500m"),
-					v1.ResourceMemory: resource.MustParse("512Mi"),
+			ImagePullPolicy:    (*corev1.PullPolicy)(pointer.String("Always")),
+			Resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
 				},
 			},
 		},
@@ -323,25 +323,25 @@ var JobExistingClusterSubmitterTest = rayv1api.RayJob{
 		ClusterSelector: map[string]string{
 			util.RayClusterUserLabelKey: "test",
 		},
-		SubmitterPodTemplate: &v1.PodTemplateSpec{
-			Spec: v1.PodSpec{
-				Containers: []v1.Container{
+		SubmitterPodTemplate: &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
 					{
 						Name:  "test-submitter",
 						Image: "image",
-						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("2"),
-								v1.ResourceMemory: resource.MustParse("1Gi"),
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("2"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
 							},
-							Requests: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("500m"),
-								v1.ResourceMemory: resource.MustParse("200Mi"),
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("200Mi"),
 							},
 						},
 					},
 				},
-				RestartPolicy: v1.RestartPolicyNever,
+				RestartPolicy: corev1.RestartPolicyNever,
 			},
 		},
 	},
@@ -406,47 +406,47 @@ var autoscalerOptions = &rayv1api.AutoscalerOptions{
 	IdleTimeoutSeconds: pointer.Int32(int32(60)),
 	UpscalingMode:      (*rayv1api.UpscalingMode)(pointer.String("Default")),
 	Image:              pointer.String("Some Image"),
-	ImagePullPolicy:    (*v1.PullPolicy)(pointer.String("Always")),
-	Env: []v1.EnvVar{
+	ImagePullPolicy:    (*corev1.PullPolicy)(pointer.String("Always")),
+	Env: []corev1.EnvVar{
 		{
 			Name:  "n1",
 			Value: "v1",
 		},
 	},
-	EnvFrom: []v1.EnvFromSource{
+	EnvFrom: []corev1.EnvFromSource{
 		{
-			ConfigMapRef: &v1.ConfigMapEnvSource{
-				LocalObjectReference: v1.LocalObjectReference{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "ConfigMap",
 				},
 			},
 		},
 		{
-			SecretRef: &v1.SecretEnvSource{
-				LocalObjectReference: v1.LocalObjectReference{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "Secret",
 				},
 			},
 		},
 	},
-	VolumeMounts: []v1.VolumeMount{
+	VolumeMounts: []corev1.VolumeMount{
 		{
 			Name:             "vmount1",
 			MountPath:        "path1",
 			ReadOnly:         false,
-			MountPropagation: (*v1.MountPropagationMode)(pointer.String("None")),
+			MountPropagation: (*corev1.MountPropagationMode)(pointer.String("None")),
 		},
 		{
 			Name:             "vmount2",
 			MountPath:        "path2",
 			ReadOnly:         true,
-			MountPropagation: (*v1.MountPropagationMode)(pointer.String("HostToContainer")),
+			MountPropagation: (*corev1.MountPropagationMode)(pointer.String("HostToContainer")),
 		},
 	},
-	Resources: &v1.ResourceRequirements{
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("500m"),
-			v1.ResourceMemory: resource.MustParse("512Mi"),
+	Resources: &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
 		},
 	},
 }
@@ -557,7 +557,7 @@ func TestAutoscalerOptions(t *testing.T) {
 }
 
 func TestPopulateRayClusterSpec(t *testing.T) {
-	cluster := FromCrdToApiCluster(&ClusterSpecTest, []v1.Event{})
+	cluster := FromCrdToApiCluster(&ClusterSpecTest, []corev1.Event{})
 	if len(cluster.Annotations) != 1 {
 		t.Errorf("failed to convert cluster's annotations")
 	}
@@ -565,7 +565,7 @@ func TestPopulateRayClusterSpec(t *testing.T) {
 	if cluster.ClusterSpec.AutoscalerOptions != nil {
 		t.Errorf("unexpected autoscaler annotations")
 	}
-	cluster = FromCrdToApiCluster(&ClusterSpecAutoscalerTest, []v1.Event{})
+	cluster = FromCrdToApiCluster(&ClusterSpecAutoscalerTest, []corev1.Event{})
 	assert.Equal(t, cluster.ClusterSpec.EnableInTreeAutoscaling, true)
 	if cluster.ClusterSpec.AutoscalerOptions == nil {
 		t.Errorf("autoscaler annotations not found")
@@ -631,7 +631,7 @@ func TestPopulateJob(t *testing.T) {
 }
 
 func TestPopulateService(t *testing.T) {
-	service := FromCrdToApiService(&ServiceV1Test, make([]v1.Event, 0))
+	service := FromCrdToApiService(&ServiceV1Test, make([]corev1.Event, 0))
 	fmt.Printf("serviceV1 = %#v\n", service)
 	if service.Name != "test" {
 		t.Errorf("failed to convert name")
@@ -651,7 +651,7 @@ func TestPopulateService(t *testing.T) {
 	if len(service.ServeDeploymentGraphSpec.ServeConfigs) != 3 {
 		t.Errorf("failed to convert serveConfiggs")
 	}
-	service = FromCrdToApiService(&ServiceV2Test, make([]v1.Event, 0))
+	service = FromCrdToApiService(&ServiceV2Test, make([]corev1.Event, 0))
 	fmt.Printf("serviceV2 = %#v\n", service)
 	if service.ServeDeploymentGraphSpec != nil {
 		t.Errorf("unexpected v1 serve spec")

--- a/apiserver/pkg/model/volumes.go
+++ b/apiserver/pkg/model/volumes.go
@@ -2,10 +2,10 @@ package model
 
 import (
 	api "github.com/ray-project/kuberay/proto/go_client"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
-func PopulateVolumes(podTemplate *v1.PodTemplateSpec) []*api.Volume {
+func PopulateVolumes(podTemplate *corev1.PodTemplateSpec) []*api.Volume {
 	if len(podTemplate.Spec.Volumes) == 0 {
 		return nil
 	}
@@ -85,7 +85,7 @@ func PopulateVolumes(podTemplate *v1.PodTemplateSpec) []*api.Volume {
 		}
 		if vol.VolumeSource.Ephemeral != nil {
 			// Ephimeral
-			request := vol.VolumeSource.Ephemeral.VolumeClaimTemplate.Spec.Resources.Requests[v1.ResourceStorage]
+			request := vol.VolumeSource.Ephemeral.VolumeClaimTemplate.Spec.Resources.Requests[corev1.ResourceStorage]
 			volume := api.Volume{
 				Name:                 vol.Name,
 				MountPath:            mount.MountPath,
@@ -104,7 +104,7 @@ func PopulateVolumes(podTemplate *v1.PodTemplateSpec) []*api.Volume {
 	return volumes
 }
 
-func GetVolumeMount(podTemplate *v1.PodTemplateSpec, vol string) *v1.VolumeMount {
+func GetVolumeMount(podTemplate *corev1.PodTemplateSpec, vol string) *corev1.VolumeMount {
 	for _, container := range podTemplate.Spec.Containers {
 		for _, mount := range container.VolumeMounts {
 			if mount.Name == vol {
@@ -115,35 +115,35 @@ func GetVolumeMount(podTemplate *v1.PodTemplateSpec, vol string) *v1.VolumeMount
 	return nil
 }
 
-func GetVolumeMountPropagation(mount *v1.VolumeMount) api.Volume_MountPropagationMode {
+func GetVolumeMountPropagation(mount *corev1.VolumeMount) api.Volume_MountPropagationMode {
 	if mount.MountPropagation == nil {
 		return api.Volume_NONE
 	}
-	if *mount.MountPropagation == v1.MountPropagationHostToContainer {
+	if *mount.MountPropagation == corev1.MountPropagationHostToContainer {
 		return api.Volume_HOSTTOCONTAINER
 	}
-	if *mount.MountPropagation == v1.MountPropagationBidirectional {
+	if *mount.MountPropagation == corev1.MountPropagationBidirectional {
 		return api.Volume_BIDIRECTIONAL
 	}
 	return api.Volume_NONE
 }
 
-func GetVolumeHostPathType(vol *v1.Volume) api.Volume_HostPathType {
-	if *vol.VolumeSource.HostPath.Type == v1.HostPathFile {
+func GetVolumeHostPathType(vol *corev1.Volume) api.Volume_HostPathType {
+	if *vol.VolumeSource.HostPath.Type == corev1.HostPathFile {
 		return api.Volume_FILE
 	}
 	return api.Volume_DIRECTORY
 }
 
-func GetAccessMode(vol *v1.Volume) api.Volume_AccessMode {
+func GetAccessMode(vol *corev1.Volume) api.Volume_AccessMode {
 	modes := vol.VolumeSource.Ephemeral.VolumeClaimTemplate.Spec.AccessModes
 	if len(modes) == 0 {
 		return api.Volume_RWO
 	}
-	if modes[0] == v1.ReadOnlyMany {
+	if modes[0] == corev1.ReadOnlyMany {
 		return api.Volume_ROX
 	}
-	if modes[0] == v1.ReadWriteMany {
+	if modes[0] == corev1.ReadWriteMany {
 		return api.Volume_RWX
 	}
 	return api.Volume_RWO

--- a/apiserver/pkg/model/volumes_test.go
+++ b/apiserver/pkg/model/volumes_test.go
@@ -6,24 +6,24 @@ import (
 	"testing"
 
 	api "github.com/ray-project/kuberay/proto/go_client"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
-	hostToContainer = v1.MountPropagationHostToContainer
-	bidirectonal    = v1.MountPropagationBidirectional
+	hostToContainer = corev1.MountPropagationHostToContainer
+	bidirectonal    = corev1.MountPropagationBidirectional
 	sizelimit       = resource.MustParse("100Gi")
 )
 
-var podTemplateTest = v1.PodTemplateSpec{
-	Spec: v1.PodSpec{
-		Containers: []v1.Container{
+var podTemplateTest = corev1.PodTemplateSpec{
+	Spec: corev1.PodSpec{
+		Containers: []corev1.Container{
 			{
 				Name:  "ray-head",
 				Image: "blah",
-				VolumeMounts: []v1.VolumeMount{
+				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:             "hostPath",
 						MountPath:        "/tmp/hostPath",
@@ -53,20 +53,20 @@ var podTemplateTest = v1.PodTemplateSpec{
 				},
 			},
 		},
-		Volumes: []v1.Volume{
+		Volumes: []corev1.Volume{
 			{
 				Name: "hostPath",
-				VolumeSource: v1.VolumeSource{
-					HostPath: &v1.HostPathVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
 						Path: "/tmp",
-						Type: newHostPathType(string(v1.HostPathDirectory)),
+						Type: newHostPathType(string(corev1.HostPathDirectory)),
 					},
 				},
 			},
 			{
 				Name: "pvc",
-				VolumeSource: v1.VolumeSource{
-					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "pvcclaim",
 						ReadOnly:  false,
 					},
@@ -74,18 +74,18 @@ var podTemplateTest = v1.PodTemplateSpec{
 			},
 			{
 				Name: "ephemeral",
-				VolumeSource: v1.VolumeSource{
-					Ephemeral: &v1.EphemeralVolumeSource{
-						VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
+				VolumeSource: corev1.VolumeSource{
+					Ephemeral: &corev1.EphemeralVolumeSource{
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
 									"app.kubernetes.io/managed-by": "kuberay-apiserver",
 								},
 							},
-							Spec: v1.PersistentVolumeClaimSpec{
-								Resources: v1.ResourceRequirements{
-									Requests: v1.ResourceList{
-										v1.ResourceStorage: resource.MustParse("5Gi"),
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("5Gi"),
 									},
 								},
 							},
@@ -95,12 +95,12 @@ var podTemplateTest = v1.PodTemplateSpec{
 			},
 			{
 				Name: "configMap",
-				VolumeSource: v1.VolumeSource{
-					ConfigMap: &v1.ConfigMapVolumeSource{
-						LocalObjectReference: v1.LocalObjectReference{
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "my-config-map",
 						},
-						Items: []v1.KeyToPath{
+						Items: []corev1.KeyToPath{
 							{
 								Key:  "key1",
 								Path: "path1",
@@ -115,16 +115,16 @@ var podTemplateTest = v1.PodTemplateSpec{
 			},
 			{
 				Name: "secret",
-				VolumeSource: v1.VolumeSource{
-					Secret: &v1.SecretVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
 						SecretName: "my-secret",
 					},
 				},
 			},
 			{
 				Name: "emptyDir",
-				VolumeSource: v1.VolumeSource{
-					EmptyDir: &v1.EmptyDirVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{
 						SizeLimit: &sizelimit,
 					},
 				},
@@ -183,9 +183,9 @@ var expectedVolumes = []*api.Volume{
 }
 
 // Build host path
-func newHostPathType(pathType string) *v1.HostPathType {
-	hostPathType := new(v1.HostPathType)
-	*hostPathType = v1.HostPathType(pathType)
+func newHostPathType(pathType string) *corev1.HostPathType {
+	hostPathType := new(corev1.HostPathType)
+	*hostPathType = corev1.HostPathType(pathType)
 	return hostPathType
 }
 

--- a/apiserver/pkg/server/cluster_server.go
+++ b/apiserver/pkg/server/cluster_server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ray-project/kuberay/apiserver/pkg/util"
 	api "github.com/ray-project/kuberay/proto/go_client"
 	"google.golang.org/protobuf/types/known/emptypb"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	klog "k8s.io/klog/v2"
 )
 
@@ -79,7 +79,7 @@ func (s *ClusterServer) ListCluster(ctx context.Context, request *api.ListCluste
 	if err != nil {
 		return nil, util.Wrap(err, "List clusters failed.")
 	}
-	clusterEventMap := make(map[string][]v1.Event)
+	clusterEventMap := make(map[string][]corev1.Event)
 	for _, cluster := range clusters {
 		clusterEvents, err := s.resourceManager.GetClusterEvents(ctx, cluster.Name, cluster.Namespace)
 		if err != nil {
@@ -101,7 +101,7 @@ func (s *ClusterServer) ListAllClusters(ctx context.Context, request *api.ListAl
 	if err != nil {
 		return nil, util.Wrap(err, "List clusters from all namespaces failed.")
 	}
-	clusterEventMap := make(map[string][]v1.Event)
+	clusterEventMap := make(map[string][]corev1.Event)
 	for _, cluster := range clusters {
 		clusterEvents, err := s.resourceManager.GetClusterEvents(ctx, cluster.Name, cluster.Namespace)
 		if err != nil {

--- a/apiserver/pkg/server/serve_server.go
+++ b/apiserver/pkg/server/serve_server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ray-project/kuberay/apiserver/pkg/util"
 	api "github.com/ray-project/kuberay/proto/go_client"
 	"google.golang.org/protobuf/types/known/emptypb"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	klog "k8s.io/klog/v2"
 )
 
@@ -107,7 +107,7 @@ func (s *RayServiceServer) ListRayServices(ctx context.Context, request *api.Lis
 	if err != nil {
 		return nil, util.Wrap(err, "failed to list rayservice.")
 	}
-	serviceEventMap := make(map[string][]v1.Event)
+	serviceEventMap := make(map[string][]corev1.Event)
 	for _, service := range services {
 		serviceEvents, err := s.resourceManager.GetServiceEvents(ctx, *service)
 		if err != nil {
@@ -126,7 +126,7 @@ func (s *RayServiceServer) ListAllRayServices(ctx context.Context, request *api.
 	if err != nil {
 		return nil, util.Wrap(err, "list all services failed.")
 	}
-	serviceEventMap := make(map[string][]v1.Event)
+	serviceEventMap := make(map[string][]corev1.Event)
 	for _, service := range services {
 		serviceEvents, err := s.resourceManager.GetServiceEvents(ctx, *service)
 		if err != nil {

--- a/apiserver/pkg/util/cluster_test.go
+++ b/apiserver/pkg/util/cluster_test.go
@@ -7,7 +7,7 @@ import (
 
 	api "github.com/ray-project/kuberay/proto/go_client"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -241,7 +241,7 @@ var template = api.ComputeTemplate{
 	},
 }
 
-var expectedToleration = v1.Toleration{
+var expectedToleration = corev1.Toleration{
 	Key:      "blah1",
 	Operator: "Exists",
 	Effect:   "NoExecute",
@@ -251,11 +251,11 @@ var expectedLabels = map[string]string{
 	"foo": "bar",
 }
 
-var expectedHeadNodeEnv = []v1.EnvVar{
+var expectedHeadNodeEnv = []corev1.EnvVar{
 	{
 		Name: "MY_POD_IP",
-		ValueFrom: &v1.EnvVarSource{
-			FieldRef: &v1.ObjectFieldSelector{
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
 				FieldPath: "status.podIP",
 			},
 		},
@@ -266,9 +266,9 @@ var expectedHeadNodeEnv = []v1.EnvVar{
 	},
 	{
 		Name: "REDIS_PASSWORD",
-		ValueFrom: &v1.EnvVarSource{
-			SecretKeyRef: &v1.SecretKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "redis-password-secret",
 				},
 				Key: "password",
@@ -277,9 +277,9 @@ var expectedHeadNodeEnv = []v1.EnvVar{
 	},
 	{
 		Name: "CONFIGMAP",
-		ValueFrom: &v1.EnvVarSource{
-			ConfigMapKeyRef: &v1.ConfigMapKeySelector{
-				LocalObjectReference: v1.LocalObjectReference{
+		ValueFrom: &corev1.EnvVarSource{
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "special-config",
 				},
 				Key: "special.how",
@@ -288,8 +288,8 @@ var expectedHeadNodeEnv = []v1.EnvVar{
 	},
 	{
 		Name: "ResourceFieldRef",
-		ValueFrom: &v1.EnvVarSource{
-			ResourceFieldRef: &v1.ResourceFieldSelector{
+		ValueFrom: &corev1.EnvVarSource{
+			ResourceFieldRef: &corev1.ResourceFieldSelector{
 				ContainerName: "my-container",
 				Resource:      "resource",
 			},
@@ -297,8 +297,8 @@ var expectedHeadNodeEnv = []v1.EnvVar{
 	},
 	{
 		Name: "FieldRef",
-		ValueFrom: &v1.EnvVarSource{
-			FieldRef: &v1.ObjectFieldSelector{
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
 				FieldPath: "path",
 			},
 		},
@@ -306,52 +306,52 @@ var expectedHeadNodeEnv = []v1.EnvVar{
 }
 
 func TestBuildVolumes(t *testing.T) {
-	targetVolume := v1.Volume{
+	targetVolume := corev1.Volume{
 		Name: testVolume.Name,
-		VolumeSource: v1.VolumeSource{
-			HostPath: &v1.HostPathVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
 				Path: testVolume.Source,
-				Type: newHostPathType(string(v1.HostPathDirectory)),
+				Type: newHostPathType(string(corev1.HostPathDirectory)),
 			},
 		},
 	}
-	targetFileVolume := v1.Volume{
+	targetFileVolume := corev1.Volume{
 		Name: testFileVolume.Name,
-		VolumeSource: v1.VolumeSource{
-			HostPath: &v1.HostPathVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
 				Path: testFileVolume.Source,
-				Type: newHostPathType(string(v1.HostPathFile)),
+				Type: newHostPathType(string(corev1.HostPathFile)),
 			},
 		},
 	}
 
-	targetPVCVolume := v1.Volume{
+	targetPVCVolume := corev1.Volume{
 		Name: testPVCVolume.Name,
-		VolumeSource: v1.VolumeSource{
-			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: testPVCVolume.Source,
 				ReadOnly:  testPVCVolume.ReadOnly,
 			},
 		},
 	}
 
-	targetEphemeralVolume := v1.Volume{
+	targetEphemeralVolume := corev1.Volume{
 		Name: testEphemeralVolume.Name,
-		VolumeSource: v1.VolumeSource{
-			Ephemeral: &v1.EphemeralVolumeSource{
-				VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
+		VolumeSource: corev1.VolumeSource{
+			Ephemeral: &corev1.EphemeralVolumeSource{
+				VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
 							"app.kubernetes.io/managed-by": "kuberay-apiserver",
 						},
 					},
-					Spec: v1.PersistentVolumeClaimSpec{
-						AccessModes: []v1.PersistentVolumeAccessMode{
-							v1.ReadWriteOnce,
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
 						},
-						Resources: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceStorage: resource.MustParse(testEphemeralVolume.Storage),
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse(testEphemeralVolume.Storage),
 							},
 						},
 					},
@@ -360,14 +360,14 @@ func TestBuildVolumes(t *testing.T) {
 		},
 	}
 
-	targetConfigMapVolume := v1.Volume{
+	targetConfigMapVolume := corev1.Volume{
 		Name: "configMap",
-		VolumeSource: v1.VolumeSource{
-			ConfigMap: &v1.ConfigMapVolumeSource{
-				LocalObjectReference: v1.LocalObjectReference{
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "my-config-map",
 				},
-				Items: []v1.KeyToPath{
+				Items: []corev1.KeyToPath{
 					{
 						Key:  "key1",
 						Path: "path1",
@@ -381,19 +381,19 @@ func TestBuildVolumes(t *testing.T) {
 		},
 	}
 
-	targetSecretVolume := v1.Volume{
+	targetSecretVolume := corev1.Volume{
 		Name: "secret",
-		VolumeSource: v1.VolumeSource{
-			Secret: &v1.SecretVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
 				SecretName: "my-secret",
 			},
 		},
 	}
 
-	targetEmptyDirVolume := v1.Volume{
+	targetEmptyDirVolume := corev1.Volume{
 		Name: "emptyDir",
-		VolumeSource: v1.VolumeSource{
-			EmptyDir: &v1.EmptyDirVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
 				SizeLimit: &sizelimit,
 			},
 		},
@@ -402,39 +402,39 @@ func TestBuildVolumes(t *testing.T) {
 	tests := []struct {
 		name      string
 		apiVolume []*api.Volume
-		expect    []v1.Volume
+		expect    []corev1.Volume
 	}{
 		{
 			"normal test",
 			[]*api.Volume{
 				testVolume, testFileVolume,
 			},
-			[]v1.Volume{targetVolume, targetFileVolume},
+			[]corev1.Volume{targetVolume, targetFileVolume},
 		},
 		{
 			"pvc test",
 			[]*api.Volume{testPVCVolume},
-			[]v1.Volume{targetPVCVolume},
+			[]corev1.Volume{targetPVCVolume},
 		},
 		{
 			"ephemeral test",
 			[]*api.Volume{testEphemeralVolume},
-			[]v1.Volume{targetEphemeralVolume},
+			[]corev1.Volume{targetEphemeralVolume},
 		},
 		{
 			"configmap test",
 			[]*api.Volume{testConfigMapVolume},
-			[]v1.Volume{targetConfigMapVolume},
+			[]corev1.Volume{targetConfigMapVolume},
 		},
 		{
 			"secret test",
 			[]*api.Volume{testSecretVolume},
-			[]v1.Volume{targetSecretVolume},
+			[]corev1.Volume{targetSecretVolume},
 		},
 		{
 			"empty dir test",
 			[]*api.Volume{testEmptyDirVolume},
-			[]v1.Volume{targetEmptyDirVolume},
+			[]corev1.Volume{targetEmptyDirVolume},
 		},
 	}
 	for _, tt := range tests {
@@ -458,19 +458,19 @@ func TestBuildVolumes(t *testing.T) {
 }
 
 func TestBuildVolumeMounts(t *testing.T) {
-	hostToContainer := v1.MountPropagationHostToContainer
-	targetVolumeMount := v1.VolumeMount{
+	hostToContainer := corev1.MountPropagationHostToContainer
+	targetVolumeMount := corev1.VolumeMount{
 		Name:      testVolume.Name,
 		ReadOnly:  testVolume.ReadOnly,
 		MountPath: testVolume.MountPath,
 	}
-	targetFileVolumeMount := v1.VolumeMount{
+	targetFileVolumeMount := corev1.VolumeMount{
 		Name:             testFileVolume.Name,
 		ReadOnly:         testFileVolume.ReadOnly,
 		MountPath:        testFileVolume.MountPath,
 		MountPropagation: &hostToContainer,
 	}
-	targetPVCVolumeMount := v1.VolumeMount{
+	targetPVCVolumeMount := corev1.VolumeMount{
 		Name:      testPVCVolume.Name,
 		ReadOnly:  testPVCVolume.ReadOnly,
 		MountPath: testPVCVolume.MountPath,
@@ -478,7 +478,7 @@ func TestBuildVolumeMounts(t *testing.T) {
 	tests := []struct {
 		name      string
 		apiVolume []*api.Volume
-		expect    []v1.VolumeMount
+		expect    []corev1.VolumeMount
 	}{
 		{
 			"normal test",
@@ -486,7 +486,7 @@ func TestBuildVolumeMounts(t *testing.T) {
 				testVolume,
 				testFileVolume,
 			},
-			[]v1.VolumeMount{
+			[]corev1.VolumeMount{
 				targetVolumeMount,
 				targetFileVolumeMount,
 			},
@@ -494,7 +494,7 @@ func TestBuildVolumeMounts(t *testing.T) {
 		{
 			"pvc test",
 			[]*api.Volume{testPVCVolume},
-			[]v1.VolumeMount{targetPVCVolumeMount},
+			[]corev1.VolumeMount{targetPVCVolumeMount},
 		},
 	}
 	for _, tt := range tests {
@@ -612,7 +612,7 @@ func TestBuilWorkerPodTemplate(t *testing.T) {
 	}
 }
 
-func containsEnv(envs []v1.EnvVar, key string, val string) bool {
+func containsEnv(envs []corev1.EnvVar, key string, val string) bool {
 	for _, env := range envs {
 		if env.Name == key && env.Value == val {
 			return true
@@ -621,6 +621,6 @@ func containsEnv(envs []v1.EnvVar, key string, val string) bool {
 	return false
 }
 
-func tolerationToString(toleration *v1.Toleration) string {
+func tolerationToString(toleration *corev1.Toleration) string {
 	return "Key: " + toleration.Key + " Operator: " + string(toleration.Operator) + " Effect: " + string(toleration.Effect)
 }

--- a/apiserver/pkg/util/job.go
+++ b/apiserver/pkg/util/job.go
@@ -5,7 +5,7 @@ import (
 
 	api "github.com/ray-project/kuberay/proto/go_client"
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -63,25 +63,25 @@ func NewRayJob(apiJob *api.RayJob, computeTemplateMap map[string]*api.ComputeTem
 			}
 			memorys = apiJob.JobSubmitter.Memory
 		}
-		rayJob.Spec.SubmitterPodTemplate = &v1.PodTemplateSpec{
-			Spec: v1.PodSpec{
-				Containers: []v1.Container{
+		rayJob.Spec.SubmitterPodTemplate = &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
 					{
 						Name:  "ray-job-submitter",
 						Image: apiJob.JobSubmitter.Image,
-						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse(cpus),
-								v1.ResourceMemory: resource.MustParse(memorys),
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse(cpus),
+								corev1.ResourceMemory: resource.MustParse(memorys),
 							},
-							Requests: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse(cpus),
-								v1.ResourceMemory: resource.MustParse(memorys),
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse(cpus),
+								corev1.ResourceMemory: resource.MustParse(memorys),
 							},
 						},
 					},
 				},
-				RestartPolicy: v1.RestartPolicyNever,
+				RestartPolicy: corev1.RestartPolicyNever,
 			},
 		}
 	}

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -145,7 +145,7 @@ func withNamespace() contextOption {
 		require.NotNil(t, tCtx.k8client, "A k8s client must be created prior to creating a namespace")
 		require.NotNil(t, tCtx.ctx, "A context must exist prior to creating a namespace")
 		require.NotEmpty(t, tCtx.namespaceName, "Namespace name must be set prior to creating a namespace")
-		nsName := &v1.Namespace{
+		nsName := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: tCtx.namespaceName,
 			},
@@ -392,7 +392,7 @@ func (e2etc *End2EndTestingContext) DeleteRayJobByName(t *testing.T, rayJobName 
 }
 
 func (e2etc *End2EndTestingContext) CreateConfigMap(t *testing.T, values map[string]string) string {
-	cm := &v1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: e2etc.configMapName, Namespace: e2etc.namespaceName},
 		Immutable:  new(bool),

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -28,15 +28,15 @@ type RayClusterSpec struct {
 // HeadGroupSpec are the spec for the head pod
 type HeadGroupSpec struct {
 	// ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod
-	ServiceType v1.ServiceType `json:"serviceType,omitempty"`
+	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 	// HeadService is the Kubernetes service of the head pod.
-	HeadService *v1.Service `json:"headService,omitempty"`
+	HeadService *corev1.Service `json:"headService,omitempty"`
 	// EnableIngress indicates whether operator should create ingress object for head service or not.
 	EnableIngress *bool `json:"enableIngress,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template is the exact pod template used in K8s depoyments, statefulsets, etc.
-	Template v1.PodTemplateSpec `json:"template"`
+	Template corev1.PodTemplateSpec `json:"template"`
 }
 
 // WorkerGroupSpec are the specs for the worker pods
@@ -55,7 +55,7 @@ type WorkerGroupSpec struct {
 	// RayStartParams are the params of the start command: address, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template is a pod template for the worker
-	Template v1.PodTemplateSpec `json:"template"`
+	Template corev1.PodTemplateSpec `json:"template"`
 	// ScaleStrategy defines which pods to remove
 	ScaleStrategy ScaleStrategy `json:"scaleStrategy,omitempty"`
 }
@@ -70,21 +70,21 @@ type ScaleStrategy struct {
 type AutoscalerOptions struct {
 	// Resources specifies optional resource request and limit overrides for the autoscaler container.
 	// Default values: 500m CPU request and limit. 512Mi memory request and limit.
-	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	// Image optionally overrides the autoscaler's container image. This override is for provided for autoscaler testing and development.
 	Image *string `json:"image,omitempty"`
 	// ImagePullPolicy optionally overrides the autoscaler container's image pull policy. This override is for provided for autoscaler testing and development.
-	ImagePullPolicy *v1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	ImagePullPolicy *corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// Optional list of environment variables to set in the autoscaler container.
-	Env []v1.EnvVar `json:"env,omitempty"`
+	Env []corev1.EnvVar `json:"env,omitempty"`
 	// Optional list of sources to populate environment variables in the autoscaler container.
-	EnvFrom []v1.EnvFromSource `json:"envFrom,omitempty"`
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
 	// Optional list of volumeMounts.  This is needed for enabling TLS for the autoscaler container.
-	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 	// SecurityContext defines the security options the container should be run with.
 	// If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-	SecurityContext *v1.SecurityContext `json:"securityContext,omitempty"`
+	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 	// IdleTimeoutSeconds is the number of seconds to wait before scaling down a worker pod which is not using Ray resources.
 	// Defaults to 60 (one minute). It is not read by the KubeRay operator but by the Ray autoscaler.
 	IdleTimeoutSeconds *int32 `json:"idleTimeoutSeconds,omitempty"`

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -76,7 +76,7 @@ type RayJobSpec struct {
 	// In case of transition to false a new RayCluster will be created.
 	Suspend bool `json:"suspend,omitempty"`
 	// SubmitterPodTemplate is the template for the pod that will run `ray job submit`.
-	SubmitterPodTemplate *v1.PodTemplateSpec `json:"submitterPodTemplate,omitempty"`
+	SubmitterPodTemplate *corev1.PodTemplateSpec `json:"submitterPodTemplate,omitempty"`
 	// EntrypointNumCpus specifies the number of cpus to reserve for the entrypoint command.
 	EntrypointNumCpus float32 `json:"entrypointNumCpus,omitempty"`
 	// EntrypointNumGpus specifies the number of gpus to reserve for the entrypoint command.

--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -63,7 +63,7 @@ type RayServiceSpec struct {
 	// Deprecated: This field is not used anymore. ref: https://github.com/ray-project/kuberay/issues/1685
 	DeploymentUnhealthySecondThreshold *int32 `json:"deploymentUnhealthySecondThreshold,omitempty"`
 	// ServeService is the Kubernetes service for head node and worker nodes who have healthy http proxy to serve traffics.
-	ServeService *v1.Service `json:"serveService,omitempty"`
+	ServeService *corev1.Service `json:"serveService,omitempty"`
 }
 
 type ServeDeploymentGraphSpec struct {

--- a/ray-operator/apis/ray/v1/webhook_suite_test.go
+++ b/ray-operator/apis/ray/v1/webhook_suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	//+kubebuilder:scaffold:imports
@@ -138,9 +138,9 @@ var _ = Describe("RayCluster validating webhook", func() {
 				Spec: RayClusterSpec{
 					HeadGroupSpec: HeadGroupSpec{
 						RayStartParams: map[string]string{"DEADBEEF": "DEADBEEF"},
-						Template: v1.PodTemplateSpec{
-							Spec: v1.PodSpec{
-								Containers: []v1.Container{},
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{},
 							},
 						},
 					},
@@ -148,18 +148,18 @@ var _ = Describe("RayCluster validating webhook", func() {
 						{
 							GroupName:      "group1",
 							RayStartParams: map[string]string{"DEADBEEF": "DEADBEEF"},
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
-									Containers: []v1.Container{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
 								},
 							},
 						},
 						{
 							GroupName:      "group1",
 							RayStartParams: map[string]string{"DEADBEEF": "DEADBEEF"},
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
-									Containers: []v1.Container{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
 								},
 							},
 						},

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -28,15 +28,15 @@ type RayClusterSpec struct {
 // HeadGroupSpec are the spec for the head pod
 type HeadGroupSpec struct {
 	// ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod
-	ServiceType v1.ServiceType `json:"serviceType,omitempty"`
+	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 	// HeadService is the Kubernetes service of the head pod.
-	HeadService *v1.Service `json:"headService,omitempty"`
+	HeadService *corev1.Service `json:"headService,omitempty"`
 	// EnableIngress indicates whether operator should create ingress object for head service or not.
 	EnableIngress *bool `json:"enableIngress,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template is the exact pod template used in K8s depoyments, statefulsets, etc.
-	Template v1.PodTemplateSpec `json:"template"`
+	Template corev1.PodTemplateSpec `json:"template"`
 }
 
 // WorkerGroupSpec are the specs for the worker pods
@@ -55,7 +55,7 @@ type WorkerGroupSpec struct {
 	// RayStartParams are the params of the start command: address, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template is a pod template for the worker
-	Template v1.PodTemplateSpec `json:"template"`
+	Template corev1.PodTemplateSpec `json:"template"`
 	// ScaleStrategy defines which pods to remove
 	ScaleStrategy ScaleStrategy `json:"scaleStrategy,omitempty"`
 }
@@ -70,21 +70,21 @@ type ScaleStrategy struct {
 type AutoscalerOptions struct {
 	// Resources specifies optional resource request and limit overrides for the autoscaler container.
 	// Default values: 500m CPU request and limit. 512Mi memory request and limit.
-	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	// Image optionally overrides the autoscaler's container image. This override is for provided for autoscaler testing and development.
 	Image *string `json:"image,omitempty"`
 	// ImagePullPolicy optionally overrides the autoscaler container's image pull policy. This override is for provided for autoscaler testing and development.
-	ImagePullPolicy *v1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	ImagePullPolicy *corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// Optional list of environment variables to set in the autoscaler container.
-	Env []v1.EnvVar `json:"env,omitempty"`
+	Env []corev1.EnvVar `json:"env,omitempty"`
 	// Optional list of sources to populate environment variables in the autoscaler container.
-	EnvFrom []v1.EnvFromSource `json:"envFrom,omitempty"`
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
 	// Optional list of volumeMounts.  This is needed for enabling TLS for the autoscaler container.
-	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 	// SecurityContext defines the security options the container should be run with.
 	// If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-	SecurityContext *v1.SecurityContext `json:"securityContext,omitempty"`
+	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 	// IdleTimeoutSeconds is the number of seconds to wait before scaling down a worker pod which is not using Ray resources.
 	// Defaults to 60 (one minute). It is not read by the KubeRay operator but by the Ray autoscaler.
 	IdleTimeoutSeconds *int32 `json:"idleTimeoutSeconds,omitempty"`

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -76,7 +76,7 @@ type RayJobSpec struct {
 	// In case of transition to false a new RayCluster will be created.
 	Suspend bool `json:"suspend,omitempty"`
 	// SubmitterPodTemplate is the template for the pod that will run `ray job submit`.
-	SubmitterPodTemplate *v1.PodTemplateSpec `json:"submitterPodTemplate,omitempty"`
+	SubmitterPodTemplate *corev1.PodTemplateSpec `json:"submitterPodTemplate,omitempty"`
 	// EntrypointNumCpus specifies the number of cpus to reserve for the entrypoint command.
 	EntrypointNumCpus float32 `json:"entrypointNumCpus,omitempty"`
 	// EntrypointNumGpus specifies the number of gpus to reserve for the entrypoint command.

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -63,7 +63,7 @@ type RayServiceSpec struct {
 	// Deprecated: This field is not used anymore. ref: https://github.com/ray-project/kuberay/issues/1685
 	DeploymentUnhealthySecondThreshold *int32 `json:"deploymentUnhealthySecondThreshold,omitempty"`
 	// ServeService is the Kubernetes service for head node and worker nodes who have healthy http proxy to serve traffics.
-	ServeService *v1.Service `json:"serveService,omitempty"`
+	ServeService *corev1.Service `json:"serveService,omitempty"`
 }
 
 type ServeDeploymentGraphSpec struct {

--- a/ray-operator/controllers/ray/batchscheduler/interface/interface.go
+++ b/ray-operator/controllers/ray/batchscheduler/interface/interface.go
@@ -2,7 +2,7 @@ package schedulerinterface
 
 import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -20,7 +20,7 @@ type BatchScheduler interface {
 
 	// AddMetadataToPod enriches Pod specs with metadata necessary to tie them to the scheduler.
 	// For example, setting labels for queues / priority, and setting schedulerName.
-	AddMetadataToPod(app *rayv1.RayCluster, pod *v1.Pod)
+	AddMetadataToPod(app *rayv1.RayCluster, pod *corev1.Pod)
 }
 
 // BatchSchedulerFactory handles initial setup of the scheduler plugin by registering the
@@ -53,7 +53,7 @@ func (d *DefaultBatchScheduler) DoBatchSchedulingOnSubmission(app *rayv1.RayClus
 	return nil
 }
 
-func (d *DefaultBatchScheduler) AddMetadataToPod(app *rayv1.RayCluster, pod *v1.Pod) {
+func (d *DefaultBatchScheduler) AddMetadataToPod(app *rayv1.RayCluster, pod *corev1.Pod) {
 }
 
 func (df *DefaultBatchSchedulerFactory) New(config *rest.Config) (BatchScheduler, error) {

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -9,7 +9,7 @@ import (
 	semver "github.com/Masterminds/semver/v3"
 	"github.com/google/shlex"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/yaml"
 )
@@ -137,27 +137,27 @@ func GetK8sJobCommand(rayJobInstance *rayv1.RayJob) ([]string, error) {
 }
 
 // GetDefaultSubmitterTemplate creates a default submitter template for the Ray job.
-func GetDefaultSubmitterTemplate(rayClusterInstance *rayv1.RayCluster) v1.PodTemplateSpec {
-	return v1.PodTemplateSpec{
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+func GetDefaultSubmitterTemplate(rayClusterInstance *rayv1.RayCluster) corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name: "ray-job-submitter",
 					// Use the image of the Ray head to be defensive against version mismatch issues
 					Image: rayClusterInstance.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Image,
-					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("1"),
-							v1.ResourceMemory: resource.MustParse("1Gi"),
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
 						},
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("500m"),
-							v1.ResourceMemory: resource.MustParse("200Mi"),
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("200Mi"),
 						},
 					},
 				},
 			},
-			RestartPolicy: v1.RestartPolicyNever,
+			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
 }

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/stretchr/testify/assert"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -39,7 +39,7 @@ var instance = rayv1.RayCluster{
 				"include-dashboard":   "true",
 				"log-color":           "true",
 			},
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Labels: map[string]string{
@@ -47,16 +47,16 @@ var instance = rayv1.RayCluster{
 						"ray.io/group":   "headgroup",
 					},
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
 							Name:  "ray-head",
 							Image: "repo/image:custom",
-							Env: []v1.EnvVar{
+							Env: []corev1.EnvVar{
 								{
 									Name: "MY_POD_IP",
-									ValueFrom: &v1.EnvVarSource{
-										FieldRef: &v1.ObjectFieldSelector{
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
 											FieldPath: "status.podIP",
 										},
 									},
@@ -66,14 +66,14 @@ var instance = rayv1.RayCluster{
 									Value: "TEST_ENV_VALUE",
 								},
 							},
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse("1"),
-									v1.ResourceMemory: testMemoryLimit,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: testMemoryLimit,
 								},
-								Limits: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse("1"),
-									v1.ResourceMemory: testMemoryLimit,
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: testMemoryLimit,
 								},
 							},
 						},
@@ -91,27 +91,27 @@ var instance = rayv1.RayCluster{
 					"port":     "6379",
 					"num-cpus": "1",
 				},
-				Template: v1.PodTemplateSpec{
+				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
 					},
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
 							{
 								Name:  "ray-worker",
 								Image: "repo/image:custom",
-								Resources: v1.ResourceRequirements{
-									Limits: v1.ResourceList{
-										v1.ResourceCPU:    resource.MustParse("1"),
-										v1.ResourceMemory: testMemoryLimit,
-										"nvidia.com/gpu":  resource.MustParse("3"),
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: testMemoryLimit,
+										"nvidia.com/gpu":      resource.MustParse("3"),
 									},
 								},
-								Env: []v1.EnvVar{
+								Env: []corev1.EnvVar{
 									{
 										Name: "MY_POD_IP",
-										ValueFrom: &v1.EnvVarSource{
-											FieldRef: &v1.ObjectFieldSelector{
+										ValueFrom: &corev1.EnvVarSource{
+											FieldRef: &corev1.ObjectFieldSelector{
 												FieldPath: "status.podIP",
 											},
 										},
@@ -130,39 +130,39 @@ var instance = rayv1.RayCluster{
 	},
 }
 
-var volumesNoAutoscaler = []v1.Volume{
+var volumesNoAutoscaler = []corev1.Volume{
 	{
 		Name: "shared-mem",
-		VolumeSource: v1.VolumeSource{
-			EmptyDir: &v1.EmptyDirVolumeSource{
-				Medium:    v1.StorageMediumMemory,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium:    corev1.StorageMediumMemory,
 				SizeLimit: &testMemoryLimit,
 			},
 		},
 	},
 }
 
-var volumesWithAutoscaler = []v1.Volume{
+var volumesWithAutoscaler = []corev1.Volume{
 	{
 		Name: "shared-mem",
-		VolumeSource: v1.VolumeSource{
-			EmptyDir: &v1.EmptyDirVolumeSource{
-				Medium:    v1.StorageMediumMemory,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium:    corev1.StorageMediumMemory,
 				SizeLimit: &testMemoryLimit,
 			},
 		},
 	},
 	{
 		Name: "ray-logs",
-		VolumeSource: v1.VolumeSource{
-			EmptyDir: &v1.EmptyDirVolumeSource{
-				Medium: v1.StorageMediumDefault,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium: corev1.StorageMediumDefault,
 			},
 		},
 	},
 }
 
-var volumeMountsNoAutoscaler = []v1.VolumeMount{
+var volumeMountsNoAutoscaler = []corev1.VolumeMount{
 	{
 		Name:      "shared-mem",
 		MountPath: "/dev/shm",
@@ -170,7 +170,7 @@ var volumeMountsNoAutoscaler = []v1.VolumeMount{
 	},
 }
 
-var volumeMountsWithAutoscaler = []v1.VolumeMount{
+var volumeMountsWithAutoscaler = []corev1.VolumeMount{
 	{
 		Name:      "shared-mem",
 		MountPath: "/dev/shm",
@@ -183,31 +183,31 @@ var volumeMountsWithAutoscaler = []v1.VolumeMount{
 	},
 }
 
-var autoscalerContainer = v1.Container{
+var autoscalerContainer = corev1.Container{
 	Name:            "autoscaler",
 	Image:           "repo/image:custom",
-	ImagePullPolicy: v1.PullIfNotPresent,
-	Env: []v1.EnvVar{
+	ImagePullPolicy: corev1.PullIfNotPresent,
+	Env: []corev1.EnvVar{
 		{
 			Name: RAY_CLUSTER_NAME,
-			ValueFrom: &v1.EnvVarSource{
-				FieldRef: &v1.ObjectFieldSelector{
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: fmt.Sprintf("metadata.labels['%s']", RayClusterLabelKey),
 				},
 			},
 		},
 		{
 			Name: "RAY_CLUSTER_NAMESPACE",
-			ValueFrom: &v1.EnvVarSource{
-				FieldRef: &v1.ObjectFieldSelector{
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: "metadata.namespace",
 				},
 			},
 		},
 		{
 			Name: "RAY_HEAD_POD_NAME",
-			ValueFrom: &v1.EnvVarSource{
-				FieldRef: &v1.ObjectFieldSelector{
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: "metadata.name",
 				},
 			},
@@ -227,17 +227,17 @@ var autoscalerContainer = v1.Container{
 		"--cluster-namespace",
 		"$(RAY_CLUSTER_NAMESPACE)",
 	},
-	Resources: v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("500m"),
-			v1.ResourceMemory: resource.MustParse("512Mi"),
+	Resources: corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
 		},
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("500m"),
-			v1.ResourceMemory: resource.MustParse("512Mi"),
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
 		},
 	},
-	VolumeMounts: []v1.VolumeMount{
+	VolumeMounts: []corev1.VolumeMount{
 		{
 			MountPath: "/tmp/ray",
 			Name:      "ray-logs",
@@ -248,12 +248,12 @@ var autoscalerContainer = v1.Container{
 var trueFlag = true
 
 func TestAddEmptyDirVolumes(t *testing.T) {
-	testPod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+	testPod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name: "ray-worker",
-					VolumeMounts: []v1.VolumeMount{
+					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "shared-mem",
 							MountPath: "/dev/shm",
@@ -261,12 +261,12 @@ func TestAddEmptyDirVolumes(t *testing.T) {
 					},
 				},
 			},
-			Volumes: []v1.Volume{
+			Volumes: []corev1.Volume{
 				{
 					Name: "shared-mem",
-					VolumeSource: v1.VolumeSource{
-						EmptyDir: &v1.EmptyDirVolumeSource{
-							Medium: v1.StorageMediumMemory,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium: corev1.StorageMediumMemory,
 						},
 					},
 				},
@@ -275,10 +275,10 @@ func TestAddEmptyDirVolumes(t *testing.T) {
 	}
 	assert.Equal(t, len(testPod.Spec.Containers[0].VolumeMounts), 1)
 	assert.Equal(t, len(testPod.Spec.Volumes), 1)
-	addEmptyDir(&testPod.Spec.Containers[0], testPod, "shared-mem2", "/dev/shm2", v1.StorageMediumDefault)
+	addEmptyDir(&testPod.Spec.Containers[0], testPod, "shared-mem2", "/dev/shm2", corev1.StorageMediumDefault)
 	assert.Equal(t, len(testPod.Spec.Containers[0].VolumeMounts), 2)
 	assert.Equal(t, len(testPod.Spec.Volumes), 2)
-	addEmptyDir(&testPod.Spec.Containers[0], testPod, "shared-mem2", "/dev/shm2", v1.StorageMediumDefault)
+	addEmptyDir(&testPod.Spec.Containers[0], testPod, "shared-mem2", "/dev/shm2", corev1.StorageMediumDefault)
 	assert.Equal(t, len(testPod.Spec.Containers[0].VolumeMounts), 2)
 	assert.Equal(t, len(testPod.Spec.Volumes), 2)
 }
@@ -299,7 +299,7 @@ func TestGetHeadPort(t *testing.T) {
 	}
 }
 
-func getEnvVar(container v1.Container, envName string) *v1.EnvVar {
+func getEnvVar(container corev1.Container, envName string) *corev1.EnvVar {
 	for _, env := range container.Env {
 		if env.Name == envName {
 			return &env
@@ -308,7 +308,7 @@ func getEnvVar(container v1.Container, envName string) *v1.EnvVar {
 	return nil
 }
 
-func checkContainerEnv(t *testing.T, container v1.Container, envName string, expectedValue string) {
+func checkContainerEnv(t *testing.T, container corev1.Container, envName string, expectedValue string) {
 	env := getEnvVar(container, envName)
 	if env != nil {
 		if env.Value != "" {
@@ -551,7 +551,7 @@ func TestBuildPod_WithGcsFtEnabled(t *testing.T) {
 
 	// Add "RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S" env var in the head group spec.
 	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Env = append(cluster.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Env,
-		v1.EnvVar{Name: RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: "60"})
+		corev1.EnvVar{Name: RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: "60"})
 	podTemplateSpec = DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	pod = BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, "", "", false)
 	rayContainer = pod.Spec.Containers[RayContainerIndex]
@@ -584,7 +584,7 @@ func TestBuildPod_WithGcsFtEnabled(t *testing.T) {
 
 	// Add "RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S" env var in the worker group spec.
 	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[RayContainerIndex].Env = append(cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[RayContainerIndex].Env,
-		v1.EnvVar{Name: RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: "120"})
+		corev1.EnvVar{Name: RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: "120"})
 	worker = cluster.Spec.WorkerGroupSpecs[0]
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	pod = BuildPod(podTemplateSpec, rayv1.WorkerNode, worker.RayStartParams, "6379", nil, "", fqdnRayIP, false)
@@ -601,22 +601,22 @@ func TestBuildPodWithAutoscalerOptions(t *testing.T) {
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
 
 	customAutoscalerImage := "custom-autoscaler-xxx"
-	customPullPolicy := v1.PullIfNotPresent
+	customPullPolicy := corev1.PullIfNotPresent
 	customTimeout := int32(100)
 	customUpscaling := rayv1.UpscalingMode("Aggressive")
-	customResources := v1.ResourceRequirements{
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("1"),
-			v1.ResourceMemory: testMemoryLimit,
+	customResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: testMemoryLimit,
 		},
-		Limits: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("1"),
-			v1.ResourceMemory: testMemoryLimit,
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: testMemoryLimit,
 		},
 	}
-	customEnv := []v1.EnvVar{{Name: "fooEnv", Value: "fooValue"}}
-	customEnvFrom := []v1.EnvFromSource{{Prefix: "Pre"}}
-	customVolumeMounts := []v1.VolumeMount{
+	customEnv := []corev1.EnvVar{{Name: "fooEnv", Value: "fooValue"}}
+	customEnvFrom := []corev1.EnvFromSource{{Prefix: "Pre"}}
+	customVolumeMounts := []corev1.VolumeMount{
 		{
 			Name:      "ca-tls",
 			MountPath: "/etc/ca/tls",
@@ -630,14 +630,14 @@ func TestBuildPodWithAutoscalerOptions(t *testing.T) {
 
 	// Define a custom security profile.
 	allowPrivilegeEscalation := false
-	capabilities := v1.Capabilities{
-		Drop: []v1.Capability{"ALL"},
+	capabilities := corev1.Capabilities{
+		Drop: []corev1.Capability{"ALL"},
 	}
-	seccompProfile := v1.SeccompProfile{
-		Type: v1.SeccompProfileTypeRuntimeDefault,
+	seccompProfile := corev1.SeccompProfile{
+		Type: corev1.SeccompProfileTypeRuntimeDefault,
 	}
 	runAsNonRoot := true
-	customSecurityContext := v1.SecurityContext{
+	customSecurityContext := corev1.SecurityContext{
 		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 		Capabilities:             &capabilities,
 		RunAsNonRoot:             &runAsNonRoot,
@@ -711,7 +711,7 @@ func TestHeadPodTemplate_AutoscalerImage(t *testing.T) {
 	// Case 1: If `AutoscalerOptions.Image` is not set, the Autoscaler container should use the Ray head container's image by default.
 	expectedAutoscalerImage := cluster.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Image
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
-	pod := v1.Pod{
+	pod := corev1.Pod{
 		Spec: podTemplateSpec.Spec,
 	}
 	autoscalerContainerIndex := getAutoscalerContainerIndex(pod)
@@ -790,7 +790,7 @@ func TestValidateHeadRayStartParams_OK(t *testing.T) {
 func TestValidateHeadRayStartParams_ValidWithObjectStoreMemoryError(t *testing.T) {
 	input := instance.Spec.HeadGroupSpec.DeepCopy()
 	input.RayStartParams[ObjectStoreMemoryKey] = "2000000000"
-	input.Template.Spec.Containers[0].Env = append(input.Template.Spec.Containers[0].Env, v1.EnvVar{
+	input.Template.Spec.Containers[0].Env = append(input.Template.Spec.Containers[0].Env, corev1.EnvVar{
 		Name:  AllowSlowStorageEnvVar,
 		Value: "1",
 	})
@@ -827,7 +827,7 @@ func TestCleanupInvalidVolumeMounts(t *testing.T) {
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, "", "", false)
 
-	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, []v1.VolumeMount{
+	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, []corev1.VolumeMount{
 		{
 			Name:      "mock-name1",
 			MountPath: "/mock-path1",
@@ -858,7 +858,7 @@ func TestDefaultWorkerPodTemplateWithName(t *testing.T) {
 	assert.Equal(t, worker, expectedWorker)
 }
 
-func containerPortExists(ports []v1.ContainerPort, name string, containerPort int32) error {
+func containerPortExists(ports []corev1.ContainerPort, name string, containerPort int32) error {
 	for _, port := range ports {
 		if port.Name == name {
 			if port.ContainerPort != containerPort {
@@ -872,7 +872,7 @@ func containerPortExists(ports []v1.ContainerPort, name string, containerPort in
 
 func TestDefaultHeadPodTemplateWithConfigurablePorts(t *testing.T) {
 	cluster := instance.DeepCopy()
-	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = []v1.ContainerPort{}
+	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{}
 	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	// DefaultHeadPodTemplate will add the default metrics port if user doesn't specify it.
@@ -881,11 +881,11 @@ func TestDefaultHeadPodTemplateWithConfigurablePorts(t *testing.T) {
 		t.Fatal(err)
 	}
 	customMetricsPort := int32(DefaultMetricsPort) + 1
-	metricsPort := v1.ContainerPort{
+	metricsPort := corev1.ContainerPort{
 		Name:          MetricsPortName,
 		ContainerPort: customMetricsPort,
 	}
-	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = []v1.ContainerPort{metricsPort}
+	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{metricsPort}
 	podTemplateSpec = DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	// Verify the custom metrics port exists.
 	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, MetricsPortName, customMetricsPort); err != nil {
@@ -895,7 +895,7 @@ func TestDefaultHeadPodTemplateWithConfigurablePorts(t *testing.T) {
 
 func TestDefaultWorkerPodTemplateWithConfigurablePorts(t *testing.T) {
 	cluster := instance.DeepCopy()
-	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Ports = []v1.ContainerPort{}
+	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Ports = []corev1.ContainerPort{}
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	podName := cluster.Name + DashSymbol + string(rayv1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
 	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
@@ -906,11 +906,11 @@ func TestDefaultWorkerPodTemplateWithConfigurablePorts(t *testing.T) {
 		t.Fatal(err)
 	}
 	customMetricsPort := int32(DefaultMetricsPort) + 1
-	metricsPort := v1.ContainerPort{
+	metricsPort := corev1.ContainerPort{
 		Name:          MetricsPortName,
 		ContainerPort: customMetricsPort,
 	}
-	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Ports = []v1.ContainerPort{metricsPort}
+	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Ports = []corev1.ContainerPort{metricsPort}
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	// Verify the custom metrics port exists.
 	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, MetricsPortName, customMetricsPort); err != nil {
@@ -959,23 +959,23 @@ func TestDefaultInitContainerImagePullPolicy(t *testing.T) {
 
 	cases := []struct {
 		name               string
-		imagePullPolicy    v1.PullPolicy
-		expectedPullPolicy v1.PullPolicy
+		imagePullPolicy    corev1.PullPolicy
+		expectedPullPolicy corev1.PullPolicy
 	}{
 		{
 			name:               "Always",
-			imagePullPolicy:    v1.PullAlways,
-			expectedPullPolicy: v1.PullAlways,
+			imagePullPolicy:    corev1.PullAlways,
+			expectedPullPolicy: corev1.PullAlways,
 		},
 		{
 			name:               "IfNotPresent",
-			imagePullPolicy:    v1.PullIfNotPresent,
-			expectedPullPolicy: v1.PullIfNotPresent,
+			imagePullPolicy:    corev1.PullIfNotPresent,
+			expectedPullPolicy: corev1.PullIfNotPresent,
 		},
 		{
 			name:               "Never",
-			imagePullPolicy:    v1.PullNever,
-			expectedPullPolicy: v1.PullNever,
+			imagePullPolicy:    corev1.PullNever,
+			expectedPullPolicy: corev1.PullNever,
 		},
 	}
 
@@ -1201,9 +1201,9 @@ func TestGetEnableProbesInjection(t *testing.T) {
 
 func TestInitHealthProbe(t *testing.T) {
 	// Test 1: User defines a custom HTTPGet probe.
-	httpGetProbe := v1.Probe{
-		ProbeHandler: v1.ProbeHandler{
-			HTTPGet: &v1.HTTPGetAction{
+	httpGetProbe := corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
 				// Check Raylet status
 				Path: fmt.Sprintf("/%s", RayAgentRayletHealthPath),
 				Port: intstr.FromInt(DefaultDashboardAgentListenPort),
@@ -1215,7 +1215,7 @@ func TestInitHealthProbe(t *testing.T) {
 	assert.Nil(t, httpGetProbe.Exec)
 
 	// Test 2: User does not define a custom probe. KubeRay will inject a default Exec probe.
-	probe := v1.Probe{}
+	probe := corev1.Probe{}
 	initHealthProbe(&probe, rayv1.HeadNode)
 	assert.NotNil(t, probe.Exec)
 }

--- a/ray-operator/controllers/ray/common/rbac.go
+++ b/ray-operator/controllers/ray/common/rbac.go
@@ -3,14 +3,14 @@ package common
 import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // BuildServiceAccount creates a new ServiceAccount for a head pod with autoscaler.
-func BuildServiceAccount(cluster *rayv1.RayCluster) (*v1.ServiceAccount, error) {
-	sa := &v1.ServiceAccount{
+func BuildServiceAccount(cluster *rayv1.RayCluster) (*corev1.ServiceAccount, error) {
+	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.GetHeadGroupServiceAccountName(cluster),
 			Namespace: cluster.Namespace,

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1121,14 +1120,14 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(instance rayv1.RayCluster) b
 
 	// The container's resource consumption remains constant. so hard-coding the resources is acceptable.
 	// In addition, avoid using the GPU for the Redis cleanup Job.
-	pod.Spec.Containers[common.RayContainerIndex].Resources = v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("200m"),
-			v1.ResourceMemory: resource.MustParse("256Mi"),
+	pod.Spec.Containers[common.RayContainerIndex].Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		},
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("200m"),
-			v1.ResourceMemory: resource.MustParse("256Mi"),
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		},
 	}
 

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -9,7 +9,6 @@ import (
 	fmtErrors "github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -367,8 +366,8 @@ func (r *RayJobReconciler) getOrCreateK8sJob(ctx context.Context, rayJobInstance
 }
 
 // getSubmitterTemplate builds the submitter pod template for the Ray job.
-func (r *RayJobReconciler) getSubmitterTemplate(rayJobInstance *rayv1.RayJob, rayClusterInstance *rayv1.RayCluster) (v1.PodTemplateSpec, error) {
-	var submitterTemplate v1.PodTemplateSpec
+func (r *RayJobReconciler) getSubmitterTemplate(rayJobInstance *rayv1.RayJob, rayClusterInstance *rayv1.RayCluster) (corev1.PodTemplateSpec, error) {
+	var submitterTemplate corev1.PodTemplateSpec
 
 	// Set the default value for the optional field SubmitterPodTemplate if not provided.
 	if rayJobInstance.Spec.SubmitterPodTemplate == nil {
@@ -388,7 +387,7 @@ func (r *RayJobReconciler) getSubmitterTemplate(rayJobInstance *rayv1.RayJob, ra
 
 		k8sJobCommand, err := common.GetK8sJobCommand(rayJobInstance)
 		if err != nil {
-			return v1.PodTemplateSpec{}, err
+			return corev1.PodTemplateSpec{}, err
 		}
 		submitterTemplate.Spec.Containers[common.RayContainerIndex].Command = k8sJobCommand
 		r.Log.Info("No command is specified in the user-provided template. Default command is used", "command", k8sJobCommand)
@@ -397,7 +396,7 @@ func (r *RayJobReconciler) getSubmitterTemplate(rayJobInstance *rayv1.RayJob, ra
 	}
 
 	// Set PYTHONUNBUFFERED=1 for real-time logging
-	submitterTemplate.Spec.Containers[common.RayContainerIndex].Env = append(submitterTemplate.Spec.Containers[common.RayContainerIndex].Env, v1.EnvVar{
+	submitterTemplate.Spec.Containers[common.RayContainerIndex].Env = append(submitterTemplate.Spec.Containers[common.RayContainerIndex].Env, corev1.EnvVar{
 		Name:  PythonUnbufferedEnvVarName,
 		Value: "1",
 	})
@@ -406,7 +405,7 @@ func (r *RayJobReconciler) getSubmitterTemplate(rayJobInstance *rayv1.RayJob, ra
 }
 
 // createNewK8sJob creates a new Kubernetes Job. It returns the Job's name and a boolean indicating whether a new Job was created.
-func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *rayv1.RayJob, submitterTemplate v1.PodTemplateSpec) (string, bool, error) {
+func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *rayv1.RayJob, submitterTemplate corev1.PodTemplateSpec) (string, bool, error) {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rayJobInstance.Name,


### PR DESCRIPTION
This PR unifies all `v1 "k8s.io/api/core/v1"` to `corev1 "k8s.io/api/core/v1"` and removes duplicated imports, such as here found by @kevin85421: https://github.com/ray-project/kuberay/blob/b16c705c5e6fe194932301312ade7e1a87ec0ae2/ray-operator/controllers/ray/rayjob_controller.go#L11-L12

The `corev1` alias is a better choice than `v1` given that there are a lot of other packages named `v1` such as ` k8s.io/api/batch/v1` and `k8s.io/apimachinery/pkg/apis/meta/v1`. If we just use the `v1`, we will be easily confused with other `v1`.

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
