### PR TITLE
[Test][RayJob] Kueue happy-path scenario

### DIFF
--- a/ray-operator/test/e2e/rayjob_suspend_test.go
+++ b/ray-operator/test/e2e/rayjob_suspend_test.go
@@ -20,7 +20,7 @@ func TestRayJobSuspend(t *testing.T) {
 	test.StreamKubeRayOperatorLogs()
 
 	// Job scripts
-	jobs := newConfigMap(namespace.Name, "jobs", files(test, "long_running.py"))
+	jobs := newConfigMap(namespace.Name, "jobs", files(test, "long_running.py", "counter.py"))
 	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Create(test.Ctx(), jobs, metav1.CreateOptions{})
 	test.Expect(err).NotTo(HaveOccurred())
 	test.T().Logf("Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
@@ -124,6 +124,9 @@ env_vars:
 		test.T().Logf("Waiting for RayJob %s/%s to be 'Suspended'", rayJob.Namespace, rayJob.Name)
 		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusSuspended)))
+
+		// Refresh the RayJob statuzs
+		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)
 
 		test.T().Logf("Resume the RayJob by updating `suspend` to false.")
 		rayJob.Spec.Suspend = false


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR provides an end-to-end test covering the happy-path scenario for Kueue. Specifically, it creates a suspended RayJob with `.spec.suspend = true` at creation time (achieved by Kueue using a webhook), resumes it manually, and checks for successful completion.

## Related issue number

Closes #1800 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
