### PR TITLE
Add common containerEnv section to Helm Chart

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -61,7 +61,12 @@ spec:
             securityContext:
             {{- toYaml .Values.head.securityContext | nindent 14 }}
             env:
-            {{- toYaml .Values.head.containerEnv | nindent 14}}
+            {{- with .Values.common.containerEnv }}
+            {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.head.containerEnv }}
+            {{- toYaml . | nindent 14 }}
+            {{- end }}
             {{- with .Values.head.envFrom }}
             envFrom: {{- toYaml . | nindent 14}}
             {{- end }}
@@ -142,7 +147,12 @@ spec:
             securityContext:
             {{- toYaml $values.securityContext | nindent 14 }}
             env:
-            {{- toYaml $values.containerEnv | nindent 14}}
+            {{- with $.Values.common.containerEnv }}
+            {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with $values.containerEnv }}
+            {{- toYaml . | nindent 14}}
+            {{- end }}
             {{- if $values.envFrom }}
             envFrom: {{- toYaml $values.envFrom | nindent 14 }}
             {{- end }}
@@ -221,7 +231,12 @@ spec:
             securityContext:
             {{- toYaml .Values.worker.securityContext | nindent 14 }}
             env:
-            {{- toYaml .Values.worker.containerEnv | nindent 14}}
+            {{- with .Values.common.containerEnv }}
+            {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.worker.containerEnv }}
+            {{- toYaml . | nindent 14}}
+            {{- end }}
             {{- with .Values.worker.envFrom }}
             envFrom: {{- toYaml . | nindent 14}}
             {{- end }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -18,7 +18,7 @@ imagePullSecrets: []
 
 common:
   {}
-  #containerEnv:
+  # containerEnv:
   #  - name: BLAH
   #    value: VAL
 head:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -16,6 +16,11 @@ fullnameOverride: ""
 imagePullSecrets: []
   # - name: an-existing-secret
 
+common:
+  {}
+  #containerEnv:
+  #  - name: BLAH
+  #    value: VAL
 head:
   # rayVersion determines the autoscaler's image version.
   # It should match the Ray version in the image of the containers.

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -16,9 +16,11 @@ fullnameOverride: ""
 imagePullSecrets: []
   # - name: an-existing-secret
 
+# common defined values shared between the head and worker
 common:
-  {}
-  # containerEnv:
+  # containerEnv specifies environment variables for the Ray head and worker containers.
+  # Follows standard K8s container env schema.
+  containerEnv: {}
   #  - name: BLAH
   #    value: VAL
 head:


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This adds a `common` section for values shared between the head and workers and adds an `containerEnv` section to common env vars.

## Related issue number

Closes #1934

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

Manual Tests Run:
- Leaving `common.containerEnv` blank and rendering chart
- Setting `common.containerEnv` and ensuring envs rendered in head, worker and additional worker groups
- Setting `common.containerEnv` and `head.containerEnv`
- Setting `common.containerEnv` and `worker.containerEnv`
- Setting `common.containerEnv` and `additionalWorkerGroups.smallGroup.containerEnv` (With additionalWorkerGroups enabled) 
- Setting `head.containerEnv` only
- Setting `worker.containerEnv` only