### PR TITLE
[Feat][RayCluster] Make the Head service headless

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -72,7 +72,7 @@ Flags:
       --environment string               environment of the cluster (valid values: DEV, TESTING, STAGING, PRODUCTION) (default "DEV")
       --head-compute-template string     compute template name for ray head
       --head-image string                ray head image
-      --head-service-type string         ray head service type (ClusterIP, NodePort, LoadBalancer) (default "ClusterIP")
+      --head-service-type string         ray head service type (ClusterIP, NodePort, LoadBalancer) (default "ClusterIP", which creates a headless ClusterIP service)
       --name string                      name of the cluster
   -n, --namespace string                 kubernetes namespace where the cluster will be
       --user string                      SSO username of ray cluster creator

--- a/cli/pkg/cmd/cluster/create.go
+++ b/cli/pkg/cmd/cluster/create.go
@@ -49,7 +49,7 @@ func newCmdCreate() *cobra.Command {
 	cmd.Flags().StringVar(&opts.user, "user", "", "SSO username of ray cluster creator")
 	cmd.Flags().StringVar(&opts.headComputeTemplate, "head-compute-template", "", "compute template name for ray head")
 	cmd.Flags().StringVar(&opts.headImage, "head-image", "", "ray head image")
-	cmd.Flags().StringVar(&opts.headServiceType, "head-service-type", "ClusterIP", "ray head service type (ClusterIP, NodePort, LoadBalancer)")
+	cmd.Flags().StringVar(&opts.headServiceType, "head-service-type", "ClusterIP", "ray head service type (ClusterIP, NodePort, LoadBalancer). Default value is \"ClusterIP\", which creates a headless ClusterIP service.")
 	cmd.Flags().StringVar(&opts.workerGroupName, "worker-group-name", "", "first worker group name")
 	cmd.Flags().StringVar(&opts.workerComputeTemplate, "worker-compute-template", "", "compute template name of worker in the first worker group")
 	cmd.Flags().StringVar(&opts.workerImage, "worker-image", "", "image of worker in the first worker group")

--- a/clients/python-client/python_client/utils/kuberay_cluster_builder.py
+++ b/clients/python-client/python_client/utils/kuberay_cluster_builder.py
@@ -95,7 +95,7 @@ class ClusterBuilder(IClusterBuilder):
 
         Parameters:
         - ray_image (str): Docker image for the head node. Default value is "rayproject/ray:2.9.0".
-        - service_type (str): Service type of the head node. Default value is "ClusterIP".
+        - service_type (str): Service type of the head node. Default value is "ClusterIP", which creates a headless ClusterIP service.
         - cpu_requests (str): CPU requests for the head node. Default value is "2".
         - memory_requests (str): Memory requests for the head node. Default value is "3G".
         - cpu_limits (str): CPU limits for the head node. Default value is "2".

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -103,9 +103,9 @@ env:
 # Warning: we highly recommend setting to true and let kuberay handle for you.
 # - name: ENABLE_INIT_CONTAINER_INJECTION
 #   value: "true"
-# If set to true, kuberay creates a normal ClusterIP service for a Ray Head instead of a Headless service.
+# If set to true, kuberay creates a normal ClusterIP service for a Ray Head instead of a Headless service. Default to false.
 # - name: ENABLE_RAY_HEAD_CLUSTER_IP_SERVICE
-#   value: "true"
+#   value: "false"
 # If not set or set to "", kuberay will pick up the default k8s cluster domain `cluster.local`
 # Otherwise, kuberay will use your custom domain
 # - name: CLUSTER_DOMAIN

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -103,6 +103,9 @@ env:
 # Warning: we highly recommend setting to true and let kuberay handle for you.
 # - name: ENABLE_INIT_CONTAINER_INJECTION
 #   value: "true"
+# If set to true, kuberay creates a normal ClusterIP service for a Ray Head instead of a Headless service.
+# - name: ENABLE_RAY_HEAD_CLUSTER_IP_SERVICE
+#   value: "true"
 # If not set or set to "", kuberay will pick up the default k8s cluster domain `cluster.local`
 # Otherwise, kuberay will use your custom domain
 # - name: CLUSTER_DOMAIN

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -15,13 +15,8 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 )
 
