### PR TITLE
Fixing Python client handling of env from

### DIFF
--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -533,6 +533,27 @@ func TestPopulateRayClusterSpec(t *testing.T) {
 	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.ImagePullPolicy, "Always")
 	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.Cpu, "500m")
 	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.Memory, "512Mi")
+	assert.Equal(t, len(cluster.ClusterSpec.HeadGroupSpec.Environment.ValuesFrom), 4)
+	for name, value := range cluster.ClusterSpec.HeadGroupSpec.Environment.ValuesFrom {
+		switch name {
+		case "REDIS_PASSWORD":
+			assert.Equal(t, value.Source.String(), "SECRET")
+			assert.Equal(t, value.Name, "redis-password-secret")
+			assert.Equal(t, value.Key, "password")
+		case "CONFIGMAP":
+			assert.Equal(t, value.Source.String(), "CONFIGMAP")
+			assert.Equal(t, value.Name, "special-config")
+			assert.Equal(t, value.Key, "special.how")
+		case "ResourceFieldRef":
+			assert.Equal(t, value.Source.String(), "RESOURCEFIELD")
+			assert.Equal(t, value.Name, "my-container")
+			assert.Equal(t, value.Key, "resource")
+		default:
+			assert.Equal(t, value.Source.String(), "FIELD")
+			assert.Equal(t, value.Name, "")
+			assert.Equal(t, value.Key, "path")
+		}
+	}
 }
 
 func TestPopulateTemplate(t *testing.T) {

--- a/clients/python-apiserver-client/python_apiserver_client/params/environmentvariables.py
+++ b/clients/python-apiserver-client/python_apiserver_client/params/environmentvariables.py
@@ -86,7 +86,7 @@ class EnvironmentVariables:
 
 
 def envvarfrom_decoder(dct: dict[str, any]) -> EnvVarFrom:
-    return EnvVarFrom(name=dct.get("name", ""), source=EnvarSource(int(dct.get("source", ""))), key=dct.get("key", ""))
+    return EnvVarFrom(name=dct.get("name", ""), source=EnvarSource(int(dct.get("source", 0))), key=dct.get("key", ""))
 
 
 def environmentvariables_decoder(dst: dict[str, any]) -> EnvironmentVariables:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After creating a cluster by setting environment variable valueFrom configMap, the cluster gets created correctly and the environment variables are set correctly in the cluster. However, when getting the cluster using the python client, kuberay.get_cluster()

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/1804

## Checks

- [ x] I've made sure the tests are passing. 
- Testing Strategy
   - [x ] Unit tests
   - [ x] Manual tests
   - [ ] This PR is not tested :(
