### PR TITLE
[RayJob][Status][6/n] Redefine JobDeploymentStatusComplete and clean up K8s Job after TTL

### DIFF
--- a/apiserver/pkg/model/converter.go
+++ b/apiserver/pkg/model/converter.go
@@ -439,9 +439,7 @@ func FromCrdToApiJob(job *rayv1api.RayJob) (pbJob *api.RayJob) {
 		pbJob.ClusterSpec = PopulateRayClusterSpec(*job.Spec.RayClusterSpec)
 	}
 
-	if job.Spec.TTLSecondsAfterFinished != nil {
-		pbJob.TtlSecondsAfterFinished = *job.Spec.TTLSecondsAfterFinished
-	}
+	pbJob.TtlSecondsAfterFinished = job.Spec.TTLSecondsAfterFinished
 
 	if job.DeletionTimestamp != nil {
 		pbJob.DeleteAt = &timestamp.Timestamp{Seconds: job.DeletionTimestamp.Unix()}

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -285,7 +285,7 @@ var JobNewClusterTest = rayv1api.RayJob{
 			"job_submission_id": "123",
 		},
 		RuntimeEnvYAML:          "mytest yaml",
-		TTLSecondsAfterFinished: &secondsValue,
+		TTLSecondsAfterFinished: secondsValue,
 		RayClusterSpec:          &ClusterSpecTest.Spec,
 	},
 }
