### PR TITLE
Update kind version.

### DIFF
--- a/.buildkite/setup-env.sh
+++ b/.buildkite/setup-env.sh
@@ -4,7 +4,7 @@
 export PATH=$PATH:/usr/local/go/bin
 
 # Install kind
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-amd64
 chmod +x ./kind
 mv ./kind /usr/local/bin/kind
 

--- a/.github/workflows/actions/compatibility/action.yaml
+++ b/.github/workflows/actions/compatibility/action.yaml
@@ -16,7 +16,7 @@ runs:
 
   - name: Install Kind
     run: |
-      curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+      curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-amd64
       chmod +x ./kind
       sudo mv ./kind /usr/local/bin/kind
     shell: bash

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -463,7 +463,7 @@ jobs:
 
       - name: Install Kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
           kind create cluster


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We are using a very old version of kind in our testing this is causing us to pull a very old image of kind nodes and test against a really old version of kubernetes. Logs below are from `[Compatibility Test - Nightly](https://github.com/ray-project/kuberay/actions/runs/8104366012/job/22151018968?pr=1955#logs)`

```
2024-03-01:00:17:27,958 INFO     [utils.py:356] Execute command: kind create cluster --wait 900s --config /home/runner/work/kuberay/kuberay/tests/framework/config/kind-config.yaml
Creating cluster "kind" ...
 • Ensuring node image (kindest/node:v1.21.1) 🖼  ...
 ✓ Ensuring node image (kindest/node:v1.21.1) 🖼
 • Preparing nodes 📦   ...
 ✓ Preparing nodes 📦 
 • Writing configuration 📜  ...
 ✓ Writing configuration 📜
 • Starting control-plane 🕹️  ...
 ✓ Starting control-plane 🕹️
 • Installing CNI 🔌  ...
 ✓ Installing CNI 🔌
 • Installing StorageClass 💾  ...
 ✓ Installing StorageClass 💾
 • Waiting ≤ 15m0s for control-plane = Ready ⏳  ...
 ✓ Waiting ≤ 15m0s for control-plane = Ready ⏳
 • Ready after 24s 💚
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/kuberay/issues/1935
Closes #1314 
## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
   - [x] CI tests are passing. This change only affects CI config.
