### PR TITLE
RayJob: don't delete submitter job when ShutdownAfterJobFinishes=true

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -29,9 +29,11 @@ import (
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	// +kubebuilder:scaffold:imports
@@ -43,7 +45,8 @@ var myRayJob = &rayv1.RayJob{
 		Namespace: "default",
 	},
 	Spec: rayv1.RayJobSpec{
-		Entrypoint: "sleep 999",
+		Entrypoint:               "sleep 999",
+		ShutdownAfterJobFinishes: true,
 		RayClusterSpec: &rayv1.RayClusterSpec{
 			RayVersion: "1.12.1",
 			HeadGroupSpec: rayv1.HeadGroupSpec{
@@ -288,6 +291,22 @@ var _ = Context("Inside the default namespace", func() {
 				getRayJobDeploymentStatus(ctx, myRayJob),
 				time.Second*15, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusComplete), "jobDeploymentStatus = %v", myRayJob.Status.JobDeploymentStatus)
 			Expect(myRayJob.Status.EndTime.After(now)).Should(BeTrue(), "EndTime = %v, Now = %v", myRayJob.Status.EndTime, now)
+		})
+
+		It("job completed with ShutdownAfterJobFinishes=true, RayCluster should be deleted but not the submitter Job", func() {
+			myRayCluster := &rayv1.RayCluster{}
+			Eventually(
+				func() bool {
+					return apierrors.IsNotFound(getResourceFunc(ctx, client.ObjectKey{Name: myRayJob.Status.RayClusterName, Namespace: "default"}, myRayCluster)())
+				},
+				time.Second*15, time.Millisecond*500).Should(BeTrue(), "My myRayJob  = %v", myRayJob.Name)
+
+			submitterJob := &batchv1.Job{}
+			Eventually(
+				func() error {
+					return getResourceFunc(ctx, client.ObjectKey{Name: myRayJob.Name, Namespace: "default"}, submitterJob)()
+				},
+				time.Second*5, time.Millisecond*500).Should(BeNil(), "Expected Kubernetes job to be present")
 		})
 	})
 })


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When a RayJob is configured with ShutdownAfterJobFinishes=true, Kuberay will immediately delete the associated RayCluster and submitter job once the job completes. Users can tune how long the cluster and submitter job stays around with TTLSecondsAfterFinished. Note that the RayJob resource itself is never deleted automatically, this always needs external action to be removed.

Even without setting `TTLSecondsAfterFinished`, there is very little reason to delete the submitter job. The submitter job usually contains the most useful logs for the job and is not using any cluster resources once completed. In addition, the submitter job will always be cleaned up when the RayJob is eventually deleted due it's owner reference back to the RayJob. This PR proposes to never delete the submitter job once a job completes when ShutdownAfterJobFinishes=true. The only exception is for suspended RayJob where the submitter job needs to be stopped.

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/1832

## Checks

- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
