### PR TITLE
Add missing labels on RayCluster TPU manifests

### DIFF
--- a/ray-operator/config/samples/ray-cluster.tpu-v4-multihost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v4-multihost.yaml
@@ -4,6 +4,7 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
+  # Label required for TPU webhook to initialize environments.
   labels:
     app.kubernetes.io/name: kuberay
   name: example-cluster-kuberay

--- a/ray-operator/config/samples/ray-cluster.tpu-v4-multihost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v4-multihost.yaml
@@ -4,6 +4,8 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
+  labels:
+    app.kubernetes.io/name: kuberay
   name: example-cluster-kuberay
 spec:
   headGroupSpec:

--- a/ray-operator/config/samples/ray-cluster.tpu-v4-singlehost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v4-singlehost.yaml
@@ -4,6 +4,7 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
+  # Label required for TPU webhook to initialize environments.
   labels:
     app.kubernetes.io/name: kuberay
   name: example-cluster-kuberay

--- a/ray-operator/config/samples/ray-cluster.tpu-v4-singlehost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v4-singlehost.yaml
@@ -4,6 +4,8 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
+  labels:
+    app.kubernetes.io/name: kuberay
   name: example-cluster-kuberay
 spec:
   headGroupSpec:


### PR DESCRIPTION
Adding the `app.kubernetes.io/name: kuberay` label on RayClusters which is required by the TPU webhook to inject env variables.