### PR TITLE
[Bug] All worker Pods are deleted if using KubeRay v1.0.0 CRD with KubeRay operator v1.1.0 image  

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -796,10 +796,15 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 			}
 		}
 		// A replica can contain multiple hosts, so we need to calculate this based on the number of hosts per replica.
+		// If the user doesn't install the CRD with `NumOfHosts`, the zero value of `NumOfHosts`, which is 0, will be used.
+		// Hence, all workers will be deleted. Here, we set `NumOfHosts` to max(1, `NumOfHosts`) to avoid this situation.
+		if worker.NumOfHosts <= 0 {
+			worker.NumOfHosts = 1
+		}
 		numExpectedPods := workerReplicas * worker.NumOfHosts
 		diff := numExpectedPods - int32(len(runningPods.Items))
 
-		logger.Info("reconcilePods", "workerReplicas", workerReplicas, "runningPods", len(runningPods.Items), "diff", diff)
+		logger.Info("reconcilePods", "workerReplicas", workerReplicas, "NumOfHosts", worker.NumOfHosts, "runningPods", len(runningPods.Items), "diff", diff)
 
 		if diff > 0 {
 			// pods need to be added


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some users only upgrade the KubeRay image without upgrading the CRD. For example, when a user upgrades the KubeRay operator from v1.0.0 to v1.1.0 without upgrading the CRD, the KubeRay operator will use the zero value of `NumOfHosts` in the CRD. Hence, all worker Pods will be deleted. This PR ensures that `NumOfHosts` will always be larger than or equal to 1.


## Related issue number

Closes #2084 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* Step 1: Install a KubeRay operator via KubeRay v1.0.0 Helm chart.
* Step 2: Install a RayCluster via KubeRay v1.0.0 Helm chart.
* Step 3: Build a KubeRay operator image (`controller:latest`)
* Step 4: Upgrade KubeRay operator via `helm upgrade` (note that the CRD will not be updated)
  ```sh
  helm upgrade --install kuberay-operator kuberay/kuberay-operator --version 1.1.0 --set image.repository=controller,image.tag=latest
  ```
* Step 5: Verify
  * Without this PR, the RayCluster's worker Pod will be deleted.
  * With this PR, the RayCluster's worker Pod will still be there. 
