### PR TITLE
feat: add `RayCluster.status.readyWorkerReplicas`

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -7118,6 +7118,9 @@ spec:
               observedGeneration:
                 format: int64
                 type: integer
+              readyWorkerReplicas:
+                format: int32
+                type: integer
               reason:
                 type: string
               state:
@@ -14228,6 +14231,9 @@ spec:
                 type: integer
               observedGeneration:
                 format: int64
+                type: integer
+              readyWorkerReplicas:
+                format: int32
                 type: integer
               reason:
                 type: string

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -10432,6 +10432,9 @@ spec:
                   observedGeneration:
                     format: int64
                     type: integer
+                  readyWorkerReplicas:
+                    format: int32
+                    type: integer
                   reason:
                     type: string
                   state:
@@ -20831,6 +20834,9 @@ spec:
                     type: integer
                   observedGeneration:
                     format: int64
+                    type: integer
+                  readyWorkerReplicas:
+                    format: int32
                     type: integer
                   reason:
                     type: string

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -7320,6 +7320,9 @@ spec:
                       observedGeneration:
                         format: int64
                         type: integer
+                      readyWorkerReplicas:
+                        format: int32
+                        type: integer
                       reason:
                         type: string
                       state:
@@ -7425,6 +7428,9 @@ spec:
                         type: integer
                       observedGeneration:
                         format: int64
+                        type: integer
+                      readyWorkerReplicas:
+                        format: int32
                         type: integer
                       reason:
                         type: string
@@ -14736,6 +14742,9 @@ spec:
                       observedGeneration:
                         format: int64
                         type: integer
+                      readyWorkerReplicas:
+                        format: int32
+                        type: integer
                       reason:
                         type: string
                       state:
@@ -14831,6 +14840,9 @@ spec:
                         type: integer
                       observedGeneration:
                         format: int64
+                        type: integer
+                      readyWorkerReplicas:
+                        format: int32
                         type: integer
                       reason:
                         type: string

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -121,6 +121,8 @@ type RayClusterStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	// Status reflects the status of the cluster
 	State ClusterState `json:"state,omitempty"`
+	// ReadyWorkerReplicas indicates how many worker replicas are ready in the cluster
+	ReadyWorkerReplicas int32 `json:"readyWorkerReplicas,omitempty"`
 	// AvailableWorkerReplicas indicates how many replicas are available in the cluster
 	AvailableWorkerReplicas int32 `json:"availableWorkerReplicas,omitempty"`
 	// DesiredWorkerReplicas indicates overall desired replicas claimed by the user at the cluster level.

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -119,6 +119,8 @@ type RayClusterStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	// Status reflects the status of the cluster
 	State ClusterState `json:"state,omitempty"`
+	// ReadyWorkerReplicas indicates how many worker replicas are ready in the cluster
+	ReadyWorkerReplicas int32 `json:"readyWorkerReplicas,omitempty"`
 	// AvailableWorkerReplicas indicates how many replicas are available in the cluster
 	AvailableWorkerReplicas int32 `json:"availableWorkerReplicas,omitempty"`
 	// DesiredWorkerReplicas indicates overall desired replicas claimed by the user at the cluster level.

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -7118,6 +7118,9 @@ spec:
               observedGeneration:
                 format: int64
                 type: integer
+              readyWorkerReplicas:
+                format: int32
+                type: integer
               reason:
                 type: string
               state:
@@ -14228,6 +14231,9 @@ spec:
                 type: integer
               observedGeneration:
                 format: int64
+                type: integer
+              readyWorkerReplicas:
+                format: int32
                 type: integer
               reason:
                 type: string

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -10432,6 +10432,9 @@ spec:
                   observedGeneration:
                     format: int64
                     type: integer
+                  readyWorkerReplicas:
+                    format: int32
+                    type: integer
                   reason:
                     type: string
                   state:
@@ -20831,6 +20834,9 @@ spec:
                     type: integer
                   observedGeneration:
                     format: int64
+                    type: integer
+                  readyWorkerReplicas:
+                    format: int32
                     type: integer
                   reason:
                     type: string

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -7320,6 +7320,9 @@ spec:
                       observedGeneration:
                         format: int64
                         type: integer
+                      readyWorkerReplicas:
+                        format: int32
+                        type: integer
                       reason:
                         type: string
                       state:
@@ -7425,6 +7428,9 @@ spec:
                         type: integer
                       observedGeneration:
                         format: int64
+                        type: integer
+                      readyWorkerReplicas:
+                        format: int32
                         type: integer
                       reason:
                         type: string
@@ -14736,6 +14742,9 @@ spec:
                       observedGeneration:
                         format: int64
                         type: integer
+                      readyWorkerReplicas:
+                        format: int32
+                        type: integer
                       reason:
                         type: string
                       state:
