### PR TITLE
Add HeadInfo.Ready status for RayCluster

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -7100,10 +7100,14 @@ spec:
                 properties:
                   podIP:
                     type: string
+                  ready:
+                    type: boolean
                   serviceIP:
                     type: string
                   serviceName:
                     type: string
+                required:
+                - ready
                 type: object
               lastUpdateTime:
                 format: date-time

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -10414,10 +10414,14 @@ spec:
                     properties:
                       podIP:
                         type: string
+                      ready:
+                        type: boolean
                       serviceIP:
                         type: string
                       serviceName:
                         type: string
+                    required:
+                    - ready
                     type: object
                   lastUpdateTime:
                     format: date-time

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -7302,10 +7302,14 @@ spec:
                         properties:
                           podIP:
                             type: string
+                          ready:
+                            type: boolean
                           serviceIP:
                             type: string
                           serviceName:
                             type: string
+                        required:
+                        - ready
                         type: object
                       lastUpdateTime:
                         format: date-time
@@ -7408,10 +7412,14 @@ spec:
                         properties:
                           podIP:
                             type: string
+                          ready:
+                            type: boolean
                           serviceIP:
                             type: string
                           serviceName:
                             type: string
+                        required:
+                        - ready
                         type: object
                       lastUpdateTime:
                         format: date-time

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -158,6 +158,7 @@ type HeadInfo struct {
 	PodIP       string `json:"podIP,omitempty"`
 	ServiceIP   string `json:"serviceIP,omitempty"`
 	ServiceName string `json:"serviceName,omitempty"`
+	Ready       bool   `json:"ready"`
 }
 
 // RayNodeType  the type of a ray node: head/worker

--- a/ray-operator/apis/ray/v1/rayservice_types_test.go
+++ b/ray-operator/apis/ray/v1/rayservice_types_test.go
@@ -268,7 +268,9 @@ var expected = `{
             "desiredMemory": "0",
             "desiredGPU": "0",
             "desiredTPU": "0",
-            "head":{}
+            "head":{
+               "ready":false
+            }
          }
       },
       "pendingServiceStatus":{
@@ -277,7 +279,9 @@ var expected = `{
             "desiredMemory": "0",
             "desiredGPU": "0",
             "desiredTPU": "0",
-            "head":{}
+            "head":{
+               "ready":false
+            }
          }
       }
    }

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -7100,10 +7100,14 @@ spec:
                 properties:
                   podIP:
                     type: string
+                  ready:
+                    type: boolean
                   serviceIP:
                     type: string
                   serviceName:
                     type: string
+                required:
+                - ready
                 type: object
               lastUpdateTime:
                 format: date-time

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -10414,10 +10414,14 @@ spec:
                     properties:
                       podIP:
                         type: string
+                      ready:
+                        type: boolean
                       serviceIP:
                         type: string
                       serviceName:
                         type: string
+                    required:
+                    - ready
                     type: object
                   lastUpdateTime:
                     format: date-time

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -7302,10 +7302,14 @@ spec:
                         properties:
                           podIP:
                             type: string
+                          ready:
+                            type: boolean
                           serviceIP:
                             type: string
                           serviceName:
                             type: string
+                        required:
+                        - ready
                         type: object
                       lastUpdateTime:
                         format: date-time
@@ -7408,10 +7412,14 @@ spec:
                         properties:
                           podIP:
                             type: string
+                          ready:
+                            type: boolean
                           serviceIP:
                             type: string
                           serviceName:
                             type: string
+                        required:
+                        - ready
                         type: object
                       lastUpdateTime:
                         format: date-time

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1209,7 +1209,7 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	newInstance.Status.DesiredGPU = sumGPUs(totalResources)
 	newInstance.Status.DesiredTPU = totalResources[corev1.ResourceName("google.com/tpu")]
 
