### PR TITLE
Ray serve gke gateway ingress

### DIFF
--- a/ray-operator/config/samples/ray-service.gke-http-gateway-ingress.yaml
+++ b/ray-operator/config/samples/ray-service.gke-http-gateway-ingress.yaml
@@ -9,7 +9,18 @@
 # - https://cloud.google.com/kubernetes-engine/docs/how-to/gatewayclass-capabilities
 ## Enable Gateway API
 # https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#enable-gateway 
-
+#
+# To test this out: 
+# curl --location --request POST 'http://ai.example.com/v1/chat/completions' \
+# --header 'Content-Type: application/json' \
+#--data-raw '{
+#    "model": "tiiuae/falcon-7b-instruct",
+#    "messages": [
+#      {"role": "system", "content": "You are a helpful assistant."},
+#      {"role": "user", "content": "What are the top 5 most popular Indian dishes? Please be brief."}
+#    ]
+#}'
+#
 ---
 kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -31,7 +42,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: ray-service-serve-endpoint
 spec:
-  hostnames: 
+  hostnames:
   - "ai.example.com"
   parentRefs:
   - kind: Gateway
@@ -40,12 +51,34 @@ spec:
   - 
     matches:
     - path:
-        type: Exact
+        type: PathPrefix
         value: "/v1/chat/completions"
     - path:
-        type: Exact
+        type: PathPrefix
         value: "/v1/completions"
     backendRefs:
-    - name: rayllm-service-serve-svc
+    - name: ray-service-serve-svc
       port: 8000
 
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: endpoint-healthcheck
+spec:
+  default:
+    checkIntervalSec: 10
+    timeoutSec: 10
+    healthyThreshold: 3
+    unhealthyThreshold: 3
+    logConfig:
+      enabled: true
+    config:
+      type: HTTP
+      httpHealthCheck:
+        port: 8000
+        requestPath: "/-/routes"
+  targetRef:
+    group: ""
+    kind: Service
+    name: ray-service-serve-svc

--- a/ray-operator/config/samples/ray-service.gke-http-gateway-ingress.yaml
+++ b/ray-operator/config/samples/ray-service.gke-http-gateway-ingress.yaml
@@ -1,0 +1,51 @@
+# Kubernetes Gateway API - HTTPRoute Example
+# This example usage Kubernetes Gateway API to create a HTTPRoute to RayService Serve Endpoint.
+## Gateway API for Ingress 
+# https://gateway-api.sigs.k8s.io/#gateway-api-for-ingress
+#
+## GKE GatewayAPI and GatewayClass 
+# For more information on GatewayClasses on Google Kubernetes Engine, see:
+# - https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api
+# - https://cloud.google.com/kubernetes-engine/docs/how-to/gatewayclass-capabilities
+## Enable Gateway API
+# https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#enable-gateway 
+
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: ray-service-external-http
+spec:
+  gatewayClassName: gke-l7-global-external-managed
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+       namespaces:
+         from: Same
+
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: ray-service-serve-endpoint
+spec:
+  hostnames: 
+  - "ai.example.com"
+  parentRefs:
+  - kind: Gateway
+    name: ray-service-external-http
+  rules:
+  - 
+    matches:
+    - path:
+        type: Exact
+        value: "/v1/chat/completions"
+    - path:
+        type: Exact
+        value: "/v1/completions"
+    backendRefs:
+    - name: rayllm-service-serve-svc
+      port: 8000
+

--- a/ray-operator/config/samples/ray-service.gke-model-configmap.yaml
+++ b/ray-operator/config/samples/ray-service.gke-model-configmap.yaml
@@ -1,0 +1,127 @@
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: ray-service
+spec:
+  # More details here on some of the fields: https://docs.ray.io/en/latest/serve/production-guide/kubernetes.html#setting-up-a-rayservice-custom-resource-cr
+  serviceUnhealthySecondThreshold: 720 
+  deploymentUnhealthySecondThreshold: 720 
+  serveConfigV2: |
+    applications:
+    - name: rayllm-serve
+      route_prefix: /
+      import_path: rayllm.backend:router_application
+      args:
+        models:
+        - "./models/tiiuae/falcon-7b-instruct.yaml"
+  rayClusterConfig:
+    headGroupSpec:
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.5.0
+            resources:
+              limits:
+                cpu: "2"
+                memory: "8Gi"
+              requests:
+                cpu: "2"
+                memory: "8Gi"
+            volumeMounts:
+            - mountPath: /home/ray/models
+              name: model                
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+          volumes:
+          - name: model
+            configMap:
+              name: falcon-7b-instruct-config
+              items:
+              - key: falcon-7b-instruct.yaml
+                path: tiiuae/falcon-7b-instruct.yaml              
+    workerGroupSpecs:
+    # Worker with Scale to 0 configuration
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      groupName: gpu-worker-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 20, \"accelerator_type_t4\": 1}"'
+      # pod template
+      template:
+        spec:
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.5.0
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "20"
+                memory: "24Gi"
+                nvidia.com/gpu: "1"
+              requests:
+                cpu: "20"
+                memory: "24Gi"
+                nvidia.com/gpu: "1"
+          # Please ensure the taint has been applied to the GPU nodes, if using more taints than one listed below
+          tolerations:
+            - key: "nvidia.com/gpu"
+              operator: "Equal"
+              value: "present"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-t4
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: falcon-7b-instruct-config
+data:
+  falcon-7b-instruct.yaml: |
+    deployment_config:
+      max_concurrent_queries: 24
+      ray_actor_options:
+        resources:
+          accelerator_type_t4: 0.1
+    engine_config:
+      model_id: tiiuae/falcon-7b-instruct
+      hf_model_id: tiiuae/falcon-7b-instruct
+      type: VLLMEngine
+      engine_kwargs:
+        trust_remote_code: false
+        max_num_batched_tokens: 2048
+        max_num_seqs: 64
+        gpu_memory_utilization: 0.9
+      max_total_tokens: 2048
+      generation:
+        prompt_format:
+          system: "{instruction}\n\n"
+          assistant: " {instruction} </s><s>"
+          trailing_assistant: ""
+          user: "[INST] {system}{instruction}"
+          system_in_user: true
+          default_system_message: ""
+        stopping_sequences: ["<unk>"]
+    scaling_config:
+      num_workers: 1
+      num_gpus_per_worker: 1
+      num_cpus_per_worker: 4
+      placement_strategy: "PACK"
+      resources_per_worker:
+        accelerator_type_t4: 0.1

