### PR TITLE
[RayJob][Status][7/n] Define JobDeploymentStatusNew explicitly

### DIFF
--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -33,6 +33,7 @@ func IsJobTerminal(status JobStatus) bool {
 type JobDeploymentStatus string
 
 const (
+	JobDeploymentStatusNew          JobDeploymentStatus = ""
 	JobDeploymentStatusInitializing JobDeploymentStatus = "Initializing"
 	JobDeploymentStatusRunning      JobDeploymentStatus = "Running"
 	JobDeploymentStatusComplete     JobDeploymentStatus = "Complete"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`JobDeploymentStatusNew` indicates that this is a new RayJob CR, similar to [NewState](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/8cb6c8035eabd73c045f4078b27fa35767e2a52c/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go#L333) in the [spark-on-k8s-operator](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/tree/master).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
