### PR TITLE
[RayJob] Add Cluster Name For Rayjob.

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: age
       type: date
+    - jsonPath: .status.rayClusterName
+      name: ray cluster name
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -34,6 +34,7 @@ spec:
       type: date
     - jsonPath: .status.rayClusterName
       name: ray cluster name
+      priority: 1
       type: string
     name: v1
     schema:

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -138,7 +138,7 @@ type RayJobStatus struct {
 // +kubebuilder:printcolumn:name="start time",type=string,JSONPath=".status.startTime",priority=0
 // +kubebuilder:printcolumn:name="end time",type=string,JSONPath=".status.endTime",priority=0
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp",priority=0
-// +kubebuilder:printcolumn:name="ray cluster name",type="string,JSONPath=".status.rayClusterName",priority=1
+// +kubebuilder:printcolumn:name="ray cluster name",type="string",JSONPath=".status.rayClusterName",priority=1
 // +genclient
 // RayJob is the Schema for the rayjobs API
 type RayJob struct {

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -138,7 +138,7 @@ type RayJobStatus struct {
 // +kubebuilder:printcolumn:name="start time",type=string,JSONPath=".status.startTime",priority=0
 // +kubebuilder:printcolumn:name="end time",type=string,JSONPath=".status.endTime",priority=0
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp",priority=0
-// +kubebuilder:printcolumn:name="ray cluster name",type="string",JSONPath=".status.rayClusterName",priority=1
+// +kubebuilder:printcolumn:name="ray cluster name",type="string,JSONPath=".status.rayClusterName",priority=1
 // +genclient
 // RayJob is the Schema for the rayjobs API
 type RayJob struct {

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -138,6 +138,7 @@ type RayJobStatus struct {
 // +kubebuilder:printcolumn:name="start time",type=string,JSONPath=".status.startTime",priority=0
 // +kubebuilder:printcolumn:name="end time",type=string,JSONPath=".status.endTime",priority=0
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp",priority=0
+// +kubebuilder:printcolumn:name="ray cluster name",type="string",JSONPath=".status.rayClusterName",priority=1
 // +genclient
 // RayJob is the Schema for the rayjobs API
 type RayJob struct {

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: age
       type: date
+    - jsonPath: .status.rayClusterName
+      name: ray cluster name
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -34,6 +34,7 @@ spec:
       type: date
     - jsonPath: .status.rayClusterName
       name: ray cluster name
+      priority: 1
       type: string
     name: v1
     schema:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In our online environment, we run over 200 rayjobs daily, and sometimes certain rayjobs encounter issues. Typically, users provide us with two types of information:

They inform us that a specific job named `xgboost-rayjob-batch-xxx` is failing. In such cases, we can use `kubectl describe rayjob xgboost-rayjob-batch-xxx` to identify the headnode of this rayjob. By logging into the head pod, we can examine relevant logs and resolve the problem.

Occasionally, users report problems with a particular ray cluster. In these cases, I would like to quickly locate the rayjob running on that ray cluster. Currently, I can only filter operator logs to identify the issue.

I believe it would be helpful if we could print the cluster information associated with a rayjob when users execute `kubectl get rayjob`. This would expedite problem identification. 

I plan to add some additional information for rayjobs so that when we execute `kubectl get rayjob -o wide`, the cluster information can be displayed. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