@@ -301,7 +301,7 @@ var JobExistingClusterTest = rayv1api.RayJob{
 	Spec: rayv1api.RayJobSpec{
 		Entrypoint:              "python /home/ray/samples/sample_code.py",
 		RuntimeEnvYAML:          "mytest yaml",
-		TTLSecondsAfterFinished: &secondsValue,
+		TTLSecondsAfterFinished: secondsValue,
 		ClusterSelector: map[string]string{
 			util.RayClusterUserLabelKey: "test",
 		},
@@ -319,7 +319,7 @@ var JobExistingClusterSubmitterTest = rayv1api.RayJob{
 	Spec: rayv1api.RayJobSpec{
 		Entrypoint:              "python /home/ray/samples/sample_code.py",
 		RuntimeEnvYAML:          "mytest yaml",
-		TTLSecondsAfterFinished: &secondsValue,
+		TTLSecondsAfterFinished: secondsValue,
 		ClusterSelector: map[string]string{
 			util.RayClusterUserLabelKey: "test",
 		},

--- a/apiserver/pkg/util/job.go
+++ b/apiserver/pkg/util/job.go
@@ -30,7 +30,7 @@ func NewRayJob(apiJob *api.RayJob, computeTemplateMap map[string]*api.ComputeTem
 			Metadata:                 apiJob.Metadata,
 			RuntimeEnvYAML:           apiJob.RuntimeEnv,
 			ShutdownAfterJobFinishes: apiJob.ShutdownAfterJobFinishes,
-			TTLSecondsAfterFinished:  &apiJob.TtlSecondsAfterFinished,
+			TTLSecondsAfterFinished:  apiJob.TtlSecondsAfterFinished,
 			JobId:                    apiJob.JobId,
 			RayClusterSpec:           nil,
 			ClusterSelector:          apiJob.ClusterSelector,

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -10315,6 +10315,7 @@ spec:
               suspend:
                 type: boolean
               ttlSecondsAfterFinished:
+                default: 0
                 format: int32
                 type: integer
             required:
@@ -20683,6 +20684,7 @@ spec:
               suspend:
                 type: boolean
               ttlSecondsAfterFinished:
+                default: 0
                 format: int32
                 type: integer
             required:

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -58,7 +58,8 @@ type RayJobSpec struct {
 	ShutdownAfterJobFinishes bool `json:"shutdownAfterJobFinishes,omitempty"`
 	// TTLSecondsAfterFinished is the TTL to clean up RayCluster.
 	// It's only working when ShutdownAfterJobFinishes set to true.
-	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
+	// +kubebuilder:default:=0
+	TTLSecondsAfterFinished int32 `json:"ttlSecondsAfterFinished,omitempty"`
 	// RayClusterSpec is the cluster template to run the job
 	RayClusterSpec *RayClusterSpec `json:"rayClusterSpec,omitempty"`
 	// clusterSelector is used to select running rayclusters by labels

--- a/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
@@ -403,11 +403,6 @@ func (in *RayJobSpec) DeepCopyInto(out *RayJobSpec) {
 			(*out)[key] = val
 		}
 	}
-	if in.TTLSecondsAfterFinished != nil {
-		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
-		*out = new(int32)
-		**out = **in
-	}
 	if in.RayClusterSpec != nil {
 		in, out := &in.RayClusterSpec, &out.RayClusterSpec
 		*out = new(RayClusterSpec)

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -59,7 +59,7 @@ type RayJobSpec struct {
 	// TTLSecondsAfterFinished is the TTL to clean up RayCluster.
 	// It's only working when ShutdownAfterJobFinishes set to true.
 	// +kubebuilder:default:=0
-	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
+	TTLSecondsAfterFinished int32 `json:"ttlSecondsAfterFinished,omitempty"`
 	// RayClusterSpec is the cluster template to run the job
 	RayClusterSpec *RayClusterSpec `json:"rayClusterSpec,omitempty"`
 	// clusterSelector is used to select running rayclusters by labels

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -58,6 +58,7 @@ type RayJobSpec struct {
 	ShutdownAfterJobFinishes bool `json:"shutdownAfterJobFinishes,omitempty"`
 	// TTLSecondsAfterFinished is the TTL to clean up RayCluster.
 	// It's only working when ShutdownAfterJobFinishes set to true.
+	// +kubebuilder:default:=0
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 	// RayClusterSpec is the cluster template to run the job
 	RayClusterSpec *RayClusterSpec `json:"rayClusterSpec,omitempty"`

--- a/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1alpha1/zz_generated.deepcopy.go
@@ -398,11 +398,6 @@ func (in *RayJobSpec) DeepCopyInto(out *RayJobSpec) {
 			(*out)[key] = val
 		}
 	}
-	if in.TTLSecondsAfterFinished != nil {
-		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
-		*out = new(int32)
-		**out = **in
-	}
 	if in.RayClusterSpec != nil {
 		in, out := &in.RayClusterSpec, &out.RayClusterSpec
 		*out = new(RayClusterSpec)

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -10315,6 +10315,7 @@ spec:
               suspend:
                 type: boolean
               ttlSecondsAfterFinished:
+                default: 0
                 format: int32
                 type: integer
             required:
@@ -20683,6 +20684,7 @@ spec:
               suspend:
                 type: boolean
               ttlSecondsAfterFinished:
+                default: 0
                 format: int32
                 type: integer
             required:

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
@@ -123,9 +122,33 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 	}
 
-	// Do not reconcile the RayJob if the deployment status is marked as Complete
-	if rayJobInstance.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusComplete {
-		r.Log.Info("rayjob is complete, skip reconciliation", "rayjob", rayJobInstance.Name)
+	r.Log.Info("RayJob", "name", rayJobInstance.Name, "namespace", rayJobInstance.Namespace, "JobStatus", rayJobInstance.Status.JobStatus, "JobDeploymentStatus", rayJobInstance.Status.JobDeploymentStatus)
+	switch rayJobInstance.Status.JobDeploymentStatus {
+	case rayv1.JobDeploymentStatusComplete:
+		// If this RayJob uses an existing RayCluster (i.e., ClusterSelector is set), we should not delete the RayCluster.
+		r.Log.Info("JobDeploymentStatusComplete", "RayJob", rayJobInstance.Name, "ShutdownAfterJobFinishes", rayJobInstance.Spec.ShutdownAfterJobFinishes, "ClusterSelector", rayJobInstance.Spec.ClusterSelector)
+		if rayJobInstance.Spec.ShutdownAfterJobFinishes && len(rayJobInstance.Spec.ClusterSelector) == 0 {
+			// TODO (kevin85421): Revisit EndTime and ensure it will always be set after the job is completed.
+			ttlSeconds := rayJobInstance.Spec.TTLSecondsAfterFinished
+			nowTime := time.Now()
+			shutdownTime := rayJobInstance.Status.EndTime.Add(time.Duration(ttlSeconds) * time.Second)
+			r.Log.Info(
+				"RayJob is completed",
+				"shutdownAfterJobFinishes", rayJobInstance.Spec.ShutdownAfterJobFinishes,
+				"ttlSecondsAfterFinished", ttlSeconds,
+				"Status.endTime", rayJobInstance.Status.EndTime,
+				"Now", nowTime,
+				"ShutdownTime", shutdownTime)
+			if shutdownTime.After(nowTime) {
+				delta := int32(time.Until(shutdownTime.Add(2 * time.Second)).Seconds())
+				r.Log.Info(fmt.Sprintf("shutdownTime not reached, requeue this RayJob for %d seconds", delta))
+				return ctrl.Result{RequeueAfter: time.Duration(delta) * time.Second}, nil
+			} else {
+				if err = r.releaseComputeResources(ctx, rayJobInstance); err != nil {
+					return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
+				}
+			}
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -148,14 +171,14 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			if err = r.updateState(ctx, rayJobInstance, nil, rayJobInstance.Status.JobStatus, rayv1.JobDeploymentStatusComplete); err != nil {
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 			}
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 		}
 
 		if rayClusterInstance.DeletionTimestamp != nil {
 			if err = r.updateState(ctx, rayJobInstance, nil, rayJobInstance.Status.JobStatus, rayv1.JobDeploymentStatusComplete); err != nil {
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 			}
-			return ctrl.Result{}, nil
+			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 		}
 	}
 
@@ -246,8 +269,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 			}
 
-			_, err = r.deleteCluster(ctx, rayJobInstance)
-			if err != nil && !errors.IsNotFound(err) {
+			if err = r.releaseComputeResources(ctx, rayJobInstance); err != nil {
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 			}
 			// Since RayCluster instance is gone, remove it status also
@@ -268,39 +290,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		}
 	}
 
-	// Let's use rayJobInstance.Status.JobStatus to make sure we only delete cluster after the CR is updated.
-	if isJobSucceedOrFail(rayJobInstance.Status.JobStatus) && rayJobInstance.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusRunning {
-		if rayJobInstance.Spec.ShutdownAfterJobFinishes && len(rayJobInstance.Spec.ClusterSelector) == 0 {
-			// the RayJob is submitted against the RayCluster created by THIS job, so we can tear that
-			// RayCluster down.
-			if rayJobInstance.Spec.TTLSecondsAfterFinished != nil {
-				r.Log.V(3).Info("TTLSecondsAfterSetting", "end_time", rayJobInstance.Status.EndTime.Time, "now", time.Now(), "ttl", *rayJobInstance.Spec.TTLSecondsAfterFinished)
-				ttlDuration := time.Duration(*rayJobInstance.Spec.TTLSecondsAfterFinished) * time.Second
-				if rayJobInstance.Status.EndTime.Time.Add(ttlDuration).After(time.Now()) {
-					// time.Until prints duration until target time. We add additional 2 seconds to make sure we have buffer and requeueAfter is not 0.
-					delta := int32(time.Until(rayJobInstance.Status.EndTime.Time.Add(ttlDuration).Add(2 * time.Second)).Seconds())
-					r.Log.Info("TTLSecondsAfterFinish not reached, requeue it after", "RayJob", rayJobInstance.Name, "time(s)", delta)
-					return ctrl.Result{RequeueAfter: time.Duration(delta) * time.Second}, nil
-				}
-			}
-			r.Log.Info("shutdownAfterJobFinishes set to true, we will delete cluster",
-				"RayJob", rayJobInstance.Name, "clusterName", fmt.Sprintf("%s/%s", rayJobInstance.Namespace, rayJobInstance.Status.RayClusterName))
-			_, err = r.deleteCluster(ctx, rayJobInstance)
-			if err != nil && !errors.IsNotFound(err) {
-				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
-			}
-		}
-	}
-
-	// TODO (kevin85421): Use the source of truth `jobInfo.JobStatus` instead.
-	if isJobPendingOrRunning(jobInfo.JobStatus) {
-		// Requeue the RayJob to poll its status from the running Ray job
-		r.Log.Info("Requeue the RayJob because the Ray job is not in a terminal state", "RayJob", rayJobInstance.Name, "JobStatus", jobInfo.JobStatus)
-		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
-	}
-	// Otherwise only reconcile the RayJob upon new events for watched resources
-	// to avoid infinite reconciliation.
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 }
 
 // createK8sJobIfNeed creates a Kubernetes Job for the RayJob if it doesn't exist.
@@ -404,7 +394,10 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 	return nil
 }
 
-func (r *RayJobReconciler) deleteCluster(ctx context.Context, rayJobInstance *rayv1.RayJob) (reconcile.Result, error) {
+// Delete the RayCluster and the Kubernetes Job associated with the RayJob to release the compute resources.
+func (r *RayJobReconciler) releaseComputeResources(ctx context.Context, rayJobInstance *rayv1.RayJob) error {
+	// TODO (kevin85421): The logics of RayCluster and Kubernetes Job deletion are pretty similar.
+	// It would be great if we can refactor the code to avoid code duplication.
 	clusterIdentifier := types.NamespacedName{
 		Name:      rayJobInstance.Status.RayClusterName,
 		Namespace: rayJobInstance.Namespace,
@@ -412,23 +405,54 @@ func (r *RayJobReconciler) deleteCluster(ctx context.Context, rayJobInstance *ra
 	cluster := rayv1.RayCluster{}
 	if err := r.Get(ctx, clusterIdentifier, &cluster); err != nil {
 		if !errors.IsNotFound(err) {
-			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
+			return err
 		}
+		// If the cluster is not found, it means the cluster has been already deleted.
+		// Return nil to make this function idempotent.
 		r.Log.Info("The associated cluster has been already deleted and it can not be found", "RayCluster", clusterIdentifier)
-		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
+		return nil
 	} else {
 		if cluster.DeletionTimestamp != nil {
 			r.Log.Info("The cluster deletion is ongoing.", "rayjob", rayJobInstance.Name, "raycluster", cluster.Name)
 		} else {
 			if err := r.Delete(ctx, &cluster); err != nil {
-				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
+				return err
 			}
 			r.Log.Info("The associated cluster is deleted", "RayCluster", clusterIdentifier)
 			r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, "Deleted", "Deleted cluster %s", rayJobInstance.Status.RayClusterName)
-			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
+			return nil
 		}
 	}
-	return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
+
+	// TODO (kevin85421): We should use MatchingLabels to get the job instead after we have well-defined labels.
+	// TODO (kevin85421): If KubeRay supports various submission methods in the future, we should add a check
+	// here to determine whether it's necessary to delete the Kubernetes Job.
+	jobIdentifier := types.NamespacedName{
+		Name:      rayJobInstance.Name,
+		Namespace: rayJobInstance.Namespace,
+	}
+	job := batchv1.Job{}
+	if err := r.Get(ctx, jobIdentifier, &job); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		// If the Kubernetes Job is not found, it means the Kubernetes Job has been already deleted.
+		// Return nil to make this function idempotent.
+		r.Log.Info("The associated Kubernetes Job has been already deleted and it can not be found", "Kubernetes Job", jobIdentifier)
+		return nil
+	} else {
+		if job.DeletionTimestamp != nil {
+			r.Log.Info("The Kubernetes Job deletion is ongoing.", "rayjob", rayJobInstance.Name, "Kubernetes Job", job.Name)
+		} else {
+			if err := r.Delete(ctx, &job); err != nil {
+				return err
+			}
+			r.Log.Info("The associated Kubernetes Job is deleted", "Kubernetes Job", jobIdentifier)
+			r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, "Deleted", "Deleted Kubernetes Job %s/%s", jobIdentifier.Namespace, jobIdentifier.Name)
+			return nil
+		}
+	}
+	return nil
 }
 
 // isJobSucceedOrFail indicates whether the job comes into end status.

--- a/ray-operator/test/e2e/rayjob_test.go
+++ b/ray-operator/test/e2e/rayjob_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"testing"
-	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -110,8 +109,8 @@ env_vars:
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
 
 		// And the RayJob deployment status is updated accordingly
-		test.Consistently(RayJob(test, rayJob.Namespace, rayJob.Name), 10*time.Second).
-			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusRunning)))
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
 
 		// Refresh the RayJob status
 		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)

