### PR TITLE
[RayJob][Status][12/n] Resume suspended RayJob

### DIFF
--- a/ray-operator/test/e2e/long_running.py
+++ b/ray-operator/test/e2e/long_running.py
@@ -1,0 +1,5 @@
+"""`long_running.py` is used to test RayJob `suspend` and `resume`."""
+import time
+for i in range(10000):
+    print(i)
+    time.sleep(1)

--- a/ray-operator/test/e2e/rayjob_suspend_test.go
+++ b/ray-operator/test/e2e/rayjob_suspend_test.go
@@ -39,6 +39,7 @@ func TestRayJobSuspend(t *testing.T) {
 				RayClusterSpec:           newRayClusterSpec(mountConfigMap(jobs, "/home/ray/jobs")),
 				Entrypoint:               "python /home/ray/jobs/long_running.py",
 				ShutdownAfterJobFinishes: true,
+				TTLSecondsAfterFinished:  600,
 				SubmitterPodTemplate:     jobSubmitterPodTemplate(),
 			},
 		}

--- a/ray-operator/test/e2e/rayjob_suspend_test.go
+++ b/ray-operator/test/e2e/rayjob_suspend_test.go
@@ -1,0 +1,94 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	. "github.com/ray-project/kuberay/ray-operator/test/support"
+)
+
+func TestRayJobSuspend(t *testing.T) {
+	test := With(t)
+
+	// Create a namespace
+	namespace := test.NewTestNamespace()
+
+	// Job scripts
+	jobs := newConfigMap(namespace.Name, "jobs", files(test, "long_running.py"))
+	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Create(test.Ctx(), jobs, metav1.CreateOptions{})
+	test.Expect(err).NotTo(HaveOccurred())
+	test.T().Logf("Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
+
+	test.T().Run("Suspend the RayJob when its status is 'Running', and then resume it.", func(t *testing.T) {
+		// RayJob
+		rayJob := &rayv1.RayJob{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: rayv1.GroupVersion.String(),
+				Kind:       "RayJob",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "long-running",
+				Namespace: namespace.Name,
+			},
+			Spec: rayv1.RayJobSpec{
+				RayClusterSpec:           newRayClusterSpec(mountConfigMap(jobs, "/home/ray/jobs")),
+				Entrypoint:               "python /home/ray/jobs/long_running.py",
+				ShutdownAfterJobFinishes: true,
+				SubmitterPodTemplate:     jobSubmitterPodTemplate(),
+			},
+		}
+		rayJob, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Create(test.Ctx(), rayJob, metav1.CreateOptions{})
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		test.T().Logf("Waiting for RayJob %s/%s to be 'Running'", rayJob.Namespace, rayJob.Name)
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusRunning)))
+
+		// Refresh the RayJob status
+		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+
+		test.T().Logf("Suspend the RayJob %s/%s", rayJob.Namespace, rayJob.Name)
+		rayJob.Spec.Suspend = true
+		// TODO (kevin85421): We may need to retry `Update` if 409 conflict makes the test flaky.
+		rayJob, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Update(test.Ctx(), rayJob, metav1.UpdateOptions{})
+		test.Expect(err).NotTo(HaveOccurred())
+
+		test.T().Logf("Waiting for RayJob %s/%s to be 'Suspended'", rayJob.Namespace, rayJob.Name)
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusSuspended)))
+
+		// TODO (kevin85421): We may need to use `Eventually` instead if the assertion is flaky.
+		// Assert the RayCluster has been torn down
+		_, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayJob.Status.RayClusterName, metav1.GetOptions{})
+		test.Expect(err).To(MatchError(k8serrors.NewNotFound(rayv1.Resource("rayclusters"), rayJob.Status.RayClusterName)))
+
+		// Assert the submitter Job has been cascade deleted
+		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
+
+		// TODO (kevin85421): Check whether the Pods associated with the RayCluster and the submitter Job have been deleted.
+		// For Kubernetes Jobs, the default deletion behavior is "orphanDependents," which means the Pods will not be
+		// cascadingly deleted with the Kubernetes Job by default.
+
+		// Refresh the RayJob status
+		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+
+		test.T().Logf("Resume the RayJob by updating `suspend` to false.")
+		rayJob.Spec.Suspend = false
+		// TODO (kevin85421): We may need to retry `Update` if 409 conflict makes the test flaky.
+		rayJob, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Update(test.Ctx(), rayJob, metav1.UpdateOptions{})
+		test.Expect(err).NotTo(HaveOccurred())
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusRunning)))
+
+		// Delete the RayJob
+		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+	})
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#1782 mentions that if users don't set `shutDownAfterFinishes`, the submitter Job will become `Complete` after suspension. When we resume the RayJob, a new Kubernetes Job will not be created because one already exists. Note that we currently use the RayJob name for the submitter Job to avoid duplicate creation.

* Kubernetes Job cleanup
  * The default deletion policy of K8s Job is `orphanDependents`. Hence, if you delete the Job via the client-go API, the associated Pods will not be deleted. If you use `kubectl` to delete the Job, the related Pods will be deleted.
  * `ttlSecondsAfterFinished`
  * `suspend`: When you suspend a Job, any running Pods that don't have a status of Completed will be [terminated](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination) with a SIGTERM signal. However, in our case, the submitter Job will become `Complete` after the KubeRay operator sends the `StopJob()` request to the Ray head. Hence, suspending the K8s Job and then resuming the Job doesn't work.
  * Manually delete both K8s Job and its Pods: `ttlSecondsAfterFinished` is a more k8s-native solution.

This PR deletes the Kubernetes Job when it is suspended by updating its `ttlSecondsAfterFinished`.

Follow-up: Currently, `suspend` is reversible, meaning that users can set suspend to true while in `Initializing` and `Running`, and then revert it to false before the status becomes `Suspended`. However, this may lead to unexpected side effects. Therefore, we should make this operation irreversible.



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
