### PR TITLE
Use standard golang image as build image and distroless image as base image for kuberay operator.

### DIFF
--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20.10 as builder
+FROM golang:1.20.10-bullseye as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -18,7 +18,7 @@ COPY controllers/ controllers/
 USER root
 RUN CGO_ENABLED=1 GOOS=linux go build -tags strictfipsruntime -a -o manager main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
+FROM gcr.io/distroless/base-debian11:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Standard golang images are already publicly available. The images that we are using are just built on top of the existing one. I am not sure if they are really adding any value.

I moved the base image to a distroless image which should decrease the size of the container. Using distroless images is desirable from a security point of view as it does not have a shell and this reduces the attack surface. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
