### PR TITLE
[Feature] [CLI] Add arm64 arch build for kuberay and output should should ignore by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@
 
 # Any file with a .log extension
 **/*.log
+
+**/_output/

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,8 +1,10 @@
 OUTPUT_NAME := kuberay
+OUTPUT_PATH := bin
 BUILD_GOOS = $(shell go env GOOS)
 
 COMMIT := $(shell git rev-parse --short HEAD)
 VERSION := $(shell git describe --tags $(shell git rev-list --tags --max-count=1))
+VERSION := $(shell echo $(VERSION) | sed 's/\//-/g')
 DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 REPO="github.com/ray-project/kuberay"
 
@@ -11,10 +13,15 @@ BUILD_FLAGS = -ldflags="-X '${REPO}/cli/pkg/cmd/version.Version=$(VERSION)' \
 	-X '${REPO}/cli/pkg/cmd/version.buildDate=$(DATE)'"
 
 build:
-	go build $(BUILD_FLAGS) -o $(OUTPUT_NAME) main.go
+	go build $(BUILD_FLAGS) -o $(OUTPUT_PATH)/$(OUTPUT_NAME) main.go
 
 release:
-	GOOS=linux GOARCH=amd64 make build OUTPUT_NAME=_output/linux/amd64/$(OUTPUT_NAME)
-	GOOS=darwin GOARCH=amd64 make build OUTPUT_NAME=_output/darwin/amd64/$(OUTPUT_NAME)
+	GOOS=linux GOARCH=amd64 make build OUTPUT_PATH=_output/linux/amd64
+	GOOS=darwin GOARCH=amd64 make build OUTPUT_PATH=_output/darwin/amd64
 	zip _output/kuberay-$(VERSION)-linux-amd64.zip _output/linux/amd64/$(OUTPUT_NAME)
 	zip _output/kuberay-$(VERSION)-darwin-amd64.zip _output/darwin/amd64/$(OUTPUT_NAME)
+
+	GOOS=linux GOARCH=arm64 make build OUTPUT_PATH=_output/linux/arm64
+	GOOS=darwin GOARCH=arm64 make build OUTPUT_PATH=_output/darwin/arm64
+	zip _output/kuberay-$(VERSION)-linux-arm64.zip _output/linux/arm64/$(OUTPUT_NAME)
+	zip _output/kuberay-$(VERSION)-darwin-arm64.zip _output/darwin/arm64/$(OUTPUT_NAME)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Support the arm64 arch
- The kuberay executable file should be ignored, if not it will bring troubles for developers

## Related issue number

Closes #1819

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
