### PR TITLE
Troubleshooting RayService High Availability

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1125,6 +1125,7 @@ func (r *RayServiceReconciler) labelHealthyServePods(ctx context.Context, rayClu
 		if httpProxyClient.CheckHealth() == nil {
 			pod.Labels[utils.RayClusterServingServiceLabelKey] = utils.EnableRayClusterServingServiceTrue
 		} else {
+			time.Sleep(3 * time.Second)
 			pod.Labels[utils.RayClusterServingServiceLabelKey] = utils.EnableRayClusterServingServiceFalse
 		}
 


### PR DESCRIPTION
Note: This PR is only used to demonstrate the issue. For a quick review, refer to the 'Problem Statement' and 'Root Cause & Next Steps' sections.

### **Problem Statement**

Users have found brief request failures when using Kuberay and its rayservice. The issue arises when the `ray.io/serve` label on the Ray Pod is changed. Kuberay uses this label to indicate whether a node is ready for serving and to remove corresponding endpoints from the Kubernetes service if not ready. Currently, when the serve scales down and there are no replicas in a node, the proxy actor for that node will be removed and Kuberay will begin to change the label.

### **Possible Causes of Issues**

1. Issue: Removing endpoints of Ray Pods from serve service may affect ongoing requests. 
An experiment as described below has been conducted, and we found that it does not affect ongoing requests. The theoretical reason is that Kubernetes service does not mediate established TCP connections.

```shell
# Step 1: Create a Kind cluster
kind create cluster --image=kindest/node:v1.24.0

# Step 2: Install both CRDs and the KubeRay operator v1.0.0.
helm repo add kuberay https://ray-project.github.io/kuberay-helm/
helm install kuberay-operator kuberay/kuberay-operator --version 1.0.0

# Step 3: Create a RayService, which will create:
# 1. a head Pod without any worker Pods.
# 2. a simple serve app with one deployment and one replica that waits for {seconds} and returns "Hello, {name}".
kubectl apply -f https://raw.githubusercontent.com/Yicheng-Lu-llll/serve-file/main/rayservice.yaml
# Check if the serve application is running and healthy.
kubectl describe rayservices rayservice-sample

# Step 4: Run a curl Pod and send a request to the serve app. The app will wait for 120s and then return "Hello, yicheng!"
kubectl run curl --image=radial/busyboxplus:curl -i --tty
curl -X POST -H 'Content-Type: application/json' -d '{"name": "yicheng", "seconds": "120"}' rayservice-sample-serve-svc:8000/greet/

# Step 5: While waiting for Step 4, check the endpoint of the serve service. The endpoint should be the head Pod's IP.
kubectl describe service rayservice-sample-serve-svc
# TargetPort:        8000/TCP
# Endpoints:         10.244.0.6:8000

# Step 6: While still waiting for Step 4, manually update the selector of the serve service to remove the endpoint, simulating a mid-request problem.
kubectl patch service rayservice-sample-serve-svc --type merge -p '{"spec":{"selector":{"empty":"empty"}}}'
kubectl describe service rayservice-sample-serve-svc
# TargetPort:        8000/TCP
# Endpoints:         <none>

# Step 7: Wait and observe the result from Step 4. The response should return normally.
# hello yicheng

# Step 8: Delete the Kind cluster.
kind delete cluster
```

2. Issue: Kuberay starts to remove the endpoint at the drained stage, and the proxy actor on that node has already been removed, so requests before Kuberay finish removing endpoints will fail.
Upon further investigation, it was found that Kuberay actually starts removing endpoints during the draining stage. For Ray to transition from draining to the drained, the following conditions must be met:    
    1. There are no ongoing requests.
    2. The minimum draining time has been reached, which can be controlled by an [environmental variable](https://github.com/ray-project/ray/blob/cc61565848769efc8ccd28a463a441ede3bb9734/python/ray/serve/_private/constants.py#L119-L122).

    During the draining stage, the proxy actor can still handle incoming requests and as previously mentioned, ongoing requests will not be affected while endpoints are being removed. Therefore, as long as the minimum draining time is set appropriately, there should be no failed requests. 


3. Issue: Unexpected Termination of the Proxy Actor
Upon further investigation, we discovered that the Proxy actor appears to die "immediately" after triggering serve scale down. This is unexpected considering that the Ray sets a minimum draining time of 30 seconds by default and this could be problematic as Kuberay might not have enough time to remove the endpoint if the draining time is insufficient. We have successfully reproduced this issue, as demonstrated below.

```shell
# Step 1: Create a Kind cluster
kind create cluster --image=kindest/node:v1.24.0

# Step 2: Install KubeRay operator with custom image via local Helm chart.
# The custom image only adds a 3-second delay to the path: queue -> reconcile-> change serve label-> remove endpoint from the service.
# This delay simulates a busy KubeRay operator in a large, heavy K8s cluster, 
# where the detection of an unavailable node and the removal of its endpoint from the serve service are slow.
# This delay enlarges the time window for the issue to occur. 
# We can actually set the delay to a smaller number, but 3 seconds is more stable.
# Later, we set the minimum draining time to 600s, which is much greater than 3s plus KubeRay process time.
rootPath="/home/ubuntu/kuberay" # Replace it with your own Kuberay repo path
cd $rootPath/helm-chart/kuberay-operator 
helm repo add kuberay https://ray-project.github.io/kuberay-helm/
helm install kuberay-operator --set image.repository=yichenglu/kuberay-operator --set image.tag=healthz .

# Step 3: Create a RayService (rayservice-sample) and a RayCluster (locust-cluster).
# For RayService, it includes:
#     1. A head Pod and two worker Pods.
#     2. A simple serve app with one deployment and three replicas, each replica on a different node (Pod).
#     3. The same serve app as used in https://github.com/ray-project/serve_workloads/blob/main/microbenchmarks/no_ops.py
#     4. Setting the minimum draining time to 600s.
# For RayCluster, it consists of only one head Pod with ray-project/serve_workloads/tree/main/microbenchmarks in it.
kubectl apply -f https://raw.githubusercontent.com/Yicheng-Lu-llll/serve-file/main/rayservice-config_v2.8_replicas-3.yaml

# Step 4: Wait for the RayService to become ready, then check the endpoints of the serve service. There should be three endpoints (one head IP and two worker IPs).
kubectl describe service rayservice-sample-serve-svc

# Step 5: In another terminal, enter the head node of RayCluster (locust-cluster) and start the microbenchmark.
# Utilize the microbenchmarks from https://github.com/ray-project/serve_workloads/tree/main/microbenchmarks.
# This will initiate two locust workers, each simulating 100 users sending zero-payload requests to the serve app.
# Here, QPS is not important; the microbenchmark is used to detect request failures.
kubectl exec -it $(kubectl get pods -o=name | grep locust) -- /bin/sh
cd serve_workloads/microbenchmarks
python locust_runner.py -f /home/ray/serve_workloads/microbenchmarks/qps_test_locustfile.py -u 100 -r 100 -p 0 --host http://rayservice-sample-serve-svc:8000

# Step 6: Trigger the serve scale-down by changing the replicas from 3 to 1.
# Since there is one replica per node, Ray will start draining the proxy actor in two out of the three nodes.
# KubeRay will detect the draining stage through a health check 
# and attempt to remove the endpoint from the service before the draining stage is complete.
# Ideally, with the minimum draining time set to 600s, which is significantly longer than 3s plus the KubeRay process time,
# it should be sufficient for KubeRay to remove the endpoint from the service before the draining stage ends.
# Consequently, there should be no request failures.
# However, in Ray 2.8, there is an issue (https://github.com/ray-project/ray/issues/41726) where the proxy actor is actually removed before the RAY_SERVE_PROXY_MIN_DRAINING_PERIOD_S,
# causing KubeRay to not have enough time to remove the endpoint from the service, leading to request failures when this endpoint is used.
kubectl apply -f https://raw.githubusercontent.com/Yicheng-Lu-llll/serve-file/main/rayservice-config_v2.8_replicas-1.yaml

# Step 7: Observe the microbenchmark results from Step 5. You will notice that for a short period, 
# the requests will fail, but afterwards, all requests succeed (indicating that the failures are not due to 
# overwhelming requests to the remaining  proxy actors). This behavior reproduces the issue.

# Step 8: Delete the Kind cluster.
kind delete cluster
```


### **Root Cause && Next Step**

As described above, the root cause is that the proxy actor can be removed before the minimum draining time has elapsed. This situation leads to KubeRay not having sufficient time to remove the endpoints, resulting in requests still being directed to nodes that no longer have replicas or proxy actors. This unexpected behavior has been fixed in Ray 2.9, as detailed in https://github.com/ray-project/ray/pull/41755.

For the next step, consider moving the health check (currently, KubeRay performs a health check on every Ray pod at every reconcile, which is not ideal, especially for large-scale) to a readiness probe. This would reduce the load on KubeRay and improve the high availability of RayService, as KubeRay failures would no longer affect RayService.

