### PR TITLE
Use a default user agent 'kuberay-operator' instead of the default user-agent from controller-runtime

### DIFF
--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -43,7 +43,7 @@ var (
 	scheme      = runtime.NewScheme()
 	setupLog    = ctrl.Log.WithName("setup")
 	// TODO: include the kuberay version in the user-agent. E.g. ray-operator/v1.1.0
-	userAgent = "ray-operator"
+	userAgent = "kuberay-operator"
 )
 
 func init() {

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -42,6 +42,8 @@ var (
 	_commitId_  = ""
 	scheme      = runtime.NewScheme()
 	setupLog    = ctrl.Log.WithName("setup")
+	// TODO: include the kuberay version in the user-agent. E.g. ray-operator/v1.1.0
+	userAgent = "ray-operator"
 )
 
 func init() {
@@ -208,7 +210,9 @@ func main() {
 	}
 
 	setupLog.Info("Setup manager")
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.UserAgent = userAgent
+	mgr, err := ctrl.NewManager(restConfig, options)
 	exitOnError(err, "unable to start manager")
 
 	rayClusterOptions := ray.RayClusterReconcilerOptions{


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We are currently using the default controller-runtime user-agent which is `manager/v0.0.0`. This PR updates Kuberay's user-agent to `kuberay-operator`. 

Note that it does not include the version of kuberay yet, but we should add that in a follow-up PR. Here's example HTTP log from apiserver that shows the new user-agent being used:
```
I0311 02:35:26.041556       1 httplog.go:131] "HTTP" verb="PUT" URI="/apis/ray.io/v1/namespaces/default/rayservices/rayservice-sample/status" latency="10.397049ms" userAgent="kuberay-operator" audit-ID="8b543d30-4d26-4e0f-96ff-7b2596d0ecb8" srcIP="10.244.0.3:54042" apf_pl="workload-low" apf_fs="service-accounts" apf_iseats=1 apf_fseats=0 apf_execution_time="8.0205ms" resp=200
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
