### PR TITLE
Support json structured logging 

### DIFF
--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -34,7 +34,11 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name  }}
-      volumes: []
+      {{- if and (.Values.logging.baseDir) (.Values.logging.fileName) }}
+      volumes:
+        - name: kuberay-logs
+          emptyDir: {}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -43,7 +47,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          volumeMounts: []
+          {{- if and (.Values.logging.baseDir) (.Values.logging.fileName) }}
+          volumeMounts:
+            - name: kuberay-logs
+              mountPath: "{{ .Values.logging.baseDir }}"
+          {{- end }}
           command:
             - /manager
           args:
@@ -60,6 +68,18 @@ spec:
             {{- if $watchNamespace -}}
             {{- $argList = append $argList "--watch-namespace" -}}
             {{- $argList = append $argList $watchNamespace -}}
+            {{- end -}}
+            {{- if and (.Values.logging.baseDir) (.Values.logging.fileName) -}}
+            {{- $argList = append $argList "--log-file-path" -}}
+            {{- $argList = append $argList (printf "%s/%s" .Values.logging.baseDir .Values.logging.fileName) -}}
+            {{- end -}}
+            {{- if .Values.logging.stdoutEncoder -}}
+            {{- $argList = append $argList "--log-stdout-encoder" -}}
+            {{- $argList = append $argList .Values.logging.stdoutEncoder -}}
+            {{- end -}}
+            {{- if .Values.logging.fileEncoder -}}
+            {{- $argList = append $argList "--log-file-encoder" -}}
+            {{- $argList = append $argList .Values.logging.fileEncoder -}}
             {{- end -}}
             {{- (printf "\n") -}}
             {{- $argList | toYaml | indent 12 }}

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -35,6 +35,16 @@ resources:
   #   cpu: 100m
   #   memory: 512Mi
 
+logging:
+  # Log encoder to use for stdout (one of 'json' or 'console', default is 'json')
+  stdoutEncoder: ""
+  # Log encoder to use for file logging (one of 'json' or 'console', default is 'json')
+  fileEncoder: ""
+  # Directory for kuberay-operator log file
+  baseDir: ""
+  # File name for kuberay-operator log file
+  fileName: ""
+
 livenessProbe:
   initialDelaySeconds: 10
   periodSeconds: 5

