### PR TITLE
[Feature][RayJob] Support light-weight job submission with entrypoint_num_cpus, entrypoint_num_gpus and entrypoint_resources

### DIFF
--- a/apiserver/pkg/server/ray_job_submission_service_server.go
+++ b/apiserver/pkg/server/ray_job_submission_service_server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -76,7 +77,13 @@ func (s *RayJobSubmissionServiceServer) SubmitRayJob(ctx context.Context, req *a
 		request.NumGpus = req.Jobsubmission.EntrypointNumGpus
 	}
 	if len(req.Jobsubmission.EntrypointResources) > 0 {
-		request.Resources = req.Jobsubmission.EntrypointResources
+		for k, v := range req.Jobsubmission.EntrypointResources {
+			f, err := strconv.ParseFloat(v, 32)
+			if err != nil {
+				return nil, err
+			}
+			request.Resources[k] = float32(f)
+		}
 	}
 
 	sid, err := rayDashboardClient.SubmitJobReq(ctx, request, nil)

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -202,15 +202,15 @@ type RayJobInfo struct {
 
 // RayJobRequest is the request body to submit.
 // Reference to https://docs.ray.io/en/latest/cluster/running-applications/job-submission/rest.html#ray-job-rest-api-spec
+// Reference to https://github.com/ray-project/ray/blob/cfbf98c315cfb2710c56039a3c96477d196de049/dashboard/modules/job/common.py#L325-L353
 type RayJobRequest struct {
-	// TODO (kevin85421): Double check whether the types are correct or not.
-	Entrypoint   string            `json:"entrypoint"`
-	SubmissionId string            `json:"submission_id,omitempty"`
-	RuntimeEnv   RuntimeEnvType    `json:"runtime_env,omitempty"`
-	Metadata     map[string]string `json:"metadata,omitempty"`
-	NumCpus      float32           `json:"entrypoint_num_cpus,omitempty"`
-	NumGpus      float32           `json:"entrypoint_num_gpus,omitempty"`
-	Resources    map[string]string `json:"entrypoint_resources,omitempty"`
+	Entrypoint   string             `json:"entrypoint"`
+	SubmissionId string             `json:"submission_id,omitempty"`
+	RuntimeEnv   RuntimeEnvType     `json:"runtime_env,omitempty"`
+	Metadata     map[string]string  `json:"metadata,omitempty"`
+	NumCpus      float32            `json:"entrypoint_num_cpus,omitempty"`
+	NumGpus      float32            `json:"entrypoint_num_gpus,omitempty"`
+	Resources    map[string]float32 `json:"entrypoint_resources,omitempty"`
 }
 
 type RayJobResponse struct {
@@ -431,7 +431,13 @@ func ConvertRayJobToReq(rayJob *rayv1.RayJob) (*RayJobRequest, error) {
 		}
 		req.RuntimeEnv = runtimeEnv
 	}
-	// TODO (kevin85421): Support entrypointNumCpus, entrypointNumGpus, entrypointResources
+	req.NumCpus = rayJob.Spec.EntrypointNumCpus
+	req.NumGpus = rayJob.Spec.EntrypointNumGpus
+	if rayJob.Spec.EntrypointResources != "" {
+		if err := json.Unmarshal([]byte(rayJob.Spec.EntrypointResources), &req.Resources); err != nil {
+			return nil, err
+		}
+	}
 	return req, nil
 }
 

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
@@ -62,6 +62,29 @@ var _ = Describe("RayFrameworkGenerator", func() {
 		Expect(rayJobRequest.RuntimeEnv["working_dir"]).To(Equal("./"))
 	})
 
+	It("Test ConvertRayJobToReq with EntrypointResources", func() {
+		rayJobRequest, err := ConvertRayJobToReq(&rayv1.RayJob{
+			Spec: rayv1.RayJobSpec{
+				EntrypointResources: `{"r1": 0.1, "r2": 0.2}`,
+				EntrypointNumCpus:   1.1,
+				EntrypointNumGpus:   2.2,
+			},
+		})
+		Expect(err).To(BeNil())
+		Expect(rayJobRequest.NumCpus).To(Equal(float32(1.1)))
+		Expect(rayJobRequest.NumGpus).To(Equal(float32(2.2)))
+		Expect(rayJobRequest.Resources).To(Equal(map[string]float32{"r1": 0.1, "r2": 0.2}))
+	})
+
+	It("Test ConvertRayJobToReq with invalid EntrypointResources", func() {
+		_, err := ConvertRayJobToReq(&rayv1.RayJob{
+			Spec: rayv1.RayJobSpec{
+				EntrypointResources: `{"r1": "string"}`,
+			},
+		})
+		Expect(err).Should(MatchError(ContainSubstring("json: cannot unmarshal")))
+	})
+
 	It("Test submitting/getting rayJob", func() {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()

--- a/ray-operator/test/e2e/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2e/rayjob_lightweight_test.go
@@ -82,18 +82,12 @@ env_vars:
 			WithSpec(rayv1ac.RayJobSpec().
 				WithSubmissionMode(rayv1.HTTPMode).
 				WithEntrypoint("python /home/ray/jobs/fail.py").
-				WithEntrypointNumCpus(2).
-				WithEntrypointNumGpus(2).
-				WithEntrypointResources(`{"R1": 2}`).
 				WithShutdownAfterJobFinishes(false).
 				WithRayClusterSpec(rayv1ac.RayClusterSpec().
 					WithRayVersion(GetRayVersion()).
 					WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 						WithRayStartParams(map[string]string{
 							"dashboard-host": "0.0.0.0",
-							"num-gpus":       "4",
-							"num-cpus":       "4",
-							"resources":      `'{"R1": 4}'`,
 						}).
 						WithTemplate(podTemplateSpecApplyConfiguration(headPodTemplateApplyConfiguration(),
 							mountConfigMap[corev1ac.PodTemplateSpecApplyConfiguration](jobs, "/home/ray/jobs"))))))
@@ -124,17 +118,11 @@ env_vars:
 			WithSpec(rayv1ac.RayJobSpec().
 				WithSubmissionMode(rayv1.HTTPMode).
 				WithEntrypoint("python /home/ray/jobs/stop.py").
-				WithEntrypointNumCpus(2).
-				WithEntrypointNumGpus(2).
-				WithEntrypointResources(`{"R1": 2}`).
 				WithRayClusterSpec(rayv1ac.RayClusterSpec().
 					WithRayVersion(GetRayVersion()).
 					WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 						WithRayStartParams(map[string]string{
 							"dashboard-host": "0.0.0.0",
-							"num-gpus":       "4",
-							"num-cpus":       "4",
-							"resources":      `'{"R1": 4}'`,
 						}).
 						WithTemplate(podTemplateSpecApplyConfiguration(headPodTemplateApplyConfiguration(),
 							mountConfigMap[corev1ac.PodTemplateSpecApplyConfiguration](jobs, "/home/ray/jobs"))))))

