### PR TITLE
[Chore] Run operator outside the cluster

### DIFF
--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -59,6 +59,8 @@ make clean
 
 ### End-to-end local development process on Kind
 
+#### Run the operator inside the cluster
+
 ```bash
 # Step 1: Create a Kind cluster
 kind create cluster --image=kindest/node:v1.24.0
@@ -96,6 +98,24 @@ kubectl logs {YOUR_OPERATOR_POD} | grep "Hello KubeRay"
 * Replace `{IMG_REPO}` and `{IMG_TAG}` with your own repository and tag.
 * The command `make docker-build` (Step 3) will also run `make test` (unit tests).
 * Step 6 also installs the custom resource definitions (CRDs) used by the KubeRay operator.
+
+#### Run the operator outside the cluster
+
+> Note: Running the operator outside the cluster allows you to debug the operator using your IDE. For example, you can set breakpoints in the code and inspect the state of the operator.
+
+```bash
+# Step 1: Create a Kind cluster
+kind create cluster --image=kindest/node:v1.24.0
+
+# Step 2: Install CRDs
+make -C ray-operator install
+
+# Step 3: Compile the source code
+make -C ray-operator build
+
+# Step 4: Run the KubeRay operator
+./ray-operator/bin/manager -leader-election-namespace default -use-kubernetes-proxy
+```
 
 ### Running the tests
 

--- a/ray-operator/test/support/test.go
+++ b/ray-operator/test/support/test.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -136,7 +135,6 @@ func (t *T) StreamKubeRayOperatorLogs() {
 		LabelSelector: "app.kubernetes.io/component=kuberay-operator",
 	})
 	t.Expect(err).ShouldNot(gomega.HaveOccurred())
-	t.Expect(pods.Items).ShouldNot(gomega.BeEmpty())
 	now := metav1.NewTime(time.Now())
 	for _, pod := range pods.Items {
 		go func(pod corev1.Pod, ts *metav1.Time) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Running the operator outside the cluster allows developers to set breakpoints in their IDEs for debugging purposes.

![image](https://github.com/ray-project/kuberay/assets/47914085/b26ee738-5a34-4fc8-bc36-846dd01d376a)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

N/A

## Steps to Reproduce

1. Create a Kubernetes cluster by `kind create cluster --image=kindest/node:v1.24.0` or `k3d cluster create` or `minikube start`
3. `make -C ray-operator install`
4. `make -C ray-operator build`
5. `./ray-operator/bin/manager -leader-election-namespace default -use-kubernetes-proxy`
6. `make -C ray-operator test-e2e`

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
