### PR TITLE
[CI] Fix variable initializations used in test case declarations

### DIFF
--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -154,9 +154,9 @@ class RayFTTestCase(unittest.TestCase):
             self.fail(f"Fail to execute test_ray_serve_2.py. The exit code is {exit_code}.")
 
     @unittest.skipIf(
-        ray_version == '2.8.0' or ray_version == 'nightly',
-        'test_detached_actor is too flaky with Ray 2.8.0 due to'
-        'https://github.com/ray-project/ray/issues/41343.'
+        ray_version == '2.8.0',
+        'test_detached_actor is too flaky with Ray 2.8.0 due to '
+        'https://github.com/ray-project/ray/issues/41343. '
         'It is fixed in Ray 2.9.0 and the nightly.'
     )
     def test_detached_actor(self):

--- a/tests/compatibility-test.py
+++ b/tests/compatibility-test.py
@@ -28,8 +28,11 @@ logging.basicConfig(
     level=logging.INFO
 )
 
-# Default Ray version
-ray_version = '2.9.0'
+# parse global variables from env
+ray_image = os.getenv('RAY_IMAGE', 'rayproject/ray:2.9.0')
+ray_version = ray_image.split(':')[-1]
+kuberay_operator_image = os.getenv('OPERATOR_IMAGE')
+
 
 class BasicRayTestCase(unittest.TestCase):
     """Test the basic functionalities of RayCluster by executing simple jobs."""
@@ -150,17 +153,14 @@ class RayFTTestCase(unittest.TestCase):
             show_cluster_info(RayFTTestCase.ray_cluster_ns)
             self.fail(f"Fail to execute test_ray_serve_2.py. The exit code is {exit_code}.")
 
+    @unittest.skipIf(
+        ray_version == '2.8.0' or ray_version == 'nightly',
+        'test_detached_actor is too flaky with Ray 2.8.0 due to'
+        'https://github.com/ray-project/ray/issues/41343.'
+        'It is fixed in Ray 2.9.0 and the nightly.'
+    )
     def test_detached_actor(self):
         """Kill GCS process on the head Pod and then test a detached actor."""
-
-        # We must do this check here and not in a @unittest.skipIf decorator because
-        # the decorator is evaluated at import time, and the environment variables
-        # modifying the global variable `ray_version` are not read until runtime.
-        if ray_version == '2.8.0':
-            raise unittest.SkipTest(
-                'test_detached_actor is too flaky with Ray 2.8.0 due to'
-                'https://github.com/ray-project/ray/issues/41343.'
-                'It is fixed in Ray 2.9.0 and the nightly.')
 
         headpod = get_head_pod(RayFTTestCase.ray_cluster_ns)
         headpod_name = headpod.metadata.name
@@ -266,18 +266,8 @@ class KubeRayHealthCheckTestCase(unittest.TestCase):
         utils.wait_for_new_head(CONST.CREATE_NEW_POD, old_head_pod_name, restart_count,
             RayFTTestCase.ray_cluster_ns, timeout=300, retry_interval_ms=1000)
 
-def parse_environment():
-    global ray_version, ray_image, kuberay_operator_image
-    for k, v in os.environ.items():
-        if k == 'RAY_IMAGE':
-            ray_image = v
-            ray_version = ray_image.split(':')[-1]
-        elif k == 'OPERATOR_IMAGE':
-            kuberay_operator_image = v
-
 
 if __name__ == '__main__':
-    parse_environment()
     logger.info('Setting Ray image to: {}'.format(ray_image))
     logger.info('Setting Ray version to: {}'.format(ray_version))
     logger.info('Setting KubeRay operator image to: {}'.format(kuberay_operator_image))


### PR DESCRIPTION
These global variables `ray_image`, `ray_version`, and `kuberay_operator_image` are heavily used in test case declarations. But currently, their value will be changed in the `if __name__ == '__main__'` block which runs after test case declarations.

Therefore, it causes undesired evaluations in some cases, such as https://github.com/ray-project/kuberay/blob/59503c647d8708e7e70ae8bb0bde83d7c4142465/tests/compatibility-test.py#L153-L154

where it always evaluates the `ray_version` to the initial default value, instead of the value we inject via the env later. 
 See more details: https://github.com/ray-project/kuberay/pull/1770#discussion_r1436669602

This PR fixes their values at the beginning of the test script and does not change them after initialization.

## Related issue number

https://github.com/ray-project/kuberay/issues/1773

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
