### PR TITLE
[RayJob] Add additional print columns for RayJob

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -16,7 +16,23 @@ spec:
     singular: rayjob
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.jobStatus
+      name: job status
+      type: string
+    - jsonPath: .status.jobDeploymentStatus
+      name: deployment status
+      type: string
+    - jsonPath: .status.startTime
+      name: start time
+      type: string
+    - jsonPath: .status.endTime
+      name: end time
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         properties:

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -110,6 +110,11 @@ type RayJobStatus struct {
 // +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="job status",type=string,JSONPath=".status.jobStatus",priority=0
+// +kubebuilder:printcolumn:name="deployment status",type=string,JSONPath=".status.jobDeploymentStatus",priority=0
+// +kubebuilder:printcolumn:name="start time",type=string,JSONPath=".status.startTime",priority=0
+// +kubebuilder:printcolumn:name="end time",type=string,JSONPath=".status.endTime",priority=0
+// +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp",priority=0
 // +genclient
 // RayJob is the Schema for the rayjobs API
 type RayJob struct {

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -16,7 +16,23 @@ spec:
     singular: rayjob
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.jobStatus
+      name: job status
+      type: string
+    - jsonPath: .status.jobDeploymentStatus
+      name: deployment status
+      type: string
+    - jsonPath: .status.startTime
+      name: start time
+      type: string
+    - jsonPath: .status.endTime
+      name: end time
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         properties:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why are these changes needed?

When listing RayJob with kubectl, only the name and age of the RayJob was printed. This PR adds additional print columns to also print the status, start time and end time of a RayJob.
```
$ kubectl get rayjob
NAME                  JOB STATUS   DEPLOYMENT STATUS   START TIME   END TIME   AGE
rayjob-sample-x98k6                Initializing                                13s
$ kubectl get rayjob
NAME                  JOB STATUS   DEPLOYMENT STATUS   START TIME   END TIME   AGE
rayjob-sample-x98k6                Running                                     70s
$ kubectl get rayjob
NAME                  JOB STATUS   DEPLOYMENT STATUS   START TIME             END TIME   AGE
rayjob-sample-psgrj   RUNNING      Running             2024-02-01T17:55:49Z              46s
$ kubectl get rayjob
NAME                  JOB STATUS   DEPLOYMENT STATUS   START TIME             END TIME               AGE
rayjob-sample-psgrj   SUCCEEDED    Complete            2024-02-01T17:55:49Z   2024-02-01T17:56:05Z   66s
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
