### PR TITLE
feat: record last state transition times

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -7122,6 +7122,11 @@ spec:
                 type: string
               state:
                 type: string
+              stateTransitionTimes:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                type: object
             type: object
         type: object
     served: true

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -10430,6 +10430,11 @@ spec:
                     type: string
                   state:
                     type: string
+                  stateTransitionTimes:
+                    additionalProperties:
+                      format: date-time
+                      type: string
+                    type: object
                 type: object
               reason:
                 type: string

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -7324,6 +7324,11 @@ spec:
                         type: string
                       state:
                         type: string
+                      stateTransitionTimes:
+                        additionalProperties:
+                          format: date-time
+                          type: string
+                        type: object
                     type: object
                 type: object
               lastUpdateTime:
@@ -7425,6 +7430,11 @@ spec:
                         type: string
                       state:
                         type: string
+                      stateTransitionTimes:
+                        additionalProperties:
+                          format: date-time
+                          type: string
+                        type: object
                     type: object
                 type: object
               serviceStatus:

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -140,6 +140,8 @@ type RayClusterStatus struct {
 	// LastUpdateTime indicates last update timestamp for this cluster status.
 	// +nullable
 	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty"`
+	// StateTransitionTimes indicates the time of the last state transition for each state.
+	StateTransitionTimes map[ClusterState]*metav1.Time `json:"stateTransitionTimes,omitempty"`
 	// Service Endpoints
 	Endpoints map[string]string `json:"endpoints,omitempty"`
 	// Head info

--- a/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
@@ -6,6 +6,7 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -263,6 +264,13 @@ func (in *RayClusterStatus) DeepCopyInto(out *RayClusterStatus) {
 	if in.LastUpdateTime != nil {
 		in, out := &in.LastUpdateTime, &out.LastUpdateTime
 		*out = (*in).DeepCopy()
+	}
+	if in.StateTransitionTimes != nil {
+		in, out := &in.StateTransitionTimes, &out.StateTransitionTimes
+		*out = make(map[ClusterState]*metav1.Time, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
 	}
 	if in.Endpoints != nil {
 		in, out := &in.Endpoints, &out.Endpoints

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -7122,6 +7122,11 @@ spec:
                 type: string
               state:
                 type: string
+              stateTransitionTimes:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                type: object
             type: object
         type: object
     served: true

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -10430,6 +10430,11 @@ spec:
                     type: string
                   state:
                     type: string
+                  stateTransitionTimes:
+                    additionalProperties:
+                      format: date-time
+                      type: string
+                    type: object
                 type: object
               reason:
                 type: string

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -7324,6 +7324,11 @@ spec:
                         type: string
                       state:
                         type: string
+                      stateTransitionTimes:
+                        additionalProperties:
+                          format: date-time
+                          type: string
+                        type: object
                     type: object
                 type: object
               lastUpdateTime:
@@ -7425,6 +7430,11 @@ spec:
                         type: string
                       state:
                         type: string
+                      stateTransitionTimes:
+                        additionalProperties:
+                          format: date-time
+                          type: string
+                        type: object
                     type: object
                 type: object
               serviceStatus:

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1252,6 +1252,13 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	timeNow := metav1.Now()
 	newInstance.Status.LastUpdateTime = &timeNow
 
+	if instance.Status.State != newInstance.Status.State {
+		if newInstance.Status.StateTransitionTimes == nil {
+			newInstance.Status.StateTransitionTimes = make(map[rayv1.ClusterState]*metav1.Time)
+		}
+		newInstance.Status.StateTransitionTimes[newInstance.Status.State] = &timeNow
+	}
+
 	return newInstance, nil
 }
 

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -470,6 +470,15 @@ var _ = Context("Inside the default namespace", func() {
 				getClusterState(ctx, namespace, rayCluster.Name),
 				time.Second*3, time.Millisecond*500).Should(Equal(rayv1.Ready))
 		})
+
+		It("RayCluster's .status.stateTransitionTimes should include a time for ready state", func() {
+			Eventually(
+				func() *metav1.Time {
+					status := getClusterStatus(ctx, namespace, rayCluster.Name)()
+					return status.StateTransitionTimes[rayv1.Ready]
+				},
+				time.Second*3, time.Millisecond*500).Should(Not(BeNil()))
+		})
 	})
 
 	Describe("RayCluster with a multi-host worker group", func() {

--- a/ray-operator/controllers/ray/suite_helpers_test.go
+++ b/ray-operator/controllers/ray/suite_helpers_test.go
@@ -49,6 +49,16 @@ func getClusterState(ctx context.Context, namespace string, clusterName string) 
 	}
 }
 
