### PR TITLE
[Doc] Update best practice doc to mention entrypoint_num_cpus

### DIFF
--- a/docs/best-practice/worker-head-reconnection.md
+++ b/docs/best-practice/worker-head-reconnection.md
@@ -30,6 +30,6 @@ We recommend using the latest version of KubeRay. After version 0.5.0, the GCS F
 
 For older version (Kuberay <=0.4.0, ray <=2.1.0). To reduce the chances of a lost worker-head connection, there are two other options:
 
-- Make head more stable: when creating the cluster, allocate sufficient amount of resources on head pod such that it tends to be stable and not easy to crash. You can also set {"num-cpus": "0"} in "rayStartParams" of "headGroupSpec" such that Ray scheduler will skip the head node when scheduling workloads. This also helps to maintain the stability of the head. 
+- Make head more stable: when creating the cluster, allocate sufficient amount of resources on head pod such that it tends to be stable and not easy to crash. You can also set {"num-cpus": "0"} in "rayStartParams" of "headGroupSpec" such that Ray scheduler will skip the head node when scheduling Ray tasks and actors. This also helps to maintain the stability of the head. (Note: For Ray jobs, the job entrypoint will still be scheduled on the head node by default even if `num-cpus` is set to `0`. To force the entrypoint to run on a worker node in this case, you can set `entrypoint_num_cpus`; see the [doc](https://docs.ray.io/en/latest/cluster/running-applications/job-submission/sdk.html#specifying-cpu-and-gpu-resources) for details.)
 
 - Make reconnection shorter: for version <= 1.9.1, you can set this head param --system-config='{"ping_gcs_rpc_server_max_retries": 20}' to reduce the delay from 600s down to 20s before workers reconnect to the new head. 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The current best practice doc mentions that workloads will not be scheduled on the head node if `num-cpus` is set to zero.  This is misleading in the case of Ray Jobs, because those are always scheduled on the head node even if `num-cpus` is zero.  This PR clarifies this point and links to the doc for `entrypoint_num_cpus`.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/42432
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
