### PR TITLE
[CRD] Add ray_raycluster_editor_role and ray_raycluster_viewer_role

### DIFF
--- a/helm-chart/kuberay-operator/templates/ray_raycluster_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_raycluster_editor_role.yaml
@@ -1,0 +1,28 @@
+# permissions for end users to edit rayclusters.
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
+  name: raycluster-editor-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters/status
+  verbs:
+  - get
+{{- end }}

--- a/helm-chart/kuberay-operator/templates/ray_raycluster_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_raycluster_viewer_role.yaml
@@ -1,4 +1,4 @@
-# permissions for end users to edit rayclusters.
+# permissions for end users to view rayclusters.
 {{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
 
 kind: ClusterRole

--- a/helm-chart/kuberay-operator/templates/ray_raycluster_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_raycluster_viewer_role.yaml
@@ -1,0 +1,24 @@
+# permissions for end users to edit rayclusters.
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
+  name: raycluster-viewer-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters/status
+  verbs:
+  - get
+{{- end }}


### PR DESCRIPTION
## Why are these changes needed?

Similar to rayjob-editor-role, rayjob-viewer-role, rayservice-editor-role and rayservice-viewer-role. This PR adds the missing roles for raycluster.