-	if utils.IsRunningAndReady(headPod) && utils.CheckAllPodsRunning(ctx, workerPods) {
+	if utils.CheckAllPodsRunning(ctx, corev1.PodList{Items: append(headPods.Items, workerPods.Items...)}) {
 		newInstance.Status.State = rayv1.Ready
 	}
 

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -292,12 +292,9 @@ func CalculateMaxReplicas(cluster *rayv1.RayCluster) int32 {
 
 // CalculateAvailableReplicas calculates available worker replicas at the cluster level
 // A worker is available if its Pod is running
-func CalculateAvailableReplicas(pods corev1.PodList) int32 {
+func CalculateAvailableReplicas(workerPods corev1.PodList) int32 {
 	count := int32(0)
-	for _, pod := range pods.Items {
-		if val, ok := pod.Labels["ray.io/node-type"]; !ok || val != string(rayv1.WorkerNode) {
-			continue
-		}
+	for _, pod := range workerPods.Items {
 		if pod.Status.Phase == corev1.PodRunning {
 			count++
 		}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -70,7 +70,7 @@ func IsCreated(pod *corev1.Pod) bool {
 
 // IsRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.
 func IsRunningAndReady(pod *corev1.Pod) bool {
-	if pod == nil || pod.Status.Phase != corev1.PodRunning {
+	if pod.Status.Phase != corev1.PodRunning {
 		return false
 	}
 	for _, cond := range pod.Status.Conditions {

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -70,7 +70,7 @@ func IsCreated(pod *corev1.Pod) bool {
 
 // IsRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.
 func IsRunningAndReady(pod *corev1.Pod) bool {
-	if pod.Status.Phase != corev1.PodRunning {
+	if pod == nil || pod.Status.Phase != corev1.PodRunning {
 		return false
 	}
 	for _, cond := range pod.Status.Conditions {

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -256,17 +256,6 @@ func TestCalculateAvailableReplicas(t *testing.T) {
 		Items: []corev1.Pod{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "pod1",
-					Labels: map[string]string{
-						"ray.io/node-type": string(rayv1.HeadNode),
-					},
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod2",
 					Labels: map[string]string{
 						"ray.io/node-type": string(rayv1.WorkerNode),

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/headinfo.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/headinfo.go
@@ -8,6 +8,7 @@ type HeadInfoApplyConfiguration struct {
 	PodIP       *string `json:"podIP,omitempty"`
 	ServiceIP   *string `json:"serviceIP,omitempty"`
 	ServiceName *string `json:"serviceName,omitempty"`
+	Ready       *bool   `json:"ready,omitempty"`
 }
 
 // HeadInfoApplyConfiguration constructs an declarative configuration of the HeadInfo type for use with
@@ -37,5 +38,13 @@ func (b *HeadInfoApplyConfiguration) WithServiceIP(value string) *HeadInfoApplyC
 // If called multiple times, the ServiceName field is set to the value of the last call.
 func (b *HeadInfoApplyConfiguration) WithServiceName(value string) *HeadInfoApplyConfiguration {
 	b.ServiceName = &value
+	return b
+}
+
+// WithReady sets the Ready field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Ready field is set to the value of the last call.
+func (b *HeadInfoApplyConfiguration) WithReady(value bool) *HeadInfoApplyConfiguration {
+	b.Ready = &value
 	return b
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As explained here: https://github.com/ray-project/kuberay/pull/1930#pullrequestreview-1978124073, we need to add a field in [HeadInfo](https://github.com/ray-project/kuberay/blob/d3b7d96ff56d7a45c9afc5eb1c78cd7ae8c8bb1a/ray-operator/apis/ray/v1/raycluster_types.go#L147) to indicate whether the head Pod is ready or not.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

```shell
# 1. Create a RayCluster
kubectl apply -f /home/ubuntu/kuberay/ray-operator/config/samples/ray-cluster.complete.yaml

# 2. When head Pod is not ready.
kubectl get pod
# raycluster-complete-head-t24sk                 0/1     Running    0          2s
kubectl describe raycluster
# Head:
# Pod IP:             10.244.0.8
# Ready:              false
# Service IP:         10.96.68.134
# Service Name:       raycluster-complete-head-svc

# 3. When head Pod is ready.
kubectl get pod
# raycluster-complete-head-t24sk                 1/1     Running   0          69s
kubectl describe raycluster
# Head:
# Pod IP:             10.244.0.8
# Ready:              true
# Service IP:         10.96.68.134
# Service Name:       raycluster-complete-head-svc
```

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
