### PR TITLE
[Refactor][RayCluster] Replace RayClusterReconciler.Log with LogConstructor

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -491,7 +491,6 @@ func TestReconcile_RemoveWorkersToDelete_RandomDelete(t *testing.T) {
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
 				Scheme:   scheme.Scheme,
-				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
 
 			err = testRayClusterReconciler.reconcilePods(ctx, testRayCluster)
@@ -585,7 +584,6 @@ func TestReconcile_RemoveWorkersToDelete_NoRandomDelete(t *testing.T) {
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
 				Scheme:   scheme.Scheme,
-				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
 
 			err = testRayClusterReconciler.reconcilePods(ctx, testRayCluster)
@@ -634,7 +632,6 @@ func TestReconcile_RandomDelete_OK(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	err = testRayClusterReconciler.reconcilePods(ctx, testRayCluster)
@@ -698,7 +695,6 @@ func TestReconcile_PodDeleted_Diff0_OK(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	// Since the desired state of the workerGroup is 3 replicas,
@@ -756,7 +752,6 @@ func TestReconcile_PodDeleted_DiffLess0_OK(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	// Since the desired state of the workerGroup is 3 replicas, the controller
@@ -812,7 +807,6 @@ func TestReconcile_Diff0_WorkersToDelete_OK(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	// Pod3 and Pod4 should be deleted because of the workersToDelete.
@@ -885,7 +879,6 @@ func TestReconcile_PodCrash_DiffLess0_OK(t *testing.T) {
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
 				Scheme:   scheme.Scheme,
-				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
 
 			if tc.ENABLE_RANDOM_POD_DELETE {
@@ -947,7 +940,6 @@ func TestReconcile_PodEvicted_DiffLess0_OK(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	err = testRayClusterReconciler.reconcilePods(ctx, testRayCluster)
@@ -1004,7 +996,6 @@ func TestReconcileHeadService(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	// Case 1: Head service does not exist.
@@ -1074,7 +1065,6 @@ func TestReconcileHeadlessService(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	headlessServiceSelector := labels.SelectorFromSet(map[string]string{
@@ -1150,7 +1140,6 @@ func TestReconcile_AutoscalerServiceAccount(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	err = testRayClusterReconciler.reconcileAutoscalerServiceAccount(ctx, testRayCluster)
@@ -1184,7 +1173,6 @@ func TestReconcile_Autoscaler_ServiceAccountName(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	// If users specify ServiceAccountName for the head Pod, they need to create a ServiceAccount themselves.
@@ -1205,7 +1193,6 @@ func TestReconcile_Autoscaler_ServiceAccountName(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	err = testRayClusterReconciler.reconcileAutoscalerServiceAccount(ctx, cluster)
@@ -1231,7 +1218,6 @@ func TestReconcile_AutoscalerRoleBinding(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	err = testRayClusterReconciler.reconcileAutoscalerRoleBinding(ctx, testRayCluster)
@@ -1268,7 +1254,6 @@ func TestReconcile_UpdateClusterReason(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 	reason := "test reason"
 
@@ -1289,7 +1274,6 @@ func TestUpdateEndpoints(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	if err := testRayClusterReconciler.updateEndpoints(ctx, testRayCluster); err != nil {
@@ -1356,7 +1340,6 @@ func TestGetHeadPodIP(t *testing.T) {
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
 				Scheme:   scheme.Scheme,
-				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
 
 			ip, err := testRayClusterReconciler.getHeadPodIP(context.TODO(), testRayCluster)
@@ -1423,7 +1406,6 @@ func TestGetHeadServiceIP(t *testing.T) {
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
 				Scheme:   scheme.Scheme,
-				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
 
 			ip, err := testRayClusterReconciler.getHeadServiceIP(context.TODO(), testRayCluster)
@@ -1483,7 +1465,6 @@ func TestUpdateStatusObservedGeneration(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	// Compare the values of `Generation` and `ObservedGeneration` to check if they match.
@@ -1520,7 +1501,6 @@ func TestReconcile_UpdateClusterState(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   newScheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	state := rayv1.Ready
@@ -1540,7 +1520,6 @@ func TestInconsistentRayClusterStatus(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	// Mock data
@@ -1659,7 +1638,6 @@ func TestCalculateStatus(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	// Test head information
@@ -1715,7 +1693,6 @@ func Test_TerminatedWorkers_NoAutoscaler(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	// Since the desired state of the workerGroup is 3 replicas, the controller
@@ -1839,7 +1816,6 @@ func Test_TerminatedHead_RestartPolicy(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   newScheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	// The head Pod will not be deleted because the restart policy is `Always`.
@@ -1923,7 +1899,6 @@ func Test_RunningPods_RayContainerTerminated(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   newScheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 	}
 
 	// The head Pod will be deleted and the controller will return an error
@@ -2097,7 +2072,6 @@ func Test_RedisCleanupFeatureFlag(t *testing.T) {
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
 				Scheme:   newScheme,
-				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
 
 			rayClusterList := rayv1.RayClusterList{}
@@ -2270,7 +2244,6 @@ func Test_RedisCleanup(t *testing.T) {
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
 				Scheme:   newScheme,
-				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
 
 			// Check Job
@@ -2386,7 +2359,6 @@ func TestReconcile_Replicas_Optional(t *testing.T) {
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
 				Scheme:   scheme.Scheme,
-				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
 
 			// Since the desired state of the workerGroup is 1 replica,
@@ -2479,7 +2451,6 @@ func TestReconcile_Multihost_Replicas(t *testing.T) {
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
 				Scheme:   scheme.Scheme,
-				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
 
 			// Since the desired state of the workerGroup is 1 replica,
@@ -2548,7 +2519,6 @@ func TestReconcile_NumOfHosts(t *testing.T) {
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
 				Scheme:   scheme.Scheme,
-				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
 
 			err = testRayClusterReconciler.reconcilePods(ctx, cluster)
@@ -2651,7 +2621,6 @@ func TestDeleteAllPods(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   newScheme,
-		Log:      ctrl.Log.WithName("controllers"),
 	}
 	ctx := context.Background()
 	// The first `deleteAllPods` function call should delete the "alive" Pod.

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -63,7 +62,6 @@ func TestCreateK8sJobIfNeed(t *testing.T) {
 
 	rayJobReconciler := &RayJobReconciler{
 		Client:   fakeClient,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayJob"),
 		Scheme:   newScheme,
 		Recorder: &record.FakeRecorder{},
 	}
@@ -149,9 +147,7 @@ func TestGetSubmitterTemplate(t *testing.T) {
 		},
 	}
 
-	r := &RayJobReconciler{
-		Log: ctrl.Log.WithName("controllers").WithName("RayJob"),
-	}
+	r := &RayJobReconciler{}
 	ctx := context.Background()
 
 	// Test 1: User provided template with command
@@ -248,7 +244,6 @@ func TestUpdateStatusToSuspendingIfNeeded(t *testing.T) {
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
 				Scheme:   newScheme,
-				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
 			shouldUpdate := testRayJobReconciler.updateStatusToSuspendingIfNeeded(ctx, rayJob)
 			assert.Equal(t, tc.expectedShouldUpdate, shouldUpdate)
@@ -316,7 +311,6 @@ func TestUpdateRayJobStatus(t *testing.T) {
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
 				Scheme:   newScheme,
-				Log:      ctrl.Log.WithName("controllers").WithName("RayCluster"),
 			}
 
 			err = testRayJobReconciler.updateRayJobStatus(ctx, oldRayJob, newRayJob)

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -157,9 +156,7 @@ func TestGetClusterAction(t *testing.T) {
 }
 
 func TestInconsistentRayServiceStatuses(t *testing.T) {
-	r := &RayServiceReconciler{
-		Log: ctrl.Log.WithName("controllers").WithName("RayService"),
-	}
+	r := &RayServiceReconciler{}
 
 	timeNow := metav1.Now()
 	oldStatus := rayv1.RayServiceStatuses{
@@ -243,9 +240,7 @@ func TestInconsistentRayServiceStatus(t *testing.T) {
 		},
 	}
 
-	r := &RayServiceReconciler{
-		Log: ctrl.Log.WithName("controllers").WithName("RayService"),
-	}
+	r := &RayServiceReconciler{}
 	ctx := context.Background()
 
 	// Test 1: Only HealthLastUpdateTime is updated.
@@ -301,7 +296,6 @@ func TestIsHeadPodRunningAndReady(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayService"),
 	}
 
 	// Test 1: There is no head pod. `isHeadPodRunningAndReady` should return false.
@@ -383,7 +377,6 @@ func TestReconcileServices_UpdateService(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayService"),
 	}
 
 	ctx := context.TODO()
@@ -468,7 +461,6 @@ func TestFetchHeadServiceURL(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayService"),
 	}
 
 	url, err := utils.FetchHeadServiceURL(ctx, r.Client, &cluster, utils.DashboardPortName)
@@ -492,7 +484,6 @@ func TestGetAndCheckServeStatus(t *testing.T) {
 		Client:   fakeClient,
 		Recorder: &record.FakeRecorder{},
 		Scheme:   scheme.Scheme,
-		Log:      ctrl.Log.WithName("controllers").WithName("RayService"),
 	}
 	serveAppName := "serve-app-1"
 	longPeriod := time.Duration(10000)
@@ -644,7 +635,6 @@ func TestCheckIfNeedSubmitServeDeployment(t *testing.T) {
 		Client:       fakeClient,
 		Recorder:     &record.FakeRecorder{},
 		Scheme:       scheme.Scheme,
-		Log:          ctrl.Log.WithName("controllers").WithName("RayService"),
 		ServeConfigs: cmap.New[string](),
 	}
 
@@ -803,7 +793,6 @@ func TestReconcileRayCluster(t *testing.T) {
 			fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
 			r := RayServiceReconciler{
 				Client: fakeClient,
-				Log:    ctrl.Log.WithName("controllers").WithName("RayService"),
 			}
 			service := rayService.DeepCopy()
 			if tc.updateRayClusterSpec {


### PR DESCRIPTION
## Why are these changes needed?

As @astefanutti suggested here https://github.com/ray-project/kuberay/pull/1945#discussion_r1503835776, it could be better to use the `LogConstructor` option to construct a logger because the logger is shared between controller-runtime and the controller itself.

But I then gave the wrong [example](https://github.com/ray-project/kuberay/pull/1945#discussion_r1504214798). Now I would like to fix that.

This PR uses the `LogConstructor` inside the `WithOption` call instead of a `WithLogConstructor`, which will be overridden by the former one, and then removes the no longer needed`RayClusterReconciler.Log`.

The `r.Log` loggers in the tests are also removed since they were already not used in tests previously.

## Screenshot

This is what the logs look like, including the reconcileID.

<img width="1644" alt="image" src="https://github.com/ray-project/kuberay/assets/2727535/b5033736-a57f-4751-9115-c229dde64d2f">


## Related issue number

https://github.com/ray-project/kuberay/issues/1947

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
