### PR TITLE
[RayJob][Status][9/n] RayJob should not pass any changes to RayCluster

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -515,101 +515,46 @@ func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, ra
 	}
 
 	rayClusterInstance := &rayv1.RayCluster{}
-	err := r.Get(ctx, rayClusterNamespacedName, rayClusterInstance)
-	if err == nil {
-		r.Log.Info("Found associated RayCluster for RayJob", "rayjob", rayJobInstance.Name, "raycluster", rayClusterNamespacedName)
-
-		// Case1: The job is submitted to an existing ray cluster, simply return the rayClusterInstance.
-		// We do not use rayJobInstance.Spec.RayClusterSpec == nil to check if the cluster selector mode is activated.
-		// This is because a user might set both RayClusterSpec and ClusterSelector. with rayJobInstance.Spec.RayClusterSpec == nil,
-		// though the RayJob controller will still use ClusterSelector, but it's now able to update the replica.
-		// this could result in a conflict as both the RayJob controller and the autoscaler in the existing RayCluster might try to update replicas simultaneously.
-		if len(rayJobInstance.Spec.ClusterSelector) != 0 {
-			r.Log.Info("ClusterSelector is being used to select an existing RayCluster. RayClusterSpec will be disregarded", "raycluster", rayClusterNamespacedName)
-			return rayClusterInstance, nil
-		}
-
-		// Note, unlike the RayService, which creates new Ray clusters if any spec is changed,
-		// RayJob only supports changing the replicas. Changes to other specs may lead to
-		// unexpected behavior. Therefore, the following code focuses solely on updating replicas.
-
-		// Case2: In-tree autoscaling is enabled, only the autoscaler should update replicas to prevent race conditions
-		// between user updates and autoscaler decisions. RayJob controller should not modify the replica. Consider this scenario:
-		// 1. The autoscaler updates replicas to 10 based on the current workload.
-		// 2. The user updates replicas to 15 in the RayJob YAML file.
-		// 3. Both RayJob controller and the autoscaler attempt to update replicas, causing worker pods to be repeatedly created and terminated.
-		if rayJobInstance.Spec.RayClusterSpec.EnableInTreeAutoscaling != nil && *rayJobInstance.Spec.RayClusterSpec.EnableInTreeAutoscaling {
-			// Note, currently, there is no method to verify if the user has updated the RayJob since the last reconcile.
-			// In future, we could utilize annotation that stores the hash of the RayJob since last reconcile to compare.
-			// For now, we just log a warning message to remind the user regadless whether user has updated RayJob.
-			r.Log.Info("Since in-tree autoscaling is enabled, any adjustments made to the RayJob will be disregarded and will not be propagated to the RayCluster.")
-			return rayClusterInstance, nil
-		}
-
-		// Case3: In-tree autoscaling is disabled, respect the user's replicas setting.
-		// Loop over all worker groups and update replicas.
-		areReplicasIdentical := true
-		for i := range rayJobInstance.Spec.RayClusterSpec.WorkerGroupSpecs {
-			if *rayClusterInstance.Spec.WorkerGroupSpecs[i].Replicas != *rayJobInstance.Spec.RayClusterSpec.WorkerGroupSpecs[i].Replicas {
-				areReplicasIdentical = false
-				*rayClusterInstance.Spec.WorkerGroupSpecs[i].Replicas = *rayJobInstance.Spec.RayClusterSpec.WorkerGroupSpecs[i].Replicas
+	if err := r.Get(ctx, rayClusterNamespacedName, rayClusterInstance); err != nil {
+		if errors.IsNotFound(err) {
+			// TODO: If both ClusterSelector and RayClusterSpec are not set, we should avoid retrieving a RayCluster instance.
+			// Consider moving this logic to a more appropriate location.
+			if len(rayJobInstance.Spec.ClusterSelector) == 0 && rayJobInstance.Spec.RayClusterSpec == nil {
+				err := fmt.Errorf("one of ClusterSelector or RayClusterSpec must be set, but both are undefined, err: %v", err)
+				return nil, err
 			}
-		}
 
-		// Other specs rather than replicas are changed, warn the user that the RayJob supports replica changes only.
-		if !utils.CompareJsonStruct(rayClusterInstance.Spec, *rayJobInstance.Spec.RayClusterSpec) {
-			r.Log.Info("RayJob supports replica changes only. Adjustments made to other specs will be disregarded as they may cause unexpected behavior")
-		}
+			if len(rayJobInstance.Spec.ClusterSelector) != 0 {
+				err := fmt.Errorf("we have choosed the cluster selector mode, failed to find the cluster named %v, err: %v", rayClusterInstanceName, err)
+				return nil, err
+			}
 
-		// Avoid updating the RayCluster's replicas if it's identical to the RayJob's replicas.
-		if areReplicasIdentical {
-			return rayClusterInstance, nil
-		}
+			// special case: don't create a cluster instance and don't return an error if the suspend flag of the job is true
+			if rayJobInstance.Spec.Suspend {
+				return nil, nil
+			}
 
-		r.Log.Info("Update RayCluster replica", "RayCluster", rayClusterNamespacedName)
-		if err := r.Update(ctx, rayClusterInstance); err != nil {
-			r.Log.Error(err, "Fail to update RayCluster replica!", "RayCluster", rayClusterNamespacedName)
-			// Error updating the RayCluster object.
-			return nil, client.IgnoreNotFound(err)
-		}
-
-	} else if errors.IsNotFound(err) {
-		// TODO: If both ClusterSelector and RayClusterSpec are not set, we should avoid retrieving a RayCluster instance.
-		// Consider moving this logic to a more appropriate location.
-		if len(rayJobInstance.Spec.ClusterSelector) == 0 && rayJobInstance.Spec.RayClusterSpec == nil {
-			err := fmt.Errorf("one of ClusterSelector or RayClusterSpec must be set, but both are undefined, err: %v", err)
+			r.Log.Info("RayCluster not found, creating RayCluster!", "raycluster", rayClusterNamespacedName)
+			rayClusterInstance, err = r.constructRayClusterForRayJob(rayJobInstance, rayClusterInstanceName)
+			if err != nil {
+				r.Log.Error(err, "unable to construct a new rayCluster")
+				// Error construct the RayCluster object - requeue the request.
+				return nil, err
+			}
+			if err := r.Create(ctx, rayClusterInstance); err != nil {
+				r.Log.Error(err, "unable to create rayCluster for rayJob", "rayCluster", rayClusterInstance)
+				// Error creating the RayCluster object - requeue the request.
+				return nil, err
+			}
+			r.Log.Info("created rayCluster for rayJob", "rayCluster", rayClusterInstance)
+			r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, "Created", "Created cluster %s", rayJobInstance.Status.RayClusterName)
+		} else {
+			r.Log.Error(err, "Fail to get RayCluster!")
+			// Error reading the RayCluster object - requeue the request.
 			return nil, err
 		}
-
-		if len(rayJobInstance.Spec.ClusterSelector) != 0 {
-			err := fmt.Errorf("we have choosed the cluster selector mode, failed to find the cluster named %v, err: %v", rayClusterInstanceName, err)
-			return nil, err
-		}
-
-		// special case: don't create a cluster instance and don't return an error if the suspend flag of the job is true
-		if rayJobInstance.Spec.Suspend {
-			return nil, nil
-		}
-
-		r.Log.Info("RayCluster not found, creating RayCluster!", "raycluster", rayClusterNamespacedName)
-		rayClusterInstance, err = r.constructRayClusterForRayJob(rayJobInstance, rayClusterInstanceName)
-		if err != nil {
-			r.Log.Error(err, "unable to construct a new rayCluster")
-			// Error construct the RayCluster object - requeue the request.
-			return nil, err
-		}
-		if err := r.Create(ctx, rayClusterInstance); err != nil {
-			r.Log.Error(err, "unable to create rayCluster for rayJob", "rayCluster", rayClusterInstance)
-			// Error creating the RayCluster object - requeue the request.
-			return nil, err
-		}
-		r.Log.Info("created rayCluster for rayJob", "rayCluster", rayClusterInstance)
-		r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, "Created", "Created cluster %s", rayJobInstance.Status.RayClusterName)
-	} else {
-		r.Log.Error(err, "Get rayCluster instance error!")
-		// Error reading the RayCluster object - requeue the request.
-		return nil, err
 	}
+	r.Log.Info("Found associated RayCluster for RayJob", "RayJob", rayJobInstance.Name, "RayCluster", rayClusterNamespacedName)
 
 	return rayClusterInstance, nil
 }


### PR DESCRIPTION
## Why are these changes needed?

Without this PR, RayJob has a complex behavior to pass changes from RayJob's spec to the associated RayCluster.

* If Ray Autoscaling is enabled, do not pass any changes to the associated RayCluster.
* If the change concerns only replicas, update the RayCluster.
* Otherwise, do not update the RayCluster.

This PR decides to remove the behavior because:
* For batch jobs, the required computation resources should be deterministic. Hence, no need to pass changes to RayCluster.
* If users still wish to update `replicas` at runtime, they should use the Ray Autoscaler instead.
* If users still want to update `replicas` manually, they still can update RayCluster directly.
* Allowing users to update `replicas` at runtime will make gang scheduling much more complex.
* The best practice for batch jobs should include the ability to tolerate downtime and implement application-level fault tolerance within the jobs themselves, such as writing and reading checkpoints from S3.

Hence, I remove this behavior in this PR to avoid unnecessary complexity of the RayJob codebase.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
