### PR TITLE
[Chore] Use new golangci-lint rules only for ray-operator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,24 +36,3 @@ repos:
         language: golang
         require_serial: true
         files: ^ray-operator/
-#      - id: golangci-lint-apiserver
-#        name: golangci-lint (apiserver)
-#        entry: bash -c 'cd apiserver && golangci-lint run --fix --exclude='SA1019' --exclude-files _generated.go\|datafile.go --timeout 10m0s; status=$?; cd ..; exit $status'
-#        types: [ go ]
-#        language: golang
-#        require_serial: true
-#        files: ^apiserver/
-#      - id: golangci-lint-cli
-#        name: golangci-lint (cli)
-#        entry: bash -c 'cd cli && golangci-lint run --fix --exclude-files _generated.go --timeout 10m0s; status=$?; cd ..; exit $status'
-#        types: [ go ]
-#        language: golang
-#        require_serial: true
-#        files: ^cli/
-#      - id: golangci-lint-experimental
-#        name: golangci-lint (experimental)
-#        entry: bash -c 'cd experimental && golangci-lint run --fix --exclude-files _generated.go --timeout 10m0s; status=$?; cd ..; exit $status'
-#        types: [ go ]
-#        language: golang
-#        require_serial: true
-#        files: ^experimental/

--- a/ray-operator/.golangci.yml
+++ b/ray-operator/.golangci.yml
@@ -4,7 +4,7 @@ linters-settings:
   ginkgolinter:
     forbid-focus-container: true
   goimports:
-    local-prefixes: github.com/ray-project/kuberay/ray-operator,github.com/ray-project/kuberay/apiserver,github.com/ray-project/kuberay/cli,github.com/ray-project/kuberay/security
+    local-prefixes: github.com/ray-project/kuberay/ray-operator
   misspell:
     locale: US
   revive:


### PR DESCRIPTION
## Why are these changes needed?

Some CI fails because other modules (e.g. `experimental`) also use `golangci-lint` and the new rules in the repository root cause them to fail.
- https://github.com/ray-project/kuberay/actions/runs/9068220792/job/24915020733?pr=2141
- https://github.com/ray-project/kuberay/actions/runs/9093023649/job/24991053965?pr=2144

Therefore, this PR moves the `.golangci.yml` into the `ray-operator` folder.

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
