### PR TITLE
[RayJob][Status][2/n] Redefine `ready` for RayCluster to avoid using HTTP requests to check dashboard status

### DIFF
--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -35,8 +35,6 @@ type JobDeploymentStatus string
 const (
 	JobDeploymentStatusInitializing                  JobDeploymentStatus = "Initializing"
 	JobDeploymentStatusFailedToGetOrCreateRayCluster JobDeploymentStatus = "FailedToGetOrCreateRayCluster"
-	JobDeploymentStatusWaitForDashboard              JobDeploymentStatus = "WaitForDashboard"
-	JobDeploymentStatusWaitForDashboardReady         JobDeploymentStatus = "WaitForDashboardReady"
 	JobDeploymentStatusWaitForK8sJob                 JobDeploymentStatus = "WaitForK8sJob"
 	JobDeploymentStatusFailedJobDeploy               JobDeploymentStatus = "FailedJobDeploy"
 	JobDeploymentStatusRunning                       JobDeploymentStatus = "Running"

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -200,6 +200,9 @@ var _ = Context("Inside the default namespace", func() {
 		})
 
 		It("cluster's .status.state should be updated to 'ready' shortly after all Pods are Running", func() {
+			// Note that RayCluster is `ready` when all Pods are Running and their PodReady conditions are true.
+			// However, in envtest, PodReady conditions are automatically set to true when Pod.Status.Phase is set to Running.
+			// We need to figure out the behavior. See https://github.com/ray-project/kuberay/issues/1736 for more details.
 			Eventually(
 				getClusterState(ctx, "default", myRayCluster.Name),
 				time.Second*(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS+5), time.Millisecond*500).Should(Equal(rayv1.Ready))

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -248,11 +248,7 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*15, time.Millisecond*500).Should(Equal(int(replicas)), fmt.Sprintf("workerGroup %v", workerPods.Items))
 			for _, workerPod := range workerPods.Items {
 				workerPod.Status.Phase = corev1.PodRunning
-				for _, cond := range workerPod.Status.Conditions {
-					if cond.Type == corev1.PodReady {
-						cond.Status = corev1.ConditionTrue
-					}
-				}
+				// TODO: Check https://github.com/ray-project/kuberay/issues/1736.
 				Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(BeNil())
 			}
 

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -380,12 +380,12 @@ func CheckAllPodsRunning(runningPods corev1.PodList) bool {
 	}
 	for _, pod := range runningPods.Items {
 		if pod.Status.Phase != corev1.PodRunning {
-			logrus.Info("CheckAllPodsRunning: Pod is not running", "Pod Name", pod.Name, "Pod Status.Phase", pod.Status.Phase)
+			logrus.Info(fmt.Sprintf("CheckAllPodsRunning: Pod is not running; Pod Name: %s; Pod Status.Phase: %v", pod.Name, pod.Status.Phase))
 			return false
 		}
 		for _, cond := range pod.Status.Conditions {
 			if cond.Type == corev1.PodReady && cond.Status != corev1.ConditionTrue {
-				logrus.Info("CheckAllPodsRunning: Pod is not ready", "Pod Name", pod.Name, "Pod Status.Conditions[PodReady]", cond)
+				logrus.Info(fmt.Sprintf("CheckAllPodsRunning: Pod is not ready; Pod Name: %s; Pod Status.Conditions[PodReady]: %v", pod.Name, cond))
 				return false
 			}
 		}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -380,7 +380,14 @@ func CheckAllPodsRunning(runningPods corev1.PodList) bool {
 	}
 	for _, pod := range runningPods.Items {
 		if pod.Status.Phase != corev1.PodRunning {
+			logrus.Info("CheckAllPodsRunning: Pod is not running", "Pod Name", pod.Name, "Pod Status.Phase", pod.Status.Phase)
 			return false
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status != corev1.ConditionTrue {
+				logrus.Info("CheckAllPodsRunning: Pod is not ready", "Pod Name", pod.Name, "Pod Status.Conditions[PodReady]", cond)
+				return false
+			}
 		}
 	}
 	return true


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#1674 introduces default readiness and liveness probes for Ray Pods, regardless of whether GCS fault tolerance is enabled. For the head Pod, the readiness probe verifies the status of GCS and Raylet. The GCS check utilizes the API endpoint from the Ray dashboard at `DASHBOARD_ADDRESS:8265/api/gcs_healthz`.

I checked with @architkulkarni and @shrekris-anyscale. I can imply that the Ray dashboard is ready for “Ray Job Submission” and Ray Serve RESTful API if `DASHBOARD_ADDRESS:8265/api/gcs_healthz` returns “success”. Hence, a "ready" RayCluster implies that all Ray Pods are running and ready, including Ray head.

* Check https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/580-pod-readiness-gates/README.md for the details of `PodReady`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
