### PR TITLE
[Refactor] Introduce utils.AddFinalizer helper

### DIFF
--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/base32"
 	"fmt"
@@ -23,6 +24,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -522,4 +525,11 @@ func IsJobFinished(j *batchv1.Job) (batchv1.JobConditionType, bool) {
 		}
 	}
 	return "", false
+}
+
+func AddFinalizer(w client.Writer, ctx context.Context, obj client.Object, finalizer string) (added bool, err error) {
+	if added = controllerutil.AddFinalizer(obj, finalizer); added {
+		err = w.Update(ctx, obj)
+	}
+	return
 }


### PR DESCRIPTION
## Why are these changes needed?

Following the PR https://github.com/ray-project/kuberay/pull/1780/files, this PR introduces an `AddFinalizer` helper to reduce the current boilerplate of checking and adding finalizer tags.

Note that the original usages of `controllerutil.ContainsFinalizer` are actually not necessary. They can be covered by checking the return value of `controllerutil.AddFinalizer`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
