### PR TITLE
[RayJob] Add JobDeploymentStatusFailed Status and Reason Field to Enhance Observability for Flyte/RayJob Integration

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -58,6 +58,17 @@ _Appears in:_
 | `template` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | Template is the exact pod template used in K8s depoyments, statefulsets, etc. |
 
 
+#### JobFailedReason
+
+_Underlying type:_ _string_
+
+JobFailedReason indicates the reason the RayJob changes its JobDeploymentStatus to 'Failed'
+
+_Appears in:_
+- [RayJobStatus](#rayjobstatus)
+
+
+
 #### JobSubmissionMode
 
 _Underlying type:_ _string_

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -10426,6 +10426,8 @@ spec:
                   state:
                     type: string
                 type: object
+              reason:
+                type: string
               startTime:
                 format: date-time
                 type: string

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -43,10 +43,13 @@ const (
 	JobDeploymentStatusSuspended    JobDeploymentStatus = "Suspended"
 )
 
+// JobFailedReason indicates the reason the RayJob changes its JobDeploymentStatus to 'Failed'
+type JobFailedReason string
+
 const (
-	JobReasonSubmissionFailed       string = "SubmissionFailed"
-	JobReasonDeadlineExceeded       string = "DeadlineExceeded"
-	JobReasonApplicationLevelFailed string = "ApplicationLevelFailed"
+	SubmissionFailed JobFailedReason = "SubmissionFailed"
+	DeadlineExceeded JobFailedReason = "DeadlineExceeded"
+	AppFailed        JobFailedReason = "AppFailed"
 )
 
 type JobSubmissionMode string
@@ -112,7 +115,7 @@ type RayJobStatus struct {
 	DashboardURL        string              `json:"dashboardURL,omitempty"`
 	JobStatus           JobStatus           `json:"jobStatus,omitempty"`
 	JobDeploymentStatus JobDeploymentStatus `json:"jobDeploymentStatus,omitempty"`
-	Reason              string              `json:"reason,omitempty"`
+	Reason              JobFailedReason     `json:"reason,omitempty"`
 	Message             string              `json:"message,omitempty"`
 	// StartTime is the time when JobDeploymentStatus transitioned from 'New' to 'Initializing'.
 	StartTime *metav1.Time `json:"startTime,omitempty"`

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -38,8 +38,15 @@ const (
 	JobDeploymentStatusInitializing JobDeploymentStatus = "Initializing"
 	JobDeploymentStatusRunning      JobDeploymentStatus = "Running"
 	JobDeploymentStatusComplete     JobDeploymentStatus = "Complete"
+	JobDeploymentStatusFailed       JobDeploymentStatus = "Failed"
 	JobDeploymentStatusSuspending   JobDeploymentStatus = "Suspending"
 	JobDeploymentStatusSuspended    JobDeploymentStatus = "Suspended"
+)
+
+const (
+	JobReasonSubmissionFailed       string = "SubmissionFailed"
+	JobReasonDeadlineExceeded       string = "DeadlineExceeded"
+	JobReasonApplicationLevelFailed string = "ApplicationLevelFailed"
 )
 
 type JobSubmissionMode string
@@ -105,6 +112,7 @@ type RayJobStatus struct {
 	DashboardURL        string              `json:"dashboardURL,omitempty"`
 	JobStatus           JobStatus           `json:"jobStatus,omitempty"`
 	JobDeploymentStatus JobDeploymentStatus `json:"jobDeploymentStatus,omitempty"`
+	Reason              string              `json:"reason,omitempty"`
 	Message             string              `json:"message,omitempty"`
 	// StartTime is the time when JobDeploymentStatus transitioned from 'New' to 'Initializing'.
 	StartTime *metav1.Time `json:"startTime,omitempty"`

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -10426,6 +10426,8 @@ spec:
                   state:
                     type: string
                 type: object
+              reason:
+                type: string
               startTime:
                 format: date-time
                 type: string

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -294,7 +294,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 	case rayv1.JobDeploymentStatusComplete, rayv1.JobDeploymentStatusFailed:
 		// If this RayJob uses an existing RayCluster (i.e., ClusterSelector is set), we should not delete the RayCluster.
-		r.Log.Info(fmt.Sprintf("%s", rayJobInstance.Status.JobDeploymentStatus), "RayJob", rayJobInstance.Name, "ShutdownAfterJobFinishes", rayJobInstance.Spec.ShutdownAfterJobFinishes, "ClusterSelector", rayJobInstance.Spec.ClusterSelector)
+		r.Log.Info(string(rayJobInstance.Status.JobDeploymentStatus), "RayJob", rayJobInstance.Name, "ShutdownAfterJobFinishes", rayJobInstance.Spec.ShutdownAfterJobFinishes, "ClusterSelector", rayJobInstance.Spec.ClusterSelector)
 		if rayJobInstance.Spec.ShutdownAfterJobFinishes && len(rayJobInstance.Spec.ClusterSelector) == 0 {
 			ttlSeconds := rayJobInstance.Spec.TTLSecondsAfterFinished
 			nowTime := time.Now()

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -300,7 +300,8 @@ var _ = Context("RayJob in K8sJobMode", func() {
 			// RayJob transitions to Complete.
 			Eventually(
 				getRayJobDeploymentStatus(ctx, rayJob),
-				time.Second*5, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusComplete), "jobDeploymentStatus = %v", rayJob.Status.JobDeploymentStatus)
+				time.Second*5, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusFailed), "jobDeploymentStatus = %v", rayJob.Status.JobDeploymentStatus)
+			Expect(rayJob.Status.Reason).To(Equal(rayv1.JobReasonDeadlineExceeded))
 		})
 	})
 })

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -301,7 +301,7 @@ var _ = Context("RayJob in K8sJobMode", func() {
 			Eventually(
 				getRayJobDeploymentStatus(ctx, rayJob),
 				time.Second*5, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusFailed), "jobDeploymentStatus = %v", rayJob.Status.JobDeploymentStatus)
-			Expect(rayJob.Status.Reason).To(Equal(rayv1.JobReasonDeadlineExceeded))
+			Expect(rayJob.Status.Reason).To(Equal(rayv1.DeadlineExceeded))
 		})
 	})
 })

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobstatus.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobstatus.go
@@ -15,6 +15,7 @@ type RayJobStatusApplyConfiguration struct {
 	DashboardURL        *string                             `json:"dashboardURL,omitempty"`
 	JobStatus           *v1.JobStatus                       `json:"jobStatus,omitempty"`
 	JobDeploymentStatus *v1.JobDeploymentStatus             `json:"jobDeploymentStatus,omitempty"`
+	Reason              *string                             `json:"reason,omitempty"`
 	Message             *string                             `json:"message,omitempty"`
 	StartTime           *metav1.Time                        `json:"startTime,omitempty"`
 	EndTime             *metav1.Time                        `json:"endTime,omitempty"`
@@ -65,6 +66,14 @@ func (b *RayJobStatusApplyConfiguration) WithJobStatus(value v1.JobStatus) *RayJ
 // If called multiple times, the JobDeploymentStatus field is set to the value of the last call.
 func (b *RayJobStatusApplyConfiguration) WithJobDeploymentStatus(value v1.JobDeploymentStatus) *RayJobStatusApplyConfiguration {
 	b.JobDeploymentStatus = &value
+	return b
+}
+
+// WithReason sets the Reason field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Reason field is set to the value of the last call.
+func (b *RayJobStatusApplyConfiguration) WithReason(value string) *RayJobStatusApplyConfiguration {
+	b.Reason = &value
 	return b
 }
 

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobstatus.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobstatus.go
@@ -15,7 +15,7 @@ type RayJobStatusApplyConfiguration struct {
 	DashboardURL        *string                             `json:"dashboardURL,omitempty"`
 	JobStatus           *v1.JobStatus                       `json:"jobStatus,omitempty"`
 	JobDeploymentStatus *v1.JobDeploymentStatus             `json:"jobDeploymentStatus,omitempty"`
-	Reason              *string                             `json:"reason,omitempty"`
+	Reason              *v1.JobFailedReason                 `json:"reason,omitempty"`
 	Message             *string                             `json:"message,omitempty"`
 	StartTime           *metav1.Time                        `json:"startTime,omitempty"`
 	EndTime             *metav1.Time                        `json:"endTime,omitempty"`
@@ -72,7 +72,7 @@ func (b *RayJobStatusApplyConfiguration) WithJobDeploymentStatus(value v1.JobDep
 // WithReason sets the Reason field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Reason field is set to the value of the last call.
-func (b *RayJobStatusApplyConfiguration) WithReason(value string) *RayJobStatusApplyConfiguration {
+func (b *RayJobStatusApplyConfiguration) WithReason(value v1.JobFailedReason) *RayJobStatusApplyConfiguration {
 	b.Reason = &value
 	return b
 }

--- a/ray-operator/test/e2e/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2e/rayjob_lightweight_test.go
@@ -97,9 +97,11 @@ env_vars:
 		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
 
-		// And the RayJob deployment status is updated accordingly
+		// Assert that the RayJob deployment status and RayJob reason have been updated accordingly.
 		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
-			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobReason, Equal(rayv1.JobReasonApplicationLevelFailed)))
 
 		// In the lightweight submission mode, the submitter Kubernetes Job should not be created.
 		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())

--- a/ray-operator/test/e2e/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2e/rayjob_lightweight_test.go
@@ -101,7 +101,7 @@ env_vars:
 		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
 		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
-			To(WithTransform(RayJobReason, Equal(rayv1.JobReasonApplicationLevelFailed)))
+			To(WithTransform(RayJobReason, Equal(rayv1.AppFailed)))
 
 		// In the lightweight submission mode, the submitter Kubernetes Job should not be created.
 		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())

