### PR TITLE
[Fix][Helm chart] Move service.headService -> head.headService in values.yaml

### DIFF
--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -106,6 +106,12 @@ head:
   # container command for head Pod.
   command: []
   args: []
+  # Optional, for the user to provide any additional fields to the service.
+  # See https://pkg.go.dev/k8s.io/Kubernetes/pkg/api/v1#Service
+  headService: {}
+    # metadata:
+    #   annotations:
+    #     prometheus.io/scrape: "true"
 
 
 worker:
@@ -230,6 +236,3 @@ additionalWorkerGroups:
 service:
   # This is optional, and the default is ClusterIP.
   type: ClusterIP
-  # Optional, for the user to provide any additional fields to the service.
-  # See https://pkg.go.dev/k8s.io/Kubernetes/pkg/api/v1#Service
-  headService: {}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

After spending a while not understanding why my monitoring annotations wouldn't be set on the head service of my clusters I noticed the chart uses `.Values.head.headService` instead of `.Values.service.headService` like specified in the default `values.yaml`

This PR would do the trick but I think using `.Values.head.serviceType` instead of `.Values.service.type` in the templates would be an even better solution for consistency :)

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Helm template
