### PR TITLE
[Feature] Warn Users When Updating the RayClusterSpec in RayJob CR

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -554,9 +554,10 @@ func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, ra
 	}
 	r.Log.Info("Found associated RayCluster for RayJob", "RayJob", rayJobInstance.Name, "RayCluster", rayClusterNamespacedName)
 
+	// Verify that RayJob is not in cluster selector mode first to avoid nil pointer dereference error during spec comparison.
+	// This is checked by ensuring len(rayJobInstance.Spec.ClusterSelector) equals 0.
 	if len(rayJobInstance.Spec.ClusterSelector) == 0 && !utils.CompareJsonStruct(rayClusterInstance.Spec, *rayJobInstance.Spec.RayClusterSpec) {
-		r.Log.Info("Detected changes in RayClusterSpec of RayJob, these changes will be disregarded", "RayJob", rayJobInstance.Name)
-		r.Log.Info("Note: RayJob supports changes to replicas only. To modify replicas, please enable autoscaling or update the RayCluster directly")
+		r.Log.Info("Disregard changes in RayClusterSpec of RayJob", "RayJob", rayJobInstance.Name)
 	}
 
 	return rayClusterInstance, nil

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -554,6 +554,11 @@ func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, ra
 	}
 	r.Log.Info("Found associated RayCluster for RayJob", "RayJob", rayJobInstance.Name, "RayCluster", rayClusterNamespacedName)
 
+	if len(rayJobInstance.Spec.ClusterSelector) == 0 && !utils.CompareJsonStruct(rayClusterInstance.Spec, *rayJobInstance.Spec.RayClusterSpec) {
+		r.Log.Info("Detected changes in RayClusterSpec of RayJob, these changes will be disregarded", "RayJob", rayJobInstance.Name)
+		r.Log.Info("Note: RayJob supports changes to replicas only. To modify replicas, please enable autoscaling or update the RayCluster directly")
+	}
+
 	return rayClusterInstance, nil
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
See https://github.com/ray-project/kuberay/pull/1776#pullrequestreview-1797420259.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #1777
<!-- For example: "Closes #1234" -->

## Checks
Work as expected:
<img width="1070" alt="image" src="https://github.com/ray-project/kuberay/assets/51814063/4383c771-3294-4aad-bb17-99fe1e2545aa">
