### PR TITLE
Add NumOfHosts to RayCluster helm-chart template

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -121,6 +121,7 @@ spec:
     replicas: {{ $values.replicas }}
     minReplicas: {{ $values.minReplicas | default 0 }}
     maxReplicas: {{ $values.maxReplicas | default 2147483647 }}
+    numOfHosts: {{ $values.numOfHosts | default 1 }}
     groupName: {{ $groupName }}
     template:
       spec:
@@ -205,6 +206,7 @@ spec:
     replicas: {{ .Values.worker.replicas }}
     minReplicas: {{ .Values.worker.minReplicas | default 0 }}
     maxReplicas: {{ .Values.worker.maxReplicas | default 2147483647 }}
+    numOfHosts: {{ .Values.worker.numOfHosts | default 1 }}
     groupName: {{ .Values.worker.groupName }}
     template:
       spec:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/kuberay/pull/1834 added NumOfHosts field to RayCluster WorkerGroupSpec. This PR updates the helm chart to include this field for Kuberay v1.1.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
