### PR TITLE
Check existing pods for suspended RayCluster before calling DeleteCollection

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -585,6 +585,15 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	// if RayCluster is suspended, delete all pods and skip reconcile
 	if instance.Spec.Suspend != nil && *instance.Spec.Suspend {
 		clusterLabel := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name}
+		allPods := corev1.PodList{}
+		if err := r.List(ctx, &allPods, client.InNamespace(instance.Namespace), clusterLabel); err != nil {
+			return err
+		}
+
+		if len(allPods.Items) == 0 {
+			return nil
+		}
+
 		if err := r.DeleteAllOf(ctx, &corev1.Pod{}, client.InNamespace(instance.Namespace), clusterLabel); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Why are these changes needed?

Follow-up to https://github.com/ray-project/kuberay/pull/1711 & https://github.com/ray-project/kuberay/pull/1741.

After https://github.com/ray-project/kuberay/pull/1741, we always run the reconcile loop for suspended RayCluster, regardless of it's state. This means that for suspended clusters we will always call DeleteCollection and record an event.

This PR makes a small optimization to check existing pods before calling DeleteCollection. This should not be susceptible to the same bug fixed in https://github.com/ray-project/kuberay/pull/1741 since we are not checking cluster state, but rather checking informer cache for existing pods.

## Related issue number

https://github.com/ray-project/kuberay/issues/1667

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