--- a/ray-operator/test/e2e/rayjob_test.go
+++ b/ray-operator/test/e2e/rayjob_test.go
@@ -108,7 +108,7 @@ env_vars:
 		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
 		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
-			To(WithTransform(RayJobReason, Equal(rayv1.JobReasonApplicationLevelFailed)))
+			To(WithTransform(RayJobReason, Equal(rayv1.AppFailed)))
 
 		// TODO (kevin85421): Ensure the RayCluster and Kubernetes Job are not deleted because `ShutdownAfterJobFinishes` is false.
 
@@ -152,7 +152,7 @@ env_vars:
 		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusNew)))
 		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
-			To(WithTransform(RayJobReason, Equal(rayv1.JobReasonSubmissionFailed)))
+			To(WithTransform(RayJobReason, Equal(rayv1.SubmissionFailed)))
 
 		// Refresh the RayJob status
 		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)
@@ -235,6 +235,6 @@ env_vars:
 		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
 		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
-			To(WithTransform(RayJobReason, Equal(rayv1.JobReasonDeadlineExceeded)))
+			To(WithTransform(RayJobReason, Equal(rayv1.DeadlineExceeded)))
 	})
 }

--- a/ray-operator/test/e2e/rayjob_test.go
+++ b/ray-operator/test/e2e/rayjob_test.go
@@ -104,9 +104,11 @@ env_vars:
 		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
 
