### PR TITLE
fix golang-lint for deprecated k8s.io/util/pointer function

### DIFF
--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -12,7 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -254,11 +254,11 @@ var ClusterSpecAutoscalerTest = rayv1api.RayCluster{
 		WorkerGroupSpecs: []rayv1api.WorkerGroupSpec{
 			workerSpecTest,
 		},
-		EnableInTreeAutoscaling: pointer.Bool(true),
+		EnableInTreeAutoscaling: ptr.To(true),
 		AutoscalerOptions: &rayv1api.AutoscalerOptions{
-			IdleTimeoutSeconds: pointer.Int32(int32(60)),
-			UpscalingMode:      (*rayv1api.UpscalingMode)(pointer.String("Default")),
-			ImagePullPolicy:    (*corev1.PullPolicy)(pointer.String("Always")),
+			IdleTimeoutSeconds: ptr.To(int32(60)),
+			UpscalingMode:      (*rayv1api.UpscalingMode)(ptr.To("Default")),
+			ImagePullPolicy:    (*corev1.PullPolicy)(ptr.To("Always")),
 			Resources: &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -361,10 +361,10 @@ var ServiceV2Test = rayv1api.RayService{
 }
 
 var autoscalerOptions = &rayv1api.AutoscalerOptions{
-	IdleTimeoutSeconds: pointer.Int32(int32(60)),
-	UpscalingMode:      (*rayv1api.UpscalingMode)(pointer.String("Default")),
-	Image:              pointer.String("Some Image"),
-	ImagePullPolicy:    (*corev1.PullPolicy)(pointer.String("Always")),
+	IdleTimeoutSeconds: ptr.To(int32(60)),
+	UpscalingMode:      (*rayv1api.UpscalingMode)(ptr.To("Default")),
+	Image:              ptr.To("Some Image"),
+	ImagePullPolicy:    (*corev1.PullPolicy)(ptr.To("Always")),
 	Env: []corev1.EnvVar{
 		{
 			Name:  "n1",
@@ -392,13 +392,13 @@ var autoscalerOptions = &rayv1api.AutoscalerOptions{
 			Name:             "vmount1",
 			MountPath:        "path1",
 			ReadOnly:         false,
-			MountPropagation: (*corev1.MountPropagationMode)(pointer.String("None")),
+			MountPropagation: (*corev1.MountPropagationMode)(ptr.To("None")),
 		},
 		{
 			Name:             "vmount2",
 			MountPath:        "path2",
 			ReadOnly:         true,
-			MountPropagation: (*corev1.MountPropagationMode)(pointer.String("HostToContainer")),
+			MountPropagation: (*corev1.MountPropagationMode)(ptr.To("HostToContainer")),
 		},
 	},
 	Resources: &corev1.ResourceRequirements{

--- a/ray-operator/apis/ray/v1/raycluster_types_test.go
+++ b/ray-operator/apis/ray/v1/raycluster_types_test.go
@@ -6,7 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var myRayCluster = &RayCluster{
@@ -55,9 +55,9 @@ var myRayCluster = &RayCluster{
 		},
 		WorkerGroupSpecs: []WorkerGroupSpec{
 			{
-				Replicas:    pointer.Int32(3),
-				MinReplicas: pointer.Int32(0),
-				MaxReplicas: pointer.Int32(10000),
+				Replicas:    ptr.To(int32(3)),
+				MinReplicas: ptr.To(int32(0)),
+				MaxReplicas: ptr.To(int32(10000)),
 				NumOfHosts:  1,
 				GroupName:   "small-group",
 				RayStartParams: map[string]string{

--- a/ray-operator/apis/ray/v1/rayjob_types_test.go
+++ b/ray-operator/apis/ray/v1/rayjob_types_test.go
@@ -9,7 +9,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var expectedRayJob = RayJob{
@@ -87,9 +87,9 @@ var expectedRayJob = RayJob{
 			},
 			WorkerGroupSpecs: []WorkerGroupSpec{
 				{
-					Replicas:    pointer.Int32(3),
-					MinReplicas: pointer.Int32(0),
-					MaxReplicas: pointer.Int32(10000),
+					Replicas:    ptr.To(int32(3)),
+					MinReplicas: ptr.To(int32(0)),
+					MaxReplicas: ptr.To(int32(10000)),
 					NumOfHosts:  1,
 					GroupName:   "small-group",
 					RayStartParams: map[string]string{

--- a/ray-operator/apis/ray/v1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1/rayservice_types_test.go
@@ -9,7 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var myRayService = &RayService{
@@ -87,9 +87,9 @@ var myRayService = &RayService{
 			},
 			WorkerGroupSpecs: []WorkerGroupSpec{
 				{
-					Replicas:    pointer.Int32(3),
-					MinReplicas: pointer.Int32(0),
-					MaxReplicas: pointer.Int32(10000),
+					Replicas:    ptr.To(int32(3)),
+					MinReplicas: ptr.To(int32(0)),
+					MaxReplicas: ptr.To(int32(10000)),
 					NumOfHosts:  1,
 					GroupName:   "small-group",
 					RayStartParams: map[string]string{

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types_test.go
@@ -6,7 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var myRayCluster = &RayCluster{
@@ -55,9 +55,9 @@ var myRayCluster = &RayCluster{
 		},
 		WorkerGroupSpecs: []WorkerGroupSpec{
 			{
-				Replicas:    pointer.Int32(3),
-				MinReplicas: pointer.Int32(0),
-				MaxReplicas: pointer.Int32(10000),
+				Replicas:    ptr.To(int32(3)),
+				MinReplicas: ptr.To(int32(0)),
+				MaxReplicas: ptr.To(int32(10000)),
 				GroupName:   "small-group",
 				RayStartParams: map[string]string{
 					"port":                        "6379",

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types_test.go
@@ -9,7 +9,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var expectedRayJob = RayJob{
@@ -87,9 +87,9 @@ var expectedRayJob = RayJob{
 			},
 			WorkerGroupSpecs: []WorkerGroupSpec{
 				{
-					Replicas:    pointer.Int32(3),
-					MinReplicas: pointer.Int32(0),
-					MaxReplicas: pointer.Int32(10000),
+					Replicas:    ptr.To(int32(3)),
+					MinReplicas: ptr.To(int32(0)),
+					MaxReplicas: ptr.To(int32(10000)),
 					GroupName:   "small-group",
 					RayStartParams: map[string]string{
 						"port":     "6379",

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types_test.go
@@ -9,7 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var myRayService = &RayService{
@@ -87,9 +87,9 @@ var myRayService = &RayService{
 			},
 			WorkerGroupSpecs: []WorkerGroupSpec{
 				{
-					Replicas:    pointer.Int32(3),
-					MinReplicas: pointer.Int32(0),
-					MaxReplicas: pointer.Int32(10000),
+					Replicas:    ptr.To(int32(3)),
+					MinReplicas: ptr.To(int32(0)),
+					MaxReplicas: ptr.To(int32(10000)),
 					GroupName:   "small-group",
 					RayStartParams: map[string]string{
 						"port":                        "6379",

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestCreatePodGroup(t *testing.T) {
@@ -68,9 +68,9 @@ func TestCreatePodGroup(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						Spec: workerSpec,
 					},
-					Replicas:    pointer.Int32(2),
-					MinReplicas: pointer.Int32(1),
-					MaxReplicas: pointer.Int32(4),
+					Replicas:    ptr.To(int32(2)),
+					MinReplicas: ptr.To(int32(1)),
+					MaxReplicas: ptr.To(int32(4)),
 				},
 			},
 		},

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -18,7 +18,7 @@ import (
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var testMemoryLimit = resource.MustParse("1Gi")
@@ -83,9 +83,9 @@ var instance = rayv1.RayCluster{
 		},
 		WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 			{
-				Replicas:    pointer.Int32(3),
-				MinReplicas: pointer.Int32(0),
-				MaxReplicas: pointer.Int32(10000),
+				Replicas:    ptr.To(int32(3)),
+				MinReplicas: ptr.To(int32(0)),
+				MaxReplicas: ptr.To(int32(10000)),
 				GroupName:   "small-group",
 				RayStartParams: map[string]string{
 					"port":     "6379",

--- a/ray-operator/controllers/ray/common/route_test.go
+++ b/ray-operator/controllers/ray/common/route_test.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var instanceWithRouteEnabled = &rayv1.RayCluster{
@@ -22,7 +22,7 @@ var instanceWithRouteEnabled = &rayv1.RayCluster{
 	},
 	Spec: rayv1.RayClusterSpec{
 		HeadGroupSpec: rayv1.HeadGroupSpec{
-			EnableIngress: pointer.Bool(true),
+			EnableIngress: ptr.To(true),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
@@ -1142,13 +1142,13 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(instance rayv1.RayCluster) b
 			Annotations: pod.Annotations,
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: pointer.Int32(0),
+			BackoffLimit: ptr.To(int32(0)),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: pod.ObjectMeta,
 				Spec:       pod.Spec,
 			},
 			// make this job be best-effort only for 5 minutes.
-			ActiveDeadlineSeconds: pointer.Int64(300),
+			ActiveDeadlineSeconds: ptr.To(int64(300)),
 		},
 	}
 

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -321,9 +321,9 @@ func setupTest(t *testing.T) {
 			},
 			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 				{
-					Replicas:    pointer.Int32(expectReplicaNum),
-					MinReplicas: pointer.Int32(0),
-					MaxReplicas: pointer.Int32(10000),
+					Replicas:    ptr.To(int32(expectReplicaNum)),
+					MinReplicas: ptr.To(int32(0)),
+					MaxReplicas: ptr.To(int32(10000)),
 					GroupName:   groupNameStr,
 					RayStartParams: map[string]string{
 						"port":     "6379",
@@ -2260,7 +2260,7 @@ func TestReconcile_Replicas_Optional(t *testing.T) {
 	assert.Equal(t, 1, len(testRayCluster.Spec.WorkerGroupSpecs), "This test assumes only one worker group.")
 
 	// Disable autoscaling so that the random Pod deletion is enabled.
-	testRayCluster.Spec.EnableInTreeAutoscaling = pointer.Bool(false)
+	testRayCluster.Spec.EnableInTreeAutoscaling = ptr.To(false)
 	testRayCluster.Spec.WorkerGroupSpecs[0].ScaleStrategy.WorkersToDelete = []string{}
 
 	tests := map[string]struct {
@@ -2273,22 +2273,22 @@ func TestReconcile_Replicas_Optional(t *testing.T) {
 			// If `Replicas` is nil, the controller will set the desired state of the workerGroup to `MinReplicas` Pods.
 			// [Note]: It is not possible for `Replicas` to be nil in practice because it has a default value in the CRD.
 			replicas:        nil,
-			minReplicas:     pointer.Int32(1),
-			maxReplicas:     pointer.Int32(10000),
+			minReplicas:     ptr.To(int32(1)),
+			maxReplicas:     ptr.To(int32(10000)),
 			desiredReplicas: 1,
 		},
 		"Replicas is smaller than MinReplicas": {
 			// If `Replicas` is smaller than `MinReplicas`, the controller will set the desired state of the workerGroup to `MinReplicas` Pods.
-			replicas:        pointer.Int32(0),
-			minReplicas:     pointer.Int32(1),
-			maxReplicas:     pointer.Int32(10000),
+			replicas:        ptr.To(int32(0)),
+			minReplicas:     ptr.To(int32(1)),
+			maxReplicas:     ptr.To(int32(10000)),
 			desiredReplicas: 1,
 		},
 		"Replicas is larger than MaxReplicas": {
 			// If `Replicas` is larger than `MaxReplicas`, the controller will set the desired state of the workerGroup to `MaxReplicas` Pods.
-			replicas:        pointer.Int32(4),
-			minReplicas:     pointer.Int32(1),
-			maxReplicas:     pointer.Int32(3),
+			replicas:        ptr.To(int32(4)),
+			minReplicas:     ptr.To(int32(1)),
+			maxReplicas:     ptr.To(int32(3)),
 			desiredReplicas: 3,
 		},
 	}

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -30,7 +30,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -83,9 +83,9 @@ var _ = Context("Inside the default namespace", func() {
 			},
 			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 				{
-					Replicas:    pointer.Int32(3),
-					MinReplicas: pointer.Int32(0),
-					MaxReplicas: pointer.Int32(4),
+					Replicas:    ptr.To(int32(3)),
+					MinReplicas: ptr.To(int32(0)),
+					MaxReplicas: ptr.To(int32(4)),
 					GroupName:   "small-group",
 					RayStartParams: map[string]string{
 						"port":     "6379",
@@ -215,7 +215,7 @@ var _ = Context("Inside the default namespace", func() {
 
 			pod := workerPods.Items[0]
 			err := k8sClient.Delete(ctx, &pod,
-				&client.DeleteOptions{GracePeriodSeconds: pointer.Int64(0)})
+				&client.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))})
 
 			Expect(err).NotTo(HaveOccurred(), "failed delete a pod")
 
@@ -232,7 +232,7 @@ var _ = Context("Inside the default namespace", func() {
 					getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),
 					time.Second*9, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
 				podToDelete := workerPods.Items[0]
-				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = pointer.Int32(2)
+				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To(int32(2))
 				myRayCluster.Spec.WorkerGroupSpecs[0].ScaleStrategy.WorkersToDelete = []string{podToDelete.Name}
 				return k8sClient.Update(ctx, myRayCluster)
 			})
@@ -254,7 +254,7 @@ var _ = Context("Inside the default namespace", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: myRayCluster.Name, Namespace: "default"}, myRayCluster),
 					time.Second*9, time.Millisecond*500).Should(BeNil(), "My raycluster = %v", myRayCluster)
-				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = pointer.Int32(5)
+				myRayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To(int32(5))
 
 				// Operator may update revision after we get cluster earlier. Update may result in 409 conflict error.
 				// We need to handle conflict error and retry the update.

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -366,7 +366,7 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 			// is attempted 3 times at the maximum, but still mitigates the case of unrecoverable
 			// application-level errors, where the maximum number of retries is reached, and the job
 			// completion time increases with no benefits, but wasted resource cycles.
-			BackoffLimit: pointer.Int32(2),
+			BackoffLimit: ptr.To(int32(2)),
 			Template:     submitterTemplate,
 		},
 	}

--- a/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
@@ -31,7 +31,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	batchv1 "k8s.io/api/batch/v1"
 
@@ -100,9 +100,9 @@ var _ = Context("Inside the default namespace", func() {
 				},
 				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
-						Replicas:       pointer.Int32(3),
-						MinReplicas:    pointer.Int32(0),
-						MaxReplicas:    pointer.Int32(10000),
+						Replicas:       ptr.To(int32(3)),
+						MinReplicas:    ptr.To(int32(0)),
+						MaxReplicas:    ptr.To(int32(10000)),
 						GroupName:      "small-group",
 						RayStartParams: map[string]string{},
 						Template: corev1.PodTemplateSpec{

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -30,7 +30,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -114,9 +114,9 @@ var myRayJob = &rayv1.RayJob{
 			},
 			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 				{
-					Replicas:    pointer.Int32(3),
-					MinReplicas: pointer.Int32(0),
-					MaxReplicas: pointer.Int32(10000),
+					Replicas:    ptr.To(int32(3)),
+					MinReplicas: ptr.To(int32(0)),
+					MaxReplicas: ptr.To(int32(10000)),
 					GroupName:   "small-group",
 					RayStartParams: map[string]string{
 						"port":                        "6379",

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -24,13 +24,13 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -155,9 +155,9 @@ var _ = Context("Inside the default namespace", func() {
 				},
 				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
-						Replicas:    pointer.Int32(3),
-						MinReplicas: pointer.Int32(0),
-						MaxReplicas: pointer.Int32(10000),
+						Replicas:    ptr.To(int32(3)),
+						MinReplicas: ptr.To(int32(0)),
+						MaxReplicas: ptr.To(int32(10000)),
 						GroupName:   "small-group",
 						RayStartParams: map[string]string{
 							"port":                        "6379",

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -36,9 +36,9 @@ func TestGenerateHashWithoutReplicasAndWorkersToDelete(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{},
 					},
-					Replicas:    pointer.Int32(2),
-					MinReplicas: pointer.Int32(1),
-					MaxReplicas: pointer.Int32(4),
+					Replicas:    ptr.To(int32(2)),
+					MinReplicas: ptr.To(int32(1)),
+					MaxReplicas: ptr.To(int32(4)),
 				},
 			},
 		},
@@ -64,9 +64,9 @@ func TestGetClusterAction(t *testing.T) {
 		RayVersion: "2.9.0",
 		WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 			{
-				Replicas:    pointer.Int32(2),
-				MinReplicas: pointer.Int32(1),
-				MaxReplicas: pointer.Int32(4),
+				Replicas:    ptr.To(int32(2)),
+				MinReplicas: ptr.To(int32(1)),
+				MaxReplicas: ptr.To(int32(4)),
 			},
 		},
 	}
@@ -85,7 +85,7 @@ func TestGetClusterAction(t *testing.T) {
 
 	// Test Case 3: Different WorkerGroupSpecs should lead to RolloutNew.
 	clusterSpec3 := clusterSpec1.DeepCopy()
-	clusterSpec3.WorkerGroupSpecs[0].MinReplicas = pointer.Int32(5)
+	clusterSpec3.WorkerGroupSpecs[0].MinReplicas = ptr.To(int32(5))
 	action, err = getClusterAction(clusterSpec1, *clusterSpec3)
 	assert.Nil(t, err)
 	assert.Equal(t, RolloutNew, action)
@@ -93,9 +93,9 @@ func TestGetClusterAction(t *testing.T) {
 	// Test Case 4: Adding a new WorkerGroupSpec should lead to Update.
 	clusterSpec4 := clusterSpec1.DeepCopy()
 	clusterSpec4.WorkerGroupSpecs = append(clusterSpec4.WorkerGroupSpecs, rayv1.WorkerGroupSpec{
-		Replicas:    pointer.Int32(2),
-		MinReplicas: pointer.Int32(1),
-		MaxReplicas: pointer.Int32(4),
+		Replicas:    ptr.To(int32(2)),
+		MinReplicas: ptr.To(int32(1)),
+		MaxReplicas: ptr.To(int32(4)),
 	})
 	action, err = getClusterAction(clusterSpec1, *clusterSpec4)
 	assert.Nil(t, err)
@@ -110,18 +110,18 @@ func TestGetClusterAction(t *testing.T) {
 
 	// Test Case 6: Only changing the number of replicas should lead to DoNothing.
 	clusterSpec6 := clusterSpec1.DeepCopy()
-	clusterSpec6.WorkerGroupSpecs[0].Replicas = pointer.Int32(3)
+	clusterSpec6.WorkerGroupSpecs[0].Replicas = ptr.To(int32(3))
 	action, err = getClusterAction(clusterSpec1, *clusterSpec6)
 	assert.Nil(t, err)
 	assert.Equal(t, DoNothing, action)
 
 	// Test Case 7: Only changing the number of replicas in an existing WorkerGroupSpec *and* adding a new WorkerGroupSpec should lead to Update.
 	clusterSpec7 := clusterSpec1.DeepCopy()
-	clusterSpec7.WorkerGroupSpecs[0].Replicas = pointer.Int32(3)
+	clusterSpec7.WorkerGroupSpecs[0].Replicas = ptr.To(int32(3))
 	clusterSpec7.WorkerGroupSpecs = append(clusterSpec7.WorkerGroupSpecs, rayv1.WorkerGroupSpec{
-		Replicas:    pointer.Int32(2),
-		MinReplicas: pointer.Int32(1),
-		MaxReplicas: pointer.Int32(4),
+		Replicas:    ptr.To(int32(2)),
+		MinReplicas: ptr.To(int32(1)),
+		MaxReplicas: ptr.To(int32(4)),
 	})
 	action, err = getClusterAction(clusterSpec1, *clusterSpec7)
 	assert.Nil(t, err)
@@ -130,14 +130,14 @@ func TestGetClusterAction(t *testing.T) {
 	// Test Case 8: Adding two new WorkerGroupSpecs should lead to Update.
 	clusterSpec8 := clusterSpec1.DeepCopy()
 	clusterSpec8.WorkerGroupSpecs = append(clusterSpec8.WorkerGroupSpecs, rayv1.WorkerGroupSpec{
-		Replicas:    pointer.Int32(2),
-		MinReplicas: pointer.Int32(1),
-		MaxReplicas: pointer.Int32(4),
+		Replicas:    ptr.To(int32(2)),
+		MinReplicas: ptr.To(int32(1)),
+		MaxReplicas: ptr.To(int32(4)),
 	})
 	clusterSpec8.WorkerGroupSpecs = append(clusterSpec8.WorkerGroupSpecs, rayv1.WorkerGroupSpec{
-		Replicas:    pointer.Int32(3),
-		MinReplicas: pointer.Int32(2),
-		MaxReplicas: pointer.Int32(5),
+		Replicas:    ptr.To(int32(3)),
+		MinReplicas: ptr.To(int32(2)),
+		MaxReplicas: ptr.To(int32(5)),
 	})
 	action, err = getClusterAction(clusterSpec1, *clusterSpec8)
 	assert.Nil(t, err)
@@ -145,11 +145,11 @@ func TestGetClusterAction(t *testing.T) {
 
 	// Test Case 9: Changing an existing WorkerGroupSpec outside of Replicas/WorkersToDelete *and* adding a new WorkerGroupSpec should lead to RolloutNew.
 	clusterSpec9 := clusterSpec1.DeepCopy()
-	clusterSpec9.WorkerGroupSpecs[0].MaxReplicas = pointer.Int32(5)
+	clusterSpec9.WorkerGroupSpecs[0].MaxReplicas = ptr.To(int32(5))
 	clusterSpec9.WorkerGroupSpecs = append(clusterSpec9.WorkerGroupSpecs, rayv1.WorkerGroupSpec{
-		Replicas:    pointer.Int32(2),
-		MinReplicas: pointer.Int32(1),
-		MaxReplicas: pointer.Int32(4),
+		Replicas:    ptr.To(int32(2)),
+		MinReplicas: ptr.To(int32(1)),
+		MaxReplicas: ptr.To(int32(4)),
 	})
 	action, err = getClusterAction(clusterSpec1, *clusterSpec9)
 	assert.Nil(t, err)

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -497,29 +497,29 @@ func TestCalculateDesiredReplicas(t *testing.T) {
 	}{
 		"Both groups' Replicas are nil": {
 			group1Replicas:    nil,
-			group1MinReplicas: pointer.Int32(1),
-			group1MaxReplicas: pointer.Int32(5),
+			group1MinReplicas: ptr.To(int32(1)),
+			group1MaxReplicas: ptr.To(int32(5)),
 			group2Replicas:    nil,
-			group2MinReplicas: pointer.Int32(2),
-			group2MaxReplicas: pointer.Int32(5),
+			group2MinReplicas: ptr.To(int32(2)),
+			group2MaxReplicas: ptr.To(int32(5)),
 			answer:            3,
 		},
 		"Group1's Replicas is smaller than MinReplicas, and Group2's Replicas is more than MaxReplicas.": {
-			group1Replicas:    pointer.Int32(0),
-			group1MinReplicas: pointer.Int32(2),
-			group1MaxReplicas: pointer.Int32(5),
-			group2Replicas:    pointer.Int32(6),
-			group2MinReplicas: pointer.Int32(2),
-			group2MaxReplicas: pointer.Int32(5),
+			group1Replicas:    ptr.To(int32(0)),
+			group1MinReplicas: ptr.To(int32(2)),
+			group1MaxReplicas: ptr.To(int32(5)),
+			group2Replicas:    ptr.To(int32(6)),
+			group2MinReplicas: ptr.To(int32(2)),
+			group2MaxReplicas: ptr.To(int32(5)),
 			answer:            7,
 		},
 		"Group1's Replicas is more than MaxReplicas.": {
-			group1Replicas:    pointer.Int32(6),
-			group1MinReplicas: pointer.Int32(2),
-			group1MaxReplicas: pointer.Int32(5),
-			group2Replicas:    pointer.Int32(3),
-			group2MinReplicas: pointer.Int32(2),
-			group2MaxReplicas: pointer.Int32(5),
+			group1Replicas:    ptr.To(int32(6)),
+			group1MinReplicas: ptr.To(int32(2)),
+			group1MaxReplicas: ptr.To(int32(5)),
+			group2Replicas:    ptr.To(int32(3)),
+			group2MinReplicas: ptr.To(int32(2)),
+			group2MaxReplicas: ptr.To(int32(5)),
 			answer:            8,
 		},
 	}

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -24,7 +24,7 @@ require (
 	k8s.io/apiserver v0.28.4
 	k8s.io/client-go v0.28.4
 	k8s.io/code-generator v0.28.4
-	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
+	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/yaml v1.3.0
 	volcano.sh/apis v1.6.0-alpha.0.0.20221012070524-685db38b4fae

--- a/ray-operator/go.sum
+++ b/ray-operator/go.sum
@@ -401,8 +401,8 @@ k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 h1:LyMgNKD2P8Wn1iAwQU5Ohx
 k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9/go.mod h1:wZK2AVp1uHCp4VamDVgBP2COHZjqD1T68Rf0CM3YjSM=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 h1:qY1Ad8PODbnymg2pRbkyMT/ylpTrCM8P2RJ0yroCyIk=
-k8s.io/utils v0.0.0-20230406110748-d93618cff8a2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20240102154912-e7106e64919e h1:eQ/4ljkx21sObifjzXwlPKpdGLrCfRziVtos3ofG/sQ=
+k8s.io/utils v0.0.0-20240102154912-e7106e64919e/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/controller-runtime v0.16.3 h1:2TuvuokmfXvDUamSx1SuAOO3eTyye+47mJCigwG62c4=
 sigs.k8s.io/controller-runtime v0.16.3/go.mod h1:j7bialYoSn142nv9sCOJmQgDXQXxnroFU4VnX/brVJ0=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Functions in k8s.io/util/pointer are now deprecated and golangci-lint will start complaining about them. This PR updates callers to use `ptr.To` (based on generics).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
