### PR TITLE
[Doc] Add a Doc and YAML for RayServe grpc support

### DIFF
--- a/gRPC-example/Dockerfile
+++ b/gRPC-example/Dockerfile
@@ -1,0 +1,17 @@
+# docker build . -t twilight1998/evalai-grpc-test:latest
+# docker run -it --rm -p 8001:8001 twilight1998/evalai-grpc-test:latest bash
+
+
+# Use Anyscale base image
+FROM rayproject/ray:2.7.0
+
+# Install dependencies
+RUN pip install --upgrade pip && pip install --upgrade protobuf
+
+WORKDIR /home/ray
+
+# Copy local code including protobuf and service definitions into docker image
+COPY . /home/ray
+
+# Add working directory into python path so they are importable
+ENV PYTHONPATH=/home/ray

--- a/gRPC-example/client.py
+++ b/gRPC-example/client.py
@@ -1,0 +1,13 @@
+import grpc
+from user_defined_protos_pb2_grpc import UserDefinedServiceStub
+from user_defined_protos_pb2 import UserDefinedMessage
+
+
+channel = grpc.insecure_channel("192.168.103.95:9012")
+stub = UserDefinedServiceStub(channel)
+request = UserDefinedMessage(name="foo", num=30, origin="bar")
+
+response, call = stub.__call__.with_call(request=request)
+print(f"status code: {call.code()}")  # grpc.StatusCode.OK
+print(f"greeting: {response.greeting}")  # "Hello foo from bar"
+print(f"num: {response.num}")  # 60

--- a/gRPC-example/protos/user_defined_protos.proto
+++ b/gRPC-example/protos/user_defined_protos.proto
@@ -1,0 +1,49 @@
+// user_defined_protos.proto
+// generate python code:
+// cd <to the upper directory of this file>
+// python -m grpc_tools.protoc -I./protos --python_out=. --pyi_out=. --grpc_python_out=. ./protos/user_defined_protos.proto
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.ray.examples.user_defined_protos";
+option java_outer_classname = "UserDefinedProtos";
+
+package userdefinedprotos;
+
+message UserDefinedMessage {
+  string name = 1;
+  string origin = 2;
+  int64 num = 3;
+}
+
+message UserDefinedResponse {
+  string greeting = 1;
+  int64 num = 2;
+}
+
+message UserDefinedMessage2 {}
+
+message UserDefinedResponse2 {
+  string greeting = 1;
+}
+
+message ImageData {
+  string url = 1;
+  string filename = 2;
+}
+
+message ImageClass {
+  repeated string classes = 1;
+  repeated float probabilities = 2;
+}
+
+service UserDefinedService {
+  rpc __call__(UserDefinedMessage) returns (UserDefinedResponse);
+  rpc Multiplexing(UserDefinedMessage2) returns (UserDefinedResponse2);
+  rpc Streaming(UserDefinedMessage) returns (stream UserDefinedResponse);
+}
+
+service ImageClassificationService {
+  rpc Predict(ImageData) returns (ImageClass);
+}

