### PR TITLE
[release][v1.1.0] Improve release doc and update KubeRay API server chart's repository

### DIFF
--- a/docs/release/helm-chart.md
+++ b/docs/release/helm-chart.md
@@ -35,7 +35,7 @@ You can validate the charts as follows:
     # Install charts (If you want to install charts for a release candidate, add `--version vX.Y.Z-rc.0` to the command below.)
     helm install kuberay-operator kuberay/kuberay-operator
     helm install kuberay-apiserver kuberay/kuberay-apiserver
-    helm install raycluster kuberay/ray-cluster 
+    helm install raycluster kuberay/ray-cluster
     ```
 
 ## Delete the existing releases

--- a/docs/release/helm-chart.md
+++ b/docs/release/helm-chart.md
@@ -32,10 +32,10 @@ You can validate the charts as follows:
     # List all charts
     helm search repo kuberay
 
-    # Install charts
+    # Install charts (If you want to install charts for a release candidate, add `--version vX.Y.Z-rc.0` to the command below.)
     helm install kuberay-operator kuberay/kuberay-operator
     helm install kuberay-apiserver kuberay/kuberay-apiserver
-    helm install raycluster kuberay/ray-cluster
+    helm install raycluster kuberay/ray-cluster 
     ```
 
 ## Delete the existing releases

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 name: "kuberay-apiserver"
 image:
-  repository: kuberay/apiserver
+  repository: quay.io/kuberay/apiserver
   tag: nightly
   pullPolicy: IfNotPresent
 
@@ -78,7 +78,7 @@ singleNamespaceInstall: false
 # security definition. Comment it out if security is not required
 security:
   proxy:
-    repository: kuberay/security-proxy
+    repository: quay.io/kuberay/security-proxy
     tag: nightly
     pullPolicy: IfNotPresent
   env:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I found that the KubeRay API server is currently using DockerHub instead of Quay when I published the Helm charts for v1.1.0-rc.0 (https://github.com/ray-project/kuberay-helm/pull/31/commits/044dbec1b451c29931570e431df371f3fc73fb5b). However, at this moment, we don't publish images to DockerHub.  



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