-const (
-	// If set to true, kuberay creates a normal ClusterIP service for a Ray Head instead of a Headless service.
-	EnableRayHeadClusterIPServiceEnvKey = "ENABLE_RAY_HEAD_CLUSTER_IP_SERVICE"
-)
-
 func getEnableRayHeadClusterIPService() bool {
-	return strings.ToLower(os.Getenv(EnableRayHeadClusterIPServiceEnvKey)) == "true"
+	return strings.ToLower(os.Getenv(utils.ENABLE_RAY_HEAD_CLUSTER_IP_SERVICE)) == "true"
 }
 
 // HeadServiceLabels returns the default labels for a cluster's head service.

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -130,8 +130,7 @@ func BuildServiceForHeadPod(ctx context.Context, cluster rayv1.RayCluster, label
 		},
 	}
 	if !getEnableRayHeadClusterIPService() && (defaultType == "" || defaultType == corev1.ServiceTypeClusterIP) {
-		// Use headless service for the Head Pod by default,
-		// since there is no sense for Head Pods to share a same virtual IP.
+		// Make the head service headless by default, because a RayCluster should have at most one head Pod.
 		headService.Spec.ClusterIP = corev1.ClusterIPNone
 		headService.Spec.PublishNotReadyAddresses = true // We don't need to hide the Head address if its health checks failed.
 	}

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -122,6 +122,7 @@ func BuildServiceForHeadPod(ctx context.Context, cluster rayv1.RayCluster, label
 		// Use headless service for the Head node by default,
 		// since there is no sense for Head nodes to share a same virtual IP.
 		headService.Spec.ClusterIP = corev1.ClusterIPNone
+		headService.Spec.PublishNotReadyAddresses = true // We don't need to hide the Head address if its health checks failed.
 	}
 
 	// This change ensures that reconciliation in rayservice_controller will not update the Service spec due to change in ports order

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -118,6 +118,11 @@ func BuildServiceForHeadPod(ctx context.Context, cluster rayv1.RayCluster, label
 			Type:     defaultType,
 		},
 	}
