### PR TITLE
Add NumOfHosts to WorkerGroupSpec (CRD change only)

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -3766,6 +3766,10 @@ spec:
                       default: 0
                       format: int32
                       type: integer
+                    numOfHosts:
+                      default: 1
+                      format: int32
+                      type: integer
                     rayStartParams:
                       additionalProperties:
                         type: string
@@ -7049,6 +7053,7 @@ spec:
                   - groupName
                   - maxReplicas
                   - minReplicas
+                  - numOfHosts
                   - rayStartParams
                   - template
                   type: object

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -3752,6 +3752,10 @@ spec:
                           default: 0
                           format: int32
                           type: integer
+                        numOfHosts:
+                          default: 1
+                          format: int32
+                          type: integer
                         rayStartParams:
                           additionalProperties:
                             type: string
@@ -7035,6 +7039,7 @@ spec:
                       - groupName
                       - maxReplicas
                       - minReplicas
+                      - numOfHosts
                       - rayStartParams
                       - template
                       type: object

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -3737,6 +3737,10 @@ spec:
                           default: 0
                           format: int32
                           type: integer
+                        numOfHosts:
+                          default: 1
+                          format: int32
+                          type: integer
                         rayStartParams:
                           additionalProperties:
                             type: string
@@ -7020,6 +7024,7 @@ spec:
                       - groupName
                       - maxReplicas
                       - minReplicas
+                      - numOfHosts
                       - rayStartParams
                       - template
                       type: object

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -56,6 +56,9 @@ type WorkerGroupSpec struct {
 	// MaxReplicas denotes the maximum number of desired Pods for this worker group, and the default value is maxInt32.
 	// +kubebuilder:default:=2147483647
 	MaxReplicas *int32 `json:"maxReplicas"`
+	// NumOfHosts denotes the number of hosts to create per replica. The default value is 1.
+	// +kubebuilder:default:=1
+	NumOfHosts *int32 `json:"numOfHosts"`
 	// RayStartParams are the params of the start command: address, object-store-memory, ...
 	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template is a pod template for the worker

--- a/ray-operator/apis/ray/v1/raycluster_types_test.go
+++ b/ray-operator/apis/ray/v1/raycluster_types_test.go
@@ -58,6 +58,7 @@ var myRayCluster = &RayCluster{
 				Replicas:    pointer.Int32(3),
 				MinReplicas: pointer.Int32(0),
 				MaxReplicas: pointer.Int32(10000),
+				NumOfHosts:  pointer.Int32(1),
 				GroupName:   "small-group",
 				RayStartParams: map[string]string{
 					"port":                        "6379",

--- a/ray-operator/apis/ray/v1/rayjob_types_test.go
+++ b/ray-operator/apis/ray/v1/rayjob_types_test.go
@@ -90,6 +90,7 @@ var expectedRayJob = RayJob{
 					Replicas:    pointer.Int32(3),
 					MinReplicas: pointer.Int32(0),
 					MaxReplicas: pointer.Int32(10000),
+					NumOfHosts:  pointer.Int32(1),
 					GroupName:   "small-group",
 					RayStartParams: map[string]string{
 						"port":     "6379",
@@ -213,7 +214,8 @@ var testRayJobJSON = `{
                     "replicas": 3,
                     "minReplicas": 0,
                     "maxReplicas": 10000,
-                    "rayStartParams": {
+		    "numOfHosts": 1,
+		    "rayStartParams": {
                         "num-cpus": "1",
                         "port": "6379"
                     },

--- a/ray-operator/apis/ray/v1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1/rayservice_types_test.go
@@ -90,6 +90,7 @@ var myRayService = &RayService{
 					Replicas:    pointer.Int32(3),
 					MinReplicas: pointer.Int32(0),
 					MaxReplicas: pointer.Int32(10000),
+					NumOfHosts:  pointer.Int32(1),
 					GroupName:   "small-group",
 					RayStartParams: map[string]string{
 						"port":                        "6379",
@@ -211,7 +212,8 @@ var expected = `{
                "replicas":3,
                "minReplicas":0,
                "maxReplicas":10000,
-               "rayStartParams":{
+	       "numOfHosts":1,
+	       "rayStartParams":{
                   "dashboard-agent-listen-port":"52365",
                   "num-cpus":"1",
                   "port":"6379"

--- a/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
@@ -617,6 +617,11 @@ func (in *WorkerGroupSpec) DeepCopyInto(out *WorkerGroupSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.NumOfHosts != nil {
+		in, out := &in.NumOfHosts, &out.NumOfHosts
+		*out = new(int32)
+		**out = **in
+	}
 	if in.RayStartParams != nil {
 		in, out := &in.RayStartParams, &out.RayStartParams
 		*out = make(map[string]string, len(*in))

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -3766,6 +3766,10 @@ spec:
                       default: 0
                       format: int32
                       type: integer
+                    numOfHosts:
+                      default: 1
+                      format: int32
+                      type: integer
                     rayStartParams:
                       additionalProperties:
                         type: string
@@ -7049,6 +7053,7 @@ spec:
                   - groupName
                   - maxReplicas
                   - minReplicas
+                  - numOfHosts
                   - rayStartParams
                   - template
                   type: object

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -3752,6 +3752,10 @@ spec:
                           default: 0
                           format: int32
                           type: integer
+                        numOfHosts:
+                          default: 1
+                          format: int32
+                          type: integer
                         rayStartParams:
                           additionalProperties:
                             type: string
@@ -7035,6 +7039,7 @@ spec:
                       - groupName
                       - maxReplicas
                       - minReplicas
+                      - numOfHosts
                       - rayStartParams
                       - template
                       type: object

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -3737,6 +3737,10 @@ spec:
                           default: 0
                           format: int32
                           type: integer
+                        numOfHosts:
+                          default: 1
+                          format: int32
+                          type: integer
                         rayStartParams:
                           additionalProperties:
                             type: string
@@ -7020,6 +7024,7 @@ spec:
                       - groupName
                       - maxReplicas
                       - minReplicas
+                      - numOfHosts
                       - rayStartParams
                       - template
                       type: object


### PR DESCRIPTION


## Why are these changes needed?

Adds "NumOfHosts" as an int32 field in RayCluster CR's WorkerGroupSpec section. NumOfHosts will be used to denote WorkerGroup replicas consisting of multiple hosts (for example, TPU hosts in a multi-host pod).


## Related issue number

https://github.com/ray-project/ray/issues/39781

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
