### PR TITLE
Init dashboardClientFunc and httpProxyClientFunc by the config arg

### DIFF
--- a/ray-operator/apis/config/v1alpha1/configuration_types.go
+++ b/ray-operator/apis/config/v1alpha1/configuration_types.go
@@ -9,11 +9,6 @@ import (
 
 //+kubebuilder:object:root=true
 
-type ClientProvider interface {
-	GetDashboardClient(mgr manager.Manager) func() utils.RayDashboardClientInterface
-	GetHttpProxyClient(mgr manager.Manager) func() utils.RayHttpProxyClientInterface
-}
-
 // Configuration is the Schema for Ray operator config.
 type Configuration struct {
 	metav1.TypeMeta `json:",inline"`

--- a/ray-operator/apis/config/v1alpha1/configuration_types.go
+++ b/ray-operator/apis/config/v1alpha1/configuration_types.go
@@ -1,11 +1,18 @@
 package v1alpha1
 
 import (
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 //+kubebuilder:object:root=true
+
+type ClientProvider interface {
+	GetDashboardClient(mgr manager.Manager) func() utils.RayDashboardClientInterface
+	GetHttpProxyClient(mgr manager.Manager) func() utils.RayHttpProxyClientInterface
+}
 
 // Configuration is the Schema for Ray operator config.
 type Configuration struct {
@@ -63,4 +70,12 @@ type Configuration struct {
 	// WorkerSidecarContainers includes specification for a sidecar container
 	// to inject into every Worker pod.
 	WorkerSidecarContainers []corev1.Container `json:"workerSidecarContainers,omitempty"`
+}
+
+func (config Configuration) GetDashboardClient(mgr manager.Manager) func() utils.RayDashboardClientInterface {
+	return utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)
+}
+
+func (config Configuration) GetHttpProxyClient(mgr manager.Manager) func() utils.RayHttpProxyClientInterface {
+	return utils.GetRayHttpProxyClientFunc(mgr, config.UseKubernetesProxy)
 }

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -44,8 +44,17 @@ type RayJobReconciler struct {
 }
 
 // NewRayJobReconciler returns a new reconcile.Reconciler
-func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, config configv1.Configuration) *RayJobReconciler {
+func NewRayJobReconcilerFromConfig(ctx context.Context, mgr manager.Manager, config configv1.Configuration) *RayJobReconciler {
 	var dashboardClientFunc = utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)
+	return &RayJobReconciler{
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		Recorder:            mgr.GetEventRecorderFor("rayjob-controller"),
+		dashboardClientFunc: dashboardClientFunc,
+	}
+}
+
+func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, dashboardClientFunc func() utils.RayDashboardClientInterface) *RayJobReconciler {
 	return &RayJobReconciler{
 		Client:              mgr.GetClient(),
 		Scheme:              mgr.GetScheme(),

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -44,7 +44,7 @@ type RayJobReconciler struct {
 
 // NewRayJobReconciler returns a new reconcile.Reconciler
 func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, provider utils.ClientProvider) *RayJobReconciler {
-	var dashboardClientFunc = provider.GetDashboardClient(mgr)
+	dashboardClientFunc := provider.GetDashboardClient(mgr)
 	return &RayJobReconciler{
 		Client:              mgr.GetClient(),
 		Scheme:              mgr.GetScheme(),

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -3,7 +3,6 @@ package ray
 import (
 	"context"
 	"fmt"
-	"github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -25,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	configv1 "github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
@@ -44,7 +44,7 @@ type RayJobReconciler struct {
 }
 
 // NewRayJobReconciler returns a new reconcile.Reconciler
-func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, config v1alpha1.Configuration) *RayJobReconciler {
+func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, config configv1.Configuration) *RayJobReconciler {
 	var dashboardClientFunc = utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)
 	return &RayJobReconciler{
 		Client:              mgr.GetClient(),

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -3,6 +3,7 @@ package ray
 import (
 	"context"
 	"fmt"
+	"github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -43,7 +44,8 @@ type RayJobReconciler struct {
 }
 
 // NewRayJobReconciler returns a new reconcile.Reconciler
-func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, dashboardClientFunc func() utils.RayDashboardClientInterface) *RayJobReconciler {
+func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, config v1alpha1.Configuration) *RayJobReconciler {
+	var dashboardClientFunc = utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)
 	return &RayJobReconciler{
 		Client:              mgr.GetClient(),
 		Scheme:              mgr.GetScheme(),

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -44,17 +44,8 @@ type RayJobReconciler struct {
 }
 
 // NewRayJobReconciler returns a new reconcile.Reconciler
-func NewRayJobReconcilerFromConfig(ctx context.Context, mgr manager.Manager, config configapi.Configuration) *RayJobReconciler {
-	var dashboardClientFunc = utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)
-	return &RayJobReconciler{
-		Client:              mgr.GetClient(),
-		Scheme:              mgr.GetScheme(),
-		Recorder:            mgr.GetEventRecorderFor("rayjob-controller"),
-		dashboardClientFunc: dashboardClientFunc,
-	}
-}
-
-func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, dashboardClientFunc func() utils.RayDashboardClientInterface) *RayJobReconciler {
+func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, provider configapi.ClientProvider) *RayJobReconciler {
+	var dashboardClientFunc = provider.GetDashboardClient(mgr)
 	return &RayJobReconciler{
 		Client:              mgr.GetClient(),
 		Scheme:              mgr.GetScheme(),

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	configapi "github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
@@ -44,7 +43,7 @@ type RayJobReconciler struct {
 }
 
 // NewRayJobReconciler returns a new reconcile.Reconciler
-func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, provider configapi.ClientProvider) *RayJobReconciler {
+func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, provider utils.ClientProvider) *RayJobReconciler {
 	var dashboardClientFunc = provider.GetDashboardClient(mgr)
 	return &RayJobReconciler{
 		Client:              mgr.GetClient(),

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	configv1 "github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
+	configapi "github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
@@ -44,7 +44,7 @@ type RayJobReconciler struct {
 }
 
 // NewRayJobReconciler returns a new reconcile.Reconciler
-func NewRayJobReconcilerFromConfig(ctx context.Context, mgr manager.Manager, config configv1.Configuration) *RayJobReconciler {
+func NewRayJobReconcilerFromConfig(ctx context.Context, mgr manager.Manager, config configapi.Configuration) *RayJobReconciler {
 	var dashboardClientFunc = utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)
 	return &RayJobReconciler{
 		Client:              mgr.GetClient(),

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -36,7 +36,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configapi "github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
@@ -61,7 +60,7 @@ type RayServiceReconciler struct {
 }
 
 // NewRayServiceReconciler returns a new reconcile.Reconciler
-func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, provider configapi.ClientProvider) *RayServiceReconciler {
+func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, provider utils.ClientProvider) *RayServiceReconciler {
 	var dashboardClientFunc = provider.GetDashboardClient(mgr)
 	var httpProxyClientFunc = provider.GetHttpProxyClient(mgr)
 	return &RayServiceReconciler{

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -3,7 +3,6 @@ package ray
 import (
 	"context"
 	"fmt"
-	"github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
 	"os"
 	"reflect"
 	"strconv"
@@ -37,6 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configv1 "github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
@@ -61,7 +61,7 @@ type RayServiceReconciler struct {
 }
 
 // NewRayServiceReconciler returns a new reconcile.Reconciler
-func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, config v1alpha1.Configuration) *RayServiceReconciler {
+func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, config configv1.Configuration) *RayServiceReconciler {
 	var dashboardClientFunc = utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)
 	var httpProxyClientFunc = utils.GetRayHttpProxyClientFunc(mgr, config.UseKubernetesProxy)
 	return &RayServiceReconciler{

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -3,6 +3,7 @@ package ray
 import (
 	"context"
 	"fmt"
+	"github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
 	"os"
 	"reflect"
 	"strconv"
@@ -60,7 +61,9 @@ type RayServiceReconciler struct {
 }
 
 // NewRayServiceReconciler returns a new reconcile.Reconciler
-func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, dashboardClientFunc func() utils.RayDashboardClientInterface, httpProxyClientFunc func() utils.RayHttpProxyClientInterface) *RayServiceReconciler {
+func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, config v1alpha1.Configuration) *RayServiceReconciler {
+	var dashboardClientFunc = utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)
+	var httpProxyClientFunc = utils.GetRayHttpProxyClientFunc(mgr, config.UseKubernetesProxy)
 	return &RayServiceReconciler{
 		Client:                       mgr.GetClient(),
 		Scheme:                       mgr.GetScheme(),

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -36,7 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configv1 "github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
+	configapi "github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
@@ -61,7 +61,7 @@ type RayServiceReconciler struct {
 }
 
 // NewRayServiceReconciler returns a new reconcile.Reconciler
-func NewRayServiceReconcilerFromConfig(ctx context.Context, mgr manager.Manager, config configv1.Configuration) *RayServiceReconciler {
+func NewRayServiceReconcilerFromConfig(ctx context.Context, mgr manager.Manager, config configapi.Configuration) *RayServiceReconciler {
 	var dashboardClientFunc = utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)
 	var httpProxyClientFunc = utils.GetRayHttpProxyClientFunc(mgr, config.UseKubernetesProxy)
 	return &RayServiceReconciler{

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -61,8 +61,8 @@ type RayServiceReconciler struct {
 
 // NewRayServiceReconciler returns a new reconcile.Reconciler
 func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, provider utils.ClientProvider) *RayServiceReconciler {
-	var dashboardClientFunc = provider.GetDashboardClient(mgr)
-	var httpProxyClientFunc = provider.GetHttpProxyClient(mgr)
+	dashboardClientFunc := provider.GetDashboardClient(mgr)
+	httpProxyClientFunc := provider.GetHttpProxyClient(mgr)
 	return &RayServiceReconciler{
 		Client:                       mgr.GetClient(),
 		Scheme:                       mgr.GetScheme(),

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -61,9 +61,22 @@ type RayServiceReconciler struct {
 }
 
 // NewRayServiceReconciler returns a new reconcile.Reconciler
-func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, config configv1.Configuration) *RayServiceReconciler {
+func NewRayServiceReconcilerFromConfig(ctx context.Context, mgr manager.Manager, config configv1.Configuration) *RayServiceReconciler {
 	var dashboardClientFunc = utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)
 	var httpProxyClientFunc = utils.GetRayHttpProxyClientFunc(mgr, config.UseKubernetesProxy)
+	return &RayServiceReconciler{
+		Client:                       mgr.GetClient(),
+		Scheme:                       mgr.GetScheme(),
+		Recorder:                     mgr.GetEventRecorderFor("rayservice-controller"),
+		ServeConfigs:                 cmap.New[string](),
+		RayClusterDeletionTimestamps: cmap.New[time.Time](),
+
+		dashboardClientFunc: dashboardClientFunc,
+		httpProxyClientFunc: httpProxyClientFunc,
+	}
+}
+
+func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, dashboardClientFunc func() utils.RayDashboardClientInterface, httpProxyClientFunc func() utils.RayHttpProxyClientInterface) *RayServiceReconciler {
 	return &RayServiceReconciler{
 		Client:                       mgr.GetClient(),
 		Scheme:                       mgr.GetScheme(),

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -61,22 +61,9 @@ type RayServiceReconciler struct {
 }
 
 // NewRayServiceReconciler returns a new reconcile.Reconciler
-func NewRayServiceReconcilerFromConfig(ctx context.Context, mgr manager.Manager, config configapi.Configuration) *RayServiceReconciler {
-	var dashboardClientFunc = utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)
-	var httpProxyClientFunc = utils.GetRayHttpProxyClientFunc(mgr, config.UseKubernetesProxy)
-	return &RayServiceReconciler{
-		Client:                       mgr.GetClient(),
-		Scheme:                       mgr.GetScheme(),
-		Recorder:                     mgr.GetEventRecorderFor("rayservice-controller"),
-		ServeConfigs:                 cmap.New[string](),
-		RayClusterDeletionTimestamps: cmap.New[time.Time](),
-
-		dashboardClientFunc: dashboardClientFunc,
-		httpProxyClientFunc: httpProxyClientFunc,
-	}
-}
-
-func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, dashboardClientFunc func() utils.RayDashboardClientInterface, httpProxyClientFunc func() utils.RayHttpProxyClientInterface) *RayServiceReconciler {
+func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, provider configapi.ClientProvider) *RayServiceReconciler {
+	var dashboardClientFunc = provider.GetDashboardClient(mgr)
+	var httpProxyClientFunc = provider.GetHttpProxyClient(mgr)
 	return &RayServiceReconciler{
 		Client:                       mgr.GetClient(),
 		Scheme:                       mgr.GetScheme(),

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -18,6 +18,7 @@ package ray
 import (
 	"os"
 	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"testing"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -50,6 +51,20 @@ var (
 	fakeRayDashboardClient *utils.FakeRayDashboardClient
 	fakeRayHttpProxyClient *utils.FakeRayHttpProxyClient
 )
+
+type TestClientProvider struct{}
+
+func (testProvider TestClientProvider) GetDashboardClient(mgr manager.Manager) func() utils.RayDashboardClientInterface {
+	return func() utils.RayDashboardClientInterface {
+		return fakeRayDashboardClient
+	}
+}
+
+func (testProvider TestClientProvider) GetHttpProxyClient(mgr manager.Manager) func() utils.RayHttpProxyClientInterface {
+	return func() utils.RayHttpProxyClientInterface {
+		return fakeRayHttpProxyClient
+	}
+}
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -107,16 +122,11 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	err = NewReconciler(ctx, mgr, options).SetupWithManager(mgr, 1)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayCluster controller")
 
-	err = NewRayServiceReconciler(ctx, mgr, func() utils.RayDashboardClientInterface {
-		return fakeRayDashboardClient
-	}, func() utils.RayHttpProxyClientInterface {
-		return fakeRayHttpProxyClient
-	}).SetupWithManager(mgr)
+	testClientProvider := TestClientProvider{}
+	err = NewRayServiceReconciler(ctx, mgr, testClientProvider).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayService controller")
 
-	err = NewRayJobReconciler(ctx, mgr, func() utils.RayDashboardClientInterface {
-		return fakeRayDashboardClient
-	}).SetupWithManager(mgr)
+	err = NewRayJobReconciler(ctx, mgr, testClientProvider).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayJob controller")
 
 	go func() {

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -18,8 +18,9 @@ package ray
 import (
 	"os"
 	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -13,6 +13,8 @@ import (
 	"time"
 	"unicode"
 
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 
@@ -560,4 +562,9 @@ func EnvVarByName(envName string, envVars []corev1.EnvVar) (corev1.EnvVar, bool)
 		}
 	}
 	return corev1.EnvVar{}, false
+}
+
+type ClientProvider interface {
+	GetDashboardClient(mgr manager.Manager) func() RayDashboardClientInterface
+	GetHttpProxyClient(mgr manager.Manager) func() RayHttpProxyClientInterface
 }

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -213,9 +213,9 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 	exitOnError(ray.NewReconciler(ctx, mgr, rayClusterOptions).SetupWithManager(mgr, config.ReconcileConcurrency),
 		"unable to create controller", "controller", "RayCluster")
-	exitOnError(ray.NewRayServiceReconciler(ctx, mgr, config).SetupWithManager(mgr),
+	exitOnError(ray.NewRayServiceReconcilerFromConfig(ctx, mgr, config).SetupWithManager(mgr),
 		"unable to create controller", "controller", "RayService")
-	exitOnError(ray.NewRayJobReconciler(ctx, mgr, config).SetupWithManager(mgr),
+	exitOnError(ray.NewRayJobReconcilerFromConfig(ctx, mgr, config).SetupWithManager(mgr),
 		"unable to create controller", "controller", "RayJob")
 
 	if os.Getenv("ENABLE_WEBHOOKS") == "true" {

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -213,9 +213,9 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 	exitOnError(ray.NewReconciler(ctx, mgr, rayClusterOptions).SetupWithManager(mgr, config.ReconcileConcurrency),
 		"unable to create controller", "controller", "RayCluster")
-	exitOnError(ray.NewRayServiceReconcilerFromConfig(ctx, mgr, config).SetupWithManager(mgr),
+	exitOnError(ray.NewRayServiceReconciler(ctx, mgr, config).SetupWithManager(mgr),
 		"unable to create controller", "controller", "RayService")
-	exitOnError(ray.NewRayJobReconcilerFromConfig(ctx, mgr, config).SetupWithManager(mgr),
+	exitOnError(ray.NewRayJobReconciler(ctx, mgr, config).SetupWithManager(mgr),
 		"unable to create controller", "controller", "RayJob")
 
 	if os.Getenv("ENABLE_WEBHOOKS") == "true" {

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -213,9 +213,9 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 	exitOnError(ray.NewReconciler(ctx, mgr, rayClusterOptions).SetupWithManager(mgr, config.ReconcileConcurrency),
 		"unable to create controller", "controller", "RayCluster")
-	exitOnError(ray.NewRayServiceReconciler(ctx, mgr, utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy), utils.GetRayHttpProxyClientFunc(mgr, config.UseKubernetesProxy)).SetupWithManager(mgr),
+	exitOnError(ray.NewRayServiceReconciler(ctx, mgr, config).SetupWithManager(mgr),
 		"unable to create controller", "controller", "RayService")
-	exitOnError(ray.NewRayJobReconciler(ctx, mgr, utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)).SetupWithManager(mgr),
+	exitOnError(ray.NewRayJobReconciler(ctx, mgr, config).SetupWithManager(mgr),
 		"unable to create controller", "controller", "RayJob")
 
 	if os.Getenv("ENABLE_WEBHOOKS") == "true" {


### PR DESCRIPTION
## Why are these changes needed?
 - Based on @kevin85421's suggestion at https://github.com/ray-project/kuberay/pull/1980#discussion_r1550243563
 - Instead of passing function(s) to `NewRayServiceReconciler` and `NewRayJobReconciler`, initialing them by the `v1alpha1.Configuration` configuration

## Related issue number
 - https://github.com/ray-project/kuberay/pull/1980

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
