### PR TITLE
[Refactor] Use RayClusterHeadPodsAssociationOptions to replace MatchingLabels

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -232,8 +232,14 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*15, time.Millisecond*500).Should(Not(BeEmpty()), "Pending RayCluster name  = %v", myRayService.Status.PendingServiceStatus.RayClusterName)
 			pendingRayClusterName := myRayService.Status.PendingServiceStatus.RayClusterName
 
+			// Get the pending RayCluster instance
+			var pendingRayCluster rayv1.RayCluster
+			Eventually(
+				getResourceFunc(ctx, client.ObjectKey{Name: pendingRayClusterName, Namespace: "default"}, &pendingRayCluster),
+				time.Second*3, time.Millisecond*500).Should(BeNil(), "Failed to get RayCluster instance")
+
 			// Update the status of the head Pod to Running.
-			updateHeadPodToRunningAndReady(ctx, pendingRayClusterName)
+			updateHeadPodToRunningAndReady(ctx, &pendingRayCluster)
 
 			// Make sure the pending RayCluster becomes the active RayCluster.
 			Eventually(
@@ -303,8 +309,14 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*15, time.Millisecond*500).Should(Not(BeEmpty()), "Pending RayCluster name  = %v", myRayService.Status.PendingServiceStatus.RayClusterName)
 			pendingRayClusterName := myRayService.Status.PendingServiceStatus.RayClusterName
 
+			// Get the pending RayCluster instance
+			var pendingRayCluster rayv1.RayCluster
+			Eventually(
+				getResourceFunc(ctx, client.ObjectKey{Name: pendingRayClusterName, Namespace: "default"}, &pendingRayCluster),
+				time.Second*3, time.Millisecond*500).Should(BeNil(), "Failed to get RayCluster instance")
+
 			// Update the status of the head Pod to Running.
