### PR TITLE
[RayJob] Inject RAY_SUBMISSION_ID env variable for user provided submitter template

### DIFF
--- a/ray-operator/config/samples/ray-job.sample.yaml
+++ b/ray-operator/config/samples/ray-job.sample.yaml
@@ -102,7 +102,7 @@ spec:
   #         image: rayproject/ray:2.9.0
   #         # If Command is not specified, the correct command will be supplied at runtime using the RayJob spec `entrypoint` field.
   #         # Specifying Command is not recommended.
-  #         command: ["sh", "-c", "ray job submit --address=http://$RAY_DASHBOARD_ADDRESS --submission-id=$RAY_JOB_SUBMISSION_ID -- echo hello world"]
+  #         # command: ["sh", "-c", "ray job submit --address=http://$RAY_DASHBOARD_ADDRESS --submission-id=$RAY_JOB_SUBMISSION_ID -- echo hello world"]
 
 
 ######################Ray code sample#################################

--- a/ray-operator/config/samples/ray-job.sample.yaml
+++ b/ray-operator/config/samples/ray-job.sample.yaml
@@ -102,7 +102,7 @@ spec:
   #         image: rayproject/ray:2.9.0
   #         # If Command is not specified, the correct command will be supplied at runtime using the RayJob spec `entrypoint` field.
   #         # Specifying Command is not recommended.
-  #         command: ["sh", "-c", "ray job submit --address=http://$RAY_DASHBOARD_ADDRESS -- echo hello world"]
+  #         command: ["sh", "-c", "ray job submit --address=http://$RAY_DASHBOARD_ADDRESS --submission-id=$RAY_JOB_SUBMISSION_ID -- echo hello world"]
 
 
 ######################Ray code sample#################################

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -348,10 +348,16 @@ func (r *RayJobReconciler) getSubmitterTemplate(rayJobInstance *rayv1.RayJob, ra
 		Value: "1",
 	})
 
-	// Set RAY_DASHBOARD_ADDRESS so that the Ray address can be discovered at runtime
+	// Users can use `RAY_DASHBOARD_ADDRESS` to specify the dashboard address and `RAY_JOB_SUBMISSION_ID` to specify the job id to avoid
+	// double submission in the `ray job submit` command. For example:
+	// ray job submit --address=http://$RAY_DASHBOARD_ADDRESS --submission-id=$RAY_JOB_SUBMISSION_ID ...
 	submitterTemplate.Spec.Containers[utils.RayContainerIndex].Env = append(submitterTemplate.Spec.Containers[utils.RayContainerIndex].Env, corev1.EnvVar{
 		Name:  utils.RAY_DASHBOARD_ADDRESS,
 		Value: rayJobInstance.Status.DashboardURL,
+	})
+	submitterTemplate.Spec.Containers[utils.RayContainerIndex].Env = append(submitterTemplate.Spec.Containers[utils.RayContainerIndex].Env, corev1.EnvVar{
+		Name:  utils.RAY_JOB_SUBMISSION_ID,
+		Value: rayJobInstance.Status.JobId,
 	})
 
 	return submitterTemplate, nil

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -86,7 +86,6 @@ const (
 	RAY_CLUSTER_NAME                        = "RAY_CLUSTER_NAME"
 	RAY_IP                                  = "RAY_IP"
 	FQ_RAY_IP                               = "FQ_RAY_IP"
-	RAY_DASHBOARD_ADDRESS                   = "RAY_DASHBOARD_ADDRESS"
 	RAY_PORT                                = "RAY_PORT"
 	RAY_ADDRESS                             = "RAY_ADDRESS"
 	REDIS_PASSWORD                          = "REDIS_PASSWORD"
@@ -100,6 +99,12 @@ const (
 	RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV  = "RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV"
 	RAYCLUSTER_DEFAULT_REQUEUE_SECONDS      = 300
 	KUBERAY_GEN_RAY_START_CMD               = "KUBERAY_GEN_RAY_START_CMD"
+
+	// Environment variables for RayJob submitter Kubernetes Job.
+	// Example: ray job submit --address=http://$RAY_DASHBOARD_ADDRESS --submission-id=$RAY_JOB_SUBMISSION_ID ...
+	RAY_DASHBOARD_ADDRESS = "RAY_DASHBOARD_ADDRESS"
+	RAY_JOB_SUBMISSION_ID = "RAY_JOB_SUBMISSION_ID"
+
 	// This environment variable is used by Ray Autoscaler V2. For the Autoscaler V2 alpha
 	// release, its value is the Pod name. This may change in the future.
 	RAY_CLOUD_INSTANCE_ID = "RAY_CLOUD_INSTANCE_ID"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Inject RAY_SUBMISSION_ID env variable for the user provided submitter template to avoid double submission. With the submission ID, the second submission will be rejected by Ray, and users will get the following exception:

```
ValueError: Job with submission_id rayjob-sample-fjnb8 already exists. Please use a different submission_id.       
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

<img width="995" alt="Screen Shot 2024-01-25 at 3 22 42 PM" src="https://github.com/ray-project/kuberay/assets/20109646/b2f877d8-da7a-452a-8f98-d69717d627e4">