### PR TITLE
[Chore][Samples] Rename ray-cluster.mini.yaml and add workerGroupSpecs

### DIFF
--- a/ray-operator/config/samples/ray-cluster.sample.yaml
+++ b/ray-operator/config/samples/ray-cluster.sample.yaml
@@ -5,19 +5,12 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
-    # A unique identifier for the head node and workers of this cluster.
-  name: raycluster-mini
+  name: raycluster-sample
 spec:
   rayVersion: '2.9.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
-    # The `rayStartParams` are used to configure the `ray start` command.
-    # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
-    # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
-    rayStartParams:
-      dashboard-host: '0.0.0.0'
+    rayStartParams: {}
     #pod template
     template:
       spec:
@@ -38,3 +31,24 @@ spec:
             name: dashboard
           - containerPort: 10001
             name: client
+  workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 1
+      maxReplicas: 5
+      # logical group name, for this called small-group, also can be functional
+      groupName: small-group
+      rayStartParams: {}
+      #pod template
+      template:
+        spec:
+          containers:
+            - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+              image: rayproject/ray:2.9.0
+              resources:
+                limits:
+                  cpu: 1
+                  memory: 1Gi
+                requests:
+                  cpu: 500m
+                  memory: 1Gi


### PR DESCRIPTION
## Why are these changes needed?

There are `ray-job.sample.yaml` and `ray-service.sample.yaml` but no `ray-cluster.sample.yaml`. Also it seems that `ray-cluster.mini.yaml` is not useful because it does not specify `workerGroupSpecs`. Therefore, this PR:

1. Rename `ray-cluster.mini.yaml` to `ray-cluster.sample.yaml`.
2. Add `workerGroupSpecs` section in that file.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
