### PR TITLE
[RayService] Add New Status: NumServeEndpoints

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -7227,6 +7227,9 @@ spec:
             type: object
           status:
             properties:
+              NumServeEndpoints:
+                format: int32
+                type: integer
               activeServiceStatus:
                 properties:
                   applicationStatuses:

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
@@ -35,6 +35,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/helm-chart/kuberay-operator/templates/role.yaml
+++ b/helm-chart/kuberay-operator/templates/role.yaml
@@ -31,6 +31,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -71,6 +71,9 @@ type RayServiceStatuses struct {
 	PendingServiceStatus RayServiceStatus `json:"pendingServiceStatus,omitempty"`
 	// ServiceStatus indicates the current RayService status.
 	ServiceStatus ServiceStatus `json:"serviceStatus,omitempty"`
+	// NumServeEndpoints indicates the number of Ray Pods that are actively serving or have been selected by the serve service.
+	// Ray Pods without a proxy actor or those that are unhealthy will not be counted.
+	NumServeEndpoints int32 `json:"NumServeEndpoints,omitempty"`
 	// observedGeneration is the most recent generation observed for this RayService. It corresponds to the
 	// RayService's generation, which is updated on mutation by the API Server.
 	// +optional

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -7227,6 +7227,9 @@ spec:
             type: object
           status:
             properties:
+              NumServeEndpoints:
+                format: int32
+                type: integer
               activeServiceStatus:
                 properties:
                   applicationStatuses:

--- a/ray-operator/config/rbac/role.yaml
+++ b/ray-operator/config/rbac/role.yaml
@@ -28,6 +28,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -82,6 +82,7 @@ func NewRayServiceReconciler(mgr manager.Manager, dashboardClientFunc func() uti
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
@@ -212,6 +213,10 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 		}
 	}
 
+	if err := r.calculateStatus(ctx, rayServiceInstance, rayClusterInstance); err != nil {
+		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
+	}
+
 	// Final status update for any CR modification.
 	if r.inconsistentRayServiceStatuses(originalRayServiceInstance.Status, rayServiceInstance.Status) {
 		rayServiceInstance.Status.LastUpdateTime = &metav1.Time{Time: time.Now()}
@@ -222,6 +227,25 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	}
 
 	return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
+}
+
+func (r *RayServiceReconciler) calculateStatus(ctx context.Context, rayServiceInstance *rayv1.RayService, rayClusterInstance *rayv1.RayCluster) error {
+	serveSvc, err := common.BuildServeServiceForRayService(ctx, *rayServiceInstance, *rayClusterInstance)
+	if err != nil {
+		return err
+	}
+	serveEndPoints := &corev1.Endpoints{}
+	if err := r.Get(ctx, client.ObjectKey{Name: serveSvc.Name, Namespace: serveSvc.Namespace}, serveEndPoints); err != nil && !errors.IsNotFound(err) {
+		r.Log.Error(err, "Fail to retrieve the Kubernetes Endpoints from the cluster!")
+		return err
+	}
+
+	numServeEndpoints := 0
+	for _, subset := range serveEndPoints.Subsets {
+		numServeEndpoints += len(subset.Addresses)
+	}
+	rayServiceInstance.Status.NumServeEndpoints = int32(numServeEndpoints)
+	return nil
 }
 
 // Checks whether the old and new RayServiceStatus are inconsistent by comparing different fields.
