### PR TITLE
[RayJob][Status][18/n] Control the entire lifecycle of the Kubernetes submitter Job using KubeRay

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -363,12 +363,6 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 		},
 	}
 
-	// Without TTLSecondsAfterFinished, the job has a default deletion policy of `orphanDependents` causing
-	// Pods created by an unmanaged Job to be left around after that Job is fully deleted.
-	if rayJobInstance.Spec.ShutdownAfterJobFinishes {
-		job.Spec.TTLSecondsAfterFinished = pointer.Int32(rayJobInstance.Spec.TTLSecondsAfterFinished)
-	}
-
 	// Set the ownership in order to do the garbage collection by k8s.
 	if err := ctrl.SetControllerReference(rayJobInstance, job, r.Scheme); err != nil {
 		r.Log.Error(err, "failed to set controller reference")

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -214,7 +214,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		// TODO (kevin85421): Currently, Ray doesn't have a best practice to stop a Ray job gracefully. At this moment,
 		// KubeRay doesn't stop the Ray job before suspending the RayJob. If users want to stop the Ray job by SIGTERM,
 		// users need to set the Pod's preStop hook by themselves.
-		isReleaseComplete, err := r.releaseComputeResources(ctx, rayJobInstance, true)
+		isReleaseComplete, err := r.releaseComputeResources(ctx, rayJobInstance)
 		if err != nil {
 			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 		}
@@ -262,7 +262,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 				r.Log.Info(fmt.Sprintf("shutdownTime not reached, requeue this RayJob for %d seconds", delta))
 				return ctrl.Result{RequeueAfter: time.Duration(delta) * time.Second}, nil
 			} else {
-				if _, err = r.releaseComputeResources(ctx, rayJobInstance, false); err != nil {
+				if _, err = r.releaseComputeResources(ctx, rayJobInstance); err != nil {
 					return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 				}
 			}
@@ -385,17 +385,15 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 	return nil
 }
 
-// Delete the RayCluster associated with the RayJob to release the compute resources.
-// In the future, we may also need to delete other Kubernetes resources. Note that
-// this function doesn't delete the Kubernetes Job. Instead, we use the built-in
-// TTL mechanism of the Kubernetes Job for deletion.
-func (r *RayJobReconciler) releaseComputeResources(ctx context.Context, rayJobInstance *rayv1.RayJob, isSuspend bool) (bool, error) {
+// Delete the RayCluster and K8s Job associated with the RayJob to release the compute resources.
+// In the future, we may also need to delete other Kubernetes resources.
+func (r *RayJobReconciler) releaseComputeResources(ctx context.Context, rayJobInstance *rayv1.RayJob) (bool, error) {
 	namespace := rayJobInstance.Namespace
 	clusterIdentifier := types.NamespacedName{
 		Name:      rayJobInstance.Status.RayClusterName,
 		Namespace: namespace,
 	}
-	isClusterNotFound, isJobNotFound := false, !isSuspend
+	isClusterNotFound, isJobNotFound := false, false
 
 	cluster := rayv1.RayCluster{}
 	if err := r.Get(ctx, clusterIdentifier, &cluster); err != nil {
@@ -422,27 +420,25 @@ func (r *RayJobReconciler) releaseComputeResources(ctx context.Context, rayJobIn
 	// Since the name of the Kubernetes Job is the same as the RayJob, we need to delete the Kubernetes Job
 	// and its Pods when suspending. A new submitter Kubernetes Job must be created to resubmit the
 	// Ray job if the RayJob is resumed.
-	if isSuspend {
-		jobName := rayJobInstance.Name
-		job := &batchv1.Job{}
-		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: jobName}, job); err != nil {
-			if errors.IsNotFound(err) {
-				isJobNotFound = true
-				r.Log.Info("The submitter Kubernetes Job has been already deleted", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
-			} else {
-				r.Log.Error(err, "Failed to get Kubernetes Job")
+	jobName := rayJobInstance.Name
+	job := &batchv1.Job{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: jobName}, job); err != nil {
+		if errors.IsNotFound(err) {
+			isJobNotFound = true
+			r.Log.Info("The submitter Kubernetes Job has been already deleted", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
+		} else {
+			r.Log.Error(err, "Failed to get Kubernetes Job")
+			return false, err
+		}
+	} else {
+		if !job.DeletionTimestamp.IsZero() {
+			r.Log.Info("The Job deletion is ongoing.", "RayJob", rayJobInstance.Name, "Submitter K8s Job", job.Name)
+		} else {
+			if err := r.Client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
 				return false, err
 			}
-		} else {
-			if !job.DeletionTimestamp.IsZero() {
-				r.Log.Info("The Job deletion is ongoing.", "RayJob", rayJobInstance.Name, "Submitter K8s Job", job.Name)
-			} else {
-				if err := r.Client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
-					return false, err
-				}
-				r.Log.Info("The associated submitter Job is deleted", "RayJob", rayJobInstance.Name, "Submitter K8s Job", job.Name)
-				r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, "Deleted", "Deleted submitter K8s Job %s", job.Name)
-			}
+			r.Log.Info("The associated submitter Job is deleted", "RayJob", rayJobInstance.Name, "Submitter K8s Job", job.Name)
+			r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, "Deleted", "Deleted submitter K8s Job %s", job.Name)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If users create a RayJob with a buggy `entrypoint`, causing the submitter K8s Job to consistently fail, it won't respect the `ttlSecondsAfterFinished` value set by users. 

The submitter Job sends a request to the Ray head to create a Ray job. Due to the buggy `entrypoint`, the Ray job fails immediately, and KubeRay transitions the RayJob status to `Complete`. After `ttlSecondsAfterFinished` seconds following the transition of the RayJob to `Complete`, the RayCluster will be deleted.

The submitter K8s Job will retry 3 times by default. If the submitter Job attempts to send a request to the Ray head after the Ray head has been deleted, it will result in a request timeout and failure. I haven't figured out the exact timeout value, but based on my observation, it's around 1 to 2 minutes. Therefore, the K8s Job may be deleted after the RayCluster is deleted, typically within `(x-1) * time_to_fail + n * timeout_seconds + ttlSecondsAfterFinished` seconds.

* `x`: The count of Ray jobs successfully submitted by KubeRay to the Ray head. 
* `n`: The count of attempts made by the K8s Job to submit the Ray job to the RayCluster when the Ray head is unavailable. Currently, `n` is less or equal to 2.


This PR decides not to use K8s Job's built-in `ttlSecondsAfterFinished`, but control the entire lifecycle of the K8s submitter Job by KubeRay.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

I performed an experiment based on [this gist](https://gist.github.com/kevin85421/f0df6829cb4d32340c42ef959a142021).
* `entrypoint: python /home/ray/samples/sample_code_1.py` => `sample_code_1.py` doesn't exist
* `ttlSecondsAfterFinished: 10`

In my experiment, with `x` as 2 and `n` as 1, the K8s Job is deleted 150 seconds after the RayCluster is deleted.
