### PR TITLE
[RayService] Move HTTP Proxy's Health Check to Readiness Probe for Wokers

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -277,17 +277,17 @@ func initLivenessAndReadinessProbe(rayContainer *corev1.Container, rayNodeType r
 			FailureThreshold:    utils.DefaultReadinessProbeFailureThreshold,
 		}
 		rayContainer.ReadinessProbe.Exec = &corev1.ExecAction{Command: []string{"bash", "-c", strings.Join(commands, " && ")}}
-	}
 
-	// For worker Pods serving traffic, we need to add an additional HTTP proxy health check for the readiness probe.
-	// Note: head Pod checks the HTTP proxy's health at every rayservice controller reconcile instaed of using readiness probe.
-	// See https://github.com/ray-project/kuberay/pull/1808 for reasons.
-	if enableServeService && rayNodeType == rayv1.WorkerNode {
-		rayContainer.ReadinessProbe.FailureThreshold = utils.ServeReadinessProbeFailureThreshold
-		rayServeProxyHealthCommand := fmt.Sprintf(utils.BaseWgetHealthCommand,
-			utils.FindContainerPort(rayContainer, utils.ServingPortName, utils.DefaultServingPort), utils.RayServeProxyHealthPath)
-		commands = append(commands, rayServeProxyHealthCommand)
-		rayContainer.ReadinessProbe.Exec = &corev1.ExecAction{Command: []string{"bash", "-c", strings.Join(commands, " && ")}}
+		// For worker Pods serving traffic, we need to add an additional HTTP proxy health check for the readiness probe.
+		// Note: head Pod checks the HTTP proxy's health at every rayservice controller reconcile instaed of using readiness probe.
+		// See https://github.com/ray-project/kuberay/pull/1808 for reasons.
+		if enableServeService && rayNodeType == rayv1.WorkerNode {
+			rayContainer.ReadinessProbe.FailureThreshold = utils.ServeReadinessProbeFailureThreshold
+			rayServeProxyHealthCommand := fmt.Sprintf(utils.BaseWgetHealthCommand,
+				utils.FindContainerPort(rayContainer, utils.ServingPortName, utils.DefaultServingPort), utils.RayServeProxyHealthPath)
+			commands = append(commands, rayServeProxyHealthCommand)
+			rayContainer.ReadinessProbe.Exec = &corev1.ExecAction{Command: []string{"bash", "-c", strings.Join(commands, " && ")}}
+		}
 	}
 }
 

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -312,8 +312,6 @@ func initReadinessProbe(rayContainer *corev1.Container, rayNodeType rayv1.RayNod
 	} else {
 		commands = append(commands, rayAgentRayletHealthCommand)
 		if enableServeService {
-			// Note: head Pod checks the HTTP proxy's health at every rayservice controller reconcile instaed of using readiness probe.
-			// See https://github.com/ray-project/kuberay/pull/1808 for reasons.
 			commands = append(commands, rayServeProxyHealthCommand)
 		}
 	}

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	// "k8s.io/apimachinery/pkg/util/intstr"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1161,23 +1161,23 @@ func TestGetEnableProbesInjection(t *testing.T) {
 	assert.False(t, b)
 }
 