--- a/ray-operator/apis/config/v1alpha1/configuration_types.go
+++ b/ray-operator/apis/config/v1alpha1/configuration_types.go
@@ -38,6 +38,14 @@ type Configuration struct {
 	// LogFile is a path to a local file for synchronizing logs.
 	LogFile string `json:"logFile,omitempty"`
 
+	// LogFileEncoder is the encoder to use when logging to a file. Valid values are "json" and "console".
+	// Defaults to `json` if empty.
+	LogFileEncoder string `json:"logFileEncoder,omitempty"`
+
+	// LogFileEncoder is the encoder to use when logging to a file. Valid values are "json" and "console".
+	// Defaults to `json` if empty.
+	LogStdoutEncoder string `json:"logStdoutEncoder,omitempty"`
+
 	// EnableBatchScheduler enables the batch scheduler. Currently this is supported
 	// by Volcano to support gang scheduling.
 	EnableBatchScheduler bool `json:"enableBatchScheduler,omitempty"`


### PR DESCRIPTION
## Why are these changes needed?

Zapr uses structured json logging by default. However in KubeRay we have enabled development mode which enables console logging. While console logging is easier to read during development, structured logging should be used by default in production so that the key/value pairs in the logs can be used for searching.

this is some sample logs with the changes:
```
$ kubectl logs -f kuberay-operator-5987588ffc-4bfdh
{"level":"info","ts":"2024-02-06T17:26:41.668Z","logger":"setup","msg":"the operator","version:":""}
{"level":"info","ts":"2024-02-06T17:26:41.668Z","logger":"setup","msg":"Flag watchNamespace is not set. Watch custom resources in all namespaces."}
{"level":"info","ts":"2024-02-06T17:26:41.668Z","logger":"setup","msg":"Setup manager"}
{"level":"info","ts":"2024-02-06T17:26:41.767Z","logger":"controllers.RayCluster","msg":"Starting Reconciler"}
{"level":"info","ts":"2024-02-06T17:26:41.770Z","logger":"setup","msg":"starting manager"}
{"level":"info","ts":"2024-02-06T17:26:41.770Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2024-02-06T17:26:41.770Z","msg":"starting server","kind":"health probe","addr":"[::]:8082"}
{"level":"info","ts":"2024-02-06T17:26:41.771Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
I0206 17:26:41.872188       1 leaderelection.go:250] attempting to acquire leader lease default/ray-operator-leader...
I0206 17:26:41.878219       1 leaderelection.go:260] successfully acquired lease default/ray-operator-leader
{"level":"info","ts":"2024-02-06T17:26:41.879Z","msg":"Starting EventSource","controller":"raycluster-controller","controllerGroup":"ray.io","controllerKind":"RayCluster","source":"kind source: *v1.RayCluster"}
{"level":"info","ts":"2024-02-06T17:26:41.879Z","msg":"Starting EventSource","controller":"raycluster-controller","controllerGroup":"ray.io","controllerKind":"RayCluster","source":"kind source: *v1.Pod"}
{"level":"info","ts":"2024-02-06T17:26:41.879Z","msg":"Starting EventSource","controller":"raycluster-controller","controllerGroup":"ray.io","controllerKind":"RayCluster","source":"kind source: *v1.Service"}
{"level":"info","ts":"2024-02-06T17:26:41.879Z","msg":"Starting Controller","controller":"raycluster-controller","controllerGroup":"ray.io","controllerKind":"RayCluster"}
{"level":"info","ts":"2024-02-06T17:26:41.884Z","msg":"Starting EventSource","controller":"rayjob","controllerGroup":"ray.io","controllerKind":"RayJob","source":"kind source: *v1.RayJob"}
{"level":"info","ts":"2024-02-06T17:26:41.884Z","msg":"Starting EventSource","controller":"rayjob","controllerGroup":"ray.io","controllerKind":"RayJob","source":"kind source: *v1.RayCluster"}
{"level":"info","ts":"2024-02-06T17:26:41.884Z","msg":"Starting EventSource","controller":"rayservice","controllerGroup":"ray.io","controllerKind":"RayService","source":"kind source: *v1.RayService"}
{"level":"info","ts":"2024-02-06T17:26:41.884Z","msg":"Starting EventSource","controller":"rayservice","controllerGroup":"ray.io","controllerKind":"RayService","source":"kind source: *v1.RayCluster"}
{"level":"info","ts":"2024-02-06T17:26:41.884Z","msg":"Starting EventSource","controller":"rayservice","controllerGroup":"ray.io","controllerKind":"RayService","source":"kind source: *v1.Service"}
{"level":"info","ts":"2024-02-06T17:26:41.885Z","msg":"Starting EventSource","controller":"rayservice","controllerGroup":"ray.io","controllerKind":"RayService","source":"kind source: *v1.Ingress"}
{"level":"info","ts":"2024-02-06T17:26:41.885Z","msg":"Starting Controller","controller":"rayservice","controllerGroup":"ray.io","controllerKind":"RayService"}
{"level":"info","ts":"2024-02-06T17:26:41.884Z","msg":"Starting EventSource","controller":"rayjob","controllerGroup":"ray.io","controllerKind":"RayJob","source":"kind source: *v1.Service"}
{"level":"info","ts":"2024-02-06T17:26:41.885Z","msg":"Starting EventSource","controller":"rayjob","controllerGroup":"ray.io","controllerKind":"RayJob","source":"kind source: *v1.Job"}
{"level":"info","ts":"2024-02-06T17:26:41.984Z","msg":"Starting Controller","controller":"rayjob","controllerGroup":"ray.io","controllerKind":"RayJob"}
{"level":"info","ts":"2024-02-06T17:26:42.086Z","msg":"Starting workers","controller":"rayjob","controllerGroup":"ray.io","controllerKind":"RayJob","worker count":1}
{"level":"info","ts":"2024-02-06T17:26:42.086Z","msg":"Starting workers","controller":"raycluster-controller","controllerGroup":"ray.io","controllerKind":"RayCluster","worker count":1}
{"level":"info","ts":"2024-02-06T17:26:42.087Z","msg":"Starting workers","controller":"rayservice","controllerGroup":"ray.io","controllerKind":"RayService","worker count":1}
```

Note that console logging can still be enabled using `--zap-devel` flag.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
