### PR TITLE
[RayJob] Set the timeout of the HTTP client from 2 mins to 2 seconds

### DIFF
--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -103,7 +103,7 @@ func FetchHeadServiceURL(ctx context.Context, cli client.Client, rayCluster *ray
 
 func (r *RayDashboardClient) InitClient(url string) {
 	r.client = http.Client{
-		Timeout: 120 * time.Second,
+		Timeout: 2 * time.Second,
 	}
 	r.dashboardURL = "http://" + url
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Before #1733, the Ray dashboard required approximately 5 seconds to be ready to serve requests after the Ray head was running and ready. Hence, #1000 increases the timeout of the HTTP client to 2 mins to hotfix this issue. However, if the Ray dashboard crashes, the KubeRay operator will stuck there for 2 mins which is not acceptable.

After #1733, the readiness probe will verify the readiness of the Ray dashboard. Consequently, if the head Pod is ready, it implies that the Ray dashboard is also prepared to serve requests. Hence, we can set the timeout from 2 mins back to 2 seconds.
 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

Deploy RayJob with [this YAML](https://gist.github.com/kevin85421/dc1777bdbbbc762e0ff57831da781cd3) 25 times.

![Screen Shot 2024-02-05 at 8 28 14 PM](https://github.com/ray-project/kuberay/assets/20109646/7905b364-bc43-4749-a75f-0be96895e301)
