### PR TITLE
[Refactor][RayJob] Use AssociationOptions and Delete isAllPodsRunning

### DIFF
--- a/ray-operator/controllers/ray/suite_helpers_test.go
+++ b/ray-operator/controllers/ray/suite_helpers_test.go
@@ -49,10 +49,6 @@ func getClusterState(ctx context.Context, namespace string, clusterName string) 
 	}
 }
 
-func isAllPodsRunning(ctx context.Context, podlist corev1.PodList, filterLabels client.MatchingLabels, namespace string) bool {
-	return isAllPodsRunningByFilters(ctx, podlist, filterLabels, &client.ListOptions{Namespace: namespace})
-}
-
 func isAllPodsRunningByFilters(ctx context.Context, podlist corev1.PodList, opt ...client.ListOption) bool {
 	err := k8sClient.List(ctx, &podlist, opt...)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to list Pods")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR follows up on #2045. The objective of this PR is to uphold consistency in association methods and prevent the scattering of MatchingLabels usage throughout the entire codebase.

In this PR, I concentrate on modifying the files related to RayJob. This includes using the AssociationOptions function to replace the previous section and removing `isAllPodsRunning` function due to its lack of usage.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#2045 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