--- a/ray-operator/config/samples/ray-service.gke-model-configmap.yaml
+++ b/ray-operator/config/samples/ray-service.gke-model-configmap.yaml
@@ -16,6 +16,7 @@ spec:
         - "./models/tiiuae/falcon-7b-instruct.yaml"
   rayClusterConfig:
     headGroupSpec:
+      serviceType: NodePort
       rayStartParams:
         resources: '"{\"accelerator_type_cpu\": 2}"'
         dashboard-host: '0.0.0.0'
@@ -54,12 +55,12 @@ spec:
     workerGroupSpecs:
     # Worker with Scale to 0 configuration
     - replicas: 1
-      minReplicas: 0
-      maxReplicas: 1
+      minReplicas: 1
+      maxReplicas: 4
       groupName: gpu-worker-group
       rayStartParams:
         block: 'true'
-        resources: '"{\"accelerator_type_cpu\": 20, \"accelerator_type_t4\": 1}"'
+        resources: '"{\"accelerator_type_cpu\": 20, \"accelerator_type_l4\": 1}"'
       # pod template
       template:
         spec:
@@ -73,20 +74,36 @@ spec:
             resources:
               limits:
                 cpu: "20"
-                memory: "24Gi"
-                nvidia.com/gpu: "1"
+                memory: "64Gi"
+                nvidia.com/gpu: "2"
               requests:
                 cpu: "20"
-                memory: "24Gi"
-                nvidia.com/gpu: "1"
-          # Please ensure the taint has been applied to the GPU nodes, if using more taints than one listed below
+                memory: "64Gi"
+                nvidia.com/gpu: "2"
+          # Here we are loading the model from the configmap with the name falcon-7b-instruct-config
+            volumeMounts:
+              - mountPath: /home/ray/models
+                name: model
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
           tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
             - key: "nvidia.com/gpu"
               operator: "Equal"
               value: "present"
               effect: "NoSchedule"
           nodeSelector:
-            cloud.google.com/gke-accelerator: nvidia-t4
+            cloud.google.com/gke-accelerator: nvidia-l4
+            # cloud.google.com/gke-accelerator: nvidia-tesla-t4  # to use: nvidia-tesla-t4 GPUs
+          volumes:
+          - name: model
+            configMap:
+              name: falcon-7b-instruct-config
+              items:
+              - key: falcon-7b-instruct.yaml
+                path: tiiuae/falcon-7b-instruct.yaml     
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -95,10 +112,20 @@ metadata:
 data:
   falcon-7b-instruct.yaml: |
     deployment_config:
+      autoscaling_config:
+        min_replicas: 1
+        initial_replicas: 1
+        max_replicas: 4
+        target_num_ongoing_requests_per_replica: 24
+        metrics_interval_s: 10.0
+        look_back_period_s: 60.0
+        smoothing_factor: 0.5
+        downscale_delay_s: 600.0
+        upscale_delay_s: 30.0
       max_concurrent_queries: 24
       ray_actor_options:
         resources:
-          accelerator_type_t4: 0.1
+          accelerator_type_l4: 0.1 # use: accelerator_type_t4 for T4 GPUs
     engine_config:
       model_id: tiiuae/falcon-7b-instruct
       hf_model_id: tiiuae/falcon-7b-instruct
@@ -121,7 +148,7 @@ data:
     scaling_config:
       num_workers: 1
       num_gpus_per_worker: 1
-      num_cpus_per_worker: 4
+      num_cpus_per_worker: 3
       placement_strategy: "PACK"
       resources_per_worker:
-        accelerator_type_t4: 0.1
+        accelerator_type_l4: 0.1 # use: accelerator_type_t4 for T4 GPUs


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR contains an example of using Kubernetes Gateway API to expose RayServe Service on GKE with Gateway and HTTP Route Deployment.
Gateway API is the successor of Ingress and the newest way of Exposing services running in the same or multiple namespaces. Gateway API offers multiple benefits and is both powerful and flexible at the same time.
This Kubernetes page provides a list of reasons why one should switch to [GatewayAPI](https://gateway-api.sigs.k8s.io/guides/migrating-from-ingress/#reasons-to-switch-to-gateway-api)

## Related issue number
As far as I know, there is currently no logged issue for this.

## Checks

- [x] I've made sure the tests are passing - Yes, I have verified everything I am pushing.
- Testing Strategy
   - [ ] Unit tests: Not needed, example
   - [x] Manual tests: Yes, deployed and tested on GKE
   - [ ] This PR is not tested :
