### PR TITLE
[RayJob][Status][3/n] Define JobDeploymentStatusInitializing

### DIFF
--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -35,8 +35,6 @@ type JobDeploymentStatus string
 const (
 	JobDeploymentStatusInitializing                  JobDeploymentStatus = "Initializing"
 	JobDeploymentStatusFailedToGetOrCreateRayCluster JobDeploymentStatus = "FailedToGetOrCreateRayCluster"
-	JobDeploymentStatusWaitForDashboard              JobDeploymentStatus = "WaitForDashboard"
-	JobDeploymentStatusWaitForDashboardReady         JobDeploymentStatus = "WaitForDashboardReady"
 	JobDeploymentStatusWaitForK8sJob                 JobDeploymentStatus = "WaitForK8sJob"
 	JobDeploymentStatusFailedJobDeploy               JobDeploymentStatus = "FailedJobDeploy"
 	JobDeploymentStatusRunning                       JobDeploymentStatus = "Running"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR doesn’t change any code logic. Most of the work was done by #1733.

* `initRayJobStatusIfNeed` is the source of truth where `JobDeploymentStatusInitializing` is defined.
* `JobDeploymentStatusInitializing` means that `JobID`, `JobStatus`, and `RayClusterName` are initialized, so double creations of RayCluster CRs and `ray job` will not happen.
* `JobDeploymentStatusInitializing` implies that the RayJob is ready to create or get RayCluster CR.



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
