### PR TITLE
[Feature][GCS FT] succeed the redis cleanup job if the target key doesn't exist

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1123,7 +1123,7 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(instance rayv1.RayCluster) b
 			"redis_address = os.getenv('RAY_REDIS_ADDRESS', '').split(',')[0]; " +
 			"redis_address = redis_address if '://' in redis_address else 'redis://' + redis_address; " +
 			"parsed = urlparse(redis_address); " +
-			"sys.exit(1) if not cleanup_redis_storage(host=parsed.hostname, port=parsed.port, password=os.getenv('REDIS_PASSWORD', parsed.password), use_ssl=parsed.scheme=='rediss', storage_namespace=os.getenv('RAY_external_storage_namespace')) else None\"",
+			"cleanup_redis_storage(host=parsed.hostname, port=parsed.port, password=os.getenv('REDIS_PASSWORD', parsed.password), use_ssl=parsed.scheme=='rediss', storage_namespace=os.getenv('RAY_external_storage_namespace'))\"",
 	}
 
 	// Disable liveness and readiness probes because the Job will not launch processes like Raylet and GCS.


### PR DESCRIPTION
## Why are these changes needed?

In #1725, people are unable to delete a fault-tolerant RayServe CR before its Ray's head is ready because, currently, we fail the redis cleanup job if the `cleanup_redis_storage` function returns `False`.

With a closer look inside the `cleanup_redis_storage` function, we know that it will only return `False` if the redis `DEL` command returns 0, in other words, the target key does not exist. See the next section for more details.

This PR makes the cleanup job treat this case as a successful case since there is already nothing to delete.

## Behaviors of the `cleanup_redis_storage`

### Experiment 1: What will the `cleanup_redis_storage` return if it can't connect to Redis?

It won't return anything. Instead, it will retry a couple of times and throw an exception like the following eventually:

```
[2023-12-17 13:08:50,115 E 11506 10835385] redis_context.cc:375: Failed to connect to Redis due to: RedisError: Could not establish connection to Redis 127.0.0.1:6379 (context.err = 1).. Will retry in 100ms.
[2023-12-17 13:08:51,145 E 11506 10835385] redis_context.cc:375: Failed to connect to Redis due to: RedisError: Could not establish connection to Redis 127.0.0.1:6379 (context.err = 1).. Will retry in 100ms.
[2023-12-17 13:08:52,170 E 11506 10835385] redis_context.cc:375: Failed to connect to Redis due to: RedisError: Could not establish connection to Redis 127.0.0.1:6379 (context.err = 1).. Will retry in 100ms.
[2023-12-17 13:08:53,206 E 11506 10835385] redis_context.cc:375: Failed to connect to Redis due to: RedisError: Could not establish connection to Redis 127.0.0.1:6379 (context.err = 1).. Will retry in 100ms.
[2023-12-17 13:08:54,236 E 11506 10835385] redis_context.cc:375: Failed to connect to Redis due to: RedisError: Could not establish connection to Redis 127.0.0.1:6379 (context.err = 1).. Will retry in 100ms.
[2023-12-17 13:08:55,273 E 11506 10835385] redis_context.cc:375: Failed to connect to Redis due to: RedisError: Could not establish connection to Redis 127.0.0.1:6379 (context.err = 1).. Will retry in 100ms.
[2023-12-17 13:08:56,320 C 11506 10835385] redis_context.cc:369: 600 attempts to connect have all failed. Please check whether the redis storage is alive or not. The last error message was: RedisError: Could not establish connection to Redis 127.0.0.1:6379 (context.err = 1).
*** StackTrace Information ***
0   _raylet.so                          0x0000000105acbee8 _ZN3raylsERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEERKNS_10StackTraceE + 84 ray::operator<<()
1   _raylet.so                          0x0000000105af5fac _ZN3ray13SpdLogMessage5FlushEv + 220 ray::SpdLogMessage::Flush()
2   _raylet.so                          0x0000000105af5e14 _ZN3ray13SpdLogMessageD2Ev + 20 ray::SpdLogMessage::~SpdLogMessage()
3   _raylet.so                          0x0000000105acf3c4 _ZN3ray6RayLogD2Ev + 52 ray::RayLog::~RayLog()
4   _raylet.so                          0x000000010546ea90 _ZN3ray3gcs18ConnectWithRetriesI12redisContextFPS2_PKciEEENS_6StatusERKNSt3__112basic_stringIcNS8_11char_traitsIcEENS8_9allocatorIcEEEEiRKT0_PPT_ + 2128 ray::gcs::ConnectWithRetries<>()
5   _raylet.so                          0x000000010546c494 _ZN3ray3gcs12RedisContext7ConnectERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEibSA_b + 1312 ray::gcs::RedisContext::Connect()
6   _raylet.so                          0x00000001054631a4 _ZN3ray3gcs11RedisClient7ConnectENSt3__16vectorIP23instrumented_io_contextNS2_9allocatorIS5_EEEE + 376 ray::gcs::RedisClient::Connect()
7   _raylet.so                          0x0000000105462fa8 _ZN3ray3gcs11RedisClient7ConnectER23instrumented_io_context + 120 ray::gcs::RedisClient::Connect()
8   _raylet.so                          0x00000001050bd5e4 _ZN3ray3gcs15RedisDelKeySyncERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEiS9_bS9_ + 276 ray::gcs::RedisDelKeySync()
9   _raylet.so                          0x00000001051c4678 _ZL45__pyx_pw_3ray_7_raylet_27del_key_from_storageP7_objectS0_S0_ + 420 __pyx_pw_3ray_7_raylet_27del_key_from_storage()
10  python3.9                           0x0000000102c4501c cfunction_call + 80 cfunction_call
11  python3.9                           0x0000000102bf5080 _PyObject_MakeTpCall + 504 _PyObject_MakeTpCall
12  python3.9                           0x0000000102cea748 call_function + 668 call_function
13  python3.9                           0x0000000102ce6f6c _PyEval_EvalFrameDefault + 26544 _PyEval_EvalFrameDefault
14  python3.9                           0x0000000102ce0008 _PyEval_EvalCode + 2324 _PyEval_EvalCode
15  python3.9                           0x0000000102bf5c48 _PyFunction_Vectorcall + 244 _PyFunction_Vectorcall
16  python3.9                           0x0000000102cea620 call_function + 372 call_function
17  python3.9                           0x0000000102ce6fe8 _PyEval_EvalFrameDefault + 26668 _PyEval_EvalFrameDefault
18  python3.9                           0x0000000102ce0008 _PyEval_EvalCode + 2324 _PyEval_EvalCode
19  python3.9                           0x0000000102d37c18 pyrun_file + 376 pyrun_file
20  python3.9                           0x0000000102d371e4 PyRun_SimpleFileExFlags + 840 PyRun_SimpleFileExFlags
21  python3.9                           0x0000000102d59c34 Py_RunMain + 2028 Py_RunMain
22  python3.9                           0x0000000102d5adc4 pymain_main + 1268 pymain_main
23  python3.9                           0x0000000102ba4ce0 main + 56 main
24  dyld                                0x0000000186e990e0 start + 2360 start

(Exit with code 1)
```

