### PR TITLE
[Style] Fix golangci-lint rule: revive

### DIFF
--- a/ray-operator/.golangci.yml
+++ b/ray-operator/.golangci.yml
@@ -60,7 +60,7 @@ linters:
     - nilerr
     - noctx
     - predeclared
-#    - revive
+    - revive
     - staticcheck
     - typecheck
     - unconvert

--- a/ray-operator/.golangci.yml
+++ b/ray-operator/.golangci.yml
@@ -19,6 +19,7 @@ linters-settings:
       - name: error-strings
       - name: errorf
       - name: exported
+        disabled: true
       - name: if-return
       - name: increment-decrement
       - name: indent-error-flow
@@ -33,6 +34,14 @@ linters-settings:
       - name: unused-parameter
       - name: var-declaration
       - name: var-naming
+        exclude:
+          - "**/ray-operator/apis/config/v1alpha1/*.go"
+          - "**/ray-operator/apis/ray/v1alpha1/*.go"
+          - "**/ray-operator/apis/ray/v1/*.go"
+        arguments:
+          - ["ID", "JSON", "HTTP", "IP"] # AllowList
+          - [] # DenyList
+          - - upperCaseConst: true
   gocyclo:
     min-complexity: 15
   govet:

--- a/ray-operator/apis/ray/v1/raycluster_webhook.go
+++ b/ray-operator/apis/ray/v1/raycluster_webhook.go
@@ -37,7 +37,7 @@ func (r *RayCluster) ValidateCreate() (admission.Warnings, error) {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *RayCluster) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+func (r *RayCluster) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
 	rayclusterlog.Info("validate update", "name", r.Name)
 	return nil, r.validateRayCluster()
 }

--- a/ray-operator/controllers/ray/batchscheduler/interface/interface.go
+++ b/ray-operator/controllers/ray/batchscheduler/interface/interface.go
@@ -52,18 +52,18 @@ func (d *DefaultBatchScheduler) Name() string {
 	return GetDefaultPluginName()
 }
 
