### PR TITLE
Remove generate target from build/test targets

### DIFF
--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -64,12 +64,12 @@ fumpt: gofumpt
 
 test: WHAT ?= $(shell go list ./... | grep -v /test/)
 test: ENVTEST_K8S_VERSION ?= 1.24.2
-test: manifests generate fmt vet envtest ## Run tests.
+test: manifests fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(WHAT) -coverprofile cover.out
 
 # You can use `go test -timeout 30m -v ./test/e2e/rayjob_test.go ./test/e2e/support.go` if you only want to run tests in `rayjob_test.go`.
 test-e2e: WHAT ?= ./test/e2e
-test-e2e: manifests generate fmt vet ## Run e2e tests.
+test-e2e: manifests fmt vet ## Run e2e tests.
 	go test -timeout 30m -v $(WHAT)
 
 sync: helm api-docs
@@ -77,7 +77,7 @@ sync: helm api-docs
 
 ##@ Build
 
-build: generate fmt vet ## Build manager binary.
+build: fmt vet ## Build manager binary.
 	go build                                    \
     -ldflags                                    \
     "                                           \
@@ -86,7 +86,7 @@ build: generate fmt vet ## Build manager binary.
     "                                           \
     -o bin/manager main.go
 
-# run: manifests generate fmt vet
+# run: manifests fmt vet
 # Running the controller from your host may fail to reconcile resources. For example, when creating a RayService
 # KubeRay sends HTTP requests to the Ray head using ${HEAD_SVC_FQDN}:52365 which is not reachable from outside of a K8s cluster.
 # For detail, see https://docs.ray.io/en/master/cluster/kubernetes/troubleshooting/rayservice-troubleshooting.html#issue-5-fail-to-create-update-serve-applications

--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -45,7 +45,7 @@ help: ## Display this help.
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=kuberay-operator webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
-generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, DeepCopyObject methods and generated client for ApplyConfiguration.
+generate: manifests api-docs controller-gen ## Generate code containing DeepCopy, DeepCopyInto, DeepCopyObject methods and generated client for ApplyConfiguration.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	./hack/update-codegen.sh
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Since adding applyconfiguration for generated clients (https://github.com/ray-project/kuberay/pull/1818), code generation has taken longer (~2 mins). We currently run `generate` for the build / test targets and the additional 2 minutes adds up over time. 

This PR removes the `generate` target from build/test targets, removing the 2 min delay. I was initially hesitant about removing this target because it would make it easier to forget code generation. However, I think this mostly mitigated by the fact that we have [checks to verify generated code](https://github.com/ray-project/kuberay/blob/master/.github/workflows/consistency-check.yaml#L30-L36). 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
