### PR TITLE
[Refactor][RayCluster] Make ray.io/group=headgroup be constant

### DIFF
--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -8,6 +8,7 @@ import (
 	util "github.com/ray-project/kuberay/apiserver/pkg/util"
 	api "github.com/ray-project/kuberay/proto/go_client"
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -45,7 +46,7 @@ var headSpecTest = rayv1api.HeadGroupSpec{
 				"app.kubernetes.io/name":       "kuberay",
 				"ray.io/cluster":               "boris-cluster",
 				"ray.io/cluster-dashboard":     "boris-cluster-dashboard",
-				"ray.io/group":                 "headgroup",
+				"ray.io/group":                 utils.RayNodeHeadGroupLabelValue,
 				"ray.io/identifier":            "boris-cluster-head",
 				"ray.io/is-ray-node":           "yes",
 				"ray.io/node-type":             "head",

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -101,7 +101,7 @@ func DefaultHeadPodTemplate(ctx context.Context, instance rayv1.RayCluster, head
 	if podTemplate.Labels == nil {
 		podTemplate.Labels = make(map[string]string)
 	}
-	podTemplate.Labels = labelPod(rayv1.HeadNode, instance.Name, "headgroup", instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels)
+	podTemplate.Labels = labelPod(rayv1.HeadNode, instance.Name, utils.RayNodeHeadGroupLabelValue, instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels)
 	headSpec.RayStartParams = setMissingRayStartParams(ctx, headSpec.RayStartParams, rayv1.HeadNode, headPort, "", instance.Annotations)
 
 	initTemplateAnnotations(instance, &podTemplate)

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -337,7 +337,7 @@ func TestBuildPod(t *testing.T) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
 	actualResult = pod.Labels[utils.RayNodeGroupLabelKey]
-	expectedResult = "headgroup"
+	expectedResult = utils.RayNodeHeadGroupLabelValue
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
@@ -435,7 +435,7 @@ func TestBuildPod_WithAutoscalerEnabled(t *testing.T) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
 	actualResult = pod.Labels[utils.RayNodeGroupLabelKey]
-	expectedResult = "headgroup"
+	expectedResult = utils.RayNodeHeadGroupLabelValue
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -56,7 +56,7 @@ var (
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
 						Labels: map[string]string{
-							"groupName": "headgroup",
+							"groupName": utils.RayNodeHeadGroupLabelValue,
 						},
 					},
 					Spec: corev1.PodSpec{

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1028,7 +1028,7 @@ func (r *RayClusterReconciler) createHeadPod(ctx context.Context, instance rayv1
 	}
 	if EnableBatchScheduler {
 		if scheduler, err := r.BatchSchedulerMgr.GetSchedulerForCluster(&instance); err == nil {
-			scheduler.AddMetadataToPod(&instance, "headgroup", &pod)
+			scheduler.AddMetadataToPod(&instance, utils.RayNodeHeadGroupLabelValue, &pod)
 		} else {
 			return err
 		}

--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -2148,7 +2148,7 @@ func Test_RedisCleanup(t *testing.T) {
 	gcsFTEnabledCluster.DeletionTimestamp = &now
 
 	// TODO (kevin85421): Create a constant variable in constant.go for the head group name.
-	const headGroupName = "headgroup"
+	const headGroupName = utils.RayNodeHeadGroupLabelValue
 
 	headPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -92,7 +92,7 @@ var _ = Context("Inside the default namespace", func() {
 		headPods := corev1.PodList{}
 		workerPods := corev1.PodList{}
 		workerFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: rayCluster.Name, utils.RayNodeGroupLabelKey: rayCluster.Spec.WorkerGroupSpecs[0].GroupName}
-		headFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: rayCluster.Name, utils.RayNodeGroupLabelKey: "headgroup"}
+		headFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: rayCluster.Name, utils.RayNodeGroupLabelKey: utils.RayNodeHeadGroupLabelValue}
 
 		It("Verify RayCluster spec", func() {
 			// These test are designed based on the following assumptions:
@@ -323,7 +323,7 @@ var _ = Context("Inside the default namespace", func() {
 		headPods := corev1.PodList{}
 		workerPods := corev1.PodList{}
 		workerFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: rayCluster.Name, utils.RayNodeGroupLabelKey: rayCluster.Spec.WorkerGroupSpecs[0].GroupName}
-		headFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: rayCluster.Name, utils.RayNodeGroupLabelKey: "headgroup"}
+		headFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: rayCluster.Name, utils.RayNodeGroupLabelKey: utils.RayNodeHeadGroupLabelValue}
 
 		It("Verify RayCluster spec", func() {
 			// These test are designed based on the following assumptions:
@@ -571,7 +571,7 @@ var _ = Context("Inside the default namespace", func() {
 		headPods := corev1.PodList{}
 		workerPods := corev1.PodList{}
 		workerFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: rayCluster.Name, utils.RayNodeGroupLabelKey: rayCluster.Spec.WorkerGroupSpecs[0].GroupName}
-		headFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: rayCluster.Name, utils.RayNodeGroupLabelKey: "headgroup"}
+		headFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: rayCluster.Name, utils.RayNodeGroupLabelKey: utils.RayNodeHeadGroupLabelValue}
 
 		It("Create a RayCluster with PodTemplate referencing a different namespace.", func() {
 			rayCluster.Spec.HeadGroupSpec.Template.ObjectMeta.Namespace = "not-default"

--- a/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
@@ -180,7 +180,7 @@ var _ = Context("Inside the default namespace", func() {
 			err := k8sClient.List(ctx, &headPods,
 				client.MatchingLabels{
 					utils.RayClusterLabelKey:   mySuspendedRayCluster.Name,
-					utils.RayNodeGroupLabelKey: "headgroup",
+					utils.RayNodeGroupLabelKey: utils.RayNodeHeadGroupLabelValue,
 				},
 				&client.ListOptions{Namespace: "default"},
 				client.InNamespace(mySuspendedRayCluster.Namespace))
@@ -224,7 +224,7 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				isAllPodsRunning(ctx, headPods, client.MatchingLabels{
 					utils.RayClusterLabelKey:   mySuspendedRayCluster.Name,
-					utils.RayNodeGroupLabelKey: "headgroup",
+					utils.RayNodeGroupLabelKey: utils.RayNodeHeadGroupLabelValue,
 				}, "default"),
 				time.Second*15, time.Millisecond*500).Should(Equal(true), "Head Pod should be running.")
 

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -179,7 +179,7 @@ var _ = Context("RayJob in K8sJobMode", func() {
 
 			// The number of head Pods should be 1.
 			headPods := corev1.PodList{}
-			headFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: rayCluster.Name, utils.RayNodeGroupLabelKey: "headgroup"}
+			headFilterLabels := client.MatchingLabels{utils.RayClusterLabelKey: rayCluster.Name, utils.RayNodeGroupLabelKey: utils.RayNodeHeadGroupLabelValue}
 			Eventually(
 				listResourceFunc(ctx, &headPods, headFilterLabels, &client.ListOptions{Namespace: namespace}),
 				time.Second*3, time.Millisecond*500).Should(Equal(1), fmt.Sprintf("head Pod: %v", headPods.Items))

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -91,7 +91,7 @@ var _ = Context("Inside the default namespace", func() {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"groupName": "headgroup",
+								"groupName": utils.RayNodeHeadGroupLabelValue,
 							},
 							Annotations: map[string]string{
 								"key": "value",

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -165,6 +165,9 @@ const (
 
 	// Finalizers for RayJob
 	RayJobStopJobFinalizer = "ray.io/rayjob-finalizer"
+
+	// RayNodeHeadGroupLabelValue is the value for the RayNodeGroupLabelKey label on a head node
+	RayNodeHeadGroupLabelValue = "headgroup"
 )
 
 type ServiceType string


### PR DESCRIPTION
## Why are these changes needed?

The labels `ray.io/group=headgroup` are scattered around the kuberay source.

This PR makes the `headgroup` constant in the `utils/constant.go` which lowers the possibility of using a wrong value in the future.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
