### PR TITLE
[Hotfix][Bug] `suspend` is not a stateless operation 

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -312,11 +312,6 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 		return ctrl.Result{}, nil
 	}
 
-	if instance.Spec.Suspend != nil && *instance.Spec.Suspend && instance.Status.State == rayv1.Suspended {
-		r.Log.Info("RayCluster is suspended, skipping reconcile", "cluster name", request.Name)
-		return ctrl.Result{}, nil
-	}
-
 	if err := r.reconcileAutoscalerServiceAccount(ctx, instance); err != nil {
 		if updateErr := r.updateClusterState(ctx, instance, rayv1.Failed); updateErr != nil {
 			r.Log.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -321,7 +321,7 @@ var _ = Context("Inside the default namespace", func() {
 		})
 
 		It("set suspend to false and then revert it to true before all Pods are running", func() {
-			// suspend a Raycluster and check that all pods are deleted.
+			// set suspend to false
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -320,6 +320,58 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS+5), time.Millisecond*500).Should(Equal(rayv1.Suspended))
 		})
 
+		It("set suspend to false and then revert it to true before all Pods are running", func() {
+			// suspend a Raycluster and check that all pods are deleted.
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				Eventually(
+					getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),
+					time.Second*9, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
+				suspend := false
+				myRayCluster.Spec.Suspend = &suspend
+				return k8sClient.Update(ctx, myRayCluster)
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to update test RayCluster resource")
+
+			// check that all pods are created
+			Eventually(
+				listResourceFunc(ctx, &headPods, headFilterLabels, &client.ListOptions{Namespace: "default"}),
+				time.Second*15, time.Millisecond*500).Should(Equal(1), fmt.Sprintf("head %v", headPods.Items))
+			Eventually(
+				listResourceFunc(ctx, &workerPods, workerFilterLabels, &client.ListOptions{Namespace: "default"}),
+				time.Second*15, time.Millisecond*500).Should(Equal(4), fmt.Sprintf("workerGroup %v", workerPods.Items))
+
+			// We only update worker Pod statuses so that the head Pod status is still Pending.
+			for _, workerPod := range workerPods.Items {
+				workerPod.Status.Phase = corev1.PodRunning
+				Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(BeNil())
+			}
+
+			// Change suspend to true before all Pods are Running.
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				Eventually(
+					getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),
+					time.Second*9, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
+				suspend := true
+				myRayCluster.Spec.Suspend = &suspend
+				return k8sClient.Update(ctx, myRayCluster)
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to update test RayCluster resource")
+
+			// check that all pods are deleted
+			Eventually(
+				listResourceFunc(ctx, &workerPods, workerFilterLabels, &client.ListOptions{Namespace: "default"}),
+				time.Second*15, time.Millisecond*500).Should(Equal(0), fmt.Sprintf("workerGroup %v", workerPods.Items))
+
+			Eventually(
+				listResourceFunc(ctx, &headPods, headFilterLabels, &client.ListOptions{Namespace: "default"}),
+				time.Second*15, time.Millisecond*500).Should(Equal(0), fmt.Sprintf("head %v", headPods.Items))
+
+			// RayCluster should be in Suspended state.
+			Eventually(
+				getClusterState(ctx, "default", myRayCluster.Name),
+				time.Second*(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS+5), time.Millisecond*500).Should(Equal(rayv1.Suspended))
+		})
+
 		It("should run all head and worker pods if un-suspended", func() {
 			// suspend a Raycluster and check that all pods are deleted.
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -340,13 +340,13 @@ var _ = Context("Inside the default namespace", func() {
 				listResourceFunc(ctx, &workerPods, workerFilterLabels, &client.ListOptions{Namespace: "default"}),
 				time.Second*15, time.Millisecond*500).Should(Equal(4), fmt.Sprintf("workerGroup %v", workerPods.Items))
 
-			// We only update worker Pod statuses so that the head Pod status is still Pending.
+			// only update worker Pod statuses so that the head Pod status is still Pending.
 			for _, workerPod := range workerPods.Items {
 				workerPod.Status.Phase = corev1.PodRunning
 				Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(BeNil())
 			}
 
-			// Change suspend to true before all Pods are Running.
+			// change suspend to true before all Pods are Running.
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Reproduce the error
  * Step 1: Set `suspend` to true.
  * Step 2: The status changes to `suspended` after all Pods are deleted.
  * Step 3: Set `suspend` back to false; this will trigger the creation of Pods.
  * Step 4: Set `suspend` back to true before all Pods are fully operational. In this case, the state remains `suspended` instead of becoming `ready`.
  * Step 5: At this moment, the KubeRay operator will skip the reconciliation because `suspend: true` and the status is `suspended`.

The function `reconcilePods` should only create Pods when `suspend` is false and the status is not `suspended`. However, RayCluster currently does not have a well-defined state machine. To avoid adding complexity to the codebase, I decided not to skip the reconciliation until we have a well-defined state machine.

## Related issue number

#1711
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
