### PR TITLE
Show cluster name in kubectl get rayjob

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .status.jobDeploymentStatus
       name: deployment status
       type: string
+    - jsonPath: .status.rayClusterName
+      name: ray cluster name
+      type: string
     - jsonPath: .status.startTime
       name: start time
       type: string
@@ -32,10 +35,6 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: age
       type: date
-    - jsonPath: .status.rayClusterName
-      name: ray cluster name
-      priority: 1
-      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -135,10 +135,10 @@ type RayJobStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="job status",type=string,JSONPath=".status.jobStatus",priority=0
 // +kubebuilder:printcolumn:name="deployment status",type=string,JSONPath=".status.jobDeploymentStatus",priority=0
+// +kubebuilder:printcolumn:name="ray cluster name",type="string",JSONPath=".status.rayClusterName",priority=0
 // +kubebuilder:printcolumn:name="start time",type=string,JSONPath=".status.startTime",priority=0
 // +kubebuilder:printcolumn:name="end time",type=string,JSONPath=".status.endTime",priority=0
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp",priority=0
-// +kubebuilder:printcolumn:name="ray cluster name",type="string",JSONPath=".status.rayClusterName",priority=1
 // +genclient
 // RayJob is the Schema for the rayjobs API
 type RayJob struct {

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .status.jobDeploymentStatus
       name: deployment status
       type: string
+    - jsonPath: .status.rayClusterName
+      name: ray cluster name
+      type: string
     - jsonPath: .status.startTime
       name: start time
       type: string
@@ -32,10 +35,6 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: age
       type: date
-    - jsonPath: .status.rayClusterName
-      name: ray cluster name
-      priority: 1
-      type: string
     name: v1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
```
(ray) ubuntu@jjyao-dev:~/Workspace/kuberay/ray-operator/config/samples (jjyao/first)$ sudo kubectl get rayjob
NAME            JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME                 START TIME             END TIME               AGE
rayjob-sample   SUCCEEDED    Complete            rayjob-sample-raycluster-znv6g   2024-04-04T21:11:16Z   2024-04-04T21:13:01Z   2m25s
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
