### PR TITLE
[Hotfix] Increase the timeout of the ProxyActor health check

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1138,7 +1138,7 @@ func (r *RayServiceReconciler) labelHeadPodForServeStatus(ctx context.Context, r
 		originalLabels[key] = value
 	}
 
-	if httpProxyClient.CheckHealth() == nil {
+	if err = httpProxyClient.CheckProxyActorHealth(ctx); err == nil {
 		headPod.Labels[utils.RayClusterServingServiceLabelKey] = utils.EnableRayClusterServingServiceTrue
 	} else {
 		headPod.Labels[utils.RayClusterServingServiceLabelKey] = utils.EnableRayClusterServingServiceFalse

--- a/ray-operator/controllers/ray/utils/fake_httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/fake_httpproxy_httpclient.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -21,7 +22,7 @@ func (r *FakeRayHttpProxyClient) SetHostIp(hostIp string, port int) {
 	r.httpProxyURL = fmt.Sprintf("http://%s:%d", hostIp, port)
 }
 
-func (r *FakeRayHttpProxyClient) CheckHealth() error {
+func (r *FakeRayHttpProxyClient) CheckProxyActorHealth(ctx context.Context) error {
 	// TODO: test check return error cases.
 	// Always return successful.
 	return nil


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I observed that `NumServeEndpoints` changes frequently especially after we start to watch `Endpoints` in #2080. The error message is: 

```
Get \"http://10.244.0.6:8000/-/healthz\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

The [timeout](https://github.com/ray-project/kuberay/blob/3738f78fa8e89a2b61d2d28e3f2710c5036f3a33/ray-operator/controllers/ray/utils/httpproxy_httpclient.go#L27) of the HTTP client is 20 ms. Hence, I increase the timeout to 2 seconds which is the same as the [dashboard HTTP client](https://github.com/ray-project/kuberay/blob/3738f78fa8e89a2b61d2d28e3f2710c5036f3a33/ray-operator/controllers/ray/utils/dashboard_httpclient.go#L106).

* Test
  * With this PR, `CheckProxyActorHealth` does not fail during my 30-minute experiment. See [this gist](https://gist.github.com/kevin85421/cfa21f304eb49be7706ca2f0cd08da01) for more details.
  * Without this PR (also no #2080), `CheckHealth` fails 6 times in my 30-minute experiment. See [this gist](https://gist.github.com/kevin85421/16458127560a1c3055a4e2741ed2adeb) for more details

I marked it as 'Hotfix' because I think 20 ms should be enough for my very simple setup (single Ray node, local Kind cluster, no requests). Hence, the instability may be a Ray Serve issue.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