--- a/gRPC-example/ray-serve-grpc.yaml
+++ b/gRPC-example/ray-serve-grpc.yaml
@@ -1,0 +1,83 @@
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: rayservice-grpc
+spec:
+  serveConfigV2: |
+    grpc_options:
+      port: 9012
+      grpc_servicer_functions:
+        - user_defined_protos_pb2_grpc.add_UserDefinedServiceServicer_to_server
+        - user_defined_protos_pb2_grpc.add_ImageClassificationServiceServicer_to_server
+    
+    applications:
+    - name: app1
+      route_prefix: /app1
+      import_path: test_deployment_v2:g
+      runtime_env: {}
+
+  rayClusterConfig:
+    rayVersion: '2.7.0' # should match the Ray version in the image of the containers
+    ######################headGroupSpecs#################################
+    # Ray head pod template.
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        dashboard-host: '0.0.0.0'
+        num-cpus: '10'
+      #pod template
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: twilight1998/evalai-grpc-test:latest  # <---- Built my own image
+              imagePullPolicy: IfNotPresent
+              resources:
+                limits:
+                  cpu: 1
+                  memory: 4Gi
+                requests:
+                  cpu: 1
+                  memory: 4Gi
+              ports:
+                - containerPort: 6379
+                  name: gcs-server
+                - containerPort: 8265 # Ray dashboard
+                  name: dashboard
+                - containerPort: 10001
+                  name: client
+                - containerPort: 8000
+                  name: serve
+                - containerPort: 9012  # <---- Open port 9012 for gRPC
+                  name: serve-grpc
+    workerGroupSpecs:
+      # the pod replicas in this group typed worker
+      - replicas: 1
+        minReplicas: 1
+        maxReplicas: 5
+        # logical group name, for this called small-group, also can be functional
+        groupName: worker
+        # The `rayStartParams` are used to configure the `ray start` command.
+        # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+        # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+        rayStartParams: {}
+        #pod template
+        template:
+          spec:
+            containers:
+              - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+                image: twilight1998/evalai-grpc-test:latest
+                imagePullPolicy: IfNotPresent
+                lifecycle:
+                  preStop:
+                    exec:
+                      command: ["/bin/sh","-c","ray stop"]
+                resources:
+                  limits:
+                    cpu: "1"
+                    memory: "4Gi"
+                  requests:
+                    cpu: "1"
+                    memory: "4Gi"

--- a/gRPC-example/test_deployment_v2.py
+++ b/gRPC-example/test_deployment_v2.py
@@ -1,0 +1,55 @@
+import time
+
+from typing import Generator
+
+from user_defined_protos_pb2 import (
+    UserDefinedMessage,
+    UserDefinedMessage2,
+    UserDefinedResponse,
+    UserDefinedResponse2,
+)
+
+import ray
+from ray import serve
+
+@serve.deployment
+class GrpcDeployment:
+    def __call__(self, user_message: UserDefinedMessage) -> UserDefinedResponse:
+        greeting = f"Hello {user_message.name} from {user_message.origin}"
+        num = user_message.num * 2
+        user_response = UserDefinedResponse(
+            greeting=greeting,
+            num=num,
+        )
+        return user_response
+
+    @serve.multiplexed(max_num_models_per_replica=1)
+    async def get_model(self, model_id: str) -> str:
+        return f"loading model: {model_id}"
+
+    async def Multiplexing(
+            self, user_message: UserDefinedMessage2
+    ) -> UserDefinedResponse2:
+        model_id = serve.get_multiplexed_model_id()
+        model = await self.get_model(model_id)
+        user_response = UserDefinedResponse2(
+            greeting=f"Method2 called model, {model}",
+        )
+        return user_response
+
+    def Streaming(
+            self, user_message: UserDefinedMessage
+    ) -> Generator[UserDefinedResponse, None, None]:
+        for i in range(10):
+            greeting = f"{i}: Hello {user_message.name} from {user_message.origin}"
+            num = user_message.num * 2 + i
+            user_response = UserDefinedResponse(
+                greeting=greeting,
+                num=num,
+            )
+            yield user_response
+
+            time.sleep(0.1)
+
+
+g = GrpcDeployment.bind()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This is an example of setting up gRPC on KubeRay, and this example is consistent with [that on Ray Serve](https://docs.ray.io/en/latest/serve/advanced-guides/grpc-guide.html#send-grpc-requests-to-serve-deployments).

The following are the steps:

1. Use the command `python -m grpc_tools.protoc -I./protos --python_out=. --pyi_out=. --grpc_python_out=. ./protos/user_defined_protos.proto`  which is provided in the proto file to generate the Python code.
This command would generate three files, including `user_defined_protos_pb2.py`, `user_defined_protos_pb2.pyi`, `user_defined_protos_pb2_grpc.py`.

2. Use the YAML file `ray-serve-grpc.yaml` to create the RayService CR.

3. Use client.py to test whether the gRPC works well or not.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#1555 

<!-- For example: "Closes #1234" -->

## Checks
The screenshot of the result:

![image](https://github.com/ray-project/kuberay/assets/139951533/ef486815-ef5c-4da1-bf68-7c6ef906b6da)



- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
