### PR TITLE
[RayService] Fixed issue where the custom serve port is not reflected in the serve health check for worker Pods

### DIFF
--- a/ray-operator/config/samples/ray-service.different-port.yaml
+++ b/ray-operator/config/samples/ray-service.different-port.yaml
@@ -2,6 +2,7 @@
 # file demonstrates how to change the port to 9000. To achieve this, follow these steps:
 # (1) Modify `spec.serveConfig.port` to 9000.
 # (2) Modify the container `ray-head`'s `serve` port to 9000.
+# (3) Modify the container `ray-worker`'s `serve` port to 9000.
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
@@ -93,3 +94,6 @@ spec:
                   requests:
                     cpu: "500m"
                     memory: "2Gi"
+                ports:
+                  - containerPort: 9000
+                    name: serve


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As title.

`ray-service.different-port.yaml` is used to demonstrate how to set custom serve port. However, the instruction is not complete.

when running `ray-service.different-port.yaml`, it may appear that everything is functioning correctly. However, the custom serve port is not accurately reflected in the serve health check for worker Pods. The absence of errors is due to the serve app only requiring a minimal amount of CPU resources. Consequently, the worker Pod might not even host a serve replica.

To illustrate this issue, I have created a Ray service similar to ray-service.different-port.yaml, but with a modified serve app configuration ensuring each Pod has one serve replica. As shown in the experiment below, the worker Pod consistently fails the health check because it defaults to using the serve port value of 8000.

```shell
kubectl apply -f https://raw.githubusercontent.com/Yicheng-Lu-llll/serve-file/main/ray-service.different-port.bad.example.yaml

# The ray.io/serve label is used to indicate whether a Pod passes the serve health check.
kubectl describe $(kubectl get pods -o=name | grep worker) | grep  "ray.io/serve"
#ray.io/serve=false

```

This issue occurs because Kuberay determines the serve port by [examining the ray container](https://github.com/ray-project/kuberay/blob/1eed068d7641d2932a177cbd0530553b6df75588/ray-operator/controllers/ray/rayservice_controller.go#L1141). If the serve port is not set in the worker configuration, it defaults to port 8000.


btw, I am not sure if it is a good idea to change every Rayservice samples to enforce every Ray Pod at least has one replica. This kind of error may occur in future.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
```
# Add a custom serve port to both head pod and worker Pod.
kubectl apply -f https://raw.githubusercontent.com/Yicheng-Lu-llll/serve-file/main/ray-service.different-port.yaml

# The ray.io/serve label is used to indicate whether a Pod passes the serve health check.
kubectl describe $(kubectl get pods -o=name | grep worker) | grep  "ray.io/serve"
#ray.io/serve=true
```

