### PR TITLE
[Style] Fix golangci-lint rule: unconvert

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,7 +63,7 @@ linters:
 #    - revive
     - staticcheck
     - typecheck
-#    - unconvert
+    - unconvert
 #    - unparam
     - unused
     - wastedassign

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -130,7 +130,7 @@ func TestBuildServiceForHeadPod(t *testing.T) {
 	assert.Nil(t, err)
 
 	actualResult := svc.Spec.Selector[utils.RayClusterLabelKey]
-	expectedResult := string(instanceWithWrongSvc.Name)
+	expectedResult := instanceWithWrongSvc.Name
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
@@ -432,7 +432,7 @@ func TestBuildServeServiceForRayService(t *testing.T) {
 	assert.Nil(t, err)
 
 	actualResult := svc.Spec.Selector[utils.RayClusterLabelKey]
-	expectedResult := string(instanceWithWrongSvc.Name)
+	expectedResult := instanceWithWrongSvc.Name
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}
@@ -464,7 +464,7 @@ func TestBuildServeServiceForRayCluster(t *testing.T) {
 	assert.Nil(t, err)
 
 	actualResult := svc.Spec.Selector[utils.RayClusterLabelKey]
-	expectedResult := string(instanceForServeSvc.Name)
+	expectedResult := instanceForServeSvc.Name
 	if !reflect.DeepEqual(expectedResult, actualResult) {
 		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
 	}

--- a/ray-operator/controllers/ray/suite_helpers_test.go
+++ b/ray-operator/controllers/ray/suite_helpers_test.go
@@ -257,7 +257,7 @@ func updateWorkerPodsToRunningAndReady(ctx context.Context, rayClusterName strin
 
 	gomega.Eventually(
 		listResourceFunc(ctx, &workerPods, workerLabels...),
-		time.Second*3, time.Millisecond*500).Should(gomega.Equal(int(numWorkerPods)), "workerGroup: %v", workerPods.Items)
+		time.Second*3, time.Millisecond*500).Should(gomega.Equal(numWorkerPods), "workerGroup: %v", workerPods.Items)
 
 	for _, pod := range workerPods.Items {
 		pod.Status.Phase = corev1.PodRunning

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -473,7 +473,7 @@ func GenerateJsonHash(obj interface{}) (string, error) {
 	hashBytes := sha1.Sum(serialObj)
 
 	// Convert to an ASCII string
-	hashStr := string(base32.HexEncoding.EncodeToString(hashBytes[:]))
+	hashStr := base32.HexEncoding.EncodeToString(hashBytes[:])
 
 	return hashStr, nil
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Based on https://github.com/ray-project/kuberay/pull/2128, there are some rules that need manual fixing. This PR fixes the rule: `unconvert`

See https://golangci-lint.run/usage/linters/ for details.

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