@@ -14831,6 +14840,9 @@ spec:
                         type: integer
                       observedGeneration:
                         format: int64
+                        type: integer
+                      readyWorkerReplicas:
+                        format: int32
                         type: integer
                       reason:
                         type: string

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -400,13 +400,22 @@ func (r *RayClusterReconciler) inconsistentRayClusterStatus(ctx context.Context,
 			oldStatus.State, newStatus.State, oldStatus.Reason, newStatus.Reason))
 		return true
 	}
-	if oldStatus.AvailableWorkerReplicas != newStatus.AvailableWorkerReplicas || oldStatus.DesiredWorkerReplicas != newStatus.DesiredWorkerReplicas ||
-		oldStatus.MinWorkerReplicas != newStatus.MinWorkerReplicas || oldStatus.MaxWorkerReplicas != newStatus.MaxWorkerReplicas {
+	if oldStatus.ReadyWorkerReplicas != newStatus.ReadyWorkerReplicas ||
+		oldStatus.AvailableWorkerReplicas != newStatus.AvailableWorkerReplicas ||
+		oldStatus.DesiredWorkerReplicas != newStatus.DesiredWorkerReplicas ||
+		oldStatus.MinWorkerReplicas != newStatus.MinWorkerReplicas ||
+		oldStatus.MaxWorkerReplicas != newStatus.MaxWorkerReplicas {
 		logger.Info("inconsistentRayClusterStatus", "detect inconsistency", fmt.Sprintf(
-			"old AvailableWorkerReplicas: %d, new AvailableWorkerReplicas: %d, old DesiredWorkerReplicas: %d, new DesiredWorkerReplicas: %d, "+
-				"old MinWorkerReplicas: %d, new MinWorkerReplicas: %d, old MaxWorkerReplicas: %d, new MaxWorkerReplicas: %d",
-			oldStatus.AvailableWorkerReplicas, newStatus.AvailableWorkerReplicas, oldStatus.DesiredWorkerReplicas, newStatus.DesiredWorkerReplicas,
-			oldStatus.MinWorkerReplicas, newStatus.MinWorkerReplicas, oldStatus.MaxWorkerReplicas, newStatus.MaxWorkerReplicas))
+			"old ReadyWorkerReplicas: %d, new ReadyWorkerReplicas: %d, "+
+				"old AvailableWorkerReplicas: %d, new AvailableWorkerReplicas: %d, "+
+				"old DesiredWorkerReplicas: %d, new DesiredWorkerReplicas: %d, "+
+				"old MinWorkerReplicas: %d, new MinWorkerReplicas: %d, "+
+				"old MaxWorkerReplicas: %d, new MaxWorkerReplicas: %d",
+			oldStatus.ReadyWorkerReplicas, newStatus.ReadyWorkerReplicas,
+			oldStatus.AvailableWorkerReplicas, newStatus.AvailableWorkerReplicas,
+			oldStatus.DesiredWorkerReplicas, newStatus.DesiredWorkerReplicas,
+			oldStatus.MinWorkerReplicas, newStatus.MinWorkerReplicas,
+			oldStatus.MaxWorkerReplicas, newStatus.MaxWorkerReplicas))
 		return true
 	}
 	if !reflect.DeepEqual(oldStatus.Endpoints, newStatus.Endpoints) || !reflect.DeepEqual(oldStatus.Head, newStatus.Head) {
@@ -1222,6 +1231,7 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 		return nil, err
 	}
 
