### PR TITLE
support using proxy subresources when connecting to Ray head node

### DIFF
--- a/apiserver/pkg/server/ray_job_submission_service_server.go
+++ b/apiserver/pkg/server/ray_job_submission_service_server.go
@@ -38,7 +38,7 @@ type RayJobSubmissionServiceServer struct {
 // Create RayJobSubmissionServiceServer
 func NewRayJobSubmissionServiceServer(clusterServer *ClusterServer, options *RayJobSubmissionServiceServerOptions) *RayJobSubmissionServiceServer {
 	zl := zerolog.New(os.Stdout).Level(zerolog.DebugLevel)
-	return &RayJobSubmissionServiceServer{clusterServer: clusterServer, options: options, log: zerologr.New(&zl).WithName("jobsubmissionservice"), dashboardClientFunc: utils.GetRayDashboardClient}
+	return &RayJobSubmissionServiceServer{clusterServer: clusterServer, options: options, log: zerologr.New(&zl).WithName("jobsubmissionservice"), dashboardClientFunc: utils.GetRayDashboardClientFunc(nil)}
 }
 
 // Submit Ray job

--- a/apiserver/pkg/server/ray_job_submission_service_server.go
+++ b/apiserver/pkg/server/ray_job_submission_service_server.go
@@ -38,7 +38,7 @@ type RayJobSubmissionServiceServer struct {
 // Create RayJobSubmissionServiceServer
 func NewRayJobSubmissionServiceServer(clusterServer *ClusterServer, options *RayJobSubmissionServiceServerOptions) *RayJobSubmissionServiceServer {
 	zl := zerolog.New(os.Stdout).Level(zerolog.DebugLevel)
-	return &RayJobSubmissionServiceServer{clusterServer: clusterServer, options: options, log: zerologr.New(&zl).WithName("jobsubmissionservice"), dashboardClientFunc: utils.GetRayDashboardClientFunc(nil)}
+	return &RayJobSubmissionServiceServer{clusterServer: clusterServer, options: options, log: zerologr.New(&zl).WithName("jobsubmissionservice"), dashboardClientFunc: utils.GetRayDashboardClientFunc(nil, false)}
 }
 
 // Submit Ray job
@@ -50,7 +50,10 @@ func (s *RayJobSubmissionServiceServer) SubmitRayJob(ctx context.Context, req *a
 		return nil, err
 	}
 	rayDashboardClient := s.dashboardClientFunc()
-	rayDashboardClient.InitClient(*url)
+	// TODO: support proxy subresources in kuberay-apiserver
+	if err := rayDashboardClient.InitClient(*url, nil); err != nil {
+		return nil, err
+	}
 	request := &utils.RayJobRequest{Entrypoint: req.Jobsubmission.Entrypoint}
 	if req.Jobsubmission.SubmissionId != "" {
 		request.SubmissionId = req.Jobsubmission.SubmissionId
@@ -102,7 +105,10 @@ func (s *RayJobSubmissionServiceServer) GetJobDetails(ctx context.Context, req *
 		return nil, err
 	}
 	rayDashboardClient := s.dashboardClientFunc()
-	rayDashboardClient.InitClient(*url)
+	// TODO: support proxy subresources in kuberay-apiserver
+	if err := rayDashboardClient.InitClient(*url, nil); err != nil {
+		return nil, err
+	}
 	nodeInfo, err := rayDashboardClient.GetJobInfo(ctx, req.Submissionid)
 	if err != nil {
 		return nil, err
@@ -122,7 +128,10 @@ func (s *RayJobSubmissionServiceServer) GetJobLog(ctx context.Context, req *api.
 		return nil, err
 	}
 	rayDashboardClient := s.dashboardClientFunc()
-	rayDashboardClient.InitClient(*url)
+	// TODO: support proxy subresources in kuberay-apiserver
+	if err := rayDashboardClient.InitClient(*url, nil); err != nil {
+		return nil, err
+	}
 	jlog, err := rayDashboardClient.GetJobLog(ctx, req.Submissionid)
 	if err != nil {
 		return nil, err
@@ -142,7 +151,10 @@ func (s *RayJobSubmissionServiceServer) ListJobDetails(ctx context.Context, req 
 		return nil, err
 	}
 	rayDashboardClient := s.dashboardClientFunc()
-	rayDashboardClient.InitClient(*url)
+	// TODO: support proxy subresources in kuberay-apiserver
+	if err := rayDashboardClient.InitClient(*url, nil); err != nil {
+		return nil, err
+	}
 	nodesInfo, err := rayDashboardClient.ListJobs(ctx)
 	if err != nil {
 		return nil, err
@@ -163,7 +175,10 @@ func (s *RayJobSubmissionServiceServer) StopRayJob(ctx context.Context, req *api
 		return nil, err
 	}
 	rayDashboardClient := s.dashboardClientFunc()
-	rayDashboardClient.InitClient(*url)
+	// TODO: support proxy subresources in kuberay-apiserver
+	if err := rayDashboardClient.InitClient(*url, nil); err != nil {
+		return nil, err
+	}
 	err = rayDashboardClient.StopJob(ctx, req.Submissionid)
 	if err != nil {
 		return nil, err
@@ -180,7 +195,10 @@ func (s *RayJobSubmissionServiceServer) DeleteRayJob(ctx context.Context, req *a
 		return nil, err
 	}
 	rayDashboardClient := s.dashboardClientFunc()
-	rayDashboardClient.InitClient(*url)
+	// TODO: support proxy subresources in kuberay-apiserver
+	if err := rayDashboardClient.InitClient(*url, nil); err != nil {
+		return nil, err
+	}
 	err = rayDashboardClient.DeleteJob(ctx, req.Submissionid)
 	if err != nil {
 		return nil, err

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
@@ -67,6 +67,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/proxy
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
   - pods/status
   verbs:
   - create
@@ -98,6 +106,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/proxy
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/helm-chart/kuberay-operator/templates/role.yaml
+++ b/helm-chart/kuberay-operator/templates/role.yaml
@@ -64,6 +64,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/proxy
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
   - pods/status
   verbs:
   - create
@@ -95,6 +103,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/proxy
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/ray-operator/apis/config/v1alpha1/configuration_types.go
+++ b/ray-operator/apis/config/v1alpha1/configuration_types.go
@@ -50,6 +50,12 @@ type Configuration struct {
 	// by Volcano to support gang scheduling.
 	EnableBatchScheduler bool `json:"enableBatchScheduler,omitempty"`
 
+	// UseKubernetesProxy indicates that the services/proxy and pods/proxy subresource should be used
+	// when connecting to the Ray Head node. This is useful when network policies disallow
+	// ingress traffic to the Ray cluster from other pods or Kuberay is running in a network without
+	// connectivity to Pods.
+	UseKubernetesProxy bool `json:"useKubernetesProxy,omitempty"`
+
 	// HeadSidecarContainers includes specification for a sidecar container
 	// to inject into every Head pod.
 	HeadSidecarContainers []corev1.Container `json:"headSidecarContainers,omitempty"`

--- a/ray-operator/config/rbac/role.yaml
+++ b/ray-operator/config/rbac/role.yaml
@@ -61,6 +61,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/proxy
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
   - pods/status
   verbs:
   - create
@@ -92,6 +100,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/proxy
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -111,12 +111,12 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 		return fakeRayDashboardClient
 	}, func() utils.RayHttpProxyClientInterface {
 		return fakeRayHttpProxyClient
-	}, false).SetupWithManager(mgr)
+	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayService controller")
 
 	err = NewRayJobReconciler(ctx, mgr, func() utils.RayDashboardClientInterface {
 		return fakeRayDashboardClient
-	}, false).SetupWithManager(mgr)
+	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayJob controller")
 
 	go func() {

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -111,12 +111,12 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 		return fakeRayDashboardClient
 	}, func() utils.RayHttpProxyClientInterface {
 		return fakeRayHttpProxyClient
-	}).SetupWithManager(mgr)
+	}, false).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayService controller")
 
 	err = NewRayJobReconciler(ctx, mgr, func() utils.RayDashboardClientInterface {
 		return fakeRayDashboardClient
-	}).SetupWithManager(mgr)
+	}, false).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayJob controller")
 
 	go func() {

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
@@ -3,12 +3,15 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/jarcoal/httpmock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
@@ -34,6 +37,8 @@ var _ = Describe("RayFrameworkGenerator", func() {
 		expectJobId        string
 		errorJobId         string
 		rayDashboardClient *RayDashboardClient
+		testEnv            *envtest.Environment
+		mgr                ctrl.Manager
 	)
 
 	BeforeEach(func() {
@@ -51,7 +56,17 @@ var _ = Describe("RayFrameworkGenerator", func() {
 				RuntimeEnvYAML: runtimeEnvStr,
 			},
 		}
-		rayDashboardClient = &RayDashboardClient{}
+
+		testEnv = &envtest.Environment{}
+
+		cfg, err := testEnv.Start()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg).ToNot(BeNil())
+
+		mgr, err = ctrl.NewManager(cfg, ctrl.Options{})
+		Expect(err).NotTo(HaveOccurred(), "failed to create manager")
+
+		rayDashboardClient = &RayDashboardClient{mgr: mgr}
 		rayDashboardClient.InitClient("127.0.0.1:8090")
 	})
 
@@ -168,5 +183,12 @@ var _ = Describe("RayFrameworkGenerator", func() {
 
 		err := rayDashboardClient.StopJob(context.TODO(), "stop-job-1")
 		Expect(err).To(BeNil())
+	})
+
+	It("Test WithKubernetesServiceProxy", func() {
+		rayDashboardClient.WithKubernetesServiceProxy("test-namespace", "test-svc")
+
+		Expect(rayDashboardClient.dashboardURL).To(Equal(fmt.Sprintf("%s/api/v1/namespaces/%s/services/%s:dashboard/proxy", mgr.GetConfig().Host, "test-namespace", "test-svc")))
+		Expect(rayDashboardClient.client).To(Equal(mgr.GetHTTPClient()))
 	})
 })

--- a/ray-operator/controllers/ray/utils/fake_httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/fake_httpproxy_httpclient.go
@@ -18,10 +18,7 @@ func (r *FakeRayHttpProxyClient) InitClient() {
 	}
 }
 
