### PR TITLE
Add a sample RayJob to fine-tune a PyTorch lightning text classifier with Ray Data

### DIFF
--- a/ray-operator/config/samples/pytorch-text-classifier/fine-tune-pytorch-text-classifier.py
+++ b/ray-operator/config/samples/pytorch-text-classifier/fine-tune-pytorch-text-classifier.py
@@ -1,0 +1,153 @@
+import ray
+import torch
+import numpy as np
+import pytorch_lightning as pl
+import torch.nn.functional as F
+import ray.train
+from torch.utils.data import DataLoader, random_split
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+from datasets import load_dataset, load_metric
+from ray.train.lightning import (
+    prepare_trainer,
+    RayDDPStrategy,
+    RayLightningEnvironment,
+    RayTrainReportCallback,
+)
+from ray.train.torch import TorchTrainer
+from ray.train import RunConfig, ScalingConfig, CheckpointConfig, DataConfig
+
+class SentimentModel(pl.LightningModule):
+    def __init__(self, lr=2e-5, eps=1e-8):
+        super().__init__()
+        self.lr = lr
+        self.eps = eps
+        self.num_classes = 2
+        self.model = AutoModelForSequenceClassification.from_pretrained(
+            "bert-base-cased", num_labels=self.num_classes
+        )
+        self.metric = load_metric("glue", "cola")
+        self.predictions = []
+        self.references = []
+
+    def forward(self, batch):
+        input_ids, attention_mask = batch["input_ids"], batch["attention_mask"]
+        outputs = self.model(input_ids, attention_mask=attention_mask)
+        logits = outputs.logits
+        return logits
+
+    def training_step(self, batch, batch_idx):
+        labels = batch["label"]
+        logits = self.forward(batch)
+        loss = F.cross_entropy(logits.view(-1, self.num_classes), labels)
+        self.log("train_loss", loss)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        labels = batch["label"]
+        logits = self.forward(batch)
+        preds = torch.argmax(logits, dim=1)
+        self.predictions.append(preds)
+        self.references.append(labels)
+
+    def on_validation_epoch_end(self):
+        predictions = torch.concat(self.predictions).view(-1)
+        references = torch.concat(self.references).view(-1)
+        matthews_correlation = self.metric.compute(
+            predictions=predictions, references=references
+        )
+
+        # self.metric.compute() returns a dictionary:
+        # e.g. {"matthews_correlation": 0.53}
+        self.log_dict(matthews_correlation, sync_dist=True)
+        self.predictions.clear()
+        self.references.clear()
+
+    def configure_optimizers(self):
+        return torch.optim.AdamW(self.parameters(), lr=self.lr, eps=self.eps)
+
+def tokenize_sentence(batch):
+    outputs = tokenizer(
+        batch["sentence"].tolist(),
+        max_length=128,
+        truncation=True,
+        padding="max_length",
+        return_tensors="np",
+    )
+    outputs["label"] = batch["label"]
+    return outputs
+
+train_func_config = {
+    "lr": 1e-5,
+    "eps": 1e-8,
+    "batch_size": 16,
+    "max_epochs": 5,
+}
+
+def train_func(config):
+    # Unpack the input configs passed from `TorchTrainer(train_loop_config)`
+    lr = config["lr"]
+    eps = config["eps"]
+    batch_size = config["batch_size"]
+    max_epochs = config["max_epochs"]
+
+    # Fetch the Dataset shards
+    train_ds = ray.train.get_dataset_shard("train")
+    val_ds = ray.train.get_dataset_shard("validation")
+
+    # Create a dataloader for Ray Datasets
+    train_ds_loader = train_ds.iter_torch_batches(batch_size=batch_size)
+    val_ds_loader = val_ds.iter_torch_batches(batch_size=batch_size)
+
+    # Model
+    model = SentimentModel(lr=lr, eps=eps)
+
+    trainer = pl.Trainer(
+        max_epochs=max_epochs,
+        accelerator="auto",
+        devices="auto",
+        strategy=RayDDPStrategy(),
+        plugins=[RayLightningEnvironment()],
+        callbacks=[RayTrainReportCallback()],
+        enable_progress_bar=False,
+    )
+
+    trainer = prepare_trainer(trainer)
+
+    trainer.fit(model, train_dataloaders=train_ds_loader, val_dataloaders=val_ds_loader)
+
+
+if __name__ == "__main__":
+    dataset = load_dataset("glue", "cola")
+
+    train_dataset = ray.data.from_huggingface(dataset["train"])
+    validation_dataset = ray.data.from_huggingface(dataset["validation"])
+
+    tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
+
+    train_dataset = train_dataset.map_batches(tokenize_sentence, batch_format="numpy")
+    validation_dataset = validation_dataset.map_batches(tokenize_sentence, batch_format="numpy")
+
+    # Save the top-2 checkpoints according to the evaluation metric
+    # The checkpoints and metrics are reported by `RayTrainReportCallback`
+    run_config = RunConfig(
+        name="ptl-sent-classification",
+        checkpoint_config=CheckpointConfig(
+            num_to_keep=2,
+            checkpoint_score_attribute="matthews_correlation",
+            checkpoint_score_order="max",
+        ),
+    )
+
+    # Schedule 2 workers for DDP training (1 GPU/worker by default)
+    scaling_config = ScalingConfig(num_workers=1, use_gpu=True)
+
+    trainer = TorchTrainer(
+        train_loop_per_worker=train_func,
+        train_loop_config=train_func_config,
+        scaling_config=scaling_config, 
+        run_config=run_config,
+        datasets={"train": train_dataset, "validation": validation_dataset}, # <- Feed the Ray Datasets here
+    )
+
+    result = trainer.fit()
+    print(result)