-		// And the RayJob deployment status is updated accordingly
+		// Assert that the RayJob deployment status and RayJob reason have been updated accordingly.
 		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
-			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobReason, Equal(rayv1.JobReasonApplicationLevelFailed)))
 
 		// TODO (kevin85421): Ensure the RayCluster and Kubernetes Job are not deleted because `ShutdownAfterJobFinishes` is false.
 
@@ -146,9 +148,11 @@ env_vars:
 
 		test.T().Logf("Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
 		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
-		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-			Should(WithTransform(RayJobStatus, Equal(rayv1.JobStatusNew)))
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusNew)))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobReason, Equal(rayv1.JobReasonSubmissionFailed)))
 
 		// Refresh the RayJob status
 		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)
@@ -229,6 +233,8 @@ env_vars:
 		// The RayJob will transition to `Complete` because it has passed `ActiveDeadlineSeconds`.
 		test.T().Logf("Waiting for RayJob %s/%s to be 'Complete'", rayJob.Namespace, rayJob.Name)
 		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
-			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobReason, Equal(rayv1.JobReasonDeadlineExceeded)))
 	})
 }

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -28,6 +28,10 @@ func RayJobDeploymentStatus(job *rayv1.RayJob) rayv1.JobDeploymentStatus {
 	return job.Status.JobDeploymentStatus
 }
 
