### PR TITLE
[RayJob] Support ActiveDeadlineSeconds

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -140,6 +140,7 @@ _Appears in:_
 | `jobId` _string_ | If jobId is not set, a new jobId will be auto-generated. |
 | `shutdownAfterJobFinishes` _boolean_ | ShutdownAfterJobFinishes will determine whether to delete the ray cluster once rayJob succeed or failed. |
 | `ttlSecondsAfterFinished` _integer_ | TTLSecondsAfterFinished is the TTL to clean up RayCluster. It's only working when ShutdownAfterJobFinishes set to true. |
+| `activeDeadlineSeconds` _integer_ | ActiveDeadlineSeconds is the duration in seconds that the RayJob may be active before KubeRay actively tries to terminate the RayJob; value must be positive integer. |
 | `rayClusterSpec` _[RayClusterSpec](#rayclusterspec)_ | RayClusterSpec is the cluster template to run the job |
 | `clusterSelector` _object (keys:string, values:string)_ | clusterSelector is used to select running rayclusters by labels |
 | `submissionMode` _[JobSubmissionMode](#jobsubmissionmode)_ | SubmissionMode specifies how RayJob submits the Ray job to the RayCluster. In "K8sJobMode", the KubeRay operator creates a submitter Kubernetes Job to submit the Ray job. In "HTTPMode", the KubeRay operator sends a request to the RayCluster to create a Ray job. |

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -44,6 +44,9 @@ spec:
             type: object
           spec:
             properties:
+              activeDeadlineSeconds:
+                format: int32
+                type: integer
               clusterSelector:
                 additionalProperties:
                   type: string

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -149,7 +149,6 @@ type RayClusterStatus struct {
 	Reason string `json:"reason,omitempty"`
 	// observedGeneration is the most recent generation observed for this RayCluster. It corresponds to the
 	// RayCluster's generation, which is updated on mutation by the API Server.
-	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -67,6 +67,9 @@ type RayJobSpec struct {
 	// It's only working when ShutdownAfterJobFinishes set to true.
 	// +kubebuilder:default:=0
 	TTLSecondsAfterFinished int32 `json:"ttlSecondsAfterFinished,omitempty"`
+	// ActiveDeadlineSeconds is the duration in seconds that the RayJob may be active before
+	// KubeRay actively tries to terminate the RayJob; value must be positive integer.
+	ActiveDeadlineSeconds *int32 `json:"activeDeadlineSeconds,omitempty"`
 	// RayClusterSpec is the cluster template to run the job
 	RayClusterSpec *RayClusterSpec `json:"rayClusterSpec,omitempty"`
 	// clusterSelector is used to select running rayclusters by labels
@@ -103,9 +106,7 @@ type RayJobStatus struct {
 	JobStatus           JobStatus           `json:"jobStatus,omitempty"`
 	JobDeploymentStatus JobDeploymentStatus `json:"jobDeploymentStatus,omitempty"`
 	Message             string              `json:"message,omitempty"`
-	// Represents time when the job was acknowledged by the Ray cluster.
-	// It is not guaranteed to be set in happens-before order across separate operations.
-	// It is represented in RFC3339 form
+	// StartTime is the time when JobDeploymentStatus transitioned from 'New' to 'Initializing'.
 	StartTime *metav1.Time `json:"startTime,omitempty"`
 	// EndTime is the time when JobDeploymentStatus transitioned to 'Complete' status.
 	// This occurs when the Ray job reaches a terminal state (SUCCEEDED, FAILED, STOPPED)
@@ -114,7 +115,6 @@ type RayJobStatus struct {
 	RayClusterStatus RayClusterStatus `json:"rayClusterStatus,omitempty"`
 	// observedGeneration is the most recent generation observed for this RayJob. It corresponds to the
 	// RayJob's generation, which is updated on mutation by the API Server.
-	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 

--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -76,7 +76,6 @@ type RayServiceStatuses struct {
 	NumServeEndpoints int32 `json:"NumServeEndpoints,omitempty"`
 	// observedGeneration is the most recent generation observed for this RayService. It corresponds to the
 	// RayService's generation, which is updated on mutation by the API Server.
-	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// LastUpdateTime represents the timestamp when the RayService status was last updated.
 	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty"`

--- a/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
@@ -353,6 +353,11 @@ func (in *RayJobSpec) DeepCopyInto(out *RayJobSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.ActiveDeadlineSeconds != nil {
+		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	if in.RayClusterSpec != nil {
 		in, out := &in.RayClusterSpec, &out.RayClusterSpec
 		*out = new(RayClusterSpec)

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -146,7 +146,6 @@ type RayClusterStatus struct {
 	Reason string `json:"reason,omitempty"`
 	// observedGeneration is the most recent generation observed for this RayCluster. It corresponds to the
 	// RayCluster's generation, which is updated on mutation by the API Server.
-	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 

--- a/ray-operator/apis/ray/v1alpha1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayjob_types.go
@@ -99,7 +99,6 @@ type RayJobStatus struct {
 	RayClusterStatus RayClusterStatus `json:"rayClusterStatus,omitempty"`
 	// observedGeneration is the most recent generation observed for this RayJob. It corresponds to the
 	// RayJob's generation, which is updated on mutation by the API Server.
-	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -74,7 +74,6 @@ type RayServiceStatuses struct {
 	ServiceStatus ServiceStatus `json:"serviceStatus,omitempty"`
 	// observedGeneration is the most recent generation observed for this RayService. It corresponds to the
 	// RayService's generation, which is updated on mutation by the API Server.
-	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// LastUpdateTime represents the timestamp when the RayService status was last updated.
 	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty"`

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -44,6 +44,9 @@ spec:
             type: object
           spec:
             properties:
+              activeDeadlineSeconds:
+                format: int32
+                type: integer
               clusterSelector:
                 additionalProperties:
                   type: string

--- a/ray-operator/config/samples/ray-job.sample.yaml
+++ b/ray-operator/config/samples/ray-job.sample.yaml
@@ -14,6 +14,10 @@ spec:
   # ttlSecondsAfterFinished specifies the number of seconds after which the RayCluster will be deleted after the RayJob finishes.
   # ttlSecondsAfterFinished: 10
 
+  # activeDeadlineSeconds is the duration in seconds that the RayJob may be active before
+  # KubeRay actively tries to terminate the RayJob; value must be positive integer.
+  # activeDeadlineSeconds: 120
+
   # RuntimeEnvYAML represents the runtime environment configuration provided as a multi-line YAML string.
   # See https://docs.ray.io/en/latest/ray-core/handling-dependencies.html for details.
   # (New in KubeRay version 1.0.)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -708,6 +708,9 @@ func validateRayJobSpec(rayJob *rayv1.RayJob) error {
 	if _, err := utils.UnmarshalRuntimeEnvYAML(rayJob.Spec.RuntimeEnvYAML); err != nil {
 		return err
 	}
+	if rayJob.Spec.ActiveDeadlineSeconds != nil && *rayJob.Spec.ActiveDeadlineSeconds <= 0 {
+		return fmt.Errorf("activeDeadlineSeconds must be a positive integer")
+	}
 	return nil
 }
 

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -142,6 +142,11 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		if shouldUpdate := r.updateStatusToSuspendingIfNeeded(ctx, rayJobInstance); shouldUpdate {
 			break
 		}
+		if pastActiveDeadline(rayJobInstance) {
+			r.Log.Info("The RayJob has passed the activeDeadlineSeconds. Transition the status to `Complete`.", "StartTime", rayJobInstance.Status.StartTime, "ActiveDeadlineSeconds", *rayJobInstance.Spec.ActiveDeadlineSeconds)
+			rayJobInstance.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusComplete
+			break
+		}
 
 		var rayClusterInstance *rayv1.RayCluster
 		if rayClusterInstance, err = r.getOrCreateRayClusterInstance(ctx, rayJobInstance); err != nil {
@@ -175,12 +180,19 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		if shouldUpdate := r.updateStatusToSuspendingIfNeeded(ctx, rayJobInstance); shouldUpdate {
 			break
 		}
+		if pastActiveDeadline(rayJobInstance) {
+			r.Log.Info("The RayJob has passed the activeDeadlineSeconds. Transition the status to `Complete`.", "StartTime", rayJobInstance.Status.StartTime, "ActiveDeadlineSeconds", *rayJobInstance.Spec.ActiveDeadlineSeconds)
+			rayJobInstance.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusComplete
+			break
+		}
 
-		// TODO (kevin85421): For light-weight mode, calculate the number of failed retries and transition
-		// the status to `Complete` if the number of failed retries exceeds the threshold.
 		job := &batchv1.Job{}
 		if rayJobInstance.Spec.SubmissionMode == rayv1.K8sJobMode {
-			// If the Job reaches the backoff limit, transition the status to `Complete`.
+			// If the submitting Kubernetes Job reaches the backoff limit, transition the status to `Complete`. This is because,
+			// beyond this point, it becomes impossible for the submitter to submit any further Ray jobs. For light-weight mode,
+			// we don't transition the status to `Complete` based on the number of failed requests. Instead, users can use the
+			// `ActiveDeadlineSeconds` to ensure that the RayJob in the light-weight mode is not stuck in the `Running` status
+			// indefinitely.
 			namespacedName := getK8sJobNamespacedName(rayJobInstance)
 			if err := r.Client.Get(ctx, namespacedName, job); err != nil {
 				r.Log.Error(err, "Failed to get the submitter Kubernetes Job", "NamespacedName", namespacedName)
@@ -236,7 +248,6 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		rayJobInstance.Status.RayClusterStatus = rayClusterInstance.Status
 		rayJobInstance.Status.JobStatus = jobInfo.JobStatus
 		rayJobInstance.Status.Message = jobInfo.Message
-		rayJobInstance.Status.StartTime = utils.ConvertUnixTimeToMetav1Time(jobInfo.StartTime)
 		rayJobInstance.Status.JobDeploymentStatus = jobDeploymentStatus
 	case rayv1.JobDeploymentStatusSuspending:
 		// The `suspend` operation should be atomic. In other words, if users set the `suspend` flag to true and then immediately
@@ -510,7 +521,8 @@ func (r *RayJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // This function is the sole place where `JobDeploymentStatusInitializing` is defined. It initializes `Status.JobId` and `Status.RayClusterName`
-// prior to job submissions and RayCluster creations. This is used to avoid duplicate job submissions and cluster creations.
+// prior to job submissions and RayCluster creations. This is used to avoid duplicate job submissions and cluster creations. In addition, this
+// function also sets `Status.StartTime` to support `ActiveDeadlineSeconds`.
 func (r *RayJobReconciler) initRayJobStatusIfNeed(ctx context.Context, rayJob *rayv1.RayJob) error {
 	shouldUpdateStatus := rayJob.Status.JobId == "" || rayJob.Status.RayClusterName == "" || rayJob.Status.JobStatus == ""
 	// Please don't update `shouldUpdateStatus` below.
@@ -546,6 +558,7 @@ func (r *RayJobReconciler) initRayJobStatusIfNeed(ctx context.Context, rayJob *r
 		rayJob.Status.JobStatus = rayv1.JobStatusNew
 	}
 	rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusInitializing
+	rayJob.Status.StartTime = &metav1.Time{Time: time.Now()}
 	return nil
 }
 
@@ -668,6 +681,13 @@ func (r *RayJobReconciler) checkK8sJobAndUpdateStatusIfNeeded(ctx context.Contex
 		}
 	}
 	return false
+}
+
+func pastActiveDeadline(rayJob *rayv1.RayJob) bool {
+	if rayJob.Spec.ActiveDeadlineSeconds == nil {
+		return false
+	}
+	return time.Now().After(rayJob.Status.StartTime.Add(time.Duration(*rayJob.Spec.ActiveDeadlineSeconds) * time.Second))
 }
 
 func validateRayJobSpec(rayJob *rayv1.RayJob) error {

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobspec.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobspec.go
@@ -16,6 +16,7 @@ type RayJobSpecApplyConfiguration struct {
 	JobId                    *string                                   `json:"jobId,omitempty"`
 	ShutdownAfterJobFinishes *bool                                     `json:"shutdownAfterJobFinishes,omitempty"`
 	TTLSecondsAfterFinished  *int32                                    `json:"ttlSecondsAfterFinished,omitempty"`
+	ActiveDeadlineSeconds    *int32                                    `json:"activeDeadlineSeconds,omitempty"`
 	RayClusterSpec           *RayClusterSpecApplyConfiguration         `json:"rayClusterSpec,omitempty"`
 	ClusterSelector          map[string]string                         `json:"clusterSelector,omitempty"`
 	SubmissionMode           *rayv1.JobSubmissionMode                  `json:"submissionMode,omitempty"`
@@ -83,6 +84,14 @@ func (b *RayJobSpecApplyConfiguration) WithShutdownAfterJobFinishes(value bool) 
 // If called multiple times, the TTLSecondsAfterFinished field is set to the value of the last call.
 func (b *RayJobSpecApplyConfiguration) WithTTLSecondsAfterFinished(value int32) *RayJobSpecApplyConfiguration {
 	b.TTLSecondsAfterFinished = &value
+	return b
+}
+
+// WithActiveDeadlineSeconds sets the ActiveDeadlineSeconds field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ActiveDeadlineSeconds field is set to the value of the last call.
+func (b *RayJobSpecApplyConfiguration) WithActiveDeadlineSeconds(value int32) *RayJobSpecApplyConfiguration {
+	b.ActiveDeadlineSeconds = &value
 	return b
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
* Initially, `StartTime` refers to the time when the Ray job starts running on the RayCluster. This PR redefines `StartTime` to the time when `JobDeploymentStatus` transitioned from `New` to `Initializing`.
* `ActiveDeadlineSeconds`: Similar to `ActiveDeadlineSeconds` in K8s Job https://kubernetes.io/docs/concepts/workloads/controllers/job/.
* We don't check `ActiveDeadlineSeconds` if the RayJob is in `New`, `Complete`, `Suspending`, and `Suspended`.
* We only check `ActiveDeadlineSeconds` if the RayJob is in the `Initializing` or `Running` state, which may occupy some computing resources.
  * If the RayJob passes `ActiveDeadlineSeconds`, KubeRay will transition the status to `Complete`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
