### PR TITLE
add toleration for GPUs in sample pytorch RayJob

### DIFF
--- a/ray-operator/config/samples/pytorch-text-classifier/ray-job.pytorch-distributed-training.yaml
+++ b/ray-operator/config/samples/pytorch-text-classifier/ray-job.pytorch-distributed-training.yaml
@@ -21,6 +21,10 @@ spec:
         dashboard-host: '0.0.0.0'
       template:
         spec:
+          tolerations:
+          - key: "nvidia.com/gpu"
+            operator: "Exists"
+            effect: "NoSchedule"
           containers:
             - name: ray-head
               image: rayproject/ray-ml:2.9.0-gpu


### PR DESCRIPTION
## Why are these changes needed?

Even though Kuberay automatically adds taints for `nvidia.com/gpu`, some of Kueue's features will directly inspect the PodTemplate from the RayJob before the tolerations are applied. This change adds the toleration premptively to optimize Kueue's scheduling logic  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
