### PR TITLE
[Perf] Improve perf-test YAMLs and README

### DIFF
--- a/benchmark/perf-tests/100-raycluster/raycluster.yaml
+++ b/benchmark/perf-tests/100-raycluster/raycluster.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   rayVersion: '2.9.3'
   headGroupSpec:
-    serviceType: ClusterIP
     rayStartParams:
       dashboard-host: '0.0.0.0'
     template:
@@ -20,10 +19,6 @@ spec:
             name: dashboard
           - containerPort: 10001
             name: client
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           volumeMounts:
             - mountPath: /tmp/ray
               name: ray-logs
@@ -47,10 +42,6 @@ spec:
         containers:
         - name: ray-worker
           image: rayproject/ray:2.9.3
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           volumeMounts:
             - mountPath: /tmp/ray
               name: ray-logs

--- a/benchmark/perf-tests/100-rayjob/rayjob.yaml
+++ b/benchmark/perf-tests/100-rayjob/rayjob.yaml
@@ -38,10 +38,6 @@ spec:
             containers:
               - name: ray-worker
                 image: rayproject/ray:2.9.3
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: [ "/bin/sh","-c","ray stop" ]
                 resources:
                   limits:
                     cpu: "1"

--- a/benchmark/perf-tests/README.md
+++ b/benchmark/perf-tests/README.md
@@ -6,15 +6,17 @@ clusterloader2 is a Kubernetes load testing tool by [SIG Scalability](https://gi
 ## Running clusterloader2 tests
 
 First, install the perf-tests repository and compile the clusterloader2 binary
-```
+
+```sh
 git clone git@github.com:kubernetes/perf-tests.git
 cd perf-tests/clusterloader2
 go build -o clusterloader2 ./cmd
 ```
 
-Run the following command to run clusterloader2 against one of the test folders. In this example we'll run the test configured in the [100-raycluster](./100-raycluster/) folder.
-```
-clusterloader2 --provider=<provider-name> --kubeconfig=<path to kubeconfig> --testconfig=100-raycluster/config.yaml
+Run the following command to run clusterloader2 against one of the test folders. In this example we'll run the test configured in the [100-rayjob](./100-rayjob/) folder.
+
+```sh
+clusterloader2 --provider=<provider-name> --kubeconfig=<path to kubeconfig> --testconfig=100-rayjob/config.yaml
 ```
 
 ## Tests & Results
@@ -24,6 +26,7 @@ for previously executed runs of the tests.
 
 The current lists of tests are:
 * [100 RayCluster test](./100-raycluster/)
+* [100 RayJob test](./100-rayjob/)
 
 
 ## Run a performance test with Kind
@@ -31,16 +34,18 @@ The current lists of tests are:
 You can test clusterloader2 configs using Kind.
 
 First create a kind cluster:
-```
+```sh
 kind create cluster --image=kindest/node:v1.27.3
 ```
 
-Install kuberay;
-```
+Install KubeRay;
+```sh
 helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0
 ```
 
 Run a clusterloader2 test:
+```sh
+clusterloader2 --provider kind --kubeconfig ~/.kube/config --testconfig ./100-rayjob/config.yaml
 ```
-clusterloader2 --provider kind --kubeconfig ~/.kube/config --testconfig ./100-raycluster/config.yaml
-```
+
+Note: If you want to generate a number of RayJob custom resources other than 100, you need to make the following changes: (1) modify `replicasPerNamespace` in the "Creating RayJobs" step of the config.yaml file, and (2) adjust `expect_succeeded` in the `wait-for-rayjobs.sh` file.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

TODO:
* [Prometheus metrics](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2#prometheus-metrics)
* If RayJob custom resources cannot complete indefinitely due to the lack of gang scheduling, it appears that the `clusterloader` process does not time out even after 20 minutes.

## Related issue number

#2102 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

I modified the script a bit to create 10 RayJob CRs on my local Kind cluster.

<img width="1312" alt="Screenshot 2024-04-30 at 10 02 33 PM" src="https://github.com/ray-project/kuberay/assets/20109646/4cfe6216-6624-4f80-8aa4-ef13acf225d5">
<img width="1339" alt="Screenshot 2024-04-30 at 10 04 24 PM" src="https://github.com/ray-project/kuberay/assets/20109646/74ef332a-4f30-405a-9f4e-dc8278640a4b">

