### PR TITLE
[Chore] Turn off no-commit-to-branch rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,6 @@ repos:
         args: [--autofix, --no-sort-keys, --no-ensure-ascii]
       - id: mixed-line-ending
         args: [--fix=lf]
-      - id: no-commit-to-branch
       - id: detect-private-key
 
   - repo: https://github.com/gitleaks/gitleaks


### PR DESCRIPTION
## Why are these changes needed?

Because we use pre-commit in CI, the `no-commit-to-branch` rule must be turned off.

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
