### PR TITLE
[RayJob][Status][15/n] Unify the codepath for the status transition to `Suspended`

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
@@ -139,18 +139,9 @@ var _ = Context("Inside the default namespace", func() {
 		})
 
 		It("should NOT create a raycluster object", func() {
-			// Ray Cluster name can be present on RayJob's CRD
-			Eventually(
+			Consistently(
 				getRayClusterNameForRayJob(ctx, mySuspendedRayJob),
-				time.Second*15, time.Millisecond*500).Should(Not(BeEmpty()))
-			// However the actual cluster instance and underlying resources should not be created while suspend == true
-			Eventually(
-				// k8sClient client throws error if resource not found
-				func() bool {
-					err := getResourceFunc(ctx, client.ObjectKey{Name: mySuspendedRayJob.Status.RayClusterName, Namespace: "default"}, mySuspendedRayCluster)()
-					return errors.IsNotFound(err)
-				},
-				time.Second*10, time.Millisecond*500).Should(BeTrue())
+				time.Second*3, time.Millisecond*500).Should(BeEmpty())
 		})
 
 		It("should unsuspend a rayjob object", func() {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Currently, there are two paths to transition to the `Suspended` status.
  * `Initializing` -> `Suspended`
  * `Running` -> `Suspending` -> `Suspended`
* The case "Initializing -> Suspended" is pretty tricky:
  * Case 1: Set `suspend` to true before creating the RayCluster.
    * The status will transition to `Suspended` directly.
  * Case 2: Set `suspend` to true after the RayCluster is created and before the K8s Job creation.
    * The status will first transition to `Running` and then to `Suspending`. Additionally, the user must wait until both the RayCluster and the Kubernetes Job are ready to transition to `Running`, which **may take a considerable amount of time** (depending on the time of pulling images).
* This PR unifies the codepath for the status transition to `Suspended`.
  * `Initializing` -> `Suspending` -> `Suspended`
    * Users don't need to wait until the RayCluster and K8s Job are ready. 
  * `Running` -> `Suspending` -> `Suspended`



* Note
  * If we don't add `WithStatusSubresource` to the fake client, the function `r.Status().Update(...)` will complain that the RayJob cannot be found. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
