### PR TITLE
[Bug][GCS FT] Clean up the Redis key before the head Pod is deleted

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_fake_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_fake_test.go
@@ -2624,15 +2624,13 @@ func TestDeleteAllPods(t *testing.T) {
 	}
 	ctx := context.Background()
 	// The first `deleteAllPods` function call should delete the "alive" Pod.
-	active, pods, err := testRayClusterReconciler.deleteAllPods(ctx, ns, filter)
+	pods, err := testRayClusterReconciler.deleteAllPods(ctx, ns, filter)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, active)
 	assert.Equal(t, 2, len(pods.Items))
 	assert.Subset(t, []string{"alive", "deleted"}, []string{pods.Items[0].Name, pods.Items[1].Name})
 	// The second `deleteAllPods` function call should delete no Pods because none are active.
-	active, pods, err = testRayClusterReconciler.deleteAllPods(ctx, ns, filter)
+	pods, err = testRayClusterReconciler.deleteAllPods(ctx, ns, filter)
 	assert.Nil(t, err)
-	assert.Equal(t, 0, active)
 	assert.Equal(t, 1, len(pods.Items))
 	assert.Equal(t, "deleted", pods.Items[0].Name)
 	// Make sure that the above `deleteAllPods` calls didn't remove other Pods.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#1785 checks `numDeletedHeads` to determine whether to create the Redis cleanup Kubernetes Job or not. However, `numDeletedHeads` does not always indicate the number of head Pods that have been deleted but rather those that are in the process of being deleted. Hence, since GCS is still running, the Redis key will not be fully deleted.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

* Create a RayCluster with [ray-cluster.external-redis-uri.yaml](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.external-redis-uri.yaml).
* Delete the RayCluster: `kubectl delete rayclusters.ray.io raycluster-external-redis-uri`
* Check the Redis after all Ray Pods are deleted.
  ```sh
  kubectl exec -it $YOUR_REDIS_POD -- redis-cli -a "5241590000000000"
  KEYS * # expected behavior: no key (without this PR), 1 key (with this PR)
  ```

