### PR TITLE
Add `ray.io/originated-from` labels

### DIFF
--- a/apiserver/pkg/util/config.go
+++ b/apiserver/pkg/util/config.go
@@ -13,7 +13,6 @@ const (
 	RayClusterUserLabelKey            = "ray.io/user"
 	RayClusterVersionLabelKey         = "ray.io/version"
 	RayClusterEnvironmentLabelKey     = "ray.io/environment"
-	RayOriginatedFromLabelKey         = "ray.io/originated-from"
 	KubernetesApplicationNameLabelKey = "app.kubernetes.io/name"
 	KubernetesManagedByLabelKey       = "app.kubernetes.io/managed-by"
 
@@ -31,10 +30,4 @@ const (
 
 	// The component name for apiserver
 	ComponentName = "kuberay-apiserver"
-
-	RayServiceOriginatedFromLabelValueType = "rayservice"
 )
-
-func RayOriginatedFromServiceLabelValue(name string) string {
-	return RayServiceOriginatedFromLabelValueType + "_" + name
-}

--- a/apiserver/pkg/util/config.go
+++ b/apiserver/pkg/util/config.go
@@ -13,7 +13,8 @@ const (
 	RayClusterUserLabelKey            = "ray.io/user"
 	RayClusterVersionLabelKey         = "ray.io/version"
 	RayClusterEnvironmentLabelKey     = "ray.io/environment"
-	RayServiceLabelKey                = "ray.io/service"
+	RayOriginatedFromNameLabelKey     = "ray.io/originated-from-name"
+	RayOriginatedFromTypeLabelKey     = "ray.io/originated-from-type"
 	KubernetesApplicationNameLabelKey = "app.kubernetes.io/name"
 	KubernetesManagedByLabelKey       = "app.kubernetes.io/managed-by"
 
@@ -31,4 +32,6 @@ const (
 
 	// The component name for apiserver
 	ComponentName = "kuberay-apiserver"
+
+	RayServiceOriginatedFromTypeLabelValue = "rayservice"
 )

--- a/apiserver/pkg/util/config.go
+++ b/apiserver/pkg/util/config.go
@@ -13,8 +13,7 @@ const (
 	RayClusterUserLabelKey            = "ray.io/user"
 	RayClusterVersionLabelKey         = "ray.io/version"
 	RayClusterEnvironmentLabelKey     = "ray.io/environment"
-	RayOriginatedFromNameLabelKey     = "ray.io/originated-from-name"
-	RayOriginatedFromTypeLabelKey     = "ray.io/originated-from-type"
+	RayOriginatedFromLabelKey         = "ray.io/originated-from"
 	KubernetesApplicationNameLabelKey = "app.kubernetes.io/name"
 	KubernetesManagedByLabelKey       = "app.kubernetes.io/managed-by"
 
@@ -33,5 +32,9 @@ const (
 	// The component name for apiserver
 	ComponentName = "kuberay-apiserver"
 
-	RayServiceOriginatedFromTypeLabelValue = "rayservice"
+	RayServiceOriginatedFromLabelValueType = "rayservice"
 )
+
+func RayOriginatedFromServiceLabelValue(name string) string {
+	return RayServiceOriginatedFromLabelValueType + "_" + name
+}

--- a/apiserver/pkg/util/service.go
+++ b/apiserver/pkg/util/service.go
@@ -37,8 +37,7 @@ func NewRayService(apiService *api.RayService, computeTemplateMap map[string]*ap
 
 func buildRayServiceLabels(apiService *api.RayService) map[string]string {
 	labels := map[string]string{}
-	labels[RayOriginatedFromNameLabelKey] = apiService.Name
-	labels[RayOriginatedFromTypeLabelKey] = RayServiceOriginatedFromTypeLabelValue
+	labels[RayOriginatedFromLabelKey] = RayOriginatedFromServiceLabelValue(apiService.Name)
 	labels[RayClusterUserLabelKey] = apiService.User
 	labels[KubernetesApplicationNameLabelKey] = ApplicationName
 	labels[KubernetesManagedByLabelKey] = ComponentName

--- a/apiserver/pkg/util/service.go
+++ b/apiserver/pkg/util/service.go
@@ -6,8 +6,6 @@ import (
 	api "github.com/ray-project/kuberay/proto/go_client"
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 )
 
 type RayService struct {
@@ -39,7 +37,6 @@ func NewRayService(apiService *api.RayService, computeTemplateMap map[string]*ap
 
 func buildRayServiceLabels(apiService *api.RayService) map[string]string {
 	labels := map[string]string{}
-	labels[utils.RayOriginatedFromLabelKey] = utils.RayOriginatedFromServiceLabelValue(apiService.Name)
 	labels[RayClusterUserLabelKey] = apiService.User
 	labels[KubernetesApplicationNameLabelKey] = ApplicationName
 	labels[KubernetesManagedByLabelKey] = ComponentName

--- a/apiserver/pkg/util/service.go
+++ b/apiserver/pkg/util/service.go
@@ -6,6 +6,8 @@ import (
 	api "github.com/ray-project/kuberay/proto/go_client"
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 )
 
 type RayService struct {
@@ -37,7 +39,7 @@ func NewRayService(apiService *api.RayService, computeTemplateMap map[string]*ap
 
 func buildRayServiceLabels(apiService *api.RayService) map[string]string {
 	labels := map[string]string{}
-	labels[RayOriginatedFromLabelKey] = RayOriginatedFromServiceLabelValue(apiService.Name)
+	labels[utils.RayOriginatedFromLabelKey] = utils.RayOriginatedFromServiceLabelValue(apiService.Name)
 	labels[RayClusterUserLabelKey] = apiService.User
 	labels[KubernetesApplicationNameLabelKey] = ApplicationName
 	labels[KubernetesManagedByLabelKey] = ComponentName

--- a/apiserver/pkg/util/service.go
+++ b/apiserver/pkg/util/service.go
@@ -5,7 +5,6 @@ import (
 
 	api "github.com/ray-project/kuberay/proto/go_client"
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,7 +37,8 @@ func NewRayService(apiService *api.RayService, computeTemplateMap map[string]*ap
 
 func buildRayServiceLabels(apiService *api.RayService) map[string]string {
 	labels := map[string]string{}
-	labels[RayServiceLabelKey] = apiService.Name
+	labels[RayOriginatedFromNameLabelKey] = apiService.Name
+	labels[RayOriginatedFromTypeLabelKey] = RayServiceOriginatedFromTypeLabelValue
 	labels[RayClusterUserLabelKey] = apiService.User
 	labels[KubernetesApplicationNameLabelKey] = ApplicationName
 	labels[KubernetesManagedByLabelKey] = ComponentName

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -589,7 +589,7 @@ func setContainerEnvVars(pod *corev1.Pod, rayNodeType rayv1.RayNodeType, rayStar
 		container.Env = append(container.Env, portEnv)
 	}
 
-	if strings.ToLower(creator) == utils.RayServiceCreatorLabelValue {
+	if strings.ToLower(creator) == utils.RayServiceOriginatedFromTypeLabelValue {
 		// Only add this env for Ray Service cluster to improve service SLA.
 		if !envVarExists(utils.RAY_TIMEOUT_MS_TASK_WAIT_FOR_DEATH_INFO, container.Env) {
 			deathEnv := corev1.EnvVar{Name: utils.RAY_TIMEOUT_MS_TASK_WAIT_FOR_DEATH_INFO, Value: "0"}

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -589,7 +589,7 @@ func setContainerEnvVars(pod *corev1.Pod, rayNodeType rayv1.RayNodeType, rayStar
 		container.Env = append(container.Env, portEnv)
 	}
 
-	if strings.ToLower(creator) == utils.RayServiceOriginatedFromTypeLabelValue {
+	if strings.ToLower(creator) == utils.RayServiceOriginatedFromLabelValueType {
 		// Only add this env for Ray Service cluster to improve service SLA.
 		if !envVarExists(utils.RAY_TIMEOUT_MS_TASK_WAIT_FOR_DEATH_INFO, container.Env) {
 			deathEnv := corev1.EnvVar{Name: utils.RAY_TIMEOUT_MS_TASK_WAIT_FOR_DEATH_INFO, Value: "0"}

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -589,7 +589,7 @@ func setContainerEnvVars(pod *corev1.Pod, rayNodeType rayv1.RayNodeType, rayStar
 		container.Env = append(container.Env, portEnv)
 	}
 
-	if strings.ToLower(creator) == utils.RayServiceOriginatedFromLabelValueType {
+	if strings.EqualFold(creator, string(utils.RayServiceCRD)) {
 		// Only add this env for Ray Service cluster to improve service SLA.
 		if !envVarExists(utils.RAY_TIMEOUT_MS_TASK_WAIT_FOR_DEATH_INFO, container.Env) {
 			deathEnv := corev1.EnvVar{Name: utils.RAY_TIMEOUT_MS_TASK_WAIT_FOR_DEATH_INFO, Value: "0"}

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -504,7 +504,7 @@ func TestBuildPod_WithCreatedByRayService(t *testing.T) {
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
 	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
-	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", &trueFlag, utils.RayServiceOriginatedFromLabelValueType, "", false)
+	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", &trueFlag, string(utils.RayServiceCRD), "", false)
 
 	hasCorrectDeathEnv := false
 	for _, container := range pod.Spec.Containers {

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -504,7 +504,7 @@ func TestBuildPod_WithCreatedByRayService(t *testing.T) {
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
 	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
-	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", &trueFlag, utils.RayServiceOriginatedFromTypeLabelValue, "", false)
+	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", &trueFlag, utils.RayServiceOriginatedFromLabelValueType, "", false)
 
 	hasCorrectDeathEnv := false
 	for _, container := range pod.Spec.Containers {

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -504,7 +504,7 @@ func TestBuildPod_WithCreatedByRayService(t *testing.T) {
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
 	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(*cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
-	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", &trueFlag, utils.RayServiceCreatorLabelValue, "", false)
+	pod := BuildPod(podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", &trueFlag, utils.RayServiceOriginatedFromTypeLabelValue, "", false)
 
 	hasCorrectDeathEnv := false
 	for _, container := range pod.Spec.Containers {

--- a/ray-operator/controllers/ray/common/route.go
+++ b/ray-operator/controllers/ray/common/route.go
@@ -61,24 +61,3 @@ func BuildRouteForHeadService(cluster rayv1.RayCluster) (*routev1.Route, error) 
 
 	return route, nil
 }
-
-// BuildRouteForRayService Builds the route for head service dashboard for RayService.
-// This is used to expose dashboard for external traffic.
-// RayService controller updates the ingress whenever a new RayCluster serves the traffic.
-func BuildRouteForRayService(service rayv1.RayService, cluster rayv1.RayCluster) (*routev1.Route, error) {
-	route, err := BuildRouteForHeadService(cluster)
-	if err != nil {
-		return nil, err
-	}
-
-	serviceName, err := utils.GenerateHeadServiceName("RayService", cluster.Spec, cluster.Name)
-	if err != nil {
-		return nil, err
-	}
-	route.ObjectMeta.Name = serviceName
-	route.ObjectMeta.Namespace = service.Namespace
-	route.ObjectMeta.Labels[utils.RayOriginatedFromLabelKey] = utils.RayOriginatedFromServiceLabelValue(service.Name)
-	route.ObjectMeta.Labels[utils.RayIDLabelKey] = utils.CheckLabel(utils.GenerateIdentifier(service.Name, rayv1.HeadNode))
-
-	return route, nil
-}

--- a/ray-operator/controllers/ray/common/route.go
+++ b/ray-operator/controllers/ray/common/route.go
@@ -77,8 +77,7 @@ func BuildRouteForRayService(service rayv1.RayService, cluster rayv1.RayCluster)
 	}
 	route.ObjectMeta.Name = serviceName
 	route.ObjectMeta.Namespace = service.Namespace
-	route.ObjectMeta.Labels[utils.RayOriginatedFromNameLabelKey] = service.Name
-	route.ObjectMeta.Labels[utils.RayOriginatedFromTypeLabelKey] = utils.RayServiceOriginatedFromTypeLabelValue
+	route.ObjectMeta.Labels[utils.RayOriginatedFromLabelKey] = utils.RayOriginatedFromServiceLabelValue(service.Name)
 	route.ObjectMeta.Labels[utils.RayIDLabelKey] = utils.CheckLabel(utils.GenerateIdentifier(service.Name, rayv1.HeadNode))
 
 	return route, nil

--- a/ray-operator/controllers/ray/common/route.go
+++ b/ray-operator/controllers/ray/common/route.go
@@ -77,7 +77,8 @@ func BuildRouteForRayService(service rayv1.RayService, cluster rayv1.RayCluster)
 	}
 	route.ObjectMeta.Name = serviceName
 	route.ObjectMeta.Namespace = service.Namespace
-	route.ObjectMeta.Labels[utils.RayServiceLabelKey] = service.Name
+	route.ObjectMeta.Labels[utils.RayOriginatedFromNameLabelKey] = service.Name
+	route.ObjectMeta.Labels[utils.RayOriginatedFromTypeLabelKey] = utils.RayServiceOriginatedFromTypeLabelValue
 	route.ObjectMeta.Labels[utils.RayIDLabelKey] = utils.CheckLabel(utils.GenerateIdentifier(service.Name, rayv1.HeadNode))
 
 	return route, nil

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -143,9 +143,10 @@ func BuildHeadServiceForRayService(rayService rayv1.RayService, rayCluster rayv1
 	service.ObjectMeta.Name = headSvcName
 	service.ObjectMeta.Namespace = rayService.Namespace
 	service.ObjectMeta.Labels = map[string]string{
-		utils.RayServiceLabelKey:  rayService.Name,
-		utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
-		utils.RayIDLabelKey:       utils.CheckLabel(utils.GenerateIdentifier(rayService.Name, rayv1.HeadNode)),
+		utils.RayOriginatedFromNameLabelKey: rayService.Name,
+		utils.RayOriginatedFromTypeLabelKey: utils.RayServiceOriginatedFromTypeLabelValue,
+		utils.RayNodeTypeLabelKey:           string(rayv1.HeadNode),
+		utils.RayIDLabelKey:                 utils.CheckLabel(utils.GenerateIdentifier(rayService.Name, rayv1.HeadNode)),
 	}
 
 	return service, nil
@@ -171,7 +172,8 @@ func BuildServeService(rayService rayv1.RayService, rayCluster rayv1.RayCluster,
 	}
 
 	labels := map[string]string{
-		utils.RayServiceLabelKey:               name,
+		utils.RayOriginatedFromNameLabelKey:    name,
+		utils.RayOriginatedFromTypeLabelKey:    utils.RayServiceOriginatedFromTypeLabelValue,
 		utils.RayClusterServingServiceLabelKey: utils.GenerateServeServiceLabel(name),
 	}
 	selectorLabels := map[string]string{

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -143,10 +143,9 @@ func BuildHeadServiceForRayService(rayService rayv1.RayService, rayCluster rayv1
 	service.ObjectMeta.Name = headSvcName
 	service.ObjectMeta.Namespace = rayService.Namespace
 	service.ObjectMeta.Labels = map[string]string{
-		utils.RayOriginatedFromNameLabelKey: rayService.Name,
-		utils.RayOriginatedFromTypeLabelKey: utils.RayServiceOriginatedFromTypeLabelValue,
-		utils.RayNodeTypeLabelKey:           string(rayv1.HeadNode),
-		utils.RayIDLabelKey:                 utils.CheckLabel(utils.GenerateIdentifier(rayService.Name, rayv1.HeadNode)),
+		utils.RayOriginatedFromLabelKey: utils.RayOriginatedFromServiceLabelValue(rayService.Name),
+		utils.RayNodeTypeLabelKey:       string(rayv1.HeadNode),
+		utils.RayIDLabelKey:             utils.CheckLabel(utils.GenerateIdentifier(rayService.Name, rayv1.HeadNode)),
 	}
 
 	return service, nil
@@ -172,8 +171,7 @@ func BuildServeService(rayService rayv1.RayService, rayCluster rayv1.RayCluster,
 	}
 
 	labels := map[string]string{
-		utils.RayOriginatedFromNameLabelKey:    name,
-		utils.RayOriginatedFromTypeLabelKey:    utils.RayServiceOriginatedFromTypeLabelValue,
+		utils.RayOriginatedFromLabelKey:        utils.RayOriginatedFromServiceLabelValue(name),
 		utils.RayClusterServingServiceLabelKey: utils.GenerateServeServiceLabel(name),
 	}
 	selectorLabels := map[string]string{

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -143,7 +143,7 @@ func BuildHeadServiceForRayService(rayService rayv1.RayService, rayCluster rayv1
 	service.ObjectMeta.Name = headSvcName
 	service.ObjectMeta.Namespace = rayService.Namespace
 	service.ObjectMeta.Labels = map[string]string{
-		utils.RayOriginatedFromLabelKey: utils.RayOriginatedFromServiceLabelValue(rayService.Name),
+		utils.RayOriginatedFromLabelKey: utils.RayOriginatedFromLabelValue(utils.RayServiceCRD, rayService.Name),
 		utils.RayNodeTypeLabelKey:       string(rayv1.HeadNode),
 		utils.RayIDLabelKey:             utils.CheckLabel(utils.GenerateIdentifier(rayService.Name, rayv1.HeadNode)),
 	}
@@ -171,7 +171,7 @@ func BuildServeService(rayService rayv1.RayService, rayCluster rayv1.RayCluster,
 	}
 
 	labels := map[string]string{
-		utils.RayOriginatedFromLabelKey:        utils.RayOriginatedFromServiceLabelValue(name),
+		utils.RayOriginatedFromLabelKey:        utils.RayOriginatedFromLabelValue(utils.RayServiceCRD, name),
 		utils.RayClusterServingServiceLabelKey: utils.GenerateServeServiceLabel(name),
 	}
 	selectorLabels := map[string]string{

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -435,8 +435,8 @@ func TestBuildServeServiceForRayService(t *testing.T) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
 
-	actualLabel := svc.Labels[utils.RayOriginatedFromNameLabelKey]
-	expectedLabel := string(serviceInstance.Name)
+	actualLabel := svc.Labels[utils.RayOriginatedFromLabelKey]
+	expectedLabel := utils.RayOriginatedFromServiceLabelValue(serviceInstance.Name)
 	if !reflect.DeepEqual(expectedLabel, actualLabel) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedLabel, actualLabel)
 	}
@@ -461,8 +461,8 @@ func TestBuildServeServiceForRayCluster(t *testing.T) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
 
-	actualLabel := svc.Labels[utils.RayOriginatedFromNameLabelKey]
-	expectedLabel := string(instanceForServeSvc.Name)
+	actualLabel := svc.Labels[utils.RayOriginatedFromLabelKey]
+	expectedLabel := utils.RayOriginatedFromServiceLabelValue(instanceForServeSvc.Name)
 	if !reflect.DeepEqual(expectedLabel, actualLabel) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedLabel, actualLabel)
 	}

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -436,7 +436,7 @@ func TestBuildServeServiceForRayService(t *testing.T) {
 	}
 
 	actualLabel := svc.Labels[utils.RayOriginatedFromLabelKey]
-	expectedLabel := utils.RayOriginatedFromServiceLabelValue(serviceInstance.Name)
+	expectedLabel := utils.RayOriginatedFromLabelValue(utils.RayServiceCRD, serviceInstance.Name)
 	if !reflect.DeepEqual(expectedLabel, actualLabel) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedLabel, actualLabel)
 	}
@@ -462,7 +462,7 @@ func TestBuildServeServiceForRayCluster(t *testing.T) {
 	}
 
 	actualLabel := svc.Labels[utils.RayOriginatedFromLabelKey]
-	expectedLabel := utils.RayOriginatedFromServiceLabelValue(instanceForServeSvc.Name)
+	expectedLabel := utils.RayOriginatedFromLabelValue(utils.RayServiceCRD, instanceForServeSvc.Name)
 	if !reflect.DeepEqual(expectedLabel, actualLabel) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedLabel, actualLabel)
 	}

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -435,7 +435,7 @@ func TestBuildServeServiceForRayService(t *testing.T) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
 
-	actualLabel := svc.Labels[utils.RayServiceLabelKey]
+	actualLabel := svc.Labels[utils.RayOriginatedFromNameLabelKey]
 	expectedLabel := string(serviceInstance.Name)
 	if !reflect.DeepEqual(expectedLabel, actualLabel) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedLabel, actualLabel)
@@ -461,7 +461,7 @@ func TestBuildServeServiceForRayCluster(t *testing.T) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
 
-	actualLabel := svc.Labels[utils.RayServiceLabelKey]
+	actualLabel := svc.Labels[utils.RayOriginatedFromNameLabelKey]
 	expectedLabel := string(instanceForServeSvc.Name)
 	if !reflect.DeepEqual(expectedLabel, actualLabel) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedLabel, actualLabel)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -359,7 +359,7 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 			Namespace: rayJobInstance.Namespace,
 			Labels: map[string]string{
 				utils.RayOriginatedFromNameLabelKey: rayJobInstance.Name,
-				utils.RayOriginatedFromTypeLabelKey: utils.RayJobCreatorLabelValue,
+				utils.RayOriginatedFromTypeLabelKey: utils.RayJobOriginatedFromTypeLabelValue,
 				utils.KubernetesCreatedByLabelKey:   utils.ComponentName,
 			},
 		},
@@ -579,7 +579,7 @@ func (r *RayJobReconciler) constructRayClusterForRayJob(rayJobInstance *rayv1.Ra
 		labels[key] = value
 	}
 	labels[utils.RayOriginatedFromNameLabelKey] = rayJobInstance.Name
-	labels[utils.RayOriginatedFromTypeLabelKey] = utils.RayJobCreatorLabelValue
+	labels[utils.RayOriginatedFromTypeLabelKey] = utils.RayJobOriginatedFromTypeLabelValue
 	rayCluster := &rayv1.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      labels,

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -358,7 +358,9 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 			Name:      rayJobInstance.Name,
 			Namespace: rayJobInstance.Namespace,
 			Labels: map[string]string{
-				utils.KubernetesCreatedByLabelKey: utils.ComponentName,
+				utils.RayOriginatedFromNameLabelKey: rayJobInstance.Name,
+				utils.RayOriginatedFromTypeLabelKey: utils.RayJobCreatorLabelValue,
+				utils.KubernetesCreatedByLabelKey:   utils.ComponentName,
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -572,9 +574,15 @@ func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, ra
 }
 
 func (r *RayJobReconciler) constructRayClusterForRayJob(rayJobInstance *rayv1.RayJob, rayClusterName string) (*rayv1.RayCluster, error) {
+	labels := make(map[string]string, len(rayJobInstance.Labels))
+	for key, value := range rayJobInstance.Labels {
+		labels[key] = value
+	}
+	labels[utils.RayOriginatedFromNameLabelKey] = rayJobInstance.Name
+	labels[utils.RayOriginatedFromTypeLabelKey] = utils.RayJobCreatorLabelValue
 	rayCluster := &rayv1.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      rayJobInstance.Labels,
+			Labels:      labels,
 			Annotations: rayJobInstance.Annotations,
 			Name:        rayClusterName,
 			Namespace:   rayJobInstance.Namespace,

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -358,9 +358,8 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 			Name:      rayJobInstance.Name,
 			Namespace: rayJobInstance.Namespace,
 			Labels: map[string]string{
-				utils.RayOriginatedFromNameLabelKey: rayJobInstance.Name,
-				utils.RayOriginatedFromTypeLabelKey: utils.RayJobOriginatedFromTypeLabelValue,
-				utils.KubernetesCreatedByLabelKey:   utils.ComponentName,
+				utils.RayOriginatedFromLabelKey:   utils.RayOriginatedFromJobLabelValue(rayJobInstance.Name),
+				utils.KubernetesCreatedByLabelKey: utils.ComponentName,
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -578,8 +577,7 @@ func (r *RayJobReconciler) constructRayClusterForRayJob(rayJobInstance *rayv1.Ra
 	for key, value := range rayJobInstance.Labels {
 		labels[key] = value
 	}
-	labels[utils.RayOriginatedFromNameLabelKey] = rayJobInstance.Name
-	labels[utils.RayOriginatedFromTypeLabelKey] = utils.RayJobOriginatedFromTypeLabelValue
+	labels[utils.RayOriginatedFromLabelKey] = utils.RayOriginatedFromJobLabelValue(rayJobInstance.Name)
 	rayCluster := &rayv1.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      labels,

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -358,7 +358,7 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 			Name:      rayJobInstance.Name,
 			Namespace: rayJobInstance.Namespace,
 			Labels: map[string]string{
-				utils.RayOriginatedFromLabelKey:   utils.RayOriginatedFromJobLabelValue(rayJobInstance.Name),
+				utils.RayOriginatedFromLabelKey:   utils.RayOriginatedFromLabelValue(utils.RayJobCRD, rayJobInstance.Name),
 				utils.KubernetesCreatedByLabelKey: utils.ComponentName,
 			},
 		},
@@ -577,7 +577,7 @@ func (r *RayJobReconciler) constructRayClusterForRayJob(rayJobInstance *rayv1.Ra
 	for key, value := range rayJobInstance.Labels {
 		labels[key] = value
 	}
-	labels[utils.RayOriginatedFromLabelKey] = utils.RayOriginatedFromJobLabelValue(rayJobInstance.Name)
+	labels[utils.RayOriginatedFromLabelKey] = utils.RayOriginatedFromLabelValue(utils.RayJobCRD, rayJobInstance.Name)
 	rayCluster := &rayv1.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      labels,

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -193,7 +193,7 @@ var _ = Context("Inside the default namespace", func() {
 				getResourceFunc(ctx, client.ObjectKey{Name: myRayJob.Status.RayClusterName, Namespace: "default"}, myRayCluster),
 				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayCluster  = %v", myRayCluster.Name)
 			Expect(myRayCluster.Labels).Should(HaveKeyWithValue(utils.RayOriginatedFromNameLabelKey, myRayJob.Name))
-			Expect(myRayCluster.Labels).Should(HaveKeyWithValue(utils.RayOriginatedFromTypeLabelKey, utils.RayJobCreatorLabelValue))
+			Expect(myRayCluster.Labels).Should(HaveKeyWithValue(utils.RayOriginatedFromTypeLabelKey, utils.RayJobOriginatedFromTypeLabelValue))
 		})
 
 		It("Should create a number of workers equal to the replica setting", func() {

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -192,6 +192,8 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: myRayJob.Status.RayClusterName, Namespace: "default"}, myRayCluster),
 				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayCluster  = %v", myRayCluster.Name)
+			Expect(myRayCluster.Labels).Should(HaveKeyWithValue(utils.RayOriginatedFromNameLabelKey, myRayJob.Name))
+			Expect(myRayCluster.Labels).Should(HaveKeyWithValue(utils.RayOriginatedFromTypeLabelKey, utils.RayJobCreatorLabelValue))
 		})
 
 		It("Should create a number of workers equal to the replica setting", func() {

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -192,8 +192,7 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: myRayJob.Status.RayClusterName, Namespace: "default"}, myRayCluster),
 				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayCluster  = %v", myRayCluster.Name)
-			Expect(myRayCluster.Labels).Should(HaveKeyWithValue(utils.RayOriginatedFromNameLabelKey, myRayJob.Name))
-			Expect(myRayCluster.Labels).Should(HaveKeyWithValue(utils.RayOriginatedFromTypeLabelKey, utils.RayJobOriginatedFromTypeLabelValue))
+			Expect(myRayCluster.Labels).Should(HaveKeyWithValue(utils.RayOriginatedFromLabelKey, utils.RayOriginatedFromJobLabelValue(myRayJob.Name)))
 		})
 
 		It("Should create a number of workers equal to the replica setting", func() {

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -192,7 +192,7 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: myRayJob.Status.RayClusterName, Namespace: "default"}, myRayCluster),
 				time.Second*3, time.Millisecond*500).Should(BeNil(), "My myRayCluster  = %v", myRayCluster.Name)
-			Expect(myRayCluster.Labels).Should(HaveKeyWithValue(utils.RayOriginatedFromLabelKey, utils.RayOriginatedFromJobLabelValue(myRayJob.Name)))
+			Expect(myRayCluster.Labels).Should(HaveKeyWithValue(utils.RayOriginatedFromLabelKey, utils.RayOriginatedFromLabelValue(utils.RayJobCRD, myRayJob.Name)))
 		})
 
 		It("Should create a number of workers equal to the replica setting", func() {

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -85,7 +85,7 @@ func TestCreateK8sJobIfNeed(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, k8sJob.Labels[utils.RayOriginatedFromNameLabelKey], rayJob.Name)
-	assert.Equal(t, k8sJob.Labels[utils.RayOriginatedFromTypeLabelKey], utils.RayJobCreatorLabelValue)
+	assert.Equal(t, k8sJob.Labels[utils.RayOriginatedFromTypeLabelKey], utils.RayJobOriginatedFromTypeLabelValue)
 }
 
 func TestGetSubmitterTemplate(t *testing.T) {

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -84,7 +84,7 @@ func TestCreateK8sJobIfNeed(t *testing.T) {
 	}, k8sJob, nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, k8sJob.Labels[utils.RayOriginatedFromLabelKey], utils.RayOriginatedFromJobLabelValue(rayJob.Name))
+	assert.Equal(t, k8sJob.Labels[utils.RayOriginatedFromLabelKey], utils.RayOriginatedFromLabelValue(utils.RayJobCRD, rayJob.Name))
 }
 
 func TestGetSubmitterTemplate(t *testing.T) {

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -77,6 +77,15 @@ func TestCreateK8sJobIfNeed(t *testing.T) {
 
 	err = rayJobReconciler.createK8sJobIfNeed(ctx, rayJob, rayCluster)
 	assert.NoError(t, err)
+
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Namespace: k8sJob.Namespace,
+		Name:      k8sJob.Name,
+	}, k8sJob, nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, k8sJob.Labels[utils.RayOriginatedFromNameLabelKey], rayJob.Name)
+	assert.Equal(t, k8sJob.Labels[utils.RayOriginatedFromTypeLabelKey], utils.RayJobCreatorLabelValue)
 }
 
 func TestGetSubmitterTemplate(t *testing.T) {

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -84,8 +84,7 @@ func TestCreateK8sJobIfNeed(t *testing.T) {
 	}, k8sJob, nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, k8sJob.Labels[utils.RayOriginatedFromNameLabelKey], rayJob.Name)
-	assert.Equal(t, k8sJob.Labels[utils.RayOriginatedFromTypeLabelKey], utils.RayJobOriginatedFromTypeLabelValue)
+	assert.Equal(t, k8sJob.Labels[utils.RayOriginatedFromLabelKey], utils.RayOriginatedFromJobLabelValue(rayJob.Name))
 }
 
 func TestGetSubmitterTemplate(t *testing.T) {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -391,7 +391,7 @@ func (r *RayServiceReconciler) reconcileRayCluster(ctx context.Context, rayServi
 // cleanUpRayClusterInstance cleans up all the dangling RayCluster instances that are owned by the RayService instance.
 func (r *RayServiceReconciler) cleanUpRayClusterInstance(ctx context.Context, rayServiceInstance *rayv1.RayService) error {
 	rayClusterList := rayv1.RayClusterList{}
-	filterLabels := client.MatchingLabels{utils.RayOriginatedFromNameLabelKey: rayServiceInstance.Name, utils.RayOriginatedFromTypeLabelKey: utils.RayServiceOriginatedFromTypeLabelValue}
+	filterLabels := client.MatchingLabels{utils.RayOriginatedFromLabelKey: utils.RayOriginatedFromServiceLabelValue(rayServiceInstance.Name)}
 	var err error
 	if err = r.List(ctx, &rayClusterList, client.InNamespace(rayServiceInstance.Namespace), filterLabels); err != nil {
 		r.Log.Error(err, "Fail to list RayCluster for "+rayServiceInstance.Name)
@@ -671,8 +671,7 @@ func (r *RayServiceReconciler) constructRayClusterForRayService(rayService *rayv
 	for k, v := range rayService.Labels {
 		rayClusterLabel[k] = v
 	}
-	rayClusterLabel[utils.RayOriginatedFromNameLabelKey] = rayService.Name
-	rayClusterLabel[utils.RayOriginatedFromTypeLabelKey] = utils.RayServiceOriginatedFromTypeLabelValue
+	rayClusterLabel[utils.RayOriginatedFromLabelKey] = utils.RayOriginatedFromServiceLabelValue(rayService.Name)
 
 	rayClusterAnnotations := make(map[string]string)
 	for k, v := range rayService.Annotations {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -391,7 +391,7 @@ func (r *RayServiceReconciler) reconcileRayCluster(ctx context.Context, rayServi
 // cleanUpRayClusterInstance cleans up all the dangling RayCluster instances that are owned by the RayService instance.
 func (r *RayServiceReconciler) cleanUpRayClusterInstance(ctx context.Context, rayServiceInstance *rayv1.RayService) error {
 	rayClusterList := rayv1.RayClusterList{}
-	filterLabels := client.MatchingLabels{utils.RayOriginatedFromLabelKey: utils.RayOriginatedFromServiceLabelValue(rayServiceInstance.Name)}
+	filterLabels := client.MatchingLabels{utils.RayOriginatedFromLabelKey: utils.RayOriginatedFromLabelValue(utils.RayServiceCRD, rayServiceInstance.Name)}
 	var err error
 	if err = r.List(ctx, &rayClusterList, client.InNamespace(rayServiceInstance.Namespace), filterLabels); err != nil {
 		r.Log.Error(err, "Fail to list RayCluster for "+rayServiceInstance.Name)
@@ -671,7 +671,7 @@ func (r *RayServiceReconciler) constructRayClusterForRayService(rayService *rayv
 	for k, v := range rayService.Labels {
 		rayClusterLabel[k] = v
 	}
-	rayClusterLabel[utils.RayOriginatedFromLabelKey] = utils.RayOriginatedFromServiceLabelValue(rayService.Name)
+	rayClusterLabel[utils.RayOriginatedFromLabelKey] = utils.RayOriginatedFromLabelValue(utils.RayServiceCRD, rayService.Name)
 
 	rayClusterAnnotations := make(map[string]string)
 	for k, v := range rayService.Annotations {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -391,7 +391,7 @@ func (r *RayServiceReconciler) reconcileRayCluster(ctx context.Context, rayServi
 // cleanUpRayClusterInstance cleans up all the dangling RayCluster instances that are owned by the RayService instance.
 func (r *RayServiceReconciler) cleanUpRayClusterInstance(ctx context.Context, rayServiceInstance *rayv1.RayService) error {
 	rayClusterList := rayv1.RayClusterList{}
-	filterLabels := client.MatchingLabels{utils.RayServiceLabelKey: rayServiceInstance.Name}
+	filterLabels := client.MatchingLabels{utils.RayOriginatedFromNameLabelKey: rayServiceInstance.Name, utils.RayOriginatedFromTypeLabelKey: utils.RayServiceOriginatedFromTypeLabelValue}
 	var err error
 	if err = r.List(ctx, &rayClusterList, client.InNamespace(rayServiceInstance.Namespace), filterLabels); err != nil {
 		r.Log.Error(err, "Fail to list RayCluster for "+rayServiceInstance.Name)
@@ -671,8 +671,8 @@ func (r *RayServiceReconciler) constructRayClusterForRayService(rayService *rayv
 	for k, v := range rayService.Labels {
 		rayClusterLabel[k] = v
 	}
-	rayClusterLabel[utils.RayServiceLabelKey] = rayService.Name
-	rayClusterLabel[utils.KubernetesCreatedByLabelKey] = utils.RayServiceCreatorLabelValue
+	rayClusterLabel[utils.RayOriginatedFromNameLabelKey] = rayService.Name
+	rayClusterLabel[utils.RayOriginatedFromTypeLabelKey] = utils.RayServiceOriginatedFromTypeLabelValue
 
 	rayClusterAnnotations := make(map[string]string)
 	for k, v := range rayService.Annotations {

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -5,7 +5,6 @@ const (
 	// Default application name
 	DefaultServeAppName = "default"
 	// Belows used as label key
-	RayServiceLabelKey                       = "ray.io/service"
 	RayOriginatedFromNameLabelKey            = "ray.io/originated-from-name"
 	RayOriginatedFromTypeLabelKey            = "ray.io/originated-from-type"
 	RayClusterLabelKey                       = "ray.io/cluster"
@@ -77,10 +76,10 @@ const (
 	ComponentName = "kuberay-operator"
 
 	// The defaule RayService Identifier.
-	RayServiceCreatorLabelValue = "rayservice"
+	RayServiceOriginatedFromTypeLabelValue = "rayservice"
 
 	// The defaule RayJob Identifier.
-	RayJobCreatorLabelValue = "rayjob"
+	RayJobOriginatedFromTypeLabelValue = "rayjob"
 
 	// Use as container env variable
 	RAY_CLUSTER_NAME                        = "RAY_CLUSTER_NAME"

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -5,8 +5,7 @@ const (
 	// Default application name
 	DefaultServeAppName = "default"
 	// Belows used as label key
-	RayOriginatedFromNameLabelKey            = "ray.io/originated-from-name"
-	RayOriginatedFromTypeLabelKey            = "ray.io/originated-from-type"
+	RayOriginatedFromLabelKey                = "ray.io/originated-from"
 	RayClusterLabelKey                       = "ray.io/cluster"
 	RayNodeTypeLabelKey                      = "ray.io/node-type"
 	RayNodeGroupLabelKey                     = "ray.io/group"
@@ -76,10 +75,10 @@ const (
 	ComponentName = "kuberay-operator"
 
 	// The defaule RayService Identifier.
-	RayServiceOriginatedFromTypeLabelValue = "rayservice"
+	RayServiceOriginatedFromLabelValueType = "rayservice"
 
 	// The defaule RayJob Identifier.
-	RayJobOriginatedFromTypeLabelValue = "rayjob"
+	RayJobOriginatedFromLabelValueType = "rayjob"
 
 	// Use as container env variable
 	RAY_CLUSTER_NAME                        = "RAY_CLUSTER_NAME"
@@ -158,3 +157,11 @@ const (
 	HeadService    ServiceType = "headService"
 	ServingService ServiceType = "serveService"
 )
+
+func RayOriginatedFromServiceLabelValue(name string) string {
+	return RayServiceOriginatedFromLabelValueType + "_" + name
+}
+
+func RayOriginatedFromJobLabelValue(name string) string {
+	return RayJobOriginatedFromLabelValueType + "_" + name
+}

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -8,7 +8,12 @@ const (
 
 	// RayOriginatedFromLabelKey is the label used to associate the root KubeRay Custom Resource.
 	// For example, if a RayCluster is created by a RayJob named myjob, then the cluster will have
-	// a label ray.io/originated-from=RayJob_myjob. See RayOriginatedFromJobLabelValue for more details.
+	// A ray.io/originated-from=RayService_mysvc label will be added to the following resources if they are originated from a RayService mysvc.
+	//   * Kubernetes Services
+	//   * RayClusters
+	// A ray.io/originated-from=RayJob_myjob label will be added to the following resources if they are originated from a RayJob myjob.
+	//   * Kubernetes Jobs
+	//   * RayClusters
 	RayOriginatedFromLabelKey                = "ray.io/originated-from"
 	RayClusterLabelKey                       = "ray.io/cluster"
 	RayNodeTypeLabelKey                      = "ray.io/node-type"
@@ -156,15 +161,9 @@ const (
 	ServingService ServiceType = "serveService"
 )
 
-// RayOriginatedFromServiceLabelValue generates a RayService value for the label RayOriginatedFromLabelKey
-// This is also the only function to construct label filter of resources originated from a given RayService.
-func RayOriginatedFromServiceLabelValue(name string) string {
+// RayOriginatedFromLabelValue generates a value for the label RayOriginatedFromLabelKey
+// This is also the only function to construct label filter of resources originated from a given CRDType.
+func RayOriginatedFromLabelValue(kind CRDType, name string) string {
 	// we choose the _ as the separator because it is the only choice. ref: https://github.com/ray-project/kuberay/pull/1830#discussion_r1452547074
-	return string(RayServiceCRD) + "_" + name
-}
-
-// RayOriginatedFromJobLabelValue generates a RayJob value for the label RayOriginatedFromLabelKey
-// This is also the only function to construct label filter of resources originated from a given RayJob.
-func RayOriginatedFromJobLabelValue(name string) string {
-	return string(RayJobCRD) + "_" + name
+	return string(kind) + "_" + name
 }

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -5,6 +5,10 @@ const (
 	// Default application name
 	DefaultServeAppName = "default"
 	// Belows used as label key
+
+	// RayOriginatedFromLabelKey is the label used to associate the root KubeRay Custom Resource.
+	// For example, if a RayCluster is created by a RayJob named myjob, then the cluster will have
+	// a label ray.io/originated-from=RayJob_myjob. See RayOriginatedFromJobLabelValue for more details.
 	RayOriginatedFromLabelKey                = "ray.io/originated-from"
 	RayClusterLabelKey                       = "ray.io/cluster"
 	RayNodeTypeLabelKey                      = "ray.io/node-type"
@@ -73,12 +77,6 @@ const (
 
 	// The default name for kuberay operator
 	ComponentName = "kuberay-operator"
-
-	// The defaule RayService Identifier.
-	RayServiceOriginatedFromLabelValueType = "rayservice"
-
-	// The defaule RayJob Identifier.
-	RayJobOriginatedFromLabelValueType = "rayjob"
 
 	// Use as container env variable
 	RAY_CLUSTER_NAME                        = "RAY_CLUSTER_NAME"
@@ -158,10 +156,15 @@ const (
 	ServingService ServiceType = "serveService"
 )
 
+// RayOriginatedFromServiceLabelValue generates a RayService value for the label RayOriginatedFromLabelKey
+// This is also the only function to construct label filter of resources originated from a given RayService.
 func RayOriginatedFromServiceLabelValue(name string) string {
-	return RayServiceOriginatedFromLabelValueType + "_" + name
+	// we choose the _ as the separator because it is the only choice. ref: https://github.com/ray-project/kuberay/pull/1830#discussion_r1452547074
+	return string(RayServiceCRD) + "_" + name
 }
 
+// RayOriginatedFromJobLabelValue generates a RayJob value for the label RayOriginatedFromLabelKey
+// This is also the only function to construct label filter of resources originated from a given RayJob.
 func RayOriginatedFromJobLabelValue(name string) string {
-	return RayJobOriginatedFromLabelValueType + "_" + name
+	return string(RayJobCRD) + "_" + name
 }

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -6,6 +6,8 @@ const (
 	DefaultServeAppName = "default"
 	// Belows used as label key
 	RayServiceLabelKey                       = "ray.io/service"
+	RayOriginatedFromNameLabelKey            = "ray.io/originated-from-name"
+	RayOriginatedFromTypeLabelKey            = "ray.io/originated-from-type"
 	RayClusterLabelKey                       = "ray.io/cluster"
 	RayNodeTypeLabelKey                      = "ray.io/node-type"
 	RayNodeGroupLabelKey                     = "ray.io/group"
@@ -76,6 +78,9 @@ const (
 
 	// The defaule RayService Identifier.
 	RayServiceCreatorLabelValue = "rayservice"
+
+	// The defaule RayJob Identifier.
+	RayJobCreatorLabelValue = "rayjob"
 
 	// Use as container env variable
 	RAY_CLUSTER_NAME                        = "RAY_CLUSTER_NAME"

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -470,7 +470,7 @@ class RayServiceFullCREvent(CREvent):
                 namespace = self.namespace, label_selector='ray.io/node-type=worker')
             head_services = k8s_v1_api.list_namespaced_service(
                 namespace = self.namespace, label_selector =
-                f"ray.io/originated-from=rayservice_{self.custom_resource_object['metadata']['name']}-serve")
+                f"ray.io/originated-from=RayService_{self.custom_resource_object['metadata']['name']}-serve")
             if (len(head_services.items) == 1 and len(headpods.items) == expected_head_pods
                     and len(workerpods.items) == expected_worker_pods
                     and check_pod_running(headpods.items) and check_pod_running(workerpods.items)):

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -470,7 +470,7 @@ class RayServiceFullCREvent(CREvent):
                 namespace = self.namespace, label_selector='ray.io/node-type=worker')
             head_services = k8s_v1_api.list_namespaced_service(
                 namespace = self.namespace, label_selector =
-                f"ray.io/serve={self.custom_resource_object['metadata']['name']}-serve")
+                f"ray.io/originated-from-name={self.custom_resource_object['metadata']['name']}-serve")
             if (len(head_services.items) == 1 and len(headpods.items) == expected_head_pods
                     and len(workerpods.items) == expected_worker_pods
                     and check_pod_running(headpods.items) and check_pod_running(workerpods.items)):

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -470,7 +470,7 @@ class RayServiceFullCREvent(CREvent):
                 namespace = self.namespace, label_selector='ray.io/node-type=worker')
             head_services = k8s_v1_api.list_namespaced_service(
                 namespace = self.namespace, label_selector =
-                f"ray.io/originated-from-name={self.custom_resource_object['metadata']['name']}-serve")
+                f"ray.io/originated-from=rayservice_{self.custom_resource_object['metadata']['name']}-serve")
             if (len(head_services.items) == 1 and len(headpods.items) == expected_head_pods
                     and len(workerpods.items) == expected_worker_pods
                     and check_pod_running(headpods.items) and check_pod_running(workerpods.items)):

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -62,7 +62,7 @@ class RayServiceAddCREvent(CREvent):
                 namespace = self.namespace, label_selector='ray.io/node-type=worker')
             serve_services = k8s_v1_api.list_namespaced_service(
                 namespace = self.namespace, label_selector =
-                f"ray.io/originated-from-name={self.custom_resource_object['metadata']['name']}-serve")
+                f"ray.io/originated-from=rayservice_{self.custom_resource_object['metadata']['name']}-serve")
 
             if (len(serve_services.items) == 1 and len(headpods.items) == expected_head_pods
                     and len(workerpods.items) == expected_worker_pods

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -62,7 +62,7 @@ class RayServiceAddCREvent(CREvent):
                 namespace = self.namespace, label_selector='ray.io/node-type=worker')
             serve_services = k8s_v1_api.list_namespaced_service(
                 namespace = self.namespace, label_selector =
-                f"ray.io/originated-from=rayservice_{self.custom_resource_object['metadata']['name']}-serve")
+                f"ray.io/originated-from=RayService_{self.custom_resource_object['metadata']['name']}-serve")
 
             if (len(serve_services.items) == 1 and len(headpods.items) == expected_head_pods
                     and len(workerpods.items) == expected_worker_pods

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -62,7 +62,7 @@ class RayServiceAddCREvent(CREvent):
                 namespace = self.namespace, label_selector='ray.io/node-type=worker')
             serve_services = k8s_v1_api.list_namespaced_service(
                 namespace = self.namespace, label_selector =
-                f"ray.io/serve={self.custom_resource_object['metadata']['name']}-serve")
+                f"ray.io/originated-from-name={self.custom_resource_object['metadata']['name']}-serve")
 
             if (len(serve_services.items) == 1 and len(headpods.items) == expected_head_pods
                     and len(workerpods.items) == expected_worker_pods


### PR DESCRIPTION
## Why are these changes needed?

Previously, we didn't have a label for querying resources, such as the underlying ray cluster, created by a RayJob, while we had the `ray.io/service` label for querying resources created by a RayService.

We could introduce a new `ray.io/job` label for this purpose, and that would result in having three labels that look similar:
* `ray.io/job`
* `ray.io/service`
* `ray.io/cluster`

However, the current usage of the `ray.io/cluster` label differs greatly from the first two.

After a discussion with @kevin85421, we think we could clarify the usage of the first two by replacing them with the following labels:
* `ray.io/originated-from-name`
* `ray.io/originated-from-type`

Examples:
```sh
# rayjob
ray.io/originated-from-name: myjob
ray.io/originated-from-type: rayjob
# rayservice
ray.io/originated-from-name: myservice
ray.io/originated-from-type: rayservice
```

To summarize, this PR removes the existing `ray.io/service` label and introduces `ray.io/originated-from-name` and `ray.io/originated-from-type` for both clarifying and unifying how to query resources created by a RayJob or a RayService.

Additionally, to make us more confident that `ray.io/service` is removable, I have searched its usage on GitHub and found that no one else uses this label.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
