### PR TITLE
[Structure Logging][1/n] Make the format of the controller name consistent

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1163,7 +1163,6 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instanc
 // SetupWithManager builds the reconciler.
 func (r *RayClusterReconciler) SetupWithManager(mgr ctrl.Manager, reconcileConcurrency int) error {
 	b := ctrl.NewControllerManagedBy(mgr).
-		Named("raycluster-controller").
 		For(&rayv1.RayCluster{}, builder.WithPredicates(predicate.Or(
 			predicate.GenerationChangedPredicate{},
 			predicate.LabelChangedPredicate{},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The name of the RayJob controller is `rayjob`, and the name of the RayService controller is `rayservice`. However, the name of the RayCluster controller is `raycluster-controller`.
* Without this PR
  <img width="1592" alt="Screen Shot 2024-02-22 at 1 39 39 PM" src="https://github.com/ray-project/kuberay/assets/20109646/b7e58218-aad1-41d0-b468-2dab9244340c">
* With this PR
  <img width="1628" alt="Screen Shot 2024-02-22 at 1 44 27 PM" src="https://github.com/ray-project/kuberay/assets/20109646/12e778f1-3252-4e66-a3c4-79b4cf009c68">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
