### PR TITLE
[Refactor][RayService] Add GetRayClusterWithRayServiceAssociationOptions

### DIFF
--- a/ray-operator/controllers/ray/common/association.go
+++ b/ray-operator/controllers/ray/common/association.go
@@ -93,7 +93,7 @@ func RayClusterAllPodsAssociationOptions(instance *rayv1.RayCluster) Association
 	}
 }
 
-func RayServiceGetRayClustersAssociationOptions(rayService *rayv1.RayService) AssociationOptions {
+func RayServiceRayClustersAssociationOptions(rayService *rayv1.RayService) AssociationOptions {
 	return AssociationOptions{
 		client.InNamespace(rayService.Namespace),
 		client.MatchingLabels{

--- a/ray-operator/controllers/ray/common/association.go
+++ b/ray-operator/controllers/ray/common/association.go
@@ -93,7 +93,7 @@ func RayClusterAllPodsAssociationOptions(instance *rayv1.RayCluster) Association
 	}
 }
 
-func GetRayClusterWithRayServiceAssociationOptions(rayService *rayv1.RayService) AssociationOptions {
+func RayServiceGetRayClustersAssociationOptions(rayService *rayv1.RayService) AssociationOptions {
 	return AssociationOptions{
 		client.InNamespace(rayService.Namespace),
 		client.MatchingLabels{

--- a/ray-operator/controllers/ray/common/association.go
+++ b/ray-operator/controllers/ray/common/association.go
@@ -93,6 +93,16 @@ func RayClusterAllPodsAssociationOptions(instance *rayv1.RayCluster) Association
 	}
 }
 
+func GetRayClusterWithRayServiceAssociationOptions(rayService *rayv1.RayService) AssociationOptions {
+	return AssociationOptions{
+		client.InNamespace(rayService.Namespace),
+		client.MatchingLabels{
+			utils.RayOriginatedFromCRNameLabelKey: rayService.Name,
+			utils.RayOriginatedFromCRDLabelKey:    utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
+		},
+	}
+}
+
 func RayServiceServeServiceNamespacedName(rayService *rayv1.RayService) types.NamespacedName {
 	if rayService.Spec.ServeService != nil && rayService.Spec.ServeService.Name != "" {
 		return types.NamespacedName{

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -437,7 +437,7 @@ func (r *RayServiceReconciler) cleanUpRayClusterInstance(ctx context.Context, ra
 	rayClusterList := rayv1.RayClusterList{}
 
 	var err error
-	if err = r.List(ctx, &rayClusterList, common.GetRayClusterWithRayServiceAssociationOptions(rayServiceInstance).ToListOptions()...); err != nil {
+	if err = r.List(ctx, &rayClusterList, common.RayServiceGetRayClustersAssociationOptions(rayServiceInstance).ToListOptions()...); err != nil {
 		logger.Error(err, "Fail to list RayCluster for "+rayServiceInstance.Name)
 		return err
 	}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -437,7 +437,7 @@ func (r *RayServiceReconciler) cleanUpRayClusterInstance(ctx context.Context, ra
 	rayClusterList := rayv1.RayClusterList{}
 
 	var err error
-	if err = r.List(ctx, &rayClusterList, common.RayServiceGetRayClustersAssociationOptions(rayServiceInstance).ToListOptions()...); err != nil {
+	if err = r.List(ctx, &rayClusterList, common.RayServiceRayClustersAssociationOptions(rayServiceInstance).ToListOptions()...); err != nil {
 		logger.Error(err, "Fail to list RayCluster for "+rayServiceInstance.Name)
 		return err
 	}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -435,12 +435,9 @@ func (r *RayServiceReconciler) reconcileRayCluster(ctx context.Context, rayServi
 func (r *RayServiceReconciler) cleanUpRayClusterInstance(ctx context.Context, rayServiceInstance *rayv1.RayService) error {
 	logger := ctrl.LoggerFrom(ctx)
 	rayClusterList := rayv1.RayClusterList{}
-	filterLabels := client.MatchingLabels{
-		utils.RayOriginatedFromCRNameLabelKey: rayServiceInstance.Name,
-		utils.RayOriginatedFromCRDLabelKey:    utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
-	}
+
 	var err error
-	if err = r.List(ctx, &rayClusterList, client.InNamespace(rayServiceInstance.Namespace), filterLabels); err != nil {
+	if err = r.List(ctx, &rayClusterList, common.GetRayClusterWithRayServiceAssociationOptions(rayServiceInstance).ToListOptions()...); err != nil {
 		logger.Error(err, "Fail to list RayCluster for "+rayServiceInstance.Name)
 		return err
 	}
@@ -1237,9 +1234,7 @@ func isServeAppUnhealthyOrDeployedFailed(appStatus string) bool {
 // TODO: Move this function to util.go and always use this function to retrieve the head Pod.
 func (r *RayServiceReconciler) getHeadPod(ctx context.Context, instance *rayv1.RayCluster) (*corev1.Pod, error) {
 	podList := corev1.PodList{}
-	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: instance.Name, utils.RayNodeTypeLabelKey: string(rayv1.HeadNode)}
-
-	if err := r.List(ctx, &podList, client.InNamespace(instance.Namespace), filterLabels); err != nil {
+	if err := r.List(ctx, &podList, common.RayClusterHeadPodsAssociationOptions(instance).ToListOptions()...); err != nil {
 		return nil, err
 	}
 

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -249,13 +249,8 @@ var _ = Context("Inside the default namespace", func() {
 		})
 
 		It("should create more than 1 worker", func() {
-			var instance rayv1.RayCluster
 			Eventually(
-				getResourceFunc(ctx, client.ObjectKey{Name: myRayService.Status.ActiveServiceStatus.RayClusterName, Namespace: "default"}, &instance),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", myRayService.Status.ActiveServiceStatus.RayClusterName)
-
-			Eventually(
-				listResourceFunc(ctx, &workerPods, common.RayClusterGroupPodsAssociationOptions(&instance, "small-group").ToListOptions()...),
+				listResourceFunc(ctx, &workerPods, common.RayClusterGroupPodsAssociationOptions(myRayCluster, "small-group").ToListOptions()...),
 				time.Second*15, time.Millisecond*500).Should(Equal(3), fmt.Sprintf("workerGroup %v", workerPods.Items))
 			if len(workerPods.Items) > 0 {
 				Expect(workerPods.Items[0].Status.Phase).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
+
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -247,9 +249,13 @@ var _ = Context("Inside the default namespace", func() {
 		})
 
 		It("should create more than 1 worker", func() {
-			filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: myRayService.Status.ActiveServiceStatus.RayClusterName, utils.RayNodeGroupLabelKey: "small-group"}
+			var instance rayv1.RayCluster
 			Eventually(
-				listResourceFunc(ctx, &workerPods, filterLabels, &client.ListOptions{Namespace: "default"}),
+				getResourceFunc(ctx, client.ObjectKey{Name: myRayService.Status.ActiveServiceStatus.RayClusterName, Namespace: "default"}, &instance),
+				time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", myRayService.Status.ActiveServiceStatus.RayClusterName)
+
+			Eventually(
+				listResourceFunc(ctx, &workerPods, common.RayClusterGroupPodsAssociationOptions(&instance, "small-group").ToListOptions()...),
 				time.Second*15, time.Millisecond*500).Should(Equal(3), fmt.Sprintf("workerGroup %v", workerPods.Items))
 			if len(workerPods.Items) > 0 {
 				Expect(workerPods.Items[0].Status.Phase).Should(Or(Equal(corev1.PodRunning), Equal(corev1.PodPending)))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->
This PR aims to follow up https://github.com/ray-project/kuberay/issues/2045. The purpose of this initiative is to maintain consistency in association methods and avoid scattering MatchingLabels usage throughout the entire codebase.

In this PR, I update the files related with RayService, and add a new AssociationOptions `GetRayClusterWithRayServiceAssociationOptions`.

## Related issue number
<!-- For example: "Closes #1234" -->
#2045 


## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
