### PR TITLE
[N/N][Chore] Add golangci-lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,75 @@
+linters-settings:
+  gofmt:
+    simplify: true
+  ginkgolinter:
+    forbid-focus-container: true
+  goimports:
+    local-prefixes: github.com/ray-project/kuberay/ray-operator,github.com/ray-project/kuberay/apiserver,github.com/ray-project/kuberay/cli,github.com/ray-project/kuberay/security
+  misspell:
+    locale: US
+  revive:
+    ignore-generated-header: true
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
+  gocyclo:
+    min-complexity: 15
+  govet:
+    enable:
+      - fieldalignment
+  lll:
+    line-length: 120
+linters:
+  enable:
+    - asciicheck
+    - errcheck
+#    - errorlint
+#    - ginkgolinter
+#    - gocyclo
+    - gofmt
+    - gofumpt
+    - goimports
+#    - gosec
+    - gosimple
+#    - govet
+    - ineffassign
+#    - lll
+    - makezero
+    - misspell
+    - nilerr
+#    - noctx
+    - predeclared
+#    - revive
+    - staticcheck
+    - typecheck
+#    - unconvert
+#    - unparam
+    - unused
+    - wastedassign
+  disable-all: true
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+run:
+  timeout: 3m


### PR DESCRIPTION
## Why are these changes needed?

Add golangci-lint rules.

Reference:
1. https://github.com/nginxinc/nginx-gateway-fabric/blob/0b0f7111364cd6f06883e414f7ef118207ee7677/.golangci.yml
2. https://github.com/ray-project/kuberay/blob/f77ee03117d2a48b31e041da58e49e16649fd487/.github/workflows/test-job.yaml

Related PR: https://github.com/ray-project/kuberay/pull/2127

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
