### PR TITLE
feat: set appProtocol based on target service

### DIFF
--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -44,8 +44,8 @@ func BuildIngressForHeadService(ctx context.Context, cluster rayv1.RayCluster) (
 	pathType := networkingv1.PathTypeExact
 	servicePorts := getServicePorts(cluster)
 	dashboardPort := int32(utils.DefaultDashboardPort)
-	if port, ok := servicePorts["dashboard"]; ok {
-		dashboardPort = port
+	if portInfo, ok := servicePorts["dashboard"]; ok {
+		dashboardPort = portInfo.PortNumber
 	}
 
 	headSvcName, err := utils.GenerateHeadServiceName(utils.RayClusterCRD, cluster.Spec, cluster.Name)

--- a/ray-operator/controllers/ray/common/route.go
+++ b/ray-operator/controllers/ray/common/route.go
@@ -28,8 +28,8 @@ func BuildRouteForHeadService(cluster rayv1.RayCluster) (*routev1.Route, error) 
 
 	servicePorts := getServicePorts(cluster)
 	dashboardPort := utils.DefaultDashboardPort
-	if port, ok := servicePorts["dashboard"]; ok {
-		dashboardPort = int(port)
+	if portInfo, ok := servicePorts[utils.DashboardPortName]; ok {
+		dashboardPort = int(portInfo.PortNumber)
 	}
 
 	weight := int32(100)

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -191,7 +191,7 @@ func TestBuildServiceForHeadPodWithAnnotations(t *testing.T) {
 }
 
 func TestGetPortsFromCluster(t *testing.T) {
-	svcPorts, err := getPortsFromCluster(*instanceWithWrongSvc)
+	servicePorts, err := getPortsFromCluster(*instanceWithWrongSvc)
 	assert.Nil(t, err)
 
 	// getPortsFromCluster creates service ports based on the container ports.
@@ -199,11 +199,11 @@ func TestGetPortsFromCluster(t *testing.T) {
 	// is not defined. To compare created service ports with container ports,
 	// all generated service port names need to be reverted to empty strings.
 	svcNames := map[int32]string{}
-	for name, port := range svcPorts {
-		if name == (fmt.Sprint(port) + "-port") {
-			name = ""
+	for svc, portInfo := range servicePorts {
+		if svc == (fmt.Sprint(portInfo.PortNumber) + "-port") {
+			svc = ""
 		}
-		svcNames[port] = name
+		svcNames[portInfo.PortNumber] = svc
 	}
 
 	cPorts := instanceWithWrongSvc.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Ports
@@ -222,10 +222,10 @@ func TestGetServicePortsWithMetricsPort(t *testing.T) {
 
 	// Test case 1: No ports are specified by the user.
 	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{}
-	ports := getServicePorts(*cluster)
+	servicePorts := getServicePorts(*cluster)
 	// Verify that getServicePorts sets the default metrics port when the user doesn't specify any ports.
-	if ports[utils.MetricsPortName] != int32(utils.DefaultMetricsPort) {
-		t.Fatalf("Expected `%v` but got `%v`", int32(utils.DefaultMetricsPort), ports[utils.MetricsPortName])
+	if servicePorts[utils.MetricsPortName].PortNumber != int32(utils.DefaultMetricsPort) {
+		t.Fatalf("Expected `%v` but got `%v`", int32(utils.DefaultMetricsPort), servicePorts[utils.MetricsPortName].PortNumber)
 	}
 
 	// Test case 2: Only a random port is specified by the user.
@@ -235,10 +235,10 @@ func TestGetServicePortsWithMetricsPort(t *testing.T) {
 			ContainerPort: 1234,
 		},
 	}
-	ports = getServicePorts(*cluster)
+	servicePorts = getServicePorts(*cluster)
 	// Verify that getServicePorts sets the default metrics port when the user doesn't specify the metrics port but specifies other ports.
-	if ports[utils.MetricsPortName] != int32(utils.DefaultMetricsPort) {
-		t.Fatalf("Expected `%v` but got `%v`", int32(utils.DefaultMetricsPort), ports[utils.MetricsPortName])
+	if servicePorts[utils.MetricsPortName].PortNumber != int32(utils.DefaultMetricsPort) {
+		t.Fatalf("Expected `%v` but got `%v`", int32(utils.DefaultMetricsPort), servicePorts[utils.MetricsPortName].PortNumber)
 	}
 
 	// Test case 3: A custom metrics port is specified by the user.
@@ -248,10 +248,10 @@ func TestGetServicePortsWithMetricsPort(t *testing.T) {
 		ContainerPort: customMetricsPort,
 	}
 	cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = append(cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports, metricsPort)
-	ports = getServicePorts(*cluster)
+	servicePorts = getServicePorts(*cluster)
 	// Verify that getServicePorts uses the user's custom metrics port when the user specifies the metrics port.
-	if ports[utils.MetricsPortName] != customMetricsPort {
-		t.Fatalf("Expected `%v` but got `%v`", customMetricsPort, ports[utils.MetricsPortName])
+	if servicePorts[utils.MetricsPortName].PortNumber != customMetricsPort {
+		t.Fatalf("Expected `%v` but got `%v`", customMetricsPort, servicePorts[utils.MetricsPortName].PortNumber)
 	}
 }
 

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -78,6 +78,9 @@ const (
 	// The default AppProtocol for Kubernetes service
 	DefaultServiceAppProtocol = "tcp"
 
+	HTTPProtocol = "http"
+	GRPCProtocol = "grpc"
+
 	// The default application name
 	ApplicationName = "kuberay"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/kuberay/pull/668  always set app protocol to `tcp`. This change dynamically adjusts the port protocol based on the target service.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/kuberay/issues/1946


## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
