### PR TITLE
fix: validate RayCluster name with validating webhook

### DIFF
--- a/ray-operator/apis/ray/v1/webhook_suite_test.go
+++ b/ray-operator/apis/ray/v1/webhook_suite_test.go
@@ -120,6 +120,33 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = Describe("RayCluster validating webhook", func() {
+	Context("when name is invalid", func() {
+		It("should return error", func() {
+			rayCluster := RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "invalid.name",
+				},
+				Spec: RayClusterSpec{
+					HeadGroupSpec: HeadGroupSpec{
+						RayStartParams: map[string]string{"DEADBEEF": "DEADBEEF"},
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{},
+							},
+						},
+					},
+					WorkerGroupSpecs: []WorkerGroupSpec{},
+				},
+			}
+
+			err := k8sClient.Create(context.TODO(), &rayCluster)
+			Expect(err).To(HaveOccurred())
+
+			Expect(err.Error()).To(ContainSubstring("RayCluster.ray.io \"invalid.name\" is invalid: metadata.name:"))
+		})
+	})
+
 	Context("when groupNames are not unique", func() {
 		var name, namespace string
 		var rayCluster RayCluster


### PR DESCRIPTION
## Why are these changes needed?

This change prevents RayClusters with invalid names from being created
with actionable error messages instead of allowing their creation but
failing later with hidden errors.

```
❯ head /tmp/raycluster.yaml                                                                                                                                                                                                                                                                (base)
---
apiVersion: ray.io/v1
kind: RayCluster
metadata:
  name: sample.foo
...

❯ kubectl apply -f /tmp/raycluster.yaml                                                                                                                                                                                (base)
The RayCluster "sample.foo" is invalid: metadata.name: Invalid value:
"sample.foo": name must consist of lower case alphanumeric characters or '-',
start with an alphabetic character, and end with an alphanumeric character
(e.g. 'my-name',  or 'abc-123', regex used for validation is
'[a-z]([-a-z0-9]*[a-z0-9])?')
```

## Related issue number

closes #1009

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
