### PR TITLE
[Test][RayCluster] Test redis cleanup job in the e2e compatibility test

### DIFF
--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -424,11 +424,6 @@ class RayClusterAddCREvent(CREvent):
             show_cluster_info(self.namespace)
             raise Exception("RayClusterAddCREvent clean_up() timeout")
 
-        """Make sure the external redis has been cleaned"""
-        if search_path(self.custom_resource_object, ['metadata', 'annotations', 'ray.io/ft-enabled']) == 'true':
-            if shell_subprocess_run("test $(kubectl exec deploy/redis -- redis-cli --no-auth-warning -a $(kubectl get secret redis-password-secret -o jsonpath='{.data.password}' | base64 --decode) DBSIZE) = '0'") != 0:
-                raise Exception("The external redis is not cleaned")
-
         """Delete other resources in the yaml"""
         if self.filepath:
             logger.info("Delete other resources in the YAML")

--- a/tests/framework/utils.py
+++ b/tests/framework/utils.py
@@ -412,6 +412,11 @@ def pod_exec_command(pod_name, namespace, exec_command, check=True):
         f"kubectl exec {pod_name} -n {namespace} -- {exec_command}", check
     )
 
+def delete_all_cr(crd_name, namespace, check=True):
+    return shell_subprocess_run(
+        f"kubectl delete {crd_name} --all -n {namespace}", check
+    )
+
 
 def start_curl_pod(name: str, namespace: str, timeout_s: int = -1):
     shell_subprocess_run(


### PR DESCRIPTION
## Why are these changes needed?

As discussed with @kevin85421 offline, we think that we should test the redis cleanup job in the `tests/compatibility-test.py`.

This PR appends the `cleanup_redis` procedure to every test in the `RayFTTestCase` to test the cleanup job by deleting the RayCluster CR and watching the Redis' `DBSIZE` to zero. If it doesn't go zero before timeout, then the test will fail.

## Related issue number

Fixes https://github.com/ray-project/kuberay/issues/1997

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
