### PR TITLE
[Structure Logging][2/n] Add context to each log message

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -96,8 +96,7 @@ func getClusterType(ctx context.Context) bool {
 }
 
 // NewReconciler returns a new reconcile.Reconciler
-func NewReconciler(mgr manager.Manager, options RayClusterReconcilerOptions) *RayClusterReconciler {
-	ctx := context.Background()
+func NewReconciler(ctx context.Context, mgr manager.Manager, options RayClusterReconcilerOptions) *RayClusterReconciler {
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1.Pod{}, podUIDIndexField, func(rawObj client.Object) []string {
 		pod := rawObj.(*corev1.Pod)
 		return []string{string(pod.UID)}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -174,7 +174,7 @@ func (r *RayClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 
 	// No match found
 	if errors.IsNotFound(err) {
-		logger.Info("Read request instance not found error!", "name", request.NamespacedName)
+		logger.Info("Read request instance not found error!")
 	} else {
 		logger.Error(err, "Read request instance error!")
 	}
@@ -194,7 +194,7 @@ func (r *RayClusterReconciler) deleteAllPods(ctx context.Context, namespace stri
 		}
 	}
 	if active > 0 {
-		logger.Info(fmt.Sprintf("Deleting all pods with labels %v in %q namespace.", filterLabels, namespace))
+		logger.Info("Deleting all Pods with labels", "filterLabels", filterLabels, "Number of active Pods", active)
 		return active, pods, r.DeleteAllOf(ctx, &corev1.Pod{}, client.InNamespace(namespace), filterLabels)
 	}
 	return active, pods, nil

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -60,7 +60,8 @@ func getDiscoveryClient(config *rest.Config) (*discovery.DiscoveryClient, error)
 
 // Check where we are running. We are trying to distinguish here whether
 // this is vanilla kubernetes cluster or Openshift
-func getClusterType(logger logr.Logger) bool {
+func getClusterType(ctx context.Context) bool {
+	logger := ctrl.LoggerFrom(ctx)
 	if os.Getenv("USE_INGRESS_ON_OPENSHIFT") == "true" {
 		// Environment is set to treat OpenShift cluster as Vanilla Kubernetes
 		return false
@@ -96,20 +97,19 @@ func getClusterType(logger logr.Logger) bool {
 
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager, options RayClusterReconcilerOptions) *RayClusterReconciler {
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, podUIDIndexField, func(rawObj client.Object) []string {
+	ctx := context.Background()
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1.Pod{}, podUIDIndexField, func(rawObj client.Object) []string {
 		pod := rawObj.(*corev1.Pod)
 		return []string{string(pod.UID)}
 	}); err != nil {
 		panic(err)
 	}
-	log := ctrl.Log.WithName("controllers").WithName("RayCluster")
-	log.Info("Starting Reconciler")
-	isOpenShift := getClusterType(log)
+	isOpenShift := getClusterType(ctx)
 
 	return &RayClusterReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
-		Log:               log,
+		Log:               ctrl.Log.WithName("controllers").WithName("RayCluster"),
 		Recorder:          mgr.GetEventRecorderFor("raycluster-controller"),
 		BatchSchedulerMgr: batchscheduler.NewSchedulerManager(mgr.GetConfig()),
 		IsOpenShift:       isOpenShift,
@@ -163,7 +163,8 @@ type RayClusterReconcilerOptions struct {
 
 // Reconcile used to bridge the desired state with the current state
 func (r *RayClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	ctx = ctrl.LoggerInto(ctx, r.Log) // TODO: add request namespace here
+	logger := r.Log.WithValues("RayCluster", request.NamespacedName)
+	ctx = ctrl.LoggerInto(ctx, logger)
 	var err error
 
 	// Try to fetch the RayCluster instance
@@ -174,15 +175,16 @@ func (r *RayClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 
 	// No match found
 	if errors.IsNotFound(err) {
-		r.Log.Info("Read request instance not found error!", "name", request.NamespacedName)
+		logger.Info("Read request instance not found error!", "name", request.NamespacedName)
 	} else {
-		r.Log.Error(err, "Read request instance error!")
+		logger.Error(err, "Read request instance error!")
 	}
 	// Error reading the object - requeue the request.
 	return ctrl.Result{}, client.IgnoreNotFound(err)
 }
 
 func (r *RayClusterReconciler) deleteAllPods(ctx context.Context, namespace string, filterLabels client.MatchingLabels) (active int, pods corev1.PodList, err error) {
+	logger := ctrl.LoggerFrom(ctx)
 	if err = r.List(ctx, &pods, client.InNamespace(namespace), filterLabels); err != nil {
 		return 0, pods, err
 	}
@@ -193,18 +195,17 @@ func (r *RayClusterReconciler) deleteAllPods(ctx context.Context, namespace stri
 		}
 	}
 	if active > 0 {
-		r.Log.Info(fmt.Sprintf("Deleting all pods with labels %v in %q namespace.", filterLabels, namespace))
+		logger.Info(fmt.Sprintf("Deleting all pods with labels %v in %q namespace.", filterLabels, namespace))
 		return active, pods, r.DeleteAllOf(ctx, &corev1.Pod{}, client.InNamespace(namespace), filterLabels)
 	}
 	return active, pods, nil
 }
 
 func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request ctrl.Request, instance *rayv1.RayCluster) (ctrl.Result, error) {
+	logger := ctrl.LoggerFrom(ctx)
+
 	// Please do NOT modify `originalRayClusterInstance` in the following code.
 	originalRayClusterInstance := instance.DeepCopy()
-
-	_ = r.Log.WithValues("raycluster", request.NamespacedName)
-	r.Log.Info("reconciling RayCluster", "cluster name", request.Name)
 
 	// The `enableGCSFTRedisCleanup` is a feature flag introduced in KubeRay v1.0.0. It determines whether
 	// the Redis cleanup job should be activated. Users can disable the feature by setting the environment
@@ -215,19 +216,19 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 	if enableGCSFTRedisCleanup && common.IsGCSFaultToleranceEnabled(*instance) {
 		if instance.DeletionTimestamp.IsZero() {
 			if !controllerutil.ContainsFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer) {
-				r.Log.Info(
+				logger.Info(
 					"GCS fault tolerance has been enabled. Implementing a finalizer to ensure that Redis is properly cleaned up once the RayCluster custom resource (CR) is deleted.",
 					"finalizer", utils.GCSFaultToleranceRedisCleanupFinalizer)
 				controllerutil.AddFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer)
 				if err := r.Update(ctx, instance); err != nil {
-					r.Log.Error(err, fmt.Sprintf("Failed to add the finalizer %s to the RayCluster.", utils.GCSFaultToleranceRedisCleanupFinalizer))
+					logger.Error(err, fmt.Sprintf("Failed to add the finalizer %s to the RayCluster.", utils.GCSFaultToleranceRedisCleanupFinalizer))
 					return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 				}
 				// Only start the RayCluster reconciliation after the finalizer is added.
 				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
 			}
 		} else {
-			r.Log.Info(
+			logger.Info(
 				fmt.Sprintf("The RayCluster with GCS enabled, %s, is being deleted. Start to handle the Redis cleanup finalizer %s.",
 					instance.Name, utils.GCSFaultToleranceRedisCleanupFinalizer),
 				"DeletionTimestamp", instance.ObjectMeta.DeletionTimestamp)
@@ -248,7 +249,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 			}
 			if numDeletedHeads > 0 {
-				r.Log.Info(fmt.Sprintf(
+				logger.Info(fmt.Sprintf(
 					"Wait for the head Pod %s to be terminated before initiating the Redis cleanup process. "+
 						"The storage namespace %s in Redis cannot be fully deleted if the GCS process on the head Pod is still writing to it.",
 					headPods.Items[0].Name, headPods.Items[0].Annotations[utils.RayExternalStorageNSAnnotationKey]))
@@ -266,7 +267,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 			if len(redisCleanupJobs.Items) != 0 {
 				// Check whether the Redis cleanup Job has been completed.
 				redisCleanupJob := redisCleanupJobs.Items[0]
-				r.Log.Info("Redis cleanup Job status", "Job name", redisCleanupJob.Name,
+				logger.Info("Redis cleanup Job status", "Job name", redisCleanupJob.Name,
 					"Active", redisCleanupJob.Status.Active, "Succeeded", redisCleanupJob.Status.Succeeded, "Failed", redisCleanupJob.Status.Failed)
 				if condition, finished := utils.IsJobFinished(&redisCleanupJob); finished {
 					controllerutil.RemoveFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer)
@@ -275,12 +276,12 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 					}
 					switch condition {
 					case batchv1.JobComplete:
-						r.Log.Info(fmt.Sprintf(
+						logger.Info(fmt.Sprintf(
 							"The Redis cleanup Job %s has been completed. "+
 								"The storage namespace %s in Redis has been fully deleted.",
 							redisCleanupJob.Name, redisCleanupJob.Annotations[utils.RayExternalStorageNSAnnotationKey]))
 					case batchv1.JobFailed:
-						r.Log.Info(fmt.Sprintf(
+						logger.Info(fmt.Sprintf(
 							"The Redis cleanup Job %s has failed, requeue the RayCluster CR after 5 minute. "+
 								"You should manually delete the storage namespace %s in Redis and remove the RayCluster's finalizer. "+
 								"Please check https://docs.ray.io/en/master/cluster/kubernetes/user-guides/kuberay-gcs-ft.html for more details.",
@@ -294,51 +295,51 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 				redisCleanupJob := r.buildRedisCleanupJob(ctx, *instance)
 				if err := r.Create(ctx, &redisCleanupJob); err != nil {
 					if errors.IsAlreadyExists(err) {
-						r.Log.Info(fmt.Sprintf("Redis cleanup Job already exists. Requeue the RayCluster CR %s.", instance.Name))
+						logger.Info(fmt.Sprintf("Redis cleanup Job already exists. Requeue the RayCluster CR %s.", instance.Name))
 						return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
 					}
-					r.Log.Error(err, "Failed to create Redis cleanup Job")
+					logger.Error(err, "Failed to create Redis cleanup Job")
 					return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 				}
-				r.Log.Info("Successfully created Redis cleanup Job", "Job name", redisCleanupJob.Name)
+				logger.Info("Successfully created Redis cleanup Job", "Job name", redisCleanupJob.Name)
 			}
 			return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
 		}
 	}
 
 	if instance.DeletionTimestamp != nil && !instance.DeletionTimestamp.IsZero() {
-		r.Log.Info("RayCluster is being deleted, just ignore", "cluster name", request.Name)
+		logger.Info("RayCluster is being deleted, just ignore", "cluster name", request.Name)
 		return ctrl.Result{}, nil
 	}
 
 	if err := r.reconcileAutoscalerServiceAccount(ctx, instance); err != nil {
 		if updateErr := r.updateClusterState(ctx, instance, rayv1.Failed); updateErr != nil {
-			r.Log.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
+			logger.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
 		}
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
 
 	if err := r.reconcileAutoscalerRole(ctx, instance); err != nil {
 		if updateErr := r.updateClusterState(ctx, instance, rayv1.Failed); updateErr != nil {
-			r.Log.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
+			logger.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
 		}
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
 	if err := r.reconcileAutoscalerRoleBinding(ctx, instance); err != nil {
 		if updateErr := r.updateClusterState(ctx, instance, rayv1.Failed); updateErr != nil {
-			r.Log.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
+			logger.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
 		}
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
 	if err := r.reconcileIngress(ctx, instance); err != nil {
 		if updateErr := r.updateClusterState(ctx, instance, rayv1.Failed); updateErr != nil {
-			r.Log.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
+			logger.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
 		}
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
 	if err := r.reconcileHeadService(ctx, instance); err != nil {
 		if updateErr := r.updateClusterState(ctx, instance, rayv1.Failed); updateErr != nil {
-			r.Log.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
+			logger.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
 		}
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
@@ -346,17 +347,17 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 	if enableServeServiceValue, exist := instance.Annotations[utils.EnableServeServiceKey]; exist && enableServeServiceValue == utils.EnableServeServiceTrue {
 		if err := r.reconcileServeService(ctx, instance); err != nil {
 			if updateErr := r.updateClusterState(ctx, instance, rayv1.Failed); updateErr != nil {
-				r.Log.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
+				logger.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
 			}
 			return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 		}
 	}
 	if err := r.reconcilePods(ctx, instance); err != nil {
 		if updateErr := r.updateClusterState(ctx, instance, rayv1.Failed); updateErr != nil {
-			r.Log.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
+			logger.Error(updateErr, "RayCluster update state error", "cluster name", request.Name)
 		}
 		if updateErr := r.updateClusterReason(ctx, instance, err.Error()); updateErr != nil {
-			r.Log.Error(updateErr, "RayCluster update reason error", "cluster name", request.Name)
+			logger.Error(updateErr, "RayCluster update reason error", "cluster name", request.Name)
 		}
 		r.Recorder.Event(instance, corev1.EventTypeWarning, string(rayv1.PodReconciliationError), err.Error())
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
@@ -365,15 +366,15 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 	// Calculate the new status for the RayCluster. Note that the function will deep copy `instance` instead of mutating it.
 	newInstance, err := r.calculateStatus(ctx, instance)
 	if err != nil {
-		r.Log.Info("Got error when calculating new status", "cluster name", request.Name, "error", err)
+		logger.Info("Got error when calculating new status", "cluster name", request.Name, "error", err)
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
 
 	// Check if need to update the status.
-	if r.inconsistentRayClusterStatus(originalRayClusterInstance.Status, newInstance.Status) {
-		r.Log.Info("rayClusterReconcile", "Update CR status", request.Name, "status", newInstance.Status)
+	if r.inconsistentRayClusterStatus(ctx, originalRayClusterInstance.Status, newInstance.Status) {
+		logger.Info("rayClusterReconcile", "Update CR status", request.Name, "status", newInstance.Status)
 		if err := r.Status().Update(ctx, newInstance); err != nil {
-			r.Log.Info("Got error when updating status", "cluster name", request.Name, "error", err, "RayCluster", newInstance)
+			logger.Info("Got error when updating status", "cluster name", request.Name, "error", err, "RayCluster", newInstance)
 			return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 		}
 	}
@@ -383,10 +384,10 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 	// environment variable is not set, requeue after the default value.
 	requeueAfterSeconds, err := strconv.Atoi(os.Getenv(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV))
 	if err != nil {
-		r.Log.Info(fmt.Sprintf("Environment variable %s is not set, using default value of %d seconds", utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV, utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS), "cluster name", request.Name)
+		logger.Info(fmt.Sprintf("Environment variable %s is not set, using default value of %d seconds", utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV, utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS), "cluster name", request.Name)
 		requeueAfterSeconds = utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS
 	}
-	r.Log.Info("Unconditional requeue after", "cluster name", request.Name, "seconds", requeueAfterSeconds)
+	logger.Info("Unconditional requeue after", "cluster name", request.Name, "seconds", requeueAfterSeconds)
 	return ctrl.Result{RequeueAfter: time.Duration(requeueAfterSeconds) * time.Second}, nil
 }
 
@@ -396,16 +397,17 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 //
 // TODO (kevin85421): The field `ObservedGeneration` is not being well-maintained at the moment. In the future,
 // this field should be used to determine whether to update this CR or not.
-func (r *RayClusterReconciler) inconsistentRayClusterStatus(oldStatus rayv1.RayClusterStatus, newStatus rayv1.RayClusterStatus) bool {
+func (r *RayClusterReconciler) inconsistentRayClusterStatus(ctx context.Context, oldStatus rayv1.RayClusterStatus, newStatus rayv1.RayClusterStatus) bool {
+	logger := ctrl.LoggerFrom(ctx)
 	if oldStatus.State != newStatus.State || oldStatus.Reason != newStatus.Reason {
-		r.Log.Info("inconsistentRayClusterStatus", "detect inconsistency", fmt.Sprintf(
+		logger.Info("inconsistentRayClusterStatus", "detect inconsistency", fmt.Sprintf(
 			"old State: %s, new State: %s, old Reason: %s, new Reason: %s",
 			oldStatus.State, newStatus.State, oldStatus.Reason, newStatus.Reason))
 		return true
 	}
 	if oldStatus.AvailableWorkerReplicas != newStatus.AvailableWorkerReplicas || oldStatus.DesiredWorkerReplicas != newStatus.DesiredWorkerReplicas ||
 		oldStatus.MinWorkerReplicas != newStatus.MinWorkerReplicas || oldStatus.MaxWorkerReplicas != newStatus.MaxWorkerReplicas {
-		r.Log.Info("inconsistentRayClusterStatus", "detect inconsistency", fmt.Sprintf(
+		logger.Info("inconsistentRayClusterStatus", "detect inconsistency", fmt.Sprintf(
 			"old AvailableWorkerReplicas: %d, new AvailableWorkerReplicas: %d, old DesiredWorkerReplicas: %d, new DesiredWorkerReplicas: %d, "+
 				"old MinWorkerReplicas: %d, new MinWorkerReplicas: %d, old MaxWorkerReplicas: %d, new MaxWorkerReplicas: %d",
 			oldStatus.AvailableWorkerReplicas, newStatus.AvailableWorkerReplicas, oldStatus.DesiredWorkerReplicas, newStatus.DesiredWorkerReplicas,
@@ -413,7 +415,7 @@ func (r *RayClusterReconciler) inconsistentRayClusterStatus(oldStatus rayv1.RayC
 		return true
 	}
 	if !reflect.DeepEqual(oldStatus.Endpoints, newStatus.Endpoints) || !reflect.DeepEqual(oldStatus.Head, newStatus.Head) {
-		r.Log.Info("inconsistentRayClusterStatus", "detect inconsistency", fmt.Sprintf(
+		logger.Info("inconsistentRayClusterStatus", "detect inconsistency", fmt.Sprintf(
 			"old Endpoints: %v, new Endpoints: %v, old Head: %v, new Head: %v",
 			oldStatus.Endpoints, newStatus.Endpoints, oldStatus.Head, newStatus.Head))
 		return true
@@ -422,7 +424,8 @@ func (r *RayClusterReconciler) inconsistentRayClusterStatus(oldStatus rayv1.RayC
 }
 
 func (r *RayClusterReconciler) reconcileIngress(ctx context.Context, instance *rayv1.RayCluster) error {
-	r.Log.Info("Reconciling Ingress")
+	logger := ctrl.LoggerFrom(ctx)
+	logger.Info("Reconciling Ingress")
 	if instance.Spec.HeadGroupSpec.EnableIngress == nil || !*instance.Spec.HeadGroupSpec.EnableIngress {
 		return nil
 	}
@@ -437,22 +440,23 @@ func (r *RayClusterReconciler) reconcileIngress(ctx context.Context, instance *r
 }
 
 func (r *RayClusterReconciler) reconcileRouteOpenShift(ctx context.Context, instance *rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
 	headRoutes := routev1.RouteList{}
 	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name}
 	if err := r.List(ctx, &headRoutes, client.InNamespace(instance.Namespace), filterLabels); err != nil {
-		r.Log.Error(err, "Route Listing error!", "Route.Error", err)
+		logger.Error(err, "Route Listing error!", "Route.Error", err)
 		return err
 	}
 
 	if headRoutes.Items != nil && len(headRoutes.Items) == 1 {
-		r.Log.Info("reconcileIngresses", "head service route found", headRoutes.Items[0].Name)
+		logger.Info("reconcileIngresses", "head service route found", headRoutes.Items[0].Name)
 		return nil
 	}
 
 	if headRoutes.Items == nil || len(headRoutes.Items) == 0 {
 		route, err := common.BuildRouteForHeadService(*instance)
 		if err != nil {
-			r.Log.Error(err, "Failed building route!", "Route.Error", err)
+			logger.Error(err, "Failed building route!", "Route.Error", err)
 			return err
 		}
 
@@ -462,7 +466,7 @@ func (r *RayClusterReconciler) reconcileRouteOpenShift(ctx context.Context, inst
 
 		err = r.createHeadRoute(ctx, route, instance)
 		if err != nil {
-			r.Log.Error(err, "Failed creating route!", "Route.Error", err)
+			logger.Error(err, "Failed creating route!", "Route.Error", err)
 			return err
 		}
 	}
@@ -471,6 +475,7 @@ func (r *RayClusterReconciler) reconcileRouteOpenShift(ctx context.Context, inst
 }
 
 func (r *RayClusterReconciler) reconcileIngressKubernetes(ctx context.Context, instance *rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
 	headIngresses := networkingv1.IngressList{}
 	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name}
 	if err := r.List(ctx, &headIngresses, client.InNamespace(instance.Namespace), filterLabels); err != nil {
@@ -478,7 +483,7 @@ func (r *RayClusterReconciler) reconcileIngressKubernetes(ctx context.Context, i
 	}
 
 	if headIngresses.Items != nil && len(headIngresses.Items) == 1 {
-		r.Log.Info("reconcileIngresses", "head service ingress found", headIngresses.Items[0].Name)
+		logger.Info("reconcileIngresses", "head service ingress found", headIngresses.Items[0].Name)
 		return nil
 	}
 
@@ -503,6 +508,7 @@ func (r *RayClusterReconciler) reconcileIngressKubernetes(ctx context.Context, i
 
 // Return nil only when the head service successfully created or already exists.
 func (r *RayClusterReconciler) reconcileHeadService(ctx context.Context, instance *rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
 	services := corev1.ServiceList{}
 	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeTypeLabelKey: string(rayv1.HeadNode)}
 
@@ -513,12 +519,12 @@ func (r *RayClusterReconciler) reconcileHeadService(ctx context.Context, instanc
 	// Check if there's existing head service in the cluster.
 	if len(services.Items) != 0 {
 		if len(services.Items) == 1 {
-			r.Log.Info("reconcileHeadService", "1 head service found", services.Items[0].Name)
+			logger.Info("reconcileHeadService", "1 head service found", services.Items[0].Name)
 			return nil
 		}
 		// This should never happen. This protects against the case that users manually create service with the same label.
 		if len(services.Items) > 1 {
-			r.Log.Info("reconcileHeadService", "Duplicate head service found", services.Items)
+			logger.Info("reconcileHeadService", "Duplicate head service found", services.Items)
 			return fmt.Errorf("%d head service found %v", len(services.Items), services.Items)
 		}
 	} else {
@@ -536,7 +542,7 @@ func (r *RayClusterReconciler) reconcileHeadService(ctx context.Context, instanc
 		headSvc, err := common.BuildServiceForHeadPod(ctx, *instance, labels, annotations)
 		// TODO (kevin85421): Provide a detailed and actionable error message. For example, which port is missing?
 		if len(headSvc.Spec.Ports) == 0 {
-			r.Log.Info("Ray head service does not have any ports set up. Service specification: %v", headSvc.Spec)
+			logger.Info("Ray head service does not have any ports set up. Service specification: %v", headSvc.Spec)
 			return fmt.Errorf("Ray head service does not have any ports set up. Service specification: %v", headSvc.Spec)
 		}
 
@@ -581,6 +587,8 @@ func (r *RayClusterReconciler) reconcileServeService(ctx context.Context, instan
 }
 
 func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
+
 	// if RayCluster is suspended, delete all pods and skip reconcile
 	if instance.Spec.Suspend != nil && *instance.Spec.Suspend {
 		clusterLabel := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name}
@@ -613,12 +621,12 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	// Reconcile head Pod
 	if len(headPods.Items) == 1 {
 		headPod := headPods.Items[0]
-		r.Log.Info("reconcilePods", "Found 1 head Pod", headPod.Name, "Pod status", headPod.Status.Phase,
+		logger.Info("reconcilePods", "Found 1 head Pod", headPod.Name, "Pod status", headPod.Status.Phase,
 			"Pod restart policy", headPod.Spec.RestartPolicy,
 			"Ray container terminated status", getRayContainerStateTerminated(headPod))
 
 		shouldDelete, reason := shouldDeletePod(headPod, rayv1.HeadNode)
-		r.Log.Info("reconcilePods", "head Pod", headPod.Name, "shouldDelete", shouldDelete, "reason", reason)
+		logger.Info("reconcilePods", "head Pod", headPod.Name, "shouldDelete", shouldDelete, "reason", reason)
 		if shouldDelete {
 			if err := r.Delete(ctx, &headPod); err != nil {
 				return err
@@ -630,7 +638,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		}
 	} else if len(headPods.Items) == 0 {
 		// Create head Pod if it does not exist.
-		r.Log.Info("reconcilePods", "Found 0 head Pods; creating a head Pod for the RayCluster.", instance.Name)
+		logger.Info("reconcilePods", "Found 0 head Pods; creating a head Pod for the RayCluster.", instance.Name)
 		common.CreatedClustersCounterInc(instance.Namespace)
 		if err := r.createHeadPod(ctx, *instance); err != nil {
 			common.FailedClustersCounterInc(instance.Namespace)
@@ -638,7 +646,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		}
 		common.SuccessfulClustersCounterInc(instance.Namespace)
 	} else if len(headPods.Items) > 1 {
-		r.Log.Info("reconcilePods", fmt.Sprintf("Found %d head Pods; deleting extra head Pods.", len(headPods.Items)), instance.Name)
+		logger.Info("reconcilePods", fmt.Sprintf("Found %d head Pods; deleting extra head Pods.", len(headPods.Items)), instance.Name)
 		// TODO (kevin85421): In-place update may not be a good idea.
 		itemLength := len(headPods.Items)
 		for index := 0; index < itemLength; index++ {
@@ -662,7 +670,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 			// head node amount is exactly 1, but we need to check if it has been changed
 			res := utils.PodNotMatchingTemplate(headPods.Items[0], instance.Spec.HeadGroupSpec.Template)
 			if res {
-				r.Log.Info(fmt.Sprintf("need to delete old head pod %s", headPods.Items[0].Name))
+				logger.Info(fmt.Sprintf("need to delete old head pod %s", headPods.Items[0].Name))
 				if err := r.Delete(ctx, &headPods.Items[0]); err != nil {
 					return err
 				}
@@ -680,9 +688,9 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 			updatedWorkerPods := false
 			for _, item := range workerPods.Items {
 				if utils.PodNotMatchingTemplate(item, worker.Template) {
-					r.Log.Info(fmt.Sprintf("need to delete old worker pod %s", item.Name))
+					logger.Info(fmt.Sprintf("need to delete old worker pod %s", item.Name))
 					if err := r.Delete(ctx, &item); err != nil {
-						r.Log.Info(fmt.Sprintf("error deleting worker pod %s", item.Name))
+						logger.Info(fmt.Sprintf("error deleting worker pod %s", item.Name))
 						return err
 					}
 					updatedWorkerPods = true
@@ -698,7 +706,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	for _, worker := range instance.Spec.WorkerGroupSpecs {
 		// workerReplicas will store the target number of pods for this worker group.
 		var workerReplicas int32 = utils.GetWorkerGroupDesiredReplicas(ctx, worker)
-		r.Log.Info("reconcilePods", "desired workerReplicas (always adhering to minReplicas/maxReplica)", workerReplicas, "worker group", worker.GroupName, "maxReplicas", worker.MaxReplicas, "minReplicas", worker.MinReplicas, "replicas", worker.Replicas)
+		logger.Info("reconcilePods", "desired workerReplicas (always adhering to minReplicas/maxReplica)", workerReplicas, "worker group", worker.GroupName, "maxReplicas", worker.MaxReplicas, "minReplicas", worker.MinReplicas, "replicas", worker.Replicas)
 
 		workerPods := corev1.PodList{}
 		filterLabels = client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeGroupLabelKey: worker.GroupName}
@@ -712,7 +720,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		numDeletedUnhealthyWorkerPods := 0
 		for _, workerPod := range workerPods.Items {
 			shouldDelete, reason := shouldDeletePod(workerPod, rayv1.WorkerNode)
-			r.Log.Info("reconcilePods", "worker Pod", workerPod.Name, "shouldDelete", shouldDelete, "reason", reason)
+			logger.Info("reconcilePods", "worker Pod", workerPod.Name, "shouldDelete", shouldDelete, "reason", reason)
 			if shouldDelete {
 				numDeletedUnhealthyWorkerPods++
 				deletedWorkers[workerPod.Name] = deleted
@@ -732,18 +740,18 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 
 		// Always remove the specified WorkersToDelete - regardless of the value of Replicas.
 		// Essentially WorkersToDelete has to be deleted to meet the expectations of the Autoscaler.
-		r.Log.Info("reconcilePods", "removing the pods in the scaleStrategy of", worker.GroupName)
+		logger.Info("reconcilePods", "removing the pods in the scaleStrategy of", worker.GroupName)
 		for _, podsToDelete := range worker.ScaleStrategy.WorkersToDelete {
 			pod := corev1.Pod{}
 			pod.Name = podsToDelete
 			pod.Namespace = utils.GetNamespace(instance.ObjectMeta)
-			r.Log.Info("Deleting pod", "namespace", pod.Namespace, "name", pod.Name)
+			logger.Info("Deleting pod", "namespace", pod.Namespace, "name", pod.Name)
 			if err := r.Delete(ctx, &pod); err != nil {
 				if !errors.IsNotFound(err) {
-					r.Log.Info("reconcilePods", "Fail to delete Pod", pod.Name, "error", err)
+					logger.Info("reconcilePods", "Fail to delete Pod", pod.Name, "error", err)
 					return err
 				}
-				r.Log.Info("reconcilePods", "The worker Pod has already been deleted", pod.Name)
+				logger.Info("reconcilePods", "The worker Pod has already been deleted", pod.Name)
 			} else {
 				deletedWorkers[pod.Name] = deleted
 				r.Recorder.Eventf(instance, corev1.EventTypeNormal, "Deleted", "Deleted pod %s", pod.Name)
@@ -761,21 +769,21 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		numExpectedPods := workerReplicas * worker.NumOfHosts
 		diff := numExpectedPods - int32(len(runningPods.Items))
 
-		r.Log.Info("reconcilePods", "workerReplicas", workerReplicas, "runningPods", len(runningPods.Items), "diff", diff)
+		logger.Info("reconcilePods", "workerReplicas", workerReplicas, "runningPods", len(runningPods.Items), "diff", diff)
 
 		if diff > 0 {
 			// pods need to be added
-			r.Log.Info("reconcilePods", "Number workers to add", diff, "Worker group", worker.GroupName)
+			logger.Info("reconcilePods", "Number workers to add", diff, "Worker group", worker.GroupName)
 			// create all workers of this group
 			var i int32
 			for i = 0; i < diff; i++ {
-				r.Log.Info("reconcilePods", "creating worker for group", worker.GroupName, fmt.Sprintf("index %d", i), fmt.Sprintf("in total %d", diff))
+				logger.Info("reconcilePods", "creating worker for group", worker.GroupName, fmt.Sprintf("index %d", i), fmt.Sprintf("in total %d", diff))
 				if err := r.createWorkerPod(ctx, *instance, *worker.DeepCopy()); err != nil {
 					return err
 				}
 			}
 		} else if diff == 0 {
-			r.Log.Info("reconcilePods", "all workers already exist for group", worker.GroupName)
+			logger.Info("reconcilePods", "all workers already exist for group", worker.GroupName)
 			continue
 		} else {
 			// diff < 0 indicates the need to delete some Pods to match the desired number of replicas. However,
@@ -798,20 +806,20 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 			if !enableInTreeAutoscaling || enableRandomPodDelete {
 				// diff < 0 means that we need to delete some Pods to meet the desired number of replicas.
 				randomlyRemovedWorkers := -diff
-				r.Log.Info("reconcilePods", "Number workers to delete randomly", randomlyRemovedWorkers, "Worker group", worker.GroupName)
+				logger.Info("reconcilePods", "Number workers to delete randomly", randomlyRemovedWorkers, "Worker group", worker.GroupName)
 				for i := 0; i < int(randomlyRemovedWorkers); i++ {
 					randomPodToDelete := runningPods.Items[i]
-					r.Log.Info("Randomly deleting Pod", "progress", fmt.Sprintf("%d / %d", i+1, randomlyRemovedWorkers), "with name", randomPodToDelete.Name)
+					logger.Info("Randomly deleting Pod", "progress", fmt.Sprintf("%d / %d", i+1, randomlyRemovedWorkers), "with name", randomPodToDelete.Name)
 					if err := r.Delete(ctx, &randomPodToDelete); err != nil {
 						if !errors.IsNotFound(err) {
 							return err
 						}
-						r.Log.Info("reconcilePods", "The worker Pod has already been deleted", randomPodToDelete.Name)
+						logger.Info("reconcilePods", "The worker Pod has already been deleted", randomPodToDelete.Name)
 					}
 					r.Recorder.Eventf(instance, corev1.EventTypeNormal, "Deleted", "Deleted Pod %s", randomPodToDelete.Name)
 				}
 			} else {
-				r.Log.Info(fmt.Sprintf("Random Pod deletion is disabled for cluster %s. The only decision-maker for Pod deletions is Autoscaler.", instance.Name))
+				logger.Info(fmt.Sprintf("Random Pod deletion is disabled for cluster %s. The only decision-maker for Pod deletions is Autoscaler.", instance.Name))
 			}
 		}
 	}
@@ -906,6 +914,8 @@ func getRayContainerStateTerminated(pod corev1.Pod) *corev1.ContainerStateTermin
 }
 
 func (r *RayClusterReconciler) createHeadIngress(ctx context.Context, ingress *networkingv1.Ingress, instance *rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
+
 	// making sure the name is valid
 	ingress.Name = utils.CheckName(ingress.Name)
 	if err := controllerutil.SetControllerReference(instance, ingress, r.Scheme); err != nil {
@@ -914,35 +924,39 @@ func (r *RayClusterReconciler) createHeadIngress(ctx context.Context, ingress *n
 
 	if err := r.Create(ctx, ingress); err != nil {
 		if errors.IsAlreadyExists(err) {
-			r.Log.Info("Ingress already exists, no need to create")
+			logger.Info("Ingress already exists, no need to create")
 			return nil
 		}
-		r.Log.Error(err, "Ingress create error!", "Ingress.Error", err)
+		logger.Error(err, "Ingress create error!", "Ingress.Error", err)
 		return err
 	}
-	r.Log.Info("Ingress created successfully", "ingress name", ingress.Name)
+	logger.Info("Ingress created successfully", "ingress name", ingress.Name)
 	r.Recorder.Eventf(instance, corev1.EventTypeNormal, "Created", "Created ingress %s", ingress.Name)
 	return nil
 }
 
 func (r *RayClusterReconciler) createHeadRoute(ctx context.Context, route *routev1.Route, instance *rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
+
 	// making sure the name is valid
 	route.Name = utils.CheckRouteName(ctx, route.Name, route.Namespace)
 
 	if err := r.Create(ctx, route); err != nil {
 		if errors.IsAlreadyExists(err) {
-			r.Log.Info("Route already exists, no need to create")
+			logger.Info("Route already exists, no need to create")
 			return nil
 		}
-		r.Log.Error(err, "Route create error!", "Route.Error", err)
+		logger.Error(err, "Route create error!", "Route.Error", err)
 		return err
 	}
-	r.Log.Info("Route created successfully", "route name", route.Name)
+	logger.Info("Route created successfully", "route name", route.Name)
 	r.Recorder.Eventf(instance, corev1.EventTypeNormal, "Created", "Created route %s", route.Name)
 	return nil
 }
 
 func (r *RayClusterReconciler) createService(ctx context.Context, raySvc *corev1.Service, instance *rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
+
 	// making sure the name is valid
 	raySvc.Name = utils.CheckName(raySvc.Name)
 	// Set controller reference
@@ -952,18 +966,20 @@ func (r *RayClusterReconciler) createService(ctx context.Context, raySvc *corev1
 
 	if err := r.Create(ctx, raySvc); err != nil {
 		if errors.IsAlreadyExists(err) {
-			r.Log.Info("Pod service already exist, no need to create")
+			logger.Info("Pod service already exist, no need to create")
 			return nil
 		}
-		r.Log.Error(err, "Pod Service create error!", "Pod.Service.Error", err)
+		logger.Error(err, "Pod Service create error!", "Pod.Service.Error", err)
 		return err
 	}
-	r.Log.Info("Pod Service created successfully", "service name", raySvc.Name)
+	logger.Info("Pod Service created successfully", "service name", raySvc.Name)
 	r.Recorder.Eventf(instance, corev1.EventTypeNormal, "Created", "Created service %s", raySvc.Name)
 	return nil
 }
 
 func (r *RayClusterReconciler) createHeadPod(ctx context.Context, instance rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
+
 	// build the pod then create it
 	pod := r.buildHeadPod(ctx, instance)
 	podIdentifier := types.NamespacedName{
@@ -978,18 +994,18 @@ func (r *RayClusterReconciler) createHeadPod(ctx context.Context, instance rayv1
 		}
 	}
 
-	r.Log.Info("createHeadPod", "head pod with name", pod.GenerateName)
+	logger.Info("createHeadPod", "head pod with name", pod.GenerateName)
 	if err := r.Create(ctx, &pod); err != nil {
 		if errors.IsAlreadyExists(err) {
 			fetchedPod := corev1.Pod{}
 			// the pod might be in terminating state, we need to check
 			if errPod := r.Get(ctx, podIdentifier, &fetchedPod); errPod == nil {
 				if fetchedPod.DeletionTimestamp != nil {
-					r.Log.Error(errPod, "create pod error!", "pod is in a terminating state, we will wait until it is cleaned up", podIdentifier)
+					logger.Error(errPod, "create pod error!", "pod is in a terminating state, we will wait until it is cleaned up", podIdentifier)
 					return err
 				}
 			}
-			r.Log.Info("Creating pod", "Pod already exists", pod.Name)
+			logger.Info("Creating pod", "Pod already exists", pod.Name)
 		} else {
 			return err
 		}
@@ -999,6 +1015,8 @@ func (r *RayClusterReconciler) createHeadPod(ctx context.Context, instance rayv1
 }
 
 func (r *RayClusterReconciler) createWorkerPod(ctx context.Context, instance rayv1.RayCluster, worker rayv1.WorkerGroupSpec) error {
+	logger := ctrl.LoggerFrom(ctx)
+
 	// build the pod then create it
 	pod := r.buildWorkerPod(ctx, instance, worker)
 	podIdentifier := types.NamespacedName{
@@ -1020,23 +1038,24 @@ func (r *RayClusterReconciler) createWorkerPod(ctx context.Context, instance ray
 			// the pod might be in terminating state, we need to check
 			if errPod := r.Get(ctx, podIdentifier, &fetchedPod); errPod == nil {
 				if fetchedPod.DeletionTimestamp != nil {
-					r.Log.Error(errPod, "create pod error!", "pod is in a terminating state, we will wait until it is cleaned up", podIdentifier)
+					logger.Error(errPod, "create pod error!", "pod is in a terminating state, we will wait until it is cleaned up", podIdentifier)
 					return err
 				}
 			}
-			r.Log.Info("Creating pod", "Pod already exists", pod.Name)
+			logger.Info("Creating pod", "Pod already exists", pod.Name)
 		} else {
-			r.Log.Error(fmt.Errorf("createWorkerPod error"), "error creating pod", "pod", pod, "err = ", err)
+			logger.Error(fmt.Errorf("createWorkerPod error"), "error creating pod", "pod", pod, "err = ", err)
 			return err
 		}
 	}
-	r.Log.Info("Created pod", "Pod ", pod.GenerateName)
+	logger.Info("Created pod", "Pod ", pod.GenerateName)
 	r.Recorder.Eventf(&instance, corev1.EventTypeNormal, "Created", "Created worker pod %s", pod.Name)
 	return nil
 }
 
 // Build head instance pod(s).
 func (r *RayClusterReconciler) buildHeadPod(ctx context.Context, instance rayv1.RayCluster) corev1.Pod {
+	logger := ctrl.LoggerFrom(ctx)
 	podName := strings.ToLower(instance.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol)
 	podName = utils.CheckName(podName)                                            // making sure the name is valid
 	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, instance, instance.Namespace) // Fully Qualified Domain Name
@@ -1047,12 +1066,12 @@ func (r *RayClusterReconciler) buildHeadPod(ctx context.Context, instance rayv1.
 	if len(r.headSidecarContainers) > 0 {
 		podConf.Spec.Containers = append(podConf.Spec.Containers, r.headSidecarContainers...)
 	}
-	r.Log.Info("head pod labels", "labels", podConf.Labels)
+	logger.Info("head pod labels", "labels", podConf.Labels)
 	creatorCRDType := getCreatorCRDType(instance)
 	pod := common.BuildPod(ctx, podConf, rayv1.HeadNode, instance.Spec.HeadGroupSpec.RayStartParams, headPort, autoscalingEnabled, creatorCRDType, fqdnRayIP)
 	// Set raycluster instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&instance, &pod, r.Scheme); err != nil {
-		r.Log.Error(err, "Failed to set controller reference for raycluster pod")
+		logger.Error(err, "Failed to set controller reference for raycluster pod")
 	}
 
 	return pod
@@ -1064,6 +1083,7 @@ func getCreatorCRDType(instance rayv1.RayCluster) utils.CRDType {
 
 // Build worker instance pods.
 func (r *RayClusterReconciler) buildWorkerPod(ctx context.Context, instance rayv1.RayCluster, worker rayv1.WorkerGroupSpec) corev1.Pod {
+	logger := ctrl.LoggerFrom(ctx)
 	podName := strings.ToLower(instance.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol)
 	podName = utils.CheckName(podName)                                            // making sure the name is valid
 	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, instance, instance.Namespace) // Fully Qualified Domain Name
@@ -1079,13 +1099,15 @@ func (r *RayClusterReconciler) buildWorkerPod(ctx context.Context, instance rayv
 	pod := common.BuildPod(ctx, podTemplateSpec, rayv1.WorkerNode, worker.RayStartParams, headPort, autoscalingEnabled, creatorCRDType, fqdnRayIP)
 	// Set raycluster instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&instance, &pod, r.Scheme); err != nil {
-		r.Log.Error(err, "Failed to set controller reference for raycluster pod")
+		logger.Error(err, "Failed to set controller reference for raycluster pod")
 	}
 
 	return pod
 }
 
 func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instance rayv1.RayCluster) batchv1.Job {
+	logger := ctrl.LoggerFrom(ctx)
+
 	pod := r.buildHeadPod(ctx, instance)
 	pod.Labels[utils.RayNodeTypeLabelKey] = string(rayv1.RedisCleanupNode)
 
@@ -1154,7 +1176,7 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instanc
 	}
 
 	if err := controllerutil.SetControllerReference(&instance, &redisCleanupJob, r.Scheme); err != nil {
-		r.Log.Error(err, "Failed to set controller reference for the Redis cleanup Job.")
+		logger.Error(err, "Failed to set controller reference for the Redis cleanup Job.")
 	}
 
 	return redisCleanupJob
@@ -1238,14 +1260,16 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 
 // Best effort to obtain the ip of the head node.
 func (r *RayClusterReconciler) getHeadPodIP(ctx context.Context, instance *rayv1.RayCluster) (string, error) {
+	logger := ctrl.LoggerFrom(ctx)
+
 	runtimePods := corev1.PodList{}
 	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeTypeLabelKey: string(rayv1.HeadNode)}
 	if err := r.List(ctx, &runtimePods, client.InNamespace(instance.Namespace), filterLabels); err != nil {
-		r.Log.Error(err, "Failed to list pods while getting head pod ip.")
+		logger.Error(err, "Failed to list pods while getting head pod ip.")
 		return "", err
 	}
 	if len(runtimePods.Items) != 1 {
-		r.Log.Info(fmt.Sprintf("Found %d head pods. cluster name %s, filter labels %v", len(runtimePods.Items), instance.Name, filterLabels))
+		logger.Info(fmt.Sprintf("Found %d head pods. cluster name %s, filter labels %v", len(runtimePods.Items), instance.Name, filterLabels))
 		return "", nil
 	}
 	return runtimePods.Items[0].Status.PodIP, nil
@@ -1269,6 +1293,7 @@ func (r *RayClusterReconciler) getHeadServiceIP(ctx context.Context, instance *r
 }
 
 func (r *RayClusterReconciler) updateEndpoints(ctx context.Context, instance *rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
 	// TODO: (@scarlet25151) There may be several K8s Services for a RayCluster.
 	// We assume we can find the right one by filtering Services with appropriate label selectors
 	// and picking the first one. We may need to select by name in the future if the Service naming is stable.
@@ -1288,7 +1313,7 @@ func (r *RayClusterReconciler) updateEndpoints(ctx context.Context, instance *ra
 		}
 		for _, port := range svc.Spec.Ports {
 			if len(port.Name) == 0 {
-				r.Log.Info("updateStatus", "service port's name is empty. Not adding it to RayCluster status.endpoints", port)
+				logger.Info("updateStatus", "service port's name is empty. Not adding it to RayCluster status.endpoints", port)
 				continue
 			}
 			if port.NodePort != 0 {
@@ -1298,11 +1323,11 @@ func (r *RayClusterReconciler) updateEndpoints(ctx context.Context, instance *ra
 			} else if port.TargetPort.StrVal != "" {
 				instance.Status.Endpoints[port.Name] = port.TargetPort.StrVal
 			} else {
-				r.Log.Info("updateStatus", "service port's targetPort is empty. Not adding it to RayCluster status.endpoints", port)
+				logger.Info("updateStatus", "service port's targetPort is empty. Not adding it to RayCluster status.endpoints", port)
 			}
 		}
 	} else {
-		r.Log.Info("updateEndpoints", "unable to find a Service for this RayCluster. Not adding RayCluster status.endpoints", instance.Name, "Service selectors", filterLabels)
+		logger.Info("updateEndpoints", "unable to find a Service for this RayCluster. Not adding RayCluster status.endpoints", instance.Name, "Service selectors", filterLabels)
 	}
 
 	return nil
@@ -1325,6 +1350,7 @@ func (r *RayClusterReconciler) updateHeadInfo(ctx context.Context, instance *ray
 }
 
 func (r *RayClusterReconciler) reconcileAutoscalerServiceAccount(ctx context.Context, instance *rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
 	if instance.Spec.EnableInTreeAutoscaling == nil || !*instance.Spec.EnableInTreeAutoscaling {
 		return nil
 	}
@@ -1342,7 +1368,7 @@ func (r *RayClusterReconciler) reconcileAutoscalerServiceAccount(ctx context.Con
 		// zero-downtime rolling updates when RayService is performed. See https://github.com/ray-project/kuberay/issues/1123
 		// for more details.
 		if instance.Spec.HeadGroupSpec.Template.Spec.ServiceAccountName == namespacedName.Name {
-			r.Log.Error(err, fmt.Sprintf(
+			logger.Error(err, fmt.Sprintf(
 				"If users specify ServiceAccountName for the head Pod, they need to create a ServiceAccount themselves. "+
 					"However, ServiceAccount %s is not found. Please create one. "+
 					"See the PR description of https://github.com/ray-project/kuberay/pull/1128 for more details.", namespacedName.Name), "ServiceAccount", namespacedName)
@@ -1365,13 +1391,13 @@ func (r *RayClusterReconciler) reconcileAutoscalerServiceAccount(ctx context.Con
 
 		if err := r.Create(ctx, serviceAccount); err != nil {
 			if errors.IsAlreadyExists(err) {
-				r.Log.Info("Pod service account already exist, no need to create")
+				logger.Info("Pod service account already exist, no need to create")
 				return nil
 			}
-			r.Log.Error(err, "Pod Service Account create error!", "Pod.ServiceAccount.Error", err)
+			logger.Error(err, "Pod Service Account create error!", "Pod.ServiceAccount.Error", err)
 			return err
 		}
-		r.Log.Info("Pod ServiceAccount created successfully", "service account name", serviceAccount.Name)
+		logger.Info("Pod ServiceAccount created successfully", "service account name", serviceAccount.Name)
 		r.Recorder.Eventf(instance, corev1.EventTypeNormal, "Created", "Created service account %s", serviceAccount.Name)
 		return nil
 	}
@@ -1380,6 +1406,7 @@ func (r *RayClusterReconciler) reconcileAutoscalerServiceAccount(ctx context.Con
 }
 
 func (r *RayClusterReconciler) reconcileAutoscalerRole(ctx context.Context, instance *rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
 	if instance.Spec.EnableInTreeAutoscaling == nil || !*instance.Spec.EnableInTreeAutoscaling {
 		return nil
 	}
@@ -1406,13 +1433,13 @@ func (r *RayClusterReconciler) reconcileAutoscalerRole(ctx context.Context, inst
 
 		if err := r.Create(ctx, role); err != nil {
 			if errors.IsAlreadyExists(err) {
-				r.Log.Info("role already exist, no need to create")
+				logger.Info("role already exist, no need to create")
 				return nil
 			}
-			r.Log.Error(err, "Role create error!", "Role.Error", err)
+			logger.Error(err, "Role create error!", "Role.Error", err)
 			return err
 		}
-		r.Log.Info("Role created successfully", "role name", role.Name)
+		logger.Info("Role created successfully", "role name", role.Name)
 		r.Recorder.Eventf(instance, corev1.EventTypeNormal, "Created", "Created role %s", role.Name)
 		return nil
 	}
@@ -1421,6 +1448,7 @@ func (r *RayClusterReconciler) reconcileAutoscalerRole(ctx context.Context, inst
 }
 
 func (r *RayClusterReconciler) reconcileAutoscalerRoleBinding(ctx context.Context, instance *rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
 	if instance.Spec.EnableInTreeAutoscaling == nil || !*instance.Spec.EnableInTreeAutoscaling {
 		return nil
 	}
@@ -1447,13 +1475,13 @@ func (r *RayClusterReconciler) reconcileAutoscalerRoleBinding(ctx context.Contex
 
 		if err := r.Create(ctx, roleBinding); err != nil {
 			if errors.IsAlreadyExists(err) {
-				r.Log.Info("role binding already exist, no need to create")
+				logger.Info("role binding already exist, no need to create")
 				return nil
 			}
-			r.Log.Error(err, "Role binding create error!", "RoleBinding.Error", err)
+			logger.Error(err, "Role binding create error!", "RoleBinding.Error", err)
 			return err
 		}
-		r.Log.Info("RoleBinding created successfully", "role binding name", roleBinding.Name)
+		logger.Info("RoleBinding created successfully", "role binding name", roleBinding.Name)
 		r.Recorder.Eventf(instance, corev1.EventTypeNormal, "Created", "Created role binding %s", roleBinding.Name)
 		return nil
 	}
@@ -1462,20 +1490,22 @@ func (r *RayClusterReconciler) reconcileAutoscalerRoleBinding(ctx context.Contex
 }
 
 func (r *RayClusterReconciler) updateClusterState(ctx context.Context, instance *rayv1.RayCluster, clusterState rayv1.ClusterState) error {
+	logger := ctrl.LoggerFrom(ctx)
 	if instance.Status.State == clusterState {
 		return nil
 	}
 	instance.Status.State = clusterState
-	r.Log.Info("updateClusterState", "Update CR Status.State", clusterState)
+	logger.Info("updateClusterState", "Update CR Status.State", clusterState)
 	return r.Status().Update(ctx, instance)
 }
 
 func (r *RayClusterReconciler) updateClusterReason(ctx context.Context, instance *rayv1.RayCluster, clusterReason string) error {
+	logger := ctrl.LoggerFrom(ctx)
 	if instance.Status.Reason == clusterReason {
 		return nil
 	}
 	instance.Status.Reason = clusterReason
-	r.Log.Info("updateClusterReason", "Update CR Status.Reason", clusterReason)
+	logger.Info("updateClusterReason", "Update CR Status.Reason", clusterReason)
 	return r.Status().Update(ctx, instance)
 }
 

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -1508,56 +1508,57 @@ func TestInconsistentRayClusterStatus(t *testing.T) {
 	// `inconsistentRayClusterStatus` is used to check whether the old and new RayClusterStatus are inconsistent
 	// by comparing different fields. If the only differences between the old and new status are the `LastUpdateTime`
 	// and `ObservedGeneration` fields (Case 9 and Case 10), the status update will not be triggered.
+	ctx := context.Background()
 
 	// Case 1: `State` is different => return true
 	newStatus := oldStatus.DeepCopy()
 	newStatus.State = rayv1.Failed
-	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
 	// Case 2: `Reason` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.Reason = "new reason"
-	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
 	// Case 3: `AvailableWorkerReplicas` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.AvailableWorkerReplicas = oldStatus.AvailableWorkerReplicas + 1
-	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
 	// Case 4: `DesiredWorkerReplicas` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.DesiredWorkerReplicas = oldStatus.DesiredWorkerReplicas + 1
-	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
 	// Case 5: `MinWorkerReplicas` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.MinWorkerReplicas = oldStatus.MinWorkerReplicas + 1
-	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
 	// Case 6: `MaxWorkerReplicas` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.MaxWorkerReplicas = oldStatus.MaxWorkerReplicas + 1
-	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
 	// Case 7: `Endpoints` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.Endpoints["fakeEndpoint"] = "10009"
-	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
 	// Case 8: `Head` is different => return true
 	newStatus = oldStatus.DeepCopy()
 	newStatus.Head.PodIP = "test head pod ip"
-	assert.True(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+	assert.True(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
 	// Case 9: `LastUpdateTime` is different => return false
 	newStatus = oldStatus.DeepCopy()
 	newStatus.LastUpdateTime = &metav1.Time{Time: timeNow.Add(time.Hour)}
-	assert.False(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+	assert.False(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 
 	// Case 10: `ObservedGeneration` is different => return false
 	newStatus = oldStatus.DeepCopy()
 	newStatus.ObservedGeneration = oldStatus.ObservedGeneration + 1
-	assert.False(t, r.inconsistentRayClusterStatus(oldStatus, *newStatus))
+	assert.False(t, r.inconsistentRayClusterStatus(ctx, oldStatus, *newStatus))
 }
 
 func TestCalculateStatus(t *testing.T) {

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -698,10 +698,11 @@ func (r *RayJobReconciler) checkK8sJobAndUpdateStatusIfNeeded(ctx context.Contex
 }
 
 func (r *RayJobReconciler) checkActiveDeadlineAndUpdateStatusIfNeeded(ctx context.Context, rayJob *rayv1.RayJob) bool {
+	logger := ctrl.LoggerFrom(ctx)
 	if rayJob.Spec.ActiveDeadlineSeconds == nil || time.Now().Before(rayJob.Status.StartTime.Add(time.Duration(*rayJob.Spec.ActiveDeadlineSeconds)*time.Second)) {
 		return false
 	}
-	r.Log.Info("The RayJob has passed the activeDeadlineSeconds. Transition the status to `Failed`.", "StartTime", rayJob.Status.StartTime, "ActiveDeadlineSeconds", *rayJob.Spec.ActiveDeadlineSeconds)
+	logger.Info("The RayJob has passed the activeDeadlineSeconds. Transition the status to `Failed`.", "StartTime", rayJob.Status.StartTime, "ActiveDeadlineSeconds", *rayJob.Spec.ActiveDeadlineSeconds)
 	rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
 	rayJob.Status.Reason = rayv1.DeadlineExceeded
 	rayJob.Status.Message = fmt.Sprintf("The RayJob has passed the activeDeadlineSeconds. StartTime: %v. ActiveDeadlineSeconds: %d", rayJob.Status.StartTime, *rayJob.Spec.ActiveDeadlineSeconds)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -42,7 +42,7 @@ type RayJobReconciler struct {
 }
 
 // NewRayJobReconciler returns a new reconcile.Reconciler
-func NewRayJobReconciler(mgr manager.Manager, dashboardClientFunc func() utils.RayDashboardClientInterface) *RayJobReconciler {
+func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, dashboardClientFunc func() utils.RayDashboardClientInterface) *RayJobReconciler {
 	return &RayJobReconciler{
 		Client:              mgr.GetClient(),
 		Scheme:              mgr.GetScheme(),

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -72,8 +72,8 @@ func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, dashboardClie
 // Automatically generate RBAC rules to allow the Controller to read and write workloads
 // Reconcile used to bridge the desired state with the current state
 func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	ctx = ctrl.LoggerInto(ctx, r.Log)
-	r.Log.Info("reconciling RayJob", "NamespacedName", request.NamespacedName)
+	logger := r.Log.WithValues("RayJob", request.NamespacedName)
+	ctx = ctrl.LoggerInto(ctx, logger)
 
 	// Get RayJob instance
 	var err error
@@ -81,16 +81,16 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	if err := r.Get(ctx, request.NamespacedName, rayJobInstance); err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request. Stop reconciliation.
-			r.Log.Info("RayJob resource not found. Ignoring since object must be deleted", "name", request.NamespacedName)
+			logger.Info("RayJob resource not found. Ignoring since object must be deleted", "name", request.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		r.Log.Error(err, "Failed to get RayJob")
+		logger.Error(err, "Failed to get RayJob")
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 	}
 
 	if !rayJobInstance.ObjectMeta.DeletionTimestamp.IsZero() {
-		r.Log.Info("RayJob is being deleted", "DeletionTimestamp", rayJobInstance.ObjectMeta.DeletionTimestamp)
+		logger.Info("RayJob is being deleted", "DeletionTimestamp", rayJobInstance.ObjectMeta.DeletionTimestamp)
 		// If the JobStatus is not terminal, it is possible that the Ray job is still running. This includes
 		// the case where JobStatus is JobStatusNew.
 		if !rayv1.IsJobTerminal(rayJobInstance.Status.JobStatus) {
@@ -98,42 +98,42 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			rayDashboardClient.InitClient(rayJobInstance.Status.DashboardURL)
 			err := rayDashboardClient.StopJob(ctx, rayJobInstance.Status.JobId)
 			if err != nil {
-				r.Log.Info("Failed to stop job for RayJob", "error", err)
+				logger.Info("Failed to stop job for RayJob", "error", err)
 			}
 		}
 
-		r.Log.Info("Remove the finalizer no matter StopJob() succeeds or not.", "finalizer", utils.RayJobStopJobFinalizer)
+		logger.Info("Remove the finalizer no matter StopJob() succeeds or not.", "finalizer", utils.RayJobStopJobFinalizer)
 		controllerutil.RemoveFinalizer(rayJobInstance, utils.RayJobStopJobFinalizer)
 		err := r.Update(ctx, rayJobInstance)
 		if err != nil {
-			r.Log.Error(err, "Failed to remove finalizer for RayJob")
+			logger.Error(err, "Failed to remove finalizer for RayJob")
 			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 		}
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 	}
 
 	if err := validateRayJobSpec(rayJobInstance); err != nil {
-		r.Log.Error(err, "The RayJob spec is invalid")
+		logger.Error(err, "The RayJob spec is invalid")
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 	}
 
 	// Please do NOT modify `originalRayJobInstance` in the following code.
 	originalRayJobInstance := rayJobInstance.DeepCopy()
 
-	r.Log.Info("RayJob", "name", rayJobInstance.Name, "namespace", rayJobInstance.Namespace, "JobStatus", rayJobInstance.Status.JobStatus, "JobDeploymentStatus", rayJobInstance.Status.JobDeploymentStatus, "SubmissionMode", rayJobInstance.Spec.SubmissionMode)
+	logger.Info("RayJob", "name", rayJobInstance.Name, "namespace", rayJobInstance.Namespace, "JobStatus", rayJobInstance.Status.JobStatus, "JobDeploymentStatus", rayJobInstance.Status.JobDeploymentStatus, "SubmissionMode", rayJobInstance.Spec.SubmissionMode)
 	switch rayJobInstance.Status.JobDeploymentStatus {
 	case rayv1.JobDeploymentStatusNew:
 		if !controllerutil.ContainsFinalizer(rayJobInstance, utils.RayJobStopJobFinalizer) {
-			r.Log.Info("Add a finalizer", "finalizer", utils.RayJobStopJobFinalizer)
+			logger.Info("Add a finalizer", "finalizer", utils.RayJobStopJobFinalizer)
 			controllerutil.AddFinalizer(rayJobInstance, utils.RayJobStopJobFinalizer)
 			if err := r.Update(ctx, rayJobInstance); err != nil {
-				r.Log.Error(err, "Failed to update RayJob with finalizer")
+				logger.Error(err, "Failed to update RayJob with finalizer")
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 			}
 		}
 		// Set `Status.JobDeploymentStatus` to `JobDeploymentStatusInitializing`, and initialize `Status.JobId`
 		// and `Status.RayClusterName` prior to avoid duplicate job submissions and cluster creations.
-		r.Log.Info("JobDeploymentStatusNew", "RayJob", rayJobInstance.Name)
+		logger.Info("JobDeploymentStatusNew", "RayJob", rayJobInstance.Name)
 		if err = r.initRayJobStatusIfNeed(ctx, rayJobInstance); err != nil {
 			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 		}
@@ -142,7 +142,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			break
 		}
 		if pastActiveDeadline(rayJobInstance) {
-			r.Log.Info("The RayJob has passed the activeDeadlineSeconds. Transition the status to `Complete`.", "StartTime", rayJobInstance.Status.StartTime, "ActiveDeadlineSeconds", *rayJobInstance.Spec.ActiveDeadlineSeconds)
+			logger.Info("The RayJob has passed the activeDeadlineSeconds. Transition the status to `Complete`.", "StartTime", rayJobInstance.Status.StartTime, "ActiveDeadlineSeconds", *rayJobInstance.Spec.ActiveDeadlineSeconds)
 			rayJobInstance.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusComplete
 			break
 		}
@@ -155,12 +155,12 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		// Check the current status of RayCluster before submitting.
 		if clientURL := rayJobInstance.Status.DashboardURL; clientURL == "" {
 			if rayClusterInstance.Status.State != rayv1.Ready {
-				r.Log.Info("Wait for the RayCluster.Status.State to be ready before submitting the job.", "RayCluster", rayClusterInstance.Name, "State", rayClusterInstance.Status.State)
+				logger.Info("Wait for the RayCluster.Status.State to be ready before submitting the job.", "RayCluster", rayClusterInstance.Name, "State", rayClusterInstance.Status.State)
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 			}
 
 			if clientURL, err = utils.FetchHeadServiceURL(ctx, r.Client, rayClusterInstance, utils.DashboardPortName); err != nil || clientURL == "" {
-				r.Log.Error(err, "Failed to get the dashboard URL after the RayCluster is ready!", "RayCluster", rayClusterInstance.Name)
+				logger.Error(err, "Failed to get the dashboard URL after the RayCluster is ready!", "RayCluster", rayClusterInstance.Name)
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 			}
 			rayJobInstance.Status.DashboardURL = clientURL
@@ -172,7 +172,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			}
 		}
 
-		r.Log.Info("Both RayCluster and the submitter K8s Job are created. Transition the status from `Initializing` to `Running`.",
+		logger.Info("Both RayCluster and the submitter K8s Job are created. Transition the status from `Initializing` to `Running`.",
 			"RayJob", rayJobInstance.Name, "RayCluster", rayJobInstance.Status.RayClusterName)
 		rayJobInstance.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusRunning
 	case rayv1.JobDeploymentStatusRunning:
@@ -180,7 +180,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			break
 		}
 		if pastActiveDeadline(rayJobInstance) {
-			r.Log.Info("The RayJob has passed the activeDeadlineSeconds. Transition the status to `Complete`.", "StartTime", rayJobInstance.Status.StartTime, "ActiveDeadlineSeconds", *rayJobInstance.Spec.ActiveDeadlineSeconds)
+			logger.Info("The RayJob has passed the activeDeadlineSeconds. Transition the status to `Complete`.", "StartTime", rayJobInstance.Status.StartTime, "ActiveDeadlineSeconds", *rayJobInstance.Spec.ActiveDeadlineSeconds)
 			rayJobInstance.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusComplete
 			break
 		}
@@ -194,7 +194,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			// indefinitely.
 			namespacedName := common.RayJobK8sJobNamespacedName(rayJobInstance)
 			if err := r.Client.Get(ctx, namespacedName, job); err != nil {
-				r.Log.Error(err, "Failed to get the submitter Kubernetes Job", "NamespacedName", namespacedName)
+				logger.Error(err, "Failed to get the submitter Kubernetes Job", "NamespacedName", namespacedName)
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 			}
 			if shouldUpdate := r.checkK8sJobAndUpdateStatusIfNeeded(ctx, rayJobInstance, job); shouldUpdate {
@@ -216,17 +216,17 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		if err != nil {
 			// If the Ray job was not found, GetJobInfo returns a BadRequest error.
 			if rayJobInstance.Spec.SubmissionMode == rayv1.HTTPMode && errors.IsBadRequest(err) {
-				r.Log.Info("The Ray job was not found. Submit a Ray job via an HTTP request.", "JobId", rayJobInstance.Status.JobId)
+				logger.Info("The Ray job was not found. Submit a Ray job via an HTTP request.", "JobId", rayJobInstance.Status.JobId)
 				if _, err := rayDashboardClient.SubmitJob(ctx, rayJobInstance); err != nil {
-					r.Log.Error(err, "Failed to submit the Ray job", "JobId", rayJobInstance.Status.JobId)
+					logger.Error(err, "Failed to submit the Ray job", "JobId", rayJobInstance.Status.JobId)
 					return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 				}
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 			}
-			r.Log.Error(err, "Failed to get job info", "JobId", rayJobInstance.Status.JobId)
+			logger.Error(err, "Failed to get job info", "JobId", rayJobInstance.Status.JobId)
 			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 		}
-		r.Log.Info("GetJobInfo", "Job Info", jobInfo)
+		logger.Info("GetJobInfo", "Job Info", jobInfo)
 
 		// If the JobStatus is in a terminal status, such as SUCCEEDED, FAILED, or STOPPED, it is impossible for the Ray job
 		// to transition to any other. Additionally, RayJob does not currently support retries. Hence, we can mark the RayJob
@@ -238,7 +238,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 				jobDeploymentStatus = rayv1.JobDeploymentStatusComplete
 			case rayv1.K8sJobMode:
 				if _, finished := utils.IsJobFinished(job); finished {
-					r.Log.Info("The submitter Kubernetes Job is finished", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
+					logger.Info("The submitter Kubernetes Job is finished", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
 					jobDeploymentStatus = rayv1.JobDeploymentStatusComplete
 				}
 			}
@@ -266,7 +266,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 		}
 		if !isClusterDeleted || !isJobDeleted {
-			r.Log.Info("The release of the compute resources has not been completed yet. " +
+			logger.Info("The release of the compute resources has not been completed yet. " +
 				"Wait for the resources to be deleted before the status transitions to avoid a resource leak.")
 			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 		}
@@ -282,7 +282,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		rayJobInstance.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusSuspended
 	case rayv1.JobDeploymentStatusSuspended:
 		if !rayJobInstance.Spec.Suspend {
-			r.Log.Info("The status is 'Suspended', but the suspend flag is false. Transition the status to 'New'.")
+			logger.Info("The status is 'Suspended', but the suspend flag is false. Transition the status to 'New'.")
 			rayJobInstance.Status.JobStatus = rayv1.JobStatusNew
 			rayJobInstance.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusNew
 			break
@@ -291,12 +291,12 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 	case rayv1.JobDeploymentStatusComplete:
 		// If this RayJob uses an existing RayCluster (i.e., ClusterSelector is set), we should not delete the RayCluster.
-		r.Log.Info("JobDeploymentStatusComplete", "RayJob", rayJobInstance.Name, "ShutdownAfterJobFinishes", rayJobInstance.Spec.ShutdownAfterJobFinishes, "ClusterSelector", rayJobInstance.Spec.ClusterSelector)
+		logger.Info("JobDeploymentStatusComplete", "RayJob", rayJobInstance.Name, "ShutdownAfterJobFinishes", rayJobInstance.Spec.ShutdownAfterJobFinishes, "ClusterSelector", rayJobInstance.Spec.ClusterSelector)
 		if rayJobInstance.Spec.ShutdownAfterJobFinishes && len(rayJobInstance.Spec.ClusterSelector) == 0 {
 			ttlSeconds := rayJobInstance.Spec.TTLSecondsAfterFinished
 			nowTime := time.Now()
 			shutdownTime := rayJobInstance.Status.EndTime.Add(time.Duration(ttlSeconds) * time.Second)
-			r.Log.Info(
+			logger.Info(
 				"RayJob is completed",
 				"shutdownAfterJobFinishes", rayJobInstance.Spec.ShutdownAfterJobFinishes,
 				"ttlSecondsAfterFinished", ttlSeconds,
@@ -305,7 +305,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 				"ShutdownTime", shutdownTime)
 			if shutdownTime.After(nowTime) {
 				delta := int32(time.Until(shutdownTime.Add(2 * time.Second)).Seconds())
-				r.Log.Info(fmt.Sprintf("shutdownTime not reached, requeue this RayJob for %d seconds", delta))
+				logger.Info(fmt.Sprintf("shutdownTime not reached, requeue this RayJob for %d seconds", delta))
 				return ctrl.Result{RequeueAfter: time.Duration(delta) * time.Second}, nil
 			} else {
 				// We only need to delete the RayCluster. We don't need to delete the submitter Kubernetes Job so that users can still access
@@ -318,14 +318,14 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		// If the RayJob is completed, we should not requeue it.
 		return ctrl.Result{}, nil
 	default:
-		r.Log.Info("Unknown JobDeploymentStatus", "JobDeploymentStatus", rayJobInstance.Status.JobDeploymentStatus)
+		logger.Info("Unknown JobDeploymentStatus", "JobDeploymentStatus", rayJobInstance.Status.JobDeploymentStatus)
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 	}
 
 	// This is the only place where we update the RayJob status. Please do NOT add any code
 	// between the above switch statement and the following code.
 	if err = r.updateRayJobStatus(ctx, originalRayJobInstance, rayJobInstance); err != nil {
-		r.Log.Info("Failed to update RayJob status", "error", err)
+		logger.Info("Failed to update RayJob status", "error", err)
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 	}
 	return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
@@ -333,38 +333,40 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 
 // createK8sJobIfNeed creates a Kubernetes Job for the RayJob if it doesn't exist.
 func (r *RayJobReconciler) createK8sJobIfNeed(ctx context.Context, rayJobInstance *rayv1.RayJob, rayClusterInstance *rayv1.RayCluster) error {
+	logger := ctrl.LoggerFrom(ctx)
 	job := &batchv1.Job{}
 	namespacedName := common.RayJobK8sJobNamespacedName(rayJobInstance)
 	if err := r.Client.Get(ctx, namespacedName, job); err != nil {
 		if errors.IsNotFound(err) {
-			submitterTemplate, err := r.getSubmitterTemplate(rayJobInstance, rayClusterInstance)
+			submitterTemplate, err := r.getSubmitterTemplate(ctx, rayJobInstance, rayClusterInstance)
 			if err != nil {
-				r.Log.Error(err, "failed to get submitter template")
+				logger.Error(err, "failed to get submitter template")
 				return err
 			}
 			return r.createNewK8sJob(ctx, rayJobInstance, submitterTemplate)
 		}
 
 		// Some other error occurred while trying to get the Job
-		r.Log.Error(err, "failed to get Kubernetes Job")
+		logger.Error(err, "failed to get Kubernetes Job")
 		return err
 	}
 
-	r.Log.Info("Kubernetes Job already exists", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
+	logger.Info("Kubernetes Job already exists", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
 	return nil
 }
 
 // getSubmitterTemplate builds the submitter pod template for the Ray job.
-func (r *RayJobReconciler) getSubmitterTemplate(rayJobInstance *rayv1.RayJob, rayClusterInstance *rayv1.RayCluster) (corev1.PodTemplateSpec, error) {
+func (r *RayJobReconciler) getSubmitterTemplate(ctx context.Context, rayJobInstance *rayv1.RayJob, rayClusterInstance *rayv1.RayCluster) (corev1.PodTemplateSpec, error) {
+	logger := ctrl.LoggerFrom(ctx)
 	var submitterTemplate corev1.PodTemplateSpec
 
 	// Set the default value for the optional field SubmitterPodTemplate if not provided.
 	if rayJobInstance.Spec.SubmitterPodTemplate == nil {
 		submitterTemplate = common.GetDefaultSubmitterTemplate(rayClusterInstance)
-		r.Log.Info("default submitter template is used")
+		logger.Info("default submitter template is used")
 	} else {
 		submitterTemplate = *rayJobInstance.Spec.SubmitterPodTemplate.DeepCopy()
-		r.Log.Info("user-provided submitter template is used; the first container is assumed to be the submitter")
+		logger.Info("user-provided submitter template is used; the first container is assumed to be the submitter")
 	}
 
 	// If the command in the submitter pod template isn't set, use the default command.
@@ -374,9 +376,9 @@ func (r *RayJobReconciler) getSubmitterTemplate(rayJobInstance *rayv1.RayJob, ra
 			return corev1.PodTemplateSpec{}, err
 		}
 		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = k8sJobCommand
-		r.Log.Info("No command is specified in the user-provided template. Default command is used", "command", k8sJobCommand)
+		logger.Info("No command is specified in the user-provided template. Default command is used", "command", k8sJobCommand)
 	} else {
-		r.Log.Info("User-provided command is used", "command", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
+		logger.Info("User-provided command is used", "command", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
 	}
 
 	// Set PYTHONUNBUFFERED=1 for real-time logging
@@ -402,6 +404,7 @@ func (r *RayJobReconciler) getSubmitterTemplate(rayJobInstance *rayv1.RayJob, ra
 
 // createNewK8sJob creates a new Kubernetes Job. It returns an error.
 func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *rayv1.RayJob, submitterTemplate corev1.PodTemplateSpec) error {
+	logger := ctrl.LoggerFrom(ctx)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rayJobInstance.Name,
@@ -424,22 +427,23 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 
 	// Set the ownership in order to do the garbage collection by k8s.
 	if err := ctrl.SetControllerReference(rayJobInstance, job, r.Scheme); err != nil {
-		r.Log.Error(err, "failed to set controller reference")
+		logger.Error(err, "failed to set controller reference")
 		return err
 	}
 
 	// Create the Kubernetes Job
 	if err := r.Client.Create(ctx, job); err != nil {
-		r.Log.Error(err, "failed to create k8s Job")
+		logger.Error(err, "failed to create k8s Job")
 		return err
 	}
-	r.Log.Info("Kubernetes Job created", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
+	logger.Info("Kubernetes Job created", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
 	r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, "Created", "Created Kubernetes Job %s", job.Name)
 	return nil
 }
 
 // deleteSubmitterJob deletes the submitter Job associated with the RayJob.
 func (r *RayJobReconciler) deleteSubmitterJob(ctx context.Context, rayJobInstance *rayv1.RayJob) (bool, error) {
+	logger := ctrl.LoggerFrom(ctx)
 	if rayJobInstance.Spec.SubmissionMode == rayv1.HTTPMode {
 		return true, nil
 	}
@@ -453,29 +457,30 @@ func (r *RayJobReconciler) deleteSubmitterJob(ctx context.Context, rayJobInstanc
 	if err := r.Client.Get(ctx, namespacedName, job); err != nil {
 		if errors.IsNotFound(err) {
 			isJobDeleted = true
-			r.Log.Info("The submitter Kubernetes Job has been already deleted", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
+			logger.Info("The submitter Kubernetes Job has been already deleted", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
 		} else {
-			r.Log.Error(err, "Failed to get Kubernetes Job")
+			logger.Error(err, "Failed to get Kubernetes Job")
 			return false, err
 		}
 	} else {
 		if !job.DeletionTimestamp.IsZero() {
-			r.Log.Info("The Job deletion is ongoing.", "RayJob", rayJobInstance.Name, "Submitter K8s Job", job.Name)
+			logger.Info("The Job deletion is ongoing.", "RayJob", rayJobInstance.Name, "Submitter K8s Job", job.Name)
 		} else {
 			if err := r.Client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
 				return false, err
 			}
-			r.Log.Info("The associated submitter Job is deleted", "RayJob", rayJobInstance.Name, "Submitter K8s Job", job.Name)
+			logger.Info("The associated submitter Job is deleted", "RayJob", rayJobInstance.Name, "Submitter K8s Job", job.Name)
 			r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, "Deleted", "Deleted submitter K8s Job %s", job.Name)
 		}
 	}
 
-	r.Log.Info("deleteSubmitterJob", "isJobDeleted", isJobDeleted)
+	logger.Info("deleteSubmitterJob", "isJobDeleted", isJobDeleted)
 	return isJobDeleted, nil
 }
 
 // deleteClusterResources deletes the RayCluster associated with the RayJob to release the compute resources.
 func (r *RayJobReconciler) deleteClusterResources(ctx context.Context, rayJobInstance *rayv1.RayJob) (bool, error) {
+	logger := ctrl.LoggerFrom(ctx)
 	clusterIdentifier := common.RayJobRayClusterNamespacedName(rayJobInstance)
 
 	var isClusterDeleted bool
@@ -485,23 +490,23 @@ func (r *RayJobReconciler) deleteClusterResources(ctx context.Context, rayJobIns
 			// If the cluster is not found, it means the cluster has been already deleted.
 			// Don't return error to make this function idempotent.
 			isClusterDeleted = true
-			r.Log.Info("The associated cluster has been already deleted and it can not be found", "RayCluster", clusterIdentifier)
+			logger.Info("The associated cluster has been already deleted and it can not be found", "RayCluster", clusterIdentifier)
 		} else {
 			return false, err
 		}
 	} else {
 		if !cluster.DeletionTimestamp.IsZero() {
-			r.Log.Info("The cluster deletion is ongoing.", "rayjob", rayJobInstance.Name, "raycluster", cluster.Name)
+			logger.Info("The cluster deletion is ongoing.", "rayjob", rayJobInstance.Name, "raycluster", cluster.Name)
 		} else {
 			if err := r.Delete(ctx, &cluster); err != nil {
 				return false, err
 			}
-			r.Log.Info("The associated cluster is deleted", "RayCluster", clusterIdentifier)
+			logger.Info("The associated cluster is deleted", "RayCluster", clusterIdentifier)
 			r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, "Deleted", "Deleted cluster %s", rayJobInstance.Status.RayClusterName)
 		}
 	}
 
-	r.Log.Info("deleteClusterResources", "isClusterDeleted", isClusterDeleted)
+	logger.Info("deleteClusterResources", "isClusterDeleted", isClusterDeleted)
 	return isClusterDeleted, nil
 }
 
@@ -519,9 +524,10 @@ func (r *RayJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // prior to job submissions and RayCluster creations. This is used to avoid duplicate job submissions and cluster creations. In addition, this
 // function also sets `Status.StartTime` to support `ActiveDeadlineSeconds`.
 func (r *RayJobReconciler) initRayJobStatusIfNeed(ctx context.Context, rayJob *rayv1.RayJob) error {
+	logger := ctrl.LoggerFrom(ctx)
 	shouldUpdateStatus := rayJob.Status.JobId == "" || rayJob.Status.RayClusterName == "" || rayJob.Status.JobStatus == ""
 	// Please don't update `shouldUpdateStatus` below.
-	r.Log.Info("initRayJobStatusIfNeed", "shouldUpdateStatus", shouldUpdateStatus, "RayJob", rayJob.Name, "jobId", rayJob.Status.JobId, "rayClusterName", rayJob.Status.RayClusterName, "jobStatus", rayJob.Status.JobStatus)
+	logger.Info("initRayJobStatusIfNeed", "shouldUpdateStatus", shouldUpdateStatus, "RayJob", rayJob.Name, "jobId", rayJob.Status.JobId, "rayClusterName", rayJob.Status.RayClusterName, "jobStatus", rayJob.Status.JobStatus)
 	if !shouldUpdateStatus {
 		return nil
 	}
@@ -558,9 +564,10 @@ func (r *RayJobReconciler) initRayJobStatusIfNeed(ctx context.Context, rayJob *r
 }
 
 func (r *RayJobReconciler) updateRayJobStatus(ctx context.Context, oldRayJob *rayv1.RayJob, newRayJob *rayv1.RayJob) error {
+	logger := ctrl.LoggerFrom(ctx)
 	oldRayJobStatus := oldRayJob.Status
 	newRayJobStatus := newRayJob.Status
-	r.Log.Info("updateRayJobStatus", "oldRayJobStatus", oldRayJobStatus, "newRayJobStatus", newRayJobStatus)
+	logger.Info("updateRayJobStatus", "oldRayJobStatus", oldRayJobStatus, "newRayJobStatus", newRayJobStatus)
 	// If a status field is crucial for the RayJob state machine, it MUST be
 	// updated with a distinct JobStatus or JobDeploymentStatus value.
 	if oldRayJobStatus.JobStatus != newRayJobStatus.JobStatus ||
@@ -570,7 +577,7 @@ func (r *RayJobReconciler) updateRayJobStatus(ctx context.Context, oldRayJob *ra
 			newRayJob.Status.EndTime = &metav1.Time{Time: time.Now()}
 		}
 
-		r.Log.Info("updateRayJobStatus", "old JobStatus", oldRayJobStatus.JobStatus, "new JobStatus", newRayJobStatus.JobStatus,
+		logger.Info("updateRayJobStatus", "old JobStatus", oldRayJobStatus.JobStatus, "new JobStatus", newRayJobStatus.JobStatus,
 			"old JobDeploymentStatus", oldRayJobStatus.JobDeploymentStatus, "new JobDeploymentStatus", newRayJobStatus.JobDeploymentStatus)
 		if err := r.Status().Update(ctx, newRayJob); err != nil {
 			return err
@@ -580,40 +587,41 @@ func (r *RayJobReconciler) updateRayJobStatus(ctx context.Context, oldRayJob *ra
 }
 
 func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, rayJobInstance *rayv1.RayJob) (*rayv1.RayCluster, error) {
+	logger := ctrl.LoggerFrom(ctx)
 	rayClusterNamespacedName := common.RayJobRayClusterNamespacedName(rayJobInstance)
-	r.Log.Info("try to find existing RayCluster instance", "name", rayClusterNamespacedName.Name)
+	logger.Info("try to find existing RayCluster instance", "name", rayClusterNamespacedName.Name)
 
 	rayClusterInstance := &rayv1.RayCluster{}
 	if err := r.Get(ctx, rayClusterNamespacedName, rayClusterInstance); err != nil {
 		if errors.IsNotFound(err) {
-			r.Log.Info("RayCluster not found", "RayJob", rayJobInstance.Name, "RayCluster", rayClusterNamespacedName)
+			logger.Info("RayCluster not found", "RayJob", rayJobInstance.Name, "RayCluster", rayClusterNamespacedName)
 			if len(rayJobInstance.Spec.ClusterSelector) != 0 {
 				err := fmt.Errorf("we have choosed the cluster selector mode, failed to find the cluster named %v, err: %v", rayClusterNamespacedName.Name, err)
 				return nil, err
 			}
 
-			r.Log.Info("RayCluster not found, creating RayCluster!", "RayCluster", rayClusterNamespacedName)
+			logger.Info("RayCluster not found, creating RayCluster!", "RayCluster", rayClusterNamespacedName)
 			rayClusterInstance, err = r.constructRayClusterForRayJob(rayJobInstance, rayClusterNamespacedName.Name)
 			if err != nil {
-				r.Log.Error(err, "unable to construct a new RayCluster")
+				logger.Error(err, "unable to construct a new RayCluster")
 				return nil, err
 			}
 			if err := r.Create(ctx, rayClusterInstance); err != nil {
-				r.Log.Error(err, "unable to create RayCluster for RayJob", "RayCluster", rayClusterInstance)
+				logger.Error(err, "unable to create RayCluster for RayJob", "RayCluster", rayClusterInstance)
 				return nil, err
 			}
 			r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, "Created", "Created RayCluster %s", rayJobInstance.Status.RayClusterName)
 		} else {
-			r.Log.Error(err, "Fail to get RayCluster!")
+			logger.Error(err, "Fail to get RayCluster!")
 			return nil, err
 		}
 	}
-	r.Log.Info("Found associated RayCluster for RayJob", "RayJob", rayJobInstance.Name, "RayCluster", rayClusterNamespacedName)
+	logger.Info("Found associated RayCluster for RayJob", "RayJob", rayJobInstance.Name, "RayCluster", rayClusterNamespacedName)
 
 	// Verify that RayJob is not in cluster selector mode first to avoid nil pointer dereference error during spec comparison.
 	// This is checked by ensuring len(rayJobInstance.Spec.ClusterSelector) equals 0.
 	if len(rayJobInstance.Spec.ClusterSelector) == 0 && !utils.CompareJsonStruct(rayClusterInstance.Spec, *rayJobInstance.Spec.RayClusterSpec) {
-		r.Log.Info("Disregard changes in RayClusterSpec of RayJob", "RayJob", rayJobInstance.Name)
+		logger.Info("Disregard changes in RayClusterSpec of RayJob", "RayJob", rayJobInstance.Name)
 	}
 
 	return rayClusterInstance, nil
@@ -645,6 +653,7 @@ func (r *RayJobReconciler) constructRayClusterForRayJob(rayJobInstance *rayv1.Ra
 }
 
 func (r *RayJobReconciler) updateStatusToSuspendingIfNeeded(ctx context.Context, rayJob *rayv1.RayJob) bool {
+	logger := ctrl.LoggerFrom(ctx)
 	if !rayJob.Spec.Suspend {
 		return false
 	}
@@ -654,18 +663,19 @@ func (r *RayJobReconciler) updateStatusToSuspendingIfNeeded(ctx context.Context,
 		rayv1.JobDeploymentStatusInitializing: {},
 	}
 	if _, ok := validTransitions[rayJob.Status.JobDeploymentStatus]; !ok {
-		r.Log.Info("The current status is not allowed to transition to `Suspending`", "RayJob", rayJob.Name, "JobDeploymentStatus", rayJob.Status.JobDeploymentStatus)
+		logger.Info("The current status is not allowed to transition to `Suspending`", "RayJob", rayJob.Name, "JobDeploymentStatus", rayJob.Status.JobDeploymentStatus)
 		return false
 	}
-	r.Log.Info(fmt.Sprintf("Try to transition the status from `%s` to `Suspending`", rayJob.Status.JobDeploymentStatus), "RayJob", rayJob.Name)
+	logger.Info(fmt.Sprintf("Try to transition the status from `%s` to `Suspending`", rayJob.Status.JobDeploymentStatus), "RayJob", rayJob.Name)
 	rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusSuspending
 	return true
 }
 
 func (r *RayJobReconciler) checkK8sJobAndUpdateStatusIfNeeded(ctx context.Context, rayJob *rayv1.RayJob, job *batchv1.Job) bool {
+	logger := ctrl.LoggerFrom(ctx)
 	for _, cond := range job.Status.Conditions {
 		if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue {
-			r.Log.Info("The submitter Kubernetes Job has failed. Attempting to transition the status to `Complete`.", "RayJob", rayJob.Name, "Submitter K8s Job", job.Name, "Reason", cond.Reason, "Message", cond.Message)
+			logger.Info("The submitter Kubernetes Job has failed. Attempting to transition the status to `Complete`.", "RayJob", rayJob.Name, "Submitter K8s Job", job.Name, "Reason", cond.Reason, "Message", cond.Message)
 			rayJob.Status.Message = "The submitter Kubernetes Job is failed. Reason: " + cond.Reason + ". Message: " + cond.Message
 			rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusComplete
 			return true

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -59,7 +59,7 @@ type RayServiceReconciler struct {
 }
 
 // NewRayServiceReconciler returns a new reconcile.Reconciler
-func NewRayServiceReconciler(mgr manager.Manager, dashboardClientFunc func() utils.RayDashboardClientInterface, httpProxyClientFunc func() utils.RayHttpProxyClientInterface) *RayServiceReconciler {
+func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, dashboardClientFunc func() utils.RayDashboardClientInterface, httpProxyClientFunc func() utils.RayHttpProxyClientInterface) *RayServiceReconciler {
 	return &RayServiceReconciler{
 		Client:                       mgr.GetClient(),
 		Scheme:                       mgr.GetScheme(),

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -104,17 +104,17 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 			},
 		},
 	}
-	err = NewReconciler(mgr, options).SetupWithManager(mgr, 1)
+	err = NewReconciler(ctx, mgr, options).SetupWithManager(mgr, 1)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayCluster controller")
 
-	err = NewRayServiceReconciler(mgr, func() utils.RayDashboardClientInterface {
+	err = NewRayServiceReconciler(ctx, mgr, func() utils.RayDashboardClientInterface {
 		return fakeRayDashboardClient
 	}, func() utils.RayHttpProxyClientInterface {
 		return fakeRayHttpProxyClient
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayService controller")
 
-	err = NewRayJobReconciler(mgr, func() utils.RayDashboardClientInterface {
+	err = NewRayJobReconciler(ctx, mgr, func() utils.RayDashboardClientInterface {
 		return fakeRayDashboardClient
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayJob controller")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, KubeRay log messages lack information about which CR is being processed. Hence, we can't search the logs based on the namespaced name of the CR in the logging infrastructure. This PR adds the context information to the logger: `logger := r.Log.WithValues("RayCluster", request.NamespacedName)`.

* With this PR
  ```
  {"level":"info","ts":"2024-02-27T23:20:02.309Z","logger":"controllers.RayCluster","msg":"Reconciling Ingress","RayCluster":{"name":"raycluster-complete","namespace":"default"}}
  ```
* Without this PR
  ```
  {"level":"info","ts":"2024-02-28T00:04:17.240Z","logger":"controllers.RayCluster","msg":"Reconciling Ingress"}    
  ```


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

* [example log](https://gist.github.com/kevin85421/ec7bcdfdd2f67bcc3e1769d2aee3bd57) (1 RayCluster + 1 RayJob + 1 RayService)