### PR TITLE
Exposing min/max replica counts for default worker group

### DIFF
--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -114,6 +114,8 @@ worker:
   # disabled: true
   groupName: workergroup
   replicas: 1
+  minReplicas: 1
+  maxReplicas: 3
   labels: {}
   serviceAccountName: ""
   rayStartParams: {}


### PR DESCRIPTION
## Why are these changes needed?
When auto-scaling is enabled with the default worker group, the max replica count defaults to `2147483647`. 
```
> kubectl -n kuberay describe RayCluster kuberay | grep "Max Replicas" -A 1
    Max Replicas:        2147483647
    Min Replicas:        0
```

Upon job submission, the head node launches too many worker nodes. On a few occasions, some of the worker nodes were in `Pending` state due to lack of resources.

This PR exposes min/max replica counts for the default worker group as in additional worker groups, providing more control over resource allocation.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

I have manually tested the patch to ensure the changes are effective.