### PR TITLE
Ray pod name is unexpectedly cut off by Kuberay

### DIFF
--- a/ray-operator/controllers/ray/common/rbac_test.go
+++ b/ray-operator/controllers/ray/common/rbac_test.go
@@ -67,7 +67,7 @@ func TestBuildRoleBindingSubjectAndRoleRefName(t *testing.T) {
 				},
 			},
 			want: []string{
-				shortString(t), // 50 chars long, truncated by utils.CheckName
+				shortString(t), // MaxNameLength chars long, truncated by utils.CheckName
 				shortString(t),
 			},
 		},

--- a/ray-operator/controllers/ray/common/test_utils.go
+++ b/ray-operator/controllers/ray/common/test_utils.go
@@ -25,6 +25,6 @@ func longString(t *testing.T) string {
 func shortString(t *testing.T) string {
 	result := utils.CheckName(longString(t))
 	// Confirm length.
-	assert.Equal(t, len(result), 50)
+	assert.Equal(t, len(result), utils.MaxNameLength)
 	return result
 }

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1036,7 +1036,7 @@ func (r *RayClusterReconciler) createWorkerPod(ctx context.Context, instance ray
 // Build head instance pod(s).
 func (r *RayClusterReconciler) buildHeadPod(ctx context.Context, instance rayv1.RayCluster) corev1.Pod {
 	podName := strings.ToLower(instance.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol)
-	podName = utils.CheckName(podName)                                            // making sure the name is valid
+	podName = utils.CheckGenerateName(podName)                               // making sure the name is valid
 	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, instance, instance.Namespace) // Fully Qualified Domain Name
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
@@ -1078,7 +1078,7 @@ func getCreator(instance rayv1.RayCluster) string {
 // Build worker instance pods.
 func (r *RayClusterReconciler) buildWorkerPod(ctx context.Context, instance rayv1.RayCluster, worker rayv1.WorkerGroupSpec) corev1.Pod {
 	podName := strings.ToLower(instance.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol)
-	podName = utils.CheckName(podName)                                            // making sure the name is valid
+	podName = utils.CheckGenerateName(podName)                               // making sure the name is valid
 	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, instance, instance.Namespace) // Fully Qualified Domain Name
 
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1036,7 +1036,7 @@ func (r *RayClusterReconciler) createWorkerPod(ctx context.Context, instance ray
 // Build head instance pod(s).
 func (r *RayClusterReconciler) buildHeadPod(ctx context.Context, instance rayv1.RayCluster) corev1.Pod {
 	podName := strings.ToLower(instance.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol)
-	podName = utils.CheckGenerateName(podName)                               // making sure the name is valid
+	podName = utils.CheckGenerateName(podName)                                    // making sure the name is valid
 	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, instance, instance.Namespace) // Fully Qualified Domain Name
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
@@ -1078,7 +1078,7 @@ func getCreator(instance rayv1.RayCluster) string {
 // Build worker instance pods.
 func (r *RayClusterReconciler) buildWorkerPod(ctx context.Context, instance rayv1.RayCluster, worker rayv1.WorkerGroupSpec) corev1.Pod {
 	podName := strings.ToLower(instance.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol)
-	podName = utils.CheckGenerateName(podName)                               // making sure the name is valid
+	podName = utils.CheckGenerateName(podName)                                    // making sure the name is valid
 	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, instance, instance.Namespace) // Fully Qualified Domain Name
 
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -156,6 +156,13 @@ const (
 
 	// Finalizers for RayJob
 	RayJobStopJobFinalizer = "ray.io/rayjob-finalizer"
+
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/ for naming rules.
+	MaxNameLength  = 63
+	MaxLabelLength = 63
+	// 5 is the length of the random string appended to the name
+	// See https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go
+	MaxGenerateNameLength = MaxNameLength - 5
 )
 
 type ServiceType string

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -94,7 +94,7 @@ func CheckName(s string) string {
 	return CheckNameWithLength(s, MaxNameLength)
 }
 
-// CheckName makes sure the name does not start with a numeric value and the total length is < MaxGenerateNameLength char
+// CheckGenerateName makes sure the name does not start with a numeric value and the total length is < MaxGenerateNameLength char
 func CheckGenerateName(s string) string {
 	return CheckNameWithLength(s, MaxGenerateNameLength)
 }

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha1"
 	"encoding/base32"
 	"fmt"
-	"math"
 	"os"
 	"reflect"
 	"strconv"
@@ -68,13 +67,10 @@ func IsRunningAndReady(pod *corev1.Pod) bool {
 	return false
 }
 
-// CheckName makes sure the name does not start with a numeric value and the total length is < 63 char
-func CheckName(s string) string {
-	maxLength := 50 // 63 - (max(8,6) + 5 ) // 6 to 8 char are consumed at the end with "-head-" or -worker- + 5 generated.
-
+func CheckNameWithLength(s string, maxLength int) string {
 	if len(s) > maxLength {
 		// shorten the name
-		offset := int(math.Abs(float64(maxLength) - float64(len(s))))
+		offset := len(s) - maxLength
 		fmt.Printf("pod name is too long: len = %v, we will shorten it by offset = %v\n", len(s), offset)
 		s = s[offset:]
 	}
@@ -93,13 +89,21 @@ func CheckName(s string) string {
 	return s
 }
 
-// CheckLabel makes sure the label value does not start with a punctuation and the total length is < 63 char
-func CheckLabel(s string) string {
-	maxLenght := 63
+// CheckName makes sure the name does not start with a numeric value and the total length is < MaxNameLength char
+func CheckName(s string) string {
+	return CheckNameWithLength(s, MaxNameLength)
+}
 
-	if len(s) > maxLenght {
+// CheckName makes sure the name does not start with a numeric value and the total length is < MaxGenerateNameLength char
+func CheckGenerateName(s string) string {
+	return CheckNameWithLength(s, MaxGenerateNameLength)
+}
+
+// CheckLabel makes sure the label value does not start with a punctuation and the total length is < MaxLabelLength char
+func CheckLabel(s string) string {
+	if len(s) > MaxLabelLength {
 		// shorten the name
-		offset := int(math.Abs(float64(maxLenght) - float64(len(s))))
+		offset := len(s) - MaxLabelLength
 		fmt.Printf("label value is too long: len = %v, we will shorten it by offset = %v\n", len(s), offset)
 		s = s[offset:]
 	}

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -71,20 +71,20 @@ func TestCheckAllPodsRunning(t *testing.T) {
 func TestCheckName(t *testing.T) {
 	// test 1 -> change
 	str := "72fbcc7e-a661-4b18e-ca41-e903-fc3ae634b18e-lazer090scholar-director-s"
-	str = CheckName(str)
-	if str != "rca41-e903-fc3ae634b18e-lazer090scholar-director-s" {
+	str = CheckNameWithLength(str, MaxNameLength)
+	if str != "re-a661-4b18e-ca41-e903-fc3ae634b18e-lazer090scholar-director-s" {
 		t.Fail()
 	}
 	// test 2 -> change
 	str = "--------566666--------444433-----------222222----------4444"
-	str = CheckName(str)
-	if str != "r6666--------444433-----------222222----------4444" {
+	str = CheckNameWithLength(str, MaxNameLength)
+	if str != "r-------566666--------444433-----------222222----------4444" {
 		t.Fail()
 	}
 
 	// test 3 -> keep
 	str = "acceptable-name-head-12345"
-	str = CheckName(str)
+	str = CheckNameWithLength(str, MaxNameLength)
 	if str != "acceptable-name-head-12345" {
 		t.Fail()
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When running RayService examples under the [sample dir](https://github.com/ray-project/kuberay/tree/master/ray-operator/config/samples), the Ray Pod name may be unexpectedly truncated by KubeRay, although the name meets all naming rules listed in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/). See below for an example:
```shell
# Run a Rayservice sample in under https://github.com/ray-project/kuberay/tree/master/ray-operator/config/samples
kubectl apply -f /home/ubuntu/kuberay/ray-operator/config/samples/ray-service.sample.yaml
kubectl get pod
# NAME                                                      READY   STATUS    RESTARTS   AGE
# ervice-sample-raycluster-bpv6l-worker-small-group-5xnlb   1/1     Running   0          6m16s
# kuberay-operator-5987588ffc-qkhgs                         1/1     Running   0          63m
# rayservice-sample-raycluster-bpv6l-head-22sgg             1/1     Running   0          6m16s
```
According to [the method KubeRay uses to create the Pod name](https://github.com/ray-project/kuberay/blob/v1.0.0/ray-operator/controllers/ray/raycluster_controller.go#L1023), the worker Pod name should be `rayservice-sample-raycluster-bpv6l-worker-small-group-5xnlb`. This name should not be truncated, as its length is 59, which is smaller than the maximum length allowed by Kubernetes (63 characters).


Kubray uses [checkName](https://github.com/ray-project/kuberay/blob/v1.0.0/ray-operator/controllers/ray/utils/util.go#L73) to make sure the name is valid, however, the function and its usage has problem. the [checkName](https://github.com/ray-project/kuberay/blob/v1.0.0/ray-operator/controllers/ray/utils/util.go#L73) assumes it:
1. Only check the generated name as it subtracts 5 from MaxNameLength. The 5 represents the length of random characters generated by Kubernetes. See the [related Kubernetes code](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go#L45) here.
2. Only check the Pod name as there are some naming assumptions for Pod names, but the usage of this function also applies to services, routes, ingresses, and service accounts.



This PR makes the checkName function general enough to check names of all types, and it utilizes the new function CheckGenerateName to verify GenerateName.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

```shell
# Run a Rayservice sample in under https://github.com/ray-project/kuberay/tree/master/ray-operator/config/samples
kubectl apply -f /home/ubuntu/kuberay/ray-operator/config/samples/ray-service.sample.yaml
kubectl get pod
# NAME                                                          READY   STATUS    RESTARTS   AGE
# kuberay-operator-5987588ffc-skw4f                             1/1     Running   0          94s
# rayservice-sample-raycluster-wldcv-head-lcwt5                 1/1     Running   0          81s
# rayservice-sample-raycluster-wldcv-worker-small-group-54q2q   1/1     Running   0          81s
```
