### PR TITLE
[Style] Fix golangci-lint rule: noctx

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,7 @@ linters:
     - makezero
     - misspell
     - nilerr
-#    - noctx
+    - noctx
     - predeclared
 #    - revive
     - staticcheck

--- a/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
@@ -50,7 +50,11 @@ func (r *RayHttpProxyClient) SetHostIp(hostIp, podNamespace, podName string, por
 
 // CheckProxyActorHealth checks the health status of the Ray Serve proxy actor.
 func (r *RayHttpProxyClient) CheckProxyActorHealth(ctx context.Context) error {
-	resp, err := r.client.Get(r.httpProxyURL + RayServeProxyHealthPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.httpProxyURL+RayServeProxyHealthPath, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := r.client.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Based on https://github.com/ray-project/kuberay/pull/2128, there are some rules that need manual fixing. This PR fixes the rule: `noctx`

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
