### PR TITLE
[CI] Pin kustomize to v5.3.0

### DIFF
--- a/.github/workflows/consistency-check.yaml
+++ b/.github/workflows/consistency-check.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           # Use the same go version with build job
-          go-version: '1.20'
+          go-version: v1.20
 
       - name: Check golang version
         working-directory: ./ray-operator
@@ -44,11 +44,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go 1.19.x
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
           # Use the same go version with build job
-          go-version: '1.19'
+          go-version: v1.20
 
       - name: Check golang version
         working-directory: ./ray-operator
@@ -69,10 +69,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           # Use the same go version with build job
-          go-version: '1.20'
+          go-version: v1.20
 
       - name: Update CRD/RBAC YAML files
         working-directory: ./ray-operator

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20'
+        go-version: v1.20
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -81,7 +81,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20'
+        go-version: v1.20
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         # Use the same go version with build job
-        go-version: '1.20'
+        go-version: v1.20
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -119,7 +119,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: v1.20
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -200,7 +200,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: v1.20
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -274,7 +274,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20'
+        go-version: v1.20
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -151,7 +151,7 @@ controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessar
 KUSTOMIZE = $(LOCALBIN)/kustomize
 $(KUSTOMIZE): $(LOCALBIN)
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-	test -s $(KUSTOMIZE) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v5@latest
+	test -s $(KUSTOMIZE) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v5@v5.3.0
 
 ENVTEST = $(LOCALBIN)/setup-envtest
 $(ENVTEST): $(LOCALBIN)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Kustomize releases v5.4.0 today, and it requires Go 1.21 instead of Go 1.20 ([ref](https://github.com/kubernetes-sigs/kustomize/blob/116b307b88c0e6bafa9f11e01df5783beafd91f5/kustomize/go.mod#L3)). This PR pins Kustomize to v5.3.0 to fix the CI failure ([example](https://github.com/ray-project/kuberay/actions/runs/8559646066/job/23460583399?pr=2064)).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
