### PR TITLE
[Bug] KubeRay operator failed to watch endpoint

### DIFF
--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -50,8 +50,7 @@
     - IMG=kuberay/operator:nightly make docker-image
     - popd
     # Use nightly KubeRay operator image
-    # - source .venv/bin/activate && BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
-    - sleep 14400
+    - source .venv/bin/activate && BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
 
 - label: 'Test RayService Sample YAMLs (latest release)'
   instance_size: large

--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -50,9 +50,7 @@
     - IMG=kuberay/operator:nightly make docker-image
     - popd
     # Use nightly KubeRay operator image
-    - source .venv/bin/activate
-    - sleep 7200
-    # BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
+    - source .venv/bin/activate && BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
 
 - label: 'Test RayService Sample YAMLs (latest release)'
   instance_size: large

--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -50,7 +50,8 @@
     - IMG=kuberay/operator:nightly make docker-image
     - popd
     # Use nightly KubeRay operator image
-    - source .venv/bin/activate && BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
+    # - source .venv/bin/activate && BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
+    - sleep 14400
 
 - label: 'Test RayService Sample YAMLs (latest release)'
   instance_size: large

--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -50,7 +50,9 @@
     - IMG=kuberay/operator:nightly make docker-image
     - popd
     # Use nightly KubeRay operator image
-    - source .venv/bin/activate && BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
+    - source .venv/bin/activate
+    - sleep 7200
+    # BUILDKITE_ENV=true OPERATOR_IMAGE=kuberay/operator:nightly python3 tests/test_sample_rayservice_yamls.py
 
 - label: 'Test RayService Sample YAMLs (latest release)'
   instance_size: large

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
@@ -39,6 +39,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/helm-chart/kuberay-operator/templates/role.yaml
+++ b/helm-chart/kuberay-operator/templates/role.yaml
@@ -35,6 +35,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/ray-operator/config/rbac/role.yaml
+++ b/ray-operator/config/rbac/role.yaml
@@ -32,6 +32,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -82,7 +82,7 @@ func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, dashboard
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list
+// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -323,6 +323,7 @@ class CurlServiceRule(Rule):
                     assert output.decode('utf-8') in query["expected_output"]
                 else:
                     assert output.decode('utf-8') == query["expected_output"]
+            time.sleep(1)
 
 class AutoscaleRule(Rule):
     def __init__(

--- a/tests/framework/prototype.py
+++ b/tests/framework/prototype.py
@@ -1,6 +1,5 @@
 """Configuration test framework for KubeRay"""
 import json
-import datetime
 import time
 import unittest
 from typing import Dict, List, Optional

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -1,12 +1,11 @@
 ''' Test sample RayService YAML files to catch invalid and outdated ones. '''
 from copy import deepcopy
-from kubernetes import client
 import logging
 import pytest
 import sys
 from tempfile import NamedTemporaryFile
 import time
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 import yaml
 
 from framework.prototype import (
@@ -15,10 +14,7 @@ from framework.prototype import (
     EasyJobRule,
     CurlServiceRule,
     AutoscaleRule,
-    get_expected_head_pods,
-    get_expected_worker_pods,
     show_cluster_info,
-    check_pod_running,
 )
 
 from framework.utils import (

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -298,7 +298,7 @@ class TestRayServiceAutoscaling:
 
         yield
 
-        # K8S_CLUSTER_MANAGER.cleanup()
+        K8S_CLUSTER_MANAGER.cleanup()
 
     def test_service_autoscaling(self, set_up_cluster):
         """This test uses a special workload that can allow us to

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -194,7 +194,7 @@ class TestRayService:
 
         yield
 
-        K8S_CLUSTER_MANAGER.cleanup()
+        # K8S_CLUSTER_MANAGER.cleanup()
 
     def test_deploy_applications(self, set_up_cluster):
         rs = RuleSet([EasyJobRule(), CurlServiceRule(queries=self.default_queries)])
@@ -283,7 +283,7 @@ class TestRayService:
                     switch_cluster=True,
                     query_while_updating=allowed_queries_during_update,
                 ),
-                RayServiceDeleteCREvent(custom_resource_object=self.cr, filepath=self.sample_path),
+                # RayServiceDeleteCREvent(custom_resource_object=self.cr, filepath=self.sample_path),
             ]
 
             for cr_event in cr_events:
@@ -302,7 +302,7 @@ class TestRayServiceAutoscaling:
 
         yield
 
-        K8S_CLUSTER_MANAGER.cleanup()
+        # K8S_CLUSTER_MANAGER.cleanup()
 
     def test_service_autoscaling(self, set_up_cluster):
         """This test uses a special workload that can allow us to
@@ -345,7 +345,7 @@ class TestRayServiceAutoscaling:
                 namespace=NAMESPACE,
                 filepath=cr_yaml_path,
             ),
-            RayServiceDeleteCREvent(cr, [], 90, NAMESPACE, cr_yaml_path),
+            # RayServiceDeleteCREvent(cr, [], 90, NAMESPACE, cr_yaml_path),
         ]
 
         for cr_event in cr_events:

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -190,7 +190,7 @@ class TestRayService:
 
         yield
 
-        # K8S_CLUSTER_MANAGER.cleanup()
+        K8S_CLUSTER_MANAGER.cleanup()
 
     def test_deploy_applications(self, set_up_cluster):
         rs = RuleSet([EasyJobRule(), CurlServiceRule(queries=self.default_queries)])
@@ -279,7 +279,7 @@ class TestRayService:
                     switch_cluster=True,
                     query_while_updating=allowed_queries_during_update,
                 ),
