### PR TITLE
[RayJob][Status][13/n] Make suspend operation atomic by introducing the new status `Suspending`

### DIFF
--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -38,6 +38,7 @@ const (
 	JobDeploymentStatusInitializing JobDeploymentStatus = "Initializing"
 	JobDeploymentStatusRunning      JobDeploymentStatus = "Running"
 	JobDeploymentStatusComplete     JobDeploymentStatus = "Complete"
+	JobDeploymentStatusSuspending   JobDeploymentStatus = "Suspending"
 	JobDeploymentStatusSuspended    JobDeploymentStatus = "Suspended"
 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `suspend` operation should be atomic. In other words, if users set the `suspend` flag to true and then immediately set it back to false, either all of the RayJob's associated resources should be cleaned up, or no resources should be cleaned up at all. To keep the atomicity, if a RayJob is in the `Suspending` status, we should delete all of its associated resources and then transition the status to `Suspended` no matter the value of the `suspend` flag.

There is a breaking change in this PR:
* This PR doesn't send a `StopJob` request to stop the Ray job to simplify logic. Currently, Ray doesn't have a best practice to stop a Ray job gracefully. At this moment, KubeRay doesn't stop the Ray job before suspending the RayJob. If users want to stop the Ray job by SIGTERM, users need to set the Pod's preStop hook by themselves. I think this change is acceptable because the `suspend` operation has not been working for several releases already.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

```sh
# ray-job.long-running.yaml: https://gist.github.com/kevin85421/68fadd3ec00fc75d112512954f62cacf
kubectl apply -f ray-job.long-running.yaml

# Wait for the JobDeploymentStatus to be `Running`.
kubectl get rayjobs.ray.io rayjob-sample -o jsonpath='{.status.jobDeploymentStatus}'
# [Expectation]: Running

# Add a finalizer to the RayCluster
kubectl patch rayclusters.ray.io rayjob-sample-raycluster-kp7c4 --type='json' -p='[{"op": "add", "path": "/metadata/finalizers", "value":["ray.io/test"]}]'

# Set `suspend` to true in `ray-job.long-running.yaml` and then apply again.
kubectl apply -f ray-job.long-running.yaml
# [Expectation]: The K8s Job should be removed, but the RayCluster will still be there.

# The status should be `Suspending`.
kubectl get rayjobs.ray.io rayjob-sample -o jsonpath='{.status.jobDeploymentStatus}'
# [Expectation]: Suspending

# Remove the finalizer
kubectl patch rayclusters.ray.io rayjob-sample-raycluster-kp7c4 --type json --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'

# The status should be `Suspended`
kubectl get rayjobs.ray.io rayjob-sample -o jsonpath='{.status.jobDeploymentStatus}'
# [Expectation]: Suspended

# Set `suspend` to false in `ray-job.long-running.yaml` and then apply again.
kubectl apply -f ray-job.long-running.yaml
# [Expectation]: The K8s Job and the RayCluster should be created again.

# The status should finally be `Running` again.
kubectl get rayjobs.ray.io rayjob-sample -o jsonpath='{.status.jobDeploymentStatus}'
# [Expectation]: Running
```
