### PR TITLE
Add finalizer to worker pods to ensure min replica

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -759,6 +759,21 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		deleted := struct{}{}
 		numDeletedUnhealthyWorkerPods := 0
 		for _, workerPod := range workerPods.Items {
+			if workerPod.ObjectMeta.DeletionTimestamp != nil {
+				if controllerutil.ContainsFinalizer(&workerPod, utils.WorkerDeletionFinalizer) {
+					if int32(len(workerPods.Items)) <= *worker.MinReplicas {
+						// If the number of worker Pods is less than or equal to the minimum number of replicas, we should not delete the Pod.
+						logger.Info("reconcilePods", "worker Pod", workerPod.Name, "shouldDelete", false, "reason", "Number of worker Pods is less than or equal to the minimum number of replicas")
+					} else {
+						controllerutil.RemoveFinalizer(&workerPod, utils.WorkerDeletionFinalizer)
+						if err := r.Update(ctx, &workerPod); err != nil {
+							return err
+						}
+					}
+
+				}
+				continue
+			}
 			shouldDelete, reason := shouldDeletePod(workerPod, rayv1.WorkerNode)
 			logger.Info("reconcilePods", "worker Pod", workerPod.Name, "shouldDelete", shouldDelete, "reason", reason)
 			if shouldDelete {
@@ -1132,6 +1147,7 @@ func (r *RayClusterReconciler) buildWorkerPod(ctx context.Context, instance rayv
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
 	autoscalingEnabled := instance.Spec.EnableInTreeAutoscaling
 	podTemplateSpec := common.DefaultWorkerPodTemplate(ctx, instance, worker, podName, fqdnRayIP, headPort)
+	podTemplateSpec.Finalizers = append(podTemplateSpec.Finalizers, utils.WorkerDeletionFinalizer)
 	if len(r.workerSidecarContainers) > 0 {
 		podTemplateSpec.Spec.Containers = append(podTemplateSpec.Spec.Containers, r.workerSidecarContainers...)
 	}

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -43,6 +43,8 @@ const (
 
 	// Finalizers for GCS fault tolerance
 	GCSFaultToleranceRedisCleanupFinalizer = "ray.io/gcs-ft-redis-cleanup-finalizer"
+	// Finalizers for worker deletion
+	WorkerDeletionFinalizer = "ray.io/worker-deletion-finalizer"
 
 	// EnableServeServiceKey is exclusively utilized to indicate if a RayCluster is directly used for serving.
 	// See https://github.com/ray-project/kuberay/pull/1672 for more details.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently all worker pods can be deleted without protection, regardless of minReplica. This change adds a protection of minReplica using finalizer.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Fix #1740

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
