### PR TITLE
[RayService] fix kubebuilder printcolumn annotations for RayService

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -16,7 +16,14 @@ spec:
     singular: rayservice
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.serviceStatus
+      name: service status
+      type: string
+    - jsonPath: .status.numServeEndpoints
+      name: num serve endpoints
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         properties:

--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -64,7 +64,6 @@ type RayServiceSpec struct {
 }
 
 // RayServiceStatuses defines the observed state of RayService
-// +kubebuilder:printcolumn:name="ServiceStatus",type=string,JSONPath=".status.serviceStatus"
 type RayServiceStatuses struct {
 	ActiveServiceStatus RayServiceStatus `json:"activeServiceStatus,omitempty"`
 	// Pending Service Status indicates a RayCluster will be created or is being created.
@@ -112,6 +111,8 @@ type ServeDeploymentStatus struct {
 // +kubebuilder:resource:categories=all
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="service status",type=string,JSONPath=".status.serviceStatus"
+// +kubebuilder:printcolumn:name="num serve endpoints",type=string,JSONPath=".status.numServeEndpoints"
 // +genclient
 // RayService is the Schema for the rayservices API
 type RayService struct {

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -16,7 +16,14 @@ spec:
     singular: rayservice
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.serviceStatus
+      name: service status
+      type: string
+    - jsonPath: .status.numServeEndpoints
+      name: num serve endpoints
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         properties:


### PR DESCRIPTION
## Why are these changes needed?

The current print coloumns for RayService are not being rendered, this is because they were added to the wrong type. 

This PR fixes the kubebuilder annotation and adds another coloumn for "NUM SERVE ENDPOINTS"

```
$ kubectl get rayservice
NAME                SERVICE STATUS   NUM SERVE ENDPOINTS
rayservice-sample   Running          2
```
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
