### PR TITLE
[CI] stream operator logs from kind in go e2e tests

### DIFF
--- a/ray-operator/test/e2e/rayjob_cluster_selector_test.go
+++ b/ray-operator/test/e2e/rayjob_cluster_selector_test.go
@@ -17,6 +17,7 @@ func TestRayJobWithClusterSelector(t *testing.T) {
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
+	test.StreamKubeRayOperatorLogs()
 
 	// Job scripts
 	jobs := newConfigMap(namespace.Name, "jobs", files(test, "counter.py", "fail.py"))

--- a/ray-operator/test/e2e/rayjob_suspend_test.go
+++ b/ray-operator/test/e2e/rayjob_suspend_test.go
@@ -17,6 +17,7 @@ func TestRayJobSuspend(t *testing.T) {
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
+	test.StreamKubeRayOperatorLogs()
 
 	// Job scripts
 	jobs := newConfigMap(namespace.Name, "jobs", files(test, "long_running.py"))

--- a/ray-operator/test/e2e/rayjob_test.go
+++ b/ray-operator/test/e2e/rayjob_test.go
@@ -17,6 +17,7 @@ func TestRayJob(t *testing.T) {
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
+	test.StreamKubeRayOperatorLogs()
 
 	// Job scripts
 	jobs := newConfigMap(namespace.Name, "jobs", files(test, "counter.py", "fail.py"))

--- a/ray-operator/test/support/test.go
+++ b/ray-operator/test/support/test.go
@@ -130,6 +130,8 @@ func (t *T) NewTestNamespace(options ...Option[*corev1.Namespace]) *corev1.Names
 func (t *T) StreamKubeRayOperatorLogs() {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.T().Cleanup(cancel)
+	// By using `.Pods("")`, we list kuberay-operators from all namespaces
+	// because they may not always be installed in the "ray-system" namespace.
 	pods, err := t.Client().Core().CoreV1().Pods("").List(ctx, metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/component=kuberay-operator",
 	})

--- a/ray-operator/test/support/test.go
+++ b/ray-operator/test/support/test.go
@@ -1,11 +1,15 @@
 package support
 
 import (
+	"bufio"
 	"context"
 	"os"
 	"path"
 	"sync"
 	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/onsi/gomega"
 
@@ -21,6 +25,7 @@ type Test interface {
 	gomega.Gomega
 
 	NewTestNamespace(...Option[*corev1.Namespace]) *corev1.Namespace
+	StreamKubeRayOperatorLogs()
 }
 
 type Option[T any] interface {
@@ -120,4 +125,35 @@ func (t *T) NewTestNamespace(options ...Option[*corev1.Namespace]) *corev1.Names
 		deleteTestNamespace(t, namespace)
 	})
 	return namespace
+}
+
+func (t *T) StreamKubeRayOperatorLogs() {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.T().Cleanup(cancel)
+	pods, err := t.Client().Core().CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/component=kuberay-operator",
+	})
+	t.Expect(err).ShouldNot(gomega.HaveOccurred())
+	t.Expect(pods.Items).ShouldNot(gomega.BeEmpty())
+	now := metav1.NewTime(time.Now())
+	for _, pod := range pods.Items {
+		go func(pod corev1.Pod, ts *metav1.Time) {
+			req := t.Client().Core().CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+				Follow:    true,
+				SinceTime: ts,
+			})
+			stream, err := req.Stream(ctx)
+			if err != nil {
+				t.T().Logf("Fail to tail logs from the pod %s/%s", pod.Namespace, pod.Name)
+				return
+			}
+			t.T().Logf("Start tailing logs from the pod %s/%s", pod.Namespace, pod.Name)
+			defer stream.Close()
+			scanner := bufio.NewScanner(stream)
+			for scanner.Scan() {
+				t.T().Log(scanner.Text())
+			}
+			t.T().Logf("Stop tailing logs from the pod %s/%s: %v", pod.Namespace, pod.Name, scanner.Err())
+		}(pod, &now)
+	}
 }


### PR DESCRIPTION
## Why are these changes needed?

The current go e2e test doesn't report operator logs and this makes troubleshooting difficult.

This PR introduces a `test.StreamKubeRayOperatorLogs()` helper to stream operator logs back until the bound `*testing.T` ends.

Under the hood, It uses the same API used by `kubectl logs -f`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
