### PR TITLE
[Bug] Ray operator crashes when specifying RayCluster with resources.limits but no resources.requests

### DIFF
--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -338,6 +338,9 @@ func calculatePodResource(podSpec corev1.PodSpec) corev1.ResourceList {
 	podResource := corev1.ResourceList{}
 	for _, container := range podSpec.Containers {
 		containerResource := container.Resources.Requests
+		if containerResource == nil {
+			containerResource = corev1.ResourceList{}
+		}
 		for name, quantity := range container.Resources.Limits {
 			if _, ok := containerResource[name]; !ok {
 				containerResource[name] = quantity


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Avoid dereferencing nil pointers when resources.requests are not set.

## Related issue number

Closes #2076 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* Install a RayCluster with [this gist](https://gist.github.com/kevin85421/06f0e2da52f21644173d3ad371ef3ade).
* Without this PR, KubeRay will crash because of nil pointer dereference as stated in #2076.
