### PR TITLE
[Refactor][Multi-host] Create a function to associate RayCluster and the headless svc

### DIFF
--- a/ray-operator/controllers/ray/common/association.go
+++ b/ray-operator/controllers/ray/common/association.go
@@ -4,6 +4,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func RayClusterServeServiceNamespacedName(instance *rayv1.RayCluster) types.NamespacedName {
@@ -23,6 +24,13 @@ func RayClusterAutoscalerRoleBindingNamespacedName(instance *rayv1.RayCluster) t
 
 func RayClusterAutoscalerServiceAccountNamespacedName(instance *rayv1.RayCluster) types.NamespacedName {
 	return types.NamespacedName{Namespace: instance.Namespace, Name: utils.GetHeadGroupServiceAccountName(instance)}
+}
+
+func RayClusterHeadlessServiceListOptions(instance *rayv1.RayCluster) []client.ListOption {
+	return []client.ListOption{
+		client.InNamespace(instance.Namespace),
+		client.MatchingLabels(map[string]string{utils.RayClusterHeadlessServiceLabelKey: instance.Name}),
+	}
 }
 
 func RayServiceServeServiceNamespacedName(rayService *rayv1.RayService) types.NamespacedName {

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -599,9 +599,9 @@ func (r *RayClusterReconciler) reconcileHeadlessService(ctx context.Context, ins
 
 	if isMultiHost {
 		services := corev1.ServiceList{}
-		filterLabels := client.MatchingLabels{utils.RayClusterHeadlessServiceLabelKey: instance.Name}
+		options := common.RayClusterHeadlessServiceListOptions(instance)
 
-		if err := r.List(ctx, &services, client.InNamespace(instance.Namespace), filterLabels); err != nil {
+		if err := r.List(ctx, &services, options...); err != nil {
 			return err
 		}
 		// Check if there's an existing headless service in the cluster.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Follow up https://github.com/ray-project/kuberay/pull/1920/files#r1503536623

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* Manually test 
  * Create a multi-host RayCluster https://gist.github.com/kevin85421/735a6243dbe3ec1fcd37d10e6100f4a8
  * 1 head + 4 worker Pods
  * headless svc should be created
  * The endpoints `raycluster-complete-headless-worker-svc` should have 4 addresses.
    <img width="1085" alt="Screen Shot 2024-02-27 at 5 42 53 PM" src="https://github.com/ray-project/kuberay/assets/20109646/0fd29cba-883a-484a-a096-c7a134231218">

