### PR TITLE
[Bug] Submitter K8s Job fails even though the RayJob has a JobDeploymentStatus `Complete` and a JobStatus `SUCCEEDED`

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -178,9 +178,9 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 
 		// TODO (kevin85421): For light-weight mode, calculate the number of failed retries and transition
 		// the status to `Complete` if the number of failed retries exceeds the threshold.
+		job := &batchv1.Job{}
 		if rayJobInstance.Spec.SubmissionMode == rayv1.K8sJobMode {
 			// If the Job reaches the backoff limit, transition the status to `Complete`.
-			job := &batchv1.Job{}
 			namespacedName := getK8sJobNamespacedName(rayJobInstance)
 			if err := r.Client.Get(ctx, namespacedName, job); err != nil {
 				r.Log.Error(err, "Failed to get the submitter Kubernetes Job", "NamespacedName", namespacedName)
@@ -222,7 +222,15 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		// as "Complete" to avoid unnecessary reconciliation.
 		jobDeploymentStatus := rayv1.JobDeploymentStatusRunning
 		if rayv1.IsJobTerminal(jobInfo.JobStatus) {
-			jobDeploymentStatus = rayv1.JobDeploymentStatusComplete
+			switch rayJobInstance.Spec.SubmissionMode {
+			case rayv1.HTTPMode:
+				jobDeploymentStatus = rayv1.JobDeploymentStatusComplete
+			case rayv1.K8sJobMode:
+				if _, finished := utils.IsJobFinished(job); finished {
+					r.Log.Info("The submitter Kubernetes Job is finished", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
+					jobDeploymentStatus = rayv1.JobDeploymentStatusComplete
+				}
+			}
 		}
 		// Always update RayClusterStatus along with JobStatus and JobDeploymentStatus updates.
 		rayJobInstance.Status.RayClusterStatus = rayClusterInstance.Status

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -243,7 +243,7 @@ var _ = Context("RayJob in K8sJobMode", func() {
 			// RayJob transitions to Complete.
 			Eventually(
 				getRayJobDeploymentStatus(ctx, rayJob),
-				time.Second*3, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusComplete), "jobDeploymentStatus = %v", rayJob.Status.JobDeploymentStatus)
+				time.Second*5, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusComplete), "jobDeploymentStatus = %v", rayJob.Status.JobDeploymentStatus)
 		})
 
 		It("If shutdownAfterJobFinishes is true, RayCluster should be deleted but not the submitter Job.", func() {

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
@@ -32,7 +33,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	// +kubebuilder:scaffold:imports
@@ -222,10 +222,28 @@ var _ = Context("RayJob in K8sJobMode", func() {
 			fakeRayDashboardClient.GetJobInfoMock.Store(&getJobInfo)
 			defer fakeRayDashboardClient.GetJobInfoMock.Store(nil)
 
+			// RayJob transitions to Complete if and only if the corresponding submitter Kubernetes Job is Complete or Failed.
+			Consistently(
+				getRayJobDeploymentStatus(ctx, rayJob),
+				time.Second*3, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusRunning), "JobDeploymentStatus = %v", rayJob.Status.JobDeploymentStatus)
+
+			// Update the submitter Kubernetes Job to Complete.
+			namespacedName := getK8sJobNamespacedName(rayJob)
+			job := &batchv1.Job{}
+			err := k8sClient.Get(ctx, namespacedName, job)
+			Expect(err).NotTo(HaveOccurred(), "failed to get Kubernetes Job")
+
+			// Update the submitter Kubernetes Job to Complete.
+			conditions := []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+			}
+			job.Status.Conditions = conditions
+			Expect(k8sClient.Status().Update(ctx, job)).Should(BeNil())
+
 			// RayJob transitions to Complete.
 			Eventually(
 				getRayJobDeploymentStatus(ctx, rayJob),
-				time.Second*5, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusComplete), "jobDeploymentStatus = %v", rayJob.Status.JobDeploymentStatus)
+				time.Second*3, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusComplete), "jobDeploymentStatus = %v", rayJob.Status.JobDeploymentStatus)
 		})
 
 		It("If shutdownAfterJobFinishes is true, RayCluster should be deleted but not the submitter Job.", func() {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When `ttlSecondsAfterFinished` is set to 0, the submitter job may fail and retry, even though the RayJob's has JobDeploymentStatus is `Complete` and JobStatus is `SUCCEEDED`. Without this PR, if the Ray job is in a terminal state (e.g. `SUCCEEDED`), the RayJob will transition from `Running` to `Complete`, and check `ttlSecondsAfterFinished` to determine whether is it ready to delete RayCluster or not. However, the submitter Kubernetes Job may fail because it still requires some time to receive the logs from the Ray head, but the head service has already been deleted.

In this PR, RayJob transitions from `Running` to `Complete` if and only if the submitter Job is `Complete` or `Failed`.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

## Without this PR

* Although all RayJob custom resources have a `Complete` (JobDeploymentStatus) and `SUCCEEDED` (JobStatus), one submitter Kubernetes Job fails among the 25 RayJob custom resources.

<img width="1439" alt="Screen Shot 2024-02-10 at 11 41 25 PM" src="https://github.com/ray-project/kuberay/assets/20109646/264235a5-92eb-4fa7-8e08-a36af76bb0d1">
<img width="880" alt="Screen Shot 2024-02-10 at 11 54 53 PM" src="https://github.com/ray-project/kuberay/assets/20109646/bd620c48-8140-44d5-aada-29af8650483c">

## With this PR

<img width="1410" alt="Screen Shot 2024-02-10 at 11 30 20 PM" src="https://github.com/ray-project/kuberay/assets/20109646/a41e62bc-d059-4450-863e-7057cefded31">
<img width="863" alt="Screen Shot 2024-02-10 at 11 30 00 PM" src="https://github.com/ray-project/kuberay/assets/20109646/dc32f0b9-3300-4c5c-9dd0-20378fd8c0c2">



