### PR TITLE
Added Pod securityContext value to Helm charts

### DIFF
--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -60,6 +60,9 @@ batchScheduler:
 
 # Set up `securityContext` to improve Pod security.
 # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md for further guidance.
+podSecurityContext: {}
+
+# Set up `securityContext` to improve container security.
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -92,6 +92,10 @@ spec:
         affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.head.tolerations | nindent 10 }}
         nodeSelector: {{- toYaml .Values.head.nodeSelector | nindent 10 }}
+        {{- with .Values.head.podSecurityContext }}
+        securityContext:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
       metadata:
         annotations: {{- toYaml .Values.head.annotations | nindent 10 }}
         {{- if .Values.head.labels }}
@@ -177,6 +181,10 @@ spec:
         affinity: {{- toYaml $values.affinity | nindent 10 }}
         tolerations: {{- toYaml $values.tolerations | nindent 10 }}
         nodeSelector: {{- toYaml $values.nodeSelector | nindent 10 }}
+        {{- with $values.podSecurityContext }}
+        securityContext:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
       metadata:
         annotations: {{- toYaml $values.annotations | nindent 10 }}
         {{- if $values.labels }}
@@ -262,6 +270,10 @@ spec:
         affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}
         tolerations: {{- toYaml .Values.worker.tolerations | nindent 10 }}
         nodeSelector: {{- toYaml .Values.worker.nodeSelector | nindent 10 }}
+        {{- with .Values.worker.podSecurityContext}}
+        securityContext:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
       metadata:
         annotations: {{- toYaml .Values.worker.annotations | nindent 10 }}
         {{- if .Values.worker.labels }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -89,6 +89,8 @@ head:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Pod security context.
+  podSecurityContext: {}
   # Ray container security context.
   securityContext: {}
   # Optional: The following volumes/volumeMounts configurations are optional but recommended because
@@ -155,6 +157,8 @@ worker:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Pod security context.
+  podSecurityContext: {}
   # Ray container security context.
   securityContext: {}
   # Optional: The following volumes/volumeMounts configurations are optional but recommended because
@@ -216,6 +220,8 @@ additionalWorkerGroups:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    # Pod security context.
+    podSecurityContext: {}
     # Ray container security context.
     securityContext: {}
     # Optional: The following volumes/volumeMounts configurations are optional but recommended because


### PR DESCRIPTION
## Why are these changes needed?

Currently you can only set the securityContext at the container level with the RayCluster Helm chart.

## Related issue number

https://github.com/ray-project/kuberay/issues/2136

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
