### PR TITLE
[Chore] Fix golangci-lint rule: gosec

### DIFF
--- a/ray-operator/.golangci.yml
+++ b/ray-operator/.golangci.yml
@@ -1,6 +1,9 @@
 linters-settings:
   gofmt:
     simplify: true
+  gosec:
+    excludes:
+      - G601
   ginkgolinter:
     forbid-focus-container: true
   goimports:
@@ -50,7 +53,7 @@ linters:
     - gofmt
     - gofumpt
     - goimports
-#    - gosec
+    - gosec
     - gosimple
 #    - govet
     - ineffassign

--- a/ray-operator/apis/ray/v1/webhook_suite_test.go
+++ b/ray-operator/apis/ray/v1/webhook_suite_test.go
@@ -110,7 +110,11 @@ var _ = BeforeSuite(func() {
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
-		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		conn, err := tls.DialWithDialer(dialer,
+			"tcp",
+			addrPort,
+			&tls.Config{InsecureSkipVerify: true}, //nolint:gosec // Allow InsecureSkipVerify because we are connecting to our own webhook server.
+		)
 		if err != nil {
 			return err
 		}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha1" //nolint:gosec // We are not using this for security purposes
 	"encoding/base32"
 	"fmt"
 	"math"
@@ -470,7 +470,7 @@ func GenerateJsonHash(obj interface{}) (string, error) {
 		return "", err
 	}
 
-	hashBytes := sha1.Sum(serialObj)
+	hashBytes := sha1.Sum(serialObj) //nolint:gosec // We are not using this for security purposes
 
 	// Convert to an ASCII string
 	hashStr := base32.HexEncoding.EncodeToString(hashBytes[:])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Based on https://github.com/ray-project/kuberay/pull/2128, there are some rules that need manual fixing. This PR fixes the rule: `gosec`

See https://golangci-lint.run/usage/linters/ for details.

This PR does the following:
- Adds a comment to explain why we can use `Sha1` hash.
- Adds a comment to explain `InsecureSkipVerify` is used.

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