--- a/ray-operator/test/e2e/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2e/rayjob_lightweight_test.go
@@ -32,6 +32,9 @@ func TestRayJobLightWeightMode(t *testing.T) {
 			WithSpec(rayv1ac.RayJobSpec().
 				WithSubmissionMode(rayv1.HTTPMode).
 				WithEntrypoint("python /home/ray/jobs/counter.py").
+				WithEntrypointNumCpus(2).
+				WithEntrypointNumGpus(2).
+				WithEntrypointResources(`{"R1": 2}`).
 				WithRuntimeEnvYAML(`
 env_vars:
   counter_name: test_counter
@@ -42,6 +45,9 @@ env_vars:
 					WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 						WithRayStartParams(map[string]string{
 							"dashboard-host": "0.0.0.0",
+							"num-gpus":       "4",
+							"num-cpus":       "4",
+							"resources":      `'{"R1": 4}'`,
 						}).
 						WithTemplate(podTemplateSpecApplyConfiguration(headPodTemplateApplyConfiguration(),
 							mountConfigMap[corev1ac.PodTemplateSpecApplyConfiguration](jobs, "/home/ray/jobs"))))))
@@ -76,12 +82,18 @@ env_vars:
 			WithSpec(rayv1ac.RayJobSpec().
 				WithSubmissionMode(rayv1.HTTPMode).
 				WithEntrypoint("python /home/ray/jobs/fail.py").
+				WithEntrypointNumCpus(2).
+				WithEntrypointNumGpus(2).
+				WithEntrypointResources(`{"R1": 2}`).
 				WithShutdownAfterJobFinishes(false).
 				WithRayClusterSpec(rayv1ac.RayClusterSpec().
 					WithRayVersion(GetRayVersion()).
 					WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 						WithRayStartParams(map[string]string{
 							"dashboard-host": "0.0.0.0",
+							"num-gpus":       "4",
+							"num-cpus":       "4",
+							"resources":      `'{"R1": 4}'`,
 						}).
 						WithTemplate(podTemplateSpecApplyConfiguration(headPodTemplateApplyConfiguration(),
 							mountConfigMap[corev1ac.PodTemplateSpecApplyConfiguration](jobs, "/home/ray/jobs"))))))
@@ -112,11 +124,17 @@ env_vars:
 			WithSpec(rayv1ac.RayJobSpec().
 				WithSubmissionMode(rayv1.HTTPMode).
 				WithEntrypoint("python /home/ray/jobs/stop.py").
+				WithEntrypointNumCpus(2).
+				WithEntrypointNumGpus(2).
+				WithEntrypointResources(`{"R1": 2}`).
 				WithRayClusterSpec(rayv1ac.RayClusterSpec().
 					WithRayVersion(GetRayVersion()).
 					WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 						WithRayStartParams(map[string]string{
 							"dashboard-host": "0.0.0.0",
+							"num-gpus":       "4",
+							"num-cpus":       "4",
+							"resources":      `'{"R1": 4}'`,
 						}).
 						WithTemplate(podTemplateSpecApplyConfiguration(headPodTemplateApplyConfiguration(),
 							mountConfigMap[corev1ac.PodTemplateSpecApplyConfiguration](jobs, "/home/ray/jobs"))))))


### PR DESCRIPTION
## Why are these changes needed?

Continue the #1893, this PR completes the lightweight job submission by adding supports of `entrypoint_num_cpus`, `entrypoint_num_gpus`, and `entrypoint_resources` parameters while generating submission requests.

I also corrected the type of `RayJobRequest.Resources` to `map[string]float32` as suggested in the ray source: https://github.com/ray-project/ray/blob/cfbf98c315cfb2710c56039a3c96477d196de049/dashboard/modules/job/common.py#L353

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
