### PR TITLE
[Bug] Change image repository for `make deploy`

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -4,8 +4,9 @@ REPO_ROOT	    := $(shell dirname ${PWD})
 REPO_ROOT_BIN	:= $(REPO_ROOT)/bin
 
 # Image URL to use all building/pushing image targets
+IMG_REPO ?= kuberay/apiserver
 IMG_TAG ?=latest
-IMG ?= kuberay/apiserver:$(IMG_TAG)
+IMG ?= $(IMG_REPO):$(IMG_TAG)
 
 # Allow for additional test flags (-v, etc)
 GO_TEST_FLAGS ?= 
@@ -187,7 +188,7 @@ deploy: ## Deploy via helm the kuberay api server to the K8s cluster specified i
 # Note that you should make your KubeRay APIServer image available by either pushing it to an image registry, such as DockerHub or Quay, or by loading the image into the Kubernetes cluster. 
 # If you are using a Kind cluster for development, you can run `make load-image` to load the newly built image into the Kind cluster.
 	helm upgrade --install kuberay-apiserver ../helm-chart/kuberay-apiserver --wait \
-	--set image.tag=${IMG_TAG} --set image.pullPolicy=IfNotPresent
+	--set image.repository=${IMG_REPO},image.tag=${IMG_TAG} --set image.pullPolicy=IfNotPresent
 
 .PHONY: undeploy
 undeploy: ## Undeploy via helm the kuberay api server to the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #2054

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

```sh
make docker-image cluster load-image deploy
# Check whether the KubeRay API server Pod uses the image `kuberay/apiserver:latest`.
```
