### PR TITLE
[Test] Move StateTransitionTimes envtest to a better place

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -175,6 +175,13 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				getClusterState(ctx, namespace, rayCluster.Name),
 				time.Second*3, time.Millisecond*500).Should(Equal(rayv1.Ready))
+			// Check that the StateTransitionTimes are set.
+			Eventually(
+				func() *metav1.Time {
+					status := getClusterStatus(ctx, namespace, rayCluster.Name)()
+					return status.StateTransitionTimes[rayv1.Ready]
+				},
+				time.Second*3, time.Millisecond*500).Should(Not(BeNil()))
 		})
 
 		// The following tests focus on checking whether KubeRay creates the correct number of Pods.
@@ -469,15 +476,6 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				getClusterState(ctx, namespace, rayCluster.Name),
 				time.Second*3, time.Millisecond*500).Should(Equal(rayv1.Ready))
-		})
-
-		It("RayCluster's .status.stateTransitionTimes should include a time for ready state", func() {
-			Eventually(
-				func() *metav1.Time {
-					status := getClusterStatus(ctx, namespace, rayCluster.Name)()
-					return status.StateTransitionTimes[rayv1.Ready]
-				},
-				time.Second*3, time.Millisecond*500).Should(Not(BeNil()))
 		})
 	})
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In PR #2053, the envtest was added to the "Suspend RayCluster", which is specific to Kueue. This PR moves the envtest to the main workflow of RayCluster.
## Related issue number

#2053 

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