-			updateHeadPodToRunningAndReady(ctx, pendingRayClusterName)
+			updateHeadPodToRunningAndReady(ctx, &pendingRayCluster)
 
 			// Confirm switch to a new Ray Cluster.
 			Eventually(
@@ -421,10 +433,16 @@ var _ = Context("Inside the default namespace", func() {
 				getPreparingRayClusterNameFunc(ctx, myRayService),
 				time.Second*5, time.Millisecond*500).Should(Equal(initialPendingClusterName), "Pending RayCluster name = %v", myRayService.Status.PendingServiceStatus.RayClusterName)
 
+			// Get the pending RayCluster instance
+			var initialPendingCluster rayv1.RayCluster
+			Eventually(
+				getResourceFunc(ctx, client.ObjectKey{Name: initialPendingClusterName, Namespace: "default"}, &initialPendingCluster),
+				time.Second*3, time.Millisecond*500).Should(BeNil(), "Failed to get RayCluster instance")
+
 			// The pending RayCluster will become the active RayCluster after:
 			// (1) The pending RayCluster's head Pod becomes Running and Ready
 			// (2) The pending RayCluster's Serve Deployments are HEALTHY.
-			updateHeadPodToRunningAndReady(ctx, initialPendingClusterName)
+			updateHeadPodToRunningAndReady(ctx, &initialPendingCluster)
 			healthyStatus := generateServeStatus(rayv1.DeploymentStatusEnum.HEALTHY, rayv1.ApplicationStatusEnum.RUNNING)
 			fakeRayDashboardClient.SetMultiApplicationStatuses(map[string]*utils.ServeApplicationStatus{testServeAppName: &healthyStatus})
 			Eventually(
@@ -518,10 +536,16 @@ var _ = Context("Inside the default namespace", func() {
 				HaveLen(oldNumWorkerGroupSpecs + 1),
 			)
 
+			// Get the pending RayCluster instance
+			var initialPendingCluster rayv1.RayCluster
+			Eventually(
+				getResourceFunc(ctx, client.ObjectKey{Name: initialPendingClusterName, Namespace: "default"}, &initialPendingCluster),
+				time.Second*3, time.Millisecond*500).Should(BeNil(), "Failed to get RayCluster instance")
+
 			// The pending RayCluster will become the active RayCluster after:
 			// (1) The pending RayCluster's head Pod becomes Running and Ready
 			// (2) The pending RayCluster's Serve Deployments are HEALTHY.
-			updateHeadPodToRunningAndReady(ctx, initialPendingClusterName)
+			updateHeadPodToRunningAndReady(ctx, &initialPendingCluster)
 			healthyStatus := generateServeStatus(rayv1.DeploymentStatusEnum.HEALTHY, rayv1.ApplicationStatusEnum.RUNNING)
 			fakeRayDashboardClient.SetMultiApplicationStatuses(map[string]*utils.ServeApplicationStatus{testServeAppName: &healthyStatus})
 			Eventually(
@@ -660,6 +684,12 @@ var _ = Context("Inside the default namespace", func() {
 
 			pendingRayClusterName := myRayService.Status.PendingServiceStatus.RayClusterName
 
+			// Get the pending RayCluster instance
+			var pendingRayCluster rayv1.RayCluster
+			Eventually(
+				getResourceFunc(ctx, client.ObjectKey{Name: pendingRayClusterName, Namespace: "default"}, &pendingRayCluster),
+				time.Second*3, time.Millisecond*500).Should(BeNil(), "Failed to get RayCluster instance")
+
 			Consistently(
 				getRayClusterNameFunc(ctx, myRayService),
 				time.Second*5, time.Millisecond*500).Should(Equal(initialClusterName), "My current RayCluster name  = %v", myRayService.Status.ActiveServiceStatus.RayClusterName)
@@ -667,7 +697,7 @@ var _ = Context("Inside the default namespace", func() {
 			// The cluster should switch once the deployments are finished updating
 			healthyStatus := generateServeStatus(rayv1.DeploymentStatusEnum.HEALTHY, rayv1.ApplicationStatusEnum.RUNNING)
 			fakeRayDashboardClient.SetMultiApplicationStatuses(map[string]*utils.ServeApplicationStatus{testServeAppName: &healthyStatus})
-			updateHeadPodToRunningAndReady(ctx, pendingRayClusterName)
+			updateHeadPodToRunningAndReady(ctx, &pendingRayCluster)
 
 			Eventually(
 				getRayClusterNameFunc(ctx, myRayService),

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -232,14 +232,8 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*15, time.Millisecond*500).Should(Not(BeEmpty()), "Pending RayCluster name  = %v", myRayService.Status.PendingServiceStatus.RayClusterName)
 			pendingRayClusterName := myRayService.Status.PendingServiceStatus.RayClusterName
 
-			// Get the pending RayCluster instance
-			var pendingRayCluster rayv1.RayCluster
-			Eventually(
-				getResourceFunc(ctx, client.ObjectKey{Name: pendingRayClusterName, Namespace: "default"}, &pendingRayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Failed to get RayCluster instance")
-
 			// Update the status of the head Pod to Running.
-			updateHeadPodToRunningAndReady(ctx, &pendingRayCluster)
+			updateHeadPodToRunningAndReady(ctx, pendingRayClusterName)
 
 			// Make sure the pending RayCluster becomes the active RayCluster.
 			Eventually(
@@ -309,14 +303,8 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*15, time.Millisecond*500).Should(Not(BeEmpty()), "Pending RayCluster name  = %v", myRayService.Status.PendingServiceStatus.RayClusterName)
 			pendingRayClusterName := myRayService.Status.PendingServiceStatus.RayClusterName
 
-			// Get the pending RayCluster instance
-			var pendingRayCluster rayv1.RayCluster
-			Eventually(
-				getResourceFunc(ctx, client.ObjectKey{Name: pendingRayClusterName, Namespace: "default"}, &pendingRayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Failed to get RayCluster instance")
-
 			// Update the status of the head Pod to Running.
-			updateHeadPodToRunningAndReady(ctx, &pendingRayCluster)
+			updateHeadPodToRunningAndReady(ctx, pendingRayClusterName)
 
 			// Confirm switch to a new Ray Cluster.
 			Eventually(
@@ -433,16 +421,10 @@ var _ = Context("Inside the default namespace", func() {
 				getPreparingRayClusterNameFunc(ctx, myRayService),
 				time.Second*5, time.Millisecond*500).Should(Equal(initialPendingClusterName), "Pending RayCluster name = %v", myRayService.Status.PendingServiceStatus.RayClusterName)
 
-			// Get the pending RayCluster instance
-			var initialPendingCluster rayv1.RayCluster
-			Eventually(
-				getResourceFunc(ctx, client.ObjectKey{Name: initialPendingClusterName, Namespace: "default"}, &initialPendingCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Failed to get RayCluster instance")
-
 			// The pending RayCluster will become the active RayCluster after:
 			// (1) The pending RayCluster's head Pod becomes Running and Ready
 			// (2) The pending RayCluster's Serve Deployments are HEALTHY.
-			updateHeadPodToRunningAndReady(ctx, &initialPendingCluster)
+			updateHeadPodToRunningAndReady(ctx, initialPendingClusterName)
 			healthyStatus := generateServeStatus(rayv1.DeploymentStatusEnum.HEALTHY, rayv1.ApplicationStatusEnum.RUNNING)
 			fakeRayDashboardClient.SetMultiApplicationStatuses(map[string]*utils.ServeApplicationStatus{testServeAppName: &healthyStatus})
 			Eventually(
@@ -536,16 +518,10 @@ var _ = Context("Inside the default namespace", func() {
 				HaveLen(oldNumWorkerGroupSpecs + 1),
 			)
 
-			// Get the pending RayCluster instance
-			var initialPendingCluster rayv1.RayCluster
-			Eventually(
-				getResourceFunc(ctx, client.ObjectKey{Name: initialPendingClusterName, Namespace: "default"}, &initialPendingCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Failed to get RayCluster instance")
-
 			// The pending RayCluster will become the active RayCluster after:
 			// (1) The pending RayCluster's head Pod becomes Running and Ready
 			// (2) The pending RayCluster's Serve Deployments are HEALTHY.
-			updateHeadPodToRunningAndReady(ctx, &initialPendingCluster)
+			updateHeadPodToRunningAndReady(ctx, initialPendingClusterName)
 			healthyStatus := generateServeStatus(rayv1.DeploymentStatusEnum.HEALTHY, rayv1.ApplicationStatusEnum.RUNNING)
 			fakeRayDashboardClient.SetMultiApplicationStatuses(map[string]*utils.ServeApplicationStatus{testServeAppName: &healthyStatus})
 			Eventually(
@@ -684,12 +660,6 @@ var _ = Context("Inside the default namespace", func() {
 
 			pendingRayClusterName := myRayService.Status.PendingServiceStatus.RayClusterName
 
-			// Get the pending RayCluster instance
-			var pendingRayCluster rayv1.RayCluster
-			Eventually(
-				getResourceFunc(ctx, client.ObjectKey{Name: pendingRayClusterName, Namespace: "default"}, &pendingRayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Failed to get RayCluster instance")
-
 			Consistently(
 				getRayClusterNameFunc(ctx, myRayService),
 				time.Second*5, time.Millisecond*500).Should(Equal(initialClusterName), "My current RayCluster name  = %v", myRayService.Status.ActiveServiceStatus.RayClusterName)
@@ -697,7 +667,7 @@ var _ = Context("Inside the default namespace", func() {
 			// The cluster should switch once the deployments are finished updating
 			healthyStatus := generateServeStatus(rayv1.DeploymentStatusEnum.HEALTHY, rayv1.ApplicationStatusEnum.RUNNING)
 			fakeRayDashboardClient.SetMultiApplicationStatuses(map[string]*utils.ServeApplicationStatus{testServeAppName: &healthyStatus})
-			updateHeadPodToRunningAndReady(ctx, &pendingRayCluster)
+			updateHeadPodToRunningAndReady(ctx, pendingRayClusterName)
 
 			Eventually(
 				getRayClusterNameFunc(ctx, myRayService),

--- a/ray-operator/controllers/ray/suite_helpers_test.go
+++ b/ray-operator/controllers/ray/suite_helpers_test.go
@@ -2,10 +2,11 @@ package ray
 
 import (
 	"context"
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"log"
 	"reflect"
 	"time"
+
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 
 	"github.com/onsi/gomega"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"

--- a/ray-operator/controllers/ray/suite_helpers_test.go
+++ b/ray-operator/controllers/ray/suite_helpers_test.go
@@ -207,9 +207,14 @@ func checkServiceHealth(ctx context.Context, rayService *rayv1.RayService) func(
 // There's no container runtime or any other K8s controllers.
 // So Pods are created, but no controller updates them from Pending to Running.
 // See https://book.kubebuilder.io/reference/envtest.html for more details.
-func updateHeadPodToRunningAndReady(ctx context.Context, instance *rayv1.RayCluster) {
+func updateHeadPodToRunningAndReady(ctx context.Context, rayClusterName string) {
+	var instance rayv1.RayCluster
+	gomega.Eventually(
+		getResourceFunc(ctx, client.ObjectKey{Name: rayClusterName, Namespace: "default"}, &instance),
+		time.Second*3, time.Millisecond*500).Should(gomega.BeNil(), "RayCluster %v not found", rayClusterName)
+
 	headPods := corev1.PodList{}
-	headLabels := common.RayClusterHeadPodsAssociationOptions(instance).ToListOptions()
+	headLabels := common.RayClusterHeadPodsAssociationOptions(&instance).ToListOptions()
 
 	gomega.Eventually(
 		listResourceFunc(ctx, &headPods, headLabels...),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR aims to follow up [issue#2045](https://github.com/ray-project/kuberay/issues/2045).  The purpose of this initiative is to maintain consistency in association methods and avoid scattering MatchingLabels usage throughout the entire codebase.
In this PR, I focus on updating the `suite_helpers_test.go` file to reflect this change.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#2045 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
