### PR TITLE
chore webhook: change K8s annotations to use `kuberay-operator`

### DIFF
--- a/ray-operator/config/certmanager/certificate.yaml
+++ b/ray-operator/config/certmanager/certificate.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: selfsigned-issuer
     app.kubernetes.io/component: certificate
-    app.kubernetes.io/created-by: ray-operator
-    app.kubernetes.io/part-of: ray-operator
+    app.kubernetes.io/created-by: kuberay-operator
+    app.kubernetes.io/part-of: kuberay-operator
     app.kubernetes.io/managed-by: kustomize
   name: selfsigned-issuer
   namespace: system
@@ -23,8 +23,8 @@ metadata:
     app.kubernetes.io/name: certificate
     app.kubernetes.io/instance: serving-cert
     app.kubernetes.io/component: certificate
-    app.kubernetes.io/created-by: ray-operator
-    app.kubernetes.io/part-of: ray-operator
+    app.kubernetes.io/created-by: kuberay-operator
+    app.kubernetes.io/part-of: kuberay-operator
     app.kubernetes.io/managed-by: kustomize
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system

--- a/ray-operator/config/default-with-webhooks/webhookcainjection_patch.yaml
+++ b/ray-operator/config/default-with-webhooks/webhookcainjection_patch.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: validatingwebhookconfiguration
     app.kubernetes.io/instance: validating-webhook-configuration
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: ray-operator
-    app.kubernetes.io/part-of: ray-operator
+    app.kubernetes.io/created-by: kuberay-operator
+    app.kubernetes.io/part-of: kuberay-operator
     app.kubernetes.io/managed-by: kustomize
   name: validating-webhook-configuration
   annotations:

--- a/ray-operator/config/webhook/service.yaml
+++ b/ray-operator/config/webhook/service.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: service
     app.kubernetes.io/instance: webhook-service
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: ray-operator
-    app.kubernetes.io/part-of: ray-operator
+    app.kubernetes.io/created-by: kuberay-operator
+    app.kubernetes.io/part-of: kuberay-operator
     app.kubernetes.io/managed-by: kustomize
   name: webhook-service
   namespace: ray-system


### PR DESCRIPTION
instead of `ray-operator`. The former seems to be more widely used in this project.

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
