### PR TITLE
[RayService] Reduce Flakiness by Avoiding Overwhelm of the Proxy Actor in RayService Tests.

### DIFF
--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -142,6 +142,7 @@ class RayServiceUpdateCREvent(CREvent):
                     logger.info(f'Ray service has fully moved to cluster "{new_cluster_name}"')
                     return
                 self.query_rule.assert_rule(self.custom_resource_object, self.namespace)
+                time.sleep(0.1)
             
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/3506#018e3637-d117-4fdc-a098-d13cdd2850d1/243-2217

The example above shows that the request sent to RayService failed during the rolling upgrade test. Upon further examination of the logs and code, I found the failure occurs at the stage where the serve service is fully updated, and the request is being sent to the new RayCluster.

KubeRay only switches to the new RayCluster once new RayCluster is ready, and the application running on it is also ready. Considering we allocate only a little cpu and memory to the Ray Pod during the test, it is possible that we are overwhelming the proxy actor.

This PR adds a delay to avoid overwhelming the proxy actor.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
