### PR TITLE
[RayJob][Status][17/n] Unify the codepath for status updates

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -511,11 +511,10 @@ func (r *RayJobReconciler) updateRayJobStatus(ctx context.Context, oldRayJob *ra
 	oldRayJobStatus := oldRayJob.Status
 	newRayJobStatus := newRayJob.Status
 	r.Log.Info("updateRayJobStatus", "oldRayJobStatus", oldRayJobStatus, "newRayJobStatus", newRayJobStatus)
+	// If a status field is crucial for the RayJob state machine, it MUST be
+	// updated with a distinct JobStatus or JobDeploymentStatus value.
 	if oldRayJobStatus.JobStatus != newRayJobStatus.JobStatus ||
-		oldRayJobStatus.JobDeploymentStatus != newRayJobStatus.JobDeploymentStatus ||
-		oldRayJobStatus.JobId != newRayJobStatus.JobId ||
-		oldRayJobStatus.RayClusterName != newRayJobStatus.RayClusterName ||
-		oldRayJobStatus.DashboardURL != newRayJobStatus.DashboardURL {
+		oldRayJobStatus.JobDeploymentStatus != newRayJobStatus.JobDeploymentStatus {
 		r.Log.Info("updateRayJobStatus", "old JobStatus", oldRayJobStatus.JobStatus, "new JobStatus", newRayJobStatus.JobStatus,
 			"old JobDeploymentStatus", oldRayJobStatus.JobDeploymentStatus, "new JobDeploymentStatus", newRayJobStatus.JobDeploymentStatus)
 		if err := r.Status().Update(ctx, newRayJob); err != nil {

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -245,12 +244,9 @@ func TestUpdateStatusToSuspendingIfNeeded(t *testing.T) {
 				Scheme:   newScheme,
 				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
-			shouldUpdate, err := testRayJobReconciler.updateStatusToSuspendingIfNeeded(ctx, rayJob)
-			assert.NoError(t, err)
+			shouldUpdate := testRayJobReconciler.updateStatusToSuspendingIfNeeded(ctx, rayJob)
 			assert.Equal(t, tc.expectedShouldUpdate, shouldUpdate)
 
-			err = fakeClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, rayJob)
-			assert.NoError(t, err)
 			if tc.expectedShouldUpdate {
 				assert.Equal(t, rayv1.JobDeploymentStatusSuspending, rayJob.Status.JobDeploymentStatus)
 			} else {

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -252,6 +253,73 @@ func TestUpdateStatusToSuspendingIfNeeded(t *testing.T) {
 			} else {
 				assert.Equal(t, tc.status, rayJob.Status.JobDeploymentStatus)
 			}
+		})
+	}
+}
+
+func TestUpdateRayJobStatus(t *testing.T) {
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+
+	rayJobTemplate := &rayv1.RayJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rayjob",
+			Namespace: "default",
+		},
+		Status: rayv1.RayJobStatus{
+			JobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
+			JobStatus:           rayv1.JobStatusRunning,
+			Message:             "old message",
+		},
+	}
+	newMessage := "new message"
+
+	tests := map[string]struct {
+		isJobDeploymentStatusChanged bool
+	}{
+		"JobDeploymentStatus is not changed": {
+			isJobDeploymentStatusChanged: false,
+		},
+		"JobDeploymentStatus is changed": {
+			isJobDeploymentStatusChanged: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldRayJob := rayJobTemplate.DeepCopy()
+
+			// Initialize a fake client with newScheme and runtimeObjects.
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(newScheme).
+				WithRuntimeObjects(oldRayJob).
+				WithStatusSubresource(oldRayJob).Build()
+			ctx := context.Background()
+
+			newRayJob := &rayv1.RayJob{}
+			err := fakeClient.Get(ctx, types.NamespacedName{Namespace: oldRayJob.Namespace, Name: oldRayJob.Name}, newRayJob)
+			assert.NoError(t, err)
+
+			// Update the status
+			newRayJob.Status.Message = newMessage
+			if tc.isJobDeploymentStatusChanged {
+				newRayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusSuspending
+			}
+
+			// Initialize a new RayClusterReconciler.
+			testRayJobReconciler := &RayJobReconciler{
+				Client:   fakeClient,
+				Recorder: &record.FakeRecorder{},
+				Scheme:   newScheme,
+				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
+			}
+
+			err = testRayJobReconciler.updateRayJobStatus(ctx, oldRayJob, newRayJob)
+			assert.NoError(t, err)
+
+			err = fakeClient.Get(ctx, types.NamespacedName{Namespace: newRayJob.Namespace, Name: newRayJob.Name}, newRayJob)
+			assert.NoError(t, err)
+			assert.Equal(t, newRayJob.Status.Message == newMessage, tc.isJobDeploymentStatusChanged)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Unify the codepath for status updates into a single place. The [ReplicaSet source code](https://sourcegraph.com/github.com/kubernetes/kubernetes@9e622d23648f4af4a12835de97484dc0e4859269/-/blob/pkg/controller/replicaset/replica_set.go?L706-L710) has the similar pattern.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
