### PR TITLE
[RayService][Hotfix] Hotfix for Flaky Zero Downtime Rollout Test

### DIFF
--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -152,6 +152,13 @@ class RayServiceUpdateCREvent(CREvent):
             assert current_cluster_name != self.old_cluster_name
             logger.info(f'Ray service has moved to cluster "{current_cluster_name}"')
 
+            # Wait 20 seconds for serve service to update.
+            # This workaround will be removed after refactoring
+            # the way of rolling out and redefining the service status.
+            # Currently, changing to 'running' status does not guarantee
+            # the serve service redirects traffic to the new Raycluster.
+            time.sleep(20)
+
 class RayServiceDeleteCREvent(CREvent):
     """CREvent for RayService deletion"""
     def exec(self):

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -152,11 +152,11 @@ class RayServiceUpdateCREvent(CREvent):
             assert current_cluster_name != self.old_cluster_name
             logger.info(f'Ray service has moved to cluster "{current_cluster_name}"')
 
-            # Wait 20 seconds for serve service to update.
-            # This workaround will be removed after refactoring
-            # the way of rolling out and redefining the service status.
-            # Currently, changing to 'running' status does not guarantee
-            # the serve service redirects traffic to the new Raycluster.
+            # Wait 20 seconds for the serve service to update.
+            # TODO (Yicheng-Lu-llll): This workaround should be removed after
+            # refactoring the way of rolling out and redefining service status.
+            # Currently, changing to 'running' status does not guarantee that
+            # the serve service will redirect traffic to the new Raycluster.
             time.sleep(20)
 
 class RayServiceDeleteCREvent(CREvent):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The Zero Downtime Rollout Test is flaky for the following reason:

The current logic for the Zero Downtime Rollout operates as follows:

1. Once the pending RayCluster is ready for service, the RayService Controller updates its status to 'running' and updates the selection label for the serve service.
2. The RayService Controller then waits for 60 seconds before deleting the old RayCluster. This 60-second interval allows time for the serve service to be updated.

However, a critical issue is that the 'running' status merely indicates the readiness of the new RayCluster to serve traffic; it does not confirm that the serve service has begun redirecting traffic to the new RayCluster. As a result, requests sent after the status change to 'running' might still be responded to by the old RayCluster.

This scenario may lead to high-probability assertion errors in RayService CI tests, as responses expected from the new RayCluster may still coming from the old RayCluster. Some examples can be found here: 
- https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/2891#018cfaca-c122-4c5a-a28d-6a8a6503ef2f/251-2146
- https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/2942#018d187d-3036-45b0-8494-5176a7755358/251-2097
- https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/2942#018d18b8-947e-4150-97fe-2cb85760f939/251-2094
- https://github.com/ray-project/kuberay/pull/1728#issuecomment-1853436780

To mitigate this, and before refactoring the Rollout logic and redefine the of status, this PR adds delay to ensure the serve service is ready to redirect traffic to the new RayCluster.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