-func (r *FakeRayHttpProxyClient) WithKubernetesPodProxy(podNamespace, podName string, port int) {
-}
-
-func (r *FakeRayHttpProxyClient) SetHostIp(hostIp string, port int) {
+func (r *FakeRayHttpProxyClient) SetHostIp(hostIp, podNamespace, podName string, port int) {
 	r.httpProxyURL = fmt.Sprintf("http://%s:%d", hostIp, port)
 }
 

--- a/ray-operator/controllers/ray/utils/fake_httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/fake_httpproxy_httpclient.go
@@ -18,6 +18,9 @@ func (r *FakeRayHttpProxyClient) InitClient() {
 	}
 }
 
+func (r *FakeRayHttpProxyClient) WithKubernetesPodProxy(podNamespace, podName string, port int) {
+}
+
 func (r *FakeRayHttpProxyClient) SetHostIp(hostIp string, port int) {
 	r.httpProxyURL = fmt.Sprintf("http://%s:%d", hostIp, port)
 }

--- a/ray-operator/controllers/ray/utils/fake_serve_httpclient.go
+++ b/ray-operator/controllers/ray/utils/fake_serve_httpclient.go
@@ -20,8 +20,11 @@ type FakeRayDashboardClient struct {
 var _ RayDashboardClientInterface = (*FakeRayDashboardClient)(nil)
 
 func (r *FakeRayDashboardClient) InitClient(url string) {
-	r.client = http.Client{}
+	r.client = &http.Client{}
 	r.dashboardURL = "http://" + url
+}
+
+func (r *FakeRayDashboardClient) WithKubernetesServiceProxy(svcNamespace, svcName string) {
 }
 
 func (r *FakeRayDashboardClient) UpdateDeployments(_ context.Context, configJson []byte) error {

--- a/ray-operator/controllers/ray/utils/fake_serve_httpclient.go
+++ b/ray-operator/controllers/ray/utils/fake_serve_httpclient.go
@@ -19,12 +19,10 @@ type FakeRayDashboardClient struct {
 
 var _ RayDashboardClientInterface = (*FakeRayDashboardClient)(nil)
 
-func (r *FakeRayDashboardClient) InitClient(url string) {
+func (r *FakeRayDashboardClient) InitClient(url string, rayCluster *rayv1.RayCluster) error {
 	r.client = &http.Client{}
 	r.dashboardURL = "http://" + url
-}
-
-func (r *FakeRayDashboardClient) WithKubernetesServiceProxy(svcNamespace, svcName string) {
+	return nil
 }
 
 func (r *FakeRayDashboardClient) UpdateDeployments(_ context.Context, configJson []byte) error {

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -213,9 +213,9 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 	exitOnError(ray.NewReconciler(ctx, mgr, rayClusterOptions).SetupWithManager(mgr, config.ReconcileConcurrency),
 		"unable to create controller", "controller", "RayCluster")
-	exitOnError(ray.NewRayServiceReconciler(ctx, mgr, utils.GetRayDashboardClientFunc(mgr), utils.GetRayHttpProxyClientFunc(mgr), config.UseKubernetesProxy).SetupWithManager(mgr),
+	exitOnError(ray.NewRayServiceReconciler(ctx, mgr, utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy), utils.GetRayHttpProxyClientFunc(mgr, config.UseKubernetesProxy)).SetupWithManager(mgr),
 		"unable to create controller", "controller", "RayService")
-	exitOnError(ray.NewRayJobReconciler(ctx, mgr, utils.GetRayDashboardClientFunc(mgr), config.UseKubernetesProxy).SetupWithManager(mgr),
+	exitOnError(ray.NewRayJobReconciler(ctx, mgr, utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)).SetupWithManager(mgr),
 		"unable to create controller", "controller", "RayJob")
 
 	if os.Getenv("ENABLE_WEBHOOKS") == "true" {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are some cases where Kuberay may not be able to directly connect to a Ray head node. For example, there might be a NetworkPolicy disallowing ingress from all Pods or KubeRay is running on a network with no connectivity to Pods. This PR allows Kuberay to use the `services/proxy` subresource to proxy HTTP requests to the Ray head node. This allows Kuberay to make requests to the head node without every connecting to it directly.

Here are some sample HTTP requests in apiserver from my testing using the proxy subresource:
```
I0310 14:30:19.596708       1 httplog.go:131] "HTTP" verb="GET" URI="/api/v1/namespaces/default/services/rayjob-sample-raycluster-phsj9-head-svc:dashboard/proxy/api/jobs/rayjob-sample-th44t" latency="7.239221ms" userAgent="manager/v0.0.0 (linux/amd64) kubernetes/$Format" audit-ID="c40152de-7a81-46b9-ac4a-f2ea296e44f0" srcIP="10.244.0.6:49524" resp=200

I0310 15:20:43.105571       1 httplog.go:131] "HTTP" verb="GET" URI="/api/v1/namespaces/default/pods/rayservice-sample-raycluster-qm2m2-head-xj44d:8000/proxy/-/healthz" latency="2.915789ms" userAgent="manager/v0.0.0 (linux/amd64) kubernetes/$Format" audit-ID="bad00c23-de01-45ed-9fb5-05bc8b2f6c2d" srcIP="10.244.0.6:47274" resp=200


I0310 15:21:07.446881       1 httplog.go:131] "HTTP" verb="GET" URI="/api/v1/namespaces/default/services/rayservice-sample-raycluster-qm2m2-head-svc:dashboard/proxy/api/serve/applications/" latency="15.347398ms" userAgent="manager/v0.0.0 (linux/amd64) kubernetes/$Format" audit-ID="54544346-b827-4f34-b593-bcbc78199611" srcIP="10.244.0.6:47274" resp=200
```

## Checks

- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
