### PR TITLE
chore: remove ConfigMap from ray-job.kueue-toy-sample.yaml

### DIFF
--- a/ray-operator/config/samples/ray-job.kueue-toy-sample.yaml
+++ b/ray-operator/config/samples/ray-job.kueue-toy-sample.yaml
@@ -7,7 +7,8 @@ spec:
   # The default value is "K8sJobMode", meaning RayJob will submit the Ray job via a submitter Kubernetes Job.
   # The alternative value is "HTTPMode", indicating that KubeRay will submit the Ray job by sending an HTTP request to the RayCluster.
   # submissionMode: "K8sJobMode"
-  entrypoint: python -c "import time; [print(i) or time.sleep(1) for i in range(600)]"
+  entrypoint: |
+    python -c "import time; import ray; ray.init(); [print(f\"iter: {i}, ray.cluster_resources(): {ray.cluster_resources()}\") or time.sleep(1) for i in range(600)]"
   # shutdownAfterJobFinishes specifies whether the RayCluster should be deleted after the RayJob finishes. Default is false.
   shutdownAfterJobFinishes: true
 

--- a/ray-operator/config/samples/ray-job.kueue-toy-sample.yaml
+++ b/ray-operator/config/samples/ray-job.kueue-toy-sample.yaml
@@ -7,7 +7,7 @@ spec:
   # The default value is "K8sJobMode", meaning RayJob will submit the Ray job via a submitter Kubernetes Job.
   # The alternative value is "HTTPMode", indicating that KubeRay will submit the Ray job by sending an HTTP request to the RayCluster.
   # submissionMode: "K8sJobMode"
-  entrypoint: python /home/ray/samples/sample_code.py
+  entrypoint: python -c "import time; [print(i) or time.sleep(1) for i in range(600)]"
   # shutdownAfterJobFinishes specifies whether the RayCluster should be deleted after the RayJob finishes. Default is false.
   shutdownAfterJobFinishes: true
 
@@ -47,16 +47,6 @@ spec:
                 requests:
                   cpu: "1"
                   memory: "2Gi"
-              volumeMounts:
-                - mountPath: /home/ray/samples
-                  name: code-sample
-          volumes:
-            - name: code-sample
-              configMap:
-                name: ray-job-code-sample
-                items:
-                  - key: sample_code.py
-                    path: sample_code.py
     workerGroupSpecs:
       - replicas: 1
         minReplicas: 1
@@ -68,10 +58,6 @@ spec:
             containers:
               - name: ray-worker
                 image: rayproject/ray:2.9.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: [ "/bin/sh","-c","ray stop" ]
                 resources:
                   limits:
                     cpu: "1"
@@ -79,14 +65,3 @@ spec:
                   requests:
                     cpu: "1"
                     memory: "2Gi"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: ray-job-code-sample
-data:
-  sample_code.py: |
-    import time
-    for i in range(600):
-      print(i)
-      time.sleep(1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/kuberay/pull/1956#discussion_r1511337275

This PR removes ConfigMap from the YAML. In [this doc](https://docs.ray.io/en/master/cluster/kubernetes/k8s-ecosystem/kueue.html#kuberay-kueue), we need to run `kubectl create -f ray-job.kueue-toy-sample.yaml` multiple times. If the YAML includes a ConfigMap, users may see a warning message indicating that the ConfigMap already exists. Removing the ConfigMap improves the UX.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