@@ -282,6 +306,11 @@ func (r *RayServiceReconciler) inconsistentRayServiceStatus(oldStatus rayv1.RayS
 func (r *RayServiceReconciler) inconsistentRayServiceStatuses(oldStatus rayv1.RayServiceStatuses, newStatus rayv1.RayServiceStatuses) bool {
 	if oldStatus.ServiceStatus != newStatus.ServiceStatus {
 		r.Log.Info(fmt.Sprintf("inconsistentRayServiceStatus RayService ServiceStatus changed from %s to %s", oldStatus.ServiceStatus, newStatus.ServiceStatus))
+		return true
+	}
+
+	if oldStatus.NumServeEndpoints != newStatus.NumServeEndpoints {
+		r.Log.Info(fmt.Sprintf("inconsistentRayServiceStatus RayService NumServeEndpoints changed from %d to %d", oldStatus.NumServeEndpoints, newStatus.NumServeEndpoints))
 		return true
 	}
 

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -241,6 +241,8 @@ func (r *RayServiceReconciler) calculateStatus(ctx context.Context, rayServiceIn
 	}
 
 	numServeEndpoints := 0
+	// Ray Pod addresses are categorized into subsets based on the IPs they share.
+	// subset.Addresses contains a list of Ray Pod addresses with ready serve port.
 	for _, subset := range serveEndPoints.Subsets {
 		numServeEndpoints += len(subset.Addresses)
 	}

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayservicestatuses.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayservicestatuses.go
@@ -13,6 +13,7 @@ type RayServiceStatusesApplyConfiguration struct {
 	ActiveServiceStatus  *RayServiceStatusApplyConfiguration `json:"activeServiceStatus,omitempty"`
 	PendingServiceStatus *RayServiceStatusApplyConfiguration `json:"pendingServiceStatus,omitempty"`
 	ServiceStatus        *rayv1.ServiceStatus                `json:"serviceStatus,omitempty"`
+	NumServeEndpoints    *int32                              `json:"NumServeEndpoints,omitempty"`
 	ObservedGeneration   *int64                              `json:"observedGeneration,omitempty"`
 	LastUpdateTime       *metav1.Time                        `json:"lastUpdateTime,omitempty"`
 }
@@ -44,6 +45,14 @@ func (b *RayServiceStatusesApplyConfiguration) WithPendingServiceStatus(value *R
 // If called multiple times, the ServiceStatus field is set to the value of the last call.
 func (b *RayServiceStatusesApplyConfiguration) WithServiceStatus(value rayv1.ServiceStatus) *RayServiceStatusesApplyConfiguration {
 	b.ServiceStatus = &value
+	return b
+}
+
+// WithNumServeEndpoints sets the NumServeEndpoints field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NumServeEndpoints field is set to the value of the last call.
+func (b *RayServiceStatusesApplyConfiguration) WithNumServeEndpoints(value int32) *RayServiceStatusesApplyConfiguration {
+	b.NumServeEndpoints = &value
 	return b
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR adds the `NumServeEndpoints` field to the RayService's status. The `NumServeEndpoints` field indicates the number of active serving Ray Pods or the number of Ray Pods selected by the serve service. If a Ray Pod has no proxy actor or is unhealthy, it will not be counted.

This new field can help users and CI tests determine how many Ray Pods are capable of serving, making debugging much easier. This is crucial because, with the high availability feature of RayService, even if some worker Pods become unhealthy, it is hard to tell since everything appears to work just fine on the surface.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

```shell
# Run a Rayservice sample under https://github.com/ray-project/kuberay/tree/master/ray-operator/config/samples
# It will create 1 head and 1 worker pod. 
# Each pod has a serve replica. So, number of active serving Ray Pods is 2.
kubectl apply -f /home/ubuntu/kuberay/ray-operator/config/samples/ray-service.sample.yaml
kubectl describe rayservice rayservice-sample | grep "Num Serve Endpoints"
# Num Serve Endpoints  2

# Run another Rayservice sample.
# It will create 1 head and 3 worker pod. Only 1 worker pod has a serve replica.
# Since head Pod always has proxy actor, so, number of active serving Ray Pods is 1+1=2.
kubectl apply -f https://raw.githubusercontent.com/Yicheng-Lu-llll/serve-file/main/rayservice-config_v2.9_replicas-1.yaml
kubectl describe rayservice rayservice-sample | grep "Num Serve Endpoints"
#   Num Serve Endpoints:  2
```

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
