### PR TITLE
[RayJob] Delete the Kubernetes Job and its Pods immediately when suspending

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -420,8 +420,8 @@ func (r *RayJobReconciler) releaseComputeResources(ctx context.Context, rayJobIn
 		}
 	}
 
-	// Since the name of the Kubernetes Job is the same as the RayJob, we need to set the TTL of the Kubernetes Job to clean
-	// up the Kubernetes Job and its Pods when suspending, and a new submitter Kubernetes Job must be created to resubmit the
+	// Since the name of the Kubernetes Job is the same as the RayJob, we need to delete the Kubernetes Job
+	// and its Pods when suspending. A new submitter Kubernetes Job must be created to resubmit the
 	// Ray job if the RayJob is resumed.
 	if isSuspend {
 		jobName := rayJobInstance.Name
@@ -429,14 +429,14 @@ func (r *RayJobReconciler) releaseComputeResources(ctx context.Context, rayJobIn
 		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: jobName}, job); err != nil {
 			if errors.IsNotFound(err) {
 				r.Log.Info("The submitter Kubernetes Job has been already deleted", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
+				return nil
 			} else {
 				r.Log.Error(err, "Failed to get Kubernetes Job")
 				return err
 			}
 		}
-		job.Spec.TTLSecondsAfterFinished = pointer.Int32(0)
-		if err := r.Client.Update(ctx, job); err != nil {
-			r.Log.Error(err, "Failed to update the TTL of the Kubernetes Job")
+		if err := r.Client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+			r.Log.Error(err, "Failed to delete the Kubernetes Job")
 			return err
 		}
 	}


### PR DESCRIPTION
## Why are these changes needed?

Currently, we set the submitter's `TTLSecondsAfterFinished` to 0 when suspending a RayJob, and we hope it will help us to clean up k8s jobs and pods. However, the submitters can actually stuck like this when it tries to tail job logs but the cluster has gone:

```python
2023-12-30 18:26:20,109	INFO cli.py:36 -- Job submission server address: http://long-running-raycluster-nh7tm-head-svc.test-ns-65xpb.svc.cluster.local:8265
2023-12-30 18:26:21,930	SUCC cli.py:60 -- -----------------------------------------------
2023-12-30 18:26:21,931	SUCC cli.py:61 -- Job 'long-running-r5mrk' submitted successfully
2023-12-30 18:26:21,931	SUCC cli.py:62 -- -----------------------------------------------
2023-12-30 18:26:21,931	INFO cli.py:285 -- Next steps
2023-12-30 18:26:21,931	INFO cli.py:286 -- Query the logs of the job:
2023-12-30 18:26:21,931	INFO cli.py:288 -- ray job logs long-running-r5mrk
2023-12-30 18:26:21,932	INFO cli.py:290 -- Query the status of the job:
2023-12-30 18:26:21,932	INFO cli.py:292 -- ray job status long-running-r5mrk
2023-12-30 18:26:21,932	INFO cli.py:294 -- Request the job to be stopped:
2023-12-30 18:26:21,932	INFO cli.py:296 -- ray job stop long-running-r5mrk
2023-12-30 18:26:21,941	INFO cli.py:303 -- Tailing logs until the job exits (disable with --no-wait):
Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.8/site-packages/urllib3/connection.py", line 174, in _new_conn
    conn = connection.create_connection(
  File "/home/ray/anaconda3/lib/python3.8/site-packages/urllib3/util/connection.py", line 95, in create_connection
    raise err
  File "/home/ray/anaconda3/lib/python3.8/site-packages/urllib3/util/connection.py", line 85, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.8/site-packages/urllib3/connectionpool.py", line 715, in urlopen
    httplib_response = self._make_request(
  File "/home/ray/anaconda3/lib/python3.8/site-packages/urllib3/connectionpool.py", line 416, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/urllib3/connection.py", line 244, in request
    super(HTTPConnection, self).request(method, url, body=body, headers=headers)
  File "/home/ray/anaconda3/lib/python3.8/http/client.py", line 1256, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/home/ray/anaconda3/lib/python3.8/http/client.py", line 1302, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/home/ray/anaconda3/lib/python3.8/http/client.py", line 1251, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/home/ray/anaconda3/lib/python3.8/http/client.py", line 1011, in _send_output
    self.send(msg)
  File "/home/ray/anaconda3/lib/python3.8/http/client.py", line 951, in send
    self.connect()
  File "/home/ray/anaconda3/lib/python3.8/site-packages/urllib3/connection.py", line 205, in connect
    conn = self._new_conn()
  File "/home/ray/anaconda3/lib/python3.8/site-packages/urllib3/connection.py", line 186, in _new_conn
    raise NewConnectionError(
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7f7c2a4327c0>: Failed to establish a new connection: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.8/site-packages/requests/adapters.py", line 486, in send
    resp = conn.urlopen(
  File "/home/ray/anaconda3/lib/python3.8/site-packages/urllib3/connectionpool.py", line 799, in urlopen
    retries = retries.increment(
  File "/home/ray/anaconda3/lib/python3.8/site-packages/urllib3/util/retry.py", line 592, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='long-running-raycluster-nh7tm-head-svc.test-ns-65xpb.svc.cluster.local', port=8265): Max retries exceeded with url: /api/jobs/long-running-r5mrk (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f7c2a4327c0>: Failed to establish a new connection: [Errno 111] Connection refused'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ray/anaconda3/bin/ray", line 8, in <module>
    sys.exit(main())
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/scripts/scripts.py", line 2498, in main
    return cli()
  File "/home/ray/anaconda3/lib/python3.8/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ray/anaconda3/lib/python3.8/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ray/anaconda3/lib/python3.8/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/modules/job/cli_utils.py", line 54, in wrapper
    return func(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/autoscaler/_private/cli_logger.py", line 856, in wrapper
    return f(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/modules/job/cli.py", line 306, in submit
    job_status = get_or_create_event_loop().run_until_complete(
  File "/home/ray/anaconda3/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/modules/job/cli.py", line 96, in _tail_logs
    return _log_job_status(client, job_id)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/modules/job/cli.py", line 75, in _log_job_status
    info = client.get_job_info(job_id)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/modules/job/sdk.py", line 354, in get_job_info
    r = self._do_request("GET", f"/api/jobs/{job_id}")
  File "/home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/modules/dashboard_sdk.py", line 303, in _do_request
    return requests.request(
  File "/home/ray/anaconda3/lib/python3.8/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/requests/adapters.py", line 519, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='long-running-raycluster-nh7tm-head-svc.test-ns-65xpb.svc.cluster.local', port=8265): Max retries exceeded with url: /api/jobs/long-running-r5mrk (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f7c2a4327c0>: Failed to establish a new connection: [Errno 111] Connection refused'))
```

This will cause the `TTLSecondsAfterFinished` to take effect only after a long period, resulting in an unexpected state when suspending a RayJob and flaky tests.

This PR uses `DeletePropagationBackground` to delete the job and its pods immediately instead.


<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
