### PR TITLE
Fixes to shorten generated Route name with consideration for namespace

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -925,7 +925,7 @@ func (r *RayClusterReconciler) createHeadIngress(ctx context.Context, ingress *n
 
 func (r *RayClusterReconciler) createHeadRoute(ctx context.Context, route *routev1.Route, instance *rayv1.RayCluster) error {
 	// making sure the name is valid
-	route.Name = utils.CheckName(route.Name)
+	route.Name = utils.CheckRouteName(route.Name, route.Namespace)
 
 	if err := r.Create(ctx, route); err != nil {
 		if errors.IsAlreadyExists(err) {

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -925,7 +925,7 @@ func (r *RayClusterReconciler) createHeadIngress(ctx context.Context, ingress *n
 
 func (r *RayClusterReconciler) createHeadRoute(ctx context.Context, route *routev1.Route, instance *rayv1.RayCluster) error {
 	// making sure the name is valid
-	route.Name = utils.CheckRouteName(route.Name, route.Namespace)
+	route.Name = utils.CheckRouteName(ctx, route.Name, route.Namespace)
 
 	if err := r.Create(ctx, route); err != nil {
 		if errors.IsAlreadyExists(err) {

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -71,11 +71,12 @@ func IsRunningAndReady(pod *corev1.Pod) bool {
 func CheckRouteName(ctx context.Context, s string, n string) string {
 	log := ctrl.LoggerFrom(ctx)
 
-	// 63 - (6 + 5) - (length of namespace name + 1) => 52 - (length of namespace name + 1)
-	// => 51 - (length of namespace name)
 	// 6 chars are consumed at the end with "-head-" + 5 generated.
 	// Namespace name will be appended to form: {name}-{namespace} for first host
 	//   segment within route
+	// 63 - (6 + 5) - (length of namespace name + 1)
+	// => 52 - (length of namespace name + 1)
+	// => 51 - (length of namespace name)
 	maxLength := 51 - len(n)
 
 	if len(s) > maxLength {

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -96,7 +96,7 @@ func CheckName(s string) string {
 	if len(s) > maxLength {
 		// shorten the name
 		offset := int(math.Abs(float64(maxLength) - float64(len(s))))
-		fmt.Printf("pod name is too long: len = %v, we will shorten it by offset = %v\n", len(s), offset)
+		fmt.Printf("pod name is too long: len = %v, we will shorten it by offset = %v", len(s), offset)
 		s = s[offset:]
 	}
 

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -71,17 +71,17 @@ func IsRunningAndReady(pod *corev1.Pod) bool {
 func CheckRouteName(ctx context.Context, s string, n string) string {
 	log := ctrl.LoggerFrom(ctx)
 
-	// 63 - (max(8,6) + 5 ) - (length of namespace name + 1) => 51 - namespace name
-	// 6 to 8 char are consumed at the end with "-head-" + 5 generated.
+	// 63 - (6 + 5) - (length of namespace name + 1) => 52 - (length of namespace name + 1)
+	// => 51 - (length of namespace name)
+	// 6 chars are consumed at the end with "-head-" + 5 generated.
 	// Namespace name will be appended to form: {name}-{namespace} for first host
 	//   segment within route
 	maxLength := 51 - len(n)
 
 	if len(s) > maxLength {
 		// shorten the name
-		offset := int(math.Abs(float64(maxLength) - float64(len(s))))
-		log.Info(fmt.Sprintf("route name is too long: len = %v, we will shorten it by offset = %v\n", len(s), offset))
-		s = s[offset:]
+		log.Info(fmt.Sprintf("route name is too long: len = %v, we will shorten it to = %v\n", len(s), maxLength))
+		s = s[:maxLength]
 	}
 
 	// Pass through CheckName for remaining string validations

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -69,11 +69,11 @@ func IsRunningAndReady(pod *corev1.Pod) bool {
 }
 
 func CheckRouteName(s string, n string) string {
-	// 63 - (max(8,6) + 5 ) - length of namespace name + 1 => 49 - namespace name
-	// 6 to 8 char are consumed at the end with "-head-" or -worker- + 5 generated.
+	// 63 - (max(8,6) + 5 ) - (length of namespace name + 1) => 51 - namespace name
+	// 6 to 8 char are consumed at the end with "-head-" + 5 generated.
 	// Namespace name will be appended to form: {name}-{namespace} for first host
 	//   segment within route
-	maxLength := 49 - len(n)
+	maxLength := 51 - len(n)
 
 	if len(s) > maxLength {
 		// shorten the name

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -68,7 +68,9 @@ func IsRunningAndReady(pod *corev1.Pod) bool {
 	return false
 }
 
-func CheckRouteName(s string, n string) string {
+func CheckRouteName(ctx context.Context, s string, n string) string {
+	log := ctrl.LoggerFrom(ctx)
+
 	// 63 - (max(8,6) + 5 ) - (length of namespace name + 1) => 51 - namespace name
 	// 6 to 8 char are consumed at the end with "-head-" + 5 generated.
 	// Namespace name will be appended to form: {name}-{namespace} for first host
@@ -78,7 +80,7 @@ func CheckRouteName(s string, n string) string {
 	if len(s) > maxLength {
 		// shorten the name
 		offset := int(math.Abs(float64(maxLength) - float64(len(s))))
-		fmt.Printf("route name is too long: len = %v, we will shorten it by offset = %v\n", len(s), offset)
+		log.Info(fmt.Sprintf("route name is too long: len = %v, we will shorten it by offset = %v\n", len(s), offset))
 		s = s[offset:]
 	}
 

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -68,6 +68,24 @@ func IsRunningAndReady(pod *corev1.Pod) bool {
 	return false
 }
 
+func CheckRouteName(s string, n string) string {
+	// 63 - (max(8,6) + 5 ) - length of namespace name + 1 => 49 - namespace name
+	// 6 to 8 char are consumed at the end with "-head-" or -worker- + 5 generated.
+	// Namespace name will be appended to form: {name}-{namespace} for first host
+	//   segment within route
+	maxLength := 49 - len(n)
+
+	if len(s) > maxLength {
+		// shorten the name
+		offset := int(math.Abs(float64(maxLength) - float64(len(s))))
+		fmt.Printf("route name is too long: len = %v, we will shorten it by offset = %v\n", len(s), offset)
+		s = s[offset:]
+	}
+
+	// Pass through CheckName for remaining string validations
+	return CheckName(s)
+}
+
 // CheckName makes sure the name does not start with a numeric value and the total length is < 63 char
 func CheckName(s string) string {
 	maxLength := 50 // 63 - (max(8,6) + 5 ) // 6 to 8 char are consumed at the end with "-head-" or -worker- + 5 generated.

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -91,25 +91,35 @@ func TestCheckName(t *testing.T) {
 }
 
 func TestCheckRouteName(t *testing.T) {
-	// test 1 -> change
-	str := "cv-traffic-training-202402090958"
-	ns := "development-namespace"
-	str = CheckRouteName(context.Background(), str, ns)
-	if str != "cv-traffic-training-2024020909" {
-		t.Fail()
-	}
-	// test 2 -> change
-	str = "2-step-cv-training-network-revisited"
-	str = CheckRouteName(context.Background(), str, ns)
-	if str != "r-step-cv-training-network-rev" {
-		t.Fail()
-	}
+	tests := []struct {
+		name      string
+		routeName string
+		namespace string
+		want      string
+	}{{
+		name:      "long route name truncated",
+		routeName: "cv-traffic-training-202402090958",
+		namespace: "development-namespace",
+		want:      "cv-traffic-training-2024020909",
+	}, {
+		name:      "long route name w/number start truncated and number replaced",
+		routeName: "2-step-cv-training-network-revisited",
+		namespace: "development-namespace",
+		want:      "r-step-cv-training-network-rev",
+	}, {
+		name:      "well-formatted and well-sized route name unaffected",
+		routeName: "acceptable-name-head-12345",
+		namespace: "development-namespace",
+		want:      "acceptable-name-head-12345",
+	}}
 
-	// test 3 -> keep
-	str = "acceptable-name-head-12345"
-	str = CheckRouteName(context.Background(), str, ns)
-	if str != "acceptable-name-head-12345" {
-		t.Fail()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name := CheckRouteName(context.Background(), tc.routeName, tc.namespace)
+			if name != tc.want {
+				t.Fatalf("got %s, want %s", name, tc.want)
+			}
+		})
 	}
 }
 

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -92,16 +92,16 @@ func TestCheckName(t *testing.T) {
 
 func TestCheckRouteName(t *testing.T) {
 	// test 1 -> change
-	str := "72fbcc7e-a661-4b18e-ca41-e903-fc3ae634b18e-lazer090scholar-director-s"
-	ns := "my-test-namespace"
+	str := "cv-traffic-training-202402090958"
+	ns := "development-namespace"
 	str = CheckRouteName(context.Background(), str, ns)
-	if str != "r2fbcc7e-a661-4b18e-ca41-e903-fc3a" {
+	if str != "cv-traffic-training-2024020909" {
 		t.Fail()
 	}
 	// test 2 -> change
-	str = "--------566666--------444433-----------222222----------4444"
+	str = "2-step-cv-training-network-revisited"
 	str = CheckRouteName(context.Background(), str, ns)
-	if str != "r-------566666--------444433------" {
+	if str != "r-step-cv-training-network-rev" {
 		t.Fail()
 	}
 

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -95,13 +95,13 @@ func TestCheckRouteName(t *testing.T) {
 	str := "72fbcc7e-a661-4b18e-ca41-e903-fc3ae634b18e-lazer090scholar-director-s"
 	ns := "my-test-namespace"
 	str = CheckRouteName(context.Background(), str, ns)
-	if str != "r34b18e-lazer090scholar-director-s" {
+	if str != "r2fbcc7e-a661-4b18e-ca41-e903-fc3a" {
 		t.Fail()
 	}
 	// test 2 -> change
 	str = "--------566666--------444433-----------222222----------4444"
 	str = CheckRouteName(context.Background(), str, ns)
-	if str != "r33-----------222222----------4444" {
+	if str != "r-------566666--------444433------" {
 		t.Fail()
 	}
 

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -90,6 +90,29 @@ func TestCheckName(t *testing.T) {
 	}
 }
 
+func TestCheckRouteName(t *testing.T) {
+	// test 1 -> change
+	str := "72fbcc7e-a661-4b18e-ca41-e903-fc3ae634b18e-lazer090scholar-director-s"
+	ns := "my-test-namespace"
+	str = CheckRouteName(str, ns)
+	if str != "rb18e-lazer090scholar-director-s" {
+		t.Fail()
+	}
+	// test 2 -> change
+	str = "--------566666--------444433-----------222222----------4444"
+	str = CheckRouteName(str, ns)
+	if str != "r-----------222222----------4444" {
+		t.Fail()
+	}
+
+	// test 3 -> keep
+	str = "acceptable-name-head-12345"
+	str = CheckRouteName(str, ns)
+	if str != "acceptable-name-head-12345" {
+		t.Fail()
+	}
+}
+
 func createSomePod() (pod *corev1.Pod) {
 	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -94,20 +94,20 @@ func TestCheckRouteName(t *testing.T) {
 	// test 1 -> change
 	str := "72fbcc7e-a661-4b18e-ca41-e903-fc3ae634b18e-lazer090scholar-director-s"
 	ns := "my-test-namespace"
-	str = CheckRouteName(str, ns)
-	if str != "rb18e-lazer090scholar-director-s" {
+	str = CheckRouteName(context.Background(), str, ns)
+	if str != "r34b18e-lazer090scholar-director-s" {
 		t.Fail()
 	}
 	// test 2 -> change
 	str = "--------566666--------444433-----------222222----------4444"
-	str = CheckRouteName(str, ns)
-	if str != "r-----------222222----------4444" {
+	str = CheckRouteName(context.Background(), str, ns)
+	if str != "r33-----------222222----------4444" {
 		t.Fail()
 	}
 
 	// test 3 -> keep
 	str = "acceptable-name-head-12345"
-	str = CheckRouteName(str, ns)
+	str = CheckRouteName(context.Background(), str, ns)
 	if str != "acceptable-name-head-12345" {
 		t.Fail()
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

OpenShift Routes `spec.host` values are a concatenation of Route `metadata.name` and `metadata.namespace`, which can expand beyond 63 characters without care, causing a failure to create the Route.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #1882

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