+func RayJobReason(job *rayv1.RayJob) string {
+	return job.Status.Reason
+}
+
 func GetRayJobId(t Test, namespace, name string) string {
 	t.T().Helper()
 	job := RayJob(t, namespace, name)(t)

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -28,7 +28,7 @@ func RayJobDeploymentStatus(job *rayv1.RayJob) rayv1.JobDeploymentStatus {
 	return job.Status.JobDeploymentStatus
 }
 
-func RayJobReason(job *rayv1.RayJob) string {
+func RayJobReason(job *rayv1.RayJob) rayv1.JobFailedReason {
 	return job.Status.Reason
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After this PR:

1. There will be two terminal deployment statuses(Inspired by [how K8s jobs define the status](https://sourcegraph.com/github.com/kubernetes/kubernetes@fc7325fbec0fe379694e58b82e09f99f166c5e6d/-/blob/staging/src/k8s.io/api/batch/v1/types.go?L531-533) and [how the Spark operator defines the terminal statuses](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/v1beta2-1.3.8-3.1.1/pkg/controller/sparkapplication/controller.go#L615)): 
    - `JobDeploymentStatusComplete`
    - `JobDeploymentStatusFailed`.  



2. If RayJob runs into `JobDeploymentStatusFailed`(Inspired by [how k8s job use `reason` and `message` fields](https://sourcegraph.com/github.com/kubernetes/kubernetes@fc7325fbec0fe379694e58b82e09f99f166c5e6d/-/blob/staging/src/k8s.io/api/batch/v1/types.go?L569-574)):
    - the `reason` field will include a machine-readable string that describes the failure reason. Other controllers like Flyte, can take actions based on this field.
    - The `message` field will include a human-readable explanation of the failure reason.

3. There are three failed reason currently:
    - `SubmissionFailed`: The submitter job failed to submit the user code.
    - `DeadlineExceeded`: This is analogous to `JobReasonDeadlineExceeded` in Kubernetes Jobs.
    - `AppFailed`: The user code throw an error.

### Additional Note:
Ideally, users should only consider the `reason` and `message` fields when the Deployment Status is `Failed`. 
But Considering the fact that the submitter job might retry, these two fields have slightly different behavior：

- The `reason` field is set only when the Deployment Status changes to `Failed`. Therefore, no failure reason will be displayed during the retry period, as the Deployment Status remains `running`. 
- the `message` field will always display the message for the current run. So, might have error message even if the Deployment Status remains `running`.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
I have changed the CI test accordingly; all changes are covered by the CI test, but I have also manually tested it to give an idea of how the current status looks like:

- The submitter job failed to submit the user code:
```
  Job Deployment Status:  Failed
  Job Id:                 rayjob-sample-wd89p
  Message:                Job submission has failed. Reason: BackoffLimitExceeded. Message: Job has reached the specified backoff limit
  Reason:      SubmissionFailed
```


- deadline exceed:
```
  End Time:               2024-02-24T21:58:47Z
  Job Deployment Status:  Failed
  Job Id:                 rayjob-sample-7gj87
  Message:                The RayJob has passed the activeDeadlineSeconds. StartTime: 2024-02-24 21:58:46 +0000 UTC. ActiveDeadlineSeconds: 1
  Reason:      DeadlineExceeded
```
- The user code throw an error:
```
  Job Deployment Status:  Failed
  Job Id:                 rayjob-sample-5bk57
  Job Status:             FAILED
  Message:                Job entrypoint command failed with exit code 1, last available logs (truncated to 20,000 chars):
2024-02-24 14:02:23,886   INFO worker.py:1715 -- Connected to Ray cluster. View the dashboard at ^[[1m^[[32mhttp://10.244.0.13:8265 ^[[39m^[[22m
test_counter got 1
test_counter got 2
test_counter got 3
test_counter got 4
test_counter got 5
Traceback (most recent call last):
  File "/home/ray/samples/sample_code.py", line 28, in <module>
    assert requests.__version__ == "2.26.0dewfrgsthsnrdyukjuytretyhgjk"
AssertionError
  Reason:                 AppFailed
```
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
