### PR TITLE
[RayJob] Improve flexibility to run specified YAML test

### DIFF
--- a/tests/test_sample_rayjob_yamls.py
+++ b/tests/test_sample_rayjob_yamls.py
@@ -3,6 +3,8 @@ import unittest
 import os
 import logging
 import yaml
+import git
+import argparse
 
 from framework.prototype import (
     RuleSet,
@@ -18,21 +20,45 @@ from framework.utils import (
 
 logger = logging.getLogger(__name__)
 
+def parse_args():
+    parser = argparse.ArgumentParser(description='Run tests for specified YAML files.')
+    parser.add_argument('--yaml-files', nargs='*', help='Use the filename under path `ray-operator/config/samples` to specify which YAML files should be tested.')
+    return parser.parse_args()
+
 if __name__ == '__main__':
     NAMESPACE = 'default'
     SAMPLE_PATH = CONST.REPO_ROOT.joinpath("ray-operator/config/samples/")
-    YAMLs = ['ray_v1alpha1_rayjob.yaml', 'ray_v1alpha1_rayjob.shutdown.yaml', 'ray-job.custom-head-svc.yaml', 'ray_v1alpha1_rayjob.resources.yaml']
 
     sample_yaml_files = []
-    for filename in YAMLs:
-        filepath = SAMPLE_PATH.joinpath(filename)
-        with open(filepath, encoding="utf-8") as cr_yaml:
+
+    # Paths of untracked files, specified as strings, relative to KubeRay git root directory.
+    untracked_files = set(
+        git.Repo(CONST.REPO_ROOT).untracked_files
+    )
+
+    args = parse_args()
+
+    for file in os.scandir(SAMPLE_PATH):
+        if not file.is_file():
+            continue
+        # For local development, skip untracked files.
+        if os.path.relpath(file.path, CONST.REPO_ROOT) in untracked_files:
+            continue
+        if args.yaml_files and file.name not in args.yaml_files:
+            continue
+
+        with open(file.path, encoding="utf-8") as cr_yaml:
             for k8s_object in yaml.safe_load_all(cr_yaml):
                 if k8s_object['kind'] == 'RayJob':
                     sample_yaml_files.append(
-                        {'path': filepath, 'name': filename, 'cr': k8s_object}
+                        {'path': file.path, 'name': file.name, 'cr': k8s_object}
                     )
                     break
+
+    skip_tests = {
+        'ray-job.batch-inference.yaml': 'Skip this test because it requires a lot of resources.',
+    }
+
     # NOTE: The Ray Job "SUCCEEDED" status is checked in the `RayJobAddCREvent` itself.
     # (The event is not considered "converged" until the job has succeeded.) The EasyJobRule
     # is only used to additionally check that the Ray Cluster remains alive and functional.
@@ -42,6 +68,9 @@ if __name__ == '__main__':
     logger.info("Building a test plan ...")
     test_cases = unittest.TestSuite()
     for index, new_cr in enumerate(sample_yaml_files):
+        if new_cr['name'] in skip_tests:
+            logger.info('[SKIP TEST %d] %s: %s', index, new_cr['name'], skip_tests[new_cr['name']])
+            continue
         logger.info('[TEST %d]: %s', index, new_cr['name'])
         addEvent = RayJobAddCREvent(new_cr['cr'], [rs], 300, NAMESPACE, new_cr['path'])
         test_cases.addTest(GeneralTestCase('runtest', addEvent))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The purpose of this PR is the same as the https://github.com/ray-project/kuberay/pull/1812#issue-2070542043 , aiming to enhance flexibility in executing sample YAML tests. 

With this PR, it is possible to specify one or multiple sample YAML test files. If no files are specified, the test will run on all sample YAML tests related to RayJob.

After the parameter `--yaml-files`, use the **filename** of the YAML for testing. Here's an example:

1. [Default] Run all YAML files.
`python3 tests/test_sample_rayjob_yamls.py`

2. Specified a single YAML file.
`python3 tests/test_sample_rayjob_yamls.py --yaml-files ray_v1alpha1_rayjob.yaml`
You can also specify multiple YAML files:
`python3 tests/test_sample_rayjob_yamls.py --yaml-files ray_v1alpha1_rayjob.yaml ray-job.custom-head-svc.yaml
`


In summary, this PR can save developers time and provide more flexible testing options.


## Related issue number
https://github.com/ray-project/kuberay/pull/1812#issuecomment-1889182458

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
  
 Following is the screenshot of manual test
 1. [Default] Run all YAML files.
 ![yaml_default](https://github.com/ray-project/kuberay/assets/139951533/09df54df-e87e-456a-a553-f4a60569eab1)
![yaml_default_res](https://github.com/ray-project/kuberay/assets/139951533/2187d8b7-3031-4a99-af2e-4359d2772762)

 
 2. Specified two YAML files.
![yaml_specify](https://github.com/ray-project/kuberay/assets/139951533/af2b94ac-3e0a-453a-b501-328c98c29d4e)
![yaml_specify_res](https://github.com/ray-project/kuberay/assets/139951533/ded1581f-6553-4190-a7ab-e9b63cdd13d7)

