### PR TITLE
[Bug][RayJob] Avoid nil pointer dereference

### DIFF
--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -351,6 +351,7 @@ type RayJobLogsResponse struct {
 	Logs string `json:"logs,omitempty"`
 }
 
+// Note that RayJobInfo and error can't be nil at the same time.
 func (r *RayDashboardClient) GetJobInfo(ctx context.Context, jobId string) (*RayJobInfo, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", r.dashboardURL+JobPath+jobId, nil)
 	if err != nil {
@@ -364,9 +365,7 @@ func (r *RayDashboardClient) GetJobInfo(ctx context.Context, jobId string) (*Ray
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		// This does the right thing, but breaks E2E test
-		//		return nil, errors.NewBadRequest("Job " + jobId + " does not exist on the cluster")
-		return nil, nil
+		return nil, errors.NewBadRequest("Job " + jobId + " does not exist on the cluster")
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/ray-operator/controllers/ray/utils/fake_serve_httpclient.go
+++ b/ray-operator/controllers/ray/utils/fake_serve_httpclient.go
@@ -60,7 +60,7 @@ func (r *FakeRayDashboardClient) GetJobInfo(ctx context.Context, jobId string) (
 	if mock := r.GetJobInfoMock.Load(); mock != nil {
 		return (*mock)(ctx, jobId)
 	}
-	return nil, nil
+	return &RayJobInfo{JobStatus: rayv1.JobStatusRunning}, nil
 }
 
 func (r *FakeRayDashboardClient) ListJobs(ctx context.Context) (*[]RayJobInfo, error) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Reproduce the error:
* Step 1: Deploy a KubeRay operator without this PR. I recommend using the nightly image [1].
* Step 2: Create a RayJob using [this YAML](https://gist.github.com/kevin85421/d39ddb40a6fa247c0662f03ebaae0169). It is configured to sleep for 1000s, giving you ample time to terminate the head Pod while the job is running.
* Step 3: Delete the head Pod after the job is submitted.
* Step 4: If the submitter Pod reaches the `backoffLimit` before the new head Pod is ready, the KubeRay operator will fail after the head Pod is restored. This failure occurs because if the job is not found, both `jobInfo` and `error` will return as `nil`. Consequently, at L274, `isJobPendingOrRunning(jobInfo.JobStatus)` will attempt to dereference a `nil` pointer.

[1] To easily reproduce the issue, I recommend using the nightly image, as its `backoffLimit` is smaller than that of v1.0.0. Hence, "the submitter Pod reaches the `backoffLimit` before the new head Pod is ready" is more likely to happen.

<img width="1440" alt="Screen Shot 2023-12-15 at 1 22 54 PM" src="https://github.com/ray-project/kuberay/assets/20109646/ffec6e11-9bc5-45f2-b46b-158af62efe3c">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

With this PR, the operator will throw an exception instead of crashing.

<img width="1406" alt="Screen Shot 2023-12-15 at 1 35 30 PM" src="https://github.com/ray-project/kuberay/assets/20109646/4e3a0eb2-1e58-4a62-959c-344e0efa100e">