--- a/ray-operator/test/e2e/rayjob_test.go
+++ b/ray-operator/test/e2e/rayjob_test.go
@@ -65,17 +65,22 @@ env_vars:
 		// Refresh the RayJob status
 		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)
 
+		// TODO (kevin85421): We may need to use `Eventually` instead if the assertion is flaky.
 		// Assert the RayCluster has been torn down
 		_, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayJob.Status.RayClusterName, metav1.GetOptions{})
 		test.Expect(err).To(MatchError(k8serrors.NewNotFound(rayv1.Resource("rayclusters"), rayJob.Status.RayClusterName)))
+
+		// Assert the submitter Job has been cascade deleted
+		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
+
+		// TODO (kevin85421): Check whether the Pods associated with the RayCluster and the submitter Job have been deleted.
+		// For Kubernetes Jobs, the default deletion behavior is "orphanDependents," which means the Pods will not be
+		// cascadingly deleted with the Kubernetes Job by default.
 
 		// Delete the RayJob
 		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
 		test.Expect(err).NotTo(HaveOccurred())
 		test.T().Logf("Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
-
-		// Assert the submitter Job has been cascade deleted
-		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
 	})
 
 	test.T().Run("Failing RayJob without cluster shutdown after finished", func(t *testing.T) {
@@ -111,6 +116,8 @@ env_vars:
 		// And the RayJob deployment status is updated accordingly
 		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
+
+		// TODO (kevin85421): Ensure the RayCluster and Kubernetes Job are not deleted because `ShutdownAfterJobFinishes` is false.
 
 		// Refresh the RayJob status
 		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Without this PR, the transition between `Running` and `Complete` is pretty confusing. If `ShutdownAfterJobFinishes` is false, the RayJob's `JobDeploymentStatus` will be `JobDeploymentStatusRunning` although the Ray job is `Succeeded` or `Failed`. Both `Succeeded` and `Failed` are terminal states, so the job can't have any state transition. However, KubeRay still has to process a lot of unnecessary code, including sending a request to the RayCluster to check the status of the Ray job.

* This PR redefines `JobDeploymentStatusComplete`. `JobDeploymentStatusComplete` means that the JobStatus is `Succeeded` or `Failed`, and we only check TTL when the RayJob is `JobDeploymentStatusComplete`.

* Currently, the lifecycles of the submitter K8s Job and its Pod are not well-defined. For example, the K8s Job will not be deleted any matter TTL and `suspend`. In addition, the default deletion behavior for a Kubernetes Job is `orphanDependents`, so the Pod will not be deleted cascadingly after the Kubernetes Job is deleted. In this PR, we set TTL for the K8s Job the same as `RayJob.Spec.TTLSecondsAfterFinished`. I will chat with users to finalize the behavior in the follow up PRs

## Related issue number

Closes #1233 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
