### PR TITLE
[Refactor] Use RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV as timeout of status check in tests

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -205,7 +205,7 @@ var _ = Context("Inside the default namespace", func() {
 			// We need to figure out the behavior. See https://github.com/ray-project/kuberay/issues/1736 for more details.
 			Eventually(
 				getClusterState(ctx, "default", myRayCluster.Name),
-				time.Second*(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS+5), time.Millisecond*500).Should(Equal(rayv1.Ready))
+				time.Second*15, time.Millisecond*500).Should(Equal(rayv1.Ready))
 		})
 
 		It("should re-create a deleted worker", func() {
@@ -311,7 +311,7 @@ var _ = Context("Inside the default namespace", func() {
 		It("cluster's .status.state should be updated to 'suspended' shortly after all Pods are terminated", func() {
 			Eventually(
 				getClusterState(ctx, "default", myRayCluster.Name),
-				time.Second*(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS+5), time.Millisecond*500).Should(Equal(rayv1.Suspended))
+				time.Second*15, time.Millisecond*500).Should(Equal(rayv1.Suspended))
 		})
 
 		It("set suspend to false and then revert it to true before all Pods are running", func() {
@@ -363,7 +363,7 @@ var _ = Context("Inside the default namespace", func() {
 			// RayCluster should be in Suspended state.
 			Eventually(
 				getClusterState(ctx, "default", myRayCluster.Name),
-				time.Second*(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS+5), time.Millisecond*500).Should(Equal(rayv1.Suspended))
+				time.Second*15, time.Millisecond*500).Should(Equal(rayv1.Suspended))
 		})
 
 		It("should run all head and worker pods if un-suspended", func() {
@@ -402,7 +402,7 @@ var _ = Context("Inside the default namespace", func() {
 		It("cluster's .status.state should be updated back to 'ready' after being un-suspended", func() {
 			Eventually(
 				getClusterState(ctx, "default", myRayCluster.Name),
-				time.Second*(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS+5), time.Millisecond*500).Should(Equal(rayv1.Ready))
+				time.Second*15, time.Millisecond*500).Should(Equal(rayv1.Ready))
 		})
 	})
 })

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -270,7 +270,7 @@ var _ = Context("Inside the default namespace", func() {
 			// The RayCluster.Status.State should be Ready.
 			Eventually(
 				getClusterState(ctx, "default", myRayCluster.Name),
-				time.Second*(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS+5), time.Millisecond*500).Should(Equal(rayv1.Ready))
+				time.Second*15, time.Millisecond*500).Should(Equal(rayv1.Ready))
 		})
 
 		It("Dashboard URL should be set", func() {

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -79,7 +79,10 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
-	// Suggested way to run tests
+	// The RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV is an insurance to keep reconciliation continuously triggered to hopefully fix an unexpected state.
+	// In a production environment, the requeue period is set to five minutes by default, which is relatively infrequent.
+	// TODO: We probably should not shorten RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV here just to make tests pass.
+	// Instead, we should fix the reconciliation if any unexpected happened.
 	os.Setenv(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV, "10")
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,


### PR DESCRIPTION
As @kevin85421 found out, we have set [`RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV`](https://github.com/ray-project/kuberay/blob/bf3fd63a97bc0b61c1858545dee3233679754c11/ray-operator/controllers/ray/suite_test.go#L83) to 10 seconds to speed up the tests. But we still wait for [`utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS+5`](https://github.com/ray-project/kuberay/blob/bf3fd63a97bc0b61c1858545dee3233679754c11/ray-operator/controllers/ray/raycluster_controller_test.go#L208), which is 305 seconds and is too long, to fail a test.

I believe this inconsistency exists because there is no convenient converter for the env variable.

In this PR, I replaced all usages of `RAYCLUSTER_DEFAULT_REQUEUE_SECONDS` with `RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV`  in tests with the help of a simple `MustGetEnvInt` converter.

This change can fail our tests faster if any unexpected occurs.

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
