### PR TITLE
[3/N][CI] Replace lint CI with pre-commit

### DIFF
--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -9,105 +9,17 @@ on:
 
 jobs:
   lint:
-    name: Lint
+    name: Lint (pre-commit)
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        # Use the same go version with build job
-        go-version: v1.20
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-      with:
-        # When checking out the repository that
-        # triggered a workflow, this defaults to the reference or SHA for that event.
-        # Default value should work for both pull_request and merge(push) event.
-        ref: ${{github.event.pull_request.head.sha}}
-
-    - name: Install goimports and gofumpt
-      run: |
-        go install golang.org/x/tools/cmd/goimports@latest
-        go install mvdan.cc/gofumpt@v0.3.1
-
-    - name: Run gofmt
-      uses: Jerome1337/gofmt-action@v1.0.4
-      with:
-        gofmt-path: 'apiserver cli ray-operator'
-        gofmt-flags: '-l -d -s'
-
-    - name: Run linter against ray operator
-      uses: golangci/golangci-lint-action@v2
-      with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.54.1
-
-          # Optional: working directory, useful for monorepos
-          working-directory: ./ray-operator
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-          args: --timeout=3m
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true then the action will use pre-installed Go.
-          skip-go-installation: true
-
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
-
-    - name: Run linter against apiserver
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.54.1
-        working-directory: ./apiserver
-        args: --timeout=3m --exclude='SA1019'
-        skip-go-installation: true
-        skip-pkg-cache: true
-
-    - name: Run linter against security proxy
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.54.1
-        working-directory: ./experimental
-        args: --timeout=3m
-        skip-go-installation: true
-        skip-pkg-cache: true
-
-    - name: Run linter against cli
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.54.1
-        working-directory: ./cli
-        args: --timeout=3m
-        skip-go-installation: true
-        skip-pkg-cache: true
-
-    - name: Run goimports
-      run: test -z "$(set -o pipefail && $(go env GOPATH)/bin/goimports -l apiserver/ cli/ $(find ./ray-operator -name "*.go" | grep -v zz_generated.deepcopy.go) | tee goimports.out)" || { cat goimports.out && exit 1; }
-
-    - name: Open this to see how to fix goimports if it fails
-      run: |
-        echo "Run command 'goimports -w apiserver/ cli/ $(find ./ray-operator -name "*.go" | grep -v zz_generated.deepcopy.go)' to correct your code format."
-        echo "Proposed format changes:"
-        $(go env GOPATH)/bin/goimports -d apiserver/ cli/ $(find ./ray-operator -name "*.go" | grep -v zz_generated.deepcopy.go)
-      if: failure()
-
-    - name: Run gofumpt
-      run: test -z "$(set -o pipefail && $(go env GOPATH)/bin/gofumpt -l apiserver/ ray-operator/ cli/ | tee gofumpt.out)" || { cat gofumpt.out && exit 1; }
-
-    - name: Open this to see how to fix gofumpt if it fails
-      run: |
-        echo "Run command 'gofumpt -w apiserver/ ray-operator/ cli/' to correct your code format."
-        echo "Proposed format changes:"
-        $(go env GOPATH)/bin/gofumpt -d apiserver/ ray-operator/ cli/
-      if: failure()
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.58.1
+          mv ./bin/golangci-lint /usr/local/bin/golangci-lint
+        shell: bash
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.1
 
   build_apiserver:
     env:


### PR DESCRIPTION
## Why are these changes needed?

pre-commit hooks will be the single source of truth for formatting rules. Therefore this PR replaces all linting CI with pre-commit.

Depends on https://github.com/ray-project/kuberay/pull/2127

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
