### PR TITLE
[Test] First failure halt the test run for YAML test

### DIFF
--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -573,6 +573,7 @@ class GeneralTestCase(unittest.TestCase):
         super().__init__(methodName)
         self.cr_event = cr_event
         self.operator_manager = OperatorManager.instance()
+        self.passed = False
 
     @classmethod
     def setUpClass(cls):
@@ -586,10 +587,15 @@ class GeneralTestCase(unittest.TestCase):
     def runtest(self):
         """Run a configuration test"""
         self.cr_event.trigger()
+        self.passed = True
 
     def tearDown(self) -> None:
-        try:
-            self.cr_event.clean_up()
-        except Exception as ex:
-            logger.error(str(ex))
-            K8S_CLUSTER_MANAGER.cleanup()
+        if self.passed:
+            try:
+                self.cr_event.clean_up()
+            except Exception as ex:
+                logger.error(str(ex))
+                K8S_CLUSTER_MANAGER.cleanup()
+        else:
+            namespace = self.cr_event.namespace
+            logger.error("Preserving CR in namespace %s for debugging", namespace)

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -597,5 +597,5 @@ class GeneralTestCase(unittest.TestCase):
                 logger.error(str(ex))
                 K8S_CLUSTER_MANAGER.cleanup()
         else:
-            namespace = self.cr_event.namespace
-            logger.error("Preserving CR in namespace %s for debugging", namespace)
+            logger.info("Preserving CR in namespace %s for debugging", self.cr_event.namespace)
+            logger.info("Need to Cleanup CR manually. Use command `kubectl delete -f <yaml_file_name>.`")

--- a/tests/test_sample_raycluster_yamls.py
+++ b/tests/test_sample_raycluster_yamls.py
@@ -80,7 +80,7 @@ if __name__ == '__main__':
         test_cases.addTest(GeneralTestCase('runtest', addEvent))
 
     # Execute all tests
-    runner = unittest.TextTestRunner()
+    runner = unittest.TextTestRunner(failfast=True)
     test_result = runner.run(test_cases)
 
     # Without this line, the exit code will always be 0.

--- a/tests/test_sample_rayjob_yamls.py
+++ b/tests/test_sample_rayjob_yamls.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
         test_cases.addTest(GeneralTestCase('runtest', addEvent))
 
     # Execute all testsCRs
-    runner = unittest.TextTestRunner()
+    runner = unittest.TextTestRunner(failfast=True)
     test_result = runner.run(test_cases)
 
     # Without this line, the exit code will always be 0.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The purpose of this PR is to enhance developer efficiency. When conducting sample YAML tests, it will immediately halt in case of a test failure, replacing the previous approach of persisting through the entire test.

Without this PR, the tests will run through all specified YAML files (or all relevant YAML files if not specified), even if a failure has occurred during the process.

With this PR, the first failure or error would halt the test run which save the developer time.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
   
To simulate an error occurrence, I Intentionally misconfigured the image in ray-cluster.mini.yaml, expecting the entire testing process to terminate at this point. The subsequent ray-cluster.external-redis.yaml should not undergo testing.

Following are the screenshots:
 
![command](https://github.com/ray-project/kuberay/assets/139951533/a1b74150-dcda-48d7-add3-e959e8fc1f78)
![result](https://github.com/ray-project/kuberay/assets/139951533/8f21fddc-d04c-4ed4-9ef0-f4b7d64f79dd)
![k9s](https://github.com/ray-project/kuberay/assets/139951533/025d195b-b5b2-4161-9f3b-62f2415a386f)


