### PR TITLE
[CI] Don't push new images to DockerHub

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -57,18 +57,6 @@ jobs:
         docker build -t kuberay/apiserver:${{ steps.vars.outputs.sha_short }} -f apiserver/Dockerfile .
         docker save -o /tmp/apiserver.tar kuberay/apiserver:${{ steps.vars.outputs.sha_short }}
 
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
-    - name: Push Apiserver to DockerHub
-      run: |
-        docker push kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:${{ github.event.inputs.tag }};
-        docker push kuberay/apiserver:${{ github.event.inputs.tag }}
-
     - name: Log in to Quay.io
       uses: docker/login-action@v2
       with:

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -170,20 +170,6 @@ jobs:
           name: apiserver_img
           path: /tmp/apiserver.tar
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-        if: contains(fromJson('["refs/heads/master"]'), github.ref)
-
-      - name: Push Apiserver to DockerHub
-        run: |
-          docker push kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-          docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} kuberay/apiserver:nightly;
-          docker push kuberay/apiserver:nightly
-        if: contains(fromJson('["refs/heads/master"]'), github.ref)
-
       - name: Log in to Quay.io
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The DockerHub bot has somehow been removed from the KubeRay DockerHub account, causing KubeRay CI to fail when pushing images to DockerHub. We can resolve this by re-adding the bot. However, I lack access to set the repository secrets, which means the process could be lengthy and block every PR.

As a workaround, this PR doesn't push images to DockerHub. Instead, it only pushes images to Quay. Next week, I will discuss with the community to determine whether we should support only Quay.





## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