-                # RayServiceDeleteCREvent(custom_resource_object=self.cr, filepath=self.sample_path),
+                RayServiceDeleteCREvent(custom_resource_object=self.cr, filepath=self.sample_path),
             ]
 
             for cr_event in cr_events:
@@ -341,7 +341,7 @@ class TestRayServiceAutoscaling:
                 namespace=NAMESPACE,
                 filepath=cr_yaml_path,
             ),
-            # RayServiceDeleteCREvent(cr, [], 90, NAMESPACE, cr_yaml_path),
+            RayServiceDeleteCREvent(cr, [], 90, NAMESPACE, cr_yaml_path),
         ]
 
         for cr_event in cr_events:

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -302,7 +302,7 @@ class TestRayServiceAutoscaling:
 
         yield
 
-        # K8S_CLUSTER_MANAGER.cleanup()
+        K8S_CLUSTER_MANAGER.cleanup()
 
     def test_service_autoscaling(self, set_up_cluster):
         """This test uses a special workload that can allow us to
@@ -345,7 +345,7 @@ class TestRayServiceAutoscaling:
                 namespace=NAMESPACE,
                 filepath=cr_yaml_path,
             ),
-            # RayServiceDeleteCREvent(cr, [], 90, NAMESPACE, cr_yaml_path),
+            RayServiceDeleteCREvent(cr, [], 90, NAMESPACE, cr_yaml_path),
         ]
 
         for cr_event in cr_events:

--- a/tests/test_sample_rayservice_yamls.py
+++ b/tests/test_sample_rayservice_yamls.py
@@ -302,7 +302,7 @@ class TestRayServiceAutoscaling:
 
         yield
 
-        K8S_CLUSTER_MANAGER.cleanup()
+        # K8S_CLUSTER_MANAGER.cleanup()
 
     def test_service_autoscaling(self, set_up_cluster):
         """This test uses a special workload that can allow us to
@@ -345,7 +345,7 @@ class TestRayServiceAutoscaling:
                 namespace=NAMESPACE,
                 filepath=cr_yaml_path,
             ),
-            RayServiceDeleteCREvent(cr, [], 90, NAMESPACE, cr_yaml_path),
+            # RayServiceDeleteCREvent(cr, [], 90, NAMESPACE, cr_yaml_path),
         ]
 
         for cr_event in cr_events:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `Get` operation in controller-runtime also requires `watch` permission. See https://github.com/kubernetes-sigs/controller-runtime/issues/1156 for more details. This PR (1) adds the `watch` permission for the endpoints, and (2) improves the observability of the requests sent by `curl` commands so that users can log in to the `curl` Pod and check the response.

I observed that many requests fail due to timeout, so I think there may be resource contention if we launch 20 curl processes simultaneously. Hence, this PR also adds `time.sleep(1)` between each curl request. 

* TODO: Why does adding `watch` cause the RayService sample YAML tests to fail frequently if we don't add `time.sleep(1)`?

## Related issue number

Closes #2073

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
