### PR TITLE
[RayJob][Status][19/n] Transition to `Complete` if the K8s Job fails

### DIFF
--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -66,6 +66,7 @@ test: ENVTEST_K8S_VERSION ?= 1.24.2
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(WHAT) -coverprofile cover.out
 
+# You can use `go test -timeout 30m -v ./test/e2e/rayjob_test.go ./test/e2e/support.go` if you only want to run tests in `rayjob_test.go`.
 test-e2e: WHAT ?= ./test/e2e
 test-e2e: manifests generate fmt vet ## Run e2e tests.
 	go test -timeout 30m -v $(WHAT)

--- a/ray-operator/test/e2e/rayjob_test.go
+++ b/ray-operator/test/e2e/rayjob_test.go
@@ -143,4 +143,51 @@ env_vars:
 		// Assert the submitter Job has been cascade deleted
 		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
 	})
+
+	test.T().Run("Failing submitter K8s Job", func(t *testing.T) {
+		// RayJob
+		rayJob := &rayv1.RayJob{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: rayv1.GroupVersion.String(),
+				Kind:       "RayJob",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fail",
+				Namespace: namespace.Name,
+			},
+			Spec: rayv1.RayJobSpec{
+				RayClusterSpec:           newRayClusterSpec(mountConfigMap(jobs, "/home/ray/jobs")),
+				Entrypoint:               "The command will be overridden by the submitter Job",
+				ShutdownAfterJobFinishes: true,
+				SubmitterPodTemplate:     jobSubmitterPodTemplate(),
+			},
+		}
+		// In this test, we try to simulate the case where the submitter Job can't connect to the RayCluster successfully.
+		// Hence, KubeRay can't get the Ray job information from the RayCluster. When the submitter Job reaches the backoff
+		// limit, it will be marked as failed. Then, the RayJob should transition to `Complete`.
+		rayJob.Spec.SubmitterPodTemplate.Spec.Containers[0].Command = []string{"ray", "job", "submit", "--address", "http://do-not-exist:8265", "--", "echo 123"}
+
+		rayJob, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Create(test.Ctx(), rayJob, metav1.CreateOptions{})
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		test.T().Logf("Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobStatus, Equal(rayv1.JobStatusNew)))
+
+		// Assert the RayCluster and the submitter Job have been deleted because ShutdownAfterJobFinishes is true.
+		test.Eventually(NotFound(RayClusterOrError(test, namespace.Name, rayJob.Status.RayClusterName))).
+			Should(BeTrue())
+		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
+
+		// Refresh the RayJob status
+		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+
+		// Delete the RayJob
+		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+	})
 }

--- a/ray-operator/test/e2e/rayjob_test.go
+++ b/ray-operator/test/e2e/rayjob_test.go
@@ -152,7 +152,7 @@ env_vars:
 				Kind:       "RayJob",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fail",
+				Name:      "fail-k8s-job",
 				Namespace: namespace.Name,
 			},
 			Spec: rayv1.RayJobSpec{
@@ -177,13 +177,13 @@ env_vars:
 		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobStatus, Equal(rayv1.JobStatusNew)))
 
-		// Assert the RayCluster and the submitter Job have been deleted because ShutdownAfterJobFinishes is true.
-		test.Eventually(NotFound(RayClusterOrError(test, namespace.Name, rayJob.Status.RayClusterName))).
-			Should(BeTrue())
-		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
-
 		// Refresh the RayJob status
 		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+
+		// Assert the RayCluster and the submitter Job have been deleted because ShutdownAfterJobFinishes is true.
+		test.Eventually(NotFound(RayClusterOrError(test, namespace.Name, rayJob.Status.RayClusterName)), TestTimeoutMedium).
+			Should(BeTrue())
+		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
 
 		// Delete the RayJob
 		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#1831 addresses the case where the Ray head can receive and create the Ray job successfully, but the Ray job fails. In that case, the RayJob can transition to `JobDeploymentComplete` because the KubeRay operator can get the job information from the Ray head and the Ray job is `Failed`, a terminal state.

This PR handles a different case compared with #1831. This PR focuses on the case that the submitter K8s Job can't send a request to the Ray head successfully. Hence, the KubeRay operator can't get any Ray job information from the Ray head, and the RayJob can't transition to the `JobDeploymentComplete` status. This PR transitions the status to `JobDeploymentComplete` when the K8s Job is `Failed`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

Create a RayJob using [this YAML](https://gist.github.com/kevin85421/8be91e10f6a62b3ab457f2f52f3de035). The submitter Kubernetes Job within the RayJob attempts to submit a request to a random address, which results in the Job failing. Without this PR, the RayCluster and the Kubernetes Job will not shut down, even when the Kubernetes Job reaches its backoff limit.