### PR TITLE
[4/N][Chore] Turn off golangci-lint rules except ray-operator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,24 +37,24 @@ repos:
         language: golang
         require_serial: true
         files: ^ray-operator/
-      - id: golangci-lint-apiserver
-        name: golangci-lint (apiserver)
-        entry: bash -c 'cd apiserver && golangci-lint run --fix --exclude='SA1019' --exclude-files _generated.go\|datafile.go; cd ..'
-        types: [ go ]
-        language: golang
-        require_serial: true
-        files: ^apiserver/
-      - id: golangci-lint-cli
-        name: golangci-lint (cli)
-        entry: bash -c 'cd cli && golangci-lint run --fix --exclude-files _generated.go; cd ..'
-        types: [ go ]
-        language: golang
-        require_serial: true
-        files: ^cli/
-      - id: golangci-lint-experimental
-        name: golangci-lint (experimental)
-        entry: bash -c 'cd experimental && golangci-lint run --fix --exclude-files _generated.go; cd ..'
-        types: [ go ]
-        language: golang
-        require_serial: true
-        files: ^experimental/
+#      - id: golangci-lint-apiserver
+#        name: golangci-lint (apiserver)
+#        entry: bash -c 'cd apiserver && golangci-lint run --fix --exclude='SA1019' --exclude-files _generated.go\|datafile.go; cd ..'
+#        types: [ go ]
+#        language: golang
+#        require_serial: true
+#        files: ^apiserver/
+#      - id: golangci-lint-cli
+#        name: golangci-lint (cli)
+#        entry: bash -c 'cd cli && golangci-lint run --fix --exclude-files _generated.go; cd ..'
+#        types: [ go ]
+#        language: golang
+#        require_serial: true
+#        files: ^cli/
+#      - id: golangci-lint-experimental
+#        name: golangci-lint (experimental)
+#        entry: bash -c 'cd experimental && golangci-lint run --fix --exclude-files _generated.go; cd ..'
+#        types: [ go ]
+#        language: golang
+#        require_serial: true
+#        files: ^experimental/


### PR DESCRIPTION
## Why are these changes needed?

Because https://github.com/ray-project/kuberay/pull/2129 replaces the CI with pre-commit and https://github.com/ray-project/kuberay/pull/2128 adds new golangci-lint rules, the CI will fail. Therefore this PR temporarily turns off golangci-lint rules except `ray-operator`.

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
