### PR TITLE
[Bug] Reconciler error when changing the value of nameOverride in values.yaml of helm installation for Ray Cluster

### DIFF
--- a/helm-chart/ray-cluster/templates/_helpers.tpl
+++ b/helm-chart/ray-cluster/templates/_helpers.tpl
@@ -35,7 +35,6 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "ray-cluster.labels" -}}
-app.kubernetes.io/name: {{ include "ray-cluster.name" . }}
 helm.sh/chart: {{ include "ray-cluster.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1327,13 +1327,6 @@ func (r *RayClusterReconciler) getHeadPodIP(ctx context.Context, instance *rayv1
 func (r *RayClusterReconciler) getHeadServiceIP(ctx context.Context, instance *rayv1.RayCluster) (string, error) {
 	runtimeServices := corev1.ServiceList{}
 	filterLabels := client.MatchingLabels(common.HeadServiceLabels(*instance))
-
-	// If the head pod's application name label is not the default, such as when it's overridden by the
-	// Helm release's `nameOverride` value, update `filterLabels` to use the override's application name value instead.
-	if val, ok := instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels[utils.KubernetesApplicationNameLabelKey]; ok {
-		filterLabels[utils.KubernetesApplicationNameLabelKey] = val
-	}
-
 	if err := r.List(ctx, &runtimeServices, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 		return "", err
 	}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1327,6 +1327,13 @@ func (r *RayClusterReconciler) getHeadPodIP(ctx context.Context, instance *rayv1
 func (r *RayClusterReconciler) getHeadServiceIP(ctx context.Context, instance *rayv1.RayCluster) (string, error) {
 	runtimeServices := corev1.ServiceList{}
 	filterLabels := client.MatchingLabels(common.HeadServiceLabels(*instance))
+
+	// If the head pod's application name label is not the default, such as when it's overridden by the
+	// Helm release's `nameOverride` value, update `filterLabels` to use the override's application name value instead.
+	if val, ok := instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels[utils.KubernetesApplicationNameLabelKey]; ok {
+		filterLabels[utils.KubernetesApplicationNameLabelKey] = val
+	}
+
 	if err := r.List(ctx, &runtimeServices, client.InNamespace(instance.Namespace), filterLabels); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes a reconciler error when changing the value of `nameOverride` in the values.yaml of a Helm installation for a Ray cluster.  For example, if you update it to `raycluster-custom-name` and install, you will get the following error in the Operator:

`{"level":"info","ts":"2024-03-06T04:34:09.108Z","logger":"controllers.RayCluster","msg":"Got error when calculating new status","RayCluster":{"name":"raycluster-custom-name","namespace":"default"},"reconcileID":"01e6413b-5175-40a1-ad3b-e822cee72e9a","cluster name":"raycluster-custom-name","error":"unable to find head service. cluster name raycluster-custom-name, filter labels map[app.kubernetes.io/created-by:kuberay-operator app.kubernetes.io/name:kuberay ray.io/cluster:raycluster-custom-name ray.io/identifier:raycluster-custom-name-head ray.io/node-type:head]"}`

`{"level":"error","ts":"2024-03-06T04:34:09.109Z","logger":"controllers.RayCluster","msg":"Reconciler error","RayCluster":{"name":"raycluster-custom-name","namespace":"default"},"reconcileID":"01e6413b-5175-40a1-ad3b-e822cee72e9a","error":"unable to find head service. cluster name raycluster-custom-name, filter labels map[app.kubernetes.io/created-by:kuberay-operator app.kubernetes.io/name:kuberay ray.io/cluster:raycluster-custom-name ray.io/identifier:raycluster-custom-name-head ray.io/node-type:head]","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227"}`

I saw the following PR https://github.com/ray-project/kuberay/pull/572 which helped me understand the problem.  It errors out due to the `filterLabels` including the default `app.kubernetes.io/name:kuberay` when this label has been updated by Helm.  And since the label doesn't match with what's in the head pod, it's not able to find the head service.

My test case is to install a Ray cluster via Helm overriding the `nameOverride` value to get the error above.

Once this fix is in, ran the helm install again and the Errors went away.

## Related issue number

Fixes https://github.com/ray-project/kuberay/issues/1703

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
