### PR TITLE
[Refactor] Move constant.go from common to utils to avoid circular dependency

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/schedulermanager.go
+++ b/ray-operator/controllers/ray/batchscheduler/schedulermanager.go
@@ -11,7 +11,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	schedulerinterface "github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/interface"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/volcano"
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 )
 
 var schedulerContainers = map[string]schedulerinterface.BatchSchedulerFactory{
@@ -55,7 +55,7 @@ func NewSchedulerManager(config *rest.Config) *SchedulerManager {
 }
 
 func (batch *SchedulerManager) GetSchedulerForCluster(app *rayv1.RayCluster) (schedulerinterface.BatchScheduler, error) {
-	if schedulerName, ok := app.ObjectMeta.Labels[common.RaySchedulerName]; ok {
+	if schedulerName, ok := app.ObjectMeta.Labels[utils.RaySchedulerName]; ok {
 		return batch.GetScheduler(schedulerName)
 	}
 

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -18,7 +18,6 @@ import (
 	volcanoclient "volcano.sh/apis/pkg/client/clientset/versioned"
 
 	schedulerinterface "github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/interface"
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
@@ -128,7 +127,7 @@ func createPodGroup(
 		podGroup.Spec.Queue = queue
 	}
 
-	if priorityClassName, ok := app.ObjectMeta.Labels[common.RayPriorityClassName]; ok {
+	if priorityClassName, ok := app.ObjectMeta.Labels[utils.RayPriorityClassName]; ok {
 		podGroup.Spec.PriorityClassName = priorityClassName
 	}
 
@@ -140,7 +139,7 @@ func (v *VolcanoBatchScheduler) AddMetadataToPod(app *rayv1.RayCluster, pod *cor
 	if queue, ok := app.ObjectMeta.Labels[QueueNameLabelKey]; ok {
 		pod.Labels[QueueNameLabelKey] = queue
 	}
-	if priorityClassName, ok := app.ObjectMeta.Labels[common.RayPriorityClassName]; ok {
+	if priorityClassName, ok := app.ObjectMeta.Labels[utils.RayPriorityClassName]; ok {
 		pod.Spec.PriorityClassName = priorityClassName
 	}
 	pod.Spec.SchedulerName = v.Name()

--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -17,10 +17,10 @@ const IngressClassAnnotationKey = "kubernetes.io/ingress.class"
 // This is used to expose dashboard for external traffic.
 func BuildIngressForHeadService(cluster rayv1.RayCluster) (*networkingv1.Ingress, error) {
 	labels := map[string]string{
-		RayClusterLabelKey:                cluster.Name,
-		RayIDLabelKey:                     utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode),
-		KubernetesApplicationNameLabelKey: ApplicationName,
-		KubernetesCreatedByLabelKey:       ComponentName,
+		utils.RayClusterLabelKey:                cluster.Name,
+		utils.RayIDLabelKey:                     utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode),
+		utils.KubernetesApplicationNameLabelKey: utils.ApplicationName,
+		utils.KubernetesCreatedByLabelKey:       utils.ComponentName,
 	}
 
 	// Copy other ingress configurations from cluster annotations to provide a generic way
@@ -40,7 +40,7 @@ func BuildIngressForHeadService(cluster rayv1.RayCluster) (*networkingv1.Ingress
 	var paths []networkingv1.HTTPIngressPath
 	pathType := networkingv1.PathTypeExact
 	servicePorts := getServicePorts(cluster)
-	dashboardPort := int32(DefaultDashboardPort)
+	dashboardPort := int32(utils.DefaultDashboardPort)
 	if port, ok := servicePorts["dashboard"]; ok {
 		dashboardPort = port
 	}
@@ -113,8 +113,8 @@ func BuildIngressForRayService(service rayv1.RayService, cluster rayv1.RayCluste
 	ingress.ObjectMeta.Name = headSvcName
 	ingress.ObjectMeta.Namespace = service.Namespace
 	ingress.ObjectMeta.Labels = map[string]string{
-		RayServiceLabelKey: service.Name,
-		RayIDLabelKey:      utils.CheckLabel(utils.GenerateIdentifier(service.Name, rayv1.HeadNode)),
+		utils.RayServiceLabelKey: service.Name,
+		utils.RayIDLabelKey:      utils.CheckLabel(utils.GenerateIdentifier(service.Name, rayv1.HeadNode)),
 	}
 
 	return ingress, nil

--- a/ray-operator/controllers/ray/common/ingress_test.go
+++ b/ray-operator/controllers/ray/common/ingress_test.go
@@ -85,7 +85,7 @@ func TestBuildIngressForHeadService(t *testing.T) {
 	assert.Nil(t, err)
 
 	// check ingress.class annotation
-	actualResult := ingress.Labels[RayClusterLabelKey]
+	actualResult := ingress.Labels[utils.RayClusterLabelKey]
 	expectedResult := instanceWithIngressEnabled.Name
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -9,6 +9,7 @@ import (
 	semver "github.com/Masterminds/semver/v3"
 	"github.com/google/shlex"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/yaml"
@@ -144,7 +145,7 @@ func GetDefaultSubmitterTemplate(rayClusterInstance *rayv1.RayCluster) corev1.Po
 				{
 					Name: "ray-job-submitter",
 					// Use the image of the Ray head to be defensive against version mismatch issues
-					Image: rayClusterInstance.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Image,
+					Image: rayClusterInstance.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Image,
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("1"),

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -197,5 +198,5 @@ func TestGetDefaultSubmitterTemplate(t *testing.T) {
 		},
 	}
 	template := GetDefaultSubmitterTemplate(rayCluster)
-	assert.Equal(t, template.Spec.Containers[0].Image, rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Image)
+	assert.Equal(t, template.Spec.Containers[0].Image, rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Image)
 }

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -189,10 +189,10 @@ var autoscalerContainer = corev1.Container{
 	ImagePullPolicy: corev1.PullIfNotPresent,
 	Env: []corev1.EnvVar{
 		{
-			Name: RAY_CLUSTER_NAME,
+			Name: utils.RAY_CLUSTER_NAME,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: fmt.Sprintf("metadata.labels['%s']", RayClusterLabelKey),
+					FieldPath: fmt.Sprintf("metadata.labels['%s']", utils.RayClusterLabelKey),
 				},
 			},
 		},
@@ -331,37 +331,37 @@ func TestBuildPod(t *testing.T) {
 	cluster := instance.DeepCopy()
 
 	// Test head pod
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, "", "", false)
 
 	// Check environment variables
-	rayContainer := pod.Spec.Containers[RayContainerIndex]
-	checkContainerEnv(t, rayContainer, RAY_ADDRESS, "127.0.0.1:6379")
-	checkContainerEnv(t, rayContainer, RAY_USAGE_STATS_KUBERAY_IN_USE, "1")
-	checkContainerEnv(t, rayContainer, RAY_CLUSTER_NAME, fmt.Sprintf("metadata.labels['%s']", RayClusterLabelKey))
-	checkContainerEnv(t, rayContainer, RAY_DASHBOARD_ENABLE_K8S_DISK_USAGE, "1")
-	headRayStartCommandEnv := getEnvVar(rayContainer, KUBERAY_GEN_RAY_START_CMD)
+	rayContainer := pod.Spec.Containers[utils.RayContainerIndex]
+	checkContainerEnv(t, rayContainer, utils.RAY_ADDRESS, "127.0.0.1:6379")
+	checkContainerEnv(t, rayContainer, utils.RAY_USAGE_STATS_KUBERAY_IN_USE, "1")
+	checkContainerEnv(t, rayContainer, utils.RAY_CLUSTER_NAME, fmt.Sprintf("metadata.labels['%s']", utils.RayClusterLabelKey))
+	checkContainerEnv(t, rayContainer, utils.RAY_DASHBOARD_ENABLE_K8S_DISK_USAGE, "1")
+	headRayStartCommandEnv := getEnvVar(rayContainer, utils.KUBERAY_GEN_RAY_START_CMD)
 	assert.True(t, strings.Contains(headRayStartCommandEnv.Value, "ray start"))
 
 	// In head, init container needs FQ_RAY_IP to create a self-signed certificate for its TLS authenticate.
 	for _, initContainer := range pod.Spec.InitContainers {
-		checkContainerEnv(t, initContainer, FQ_RAY_IP, "raycluster-sample-head-svc.default.svc.cluster.local")
-		checkContainerEnv(t, rayContainer, RAY_IP, "raycluster-sample-head-svc")
+		checkContainerEnv(t, initContainer, utils.FQ_RAY_IP, "raycluster-sample-head-svc.default.svc.cluster.local")
+		checkContainerEnv(t, rayContainer, utils.RAY_IP, "raycluster-sample-head-svc")
 	}
 
 	// Check labels.
-	actualResult := pod.Labels[RayClusterLabelKey]
+	actualResult := pod.Labels[utils.RayClusterLabelKey]
 	expectedResult := cluster.Name
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
-	actualResult = pod.Labels[RayNodeTypeLabelKey]
+	actualResult = pod.Labels[utils.RayNodeTypeLabelKey]
 	expectedResult = string(rayv1.HeadNode)
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
-	actualResult = pod.Labels[RayNodeGroupLabelKey]
+	actualResult = pod.Labels[utils.RayNodeGroupLabelKey]
 	expectedResult = "headgroup"
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
@@ -383,19 +383,19 @@ func TestBuildPod(t *testing.T) {
 
 	// testing worker pod
 	worker := cluster.Spec.WorkerGroupSpecs[0]
-	podName = cluster.Name + DashSymbol + string(rayv1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
+	podName = cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
 	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	pod = BuildPod(podTemplateSpec, rayv1.WorkerNode, worker.RayStartParams, "6379", nil, "", fqdnRayIP, false)
 
 	// Check environment variables
-	rayContainer = pod.Spec.Containers[RayContainerIndex]
-	checkContainerEnv(t, rayContainer, RAY_ADDRESS, "raycluster-sample-head-svc.default.svc.cluster.local:6379")
-	checkContainerEnv(t, rayContainer, FQ_RAY_IP, "raycluster-sample-head-svc.default.svc.cluster.local")
-	checkContainerEnv(t, rayContainer, RAY_IP, "raycluster-sample-head-svc")
-	checkContainerEnv(t, rayContainer, RAY_CLUSTER_NAME, fmt.Sprintf("metadata.labels['%s']", RayClusterLabelKey))
-	checkContainerEnv(t, rayContainer, RAY_DASHBOARD_ENABLE_K8S_DISK_USAGE, "1")
-	workerRayStartCommandEnv := getEnvVar(rayContainer, KUBERAY_GEN_RAY_START_CMD)
+	rayContainer = pod.Spec.Containers[utils.RayContainerIndex]
+	checkContainerEnv(t, rayContainer, utils.RAY_ADDRESS, "raycluster-sample-head-svc.default.svc.cluster.local:6379")
+	checkContainerEnv(t, rayContainer, utils.FQ_RAY_IP, "raycluster-sample-head-svc.default.svc.cluster.local")
+	checkContainerEnv(t, rayContainer, utils.RAY_IP, "raycluster-sample-head-svc")
+	checkContainerEnv(t, rayContainer, utils.RAY_CLUSTER_NAME, fmt.Sprintf("metadata.labels['%s']", utils.RayClusterLabelKey))
+	checkContainerEnv(t, rayContainer, utils.RAY_DASHBOARD_ENABLE_K8S_DISK_USAGE, "1")
+	workerRayStartCommandEnv := getEnvVar(rayContainer, utils.KUBERAY_GEN_RAY_START_CMD)
 	assert.True(t, strings.Contains(workerRayStartCommandEnv.Value, "ray start"))
 
 	expectedCommandArg := splitAndSort("ulimit -n 65536; ray start --block --memory=1073741824 --num-cpus=1 --num-gpus=3 --address=raycluster-sample-head-svc.default.svc.cluster.local:6379 --port=6379 --metrics-export-port=8080")
@@ -405,14 +405,14 @@ func TestBuildPod(t *testing.T) {
 	}
 
 	// Check Envs
-	rayContainer = pod.Spec.Containers[RayContainerIndex]
+	rayContainer = pod.Spec.Containers[utils.RayContainerIndex]
 	checkContainerEnv(t, rayContainer, "TEST_ENV_NAME", "TEST_ENV_VALUE")
 
 	// Try to build pod for serve
 	pod = BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, "", "", true)
-	val, ok := pod.Labels[RayClusterServingServiceLabelKey]
+	val, ok := pod.Labels[utils.RayClusterServingServiceLabelKey]
 	assert.True(t, ok, "Expected serve label is not present")
-	assert.Equal(t, EnableRayClusterServingServiceTrue, val, "Wrong serve label value")
+	assert.Equal(t, utils.EnableRayClusterServingServiceTrue, val, "Wrong serve label value")
 }
 
 func TestBuildPod_WithOverwriteCommand(t *testing.T) {
@@ -420,26 +420,26 @@ func TestBuildPod_WithOverwriteCommand(t *testing.T) {
 	cluster.Annotations = map[string]string{
 		// When the value of the annotation is "true", KubeRay will not generate the command and args for the container.
 		// Instead, it will use the command and args specified by the use.
-		RayOverwriteContainerCmdAnnotationKey: "true",
+		utils.RayOverwriteContainerCmdAnnotationKey: "true",
 	}
-	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Command = []string{"I am head"}
-	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Args = []string{"I am head again"}
-	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[RayContainerIndex].Command = []string{"I am worker"}
-	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[RayContainerIndex].Args = []string{"I am worker again"}
+	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Command = []string{"I am head"}
+	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Args = []string{"I am head again"}
+	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[utils.RayContainerIndex].Command = []string{"I am worker"}
+	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[utils.RayContainerIndex].Args = []string{"I am worker again"}
 
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	headPod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, "", "", false)
-	headContainer := headPod.Spec.Containers[RayContainerIndex]
+	headContainer := headPod.Spec.Containers[utils.RayContainerIndex]
 	assert.Equal(t, headContainer.Command, []string{"I am head"})
 	assert.Equal(t, headContainer.Args, []string{"I am head again"})
 
 	worker := cluster.Spec.WorkerGroupSpecs[0]
-	podName = cluster.Name + DashSymbol + string(rayv1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
+	podName = cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
 	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	workerPod := BuildPod(podTemplateSpec, rayv1.WorkerNode, worker.RayStartParams, "6379", nil, "", fqdnRayIP, false)
-	workerContainer := workerPod.Spec.Containers[RayContainerIndex]
+	workerContainer := workerPod.Spec.Containers[utils.RayContainerIndex]
 	assert.Equal(t, workerContainer.Command, []string{"I am worker"})
 	assert.Equal(t, workerContainer.Args, []string{"I am worker again"})
 }
@@ -447,21 +447,21 @@ func TestBuildPod_WithOverwriteCommand(t *testing.T) {
 func TestBuildPod_WithAutoscalerEnabled(t *testing.T) {
 	cluster := instance.DeepCopy()
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", &trueFlag, "", "", false)
 
-	actualResult := pod.Labels[RayClusterLabelKey]
+	actualResult := pod.Labels[utils.RayClusterLabelKey]
 	expectedResult := cluster.Name
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
-	actualResult = pod.Labels[RayNodeTypeLabelKey]
+	actualResult = pod.Labels[utils.RayNodeTypeLabelKey]
 	expectedResult = string(rayv1.HeadNode)
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
-	actualResult = pod.Labels[RayNodeGroupLabelKey]
+	actualResult = pod.Labels[utils.RayNodeGroupLabelKey]
 	expectedResult = "headgroup"
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
@@ -502,9 +502,9 @@ func TestBuildPod_WithAutoscalerEnabled(t *testing.T) {
 func TestBuildPod_WithCreatedByRayService(t *testing.T) {
 	cluster := instance.DeepCopy()
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
-	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", &trueFlag, RayServiceCreatorLabelValue, "", false)
+	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", &trueFlag, utils.RayServiceCreatorLabelValue, "", false)
 
 	hasCorrectDeathEnv := false
 	for _, container := range pod.Spec.Containers {
@@ -515,7 +515,7 @@ func TestBuildPod_WithCreatedByRayService(t *testing.T) {
 			t.Fatalf("Expected death env `%v`", container)
 		}
 		for _, env := range container.Env {
-			if env.Name == RAY_TIMEOUT_MS_TASK_WAIT_FOR_DEATH_INFO {
+			if env.Name == utils.RAY_TIMEOUT_MS_TASK_WAIT_FOR_DEATH_INFO {
 				assert.Equal(t, "0", env.Value)
 				hasCorrectDeathEnv = true
 				break
@@ -529,76 +529,76 @@ func TestBuildPod_WithGcsFtEnabled(t *testing.T) {
 	// Test 1
 	cluster := instance.DeepCopy()
 	cluster.Annotations = map[string]string{
-		RayFTEnabledAnnotationKey: "true",
+		utils.RayFTEnabledAnnotationKey: "true",
 	}
 
 	// Build a head Pod.
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, "", "", false)
 
 	// Check environment variable "RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S"
-	rayContainer := pod.Spec.Containers[RayContainerIndex]
+	rayContainer := pod.Spec.Containers[utils.RayContainerIndex]
 
 	// "RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S" should not be set on the head Pod by default
-	assert.True(t, !envVarExists(RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, rayContainer.Env))
+	assert.True(t, !envVarExists(utils.RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, rayContainer.Env))
 
 	// Test 2
 	cluster = instance.DeepCopy()
 	cluster.Annotations = map[string]string{
-		RayFTEnabledAnnotationKey: "true",
+		utils.RayFTEnabledAnnotationKey: "true",
 	}
 
 	// Add "RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S" env var in the head group spec.
-	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Env = append(cluster.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Env,
-		corev1.EnvVar{Name: RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: "60"})
+	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Env = append(cluster.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Env,
+		corev1.EnvVar{Name: utils.RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: "60"})
 	podTemplateSpec = DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	pod = BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, "", "", false)
-	rayContainer = pod.Spec.Containers[RayContainerIndex]
+	rayContainer = pod.Spec.Containers[utils.RayContainerIndex]
 
 	// Check environment variable "RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S"
-	checkContainerEnv(t, rayContainer, RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, "60")
+	checkContainerEnv(t, rayContainer, utils.RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, "60")
 
 	// Test 3
 	cluster = instance.DeepCopy()
 	cluster.Annotations = map[string]string{
-		RayFTEnabledAnnotationKey: "true",
+		utils.RayFTEnabledAnnotationKey: "true",
 	}
 
 	// Build a worker pod
 	worker := cluster.Spec.WorkerGroupSpecs[0]
-	podName = cluster.Name + DashSymbol + string(rayv1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
+	podName = cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
 	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	pod = BuildPod(podTemplateSpec, rayv1.WorkerNode, worker.RayStartParams, "6379", nil, "", fqdnRayIP, false)
 
 	// Check the default value of "RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S"
-	rayContainer = pod.Spec.Containers[RayContainerIndex]
-	checkContainerEnv(t, rayContainer, RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, DefaultWorkerRayGcsReconnectTimeoutS)
+	rayContainer = pod.Spec.Containers[utils.RayContainerIndex]
+	checkContainerEnv(t, rayContainer, utils.RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, utils.DefaultWorkerRayGcsReconnectTimeoutS)
 
 	// Test 4
 	cluster = instance.DeepCopy()
 	cluster.Annotations = map[string]string{
-		RayFTEnabledAnnotationKey: "true",
+		utils.RayFTEnabledAnnotationKey: "true",
 	}
 
 	// Add "RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S" env var in the worker group spec.
-	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[RayContainerIndex].Env = append(cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[RayContainerIndex].Env,
-		corev1.EnvVar{Name: RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: "120"})
+	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[utils.RayContainerIndex].Env = append(cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[utils.RayContainerIndex].Env,
+		corev1.EnvVar{Name: utils.RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, Value: "120"})
 	worker = cluster.Spec.WorkerGroupSpecs[0]
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	pod = BuildPod(podTemplateSpec, rayv1.WorkerNode, worker.RayStartParams, "6379", nil, "", fqdnRayIP, false)
 
 	// Check the default value of "RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S"
-	rayContainer = pod.Spec.Containers[RayContainerIndex]
-	checkContainerEnv(t, rayContainer, RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, "120")
+	rayContainer = pod.Spec.Containers[utils.RayContainerIndex]
+	checkContainerEnv(t, rayContainer, utils.RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S, "120")
 }
 
 // Check that autoscaler container overrides work as expected.
 func TestBuildPodWithAutoscalerOptions(t *testing.T) {
 	cluster := instance.DeepCopy()
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 
 	customAutoscalerImage := "custom-autoscaler-xxx"
 	customPullPolicy := corev1.PullIfNotPresent
@@ -675,7 +675,7 @@ func TestBuildPodWithAutoscalerOptions(t *testing.T) {
 func TestHeadPodTemplate_WithAutoscalingEnabled(t *testing.T) {
 	cluster := instance.DeepCopy()
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 
 	// autoscaler container is injected into head pod
@@ -706,10 +706,10 @@ func TestHeadPodTemplate_AutoscalerImage(t *testing.T) {
 	cluster := instance.DeepCopy()
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
 	cluster.Spec.AutoscalerOptions = nil
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 
 	// Case 1: If `AutoscalerOptions.Image` is not set, the Autoscaler container should use the Ray head container's image by default.
-	expectedAutoscalerImage := cluster.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Image
+	expectedAutoscalerImage := cluster.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Image
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	pod := corev1.Pod{
 		Spec: podTemplateSpec.Spec,
@@ -734,7 +734,7 @@ func TestHeadPodTemplate_AutoscalerImage(t *testing.T) {
 // the head pod's service account should be an empty string.
 func TestHeadPodTemplate_WithNoServiceAccount(t *testing.T) {
 	cluster := instance.DeepCopy()
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 
 	actualResult := pod.Spec.ServiceAccountName
@@ -750,7 +750,7 @@ func TestHeadPodTemplate_WithServiceAccountNoAutoscaling(t *testing.T) {
 	cluster := instance.DeepCopy()
 	serviceAccount := "head-service-account"
 	cluster.Spec.HeadGroupSpec.Template.Spec.ServiceAccountName = serviceAccount
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 
 	actualResult := pod.Spec.ServiceAccountName
@@ -767,7 +767,7 @@ func TestHeadPodTemplate_WithServiceAccount(t *testing.T) {
 	serviceAccount := "head-service-account"
 	cluster.Spec.HeadGroupSpec.Template.Spec.ServiceAccountName = serviceAccount
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	pod := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 
 	actualResult := pod.Spec.ServiceAccountName
@@ -823,7 +823,7 @@ func TestCleanupInvalidVolumeMounts(t *testing.T) {
 	cluster := instance.DeepCopy()
 
 	// Test head pod
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, "", "", false)
 
@@ -849,7 +849,7 @@ func TestDefaultWorkerPodTemplateWithName(t *testing.T) {
 	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	worker := cluster.Spec.WorkerGroupSpecs[0]
 	worker.Template.ObjectMeta.Name = "ray-worker-test"
-	podName := cluster.Name + DashSymbol + string(rayv1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
+	podName := cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
 	expectedWorker := *worker.DeepCopy()
 
 	// Pass a deep copy of worker (*worker.DeepCopy()) to prevent "worker" from updating.
@@ -873,22 +873,22 @@ func containerPortExists(ports []corev1.ContainerPort, name string, containerPor
 func TestDefaultHeadPodTemplateWithConfigurablePorts(t *testing.T) {
 	cluster := instance.DeepCopy()
 	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{}
-	podName := strings.ToLower(cluster.Name + DashSymbol + string(rayv1.HeadNode) + DashSymbol + utils.FormatInt32(0))
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	// DefaultHeadPodTemplate will add the default metrics port if user doesn't specify it.
 	// Verify the default metrics port exists.
-	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, MetricsPortName, int32(DefaultMetricsPort)); err != nil {
+	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, utils.MetricsPortName, int32(utils.DefaultMetricsPort)); err != nil {
 		t.Fatal(err)
 	}
-	customMetricsPort := int32(DefaultMetricsPort) + 1
+	customMetricsPort := int32(utils.DefaultMetricsPort) + 1
 	metricsPort := corev1.ContainerPort{
-		Name:          MetricsPortName,
+		Name:          utils.MetricsPortName,
 		ContainerPort: customMetricsPort,
 	}
 	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{metricsPort}
 	podTemplateSpec = DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	// Verify the custom metrics port exists.
-	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, MetricsPortName, customMetricsPort); err != nil {
+	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, utils.MetricsPortName, customMetricsPort); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -897,23 +897,23 @@ func TestDefaultWorkerPodTemplateWithConfigurablePorts(t *testing.T) {
 	cluster := instance.DeepCopy()
 	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Ports = []corev1.ContainerPort{}
 	worker := cluster.Spec.WorkerGroupSpecs[0]
-	podName := cluster.Name + DashSymbol + string(rayv1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
+	podName := cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
 	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	podTemplateSpec := DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	// DefaultWorkerPodTemplate will add the default metrics port if user doesn't specify it.
 	// Verify the default metrics port exists.
-	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, MetricsPortName, int32(DefaultMetricsPort)); err != nil {
+	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, utils.MetricsPortName, int32(utils.DefaultMetricsPort)); err != nil {
 		t.Fatal(err)
 	}
-	customMetricsPort := int32(DefaultMetricsPort) + 1
+	customMetricsPort := int32(utils.DefaultMetricsPort) + 1
 	metricsPort := corev1.ContainerPort{
-		Name:          MetricsPortName,
+		Name:          utils.MetricsPortName,
 		ContainerPort: customMetricsPort,
 	}
 	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Ports = []corev1.ContainerPort{metricsPort}
 	podTemplateSpec = DefaultWorkerPodTemplate(*cluster, worker, podName, fqdnRayIP, "6379")
 	// Verify the custom metrics port exists.
-	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, MetricsPortName, customMetricsPort); err != nil {
+	if err := containerPortExists(podTemplateSpec.Spec.Containers[0].Ports, utils.MetricsPortName, customMetricsPort); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -923,7 +923,7 @@ func TestDefaultInitContainer(t *testing.T) {
 	cluster := instance.DeepCopy()
 	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	worker := cluster.Spec.WorkerGroupSpecs[0]
-	podName := cluster.Name + DashSymbol + string(rayv1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
+	podName := cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
 	expectedResult := len(cluster.Spec.WorkerGroupSpecs[0].Template.Spec.InitContainers) + 1
 
 	// Pass a deep copy of worker (*worker.DeepCopy()) to prevent "worker" from updating.
@@ -935,7 +935,7 @@ func TestDefaultInitContainer(t *testing.T) {
 	// with the Ray head using TLS authentication. Currently, we simply copied all environment variables from
 	// Ray container to the init container. This may be changed in the future.
 	healthCheckContainer := podTemplateSpec.Spec.InitContainers[numInitContainers-1]
-	rayContainer := worker.Template.Spec.Containers[RayContainerIndex]
+	rayContainer := worker.Template.Spec.Containers[utils.RayContainerIndex]
 
 	assert.NotEqual(t, len(rayContainer.Env), 0, "The test only makes sense if the Ray container has environment variables.")
 	assert.Equal(t, len(rayContainer.Env), len(healthCheckContainer.Env))
@@ -955,7 +955,7 @@ func TestDefaultInitContainerImagePullPolicy(t *testing.T) {
 	cluster := instance.DeepCopy()
 	fqdnRayIP := utils.GenerateFQDNServiceName(*cluster, cluster.Namespace)
 	worker := cluster.Spec.WorkerGroupSpecs[0]
-	podName := cluster.Name + DashSymbol + string(rayv1.WorkerNode) + DashSymbol + worker.GroupName + DashSymbol + utils.FormatInt32(0)
+	podName := cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
 
 	cases := []struct {
 		name               string
@@ -982,7 +982,7 @@ func TestDefaultInitContainerImagePullPolicy(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// set ray container imagePullPolicy
-			worker.Template.Spec.Containers[RayContainerIndex].ImagePullPolicy = tc.imagePullPolicy
+			worker.Template.Spec.Containers[utils.RayContainerIndex].ImagePullPolicy = tc.imagePullPolicy
 
 			podTemplateSpec := DefaultWorkerPodTemplate(*cluster, *worker.DeepCopy(), podName, fqdnRayIP, "6379")
 
@@ -1030,12 +1030,12 @@ func TestSetMissingRayStartParamsMetricsExportPort(t *testing.T) {
 
 	headPort := "6379"
 	fqdnRayIP := "raycluster-kuberay-head-svc.default.svc.cluster.local"
-	customMetricsPort := DefaultMetricsPort + 1
+	customMetricsPort := utils.DefaultMetricsPort + 1
 
 	// Case 1: Head node with no metrics-export-port option set.
 	rayStartParams := map[string]string{}
 	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1.HeadNode, headPort, "", nil)
-	assert.Equal(t, fmt.Sprint(DefaultMetricsPort), rayStartParams["metrics-export-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(DefaultMetricsPort), rayStartParams["metrics-export-port"]))
+	assert.Equal(t, fmt.Sprint(utils.DefaultMetricsPort), rayStartParams["metrics-export-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(utils.DefaultMetricsPort), rayStartParams["metrics-export-port"]))
 
 	// Case 2: Head node with custom metrics-export-port option set.
 	rayStartParams = map[string]string{"metrics-export-port": fmt.Sprint(customMetricsPort)}
@@ -1045,7 +1045,7 @@ func TestSetMissingRayStartParamsMetricsExportPort(t *testing.T) {
 	// Case 3: Worker node with no metrics-export-port option set.
 	rayStartParams = map[string]string{}
 	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP, nil)
-	assert.Equal(t, fmt.Sprint(DefaultMetricsPort), rayStartParams["metrics-export-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(DefaultMetricsPort), rayStartParams["metrics-export-port"]))
+	assert.Equal(t, fmt.Sprint(utils.DefaultMetricsPort), rayStartParams["metrics-export-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(utils.DefaultMetricsPort), rayStartParams["metrics-export-port"]))
 
 	// Case 4: Worker node with custom metrics-export-port option set.
 	rayStartParams = map[string]string{"metrics-export-port": fmt.Sprint(customMetricsPort)}
@@ -1128,16 +1128,16 @@ func TestSetMissingRayStartParamsAgentListenPort(t *testing.T) {
 	assert.NotContains(t, rayStartParams, "dashboard-agent-listen-port", "Worker Pod should not have a dashboard-agent-listen-port option set by default.")
 
 	// Case 3: Head node with "ray.io/enable-serve-service=true" and users do not provide "dashboard-agent-listen-port".
-	annotaions = map[string]string{EnableServeServiceKey: EnableServeServiceTrue}
+	annotaions = map[string]string{utils.EnableServeServiceKey: utils.EnableServeServiceTrue}
 	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1.HeadNode, headPort, "", annotaions)
-	assert.Equal(t, fmt.Sprint(DefaultDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(DefaultDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"]))
+	assert.Equal(t, fmt.Sprint(utils.DefaultDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(utils.DefaultDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"]))
 
 	// Case 4: Worker node with "ray.io/enable-serve-service=true" and users do not provide "dashboard-agent-listen-port".
 	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP, annotaions)
-	assert.Equal(t, fmt.Sprint(DefaultDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(DefaultDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"]))
+	assert.Equal(t, fmt.Sprint(utils.DefaultDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(utils.DefaultDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"]))
 
 	// Case 5: Head node with "ray.io/enable-serve-service=true" and users provide "dashboard-agent-listen-port".
-	customDashboardAgentListenPort := DefaultDashboardAgentListenPort + 1
+	customDashboardAgentListenPort := utils.DefaultDashboardAgentListenPort + 1
 	rayStartParams = map[string]string{"dashboard-agent-listen-port": fmt.Sprint(customDashboardAgentListenPort)}
 	rayStartParams = setMissingRayStartParams(rayStartParams, rayv1.HeadNode, headPort, "", annotaions)
 	assert.Equal(t, fmt.Sprint(customDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(customDashboardAgentListenPort), rayStartParams["dashboard-agent-listen-port"]))
@@ -1175,26 +1175,26 @@ func TestGetCustomWorkerInitImage(t *testing.T) {
 
 func TestGetEnableProbesInjection(t *testing.T) {
 	// cleanup
-	defer os.Unsetenv(ENABLE_PROBES_INJECTION)
+	defer os.Unsetenv(utils.ENABLE_PROBES_INJECTION)
 
 	// not set the env
-	os.Unsetenv(ENABLE_PROBES_INJECTION)
+	os.Unsetenv(utils.ENABLE_PROBES_INJECTION)
 	b := getEnableProbesInjection()
 	assert.True(t, b)
 	// set the env with "true"
-	os.Setenv(ENABLE_PROBES_INJECTION, "true")
+	os.Setenv(utils.ENABLE_PROBES_INJECTION, "true")
 	b = getEnableProbesInjection()
 	assert.True(t, b)
 	// set the env with "True"
-	os.Setenv(ENABLE_PROBES_INJECTION, "True")
+	os.Setenv(utils.ENABLE_PROBES_INJECTION, "True")
 	b = getEnableProbesInjection()
 	assert.True(t, b)
 	// set the env with "false"
-	os.Setenv(ENABLE_PROBES_INJECTION, "false")
+	os.Setenv(utils.ENABLE_PROBES_INJECTION, "false")
 	b = getEnableProbesInjection()
 	assert.False(t, b)
 	// set the env with "False"
-	os.Setenv(ENABLE_PROBES_INJECTION, "False")
+	os.Setenv(utils.ENABLE_PROBES_INJECTION, "False")
 	b = getEnableProbesInjection()
 	assert.False(t, b)
 }
@@ -1205,8 +1205,8 @@ func TestInitHealthProbe(t *testing.T) {
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				// Check Raylet status
-				Path: fmt.Sprintf("/%s", RayAgentRayletHealthPath),
-				Port: intstr.FromInt(DefaultDashboardAgentListenPort),
+				Path: fmt.Sprintf("/%s", utils.RayAgentRayletHealthPath),
+				Port: intstr.FromInt(utils.DefaultDashboardAgentListenPort),
 			},
 		},
 	}

--- a/ray-operator/controllers/ray/common/rbac.go
+++ b/ray-operator/controllers/ray/common/rbac.go
@@ -15,9 +15,9 @@ func BuildServiceAccount(cluster *rayv1.RayCluster) (*corev1.ServiceAccount, err
 			Name:      utils.GetHeadGroupServiceAccountName(cluster),
 			Namespace: cluster.Namespace,
 			Labels: map[string]string{
-				RayClusterLabelKey:                cluster.Name,
-				KubernetesApplicationNameLabelKey: ApplicationName,
-				KubernetesCreatedByLabelKey:       ComponentName,
+				utils.RayClusterLabelKey:                cluster.Name,
+				utils.KubernetesApplicationNameLabelKey: utils.ApplicationName,
+				utils.KubernetesCreatedByLabelKey:       utils.ComponentName,
 			},
 		},
 	}
@@ -32,9 +32,9 @@ func BuildRole(cluster *rayv1.RayCluster) (*rbacv1.Role, error) {
 			Name:      cluster.Name,
 			Namespace: cluster.Namespace,
 			Labels: map[string]string{
-				RayClusterLabelKey:                cluster.Name,
-				KubernetesApplicationNameLabelKey: ApplicationName,
-				KubernetesCreatedByLabelKey:       ComponentName,
+				utils.RayClusterLabelKey:                cluster.Name,
+				utils.KubernetesApplicationNameLabelKey: utils.ApplicationName,
+				utils.KubernetesCreatedByLabelKey:       utils.ComponentName,
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -62,9 +62,9 @@ func BuildRoleBinding(cluster *rayv1.RayCluster) (*rbacv1.RoleBinding, error) {
 			Name:      cluster.Name,
 			Namespace: cluster.Namespace,
 			Labels: map[string]string{
-				RayClusterLabelKey:                cluster.Name,
-				KubernetesApplicationNameLabelKey: ApplicationName,
-				KubernetesCreatedByLabelKey:       ComponentName,
+				utils.RayClusterLabelKey:                cluster.Name,
+				utils.KubernetesApplicationNameLabelKey: utils.ApplicationName,
+				utils.KubernetesCreatedByLabelKey:       utils.ComponentName,
 			},
 		},
 		Subjects: []rbacv1.Subject{

--- a/ray-operator/controllers/ray/common/route.go
+++ b/ray-operator/controllers/ray/common/route.go
@@ -13,10 +13,10 @@ import (
 // This is used to expose dashboard and remote submit service apis or external traffic.
 func BuildRouteForHeadService(cluster rayv1.RayCluster) (*routev1.Route, error) {
 	labels := map[string]string{
-		RayClusterLabelKey:                cluster.Name,
-		RayIDLabelKey:                     utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode),
-		KubernetesApplicationNameLabelKey: ApplicationName,
-		KubernetesCreatedByLabelKey:       ComponentName,
+		utils.RayClusterLabelKey:                cluster.Name,
+		utils.RayIDLabelKey:                     utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode),
+		utils.KubernetesApplicationNameLabelKey: utils.ApplicationName,
+		utils.KubernetesCreatedByLabelKey:       utils.ComponentName,
 	}
 
 	// Copy other configurations from cluster annotations to provide a generic way
@@ -27,7 +27,7 @@ func BuildRouteForHeadService(cluster rayv1.RayCluster) (*routev1.Route, error) 
 	}
 
 	servicePorts := getServicePorts(cluster)
-	dashboardPort := DefaultDashboardPort
+	dashboardPort := utils.DefaultDashboardPort
 	if port, ok := servicePorts["dashboard"]; ok {
 		dashboardPort = int(port)
 	}
@@ -77,8 +77,8 @@ func BuildRouteForRayService(service rayv1.RayService, cluster rayv1.RayCluster)
 	}
 	route.ObjectMeta.Name = serviceName
 	route.ObjectMeta.Namespace = service.Namespace
-	route.ObjectMeta.Labels[RayServiceLabelKey] = service.Name
-	route.ObjectMeta.Labels[RayIDLabelKey] = utils.CheckLabel(utils.GenerateIdentifier(service.Name, rayv1.HeadNode))
+	route.ObjectMeta.Labels[utils.RayServiceLabelKey] = service.Name
+	route.ObjectMeta.Labels[utils.RayIDLabelKey] = utils.CheckLabel(utils.GenerateIdentifier(service.Name, rayv1.HeadNode))
 
 	return route, nil
 }

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -181,17 +181,17 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 	// the Redis cleanup job should be activated. Users can disable the feature by setting the environment
 	// variable `ENABLE_GCS_FT_REDIS_CLEANUP` to `false`, and undertake the Redis storage namespace cleanup
 	// manually after the RayCluster CR deletion.
-	enableGCSFTRedisCleanup := strings.ToLower(os.Getenv(common.ENABLE_GCS_FT_REDIS_CLEANUP)) != "false"
+	enableGCSFTRedisCleanup := strings.ToLower(os.Getenv(utils.ENABLE_GCS_FT_REDIS_CLEANUP)) != "false"
 
 	if enableGCSFTRedisCleanup && common.IsGCSFaultToleranceEnabled(*instance) {
 		if instance.DeletionTimestamp.IsZero() {
-			if !controllerutil.ContainsFinalizer(instance, common.GCSFaultToleranceRedisCleanupFinalizer) {
+			if !controllerutil.ContainsFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer) {
 				r.Log.Info(
 					"GCS fault tolerance has been enabled. Implementing a finalizer to ensure that Redis is properly cleaned up once the RayCluster custom resource (CR) is deleted.",
-					"finalizer", common.GCSFaultToleranceRedisCleanupFinalizer)
-				controllerutil.AddFinalizer(instance, common.GCSFaultToleranceRedisCleanupFinalizer)
+					"finalizer", utils.GCSFaultToleranceRedisCleanupFinalizer)
+				controllerutil.AddFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer)
 				if err := r.Update(ctx, instance); err != nil {
-					r.Log.Error(err, fmt.Sprintf("Failed to add the finalizer %s to the RayCluster.", common.GCSFaultToleranceRedisCleanupFinalizer))
+					r.Log.Error(err, fmt.Sprintf("Failed to add the finalizer %s to the RayCluster.", utils.GCSFaultToleranceRedisCleanupFinalizer))
 					return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 				}
 				// Only start the RayCluster reconciliation after the finalizer is added.
@@ -200,12 +200,12 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 		} else {
 			r.Log.Info(
 				fmt.Sprintf("The RayCluster with GCS enabled, %s, is being deleted. Start to handle the Redis cleanup finalizer %s.",
-					instance.Name, common.GCSFaultToleranceRedisCleanupFinalizer),
+					instance.Name, utils.GCSFaultToleranceRedisCleanupFinalizer),
 				"DeletionTimestamp", instance.ObjectMeta.DeletionTimestamp)
 
 			// Delete the head Pod if it exists.
 			headPods := corev1.PodList{}
-			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeTypeLabelKey: string(rayv1.HeadNode)}
+			filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeTypeLabelKey: string(rayv1.HeadNode)}
 			if err := r.List(ctx, &headPods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 			}
@@ -218,7 +218,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 				r.Log.Info(fmt.Sprintf(
 					"Delete the head Pod %s before the Redis cleanup. "+
 						"The storage namespace %s in Redis cannot be fully deleted if the GCS process on the head Pod is still writing to it.",
-					headPod.Name, headPod.Annotations[common.RayExternalStorageNSAnnotationKey]))
+					headPod.Name, headPod.Annotations[utils.RayExternalStorageNSAnnotationKey]))
 				if err := r.Delete(ctx, &headPod); err != nil {
 					return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 				}
@@ -227,7 +227,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 			// Delete all worker Pods if they exist.
 			for _, workerGroup := range instance.Spec.WorkerGroupSpecs {
 				workerPods := corev1.PodList{}
-				filterLabels = client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeGroupLabelKey: workerGroup.GroupName}
+				filterLabels = client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeGroupLabelKey: workerGroup.GroupName}
 				if err := r.List(ctx, &workerPods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 					return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 				}
@@ -250,13 +250,13 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 				r.Log.Info(fmt.Sprintf(
 					"Wait for the head Pod %s to be terminated before initiating the Redis cleanup process. "+
 						"The storage namespace %s in Redis cannot be fully deleted if the GCS process on the head Pod is still writing to it.",
-					headPods.Items[0].Name, headPods.Items[0].Annotations[common.RayExternalStorageNSAnnotationKey]))
+					headPods.Items[0].Name, headPods.Items[0].Annotations[utils.RayExternalStorageNSAnnotationKey]))
 				// Requeue after 10 seconds because it takes much longer than DefaultRequeueDuration (2 seconds) for the head Pod to be terminated.
 				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 			}
 
 			// We can start the Redis cleanup process now because the head Pod has been terminated.
-			filterLabels = client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeTypeLabelKey: string(rayv1.RedisCleanupNode)}
+			filterLabels = client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeTypeLabelKey: string(rayv1.RedisCleanupNode)}
 			redisCleanupJobs := batchv1.JobList{}
 			if err := r.List(ctx, &redisCleanupJobs, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
@@ -271,9 +271,9 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 					r.Log.Info(fmt.Sprintf(
 						"The Redis cleanup Job %s has been completed. "+
 							"The storage namespace %s in Redis has been fully deleted.",
-						redisCleanupJob.Name, redisCleanupJob.Annotations[common.RayExternalStorageNSAnnotationKey]))
+						redisCleanupJob.Name, redisCleanupJob.Annotations[utils.RayExternalStorageNSAnnotationKey]))
 					// Remove the finalizer from the RayCluster CR.
-					controllerutil.RemoveFinalizer(instance, common.GCSFaultToleranceRedisCleanupFinalizer)
+					controllerutil.RemoveFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer)
 					if err := r.Update(ctx, instance); err != nil {
 						r.Log.Error(err, "Failed to remove finalizer for RayCluster")
 						return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
@@ -288,7 +288,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 						"The Redis cleanup Job %s has failed, requeue the RayCluster CR after 5 minute. "+
 							"You should manually delete the storage namespace %s in Redis and remove the RayCluster's finalizer. "+
 							"Please check https://docs.ray.io/en/master/cluster/kubernetes/user-guides/kuberay-gcs-ft.html for more details.",
-						redisCleanupJob.Name, redisCleanupJob.Annotations[common.RayExternalStorageNSAnnotationKey]))
+						redisCleanupJob.Name, redisCleanupJob.Annotations[utils.RayExternalStorageNSAnnotationKey]))
 					return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 				}
 			} else {
@@ -344,7 +344,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
 	// Only reconcile the K8s service for Ray Serve when the "ray.io/enable-serve-service" annotation is set to true.
-	if enableServeServiceValue, exist := instance.Annotations[common.EnableServeServiceKey]; exist && enableServeServiceValue == common.EnableServeServiceTrue {
+	if enableServeServiceValue, exist := instance.Annotations[utils.EnableServeServiceKey]; exist && enableServeServiceValue == utils.EnableServeServiceTrue {
 		if err := r.reconcileServeService(ctx, instance); err != nil {
 			if updateErr := r.updateClusterState(ctx, instance, rayv1.Failed); updateErr != nil {
 				r.Log.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
@@ -382,10 +382,10 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 	// Unconditionally requeue after the number of seconds specified in the
 	// environment variable RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV. If the
 	// environment variable is not set, requeue after the default value.
-	requeueAfterSeconds, err := strconv.Atoi(os.Getenv(common.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV))
+	requeueAfterSeconds, err := strconv.Atoi(os.Getenv(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV))
 	if err != nil {
-		r.Log.Info(fmt.Sprintf("Environment variable %s is not set, using default value of %d seconds", common.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV, common.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS), "cluster name", request.Name)
-		requeueAfterSeconds = common.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS
+		r.Log.Info(fmt.Sprintf("Environment variable %s is not set, using default value of %d seconds", utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV, utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS), "cluster name", request.Name)
+		requeueAfterSeconds = utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS
 	}
 	r.Log.Info("Unconditional requeue after", "cluster name", request.Name, "seconds", requeueAfterSeconds)
 	return ctrl.Result{RequeueAfter: time.Duration(requeueAfterSeconds) * time.Second}, nil
@@ -439,7 +439,7 @@ func (r *RayClusterReconciler) reconcileIngress(ctx context.Context, instance *r
 
 func (r *RayClusterReconciler) reconcileRouteOpenShift(ctx context.Context, instance *rayv1.RayCluster) error {
 	headRoutes := routev1.RouteList{}
-	filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name}
+	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name}
 	if err := r.List(ctx, &headRoutes, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 		r.Log.Error(err, "Route Listing error!", "Route.Error", err)
 		return err
@@ -473,7 +473,7 @@ func (r *RayClusterReconciler) reconcileRouteOpenShift(ctx context.Context, inst
 
 func (r *RayClusterReconciler) reconcileIngressKubernetes(ctx context.Context, instance *rayv1.RayCluster) error {
 	headIngresses := networkingv1.IngressList{}
-	filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name}
+	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name}
 	if err := r.List(ctx, &headIngresses, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 		return err
 	}
@@ -505,7 +505,7 @@ func (r *RayClusterReconciler) reconcileIngressKubernetes(ctx context.Context, i
 // Return nil only when the head service successfully created or already exists.
 func (r *RayClusterReconciler) reconcileHeadService(ctx context.Context, instance *rayv1.RayCluster) error {
 	services := corev1.ServiceList{}
-	filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeTypeLabelKey: string(rayv1.HeadNode)}
+	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeTypeLabelKey: string(rayv1.HeadNode)}
 
 	if err := r.List(ctx, &services, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 		return err
@@ -525,8 +525,8 @@ func (r *RayClusterReconciler) reconcileHeadService(ctx context.Context, instanc
 	} else {
 		// Create head service if there's no existing one in the cluster.
 		labels := make(map[string]string)
-		if val, ok := instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels[common.KubernetesApplicationNameLabelKey]; ok {
-			labels[common.KubernetesApplicationNameLabelKey] = val
+		if val, ok := instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels[utils.KubernetesApplicationNameLabelKey]; ok {
+			labels[utils.KubernetesApplicationNameLabelKey] = val
 		}
 		annotations := make(map[string]string)
 		// TODO (kevin85421): KubeRay has already exposed the entire head service (#1040) to users.
@@ -584,7 +584,7 @@ func (r *RayClusterReconciler) reconcileServeService(ctx context.Context, instan
 func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv1.RayCluster) error {
 	// check if all the pods exist
 	headPods := corev1.PodList{}
-	filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeTypeLabelKey: string(rayv1.HeadNode)}
+	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeTypeLabelKey: string(rayv1.HeadNode)}
 	if err := r.List(ctx, &headPods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 		return err
 	}
@@ -661,7 +661,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		// check if WorkerGroupSpecs has been changed and we need to kill worker pods
 		for _, worker := range instance.Spec.WorkerGroupSpecs {
 			workerPods := corev1.PodList{}
-			filterLabels = client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeGroupLabelKey: worker.GroupName}
+			filterLabels = client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeGroupLabelKey: worker.GroupName}
 			if err := r.List(ctx, &workerPods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 				return err
 			}
@@ -689,7 +689,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		r.Log.Info("reconcilePods", "desired workerReplicas (always adhering to minReplicas/maxReplica)", workerReplicas, "worker group", worker.GroupName, "maxReplicas", worker.MaxReplicas, "minReplicas", worker.MinReplicas, "replicas", worker.Replicas)
 
 		workerPods := corev1.PodList{}
-		filterLabels = client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeGroupLabelKey: worker.GroupName}
+		filterLabels = client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeGroupLabelKey: worker.GroupName}
 		if err := r.List(ctx, &workerPods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 			return err
 		}
@@ -774,7 +774,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 			// default behavior is stable enough, we can remove this feature flag.
 			enableRandomPodDelete := false
 			if enableInTreeAutoscaling {
-				if s := os.Getenv(common.ENABLE_RANDOM_POD_DELETE); strings.ToLower(s) == "true" {
+				if s := os.Getenv(utils.ENABLE_RANDOM_POD_DELETE); strings.ToLower(s) == "true" {
 					enableRandomPodDelete = true
 				}
 			}
@@ -879,7 +879,7 @@ func shouldDeletePod(pod corev1.Pod, nodeType rayv1.RayNodeType) (bool, string) 
 // (1) https://discuss.kubernetes.io/t/pod-spec-containers-and-pod-status-containerstatuses-can-have-a-different-order-why/25273
 // (2) https://github.com/kubernetes/kubernetes/blob/03762cbcb52b2a4394e4d795f9d3517a78a5e1a2/pkg/api/v1/pod/util.go#L261-L268
 func getRayContainerStateTerminated(pod corev1.Pod) *corev1.ContainerStateTerminated {
-	rayContainerName := pod.Spec.Containers[common.RayContainerIndex].Name
+	rayContainerName := pod.Spec.Containers[utils.RayContainerIndex].Name
 	for _, containerStatus := range pod.Status.ContainerStatuses {
 		if containerStatus.Name == rayContainerName {
 			return containerStatus.State.Terminated
@@ -1023,14 +1023,14 @@ func (r *RayClusterReconciler) createWorkerPod(ctx context.Context, instance ray
 
 // Build head instance pod(s).
 func (r *RayClusterReconciler) buildHeadPod(instance rayv1.RayCluster) corev1.Pod {
-	podName := strings.ToLower(instance.Name + common.DashSymbol + string(rayv1.HeadNode) + common.DashSymbol)
+	podName := strings.ToLower(instance.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol)
 	podName = utils.CheckName(podName)                                       // making sure the name is valid
 	fqdnRayIP := utils.GenerateFQDNServiceName(instance, instance.Namespace) // Fully Qualified Domain Name
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
 	// Check whether serve is enabled and add serve label
 	serveLabel := false
-	if enableServeServiceValue, exist := instance.Annotations[common.EnableServeServiceKey]; exist && enableServeServiceValue == common.EnableServeServiceTrue {
+	if enableServeServiceValue, exist := instance.Annotations[utils.EnableServeServiceKey]; exist && enableServeServiceValue == utils.EnableServeServiceTrue {
 		serveLabel = true
 	}
 	autoscalingEnabled := instance.Spec.EnableInTreeAutoscaling
@@ -1050,7 +1050,7 @@ func getCreator(instance rayv1.RayCluster) string {
 	if instance.Labels == nil {
 		return ""
 	}
-	creatorName, exist := instance.Labels[common.KubernetesCreatedByLabelKey]
+	creatorName, exist := instance.Labels[utils.KubernetesCreatedByLabelKey]
 
 	if !exist {
 		return ""
@@ -1061,7 +1061,7 @@ func getCreator(instance rayv1.RayCluster) string {
 
 // Build worker instance pods.
 func (r *RayClusterReconciler) buildWorkerPod(instance rayv1.RayCluster, worker rayv1.WorkerGroupSpec) corev1.Pod {
-	podName := strings.ToLower(instance.Name + common.DashSymbol + string(rayv1.WorkerNode) + common.DashSymbol + worker.GroupName + common.DashSymbol)
+	podName := strings.ToLower(instance.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol)
 	podName = utils.CheckName(podName)                                       // making sure the name is valid
 	fqdnRayIP := utils.GenerateFQDNServiceName(instance, instance.Namespace) // Fully Qualified Domain Name
 
@@ -1072,7 +1072,7 @@ func (r *RayClusterReconciler) buildWorkerPod(instance rayv1.RayCluster, worker 
 	creatorName := getCreator(instance)
 	// Check whether serve is enabled and add serve label
 	serveLabel := false
-	if enableServeServiceValue, exist := instance.Annotations[common.EnableServeServiceKey]; exist && enableServeServiceValue == common.EnableServeServiceTrue {
+	if enableServeServiceValue, exist := instance.Annotations[utils.EnableServeServiceKey]; exist && enableServeServiceValue == utils.EnableServeServiceTrue {
 		serveLabel = true
 	}
 	pod := common.BuildPod(podTemplateSpec, rayv1.WorkerNode, worker.RayStartParams, headPort, autoscalingEnabled, creatorName, fqdnRayIP, serveLabel)
@@ -1086,12 +1086,12 @@ func (r *RayClusterReconciler) buildWorkerPod(instance rayv1.RayCluster, worker 
 
 func (r *RayClusterReconciler) buildRedisCleanupJob(instance rayv1.RayCluster) batchv1.Job {
 	pod := r.buildHeadPod(instance)
-	pod.Labels[common.RayNodeTypeLabelKey] = string(rayv1.RedisCleanupNode)
+	pod.Labels[utils.RayNodeTypeLabelKey] = string(rayv1.RedisCleanupNode)
 
 	// Only keep the Ray container in the Redis cleanup Job.
-	pod.Spec.Containers = []corev1.Container{pod.Spec.Containers[common.RayContainerIndex]}
-	pod.Spec.Containers[common.RayContainerIndex].Command = []string{"/bin/bash", "-lc", "--"}
-	pod.Spec.Containers[common.RayContainerIndex].Args = []string{
+	pod.Spec.Containers = []corev1.Container{pod.Spec.Containers[utils.RayContainerIndex]}
+	pod.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/bash", "-lc", "--"}
+	pod.Spec.Containers[utils.RayContainerIndex].Args = []string{
 		"echo \"To get more information about manually delete the storage namespace in Redis and remove the RayCluster's finalizer, please check https://docs.ray.io/en/master/cluster/kubernetes/user-guides/kuberay-gcs-ft.html for more details.\" && " +
 			"python -c " +
 			"\"from ray._private.gcs_utils import cleanup_redis_storage; " +
@@ -1105,22 +1105,22 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(instance rayv1.RayCluster) b
 	}
 
 	// Disable liveness and readiness probes because the Job will not launch processes like Raylet and GCS.
-	pod.Spec.Containers[common.RayContainerIndex].LivenessProbe = nil
-	pod.Spec.Containers[common.RayContainerIndex].ReadinessProbe = nil
+	pod.Spec.Containers[utils.RayContainerIndex].LivenessProbe = nil
+	pod.Spec.Containers[utils.RayContainerIndex].ReadinessProbe = nil
 
 	// Set the environment variables to ensure that the cleanup Job has at least 60s.
-	pod.Spec.Containers[common.RayContainerIndex].Env = append(pod.Spec.Containers[common.RayContainerIndex].Env, corev1.EnvVar{
+	pod.Spec.Containers[utils.RayContainerIndex].Env = append(pod.Spec.Containers[utils.RayContainerIndex].Env, corev1.EnvVar{
 		Name:  "RAY_redis_db_connect_retries",
 		Value: "120",
 	})
-	pod.Spec.Containers[common.RayContainerIndex].Env = append(pod.Spec.Containers[common.RayContainerIndex].Env, corev1.EnvVar{
+	pod.Spec.Containers[utils.RayContainerIndex].Env = append(pod.Spec.Containers[utils.RayContainerIndex].Env, corev1.EnvVar{
 		Name:  "RAY_redis_db_connect_wait_milliseconds",
 		Value: "500",
 	})
 
 	// The container's resource consumption remains constant. so hard-coding the resources is acceptable.
 	// In addition, avoid using the GPU for the Redis cleanup Job.
-	pod.Spec.Containers[common.RayContainerIndex].Resources = corev1.ResourceRequirements{
+	pod.Spec.Containers[utils.RayContainerIndex].Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("200m"),
 			corev1.ResourceMemory: resource.MustParse("256Mi"),
@@ -1186,7 +1186,7 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	newInstance.Status.ObservedGeneration = newInstance.ObjectMeta.Generation
 
 	runtimePods := corev1.PodList{}
-	filterLabels := client.MatchingLabels{common.RayClusterLabelKey: newInstance.Name}
+	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: newInstance.Name}
 	if err := r.List(ctx, &runtimePods, client.InNamespace(newInstance.Namespace), filterLabels); err != nil {
 		return nil, err
 	}
@@ -1227,7 +1227,7 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 // Best effort to obtain the ip of the head node.
 func (r *RayClusterReconciler) getHeadPodIP(ctx context.Context, instance *rayv1.RayCluster) (string, error) {
 	runtimePods := corev1.PodList{}
-	filterLabels := client.MatchingLabels{common.RayClusterLabelKey: instance.Name, common.RayNodeTypeLabelKey: string(rayv1.HeadNode)}
+	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeTypeLabelKey: string(rayv1.HeadNode)}
 	if err := r.List(ctx, &runtimePods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 		r.Log.Error(err, "Failed to list pods while getting head pod ip.")
 		return "", err
@@ -1262,8 +1262,8 @@ func (r *RayClusterReconciler) updateEndpoints(ctx context.Context, instance *ra
 	// and picking the first one. We may need to select by name in the future if the Service naming is stable.
 	rayHeadSvc := corev1.ServiceList{}
 	filterLabels := client.MatchingLabels{
-		common.RayClusterLabelKey:  instance.Name,
-		common.RayNodeTypeLabelKey: "head",
+		utils.RayClusterLabelKey:  instance.Name,
+		utils.RayNodeTypeLabelKey: "head",
 	}
 	if err := r.List(ctx, &rayHeadSvc, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 		return err

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -84,10 +84,10 @@ func setupTest(t *testing.T) {
 				Name:      "headNode",
 				Namespace: namespaceStr,
 				Labels: map[string]string{
-					common.RayNodeLabelKey:      "yes",
-					common.RayClusterLabelKey:   instanceName,
-					common.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
-					common.RayNodeGroupLabelKey: headGroupNameStr,
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
+					utils.RayNodeGroupLabelKey: headGroupNameStr,
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -116,9 +116,9 @@ func setupTest(t *testing.T) {
 				Name:      "pod1",
 				Namespace: namespaceStr,
 				Labels: map[string]string{
-					common.RayNodeLabelKey:      "yes",
-					common.RayClusterLabelKey:   instanceName,
-					common.RayNodeGroupLabelKey: groupNameStr,
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeGroupLabelKey: groupNameStr,
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -146,9 +146,9 @@ func setupTest(t *testing.T) {
 				Name:      "pod2",
 				Namespace: namespaceStr,
 				Labels: map[string]string{
-					common.RayNodeLabelKey:      "yes",
-					common.RayClusterLabelKey:   instanceName,
-					common.RayNodeGroupLabelKey: groupNameStr,
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeGroupLabelKey: groupNameStr,
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -176,9 +176,9 @@ func setupTest(t *testing.T) {
 				Name:      "pod3",
 				Namespace: namespaceStr,
 				Labels: map[string]string{
-					common.RayNodeLabelKey:      "yes",
-					common.RayClusterLabelKey:   instanceName,
-					common.RayNodeGroupLabelKey: groupNameStr,
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeGroupLabelKey: groupNameStr,
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -206,9 +206,9 @@ func setupTest(t *testing.T) {
 				Name:      "pod4",
 				Namespace: namespaceStr,
 				Labels: map[string]string{
-					common.RayNodeLabelKey:      "yes",
-					common.RayClusterLabelKey:   instanceName,
-					common.RayNodeGroupLabelKey: groupNameStr,
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeGroupLabelKey: groupNameStr,
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -236,9 +236,9 @@ func setupTest(t *testing.T) {
 				Name:      "pod5",
 				Namespace: namespaceStr,
 				Labels: map[string]string{
-					common.RayNodeLabelKey:      "yes",
-					common.RayClusterLabelKey:   instanceName,
-					common.RayNodeGroupLabelKey: groupNameStr,
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeGroupLabelKey: groupNameStr,
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -268,10 +268,10 @@ func setupTest(t *testing.T) {
 				Name:      "headNode",
 				Namespace: namespaceStr,
 				Labels: map[string]string{
-					common.RayNodeLabelKey:      "yes",
-					common.RayClusterLabelKey:   instanceName,
-					common.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
-					common.RayNodeGroupLabelKey: headGroupNameStr,
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
+					utils.RayNodeGroupLabelKey: headGroupNameStr,
 				},
 			},
 			Status: corev1.PodStatus{
@@ -372,19 +372,19 @@ func setupTest(t *testing.T) {
 
 	instanceReqValue := []string{instanceName}
 	instanceReq, err := labels.NewRequirement(
-		common.RayClusterLabelKey,
+		utils.RayClusterLabelKey,
 		selection.Equals,
 		instanceReqValue)
 	assert.Nil(t, err, "Fail to create requirement")
 	groupNameReqValue := []string{groupNameStr}
 	groupNameReq, err := labels.NewRequirement(
-		common.RayNodeGroupLabelKey,
+		utils.RayNodeGroupLabelKey,
 		selection.Equals,
 		groupNameReqValue)
 	assert.Nil(t, err, "Fail to create requirement")
 	headNameReqValue := []string{headGroupNameStr}
 	headNameReq, err := labels.NewRequirement(
-		common.RayNodeGroupLabelKey,
+		utils.RayNodeGroupLabelKey,
 		selection.Equals,
 		headNameReqValue)
 	assert.Nil(t, err, "Fail to create requirement")
@@ -401,7 +401,7 @@ func TestReconcile_RemoveWorkersToDelete_RandomDelete(t *testing.T) {
 
 	// This test makes some assumptions about the testRayCluster object.
 	// (1) 1 workerGroup (2) The goal state of the workerGroup is 3 replicas. (3) ENABLE_RANDOM_POD_DELETE is set to true.
-	defer os.Unsetenv(common.ENABLE_RANDOM_POD_DELETE)
+	defer os.Unsetenv(utils.ENABLE_RANDOM_POD_DELETE)
 
 	assert.Equal(t, 1, len(testRayCluster.Spec.WorkerGroupSpecs), "This test assumes only one worker group.")
 	expectedNumWorkerPods := int(*testRayCluster.Spec.WorkerGroupSpecs[0].Replicas)
@@ -412,7 +412,7 @@ func TestReconcile_RemoveWorkersToDelete_RandomDelete(t *testing.T) {
 	// Case 2: If Autoscaler is enabled, we will respect the value of the feature flag. If the feature flag environment variable
 	// 		   is not set, we will disable random Pod deletion by default.
 	// Here, we enable the Autoscaler and set the feature flag `ENABLE_RANDOM_POD_DELETE` to true to enable random Pod deletion.
-	os.Setenv(common.ENABLE_RANDOM_POD_DELETE, "true")
+	os.Setenv(utils.ENABLE_RANDOM_POD_DELETE, "true")
 	enableInTreeAutoscaling := true
 
 	tests := map[string]struct {
@@ -521,7 +521,7 @@ func TestReconcile_RemoveWorkersToDelete_NoRandomDelete(t *testing.T) {
 
 	// This test makes some assumptions about the testRayCluster object.
 	// (1) 1 workerGroup (2) The goal state of the workerGroup is 3 replicas. (3) Disable random Pod deletion.
-	defer os.Unsetenv(common.ENABLE_RANDOM_POD_DELETE)
+	defer os.Unsetenv(utils.ENABLE_RANDOM_POD_DELETE)
 
 	assert.Equal(t, 1, len(testRayCluster.Spec.WorkerGroupSpecs), "This test assumes only one worker group.")
 	expectedNumWorkerPods := int(*testRayCluster.Spec.WorkerGroupSpecs[0].Replicas)
@@ -531,7 +531,7 @@ func TestReconcile_RemoveWorkersToDelete_NoRandomDelete(t *testing.T) {
 	// is not set, we will disable random Pod deletion by default. Hence, this test will disable random Pod deletion.
 	// In this case, the cluster won't achieve the target state (i.e., `expectedNumWorkerPods` worker Pods) in one reconciliation.
 	// Instead, the Ray Autoscaler will gradually scale down the cluster in subsequent reconciliations until it reaches the target state.
-	os.Unsetenv(common.ENABLE_RANDOM_POD_DELETE)
+	os.Unsetenv(utils.ENABLE_RANDOM_POD_DELETE)
 	enableInTreeAutoscaling := true
 
 	tests := map[string]struct {
@@ -830,7 +830,7 @@ func TestReconcile_Diff0_WorkersToDelete_OK(t *testing.T) {
 func TestReconcile_PodCrash_DiffLess0_OK(t *testing.T) {
 	setupTest(t)
 
-	defer os.Unsetenv(common.ENABLE_RANDOM_POD_DELETE)
+	defer os.Unsetenv(utils.ENABLE_RANDOM_POD_DELETE)
 	// TODO (kevin85421): The tests in this file are not independent. As a workaround,
 	// I added the assertion to prevent the test logic from being affected by other changes.
 	// However, we should refactor the tests in the future.
@@ -885,9 +885,9 @@ func TestReconcile_PodCrash_DiffLess0_OK(t *testing.T) {
 			}
 
 			if tc.ENABLE_RANDOM_POD_DELETE {
-				os.Setenv(common.ENABLE_RANDOM_POD_DELETE, "true")
+				os.Setenv(utils.ENABLE_RANDOM_POD_DELETE, "true")
 			} else {
-				os.Setenv(common.ENABLE_RANDOM_POD_DELETE, "false")
+				os.Setenv(utils.ENABLE_RANDOM_POD_DELETE, "false")
 			}
 			cluster := testRayCluster.DeepCopy()
 			// Case 1: ENABLE_RANDOM_POD_DELETE is true.
@@ -978,8 +978,8 @@ func TestReconcileHeadService(t *testing.T) {
 			Name:      "head-svc-1",
 			Namespace: cluster.Namespace,
 			Labels: map[string]string{
-				common.RayClusterLabelKey:  cluster.Name,
-				common.RayNodeTypeLabelKey: string(rayv1.HeadNode),
+				utils.RayClusterLabelKey:  cluster.Name,
+				utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
 			},
 		},
 	}
@@ -991,8 +991,8 @@ func TestReconcileHeadService(t *testing.T) {
 	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
 	ctx := context.TODO()
 	headServiceSelector := labels.SelectorFromSet(map[string]string{
-		common.RayClusterLabelKey:  cluster.Name,
-		common.RayNodeTypeLabelKey: string(rayv1.HeadNode),
+		utils.RayClusterLabelKey:  cluster.Name,
+		utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
 	})
 
 	// Initialize RayCluster reconciler.
@@ -1249,9 +1249,9 @@ func TestGetHeadPodIP(t *testing.T) {
 			Name:      "unexpectedExtraHeadNode",
 			Namespace: namespaceStr,
 			Labels: map[string]string{
-				common.RayClusterLabelKey:   instanceName,
-				common.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
-				common.RayNodeGroupLabelKey: headGroupNameStr,
+				utils.RayClusterLabelKey:   instanceName,
+				utils.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
+				utils.RayNodeGroupLabelKey: headGroupNameStr,
 			},
 		},
 	}
@@ -1574,8 +1574,8 @@ func TestCalculateStatus(t *testing.T) {
 			Name:      "headNode",
 			Namespace: namespaceStr,
 			Labels: map[string]string{
-				common.RayClusterLabelKey:  instanceName,
-				common.RayNodeTypeLabelKey: string(rayv1.HeadNode),
+				utils.RayClusterLabelKey:  instanceName,
+				utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
 			},
 		},
 		Status: corev1.PodStatus{
@@ -1843,7 +1843,7 @@ func Test_RunningPods_RayContainerTerminated(t *testing.T) {
 	podList.Items[0].Status.Phase = corev1.PodRunning
 	podList.Items[0].Status.ContainerStatuses = []corev1.ContainerStatus{
 		{
-			Name: podList.Items[0].Spec.Containers[common.RayContainerIndex].Name,
+			Name: podList.Items[0].Spec.Containers[utils.RayContainerIndex].Name,
 			State: corev1.ContainerState{
 				Terminated: &corev1.ContainerStateTerminated{},
 			},
@@ -1975,7 +1975,7 @@ func Test_ShouldDeletePod(t *testing.T) {
 func Test_RedisCleanupFeatureFlag(t *testing.T) {
 	setupTest(t)
 
-	defer os.Unsetenv(common.ENABLE_GCS_FT_REDIS_CLEANUP)
+	defer os.Unsetenv(utils.ENABLE_GCS_FT_REDIS_CLEANUP)
 
 	newScheme := runtime.NewScheme()
 	_ = rayv1.AddToScheme(newScheme)
@@ -1986,7 +1986,7 @@ func Test_RedisCleanupFeatureFlag(t *testing.T) {
 	if gcsFTEnabledCluster.Annotations == nil {
 		gcsFTEnabledCluster.Annotations = make(map[string]string)
 	}
-	gcsFTEnabledCluster.Annotations[common.RayFTEnabledAnnotationKey] = "true"
+	gcsFTEnabledCluster.Annotations[utils.RayFTEnabledAnnotationKey] = "true"
 	gcsFTEnabledCluster.Spec.EnableInTreeAutoscaling = nil
 	ctx := context.Background()
 
@@ -2014,9 +2014,9 @@ func Test_RedisCleanupFeatureFlag(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			if tc.enableGCSFTRedisCleanup == "unset" {
-				os.Unsetenv(common.ENABLE_GCS_FT_REDIS_CLEANUP)
+				os.Unsetenv(utils.ENABLE_GCS_FT_REDIS_CLEANUP)
 			} else {
-				os.Setenv(common.ENABLE_GCS_FT_REDIS_CLEANUP, tc.enableGCSFTRedisCleanup)
+				os.Setenv(utils.ENABLE_GCS_FT_REDIS_CLEANUP, tc.enableGCSFTRedisCleanup)
 			}
 
 			cluster := gcsFTEnabledCluster.DeepCopy()
@@ -2063,7 +2063,7 @@ func Test_RedisCleanupFeatureFlag(t *testing.T) {
 			assert.Equal(t, 1, len(rayClusterList.Items))
 			assert.Equal(t, tc.expectedNumFinalizers, len(rayClusterList.Items[0].Finalizers))
 			if tc.expectedNumFinalizers > 0 {
-				assert.True(t, controllerutil.ContainsFinalizer(&rayClusterList.Items[0], common.GCSFaultToleranceRedisCleanupFinalizer))
+				assert.True(t, controllerutil.ContainsFinalizer(&rayClusterList.Items[0], utils.GCSFaultToleranceRedisCleanupFinalizer))
 
 				// No Pod should be created before adding the GCS FT Redis cleanup finalizer.
 				podList := corev1.PodList{}
@@ -2099,11 +2099,11 @@ func Test_RedisCleanup(t *testing.T) {
 	if gcsFTEnabledCluster.Annotations == nil {
 		gcsFTEnabledCluster.Annotations = make(map[string]string)
 	}
-	gcsFTEnabledCluster.Annotations[common.RayFTEnabledAnnotationKey] = "true"
+	gcsFTEnabledCluster.Annotations[utils.RayFTEnabledAnnotationKey] = "true"
 	gcsFTEnabledCluster.Spec.EnableInTreeAutoscaling = nil
 
 	// Add the Redis cleanup finalizer to the RayCluster and modify the RayCluster's DeleteTimestamp to trigger the Redis cleanup.
-	controllerutil.AddFinalizer(gcsFTEnabledCluster, common.GCSFaultToleranceRedisCleanupFinalizer)
+	controllerutil.AddFinalizer(gcsFTEnabledCluster, utils.GCSFaultToleranceRedisCleanupFinalizer)
 	now := metav1.Now()
 	gcsFTEnabledCluster.DeletionTimestamp = &now
 
@@ -2115,9 +2115,9 @@ func Test_RedisCleanup(t *testing.T) {
 			Name:      "headNode",
 			Namespace: gcsFTEnabledCluster.Namespace,
 			Labels: map[string]string{
-				common.RayClusterLabelKey:   gcsFTEnabledCluster.Name,
-				common.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
-				common.RayNodeGroupLabelKey: headGroupName,
+				utils.RayClusterLabelKey:   gcsFTEnabledCluster.Name,
+				utils.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
+				utils.RayNodeGroupLabelKey: headGroupName,
 			},
 		},
 	}
@@ -2126,9 +2126,9 @@ func Test_RedisCleanup(t *testing.T) {
 			Name:      "workerNode",
 			Namespace: gcsFTEnabledCluster.Namespace,
 			Labels: map[string]string{
-				common.RayClusterLabelKey:   gcsFTEnabledCluster.Name,
-				common.RayNodeTypeLabelKey:  string(rayv1.WorkerNode),
-				common.RayNodeGroupLabelKey: gcsFTEnabledCluster.Spec.WorkerGroupSpecs[0].GroupName,
+				utils.RayClusterLabelKey:   gcsFTEnabledCluster.Name,
+				utils.RayNodeTypeLabelKey:  string(rayv1.WorkerNode),
+				utils.RayNodeGroupLabelKey: gcsFTEnabledCluster.Spec.WorkerGroupSpecs[0].GroupName,
 			},
 		},
 	}
@@ -2181,9 +2181,9 @@ func Test_RedisCleanup(t *testing.T) {
 				headPods := corev1.PodList{}
 				err := fakeClient.List(ctx, &headPods, client.InNamespace(namespaceStr),
 					client.MatchingLabels{
-						common.RayClusterLabelKey:   cluster.Name,
-						common.RayNodeGroupLabelKey: headGroupName,
-						common.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
+						utils.RayClusterLabelKey:   cluster.Name,
+						utils.RayNodeGroupLabelKey: headGroupName,
+						utils.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
 					})
 				assert.Nil(t, err)
 				assert.Equal(t, 1, len(headPods.Items))
@@ -2192,9 +2192,9 @@ func Test_RedisCleanup(t *testing.T) {
 				workerPods := corev1.PodList{}
 				err := fakeClient.List(ctx, &workerPods, client.InNamespace(namespaceStr),
 					client.MatchingLabels{
-						common.RayClusterLabelKey:   cluster.Name,
-						common.RayNodeGroupLabelKey: cluster.Spec.WorkerGroupSpecs[0].GroupName,
-						common.RayNodeTypeLabelKey:  string(rayv1.WorkerNode),
+						utils.RayClusterLabelKey:   cluster.Name,
+						utils.RayNodeGroupLabelKey: cluster.Spec.WorkerGroupSpecs[0].GroupName,
+						utils.RayNodeTypeLabelKey:  string(rayv1.WorkerNode),
 					})
 				assert.Nil(t, err)
 				assert.Equal(t, 1, len(workerPods.Items))
@@ -2229,7 +2229,7 @@ func Test_RedisCleanup(t *testing.T) {
 				err = fakeClient.List(ctx, &rayClusterList, client.InNamespace(namespaceStr))
 				assert.Nil(t, err, "Fail to get RayCluster list")
 				assert.Equal(t, 1, len(rayClusterList.Items))
-				assert.True(t, controllerutil.ContainsFinalizer(&rayClusterList.Items[0], common.GCSFaultToleranceRedisCleanupFinalizer))
+				assert.True(t, controllerutil.ContainsFinalizer(&rayClusterList.Items[0], utils.GCSFaultToleranceRedisCleanupFinalizer))
 
 				// Simulate the Job succeeded.
 				job := jobList.Items[0]

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -119,8 +118,8 @@ var _ = Context("Inside the default namespace", func() {
 		},
 	}
 
-	headFilterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayCluster.Name, common.RayNodeGroupLabelKey: "headgroup"}
-	workerFilterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayCluster.Name, common.RayNodeGroupLabelKey: "small-group"}
+	headFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: myRayCluster.Name, utils.RayNodeGroupLabelKey: "headgroup"}
+	workerFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: myRayCluster.Name, utils.RayNodeGroupLabelKey: "small-group"}
 
 	Describe("When creating a raycluster", func() {
 		It("should create a raycluster object", func() {
@@ -139,7 +138,7 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: "raycluster-sample-head-svc", Namespace: "default"}, svc),
 				time.Second*15, time.Millisecond*500).Should(BeNil(), "My head service = %v", svc)
-			Expect(svc.Spec.Selector[common.RayIDLabelKey]).Should(Equal(utils.GenerateIdentifier(myRayCluster.Name, rayv1.HeadNode)))
+			Expect(svc.Spec.Selector[utils.RayIDLabelKey]).Should(Equal(utils.GenerateIdentifier(myRayCluster.Name, rayv1.HeadNode)))
 		})
 
 		It("should create 3 workers", func() {
@@ -203,7 +202,7 @@ var _ = Context("Inside the default namespace", func() {
 		It("cluster's .status.state should be updated to 'ready' shortly after all Pods are Running", func() {
 			Eventually(
 				getClusterState(ctx, "default", myRayCluster.Name),
-				time.Second*(common.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS+5), time.Millisecond*500).Should(Equal(rayv1.Ready))
+				time.Second*(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS+5), time.Millisecond*500).Should(Equal(rayv1.Ready))
 		})
 
 		It("should re-create a deleted worker", func() {

--- a/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -235,8 +235,8 @@ var _ = Context("Inside the default namespace", func() {
 		It("should create 3 workers", func() {
 			Eventually(
 				listResourceFunc(ctx, &workerPods, client.MatchingLabels{
-					common.RayClusterLabelKey:   mySuspendedRayCluster.Name,
-					common.RayNodeGroupLabelKey: "small-group",
+					utils.RayClusterLabelKey:   mySuspendedRayCluster.Name,
+					utils.RayNodeGroupLabelKey: "small-group",
 				},
 					&client.ListOptions{Namespace: "default"}),
 				time.Second*15, time.Millisecond*500).Should(Equal(3), fmt.Sprintf("workerGroup %v", workerPods.Items))
@@ -248,8 +248,8 @@ var _ = Context("Inside the default namespace", func() {
 		It("should create a head pod resource", func() {
 			err := k8sClient.List(ctx, &headPods,
 				client.MatchingLabels{
-					common.RayClusterLabelKey:   mySuspendedRayCluster.Name,
-					common.RayNodeGroupLabelKey: "headgroup",
+					utils.RayClusterLabelKey:   mySuspendedRayCluster.Name,
+					utils.RayNodeGroupLabelKey: "headgroup",
 				},
 				&client.ListOptions{Namespace: "default"},
 				client.InNamespace(mySuspendedRayCluster.Namespace))
@@ -292,8 +292,8 @@ var _ = Context("Inside the default namespace", func() {
 
 			Eventually(
 				isAllPodsRunning(ctx, headPods, client.MatchingLabels{
-					common.RayClusterLabelKey:   mySuspendedRayCluster.Name,
-					common.RayNodeGroupLabelKey: "headgroup",
+					utils.RayClusterLabelKey:   mySuspendedRayCluster.Name,
+					utils.RayNodeGroupLabelKey: "headgroup",
 				}, "default"),
 				time.Second*15, time.Millisecond*500).Should(Equal(true), "Head Pod should be running.")
 
@@ -303,7 +303,7 @@ var _ = Context("Inside the default namespace", func() {
 			}
 
 			Eventually(
-				isAllPodsRunning(ctx, workerPods, client.MatchingLabels{common.RayClusterLabelKey: mySuspendedRayCluster.Name, common.RayNodeGroupLabelKey: "small-group"}, "default"),
+				isAllPodsRunning(ctx, workerPods, client.MatchingLabels{utils.RayClusterLabelKey: mySuspendedRayCluster.Name, utils.RayNodeGroupLabelKey: "small-group"}, "default"),
 				time.Second*15, time.Millisecond*500).Should(Equal(true), "All worker Pods should be running.")
 		})
 

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -198,7 +197,7 @@ var _ = Context("Inside the default namespace", func() {
 		})
 
 		It("Should create a number of workers equal to the replica setting", func() {
-			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayJob.Status.RayClusterName, common.RayNodeGroupLabelKey: myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName}
+			filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: myRayJob.Status.RayClusterName, utils.RayNodeGroupLabelKey: myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName}
 			workerPods := corev1.PodList{}
 			Eventually(
 				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
@@ -227,7 +226,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to update RayJob")
 
 			// confirm the number of worker pods increased.
-			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayJob.Status.RayClusterName, common.RayNodeGroupLabelKey: myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName}
+			filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: myRayJob.Status.RayClusterName, utils.RayNodeGroupLabelKey: myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName}
 			workerPods := corev1.PodList{}
 			Eventually(
 				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
@@ -315,7 +314,7 @@ var _ = Context("Inside the default namespace with autoscaler", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to update RayCluster replica")
 
 			// confirm a new worker pod is created.
-			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayJob.Status.RayClusterName, common.RayNodeGroupLabelKey: myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName}
+			filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: myRayJob.Status.RayClusterName, utils.RayNodeGroupLabelKey: myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName}
 			workerPods := corev1.PodList{}
 			Eventually(
 				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
@@ -352,7 +351,7 @@ var _ = Context("Inside the default namespace with autoscaler", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to update RayJob")
 
 			// confirm the number of worker pods is not changed.
-			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayJob.Status.RayClusterName, common.RayNodeGroupLabelKey: myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName}
+			filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: myRayJob.Status.RayClusterName, utils.RayNodeGroupLabelKey: myRayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName}
 			workerPods := corev1.PodList{}
 			Consistently(
 				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	utils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
@@ -151,25 +150,25 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	// Test 1: User provided template with command
 	submitterTemplate, err := r.getSubmitterTemplate(rayJobInstanceWithTemplate, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, "user-command", submitterTemplate.Spec.Containers[common.RayContainerIndex].Command[0])
+	assert.Equal(t, "user-command", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command[0])
 
 	// Test 2: User provided template without command
-	rayJobInstanceWithTemplate.Spec.SubmitterPodTemplate.Spec.Containers[common.RayContainerIndex].Command = []string{}
+	rayJobInstanceWithTemplate.Spec.SubmitterPodTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{}
 	submitterTemplate, err = r.getSubmitterTemplate(rayJobInstanceWithTemplate, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"ray", "job", "submit", "--address", "http://test-url", "--", "echo", "hello", "world"}, submitterTemplate.Spec.Containers[common.RayContainerIndex].Command)
+	assert.Equal(t, []string{"ray", "job", "submit", "--address", "http://test-url", "--", "echo", "hello", "world"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
 
 	// Test 3: User did not provide template, should use the image of the Ray Head
 	submitterTemplate, err = r.getSubmitterTemplate(rayJobInstanceWithoutTemplate, rayClusterInstance)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"ray", "job", "submit", "--address", "http://test-url", "--", "echo", "hello", "world"}, submitterTemplate.Spec.Containers[common.RayContainerIndex].Command)
-	assert.Equal(t, "rayproject/ray:custom-version", submitterTemplate.Spec.Containers[common.RayContainerIndex].Image)
+	assert.Equal(t, []string{"ray", "job", "submit", "--address", "http://test-url", "--", "echo", "hello", "world"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
+	assert.Equal(t, "rayproject/ray:custom-version", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Image)
 
 	// Test 4: Check default PYTHONUNBUFFERED setting
 	submitterTemplate, err = r.getSubmitterTemplate(rayJobInstanceWithoutTemplate, rayClusterInstance)
 	assert.NoError(t, err)
 	found := false
-	for _, envVar := range submitterTemplate.Spec.Containers[common.RayContainerIndex].Env {
+	for _, envVar := range submitterTemplate.Spec.Containers[utils.RayContainerIndex].Env {
 		if envVar.Name == PythonUnbufferedEnvVarName {
 			assert.Equal(t, "1", envVar.Value)
 			found = true

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -298,7 +297,7 @@ applications:
 		})
 
 		It("should create more than 1 worker", func() {
-			filterLabels := client.MatchingLabels{common.RayClusterLabelKey: myRayService.Status.ActiveServiceStatus.RayClusterName, common.RayNodeGroupLabelKey: "small-group"}
+			filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: myRayService.Status.ActiveServiceStatus.RayClusterName, utils.RayNodeGroupLabelKey: "small-group"}
 			Eventually(
 				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
 				time.Second*15, time.Millisecond*500).Should(Equal(3), fmt.Sprintf("workerGroup %v", workerPods.Items))
@@ -311,13 +310,13 @@ applications:
 					// Each worker Pod should have a container port with the name "dashboard-agent"
 					exist := false
 					for _, port := range pod.Spec.Containers[0].Ports {
-						if port.Name == common.DashboardAgentListenPortName {
+						if port.Name == utils.DashboardAgentListenPortName {
 							exist = true
 							break
 						}
 					}
 					if !exist {
-						Fail(fmt.Sprintf("Worker Pod %v should have a container port with the name %v", pod.Name, common.DashboardAgentListenPortName))
+						Fail(fmt.Sprintf("Worker Pod %v should have a container port with the name %v", pod.Name, utils.DashboardAgentListenPortName))
 					}
 				}
 			}
@@ -336,7 +335,7 @@ applications:
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: headSvcName, Namespace: "default"}, svc),
 				time.Second*15, time.Millisecond*500).Should(BeNil(), "My head service = %v", svc)
-			Expect(svc.Spec.Selector[common.RayIDLabelKey]).Should(Equal(utils.GenerateIdentifier(myRayCluster.Name, rayv1.HeadNode)))
+			Expect(svc.Spec.Selector[utils.RayIDLabelKey]).Should(Equal(utils.GenerateIdentifier(myRayCluster.Name, rayv1.HeadNode)))
 		})
 
 		It("should create a new serve service resource", func() {
@@ -344,7 +343,7 @@ applications:
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: utils.GenerateServeServiceName(myRayService.Name), Namespace: "default"}, svc),
 				time.Second*15, time.Millisecond*500).Should(BeNil(), "My serve service = %v", svc)
-			Expect(svc.Spec.Selector[common.RayClusterLabelKey]).Should(Equal(myRayCluster.Name))
+			Expect(svc.Spec.Selector[utils.RayClusterLabelKey]).Should(Equal(myRayCluster.Name))
 		})
 
 		It("should update a rayservice object and switch to new Ray Cluster", func() {
@@ -554,7 +553,7 @@ applications:
 				time.Second*3, time.Millisecond*500).Should(BeTrue(), "myRayService status = %v", myRayService.Status)
 
 			// Only update the LastUpdateTime and HealthLastUpdateTime fields in the active RayCluster.
-			oldTime := myRayService.Status.ActiveServiceStatus.Applications[common.DefaultServeAppName].HealthLastUpdateTime.DeepCopy()
+			oldTime := myRayService.Status.ActiveServiceStatus.Applications[utils.DefaultServeAppName].HealthLastUpdateTime.DeepCopy()
 			fakeRayDashboardClient.SetSingleApplicationStatus(generateServeStatus(rayv1.DeploymentStatusEnum.HEALTHY, rayv1.ApplicationStatusEnum.RUNNING))
 
 			// Confirm not switch to a new RayCluster
@@ -570,7 +569,7 @@ applications:
 			// Status should not be updated if the only differences are the LastUpdateTime and HealthLastUpdateTime fields.
 			// Unlike the test "Status should be updated if the differences are not only LastUpdateTime and HealthLastUpdateTime fields.",
 			// the status update will not be triggered, so we can check whether the LastUpdateTime/HealthLastUpdateTime fields are updated or not by `oldTime`.
-			Expect(myRayService.Status.ActiveServiceStatus.Applications[common.DefaultServeAppName].HealthLastUpdateTime).Should(Equal(oldTime), "myRayService status = %v", myRayService.Status)
+			Expect(myRayService.Status.ActiveServiceStatus.Applications[utils.DefaultServeAppName].HealthLastUpdateTime).Should(Equal(oldTime), "myRayService status = %v", myRayService.Status)
 		})
 
 		It("Update workerGroup.replicas in RayService and should not switch to new Ray Cluster", func() {
@@ -747,8 +746,8 @@ func checkServiceHealth(ctx context.Context, rayService *rayv1.RayService) func(
 func updateHeadPodToRunningAndReady(ctx context.Context, rayClusterName string) {
 	headPods := corev1.PodList{}
 	headFilterLabels := client.MatchingLabels{
-		common.RayClusterLabelKey:  rayClusterName,
-		common.RayNodeTypeLabelKey: string(rayv1.HeadNode),
+		utils.RayClusterLabelKey:  rayClusterName,
+		utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
 	}
 
 	Eventually(

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -10,7 +10,6 @@ import (
 
 	cmap "github.com/orcaman/concurrent-map"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme"
 	"github.com/stretchr/testify/assert"
@@ -90,7 +89,7 @@ func TestInconsistentRayServiceStatuses(t *testing.T) {
 				HealthLastUpdateTime: &timeNow,
 			},
 			Applications: map[string]rayv1.AppStatus{
-				common.DefaultServeAppName: {
+				utils.DefaultServeAppName: {
 					Status:               rayv1.ApplicationStatusEnum.RUNNING,
 					Message:              "OK",
 					HealthLastUpdateTime: &timeNow,
@@ -111,7 +110,7 @@ func TestInconsistentRayServiceStatuses(t *testing.T) {
 				HealthLastUpdateTime: &timeNow,
 			},
 			Applications: map[string]rayv1.AppStatus{
-				common.DefaultServeAppName: {
+				utils.DefaultServeAppName: {
 					Status:               rayv1.ApplicationStatusEnum.NOT_STARTED,
 					Message:              "application not started yet",
 					HealthLastUpdateTime: &timeNow,
@@ -214,8 +213,8 @@ func TestIsHeadPodRunningAndReady(t *testing.T) {
 			Name:      "head-pod",
 			Namespace: cluster.ObjectMeta.Namespace,
 			Labels: map[string]string{
-				common.RayClusterLabelKey:  cluster.ObjectMeta.Name,
-				common.RayNodeTypeLabelKey: string(rayv1.HeadNode),
+				utils.RayClusterLabelKey:  cluster.ObjectMeta.Name,
+				utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
 			},
 		},
 		Status: corev1.PodStatus{
@@ -326,7 +325,7 @@ func TestReconcileServices_UpdateService(t *testing.T) {
 
 	ctx := context.TODO()
 	// Create a head service.
-	err := r.reconcileServices(ctx, &rayService, &cluster, common.HeadService)
+	err := r.reconcileServices(ctx, &rayService, &cluster, utils.HeadService)
 	assert.Nil(t, err, "Fail to reconcile service")
 
 	svcList := corev1.ServiceList{}
@@ -342,7 +341,7 @@ func TestReconcileServices_UpdateService(t *testing.T) {
 			ContainerPort: 9999,
 		},
 	}
-	err = r.reconcileServices(ctx, &rayService, &cluster, common.HeadService)
+	err = r.reconcileServices(ctx, &rayService, &cluster, utils.HeadService)
 	assert.Nil(t, err, "Fail to reconcile service")
 
 	svcList = corev1.ServiceList{}
@@ -353,7 +352,7 @@ func TestReconcileServices_UpdateService(t *testing.T) {
 
 	// Test 2: When the RayCluster switches, the service should be updated.
 	cluster.Name = "new-cluster"
-	err = r.reconcileServices(ctx, &rayService, &cluster, common.HeadService)
+	err = r.reconcileServices(ctx, &rayService, &cluster, utils.HeadService)
 	assert.Nil(t, err, "Fail to reconcile service")
 
 	svcList = corev1.ServiceList{}
@@ -389,7 +388,7 @@ func TestFetchHeadServiceURL(t *testing.T) {
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Name: common.DashboardPortName,
+					Name: utils.DashboardPortName,
 					Port: dashboardPort,
 				},
 			},
@@ -409,7 +408,7 @@ func TestFetchHeadServiceURL(t *testing.T) {
 		Log:      ctrl.Log.WithName("controllers").WithName("RayService"),
 	}
 
-	url, err := utils.FetchHeadServiceURL(ctx, &r.Log, r.Client, &cluster, common.DashboardPortName)
+	url, err := utils.FetchHeadServiceURL(ctx, &r.Log, r.Client, &cluster, utils.DashboardPortName)
 	assert.Nil(t, err, "Fail to fetch head service url")
 	assert.Equal(t, fmt.Sprintf("test-cluster-head-svc.%s.svc.cluster.local:%d", namespace, dashboardPort), url, "Head service url is not correct")
 }
@@ -677,7 +676,7 @@ func TestReconcileRayCluster(t *testing.T) {
 			Name:      "active-cluster",
 			Namespace: namespace,
 			Annotations: map[string]string{
-				common.RayServiceClusterHashKey: hash,
+				utils.RayServiceClusterHashKey: hash,
 			},
 		},
 	}

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -78,7 +77,7 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	Expect(k8sClient).ToNot(BeNil())
 
 	// Suggested way to run tests
-	os.Setenv(common.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV, "10")
+	os.Setenv(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV, "10")
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 		Metrics: metricsserver.Options{

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -1,4 +1,4 @@
-package common
+package utils
 
 const (
 

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -30,7 +30,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler"
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -191,7 +191,7 @@ func main() {
 }
 
 func cacheSelectors() (map[client.Object]cache.ByObject, error) {
-	label, err := labels.NewRequirement(common.KubernetesCreatedByLabelKey, selection.Equals, []string{common.ComponentName})
+	label, err := labels.NewRequirement(utils.KubernetesCreatedByLabelKey, selection.Equals, []string{utils.ComponentName})
 	if err != nil {
 		return nil, err
 	}

--- a/ray-operator/test/e2e/rayjob_cluster_selector_test.go
+++ b/ray-operator/test/e2e/rayjob_cluster_selector_test.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
@@ -59,7 +59,7 @@ func TestRayJobWithClusterSelector(t *testing.T) {
 			},
 			Spec: rayv1.RayJobSpec{
 				ClusterSelector: map[string]string{
-					common.RayClusterLabelKey: rayCluster.Name,
+					utils.RayClusterLabelKey: rayCluster.Name,
 				},
 				Entrypoint: "python /home/ray/jobs/counter.py",
 				RuntimeEnvYAML: `
@@ -98,7 +98,7 @@ env_vars:
 			},
 			Spec: rayv1.RayJobSpec{
 				ClusterSelector: map[string]string{
-					common.RayClusterLabelKey: rayCluster.Name,
+					utils.RayClusterLabelKey: rayCluster.Name,
 				},
 				Entrypoint:               "python /home/ray/jobs/fail.py",
 				ShutdownAfterJobFinishes: false,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The following diagram represents the dependency graph for packages in KubeRay. Originally, `constant.go` resided in the common package. However, sometimes the `utils` package needs to use certain constant variables from `constant.go`, but importing common would cause a circular dependency. Hence, we need to hard code some values or define constant variables in the `utils` as the workaround ([example](https://github.com/ray-project/kuberay/blob/be1037386f5c52f10058a6ba6f8a18054e67b8bb/ray-operator/controllers/ray/utils/util.go#L35)). This PR moves `constant.go` from `common` to `utils`.

<img width="1001" alt="Screen Shot 2023-12-08 at 3 35 42 PM" src="https://github.com/ray-project/kuberay/assets/20109646/8cc908c8-b4c5-406f-88ca-951c950f35c1">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