-func TestInitHealthProbe(t *testing.T) {
-	// Test 1: User defines a custom HTTPGet probe.
-	httpGetProbe := corev1.Probe{
-		ProbeHandler: corev1.ProbeHandler{
-			HTTPGet: &corev1.HTTPGetAction{
-				// Check Raylet status
-				Path: fmt.Sprintf("/%s", utils.RayAgentRayletHealthPath),
-				Port: intstr.FromInt(utils.DefaultDashboardAgentListenPort),
-			},
-		},
-	}
-	initHealthProbe(&httpGetProbe, rayv1.HeadNode)
-	assert.NotNil(t, httpGetProbe.HTTPGet)
-	assert.Nil(t, httpGetProbe.Exec)
+// func TestInitHealthProbe(t *testing.T) {
+// 	// Test 1: User defines a custom HTTPGet probe.
+// 	httpGetProbe := corev1.Probe{
+// 		ProbeHandler: corev1.ProbeHandler{
+// 			HTTPGet: &corev1.HTTPGetAction{
+// 				// Check Raylet status
+// 				Path: fmt.Sprintf("/%s", utils.RayAgentRayletHealthPath),
+// 				Port: intstr.FromInt(utils.DefaultDashboardAgentListenPort),
+// 			},
+// 		},
+// 	}
+// 	initHealthProbe(&httpGetProbe, rayv1.HeadNode, false, false)
+// 	assert.NotNil(t, httpGetProbe.HTTPGet)
+// 	assert.Nil(t, httpGetProbe.Exec)
 
-	// Test 2: User does not define a custom probe. KubeRay will inject a default Exec probe.
-	probe := corev1.Probe{}
-	initHealthProbe(&probe, rayv1.HeadNode)
-	assert.NotNil(t, probe.Exec)
-}
+// 	// Test 2: User does not define a custom probe. KubeRay will inject a default Exec probe.
+// 	probe := corev1.Probe{}
+// 	initHealthProbe(&probe, rayv1.HeadNode, false, false)
+// 	assert.NotNil(t, probe.Exec)
+// }

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -204,7 +204,7 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 			err = r.updateState(ctx, rayServiceInstance, rayv1.FailedToUpdateService, err)
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
 		}
-		if err := r.labelHealthyServePods(ctx, rayClusterInstance); err != nil {
+		if err := r.labelHeadPodForServeStatus(ctx, rayClusterInstance); err != nil {
 			err = r.updateState(ctx, rayServiceInstance, rayv1.FailedToUpdateServingPodLabel, err)
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
 		}
@@ -1126,7 +1126,7 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 	return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, isReady, nil
 }
 
