### PR TITLE
[RayService] Deprecate the built-in ingress support of RayService

### DIFF
--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -17,7 +17,6 @@ const (
 	FailedToGetServeDeploymentStatus ServiceStatus = "FailedToGetServeDeploymentStatus"
 	Running                          ServiceStatus = "Running"
 	Restarting                       ServiceStatus = "Restarting"
-	FailedToUpdateIngress            ServiceStatus = "FailedToUpdateIngress"
 	FailedToUpdateServingPodLabel    ServiceStatus = "FailedToUpdateServingPodLabel"
 	FailedToUpdateService            ServiceStatus = "FailedToUpdateService"
 )

--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -95,27 +95,3 @@ func BuildIngressForHeadService(cluster rayv1.RayCluster) (*networkingv1.Ingress
 
 	return ingress, nil
 }
-
-// BuildIngressForRayService Builds the ingress for head service dashboard for RayService.
-// This is used to expose dashboard for external traffic.
-// RayService controller updates the ingress whenever a new RayCluster serves the traffic.
-func BuildIngressForRayService(service rayv1.RayService, cluster rayv1.RayCluster) (*networkingv1.Ingress, error) {
-	ingress, err := BuildIngressForHeadService(cluster)
-	if err != nil {
-		return nil, err
-	}
-
-	headSvcName, err := utils.GenerateHeadServiceName(utils.RayServiceCRD, service.Spec.RayClusterSpec, service.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	ingress.ObjectMeta.Name = headSvcName
-	ingress.ObjectMeta.Namespace = service.Namespace
-	ingress.ObjectMeta.Labels = map[string]string{
-		utils.RayServiceLabelKey: service.Name,
-		utils.RayIDLabelKey:      utils.CheckLabel(utils.GenerateIdentifier(service.Name, rayv1.HeadNode)),
-	}
-
-	return ingress, nil
-}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -196,10 +196,6 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	}
 
 	if rayClusterInstance != nil {
-		if err := r.reconcileIngress(ctx, rayServiceInstance, rayClusterInstance); err != nil {
-			err = r.updateState(ctx, rayServiceInstance, rayv1.FailedToUpdateIngress, err)
-			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
-		}
 		if err := r.reconcileServices(ctx, rayServiceInstance, rayClusterInstance, utils.HeadService); err != nil {
 			err = r.updateState(ctx, rayServiceInstance, rayv1.FailedToUpdateService, err)
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
@@ -905,53 +901,6 @@ func (r *RayServiceReconciler) updateRayClusterInfo(rayServiceInstance *rayv1.Ra
 		rayServiceInstance.Status.ActiveServiceStatus = rayServiceInstance.Status.PendingServiceStatus
 		rayServiceInstance.Status.PendingServiceStatus = rayv1.RayServiceStatus{}
 	}
-}
-
-// TODO: When start Ingress in RayService, we can disable the Ingress from RayCluster.
-func (r *RayServiceReconciler) reconcileIngress(ctx context.Context, rayServiceInstance *rayv1.RayService, rayClusterInstance *rayv1.RayCluster) error {
-	if rayClusterInstance.Spec.HeadGroupSpec.EnableIngress == nil || !*rayClusterInstance.Spec.HeadGroupSpec.EnableIngress {
-		r.Log.Info("Ingress is disabled. Skipping ingress reconcilation. " +
-			"You can enable Ingress by setting enableIngress to true in HeadGroupSpec.")
-		return nil
-	}
-
-	// Creat Ingress Struct.
-	ingress, err := common.BuildIngressForRayService(*rayServiceInstance, *rayClusterInstance)
-	if err != nil {
-		return err
-	}
-	ingress.Name = utils.CheckName(ingress.Name)
-
-	// Get Ingress instance.
-	headIngress := &networkingv1.Ingress{}
-	err = r.Get(ctx, client.ObjectKey{Name: ingress.Name, Namespace: rayServiceInstance.Namespace}, headIngress)
-
-	if err == nil {
-		// Update Ingress
-		headIngress.Spec = ingress.Spec
-		if updateErr := r.Update(ctx, ingress); updateErr != nil {
-			r.Log.Error(updateErr, "Ingress Update error!", "Ingress.Error", updateErr)
-			return updateErr
-		}
-	} else if errors.IsNotFound(err) {
-		// Create Ingress
-		if err := ctrl.SetControllerReference(rayServiceInstance, ingress, r.Scheme); err != nil {
-			return err
-		}
-		if createErr := r.Create(ctx, ingress); createErr != nil {
-			if errors.IsAlreadyExists(createErr) {
-				r.Log.Info("Ingress already exists,no need to create")
-				return nil
-			}
-			r.Log.Error(createErr, "Ingress create error!", "Ingress.Error", createErr)
-			return createErr
-		}
-	} else {
-		r.Log.Error(err, "Ingress get error!")
-		return err
-	}
-
-	return nil
 }
 
 func (r *RayServiceReconciler) reconcileServices(ctx context.Context, rayServiceInstance *rayv1.RayService, rayClusterInstance *rayv1.RayCluster, serviceType utils.ServiceType) error {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It is highly possible that the built-in ingress support in RayService hasn't been working since the day it was committed.

You can create a RayService with `EnableIngress: true` with [this gist](https://gist.github.com/kevin85421/0ec82f72369ea274687d892735086023). Initially, the RayCluster managed by the RayService will create a Kubernetes Ingress. Once the RayCluster is ready, the RayService controller will attempt to create another ingress. This occurs because both the RayCluster and RayService controllers use `HeadGroupSpec.EnableIngress` to determine whether to create a Kubernetes Ingress. However, the Ingress created by RayService will fail because of the following reason:

```
2024-01-17T08:37:17.539Z	ERROR	controllers.RayService	Ingress create error!	{"Ingress.Error": "admission webhook \"validate.nginx.ingress.kubernetes.io\" denied the request: host \"_\" and path \"/rayservice-sample-raycluster-zhz55/(.*)\" is already defined in ingress default/rayservice-sample-raycluster-zhz55-head-ingress", "error": "admission webhook \"validate.nginx.ingress.kubernetes.io\" denied the request: host \"_\" and path \"/rayservice-sample-raycluster-zhz55/(.*)\" is already defined in ingress default/rayservice-sample-raycluster-zhz55-head-ingress"}
```

Because the RayService reconciler will always get an error from the function `reconcileIngress`, the K8s service for Ray Serve will never be created.

To reproduce the issue,
* Install NGINX ingress controller
* Install KubeRay operator
* Install a RayService with `EnableIngress: true` with [this gist](https://gist.github.com/kevin85421/0ec82f72369ea274687d892735086023)


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