+func getClusterStatus(ctx context.Context, namespace string, clusterName string) func() rayv1.RayClusterStatus {
+	return func() rayv1.RayClusterStatus {
+		var cluster rayv1.RayCluster
+		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: clusterName}, &cluster); err != nil {
+			log.Fatal(err)
+		}
+		return cluster.Status
+	}
+}
+
 func isAllPodsRunningByFilters(ctx context.Context, podlist corev1.PodList, opt ...client.ListOption) bool {
 	err := k8sClient.List(ctx, &podlist, opt...)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to list Pods")

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayclusterstatus.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayclusterstatus.go
@@ -11,20 +11,21 @@ import (
 // RayClusterStatusApplyConfiguration represents an declarative configuration of the RayClusterStatus type for use
 // with apply.
 type RayClusterStatusApplyConfiguration struct {
-	State                   *v1.ClusterState            `json:"state,omitempty"`
-	AvailableWorkerReplicas *int32                      `json:"availableWorkerReplicas,omitempty"`
-	DesiredWorkerReplicas   *int32                      `json:"desiredWorkerReplicas,omitempty"`
-	MinWorkerReplicas       *int32                      `json:"minWorkerReplicas,omitempty"`
-	MaxWorkerReplicas       *int32                      `json:"maxWorkerReplicas,omitempty"`
-	DesiredCPU              *resource.Quantity          `json:"desiredCPU,omitempty"`
-	DesiredMemory           *resource.Quantity          `json:"desiredMemory,omitempty"`
-	DesiredGPU              *resource.Quantity          `json:"desiredGPU,omitempty"`
-	DesiredTPU              *resource.Quantity          `json:"desiredTPU,omitempty"`
-	LastUpdateTime          *metav1.Time                `json:"lastUpdateTime,omitempty"`
-	Endpoints               map[string]string           `json:"endpoints,omitempty"`
-	Head                    *HeadInfoApplyConfiguration `json:"head,omitempty"`
-	Reason                  *string                     `json:"reason,omitempty"`
-	ObservedGeneration      *int64                      `json:"observedGeneration,omitempty"`
+	State                   *v1.ClusterState                 `json:"state,omitempty"`
+	AvailableWorkerReplicas *int32                           `json:"availableWorkerReplicas,omitempty"`
+	DesiredWorkerReplicas   *int32                           `json:"desiredWorkerReplicas,omitempty"`
+	MinWorkerReplicas       *int32                           `json:"minWorkerReplicas,omitempty"`
+	MaxWorkerReplicas       *int32                           `json:"maxWorkerReplicas,omitempty"`
+	DesiredCPU              *resource.Quantity               `json:"desiredCPU,omitempty"`
+	DesiredMemory           *resource.Quantity               `json:"desiredMemory,omitempty"`
+	DesiredGPU              *resource.Quantity               `json:"desiredGPU,omitempty"`
+	DesiredTPU              *resource.Quantity               `json:"desiredTPU,omitempty"`
+	LastUpdateTime          *metav1.Time                     `json:"lastUpdateTime,omitempty"`
+	StateTransitionTimes    map[v1.ClusterState]*metav1.Time `json:"stateTransitionTimes,omitempty"`
+	Endpoints               map[string]string                `json:"endpoints,omitempty"`
+	Head                    *HeadInfoApplyConfiguration      `json:"head,omitempty"`
+	Reason                  *string                          `json:"reason,omitempty"`
+	ObservedGeneration      *int64                           `json:"observedGeneration,omitempty"`
 }
 
 // RayClusterStatusApplyConfiguration constructs an declarative configuration of the RayClusterStatus type for use with
@@ -110,6 +111,20 @@ func (b *RayClusterStatusApplyConfiguration) WithDesiredTPU(value resource.Quant
 // If called multiple times, the LastUpdateTime field is set to the value of the last call.
 func (b *RayClusterStatusApplyConfiguration) WithLastUpdateTime(value metav1.Time) *RayClusterStatusApplyConfiguration {
 	b.LastUpdateTime = &value
+	return b
+}
+
+// WithStateTransitionTimes puts the entries into the StateTransitionTimes field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the entries provided by each call will be put on the StateTransitionTimes field,
+// overwriting an existing map entries in StateTransitionTimes field with the same key.
+func (b *RayClusterStatusApplyConfiguration) WithStateTransitionTimes(entries map[v1.ClusterState]*metav1.Time) *RayClusterStatusApplyConfiguration {
+	if b.StateTransitionTimes == nil && len(entries) > 0 {
+		b.StateTransitionTimes = make(map[v1.ClusterState]*metav1.Time, len(entries))
+	}
+	for k, v := range entries {
+		b.StateTransitionTimes[k] = v
+	}
 	return b
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

### Problem Statement

My ML platform team runs the kuberay ray-operator. We want to measure the time
it takes for RayCluster's to transition from their initial "unhealthy" state to
some other state. This metric is important for us because our users want their
RayClusters to start in a timely manner. It seems like neither the ray-operator
nor RayClusters provide this info currently.

### Design

Add a new `.status.stateTransitionTimes` field to the `RayCluster` custom
resource. This field is a `map[ClusterState]*metav1.Time` that indicates the
time of the last state transition for each state. This field is updated
whenever the `.status.state` changes.

* [original discussion doc](https://docs.google.com/document/d/14yPSZ9iLk7a0qEg14rNWr60Btz0HEeQ3oWKP-GN9QTM)
* [related Slack thread](https://ray-distributed.slack.com/archives/C01CKH05XBN/p1709321264762029)
* [example input and output RayClusters](https://gist.github.com/davidxia/205d2b23202356a2d3172c51e0912f35)

manual testing steps:

1. `make manifests generate`
2. `kubectl config use-context CONTEXT`
3. `make docker-build docker-push deploy IMG=europe-west4-docker.pkg.dev/spotify-workbench/images/operator:$USER-$(git rev-parse --short=7 HEAD)`
4. `kubectl --context CONTEXT apply -f /path/to/raycluster.yaml`
5. verify there's a `.status.stateTransitionTimes` in the output of `kubectl --context CONTEXT -n NAMESPACE get rayclusters NAME -o yaml`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
