### PR TITLE
Improve flexibility in RayCluster yaml test 

### DIFF
--- a/tests/test_sample_raycluster_yamls.py
+++ b/tests/test_sample_raycluster_yamls.py
@@ -4,6 +4,7 @@ import unittest
 import os
 import git
 import yaml
+import argparse
 
 from framework.prototype import (
     RuleSet,
@@ -20,6 +21,11 @@ from framework.utils import (
 
 logger = logging.getLogger(__name__)
 
+def parse_args():
+    parser = argparse.ArgumentParser(description='Run tests for specified YAML files.')
+    parser.add_argument('--yaml-file', nargs='*', help='Specify the YAML files to run tests for.')
+    return parser.parse_args()
+
 if __name__ == '__main__':
     NAMESPACE = 'default'
     SAMPLE_PATH = CONST.REPO_ROOT.joinpath("ray-operator/config/samples/")
@@ -32,12 +38,18 @@ if __name__ == '__main__':
         git.Repo(CONST.REPO_ROOT).untracked_files
     )
 
+    args = parse_args()
+
     for file in os.scandir(SAMPLE_PATH):
         if not file.is_file():
             continue
         # For local development, skip untracked files.
         if os.path.relpath(file.path, CONST.REPO_ROOT) in untracked_files:
             continue
+        # Skip files that don't match the specified YAML files
+        if args.yaml_file and file.name not in args.yaml_file:
+            continue
+
         with open(file, encoding="utf-8") as cr_yaml:
             for k8s_object in yaml.safe_load_all(cr_yaml):
                 if k8s_object['kind'] == 'RayCluster':

--- a/tests/test_sample_raycluster_yamls.py
+++ b/tests/test_sample_raycluster_yamls.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Run tests for specified YAML files.')
-    parser.add_argument('--yaml-file', nargs='*', help='Specify the YAML files to run tests for.')
+    parser.add_argument('--yaml-files', nargs='*', help='Use the filename under path `ray-operator/config/samples` to specify which YAML files should be tested.')
     return parser.parse_args()
 
 if __name__ == '__main__':
@@ -47,7 +47,7 @@ if __name__ == '__main__':
         if os.path.relpath(file.path, CONST.REPO_ROOT) in untracked_files:
             continue
         # Skip files that don't match the specified YAML files
-        if args.yaml_file and file.name not in args.yaml_file:
+        if args.yaml_files and file.name not in args.yaml_files:
             continue
 
         with open(file, encoding="utf-8") as cr_yaml:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->
This PR improves the flexibility of KubeRay in sample YAML tests. Now developers can use Python command's Args to run individual YAML file.

Here's an example:
1. [Default] Run all YAML files.
`python3 tests/test_sample_raycluster_yamls.py`

2. Specified a single YAML file.
`python3 tests/test_sample_raycluster_yamls.py --yaml-file ray-cluster.mini.yaml`
You can also specify multiple YAML files:
`python3 tests/test_sample_raycluster_yamls.py --yaml-file ray-cluster.mini.yaml ray-cluster.external-redis.yaml`

Without this PR, developers have to run all sample YAML files when executing YAML tests, which would be time-consuming and inefficient.

With this PR, they can now specify particular YAML files for testing, significantly reducing the time required for developers.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

Following is the screenshot of manual test
1. [Default] Run all YAML files.
![Ex_all](https://github.com/ray-project/kuberay/assets/139951533/c17bddb5-5df7-4368-a5ea-9b36af3b08fe)
![Run_all_yaml_test](https://github.com/ray-project/kuberay/assets/139951533/b733114d-07c9-4b3c-b894-9a1e06f7ada6)

2. Specified two YAML files.
![Ex_2_yaml_test](https://github.com/ray-project/kuberay/assets/139951533/83cc8810-9c45-47aa-b462-8cd530e626a6)
![Run_2_yaml_test](https://github.com/ray-project/kuberay/assets/139951533/6f2c60a2-6aa3-4484-9bda-7826c3f45bea)