-func (r *RayServiceReconciler) labelHealthyServePods(ctx context.Context, rayClusterInstance *rayv1.RayCluster) error {
+func (r *RayServiceReconciler) labelHeadPodForServeStatus(ctx context.Context, rayClusterInstance *rayv1.RayCluster) error {
 	headPod, err := r.getHeadPod(ctx, rayClusterInstance)
 	if err != nil {
 		return err

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1236,6 +1236,7 @@ func isServeAppUnhealthyOrDeployedFailed(appStatus string) bool {
 	return appStatus == rayv1.ApplicationStatusEnum.UNHEALTHY || appStatus == rayv1.ApplicationStatusEnum.DEPLOY_FAILED
 }
 
+// TODO: Move this function to util.go and refactor the code to always use this function for retrieving the head Pod.
 func (r *RayServiceReconciler) getHeadPod(ctx context.Context, instance *rayv1.RayCluster) (*corev1.Pod, error) {
 	podList := corev1.PodList{}
 	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeTypeLabelKey: string(rayv1.HeadNode)}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1236,7 +1236,7 @@ func isServeAppUnhealthyOrDeployedFailed(appStatus string) bool {
 	return appStatus == rayv1.ApplicationStatusEnum.UNHEALTHY || appStatus == rayv1.ApplicationStatusEnum.DEPLOY_FAILED
 }
 
-// TODO: Move this function to util.go and refactor the code to always use this function for retrieving the head Pod.
+// TODO: Move this function to util.go and always use this function to retrieve the head Pod.
 func (r *RayServiceReconciler) getHeadPod(ctx context.Context, instance *rayv1.RayCluster) (*corev1.Pod, error) {
 	podList := corev1.PodList{}
 	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeTypeLabelKey: string(rayv1.HeadNode)}

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -136,7 +136,8 @@ const (
 
 	// Ray health check related configurations
 	// Note: Since the Raylet process and the dashboard agent process are fate-sharing,
-	// we use the dashboard agent's API endpoint to check both of them.
+	// only one of them needs to be checked. So, RayAgentRayletHealthPath accesses the dashboard agent's API endpoint
+	// to check the health of the Raylet process.
 	// TODO (kevin85421): Should we take the dashboard process into account?
 	RayAgentRayletHealthPath  = "api/local_raylet_healthz"
 	RayDashboardGCSHealthPath = "api/gcs_healthz"

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -125,6 +125,7 @@ const (
 	DefaultReadinessProbePeriodSeconds       = 5
 	DefaultReadinessProbeSuccessThreshold    = 1
 	DefaultReadinessProbeFailureThreshold    = 10
+	ServeReadinessProbeFailureThreshold      = 1
 
 	// Ray FT default liveness probe values
 	DefaultLivenessProbeInitialDelaySeconds = 30
@@ -134,8 +135,13 @@ const (
 	DefaultLivenessProbeFailureThreshold    = 120
 
 	// Ray health check related configurations
+	// Note: Since the Raylet process and the dashboard agent process are fate-sharing,
+	// we use the dashboard agent's API endpoint to check both of them.
+	// TODO (kevin85421): Should we take the dashboard process into account?
 	RayAgentRayletHealthPath  = "api/local_raylet_healthz"
 	RayDashboardGCSHealthPath = "api/gcs_healthz"
+	RayServeProxyHealthPath   = "-/healthz"
+	BaseWgetHealthCommand     = "wget -T 2 -q -O- http://localhost:%d/%s | grep success"
 
 	// Finalizers for RayJob
 	RayJobStopJobFinalizer = "ray.io/rayjob-finalizer"

--- a/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
@@ -7,8 +7,6 @@ import (
 	"time"
 )
 
-const healthCheckPath = "/-/healthz"
-
 type RayHttpProxyClientInterface interface {
 	InitClient()
 	CheckHealth() error
@@ -31,11 +29,11 @@ func (r *RayHttpProxyClient) InitClient() {
 }
 
 func (r *RayHttpProxyClient) SetHostIp(hostIp string, port int) {
-	r.httpProxyURL = fmt.Sprintf("http://%s:%d", hostIp, port)
+	r.httpProxyURL = fmt.Sprintf("http://%s:%d/", hostIp, port)
 }
 
 func (r *RayHttpProxyClient) CheckHealth() error {
-	req, err := http.NewRequest("GET", r.httpProxyURL+healthCheckPath, nil)
+	req, err := http.NewRequest("GET", r.httpProxyURL+RayServeProxyHealthPath, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, for high availability of RayService, KubeRay checks each serving Pod's HTTP proxy's health at every reconciliation. If not healthy, KubeRay changes the corresponding Pod's label, and that Pod will later not be selected by serve service.

This method has several shortcomings:

- KubeRay may become overloaded due to checking every Ray Pod at every reconciliation, especially if there is a large number of Ray Pods.
- If KubeRay operator Pod fails, high availability will also no longer exist. An unhealthy worker Pod cannot be removed from the serving service!

This PR mainly moves the HTTP proxy's health check to the readiness probe for all worker Pods while still checking the head Pod's HTTP proxy's health at every reconciliation for head Pod. This has several benefits:
- Reduce the load on KubeRay.
-  Decouple the current shared failure of KubeRay operator and RayService's high availability.

Note: 
- The reason for not moving the HTTP proxy's health check to the head Pod‘s readiness probe is complex. Here are two reasons:

    - If the readiness probe fails, the head Pod will be removed from all services, including the head service, which is the main way worker Pods communicate to head Pod.
    - The Serve app will not be submitted until the head Pod is in 'ready' status. If the readiness probe also checks the HTTP proxy's health, it will fail as there is no running Serve app before head Pod is in 'ready' status. However, if the readiness probe fails, the head Pod will never be in 'ready' status, and the Serve app will never be submitted to the head pod. This creates a circular dependency problem.

- After this PR, if a worker Pod has no serving replica, it will also not be in a 'READY' state, as there is no HTTP proxy. The status should be interpreted as 'not ready for serving'. So, not be surprised if you see worker Pod never be in a ready status though you have do nothing wrong, it can simply because there is not serve replica scheduled to that worker Pod. 

Additionally, This PR refactor some of the related code.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
None
<!-- For example: "Closes #1234" -->

## Checks
- Test1: 
    - Check if head and worker Pods' readiness probe and liveness probe are correctly set.
    - Check if endpoints of the serve service is correctly changed when scaling.
    - Check if no request is dropped during the scaling.
```shell
# Step 1: Create a RayService with one head Pod and three worker Pods, each worker Pod has a serve replica. There is no user defined probes.
# Also, a locust cluster is created to test the high availability of the RayService.
kubectl apply -f https://raw.githubusercontent.com/Yicheng-Lu-llll/serve-file/main/rayservice-config_v2.9_replicas-3.yaml

# Step 2: Check head Pod's readiness probe and liveness probe. 
kubectl describe $(kubectl get pods -o=name | grep head) | grep  "Readiness:\|Liveness:"
# Liveness:   exec [bash -c wget -T 2 -q -O- http://localhost:52365/api/local_raylet_healthz | grep success && wget -T 2 -q -O- http://localhost:8265/api/gcs_healthz | grep success] delay=30s timeout=1s period=5s #success=1 #failure=120
# Readiness:  exec [bash -c wget -T 2 -q -O- http://localhost:52365/api/local_raylet_healthz | grep success && wget -T 2 -q -O- http://localhost:8265/api/gcs_healthz | grep success] delay=10s timeout=1s period=5s #success=1 #failure=10

# Step 3: Check worker Pod's readiness probe and liveness probe.
kubectl describe $(kubectl get pods -o=name | grep worker) | grep  "Readiness:\|Liveness:"
# Liveness:   exec [bash -c wget -T 2 -q -O- http://localhost:52365/api/local_raylet_healthz | grep success] delay=30s timeout=1s period=5s #success=1 #failure=120
# Readiness:  exec [bash -c wget -T 2 -q -O- http://localhost:52365/api/local_raylet_healthz | grep success && wget -T 2 -q -O- http://localhost:8000/-/healthz | grep success] delay=10s timeout=1s period=5s #success=1 #failure=1

# Step 4: check the endpoints of the serve service. There should be four endpoints(1 head + 3 workers)
kubectl describe service rayservice-sample-serve-svc | grep "Endpoints"
# Endpoints:         10.244.0.19:8000,10.244.0.20:8000,10.244.0.21:8000 + 1 more...

# Step 4: scale down the RayService to 1 replica and recheck the endpoints of the serve service. 
# There should be only two endpoint(1 head + 1 workers)
kubectl apply -f https://raw.githubusercontent.com/Yicheng-Lu-llll/serve-file/main/rayservice-config_v2.9_replicas-1.yaml
kubectl describe service rayservice-sample-serve-svc | grep "Endpoints"
# Endpoints:         10.244.0.19:8000,10.244.0.21:8000

# Step 5: During all the above steps, We can also start an locust cluster to test the high availability of the RayService.
# You will find no request is dropped during the scaling down process.
kubectl apply -f https://raw.githubusercontent.com/Yicheng-Lu-llll/serve-file/main/locust_cluster.yaml
kubectl exec -it $(kubectl get pods -o=name | grep locust) -- /bin/sh
cd serve_workloads/microbenchmarks
python locust_runner.py -f /home/ray/serve_workloads/microbenchmarks/qps_test_locustfile.py -u 100 -r 100 -p 0 --host http://rayservice-sample-serve-svc:8000
```



- Test2: Check if serve requests and serve health check can still success if using custom serve port.
```shell
#  Create a RayService with one head Pod and one worker Pod with serving port 9000, each worker Pod has a serve replica.
kubectl apply -f https://raw.githubusercontent.com/Yicheng-Lu-llll/serve-file/main/ray-service.different-port.yaml

kubectl describe $(kubectl get pods -o=name | grep worker) | grep  "Readiness:\|Liveness:"
# Liveness:   exec [bash -c wget -T 2 -q -O- http://localhost:52365/api/local_raylet_healthz | grep success] delay=30s timeout=1s period=5s #success=1 #failure=120
# Readiness:  exec [bash -c wget -T 2 -q -O- http://localhost:52365/api/local_raylet_healthz | grep success && wget -T 2 -q -O- http://localhost:9000/-/healthz | grep success] delay=10s timeout=1s period=5s #success=1 #failure=1

kubectl describe svc rayservice-sample-serve-svc | grep "Endpoints"
# Endpoints:         10.244.0.6:9000,10.244.0.7:9000
```

- Test3: Check for custom serve service
```shell
# Create a RayService with one head Pod and one worker Pod, each worker Pod has a serve replica. 
kubectl apply -f https://raw.githubusercontent.com/Yicheng-Lu-llll/serve-file/main/ray-service.custom-serve-service.yaml

kubectl describe svc custom-ray-serve-service-name | grep "Endpoints"
# Endpoints:                10.244.0.18:8000,10.244.0.19:8000
```
- Test4: User has its own probes
Has already added in in CI test.