-func (d *DefaultBatchScheduler) DoBatchSchedulingOnSubmission(ctx context.Context, app *rayv1.RayCluster) error {
+func (d *DefaultBatchScheduler) DoBatchSchedulingOnSubmission(_ context.Context, _ *rayv1.RayCluster) error {
 	return nil
 }
 
-func (d *DefaultBatchScheduler) AddMetadataToPod(app *rayv1.RayCluster, groupName string, pod *corev1.Pod) {
+func (d *DefaultBatchScheduler) AddMetadataToPod(_ *rayv1.RayCluster, _ string, _ *corev1.Pod) {
 }
 
-func (df *DefaultBatchSchedulerFactory) New(config *rest.Config) (BatchScheduler, error) {
+func (df *DefaultBatchSchedulerFactory) New(_ *rest.Config) (BatchScheduler, error) {
 	return &DefaultBatchScheduler{}, nil
 }
 
-func (df *DefaultBatchSchedulerFactory) AddToScheme(scheme *runtime.Scheme) {
+func (df *DefaultBatchSchedulerFactory) AddToScheme(_ *runtime.Scheme) {
 }
 
 func (df *DefaultBatchSchedulerFactory) ConfigureReconciler(b *builder.Builder) *builder.Builder {

--- a/ray-operator/controllers/ray/batchscheduler/schedulermanager.go
+++ b/ray-operator/controllers/ray/batchscheduler/schedulermanager.go
@@ -72,18 +72,20 @@ func (batch *SchedulerManager) GetScheduler(schedulerName string) (schedulerinte
 	batch.Lock()
 	defer batch.Unlock()
 
-	if plugin, existed := batch.plugins[schedulerName]; existed && plugin != nil {
+	plugin, existed := batch.plugins[schedulerName]
+
+	if existed && plugin != nil {
 		return plugin, nil
-	} else if existed && plugin == nil {
+	}
+	if existed && plugin == nil {
 		return nil, fmt.Errorf(
 			"failed to get scheduler plugin %s, previous initialization has failed", schedulerName)
-	} else {
-		if plugin, err := factory.New(batch.config); err != nil {
-			batch.plugins[schedulerName] = nil
-			return nil, err
-		} else {
-			batch.plugins[schedulerName] = plugin
-			return plugin, nil
-		}
 	}
+	plugin, err := factory.New(batch.config)
+	if err != nil {
+		batch.plugins[schedulerName] = nil
+		return nil, err
+	}
+	batch.plugins[schedulerName] = plugin
+	return plugin, nil
 }

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -59,10 +59,7 @@ func (v *VolcanoBatchScheduler) DoBatchSchedulingOnSubmission(ctx context.Contex
 		totalResource = utils.CalculateMinResources(app)
 	}
 
-	if err := v.syncPodGroup(app, minMember, totalResource); err != nil {
-		return err
-	}
-	return nil
+	return v.syncPodGroup(app, minMember, totalResource)
 }
 
 func getAppPodGroupName(app *rayv1.RayCluster) string {

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -102,7 +102,7 @@ func DefaultHeadPodTemplate(ctx context.Context, instance rayv1.RayCluster, head
 		podTemplate.Labels = make(map[string]string)
 	}
 	podTemplate.Labels = labelPod(rayv1.HeadNode, instance.Name, utils.RayNodeHeadGroupLabelValue, instance.Spec.HeadGroupSpec.Template.ObjectMeta.Labels)
-	headSpec.RayStartParams = setMissingRayStartParams(ctx, headSpec.RayStartParams, rayv1.HeadNode, headPort, "", instance.Annotations)
+	headSpec.RayStartParams = setMissingRayStartParams(ctx, headSpec.RayStartParams, rayv1.HeadNode, headPort, "")
 
 	initTemplateAnnotations(instance, &podTemplate)
 
@@ -222,7 +222,7 @@ func DefaultWorkerPodTemplate(ctx context.Context, instance rayv1.RayCluster, wo
 		podTemplate.Labels = make(map[string]string)
 	}
 	podTemplate.Labels = labelPod(rayv1.WorkerNode, instance.Name, workerSpec.GroupName, workerSpec.Template.ObjectMeta.Labels)
-	workerSpec.RayStartParams = setMissingRayStartParams(ctx, workerSpec.RayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP, instance.Annotations)
+	workerSpec.RayStartParams = setMissingRayStartParams(ctx, workerSpec.RayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP)
 
 	initTemplateAnnotations(instance, &podTemplate)
 
@@ -666,7 +666,7 @@ func setContainerEnvVars(pod *corev1.Pod, rayNodeType rayv1.RayNodeType, rayStar
 	}
 }
 
-func setMissingRayStartParams(ctx context.Context, rayStartParams map[string]string, nodeType rayv1.RayNodeType, headPort string, fqdnRayIP string, annotations map[string]string) (completeStartParams map[string]string) {
+func setMissingRayStartParams(ctx context.Context, rayStartParams map[string]string, nodeType rayv1.RayNodeType, headPort string, fqdnRayIP string) (completeStartParams map[string]string) {
 	log := ctrl.LoggerFrom(ctx)
 	// Note: The argument headPort is unused for nodeType == rayv1.HeadNode.
 	if nodeType == rayv1.WorkerNode {
@@ -777,7 +777,7 @@ func convertParamMap(rayStartParams map[string]string) (s string) {
 func addEmptyDir(ctx context.Context, container *corev1.Container, pod *corev1.Pod, volumeName string, volumeMountPath string, storageMedium corev1.StorageMedium) {
 	log := ctrl.LoggerFrom(ctx)
 
-	if checkIfVolumeMounted(container, pod, volumeMountPath) {
+	if checkIfVolumeMounted(container, volumeMountPath) {
 		log.Info("volume already mounted", "volume", volumeName, "path", volumeMountPath)
 		return
 	}
@@ -822,7 +822,7 @@ func makeEmptyDirVolume(container *corev1.Container, volumeName string, storageM
 
 // Checks if the container has a volumeMount with the given mount path and if
 // the pod has a matching Volume.
-func checkIfVolumeMounted(container *corev1.Container, pod *corev1.Pod, volumeMountPath string) bool {
+func checkIfVolumeMounted(container *corev1.Container, volumeMountPath string) bool {
 	for _, mountedVol := range container.VolumeMounts {
 		if mountedVol.MountPath == volumeMountPath {
 			return true

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -940,23 +940,23 @@ func TestSetMissingRayStartParamsAddress(t *testing.T) {
 
 	// Case 1: Head node with no address option set.
 	rayStartParams := map[string]string{}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "", nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "")
 	assert.NotContains(t, rayStartParams, "address", "Head node should not have an address option set by default.")
 
 	// Case 2: Head node with custom address option set.
 	rayStartParams = map[string]string{"address": customAddress}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "", nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "")
 	assert.Equal(t, customAddress, rayStartParams["address"], fmt.Sprintf("Expected `%v` but got `%v`", customAddress, rayStartParams["address"]))
 
 	// Case 3: Worker node with no address option set.
 	rayStartParams = map[string]string{}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP, nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP)
 	expectedAddress := fmt.Sprintf("%s:%s", fqdnRayIP, headPort)
 	assert.Equal(t, expectedAddress, rayStartParams["address"], fmt.Sprintf("Expected `%v` but got `%v`", expectedAddress, rayStartParams["address"]))
 
 	// Case 4: Worker node with custom address option set.
 	rayStartParams = map[string]string{"address": customAddress}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP, nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP)
 	assert.Equal(t, customAddress, rayStartParams["address"], fmt.Sprintf("Expected `%v` but got `%v`", customAddress, rayStartParams["address"]))
 }
 
@@ -973,22 +973,22 @@ func TestSetMissingRayStartParamsMetricsExportPort(t *testing.T) {
 
 	// Case 1: Head node with no metrics-export-port option set.
 	rayStartParams := map[string]string{}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "", nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "")
 	assert.Equal(t, fmt.Sprint(utils.DefaultMetricsPort), rayStartParams["metrics-export-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(utils.DefaultMetricsPort), rayStartParams["metrics-export-port"]))
 
 	// Case 2: Head node with custom metrics-export-port option set.
 	rayStartParams = map[string]string{"metrics-export-port": fmt.Sprint(customMetricsPort)}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "", nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "")
 	assert.Equal(t, fmt.Sprint(customMetricsPort), rayStartParams["metrics-export-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(customMetricsPort), rayStartParams["metrics-export-port"]))
 
 	// Case 3: Worker node with no metrics-export-port option set.
 	rayStartParams = map[string]string{}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP, nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP)
 	assert.Equal(t, fmt.Sprint(utils.DefaultMetricsPort), rayStartParams["metrics-export-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(utils.DefaultMetricsPort), rayStartParams["metrics-export-port"]))
 
 	// Case 4: Worker node with custom metrics-export-port option set.
 	rayStartParams = map[string]string{"metrics-export-port": fmt.Sprint(customMetricsPort)}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP, nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP)
 	assert.Equal(t, fmt.Sprint(customMetricsPort), rayStartParams["metrics-export-port"], fmt.Sprintf("Expected `%v` but got `%v`", fmt.Sprint(customMetricsPort), rayStartParams["metrics-export-port"]))
 }
 
@@ -1004,22 +1004,22 @@ func TestSetMissingRayStartParamsBlock(t *testing.T) {
 
 	// Case 1: Head node with no --block option set.
 	rayStartParams := map[string]string{}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "", nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "")
 	assert.Equal(t, "true", rayStartParams["block"], fmt.Sprintf("Expected `%v` but got `%v`", "true", rayStartParams["block"]))
 
 	// Case 2: Head node with --block option set to false.
 	rayStartParams = map[string]string{"block": "false"}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "", nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "")
 	assert.Equal(t, "true", rayStartParams["block"], fmt.Sprintf("Expected `%v` but got `%v`", "false", rayStartParams["block"]))
 
 	// Case 3: Worker node with no --block option set.
 	rayStartParams = map[string]string{}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP, nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP)
 	assert.Equal(t, "true", rayStartParams["block"], fmt.Sprintf("Expected `%v` but got `%v`", "true", rayStartParams["block"]))
 
 	// Case 4: Worker node with --block option set to false.
 	rayStartParams = map[string]string{"block": "false"}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP, nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP)
 	assert.Equal(t, "true", rayStartParams["block"], fmt.Sprintf("Expected `%v` but got `%v`", "false", rayStartParams["block"]))
 }
 
@@ -1033,23 +1033,23 @@ func TestSetMissingRayStartParamsDashboardHost(t *testing.T) {
 
 	// Case 1: Head node with no dashboard-host option set.
 	rayStartParams := map[string]string{}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "", nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "")
 	assert.Equal(t, "0.0.0.0", rayStartParams["dashboard-host"], fmt.Sprintf("Expected `%v` but got `%v`", "0.0.0.0", rayStartParams["dashboard-host"]))
 
 	// Case 2: Head node with dashboard-host option set.
 	rayStartParams = map[string]string{"dashboard-host": "localhost"}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "", nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.HeadNode, headPort, "")
 	assert.Equal(t, "localhost", rayStartParams["dashboard-host"], fmt.Sprintf("Expected `%v` but got `%v`", "localhost", rayStartParams["dashboard-host"]))
 
 	// Case 3: Worker node with no dashboard-host option set.
 	rayStartParams = map[string]string{}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP, nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP)
 	assert.NotContains(t, rayStartParams, "dashboard-host", "workers should not have an dashboard-host option set.")
 
 	// Case 4: Worker node with dashboard-host option set.
 	// To maximize user empowerment, this option can be enabled. However, it is important to note that the dashboard is not available on worker nodes.
 	rayStartParams = map[string]string{"dashboard-host": "localhost"}
-	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP, nil)
+	rayStartParams = setMissingRayStartParams(ctx, rayStartParams, rayv1.WorkerNode, headPort, fqdnRayIP)
 	assert.Equal(t, "localhost", rayStartParams["dashboard-host"], fmt.Sprintf("Expected `%v` but got `%v`", "localhost", rayStartParams["dashboard-host"]))
 }
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -726,7 +726,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 
 		// If we delete unhealthy Pods, we will not create new Pods in this reconciliation.
 		if numDeletedUnhealthyWorkerPods > 0 {
-			return fmt.Errorf("Delete %d unhealthy worker Pods.", numDeletedUnhealthyWorkerPods)
+			return fmt.Errorf("Delete %d unhealthy worker Pods", numDeletedUnhealthyWorkerPods)
 		}
 
 		// Always remove the specified WorkersToDelete - regardless of the value of Replicas.

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
-	_ "k8s.io/api/apps/v1beta1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -571,10 +571,7 @@ func (r *RayClusterReconciler) reconcileServeService(ctx context.Context, instan
 			return err
 		}
 		// create service
-		if err := r.Create(ctx, svc); err != nil {
-			return err
-		}
-		return nil
+		return r.Create(ctx, svc)
 	}
 	return err
 }

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -851,14 +851,14 @@ func TestReconcile_PodCrash_DiffLess0_OK(t *testing.T) {
 	oldNumWorkerPods := len(testPods) - numHeadPods
 
 	tests := map[string]struct {
-		ENABLE_RANDOM_POD_DELETE bool
+		enableRandomPodDelete bool
 	}{
-		// When Autoscaler is enabled, the random Pod deletion is controleld by the feature flag `ENABLE_RANDOM_POD_DELETE`.
+		// When Autoscaler is enabled, the random Pod deletion is controleld by the feature flag `enableRandomPodDelete`.
 		"Enable random Pod deletion": {
-			ENABLE_RANDOM_POD_DELETE: true,
+			enableRandomPodDelete: true,
 		},
 		"Disable random Pod deletion": {
-			ENABLE_RANDOM_POD_DELETE: false,
+			enableRandomPodDelete: false,
 		},
 	}
 
@@ -881,16 +881,16 @@ func TestReconcile_PodCrash_DiffLess0_OK(t *testing.T) {
 				Scheme:   scheme.Scheme,
 			}
 
-			if tc.ENABLE_RANDOM_POD_DELETE {
+			if tc.enableRandomPodDelete {
 				os.Setenv(utils.ENABLE_RANDOM_POD_DELETE, "true")
 			} else {
 				os.Setenv(utils.ENABLE_RANDOM_POD_DELETE, "false")
 			}
 			cluster := testRayCluster.DeepCopy()
-			// Case 1: ENABLE_RANDOM_POD_DELETE is true.
+			// Case 1: enableRandomPodDelete is true.
 			// 	Since the desired state of the workerGroup is 3 replicas, the controller will delete a worker Pod randomly.
 			//  After the deletion, the number of worker Pods should be 3.
-			// Case 2: ENABLE_RANDOM_POD_DELETE is false.
+			// Case 2: enableRandomPodDelete is false.
 			//  Only the Pod in the `workersToDelete` will be deleted. After the deletion, the number of worker Pods should be 4.
 			err = testRayClusterReconciler.reconcilePods(ctx, cluster)
 			assert.Nil(t, err, "Fail to reconcile Pods")
@@ -901,13 +901,13 @@ func TestReconcile_PodCrash_DiffLess0_OK(t *testing.T) {
 			})
 			assert.Nil(t, err, "Fail to get pod list after reconcile")
 
-			if tc.ENABLE_RANDOM_POD_DELETE {
-				// Case 1: ENABLE_RANDOM_POD_DELETE is true.
+			if tc.enableRandomPodDelete {
+				// Case 1: enableRandomPodDelete is true.
 				assert.Equal(t, expectedNumWorkerPods, len(podList.Items))
 				assert.Equal(t, expectedNumWorkerPods, getNotFailedPodItemNum(podList),
 					"Replica number is wrong after reconcile expect %d actual %d", expectReplicaNum, getNotFailedPodItemNum(podList))
 			} else {
-				// Case 2: ENABLE_RANDOM_POD_DELETE is false.
+				// Case 2: enableRandomPodDelete is false.
 				assert.Equal(t, expectedNumWorkerPods+1, len(podList.Items))
 				assert.Equal(t, expectedNumWorkerPods+1, getNotFailedPodItemNum(podList),
 					"Replica number is wrong after reconcile expect %d actual %d", expectReplicaNum, getNotFailedPodItemNum(podList))

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -43,7 +43,7 @@ type RayJobReconciler struct {
 }
 
 // NewRayJobReconciler returns a new reconcile.Reconciler
-func NewRayJobReconciler(ctx context.Context, mgr manager.Manager, provider utils.ClientProvider) *RayJobReconciler {
+func NewRayJobReconciler(_ context.Context, mgr manager.Manager, provider utils.ClientProvider) *RayJobReconciler {
 	dashboardClientFunc := provider.GetDashboardClient(mgr)
 	return &RayJobReconciler{
 		Client:              mgr.GetClient(),

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -325,12 +325,11 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 				delta := int32(time.Until(shutdownTime.Add(2 * time.Second)).Seconds())
 				logger.Info(fmt.Sprintf("shutdownTime not reached, requeue this RayJob for %d seconds", delta))
 				return ctrl.Result{RequeueAfter: time.Duration(delta) * time.Second}, nil
-			} else {
-				// We only need to delete the RayCluster. We don't need to delete the submitter Kubernetes Job so that users can still access
-				// the driver logs. In addition, a completed Kubernetes Job does not actually use any compute resources.
-				if _, err = r.deleteClusterResources(ctx, rayJobInstance); err != nil {
-					return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
-				}
+			}
+			// We only need to delete the RayCluster. We don't need to delete the submitter Kubernetes Job so that users can still access
+			// the driver logs. In addition, a completed Kubernetes Job does not actually use any compute resources.
+			if _, err = r.deleteClusterResources(ctx, rayJobInstance); err != nil {
+				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 			}
 		}
 		// If the RayJob is completed, we should not requeue it.

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -108,7 +108,7 @@ func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, provider 
 func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
-	var isReady bool = false
+	isReady := false
 
 	var rayServiceInstance *rayv1.RayService
 	var err error

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -60,7 +60,7 @@ type RayServiceReconciler struct {
 }
 
 // NewRayServiceReconciler returns a new reconcile.Reconciler
-func NewRayServiceReconciler(ctx context.Context, mgr manager.Manager, provider utils.ClientProvider) *RayServiceReconciler {
+func NewRayServiceReconciler(_ context.Context, mgr manager.Manager, provider utils.ClientProvider) *RayServiceReconciler {
 	dashboardClientFunc := provider.GetDashboardClient(mgr)
 	httpProxyClientFunc := provider.GetHttpProxyClient(mgr)
 	return &RayServiceReconciler{

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -55,13 +55,13 @@ var (
 
 type TestClientProvider struct{}
 
-func (testProvider TestClientProvider) GetDashboardClient(mgr manager.Manager) func() utils.RayDashboardClientInterface {
+func (testProvider TestClientProvider) GetDashboardClient(_ manager.Manager) func() utils.RayDashboardClientInterface {
 	return func() utils.RayDashboardClientInterface {
 		return fakeRayDashboardClient
 	}
 }
 
-func (testProvider TestClientProvider) GetHttpProxyClient(mgr manager.Manager) func() utils.RayHttpProxyClientInterface {
+func (testProvider TestClientProvider) GetHttpProxyClient(_ manager.Manager) func() utils.RayHttpProxyClientInterface {
 	return func() utils.RayHttpProxyClientInterface {
 		return fakeRayHttpProxyClient
 	}

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -199,7 +199,7 @@ func (r *RayDashboardClient) GetServeDetails(ctx context.Context) (*ServeDetails
 func (r *RayDashboardClient) ConvertServeDetailsToApplicationStatuses(serveDetails *ServeDetails) (map[string]*ServeApplicationStatus, error) {
 	detailsJson, err := json.Marshal(serveDetails.Applications)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to marshal serve details: %v.", serveDetails.Applications)
+		return nil, fmt.Errorf("Failed to marshal serve details: %v", serveDetails.Applications)
 	}
 
 	applicationStatuses := map[string]*ServeApplicationStatus{}

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
@@ -91,7 +91,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", rayDashboardClient.dashboardURL+JobPath,
-			func(req *http.Request) (*http.Response, error) {
+			func(_ *http.Request) (*http.Response, error) {
 				body := &RayJobResponse{
 					JobId: expectJobId,
 				}
@@ -99,7 +99,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 				return httpmock.NewBytesResponse(200, bodyBytes), nil
 			})
 		httpmock.RegisterResponder("GET", rayDashboardClient.dashboardURL+JobPath+expectJobId,
-			func(req *http.Request) (*http.Response, error) {
+			func(_ *http.Request) (*http.Response, error) {
 				body := &RayJobInfo{
 					JobStatus:  rayv1.JobStatusRunning,
 					Entrypoint: rayJob.Spec.Entrypoint,
@@ -109,7 +109,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 				return httpmock.NewBytesResponse(200, bodyBytes), nil
 			})
 		httpmock.RegisterResponder("GET", rayDashboardClient.dashboardURL+JobPath+errorJobId,
-			func(req *http.Request) (*http.Response, error) {
+			func(_ *http.Request) (*http.Response, error) {
 				// return a string in the body
 				return httpmock.NewStringResponse(200, "Ray misbehaved and sent string, not JSON"), nil
 			})
@@ -133,7 +133,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", rayDashboardClient.dashboardURL+JobPath+"stop-job-1/stop",
-			func(req *http.Request) (*http.Response, error) {
+			func(_ *http.Request) (*http.Response, error) {
 				body := &RayJobStopResponse{
 					Stopped: true,
 				}
@@ -150,7 +150,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", rayDashboardClient.dashboardURL+JobPath+"stop-job-1/stop",
-			func(req *http.Request) (*http.Response, error) {
+			func(_ *http.Request) (*http.Response, error) {
 				body := &RayJobStopResponse{
 					Stopped: false,
 				}
@@ -158,7 +158,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 				return httpmock.NewBytesResponse(200, bodyBytes), nil
 			})
 		httpmock.RegisterResponder("GET", rayDashboardClient.dashboardURL+JobPath+"stop-job-1",
-			func(req *http.Request) (*http.Response, error) {
+			func(_ *http.Request) (*http.Response, error) {
 				body := &RayJobInfo{
 					JobStatus:  rayv1.JobStatusSucceeded,
 					Entrypoint: rayJob.Spec.Entrypoint,

--- a/ray-operator/controllers/ray/utils/fake_httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/fake_httpproxy_httpclient.go
@@ -18,11 +18,11 @@ func (r *FakeRayHttpProxyClient) InitClient() {
 	}
 }
 
-func (r *FakeRayHttpProxyClient) SetHostIp(hostIp, podNamespace, podName string, port int) {
+func (r *FakeRayHttpProxyClient) SetHostIp(hostIp, _, _ string, port int) {
 	r.httpProxyURL = fmt.Sprintf("http://%s:%d", hostIp, port)
 }
 
-func (r *FakeRayHttpProxyClient) CheckProxyActorHealth(ctx context.Context) error {
+func (r *FakeRayHttpProxyClient) CheckProxyActorHealth(_ context.Context) error {
 	// TODO: test check return error cases.
 	// Always return successful.
 	return nil

--- a/ray-operator/controllers/ray/utils/fake_serve_httpclient.go
+++ b/ray-operator/controllers/ray/utils/fake_serve_httpclient.go
@@ -19,13 +19,13 @@ type FakeRayDashboardClient struct {
 
 var _ RayDashboardClientInterface = (*FakeRayDashboardClient)(nil)
 
-func (r *FakeRayDashboardClient) InitClient(ctx context.Context, url string, rayCluster *rayv1.RayCluster) error {
+func (r *FakeRayDashboardClient) InitClient(_ context.Context, url string, _ *rayv1.RayCluster) error {
 	r.client = &http.Client{}
 	r.dashboardURL = "http://" + url
 	return nil
 }
 
-func (r *FakeRayDashboardClient) UpdateDeployments(_ context.Context, configJson []byte) error {
+func (r *FakeRayDashboardClient) UpdateDeployments(_ context.Context, _ []byte) error {
 	fmt.Print("UpdateDeployments fake succeeds.")
 	return nil
 }
@@ -60,23 +60,23 @@ func (r *FakeRayDashboardClient) ListJobs(ctx context.Context) (*[]RayJobInfo, e
 	return nil, nil
 }
 
-func (r *FakeRayDashboardClient) SubmitJob(_ context.Context, rayJob *rayv1.RayJob) (jobId string, err error) {
+func (r *FakeRayDashboardClient) SubmitJob(_ context.Context, _ *rayv1.RayJob) (jobId string, err error) {
 	return "", nil
 }
 
-func (r *FakeRayDashboardClient) SubmitJobReq(_ context.Context, request *RayJobRequest, name *string) (string, error) {
+func (r *FakeRayDashboardClient) SubmitJobReq(_ context.Context, _ *RayJobRequest, _ *string) (string, error) {
 	return "", nil
 }
 
-func (r *FakeRayDashboardClient) GetJobLog(_ context.Context, jobName string) (*string, error) {
+func (r *FakeRayDashboardClient) GetJobLog(_ context.Context, _ string) (*string, error) {
 	lg := "log"
 	return &lg, nil
 }
 
-func (r *FakeRayDashboardClient) StopJob(_ context.Context, jobName string) (err error) {
+func (r *FakeRayDashboardClient) StopJob(_ context.Context, _ string) (err error) {
 	return nil
 }
 
-func (r *FakeRayDashboardClient) DeleteJob(_ context.Context, jobName string) error {
+func (r *FakeRayDashboardClient) DeleteJob(_ context.Context, _ string) error {
 	return nil
 }

--- a/ray-operator/test/e2e/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2e/rayjob_lightweight_test.go
@@ -27,7 +27,7 @@ func TestRayJobLightWeightMode(t *testing.T) {
 	test.Expect(err).NotTo(HaveOccurred())
 	test.T().Logf("Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
 
-	test.T().Run("Successful RayJob", func(t *testing.T) {
+	test.T().Run("Successful RayJob", func(_ *testing.T) {
 		rayJobAC := rayv1ac.RayJob("counter", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithSubmissionMode(rayv1.HTTPMode).
@@ -77,7 +77,7 @@ env_vars:
 		test.Expect(err).To(MatchError(k8serrors.NewNotFound(rayv1.Resource("rayclusters"), rayJob.Status.RayClusterName)))
 	})
 
-	test.T().Run("Failing RayJob without cluster shutdown after finished", func(t *testing.T) {
+	test.T().Run("Failing RayJob without cluster shutdown after finished", func(_ *testing.T) {
 		rayJobAC := rayv1ac.RayJob("fail", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithSubmissionMode(rayv1.HTTPMode).
@@ -107,7 +107,7 @@ env_vars:
 		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
 	})
 
-	test.T().Run("Should transition to 'Complete' if the Ray job has stopped.", func(t *testing.T) {
+	test.T().Run("Should transition to 'Complete' if the Ray job has stopped.", func(_ *testing.T) {
 		// `stop.py` will sleep for 20 seconds so that the RayJob has enough time to transition to `RUNNING`
 		// and then stop the Ray job. If the Ray job is stopped, the RayJob should transition to `Complete`.
 		rayJobAC := rayv1ac.RayJob("stop", namespace.Name).

--- a/ray-operator/test/e2e/rayjob_suspend_test.go
+++ b/ray-operator/test/e2e/rayjob_suspend_test.go
@@ -27,7 +27,7 @@ func TestRayJobSuspend(t *testing.T) {
 	test.Expect(err).NotTo(HaveOccurred())
 	test.T().Logf("Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
 
-	test.T().Run("Suspend the RayJob when its status is 'Running', and then resume it.", func(t *testing.T) {
+	test.T().Run("Suspend the RayJob when its status is 'Running', and then resume it.", func(_ *testing.T) {
 		// RayJob
 		rayJobAC := rayv1ac.RayJob("long-running", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
@@ -79,7 +79,7 @@ func TestRayJobSuspend(t *testing.T) {
 		test.T().Logf("Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 	})
 
-	test.T().Run("Create a suspended RayJob, and then resume it.", func(t *testing.T) {
+	test.T().Run("Create a suspended RayJob, and then resume it.", func(_ *testing.T) {
 		// RayJob
 		rayJobAC := rayv1ac.RayJob("counter", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().

--- a/ray-operator/test/e2e/rayjob_test.go
+++ b/ray-operator/test/e2e/rayjob_test.go
@@ -26,7 +26,7 @@ func TestRayJob(t *testing.T) {
 	test.Expect(err).NotTo(HaveOccurred())
 	test.T().Logf("Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
 
-	test.T().Run("Successful RayJob", func(t *testing.T) {
+	test.T().Run("Successful RayJob", func(_ *testing.T) {
 		// RayJob
 		rayJobAC := rayv1ac.RayJob("counter", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
@@ -83,7 +83,7 @@ env_vars:
 		test.T().Logf("Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 	})
 
-	test.T().Run("Failing RayJob without cluster shutdown after finished", func(t *testing.T) {
+	test.T().Run("Failing RayJob without cluster shutdown after finished", func(_ *testing.T) {
 		// RayJob
 		rayJobAC := rayv1ac.RayJob("fail", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
@@ -128,7 +128,7 @@ env_vars:
 		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
 	})
 
-	test.T().Run("Failing submitter K8s Job", func(t *testing.T) {
+	test.T().Run("Failing submitter K8s Job", func(_ *testing.T) {
 		// RayJob
 		rayJobAC := rayv1ac.RayJob("fail-k8s-job", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
@@ -169,7 +169,7 @@ env_vars:
 		test.T().Logf("Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 	})
 
-	test.T().Run("Should transition to 'Complete' if the Ray job has stopped.", func(t *testing.T) {
+	test.T().Run("Should transition to 'Complete' if the Ray job has stopped.", func(_ *testing.T) {
 		// `stop.py` will sleep for 20 seconds so that the RayJob has enough time to transition to `RUNNING`
 		// and then stop the Ray job. If the Ray job is stopped, the RayJob should transition to `Complete`.
 		rayJobAC := rayv1ac.RayJob("stop", namespace.Name).
@@ -200,7 +200,7 @@ env_vars:
 		test.T().Logf("Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 	})
 
-	test.T().Run("RuntimeEnvYAML is not a valid YAML string", func(t *testing.T) {
+	test.T().Run("RuntimeEnvYAML is not a valid YAML string", func(_ *testing.T) {
 		rayJobAC := rayv1ac.RayJob("invalid-yamlstr", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithEntrypoint("python /home/ray/jobs/counter.py").
@@ -216,7 +216,7 @@ env_vars:
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusNew)))
 	})
 
-	test.T().Run("RayJob has passed ActiveDeadlineSeconds", func(t *testing.T) {
+	test.T().Run("RayJob has passed ActiveDeadlineSeconds", func(_ *testing.T) {
 		rayJobAC := rayv1ac.RayJob("long-running", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -48,7 +48,7 @@ func RayCluster(t Test, namespace, name string) func(g gomega.Gomega) *rayv1.Ray
 }
 
 func RayClusterOrError(t Test, namespace, name string) func(g gomega.Gomega) (*rayv1.RayCluster, error) {
-	return func(g gomega.Gomega) (*rayv1.RayCluster, error) {
+	return func(_ gomega.Gomega) (*rayv1.RayCluster, error) {
 		return t.Client().Ray().RayV1().RayClusters(namespace).Get(t.Ctx(), name, metav1.GetOptions{})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Based on https://github.com/ray-project/kuberay/pull/2128, there are some rules that need manual fixing. This PR fixes the rule: `revive`

See https://golangci-lint.run/usage/linters/ for details.

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
