### PR TITLE
[RayJob] Validate whether runtimeEnvYAML is a valid YAML string

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -674,6 +674,11 @@ func validateRayJobSpec(rayJob *rayv1.RayJob) error {
 	if rayJob.Spec.RayClusterSpec == nil && len(rayJob.Spec.ClusterSelector) == 0 {
 		return fmt.Errorf("one of RayClusterSpec or ClusterSelector must be set")
 	}
+	// Validate whether RuntimeEnvYAML is a valid YAML string. Note that this only checks its validity
+	// as a YAML string, not its adherence to the runtime environment schema.
+	if _, err := utils.UnmarshalRuntimeEnvYAML(rayJob.Spec.RuntimeEnvYAML); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -358,4 +358,11 @@ func TestValidateRayJobSpec(t *testing.T) {
 		},
 	})
 	assert.Error(t, err, "The RayJob is invalid because the ClusterSelector mode doesn't support the suspend operation.")
+
+	err = validateRayJobSpec(&rayv1.RayJob{
+		Spec: rayv1.RayJobSpec{
+			RuntimeEnvYAML: "invalid_yaml_str",
+		},
+	})
+	assert.Error(t, err, "The RayJob is invalid because the runtimeEnvYAML is invalid.")
 }

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -550,3 +550,37 @@ func TestCalculateDesiredReplicas(t *testing.T) {
 		})
 	}
 }
+
+func TestUnmarshalRuntimeEnv(t *testing.T) {
+	tests := map[string]struct {
+		runtimeEnvYAML string
+		isErrorNil     bool
+	}{
+		"Empty runtimeEnvYAML": {
+			runtimeEnvYAML: "",
+			isErrorNil:     true,
+		},
+		"Valid runtimeEnvYAML": {
+			runtimeEnvYAML: `
+env_vars:
+  counter_name: test_counter
+`,
+			isErrorNil: true,
+		},
+		"Invalid runtimeEnvYAML": {
+			runtimeEnvYAML: `invalid_yaml_str`,
+			isErrorNil:     false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := UnmarshalRuntimeEnvYAML(tc.runtimeEnvYAML)
+			if tc.isErrorNil {
+				assert.Nil(t, err)
+			} else {
+				assert.NotNil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Without this PR, the KubeRay operator would still create a RayCluster and a Kubernetes Job for the submitter even if `runtimeEnvYAML` is not a valid YAML string. Subsequently, the Ray job would fail, and KubeRay would transition the status to Complete after the submitter Kubernetes Job retries three times. It is wasteful to create a RayCluster and a submitter Kubernetes Job when the Ray job is destined to fail.

With this PR, the KubeRay operator will validate `runtimeEnvYAML` before taking any action, ensuring that no compute resources are wasted.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
