### PR TITLE
Fix Log to indicate we are Using DashboardPort in RayService

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -836,7 +836,7 @@ func (r *RayServiceReconciler) updateServeDeployment(ctx context.Context, raySer
 // Serve applications are ready to serve incoming traffic or not. It returns two values:
 //
 // (1) `isReady` is used to determine whether the Serve applications in the RayCluster are ready to serve incoming traffic or not.
-// (2) `err`: If `err` is not nil, it means that KubeRay failed to get Serve application statuses from the dashboard agent. We should take a look at dashboard agent rather than Ray Serve applications.
+// (2) `err`: If `err` is not nil, it means that KubeRay failed to get Serve application statuses from the dashboard. We should take a look at dashboard rather than Ray Serve applications.
 
 func (r *RayServiceReconciler) getAndCheckServeStatus(ctx context.Context, dashboardClient utils.RayDashboardClientInterface, rayServiceServeStatus *rayv1.RayServiceStatus) (bool, error) {
 	logger := ctrl.LoggerFrom(ctx)
@@ -844,7 +844,7 @@ func (r *RayServiceReconciler) getAndCheckServeStatus(ctx context.Context, dashb
 	var err error
 	if serveAppStatuses, err = dashboardClient.GetMultiApplicationStatus(ctx); err != nil {
 		err = fmt.Errorf(
-			"Failed to get Serve application statuses from the dashboard agent (the head service's port with the name `dashboard-agent`). "+
+			"Failed to get Serve application statuses from the dashboard. "+
 				"If you observe this error consistently, please check https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayservice-troubleshooting.md for more details. "+
 				"err: %v", err)
 		return false, err

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -73,7 +73,6 @@ const (
 	RedisPortName                = "redis"
 	DashboardPortName            = "dashboard"
 	MetricsPortName              = "metrics"
-	DashboardAgentListenPortName = "dashboard-agent"
 	ServingPortName              = "serve"
 
 	// The default AppProtocol for Kubernetes service

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -69,11 +69,11 @@ const (
 	DefaultDashboardAgentListenPort = 52365
 	DefaultServingPort              = 8000
 
-	ClientPortName               = "client"
-	RedisPortName                = "redis"
-	DashboardPortName            = "dashboard"
-	MetricsPortName              = "metrics"
-	ServingPortName              = "serve"
+	ClientPortName    = "client"
+	RedisPortName     = "redis"
+	DashboardPortName = "dashboard"
+	MetricsPortName   = "metrics"
+	ServingPortName   = "serve"
 
 	// The default AppProtocol for Kubernetes service
 	DefaultServiceAppProtocol = "tcp"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The previous PR 1742 changed RayService to use DashboardPort instead of DashboardAgentPort. 
This PR fixes the log and comments to reflect that change.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