### Experiment 2: What will the `cleanup_redis_storage` return if it doesn't have permission to `DEL`?

It won't return anything. Instead, it will throw the following exception:

```
[2023-12-17 13:14:14,832 I 11648 10839026] redis_context.cc:478: Resolve Redis address to 127.0.0.1
[2023-12-17 13:14:14,832 I 11648 10839026] redis_context.cc:364: Attempting to connect to address 127.0.0.1:6379.
[2023-12-17 13:14:14,833 I 11648 10839026] redis_context.cc:364: Attempting to connect to address 127.0.0.1:6379.
[2023-12-17 13:14:14,840 C 11648 10839026] redis_context.cc:522:  Check failed: parts[0] == "MOVED" && parts.size() == 3 Setup Redis cluster failed in the dummy deletion: NOPERM this user has no permissions to run the 'del' command
*** StackTrace Information ***
0   _raylet.so                          0x000000010764fee8 _ZN3raylsERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEERKNS_10StackTraceE + 84 ray::operator<<()
1   _raylet.so                          0x0000000107679fac _ZN3ray13SpdLogMessage5FlushEv + 220 ray::SpdLogMessage::Flush()
2   _raylet.so                          0x0000000107679e14 _ZN3ray13SpdLogMessageD2Ev + 20 ray::SpdLogMessage::~SpdLogMessage()
3   _raylet.so                          0x00000001076533c4 _ZN3ray6RayLogD2Ev + 52 ray::RayLog::~RayLog()
4   _raylet.so                          0x0000000106ff1974 _ZN3ray3gcs12RedisContext7ConnectERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEEibSA_b + 6656 ray::gcs::RedisContext::Connect()
5   _raylet.so                          0x0000000106fe71a4 _ZN3ray3gcs11RedisClient7ConnectENSt3__16vectorIP23instrumented_io_contextNS2_9allocatorIS5_EEEE + 376 ray::gcs::RedisClient::Connect()
6   _raylet.so                          0x0000000106fe6fa8 _ZN3ray3gcs11RedisClient7ConnectER23instrumented_io_context + 120 ray::gcs::RedisClient::Connect()
7   _raylet.so                          0x0000000106c415e4 _ZN3ray3gcs15RedisDelKeySyncERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEiS9_bS9_ + 276 ray::gcs::RedisDelKeySync()
8   _raylet.so                          0x0000000106d48678 _ZL45__pyx_pw_3ray_7_raylet_27del_key_from_storageP7_objectS0_S0_ + 420 __pyx_pw_3ray_7_raylet_27del_key_from_storage()
9   python3.9                           0x00000001047c901c cfunction_call + 80 cfunction_call
10  python3.9                           0x0000000104779080 _PyObject_MakeTpCall + 504 _PyObject_MakeTpCall
11  python3.9                           0x000000010486e748 call_function + 668 call_function
12  python3.9                           0x000000010486af6c _PyEval_EvalFrameDefault + 26544 _PyEval_EvalFrameDefault
13  python3.9                           0x0000000104864008 _PyEval_EvalCode + 2324 _PyEval_EvalCode
14  python3.9                           0x0000000104779c48 _PyFunction_Vectorcall + 244 _PyFunction_Vectorcall
15  python3.9                           0x000000010486e620 call_function + 372 call_function
16  python3.9                           0x000000010486afe8 _PyEval_EvalFrameDefault + 26668 _PyEval_EvalFrameDefault
17  python3.9                           0x0000000104864008 _PyEval_EvalCode + 2324 _PyEval_EvalCode
18  python3.9                           0x00000001048bbc18 pyrun_file + 376 pyrun_file
19  python3.9                           0x00000001048bb1e4 PyRun_SimpleFileExFlags + 840 PyRun_SimpleFileExFlags
20  python3.9                           0x00000001048ddc34 Py_RunMain + 2028 Py_RunMain
21  python3.9                           0x00000001048dedc4 pymain_main + 1268 pymain_main
22  python3.9                           0x0000000104728ce0 main + 56 main
23  dyld                                0x0000000186e990e0 start + 2360 start

(Exit with code 1)
```

Therefore, we can safely ignore the return value of the `cleanup_redis_storage`. If anything unexpected happens it will throw an exception and exit with a  non-zero code.

## Related issue number

#1725

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
