### PR TITLE
[Style] Fix golangci-lint rule: ginkgolinter

### DIFF
--- a/ray-operator/.golangci.yml
+++ b/ray-operator/.golangci.yml
@@ -45,7 +45,7 @@ linters:
     - asciicheck
     - errcheck
     - errorlint
-#    - ginkgolinter
+    - ginkgolinter
 #    - gocyclo
     - gofmt
     - gofumpt

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -200,7 +200,7 @@ var _ = Context("RayJob in K8sJobMode", func() {
 			Expect(rayJob.Spec.ShutdownAfterJobFinishes).To(BeTrue())
 
 			// This test assumes that there is only one worker group.
-			Expect(len(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs)).To(Equal(1))
+			Expect(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs).To(HaveLen(1))
 		})
 
 		It("Create a RayJob custom resource", func() {
@@ -288,7 +288,7 @@ var _ = Context("RayJob in K8sJobMode", func() {
 				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
 			}
 			job.Status.Conditions = conditions
-			Expect(k8sClient.Status().Update(ctx, job)).Should(BeNil())
+			Expect(k8sClient.Status().Update(ctx, job)).Should(Succeed())
 
 			// RayJob transitions to Complete.
 			Eventually(
@@ -322,7 +322,7 @@ var _ = Context("RayJob in K8sJobMode", func() {
 			Expect(rayJob.Spec.ActiveDeadlineSeconds).NotTo(BeNil())
 
 			// This test assumes that there is only one worker group.
-			Expect(len(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs)).To(Equal(1))
+			Expect(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs).To(HaveLen(1))
 		})
 
 		It("Create a RayJob custom resource", func() {

--- a/ray-operator/controllers/ray/suite_helpers_test.go
+++ b/ray-operator/controllers/ray/suite_helpers_test.go
@@ -60,7 +60,7 @@ func getClusterStatus(ctx context.Context, namespace string, clusterName string)
 	}
 }
 
-func isAllPodsRunningByFilters(ctx context.Context, podlist corev1.PodList, opt ...client.ListOption) bool {
+func isAllPodsRunningByFilters(ctx context.Context, podlist corev1.PodList, opt []client.ListOption) bool {
 	err := k8sClient.List(ctx, &podlist, opt...)
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to list Pods")
 	for _, pod := range podlist.Items {
@@ -240,8 +240,7 @@ func updateHeadPodToRunningAndReady(ctx context.Context, rayClusterName string, 
 
 	// Make sure the head Pod is updated.
 	gomega.Eventually(
-		isAllPodsRunningByFilters(ctx, headPods, headLabels...),
-		time.Second*15, time.Millisecond*500).Should(gomega.BeTrue(), "Head Pod should be running: %v", headPods.Items)
+		isAllPodsRunningByFilters).WithContext(ctx).WithArguments(headPods, headLabels).WithTimeout(time.Second*15).WithPolling(time.Millisecond*500).Should(gomega.BeTrue(), "Head Pod should be running: %v", headPods.Items)
 }
 
 // Update the status of the worker Pods to Running and Ready. Similar to updateHeadPodToRunningAndReady.
@@ -273,8 +272,7 @@ func updateWorkerPodsToRunningAndReady(ctx context.Context, rayClusterName strin
 
 	// Make sure all worker Pods are updated.
 	gomega.Eventually(
-		isAllPodsRunningByFilters(ctx, workerPods, workerLabels...),
-		time.Second*3, time.Millisecond*500).Should(gomega.BeTrue(), "Worker Pods should be running: %v", workerPods.Items)
+		isAllPodsRunningByFilters).WithContext(ctx).WithArguments(workerPods, workerLabels).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(gomega.BeTrue(), "Worker Pods should be running: %v", workerPods.Items)
 }
 
 func updateRayJobSuspendField(ctx context.Context, rayJob *rayv1.RayJob, suspend bool) error {

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
@@ -54,13 +54,13 @@ var _ = Describe("RayFrameworkGenerator", func() {
 
 		rayDashboardClient = &RayDashboardClient{}
 		err := rayDashboardClient.InitClient(context.Background(), "127.0.0.1:8090", nil)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("Test ConvertRayJobToReq", func() {
 		rayJobRequest, err := ConvertRayJobToReq(rayJob)
-		Expect(err).To(BeNil())
-		Expect(len(rayJobRequest.RuntimeEnv)).To(Equal(4))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rayJobRequest.RuntimeEnv).To(HaveLen(4))
 		Expect(rayJobRequest.RuntimeEnv["working_dir"]).To(Equal("./"))
 	})
 
@@ -72,7 +72,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 				EntrypointNumGpus:   2.2,
 			},
 		})
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(rayJobRequest.NumCpus).To(Equal(float32(1.1)))
 		Expect(rayJobRequest.NumGpus).To(Equal(float32(2.2)))
 		Expect(rayJobRequest.Resources).To(Equal(map[string]float32{"r1": 0.1, "r2": 0.2}))
@@ -115,16 +115,16 @@ var _ = Describe("RayFrameworkGenerator", func() {
 			})
 
 		jobId, err := rayDashboardClient.SubmitJob(context.TODO(), rayJob)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(jobId).To(Equal(expectJobId))
 
 		rayJobInfo, err := rayDashboardClient.GetJobInfo(context.TODO(), jobId)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(rayJobInfo.Entrypoint).To(Equal(rayJob.Spec.Entrypoint))
 		Expect(rayJobInfo.JobStatus).To(Equal(rayv1.JobStatusRunning))
 
 		_, err = rayDashboardClient.GetJobInfo(context.TODO(), errorJobId)
-		Expect(err).NotTo(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("GetJobInfo fail"))
 		Expect(err.Error()).To(ContainSubstring("Ray misbehaved"))
 	})
@@ -142,7 +142,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 			})
 
 		err := rayDashboardClient.StopJob(context.TODO(), "stop-job-1")
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("Test stop succeeded job", func() {
@@ -169,6 +169,6 @@ var _ = Describe("RayFrameworkGenerator", func() {
 			})
 
 		err := rayDashboardClient.StopJob(context.TODO(), "stop-job-1")
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Based on https://github.com/ray-project/kuberay/pull/2128, there are some rules that need manual fixing. This PR fixes the rule: `ginkgolinter`

See https://golangci-lint.run/usage/linters/ for details.

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
