### PR TITLE
[Feature][RayJob] Support light-weight job submission

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -142,7 +142,7 @@ _Appears in:_
 | `ttlSecondsAfterFinished` _integer_ | TTLSecondsAfterFinished is the TTL to clean up RayCluster. It's only working when ShutdownAfterJobFinishes set to true. |
 | `rayClusterSpec` _[RayClusterSpec](#rayclusterspec)_ | RayClusterSpec is the cluster template to run the job |
 | `clusterSelector` _object (keys:string, values:string)_ | clusterSelector is used to select running rayclusters by labels |
-| `submissionMode` _[JobSubmissionMode](#jobsubmissionmode)_ | If LightWeightSubmissionMode is true, KubeRay operator sends a request to the RayCluster to create a Ray job. Otherwise, the operator creates a submitter Kubernetes Job to submit the Ray job. |
+| `submissionMode` _[JobSubmissionMode](#jobsubmissionmode)_ | SubmissionMode specifies how RayJob submits the Ray job to the RayCluster. In "K8sJobMode", the KubeRay operator creates a submitter Kubernetes Job to submit the Ray job. In "HTTPMode", the KubeRay operator sends a request to the RayCluster to create a Ray job. |
 | `suspend` _boolean_ | suspend specifies whether the RayJob controller should create a RayCluster instance If a job is applied with the suspend field set to true, the RayCluster will not be created and will wait for the transition to false. If the RayCluster is already created, it will be deleted. In case of transition to false a new RayCluster will be created. |
 | `submitterPodTemplate` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | SubmitterPodTemplate is the template for the pod that will run `ray job submit`. |
 | `entrypointNumCpus` _float_ | EntrypointNumCpus specifies the number of cpus to reserve for the entrypoint command. |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -58,6 +58,17 @@ _Appears in:_
 | `template` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | Template is the exact pod template used in K8s depoyments, statefulsets, etc. |
 
 
+#### JobSubmissionMode
+
+_Underlying type:_ _string_
+
+
+
+_Appears in:_
+- [RayJobSpec](#rayjobspec)
+
+
+
 #### RayCluster
 
 
@@ -131,7 +142,7 @@ _Appears in:_
 | `ttlSecondsAfterFinished` _integer_ | TTLSecondsAfterFinished is the TTL to clean up RayCluster. It's only working when ShutdownAfterJobFinishes set to true. |
 | `rayClusterSpec` _[RayClusterSpec](#rayclusterspec)_ | RayClusterSpec is the cluster template to run the job |
 | `clusterSelector` _object (keys:string, values:string)_ | clusterSelector is used to select running rayclusters by labels |
-| `lightWeightSubmissionMode` _boolean_ | If LightWeightSubmissionMode is true, KubeRay operator sends a request to the RayCluster to create a Ray job. Otherwise, the operator creates a submitter Kubernetes Job to submit the Ray job. |
+| `submissionMode` _[JobSubmissionMode](#jobsubmissionmode)_ | If LightWeightSubmissionMode is true, KubeRay operator sends a request to the RayCluster to create a Ray job. Otherwise, the operator creates a submitter Kubernetes Job to submit the Ray job. |
 | `suspend` _boolean_ | suspend specifies whether the RayJob controller should create a RayCluster instance If a job is applied with the suspend field set to true, the RayCluster will not be created and will wait for the transition to false. If the RayCluster is already created, it will be deleted. In case of transition to false a new RayCluster will be created. |
 | `submitterPodTemplate` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | SubmitterPodTemplate is the template for the pod that will run `ray job submit`. |
 | `entrypointNumCpus` _float_ | EntrypointNumCpus specifies the number of cpus to reserve for the entrypoint command. |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -131,6 +131,7 @@ _Appears in:_
 | `ttlSecondsAfterFinished` _integer_ | TTLSecondsAfterFinished is the TTL to clean up RayCluster. It's only working when ShutdownAfterJobFinishes set to true. |
 | `rayClusterSpec` _[RayClusterSpec](#rayclusterspec)_ | RayClusterSpec is the cluster template to run the job |
 | `clusterSelector` _object (keys:string, values:string)_ | clusterSelector is used to select running rayclusters by labels |
+| `lightWeightSubmissionMode` _boolean_ | If LightWeightSubmissionMode is true, KubeRay operator sends a request to the RayCluster to create a Ray job. Otherwise, the operator creates a submitter Kubernetes Job to submit the Ray job. |
 | `suspend` _boolean_ | suspend specifies whether the RayJob controller should create a RayCluster instance If a job is applied with the suspend field set to true, the RayCluster will not be created and will wait for the transition to false. If the RayCluster is already created, it will be deleted. In case of transition to false a new RayCluster will be created. |
 | `submitterPodTemplate` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | SubmitterPodTemplate is the template for the pod that will run `ray job submit`. |
 | `entrypointNumCpus` _float_ | EntrypointNumCpus specifies the number of cpus to reserve for the entrypoint command. |

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -42,9 +42,6 @@ spec:
                 type: string
               jobId:
                 type: string
-              lightWeightSubmissionMode:
-                default: false
-                type: boolean
               metadata:
                 additionalProperties:
                   type: string
@@ -7053,6 +7050,9 @@ spec:
                 type: string
               shutdownAfterJobFinishes:
                 type: boolean
+              submissionMode:
+                default: K8sJobMode
+                type: string
               submitterPodTemplate:
                 properties:
                   metadata:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -42,6 +42,9 @@ spec:
                 type: string
               jobId:
                 type: string
+              lightWeightSubmissionMode:
+                default: false
+                type: boolean
               metadata:
                 additionalProperties:
                   type: string

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -64,6 +64,10 @@ type RayJobSpec struct {
 	RayClusterSpec *RayClusterSpec `json:"rayClusterSpec,omitempty"`
 	// clusterSelector is used to select running rayclusters by labels
 	ClusterSelector map[string]string `json:"clusterSelector,omitempty"`
+	// If LightWeightSubmissionMode is true, KubeRay operator sends a request to the RayCluster to create a
+	// Ray job. Otherwise, the operator creates a submitter Kubernetes Job to submit the Ray job.
+	// +kubebuilder:default:=false
+	LightWeightSubmissionMode bool `json:"lightWeightSubmissionMode,omitempty"`
 	// suspend specifies whether the RayJob controller should create a RayCluster instance
 	// If a job is applied with the suspend field set to true,
 	// the RayCluster will not be created and will wait for the transition to false.

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -71,8 +71,9 @@ type RayJobSpec struct {
 	RayClusterSpec *RayClusterSpec `json:"rayClusterSpec,omitempty"`
 	// clusterSelector is used to select running rayclusters by labels
 	ClusterSelector map[string]string `json:"clusterSelector,omitempty"`
-	// If LightWeightSubmissionMode is true, KubeRay operator sends a request to the RayCluster to create a
-	// Ray job. Otherwise, the operator creates a submitter Kubernetes Job to submit the Ray job.
+	// SubmissionMode specifies how RayJob submits the Ray job to the RayCluster.
+	// In "K8sJobMode", the KubeRay operator creates a submitter Kubernetes Job to submit the Ray job.
+	// In "HTTPMode", the KubeRay operator sends a request to the RayCluster to create a Ray job.
 	// +kubebuilder:default:=K8sJobMode
 	SubmissionMode JobSubmissionMode `json:"submissionMode,omitempty"`
 	// suspend specifies whether the RayJob controller should create a RayCluster instance

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -42,6 +42,13 @@ const (
 	JobDeploymentStatusSuspended    JobDeploymentStatus = "Suspended"
 )
 
+type JobSubmissionMode string
+
+const (
+	K8sJobMode JobSubmissionMode = "K8sJobMode" // Submit job via Kubernetes Job
+	HTTPMode   JobSubmissionMode = "HTTPMode"   // Submit job via HTTP request
+)
+
 // RayJobSpec defines the desired state of RayJob
 type RayJobSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
@@ -66,8 +73,8 @@ type RayJobSpec struct {
 	ClusterSelector map[string]string `json:"clusterSelector,omitempty"`
 	// If LightWeightSubmissionMode is true, KubeRay operator sends a request to the RayCluster to create a
 	// Ray job. Otherwise, the operator creates a submitter Kubernetes Job to submit the Ray job.
-	// +kubebuilder:default:=false
-	LightWeightSubmissionMode bool `json:"lightWeightSubmissionMode,omitempty"`
+	// +kubebuilder:default:=K8sJobMode
+	SubmissionMode JobSubmissionMode `json:"submissionMode,omitempty"`
 	// suspend specifies whether the RayJob controller should create a RayCluster instance
 	// If a job is applied with the suspend field set to true,
 	// the RayCluster will not be created and will wait for the transition to false.

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -42,9 +42,6 @@ spec:
                 type: string
               jobId:
                 type: string
-              lightWeightSubmissionMode:
-                default: false
-                type: boolean
               metadata:
                 additionalProperties:
                   type: string
@@ -7053,6 +7050,9 @@ spec:
                 type: string
               shutdownAfterJobFinishes:
                 type: boolean
+              submissionMode:
+                default: K8sJobMode
+                type: string
               submitterPodTemplate:
                 properties:
                   metadata:

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -42,6 +42,9 @@ spec:
                 type: string
               jobId:
                 type: string
+              lightWeightSubmissionMode:
+                default: false
+                type: boolean
               metadata:
                 additionalProperties:
                   type: string

--- a/ray-operator/config/samples/ray-job.sample.yaml
+++ b/ray-operator/config/samples/ray-job.sample.yaml
@@ -3,6 +3,10 @@ kind: RayJob
 metadata:
   name: rayjob-sample
 spec:
+  # submissionMode specifies how RayJob submits the Ray job to the RayCluster.
+  # The default value is "K8sJobMode", meaning RayJob will submit the Ray job via a submitter Kubernetes Job.
+  # The alternative value is "HTTPMode", indicating that KubeRay will submit the Ray job by sending an HTTP request to the RayCluster.
+  # submissionMode: "K8sJobMode"
   entrypoint: python /home/ray/samples/sample_code.py
   # shutdownAfterJobFinishes specifies whether the RayCluster should be deleted after the RayJob finishes. Default is false.
   # shutdownAfterJobFinishes: false

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -202,6 +202,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		rayDashboardClient.InitClient(rayJobInstance.Status.DashboardURL)
 		jobInfo, err := rayDashboardClient.GetJobInfo(ctx, rayJobInstance.Status.JobId)
 		if err != nil {
+			// If the Ray job was not found, GetJobInfo returns a BadRequest error.
 			if rayJobInstance.Spec.LightWeightSubmissionMode && errors.IsBadRequest(err) {
 				r.Log.Info("The Ray job was not found. Submit a Ray job via an HTTP request.", "JobId", rayJobInstance.Status.JobId)
 				if _, err := rayDashboardClient.SubmitJob(ctx, rayJobInstance, &r.Log); err != nil {

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -223,6 +223,7 @@ type RayJobLogsResponse struct {
 }
 
 // Note that RayJobInfo and error can't be nil at the same time.
+// Please make sure if the Ray job with JobId can't be found. Return a BadRequest error.
 func (r *RayDashboardClient) GetJobInfo(ctx context.Context, jobId string) (*RayJobInfo, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", r.dashboardURL+JobPath+jobId, nil)
 	if err != nil {

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -182,8 +182,9 @@ func (r *RayDashboardClient) ConvertServeDetailsToApplicationStatuses(serveDetai
 }
 
 // RayJobInfo is the response of "ray job status" api.
-// Reference to https://docs.ray.io/en/latest/cluster/jobs-package-ref.html#jobinfo.
+// Reference to https://docs.ray.io/en/latest/cluster/running-applications/job-submission/rest.html#ray-job-rest-api-spec
 type RayJobInfo struct {
+	// TODO (kevin85421): Double check whether the types are correct or not.
 	JobStatus    rayv1.JobStatus        `json:"status,omitempty"`
 	Entrypoint   string                 `json:"entrypoint,omitempty"`
 	JobId        string                 `json:"job_id,omitempty"`
@@ -197,8 +198,9 @@ type RayJobInfo struct {
 }
 
 // RayJobRequest is the request body to submit.
-// Reference to https://docs.ray.io/en/latest/cluster/jobs-package-ref.html#jobsubmissionclient.
+// Reference to https://docs.ray.io/en/latest/cluster/running-applications/job-submission/rest.html#ray-job-rest-api-spec
 type RayJobRequest struct {
+	// TODO (kevin85421): Double check whether the types are correct or not.
 	Entrypoint   string                 `json:"entrypoint"`
 	SubmissionId string                 `json:"submission_id,omitempty"`
 	RuntimeEnv   map[string]interface{} `json:"runtime_env,omitempty"`

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -205,7 +205,7 @@ type RayJobRequest struct {
 	Metadata     map[string]string      `json:"metadata,omitempty"`
 	NumCpus      float32                `json:"entrypoint_num_cpus,omitempty"`
 	NumGpus      float32                `json:"entrypoint_num_gpus,omitempty"`
-	Resources    map[string]interface{} `json:"entrypoint_resources,omitempty"`
+	Resources    map[string]string      `json:"entrypoint_resources,omitempty"`
 }
 
 type RayJobResponse struct {

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobspec.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobspec.go
@@ -3,26 +3,27 @@
 package v1
 
 import (
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
 // RayJobSpecApplyConfiguration represents an declarative configuration of the RayJobSpec type for use
 // with apply.
 type RayJobSpecApplyConfiguration struct {
-	Entrypoint                *string                                   `json:"entrypoint,omitempty"`
-	Metadata                  map[string]string                         `json:"metadata,omitempty"`
-	RuntimeEnvYAML            *string                                   `json:"runtimeEnvYAML,omitempty"`
-	JobId                     *string                                   `json:"jobId,omitempty"`
-	ShutdownAfterJobFinishes  *bool                                     `json:"shutdownAfterJobFinishes,omitempty"`
-	TTLSecondsAfterFinished   *int32                                    `json:"ttlSecondsAfterFinished,omitempty"`
-	RayClusterSpec            *RayClusterSpecApplyConfiguration         `json:"rayClusterSpec,omitempty"`
-	ClusterSelector           map[string]string                         `json:"clusterSelector,omitempty"`
-	LightWeightSubmissionMode *bool                                     `json:"lightWeightSubmissionMode,omitempty"`
-	Suspend                   *bool                                     `json:"suspend,omitempty"`
-	SubmitterPodTemplate      *corev1.PodTemplateSpecApplyConfiguration `json:"submitterPodTemplate,omitempty"`
-	EntrypointNumCpus         *float32                                  `json:"entrypointNumCpus,omitempty"`
-	EntrypointNumGpus         *float32                                  `json:"entrypointNumGpus,omitempty"`
-	EntrypointResources       *string                                   `json:"entrypointResources,omitempty"`
+	Entrypoint               *string                                   `json:"entrypoint,omitempty"`
+	Metadata                 map[string]string                         `json:"metadata,omitempty"`
+	RuntimeEnvYAML           *string                                   `json:"runtimeEnvYAML,omitempty"`
+	JobId                    *string                                   `json:"jobId,omitempty"`
+	ShutdownAfterJobFinishes *bool                                     `json:"shutdownAfterJobFinishes,omitempty"`
+	TTLSecondsAfterFinished  *int32                                    `json:"ttlSecondsAfterFinished,omitempty"`
+	RayClusterSpec           *RayClusterSpecApplyConfiguration         `json:"rayClusterSpec,omitempty"`
+	ClusterSelector          map[string]string                         `json:"clusterSelector,omitempty"`
+	SubmissionMode           *rayv1.JobSubmissionMode                  `json:"submissionMode,omitempty"`
+	Suspend                  *bool                                     `json:"suspend,omitempty"`
+	SubmitterPodTemplate     *corev1.PodTemplateSpecApplyConfiguration `json:"submitterPodTemplate,omitempty"`
+	EntrypointNumCpus        *float32                                  `json:"entrypointNumCpus,omitempty"`
+	EntrypointNumGpus        *float32                                  `json:"entrypointNumGpus,omitempty"`
+	EntrypointResources      *string                                   `json:"entrypointResources,omitempty"`
 }
 
 // RayJobSpecApplyConfiguration constructs an declarative configuration of the RayJobSpec type for use with
@@ -107,11 +108,11 @@ func (b *RayJobSpecApplyConfiguration) WithClusterSelector(entries map[string]st
 	return b
 }
 
-// WithLightWeightSubmissionMode sets the LightWeightSubmissionMode field in the declarative configuration to the given value
+// WithSubmissionMode sets the SubmissionMode field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the LightWeightSubmissionMode field is set to the value of the last call.
-func (b *RayJobSpecApplyConfiguration) WithLightWeightSubmissionMode(value bool) *RayJobSpecApplyConfiguration {
-	b.LightWeightSubmissionMode = &value
+// If called multiple times, the SubmissionMode field is set to the value of the last call.
+func (b *RayJobSpecApplyConfiguration) WithSubmissionMode(value rayv1.JobSubmissionMode) *RayJobSpecApplyConfiguration {
+	b.SubmissionMode = &value
 	return b
 }
 

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobspec.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobspec.go
@@ -9,19 +9,20 @@ import (
 // RayJobSpecApplyConfiguration represents an declarative configuration of the RayJobSpec type for use
 // with apply.
 type RayJobSpecApplyConfiguration struct {
-	Entrypoint               *string                                   `json:"entrypoint,omitempty"`
-	Metadata                 map[string]string                         `json:"metadata,omitempty"`
-	RuntimeEnvYAML           *string                                   `json:"runtimeEnvYAML,omitempty"`
-	JobId                    *string                                   `json:"jobId,omitempty"`
-	ShutdownAfterJobFinishes *bool                                     `json:"shutdownAfterJobFinishes,omitempty"`
-	TTLSecondsAfterFinished  *int32                                    `json:"ttlSecondsAfterFinished,omitempty"`
-	RayClusterSpec           *RayClusterSpecApplyConfiguration         `json:"rayClusterSpec,omitempty"`
-	ClusterSelector          map[string]string                         `json:"clusterSelector,omitempty"`
-	Suspend                  *bool                                     `json:"suspend,omitempty"`
-	SubmitterPodTemplate     *corev1.PodTemplateSpecApplyConfiguration `json:"submitterPodTemplate,omitempty"`
-	EntrypointNumCpus        *float32                                  `json:"entrypointNumCpus,omitempty"`
-	EntrypointNumGpus        *float32                                  `json:"entrypointNumGpus,omitempty"`
-	EntrypointResources      *string                                   `json:"entrypointResources,omitempty"`
+	Entrypoint                *string                                   `json:"entrypoint,omitempty"`
+	Metadata                  map[string]string                         `json:"metadata,omitempty"`
+	RuntimeEnvYAML            *string                                   `json:"runtimeEnvYAML,omitempty"`
+	JobId                     *string                                   `json:"jobId,omitempty"`
+	ShutdownAfterJobFinishes  *bool                                     `json:"shutdownAfterJobFinishes,omitempty"`
+	TTLSecondsAfterFinished   *int32                                    `json:"ttlSecondsAfterFinished,omitempty"`
+	RayClusterSpec            *RayClusterSpecApplyConfiguration         `json:"rayClusterSpec,omitempty"`
+	ClusterSelector           map[string]string                         `json:"clusterSelector,omitempty"`
+	LightWeightSubmissionMode *bool                                     `json:"lightWeightSubmissionMode,omitempty"`
+	Suspend                   *bool                                     `json:"suspend,omitempty"`
+	SubmitterPodTemplate      *corev1.PodTemplateSpecApplyConfiguration `json:"submitterPodTemplate,omitempty"`
+	EntrypointNumCpus         *float32                                  `json:"entrypointNumCpus,omitempty"`
+	EntrypointNumGpus         *float32                                  `json:"entrypointNumGpus,omitempty"`
+	EntrypointResources       *string                                   `json:"entrypointResources,omitempty"`
 }
 
 // RayJobSpecApplyConfiguration constructs an declarative configuration of the RayJobSpec type for use with
@@ -103,6 +104,14 @@ func (b *RayJobSpecApplyConfiguration) WithClusterSelector(entries map[string]st
 	for k, v := range entries {
 		b.ClusterSelector[k] = v
 	}
+	return b
+}
+
+// WithLightWeightSubmissionMode sets the LightWeightSubmissionMode field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the LightWeightSubmissionMode field is set to the value of the last call.
+func (b *RayJobSpecApplyConfiguration) WithLightWeightSubmissionMode(value bool) *RayJobSpecApplyConfiguration {
+	b.LightWeightSubmissionMode = &value
 	return b
 }
 

--- a/ray-operator/test/e2e/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2e/rayjob_lightweight_test.go
@@ -30,7 +30,7 @@ func TestRayJobLightWeightMode(t *testing.T) {
 	test.T().Run("Successful RayJob", func(t *testing.T) {
 		rayJobAC := rayv1ac.RayJob("counter", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
-				WithLightWeightSubmissionMode(true).
+				WithSubmissionMode(rayv1.HTTPMode).
 				WithEntrypoint("python /home/ray/jobs/counter.py").
 				WithRuntimeEnvYAML(`
 env_vars:
@@ -74,7 +74,7 @@ env_vars:
 	test.T().Run("Failing RayJob without cluster shutdown after finished", func(t *testing.T) {
 		rayJobAC := rayv1ac.RayJob("fail", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
-				WithLightWeightSubmissionMode(true).
+				WithSubmissionMode(rayv1.HTTPMode).
 				WithEntrypoint("python /home/ray/jobs/fail.py").
 				WithShutdownAfterJobFinishes(false).
 				WithRayClusterSpec(rayv1ac.RayClusterSpec().
@@ -110,7 +110,7 @@ env_vars:
 		// and then stop the Ray job. If the Ray job is stopped, the RayJob should transition to `Complete`.
 		rayJobAC := rayv1ac.RayJob("stop", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
-				WithLightWeightSubmissionMode(true).
+				WithSubmissionMode(rayv1.HTTPMode).
 				WithEntrypoint("python /home/ray/jobs/stop.py").
 				WithRayClusterSpec(rayv1ac.RayClusterSpec().
 					WithRayVersion(GetRayVersion()).

--- a/ray-operator/test/e2e/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2e/rayjob_lightweight_test.go
@@ -1,0 +1,145 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
+	. "github.com/ray-project/kuberay/ray-operator/test/support"
+)
+
+func TestRayJobLightWeightMode(t *testing.T) {
+	test := With(t)
+
+	// Create a namespace
+	namespace := test.NewTestNamespace()
+	test.StreamKubeRayOperatorLogs()
+
+	// Job scripts
+	jobs := newConfigMap(namespace.Name, "jobs", files(test, "counter.py", "fail.py", "stop.py"))
+	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Create(test.Ctx(), jobs, metav1.CreateOptions{})
+	test.Expect(err).NotTo(HaveOccurred())
+	test.T().Logf("Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
+
+	test.T().Run("Successful RayJob", func(t *testing.T) {
+		rayJobAC := rayv1ac.RayJob("counter", namespace.Name).
+			WithSpec(rayv1ac.RayJobSpec().
+				WithLightWeightSubmissionMode(true).
+				WithEntrypoint("python /home/ray/jobs/counter.py").
+				WithRuntimeEnvYAML(`
+	env_vars:
+	  counter_name: test_counter
+	`).
+				WithShutdownAfterJobFinishes(true).
+				WithRayClusterSpec(rayv1ac.RayClusterSpec().
+					WithRayVersion(GetRayVersion()).
+					WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+						WithRayStartParams(map[string]string{
+							"dashboard-host": "0.0.0.0",
+						}).
+						WithTemplate(podTemplateSpecApplyConfiguration(headPodTemplateApplyConfiguration(),
+							mountConfigMap[corev1ac.PodTemplateSpecApplyConfiguration](jobs, "/home/ray/jobs"))))))
+
+		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		test.T().Logf("Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+
+		// Assert the RayJob has completed successfully
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)))
+
+		// And the RayJob deployment status is updated accordingly
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
+
+		// Refresh the RayJob status
+		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+
+		// TODO (kevin85421): We may need to use `Eventually` instead if the assertion is flaky.
+		// Assert the RayCluster has been torn down
+		_, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayJob.Status.RayClusterName, metav1.GetOptions{})
+		test.Expect(err).To(MatchError(k8serrors.NewNotFound(rayv1.Resource("rayclusters"), rayJob.Status.RayClusterName)))
+	})
+
+	test.T().Run("Failing RayJob without cluster shutdown after finished", func(t *testing.T) {
+		rayJobAC := rayv1ac.RayJob("fail", namespace.Name).
+			WithSpec(rayv1ac.RayJobSpec().
+				WithLightWeightSubmissionMode(true).
+				WithEntrypoint("python /home/ray/jobs/fail.py").
+				WithShutdownAfterJobFinishes(false).
+				WithRayClusterSpec(rayv1ac.RayClusterSpec().
+					WithRayVersion(GetRayVersion()).
+					WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+						WithRayStartParams(map[string]string{
+							"dashboard-host": "0.0.0.0",
+						}).
+						WithTemplate(podTemplateSpecApplyConfiguration(headPodTemplateApplyConfiguration(),
+							mountConfigMap[corev1ac.PodTemplateSpecApplyConfiguration](jobs, "/home/ray/jobs"))))))
+		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		test.T().Logf("Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+
+		// Assert the Ray job has failed
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
+
+		// And the RayJob deployment status is updated accordingly
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
+
+		// In the lightweight submission mode, the submitter Kubernetes Job should not be created.
+		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
+	})
+
+	test.T().Run("Should transition to 'Complete' if the Ray job has stopped.", func(t *testing.T) {
+		// `stop.py` will sleep for 20 seconds so that the RayJob has enough time to transition to `RUNNING`
+		// and then stop the Ray job. If the Ray job is stopped, the RayJob should transition to `Complete`.
+		rayJobAC := rayv1ac.RayJob("stop", namespace.Name).
+			WithSpec(rayv1ac.RayJobSpec().
+				WithLightWeightSubmissionMode(true).
+				WithEntrypoint("python /home/ray/jobs/stop.py").
+				WithRayClusterSpec(rayv1ac.RayClusterSpec().
+					WithRayVersion(GetRayVersion()).
+					WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+						WithRayStartParams(map[string]string{
+							"dashboard-host": "0.0.0.0",
+						}).
+						WithTemplate(podTemplateSpecApplyConfiguration(headPodTemplateApplyConfiguration(),
+							mountConfigMap[corev1ac.PodTemplateSpecApplyConfiguration](jobs, "/home/ray/jobs"))))))
+
+		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		test.T().Logf("Waiting for RayJob %s/%s to be 'Running'", rayJob.Namespace, rayJob.Name)
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusRunning)))
+
+		test.T().Logf("Waiting for RayJob %s/%s to be 'Complete'", rayJob.Namespace, rayJob.Name)
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
+
+		// Refresh the RayJob status
+		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+		test.Expect(rayJob.Status.JobStatus).To(Equal(rayv1.JobStatusStopped))
+
+		// Delete the RayJob
+		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+	})
+}

--- a/ray-operator/test/e2e/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2e/rayjob_lightweight_test.go
@@ -33,9 +33,9 @@ func TestRayJobLightWeightMode(t *testing.T) {
 				WithLightWeightSubmissionMode(true).
 				WithEntrypoint("python /home/ray/jobs/counter.py").
 				WithRuntimeEnvYAML(`
-	env_vars:
-	  counter_name: test_counter
-	`).
+env_vars:
+  counter_name: test_counter
+`).
 				WithShutdownAfterJobFinishes(true).
 				WithRayClusterSpec(rayv1ac.RayClusterSpec().
 					WithRayVersion(GetRayVersion()).


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some users are not willing to allocate additional compute resources for the submitter Kubernetes Job. Hence, this PR implements the light-weight job submission which uses a HTTP request to submit the Ray job.

## Related issue number

Closes #1558 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
