### PR TITLE
[CI] Do not load Ray into `kind` cluster

### DIFF
--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -10,7 +10,7 @@
     - IMG=kuberay/operator:nightly make docker-image
     - popd
     # Use nightly KubeRay operator image
-    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.9.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_raycluster_yamls.py
+    - source .venv/bin/activate && BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_raycluster_yamls.py
 
 - label: 'Test RayCluster Sample YAMLs (latest release)'
   instance_size: large
@@ -18,7 +18,7 @@
   commands:
     - ./.buildkite/setup-env.sh
     # Use KubeRay operator image from the latest release
-    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.9.0 OPERATOR_IMAGE=kuberay/operator:v1.0.0 python3 tests/test_sample_raycluster_yamls.py
+    - source .venv/bin/activate && BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:v1.0.0 python3 tests/test_sample_raycluster_yamls.py
 
 - label: 'Test RayJob Sample YAMLs (nightly operator)'
   instance_size: large
@@ -30,7 +30,7 @@
     - IMG=kuberay/operator:nightly make docker-image
     - popd
     # Use nightly KubeRay operator image
-    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.9.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayjob_yamls.py
+    - source .venv/bin/activate && BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayjob_yamls.py
 
 - label: 'Test RayJob Sample YAMLs (latest release)'
   instance_size: large
@@ -38,7 +38,7 @@
   commands:
     - ./.buildkite/setup-env.sh
     # Use KubeRay operator image from the latest release
-    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.9.0 OPERATOR_IMAGE=kuberay/operator:v1.0.0 python3 tests/test_sample_rayjob_yamls.py
+    - source .venv/bin/activate && BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:v1.0.0 python3 tests/test_sample_rayjob_yamls.py
 
 - label: 'Test RayService Sample YAMLs (nightly operator)'
   instance_size: large
@@ -50,7 +50,7 @@
     - IMG=kuberay/operator:nightly make docker-image
     - popd
     # Use nightly KubeRay operator image
-    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.9.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
+    - source .venv/bin/activate && BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
 
 - label: 'Test RayService Sample YAMLs (latest release)'
   instance_size: large
@@ -58,4 +58,4 @@
   commands:
     - ./.buildkite/setup-env.sh
     # Use KubeRay operator image from the latest release
-    - source .venv/bin/activate && BUILDKITE_ENV=true RAY_IMAGE=rayproject/ray:2.9.0 OPERATOR_IMAGE=kuberay/operator:v1.0.0 python3 tests/test_sample_rayservice_yamls.py
+    - source .venv/bin/activate && BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:v1.0.0 python3 tests/test_sample_rayservice_yamls.py

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -26,7 +26,6 @@ class CONST:
     __slots__ = ()
     # Docker images
     OPERATOR_IMAGE_KEY = "kuberay-operator-image"
-    RAY_IMAGE_KEY = "ray-image"
     KUBERAY_LATEST_RELEASE = "kuberay/operator:v1.0.0"
 
     # Kubernetes API clients
@@ -232,7 +231,6 @@ class OperatorManager(ABC):
             if namespace == None:
                 namespace = "default"
             DEFAULT_IMAGE_DICT = {
-               CONST.RAY_IMAGE_KEY: os.getenv('RAY_IMAGE', default='rayproject/ray:2.9.0'),
                 CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE', default='kuberay/operator:nightly'),
             }
             default_operator_manager = DefaultOperatorManager(DEFAULT_IMAGE_DICT, namespace, patch, cluster_manager)
@@ -259,7 +257,7 @@ class DefaultOperatorManager(OperatorManager):
         self.cluster_manager = cluster_manager
         self.namespace = namespace
         self.values_yaml = {}
-        for key in [CONST.OPERATOR_IMAGE_KEY, CONST.RAY_IMAGE_KEY]:
+        for key in [CONST.OPERATOR_IMAGE_KEY]:
             if key not in self.docker_image_dict:
                 raise Exception(f"Image {key} does not exist!")
         repo, tag = self.docker_image_dict[CONST.OPERATOR_IMAGE_KEY].split(":")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -55,7 +55,6 @@ class PodSecurityTestCase(unittest.TestCase):
                              {PodSecurityTestCase.namespace}.kubernetes.io/enforce-version=latest")
         # Install the KubeRay operator in the namespace pod-security.
         image_dict = {
-            CONST.RAY_IMAGE_KEY: 'rayproject/ray-ml:2.9.0',
             CONST.OPERATOR_IMAGE_KEY: os.getenv('OPERATOR_IMAGE','kuberay/operator:nightly'),
         }
         logger.info(image_dict)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Before this PR, the Ray docker image was manually loaded into the `kind` cluster before running the sample YAML tests.  Some possible reasons for this are:
(1) Save time by preloading the Ray image
(2) Make it easy to configure the Ray version used, by using the RAY_IMAGE environment variable to define the image to be loaded by `kind load`.

But (2) seems to not actually be happening.  The image specified by RAY_IMAGE is indeed loaded by `kind load`, but the Ray images actually used by the sample YAML tests are specified in the sample YAML files themselves, and they don't appear to be overwritten anywhere. So RAY_IMAGE has no effect on the Ray version that actually runs in the test.

To prove this, you can run
`RAY_IMAGE=rayproject/ray:1.0.0 OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayjob_yamls.py`

And see that the tests still succeed, despite Ray Job not existing in Ray 1.0.0.

It's not clear that there is any benefit to (1) either, because there is always a one time cost of pulling the Ray image, and subsequent pulls should be fast because the image is already saved locally.

So this PR removes `RAY_IMAGE` and `kind load $RAY_IMAGE` from the sample YAML tests.  The immediate benefit is that it's a workaround for #1859 , because `kind load rayproject/ray:2.9.0` fails for some unknown reason. (Same with 2.8.0, 2.8.1, 2.9.1)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