+	newInstance.Status.ReadyWorkerReplicas = utils.CalculateReadyReplicas(runtimePods)
 	newInstance.Status.AvailableWorkerReplicas = utils.CalculateAvailableReplicas(runtimePods)
 	newInstance.Status.DesiredWorkerReplicas = utils.CalculateDesiredReplicas(ctx, newInstance)
 	newInstance.Status.MinWorkerReplicas = utils.CalculateMinReplicas(newInstance)

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1530,6 +1530,7 @@ func TestInconsistentRayClusterStatus(t *testing.T) {
 	timeNow := metav1.Now()
 	oldStatus := rayv1.RayClusterStatus{
 		State:                   rayv1.Ready,
+		ReadyWorkerReplicas:     1,
 		AvailableWorkerReplicas: 1,
 		DesiredWorkerReplicas:   1,
 		MinWorkerReplicas:       1,
@@ -1564,42 +1565,47 @@ func TestInconsistentRayClusterStatus(t *testing.T) {
 	newStatus.Reason = "new reason"
 	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
-	// Case 3: `AvailableWorkerReplicas` is different => return true
+	// Case 3: `ReadyWorkerReplicas` is different => return true
+	newStatus = oldStatus.DeepCopy()
+	newStatus.ReadyWorkerReplicas = oldStatus.ReadyWorkerReplicas + 1
+	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
+
+	// Case 4: `AvailableWorkerReplicas` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.AvailableWorkerReplicas = oldStatus.AvailableWorkerReplicas + 1
 	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
-	// Case 4: `DesiredWorkerReplicas` is different => return true
+	// Case 5: `DesiredWorkerReplicas` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.DesiredWorkerReplicas = oldStatus.DesiredWorkerReplicas + 1
 	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
-	// Case 5: `MinWorkerReplicas` is different => return true
+	// Case 6: `MinWorkerReplicas` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.MinWorkerReplicas = oldStatus.MinWorkerReplicas + 1
 	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
-	// Case 6: `MaxWorkerReplicas` is different => return true
+	// Case 7: `MaxWorkerReplicas` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.MaxWorkerReplicas = oldStatus.MaxWorkerReplicas + 1
 	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
-	// Case 7: `Endpoints` is different => return true
+	// Case 8: `Endpoints` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.Endpoints["fakeEndpoint"] = "10009"
 	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
-	// Case 8: `Head` is different => return true
+	// Case 9: `Head` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.Head.PodIP = "test head pod ip"
 	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
-	// Case 9: `LastUpdateTime` is different => return false
+	// Case 10: `LastUpdateTime` is different => return false
 	newStatus = oldStatus.DeepCopy()
 	newStatus.LastUpdateTime = &metav1.Time{Time: timeNow.Add(time.Hour)}
 	assert.False(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
-	// Case 10: `ObservedGeneration` is different => return false
+	// Case 11: `ObservedGeneration` is different => return false
 	newStatus = oldStatus.DeepCopy()
 	newStatus.ObservedGeneration = oldStatus.ObservedGeneration + 1
 	assert.False(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -290,6 +290,25 @@ func CalculateMaxReplicas(cluster *rayv1.RayCluster) int32 {
 	return count
 }
 
+// CalculateReadyReplicas calculates ready worker replicas at the cluster level
+// A worker is ready if its Pod has a PodCondition with type == Ready and status == True
+func CalculateReadyReplicas(pods corev1.PodList) int32 {
+	count := int32(0)
+	for _, pod := range pods.Items {
+		if val, ok := pod.Labels["ray.io/node-type"]; !ok || val != string(rayv1.WorkerNode) {
+			continue
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				count++
+				break
+			}
+		}
+	}
+
+	return count
+}
+
 // CalculateAvailableReplicas calculates available worker replicas at the cluster level
 // A worker is available if its Pod is running
 func CalculateAvailableReplicas(pods corev1.PodList) int32 {

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -274,6 +274,12 @@ func TestCalculateAvailableReplicas(t *testing.T) {
 				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
 				},
 			},
 			{
@@ -285,6 +291,12 @@ func TestCalculateAvailableReplicas(t *testing.T) {
 				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
 				},
 			},
 			{
@@ -300,8 +312,12 @@ func TestCalculateAvailableReplicas(t *testing.T) {
 			},
 		},
 	}
-	count := CalculateAvailableReplicas(podList)
-	assert.Equal(t, count, int32(1), "expect 1 available replica")
+
+	availableCount := CalculateAvailableReplicas(podList)
+	assert.Equal(t, availableCount, int32(1), "expect 1 available replica")
+
+	readyCount := CalculateReadyReplicas(podList)
+	assert.Equal(t, readyCount, int32(1), "expect 1 ready replica")
 }
 
 func TestFindContainerPort(t *testing.T) {

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayclusterstatus.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayclusterstatus.go
@@ -12,6 +12,7 @@ import (
 // with apply.
 type RayClusterStatusApplyConfiguration struct {
 	State                   *v1.ClusterState                 `json:"state,omitempty"`
+	ReadyWorkerReplicas     *int32                           `json:"readyWorkerReplicas,omitempty"`
 	AvailableWorkerReplicas *int32                           `json:"availableWorkerReplicas,omitempty"`
 	DesiredWorkerReplicas   *int32                           `json:"desiredWorkerReplicas,omitempty"`
 	MinWorkerReplicas       *int32                           `json:"minWorkerReplicas,omitempty"`
@@ -39,6 +40,14 @@ func RayClusterStatus() *RayClusterStatusApplyConfiguration {
 // If called multiple times, the State field is set to the value of the last call.
 func (b *RayClusterStatusApplyConfiguration) WithState(value v1.ClusterState) *RayClusterStatusApplyConfiguration {
 	b.State = &value
+	return b
+}
+
+// WithReadyWorkerReplicas sets the ReadyWorkerReplicas field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ReadyWorkerReplicas field is set to the value of the last call.
+func (b *RayClusterStatusApplyConfiguration) WithReadyWorkerReplicas(value int32) *RayClusterStatusApplyConfiguration {
+	b.ReadyWorkerReplicas = &value
 	return b
 }
 


### PR DESCRIPTION
A worker Pod is ready if it has a PodCondition with `type == Ready` and `status ==
True`. See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
