### PR TITLE
[CI] Pin crd-ref-docs to v0.0.10

### DIFF
--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -167,7 +167,7 @@ CRD_REF_DOCS = $(LOCALBIN)/crd-ref-docs
 $(CRD_REF_DOCS): $(LOCALBIN)
 .PHONY: crd-ref-docs
 crd-ref-docs: $(CRD_REF_DOCS) ## Download crd-ref-docs locally if necessary.
-	test -s $(CRD_REF_DOCS) || GOBIN=$(LOCALBIN) go install github.com/elastic/crd-ref-docs@latest
+	test -s $(CRD_REF_DOCS) || GOBIN=$(LOCALBIN) go install github.com/elastic/crd-ref-docs@v0.0.10
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

[elastic/crd-ref-docs](https://github.com/elastic/crd-ref-docs) released v0.0.11 yesterday, which caused the KubeRay CI to fail ([example](https://github.com/ray-project/kuberay/actions/runs/8259776939/job/22594249665)). This PR pins the version of crd-ref-docs to v0.0.10.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

* The test `operator-consistency-check / ray-operator-verify-api-docs (pull_request) ` passes.

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