--- a/ray-operator/config/samples/pytorch-text-classifier/ray-job-v1alpha1.pytorch-distributed-training.yaml
+++ b/ray-operator/config/samples/pytorch-text-classifier/ray-job-v1alpha1.pytorch-distributed-training.yaml
@@ -1,0 +1,41 @@
+# This RayJob is based on the "Fine-tune a PyTorch Lightning Text Classifier with Ray Data" example in the Ray documentation.
+# See https://docs.ray.io/en/master/train/examples/lightning/lightning_cola_advanced.html for more details.
+apiVersion: ray.io/v1alpha1
+kind: RayJob
+metadata:
+  generateName: pytorch-text-classifier-
+spec:
+  shutdownAfterJobFinishes: true
+  entrypoint: python ray-operator/config/samples/pytorch-text-classifier/fine-tune-pytorch-text-classifier.py
+  runtimeEnv: eyJwaXAiOlsibnVtcHkiLCAiZGF0YXNldHMiLCAidHJhbnNmb3JtZXJzPj00LjE5LjEiLCAicHl0b3JjaC1saWdodG5pbmc9PTEuNi41Il0sICJ3b3JraW5nX2RpciI6Imh0dHBzOi8vZ2l0aHViLmNvbS9yYXktcHJvamVjdC9rdWJlcmF5L2FyY2hpdmUvbWFzdGVyLnppcCJ9Cg==
+  rayClusterSpec:
+    rayVersion: '2.9.0'
+    headGroupSpec:
+      rayStartParams:
+        dashboard-host: '0.0.0.0'
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: rayproject/ray-ml:2.9.0-gpu
+              ports:
+                - containerPort: 6379
+                  name: gcs-server
+                - containerPort: 8265
+                  name: dashboard
+                - containerPort: 10001
+                  name: client
+              resources:
+                limits:
+                  memory: "8G"
+                  nvidia.com/gpu: "1"
+                requests:
+                  cpu: "2"
+                  memory: "8G"
+                  nvidia.com/gpu: "1"
+              volumeMounts:
+                - mountPath: /tmp/ray
+                  name: ray-logs
+          volumes:
+            - name: ray-logs
+              emptyDir: {}

--- a/ray-operator/config/samples/pytorch-text-classifier/ray-job.pytorch-distributed-training.yaml
+++ b/ray-operator/config/samples/pytorch-text-classifier/ray-job.pytorch-distributed-training.yaml
@@ -1,0 +1,47 @@
+# This RayJob is based on the "Fine-tune a PyTorch Lightning Text Classifier with Ray Data" example in the Ray documentation.
+# See https://docs.ray.io/en/master/train/examples/lightning/lightning_cola_advanced.html for more details.
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  generateName: pytorch-text-classifier-
+spec:
+  shutdownAfterJobFinishes: true
+  entrypoint: python ray-operator/config/samples/pytorch-text-classifier/fine-tune-pytorch-text-classifier.py
+  runtimeEnvYAML: |
+    pip:
+      - numpy
+      - datasets
+      - transformers>=4.19.1
+      - pytorch-lightning==1.6.5
+    working_dir: "https://github.com/ray-project/kuberay/archive/master.zip"
+  rayClusterSpec:
+    rayVersion: '2.9.0'
+    headGroupSpec:
+      rayStartParams:
+        dashboard-host: '0.0.0.0'
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: rayproject/ray-ml:2.9.0-gpu
+              ports:
+                - containerPort: 6379
+                  name: gcs-server
+                - containerPort: 8265
+                  name: dashboard
+                - containerPort: 10001
+                  name: client
+              resources:
+                limits:
+                  memory: "8G"
+                  nvidia.com/gpu: "1"
+                requests:
+                  cpu: "2"
+                  memory: "8G"
+                  nvidia.com/gpu: "1"
+              volumeMounts:
+                - mountPath: /tmp/ray
+                  name: ray-logs
+          volumes:
+            - name: ray-logs
+              emptyDir: {}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add a sample RayJob that packages [Fine-tune a PyTorch Lightning Text Classifier with Ray Data](https://docs.ray.io/en/master/train/examples/lightning/lightning_cola_advanced.html) into a single RayJob. 

I plan to use this sample for future documentation with Kueue, but this change could be a good sample on it's own as well.

## Related issue number

Part of https://github.com/ray-project/kuberay/issues/1890

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
