### PR TITLE
[Feature][GCS FT] Best-effort redis cleanup job

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -2230,10 +2230,12 @@ func Test_RedisCleanup(t *testing.T) {
 				assert.Nil(t, err, "Fail to get RayCluster list")
 				assert.Equal(t, 1, len(rayClusterList.Items))
 				assert.True(t, controllerutil.ContainsFinalizer(&rayClusterList.Items[0], utils.GCSFaultToleranceRedisCleanupFinalizer))
+				assert.Equal(t, int64(300), *jobList.Items[0].Spec.ActiveDeadlineSeconds)
 
 				// Simulate the Job succeeded.
 				job := jobList.Items[0]
 				job.Status.Succeeded = 1
+				job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
 				err = fakeClient.Status().Update(ctx, &job)
 				assert.Nil(t, err, "Fail to update Job status")
 

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"unicode"
 
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -507,4 +508,16 @@ func FindContainerPort(container *corev1.Container, portName string, defaultPort
 		}
 	}
 	return defaultPort
+}
+
+// IsJobFinished checks whether the given Job has finished execution.
+// It does not discriminate between successful and failed terminations.
+// src: https://github.com/kubernetes/kubernetes/blob/a8a1abc25cad87333840cd7d54be2efaf31a3177/pkg/controller/job/utils.go#L26
+func IsJobFinished(j *batchv1.Job) (batchv1.JobConditionType, bool) {
+	for _, c := range j.Status.Conditions {
+		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == corev1.ConditionTrue {
+			return c.Type, true
+		}
+	}
+	return "", false
 }


### PR DESCRIPTION
## Why are these changes needed?

Following the previous proposal https://github.com/ray-project/kuberay/issues/1557#issuecomment-1784162985, this PR introduces a new environment variable `GCS_FT_REDIS_CLEANUP_DEADLINE_SECONDS` to the kuberay-operator.

This variable will be set to the `.spec.activeDeadlineSeconds` option of the redis cleanup job of a fault-tolerant RayCluster, and it will terminate the job after the deadline no matter what.

This PR further makes the kuberay-operator remove the `ray.io/gcs-ft-redis-cleanup-finalizer` finalizer on the RayCluster allowing it to be deleted after the job is terminated.

The default value of `GCS_FT_REDIS_CLEANUP_DEADLINE_SECONDS` is 300. This essentially makes all redis cleanup jobs work in a best-effort manner for 5 minutes by default.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/kuberay/issues/1725
https://github.com/ray-project/kuberay/issues/1557


## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