+	if defaultType == "" || defaultType == corev1.ServiceTypeClusterIP {
+		// Use headless service for the Head node by default,
+		// since there is no sense for Head nodes to share a same virtual IP.
+		headService.Spec.ClusterIP = corev1.ClusterIPNone
+	}
 
 	// This change ensures that reconciliation in rayservice_controller will not update the Service spec due to change in ports order
 	// sorting the ServicePorts on their name

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -119,8 +119,8 @@ func BuildServiceForHeadPod(ctx context.Context, cluster rayv1.RayCluster, label
 		},
 	}
 	if defaultType == "" || defaultType == corev1.ServiceTypeClusterIP {
-		// Use headless service for the Head node by default,
-		// since there is no sense for Head nodes to share a same virtual IP.
+		// Use headless service for the Head Pod by default,
+		// since there is no sense for Head Pods to share a same virtual IP.
 		headService.Spec.ClusterIP = corev1.ClusterIPNone
 		headService.Spec.PublishNotReadyAddresses = true // We don't need to hide the Head address if its health checks failed.
 	}

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 
@@ -157,6 +158,17 @@ func TestBuildServiceForHeadPod(t *testing.T) {
 	// BuildServiceForHeadPod should generate a headless service for a Head Pod by default.
 	if svc.Spec.ClusterIP != corev1.ClusterIPNone {
 		t.Fatalf("Expected `%v` but got `%v`", corev1.ClusterIPNone, svc.Spec.ClusterIP)
+	}
+}
+
+func TestBuildClusterIPServiceForHeadPod(t *testing.T) {
+	os.Setenv(EnableRayHeadClusterIPServiceEnvKey, "true")
+	defer os.Unsetenv(EnableRayHeadClusterIPServiceEnvKey)
+	svc, err := BuildServiceForHeadPod(context.Background(), *instanceWithWrongSvc, nil, nil)
+	assert.Nil(t, err)
+	// BuildServiceForHeadPod should not generate a headless service for a Head Pod if EnableRayHeadClusterIPServiceEnvKey is set.
+	if svc.Spec.ClusterIP == corev1.ClusterIPNone {
+		t.Fatalf("Not expected `%v` but got `%v`", corev1.ClusterIPNone, svc.Spec.ClusterIP)
 	}
 }
 

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -162,11 +162,11 @@ func TestBuildServiceForHeadPod(t *testing.T) {
 }
 
 func TestBuildClusterIPServiceForHeadPod(t *testing.T) {
-	os.Setenv(EnableRayHeadClusterIPServiceEnvKey, "true")
-	defer os.Unsetenv(EnableRayHeadClusterIPServiceEnvKey)
+	os.Setenv(utils.ENABLE_RAY_HEAD_CLUSTER_IP_SERVICE, "true")
+	defer os.Unsetenv(utils.ENABLE_RAY_HEAD_CLUSTER_IP_SERVICE)
 	svc, err := BuildServiceForHeadPod(context.Background(), *instanceWithWrongSvc, nil, nil)
 	assert.Nil(t, err)
-	// BuildServiceForHeadPod should not generate a headless service for a Head Pod if EnableRayHeadClusterIPServiceEnvKey is set.
+	// BuildServiceForHeadPod should not generate a headless service for a Head Pod if ENABLE_RAY_HEAD_CLUSTER_IP_SERVICE is set.
 	if svc.Spec.ClusterIP == corev1.ClusterIPNone {
 		t.Fatalf("Not expected `%v` but got `%v`", corev1.ClusterIPNone, svc.Spec.ClusterIP)
 	}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1257,6 +1257,13 @@ func (r *RayClusterReconciler) getHeadServiceIPAndName(ctx context.Context, inst
 		return "", "", fmt.Errorf("found multiple head services. cluster name %s, filter labels %v", instance.Name, filterLabels)
 	} else if runtimeServices.Items[0].Spec.ClusterIP == "" {
 		return "", "", fmt.Errorf("head service IP is empty. cluster name %s, filter labels %v", instance.Name, filterLabels)
+	} else if runtimeServices.Items[0].Spec.ClusterIP == corev1.ClusterIPNone {
+		// We return Head Pod IP directly if the Head service is headless.
+		ip, err := r.getHeadPodIP(ctx, instance)
+		if err != nil {
+			return "", "", err
+		}
+		return ip, runtimeServices.Items[0].Name, nil
 	}
 
 	return runtimeServices.Items[0].Spec.ClusterIP, runtimeServices.Items[0].Name, nil

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1258,7 +1258,7 @@ func (r *RayClusterReconciler) getHeadServiceIPAndName(ctx context.Context, inst
 	} else if runtimeServices.Items[0].Spec.ClusterIP == "" {
 		return "", "", fmt.Errorf("head service IP is empty. cluster name %s, filter labels %v", instance.Name, filterLabels)
 	} else if runtimeServices.Items[0].Spec.ClusterIP == corev1.ClusterIPNone {
-		// We return Head Pod IP directly if the Head service is headless.
+		// We return Head Pod IP if the Head service is headless.
 		ip, err := r.getHeadPodIP(ctx, instance)
 		if err != nil {
 			return "", "", err

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1425,6 +1425,30 @@ func TestGetHeadServiceIPAndName(t *testing.T) {
 	}
 }
 
+func TestGetHeadServiceIPAndNameOnHeadlessService(t *testing.T) {
+	setupTest(t)
+
+	headService, err := common.BuildServiceForHeadPod(context.Background(), *testRayCluster, nil, nil)
+	if err != nil {
+		t.Errorf("failed to build head service: %v", err)
+	}
+	assert.Equal(t, headService.Spec.ClusterIP, corev1.ClusterIPNone, "BuildServiceForHeadPod returned unexpected ClusterIP")
+
+	fakeClient := clientFake.NewClientBuilder().WithRuntimeObjects(headService).WithRuntimeObjects(testPods...).Build()
+
+	testRayClusterReconciler := &RayClusterReconciler{
+		Client:   fakeClient,
+		Recorder: &record.FakeRecorder{},
+		Scheme:   scheme.Scheme,
+	}
+
+	ip, name, err := testRayClusterReconciler.getHeadServiceIPAndName(context.TODO(), testRayCluster)
+
+	assert.Nil(t, err)
+	assert.Equal(t, headNodeIP, ip, "getHeadServiceIPAndName returned unexpected IP")
+	assert.Equal(t, headService.Name, name, "getHeadServiceIPAndName returned unexpected name")
+}
+
 func TestUpdateStatusObservedGeneration(t *testing.T) {
 	setupTest(t)
 
@@ -2170,10 +2194,7 @@ func Test_RedisCleanupFeatureFlag(t *testing.T) {
 			request := ctrl.Request{NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}}
 			_, err = testRayClusterReconciler.rayClusterReconcile(ctx, request, cluster)
 			if tc.enableGCSFTRedisCleanup == "false" {
-				// No finalizer should be added to the RayCluster. The head service and Ray Pods should be created.
-				// The head service's ClusterIP is empty, so the function `getHeadServiceIP` will return an error
-				// to requeue the request when it tries to update the RayCluster's status.
-				assert.NotNil(t, err)
+				assert.Nil(t, err)
 				podList := corev1.PodList{}
 				err = fakeClient.List(ctx, &podList, client.InNamespace(namespaceStr))
 				assert.Nil(t, err)
@@ -2200,11 +2221,7 @@ func Test_RedisCleanupFeatureFlag(t *testing.T) {
 
 				// Reconcile the RayCluster again. The controller should create Pods.
 				_, err = testRayClusterReconciler.rayClusterReconcile(ctx, request, cluster)
-
-				// The head service and Ray Pods should be created. The head service's ClusterIP is empty,
-				// so the function `getHeadServiceIP` will return an error to requeue the request when it
-				// tries to update the RayCluster's status.
-				assert.NotNil(t, err)
+				assert.Nil(t, err)
 
 				err = fakeClient.List(ctx, &podList, client.InNamespace(namespaceStr))
 				assert.Nil(t, err, "Fail to get Pod list")

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -134,6 +134,9 @@ const (
 	// flag for v1.1.0 and will be removed if the behavior proves to be stable enough.
 	ENABLE_PROBES_INJECTION = "ENABLE_PROBES_INJECTION"
 
+	// If set to true, kuberay creates a normal ClusterIP service for a Ray Head instead of a Headless service.
+	ENABLE_RAY_HEAD_CLUSTER_IP_SERVICE = "ENABLE_RAY_HEAD_CLUSTER_IP_SERVICE"
+
 	// Ray core default configurations
 	DefaultWorkerRayGcsReconnectTimeoutS = "600"
 


### PR DESCRIPTION
## Why are these changes needed?

The current normal k8s service for Ray Head works very well, except for a rare [hairpin issue](https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1679595093811179?thread_ts=1678309468.145329&cid=C02GFQ82JPM) and a special need of [reducing IP usages](https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1712780988188599?thread_ts=1712333199.632539&cid=C02GFQ82JPM). However, given that the purpose of the normal k8s service is hiding multiple endpoints behind a shared virtual address, it does not make much sense in the context of Ray. A Ray cluster can only have one head node at any given time and all its worker nodes can not change their Head either. So a headless service, enabling direct access without a virtual IP, makes much sense to Ray.

This PR changes the default service for a Ray Head from a standard k8s service to a headless service. A headless service also provides A/AAAA DNS records under the same service name. So this change should not affect networking accesses through the service name. This change will also not affect currently running RayClusters because we will not recreate services. If users want to use the standard service, they must specify the `Spec.HeadGroupSpec.HeadService` explicitly.

## Related issue number

#948

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
