### PR TITLE
[Refactor] Remove global utils.GetRayXXXClientFuncs

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -372,7 +372,7 @@ var _ = Context("With a delayed dashboard client", func() {
 	Describe("When creating a rayjob", func() {
 		It("should create a rayjob object", func() {
 			// setup mock first
-			utils.GetRayDashboardClientFunc().(*utils.FakeRayDashboardClient).GetJobInfoMock.Store(&mockedGetJobInfo)
+			fakeRayDashboardClient.GetJobInfoMock.Store(&mockedGetJobInfo)
 			err := k8sClient.Create(ctx, myRayJob)
 			Expect(err).NotTo(HaveOccurred(), "failed to create test RayJob resource")
 		})
@@ -385,7 +385,7 @@ var _ = Context("With a delayed dashboard client", func() {
 
 		It("Dashboard URL should be set and deployment status should leave the JobDeploymentStatusWaitForDashboardReady", func() {
 			// clear mock to back to normal behavior
-			utils.GetRayDashboardClientFunc().(*utils.FakeRayDashboardClient).GetJobInfoMock.Store(nil)
+			fakeRayDashboardClient.GetJobInfoMock.Store(nil)
 			Eventually(
 				getDashboardURLForRayJob(ctx, myRayJob),
 				time.Second*15, time.Millisecond*500).Should(HavePrefix(myRayJob.Name), "Dashboard URL = %v", myRayJob.Status.DashboardURL)

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -254,14 +254,6 @@ applications:
 		},
 	}
 
-	fakeRayDashboardClient := prepareFakeRayDashboardClient()
-
-	utils.GetRayDashboardClientFunc = func() utils.RayDashboardClientInterface {
-		return fakeRayDashboardClient
-	}
-
-	utils.GetRayHttpProxyClientFunc = utils.GetFakeRayHttpProxyClient
-
 	myRayCluster := &rayv1.RayCluster{}
 
 	Describe("When creating a rayservice", func() {

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -45,6 +45,9 @@ var (
 	cfg       *rest.Config
 	k8sClient client.Client
 	testEnv   *envtest.Environment
+
+	fakeRayDashboardClient *utils.FakeRayDashboardClient
+	fakeRayHttpProxyClient *utils.FakeRayHttpProxyClient
 )
 
 func TestAPIs(t *testing.T) {
@@ -86,13 +89,22 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	})
 	Expect(err).NotTo(HaveOccurred(), "failed to create manager")
 
+	fakeRayDashboardClient = prepareFakeRayDashboardClient()
+	fakeRayHttpProxyClient = &utils.FakeRayHttpProxyClient{}
+
 	err = NewReconciler(mgr).SetupWithManager(mgr, 1)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayCluster controller")
 
-	err = NewRayServiceReconciler(mgr).SetupWithManager(mgr)
+	err = NewRayServiceReconciler(mgr, func() utils.RayDashboardClientInterface {
+		return fakeRayDashboardClient
+	}, func() utils.RayHttpProxyClientInterface {
+		return fakeRayHttpProxyClient
+	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayService controller")
 
-	err = NewRayJobReconciler(mgr).SetupWithManager(mgr)
+	err = NewRayJobReconciler(mgr, func() utils.RayDashboardClientInterface {
+		return fakeRayDashboardClient
+	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayJob controller")
 
 	go func() {
@@ -102,7 +114,6 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 })
 
 var _ = AfterSuite(func() {
-	utils.GetRayDashboardClientFunc = utils.GetRayDashboardClient
 	By("tearing down the test environment")
 
 	// NOTE(simon): the error is ignored because it gets raised in macOS due

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -57,9 +57,6 @@ type BaseDashboardClient struct {
 	dashboardURL string
 }
 
-// GetRayDashboardClientFunc Used for unit tests.
-var GetRayDashboardClientFunc = GetRayDashboardClient
-
 func GetRayDashboardClient() RayDashboardClientInterface {
 	return &RayDashboardClient{}
 }

--- a/ray-operator/controllers/ray/utils/fake_httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/fake_httpproxy_httpclient.go
@@ -6,10 +6,6 @@ import (
 	"time"
 )
 
-func GetFakeRayHttpProxyClient() RayHttpProxyClientInterface {
-	return &FakeRayHttpProxyClient{}
-}
-
 type FakeRayHttpProxyClient struct {
 	client       http.Client
 	httpProxyURL string

--- a/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
@@ -15,9 +15,6 @@ type RayHttpProxyClientInterface interface {
 	SetHostIp(hostIp string, port int)
 }
 
-// GetRayHttpProxyClientFunc Used for unit tests.
-var GetRayHttpProxyClientFunc = GetRayHttpProxyClient
-
 func GetRayHttpProxyClient() RayHttpProxyClientInterface {
 	return &RayHttpProxyClient{}
 }

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -172,9 +172,9 @@ func main() {
 
 	exitOnError(ray.NewReconciler(mgr).SetupWithManager(mgr, reconcileConcurrency),
 		"unable to create controller", "controller", "RayCluster")
-	exitOnError(ray.NewRayServiceReconciler(mgr).SetupWithManager(mgr),
+	exitOnError(ray.NewRayServiceReconciler(mgr, utils.GetRayDashboardClient, utils.GetRayHttpProxyClient).SetupWithManager(mgr),
 		"unable to create controller", "controller", "RayService")
-	exitOnError(ray.NewRayJobReconciler(mgr).SetupWithManager(mgr),
+	exitOnError(ray.NewRayJobReconciler(mgr, utils.GetRayDashboardClient).SetupWithManager(mgr),
 		"unable to create controller", "controller", "RayJob")
 
 	if os.Getenv("ENABLE_WEBHOOKS") == "true" {


### PR DESCRIPTION
The global `utils.GetRayDashboardClientFunc` and `utils.GetRayHttpProxyClientFunc` are used for injecting faked implementations while testing.

However, these global variables make tracing their mutations very hard and confusing. Even let developers suspect whether there were unsynchronized concurrent accesses to them or not. (https://github.com/ray-project/kuberay/pull/1724)

To reduce the scope of debugging and confusion, this PR removes these two global variables and introduces the `dashboardClientFunc` and `httpProxyClientFunc` as member fields of the `RayJobReconciler` and `RayServiceReconciler` instead. These two new member fields can only be injected when calling the `NewRayServiceReconciler` and `NewRayJobReconciler` constructors, therefore, they will be much easier to trace. 



## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
