### PR TITLE
[Refactor] Remove `cleanupInvalidVolumeMounts`

### DIFF
--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -769,32 +769,6 @@ func splitAndSort(s string) []string {
 	return result
 }
 
-func TestCleanupInvalidVolumeMounts(t *testing.T) {
-	ctx := context.Background()
-	cluster := instance.DeepCopy()
-
-	// Test head pod
-	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
-	podTemplateSpec := DefaultHeadPodTemplate(ctx, *cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
-	pod := BuildPod(ctx, podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", nil, utils.GetCRDType(""), "")
-
-	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, []corev1.VolumeMount{
-		{
-			Name:      "mock-name1",
-			MountPath: "/mock-path1",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "mock-name2",
-			MountPath: "/mock-path2",
-			ReadOnly:  true,
-		},
-	}...)
-	assert.Equal(t, len(pod.Spec.Containers[0].VolumeMounts), 3)
-	cleanupInvalidVolumeMounts(&pod.Spec.Containers[0], &pod)
-	assert.Equal(t, len(pod.Spec.Containers[0].VolumeMounts), 1)
-}
-
 func TestDefaultWorkerPodTemplateWithName(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`cleanupInvalidVolumeMounts` verifies and modifies the Pod spec directly which may introduce some unknown unknowns for users. KubeRay should only verify the RayCluster, RayJob, and RayCluster specs. For other resource specs, such as Kubernetes Pods, Jobs, and Services, we should not verify them; instead, we should only propagate the errors.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(

* Step 1: Create a RayCluster with https://gist.github.com/kevin85421/22c0f1792fe475bb80c3ec7a3180915a. The Ray container in the head Pod mounts a non-existent volume.
  ```yaml
  volumeMounts:
    - mountPath: /home/ray/samples
      name: ray-example-configmap
    - mountPath: /home/ray/
      name: not-exist
  ```
* Step 2: We can find the error by running `kubectl describe raycluster xxxx`.
  <img width="1440" alt="Screenshot 2024-04-25 at 3 43 27 PM" src="https://github.com/ray-project/kuberay/assets/20109646/e3c5d620-3eef-49aa-b808-c75892afeec1">