### PR TITLE
RayService: Omits Min and Max replicas from hash calculation

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1185,6 +1185,8 @@ func generateHashWithoutReplicasAndWorkersToDelete(rayClusterSpec rayv1.RayClust
 	updatedRayClusterSpec := rayClusterSpec.DeepCopy()
 	for i := 0; i < len(updatedRayClusterSpec.WorkerGroupSpecs); i++ {
 		updatedRayClusterSpec.WorkerGroupSpecs[i].Replicas = nil
+		updatedRayClusterSpec.WorkerGroupSpecs[i].MaxReplicas = nil
+		updatedRayClusterSpec.WorkerGroupSpecs[i].MinReplicas = nil
 		updatedRayClusterSpec.WorkerGroupSpecs[i].ScaleStrategy.WorkersToDelete = nil
 	}
 

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -67,6 +67,7 @@ func TestGetClusterAction(t *testing.T) {
 				Replicas:    pointer.Int32(2),
 				MinReplicas: pointer.Int32(1),
 				MaxReplicas: pointer.Int32(4),
+				GroupName:   "worker-group-1",
 			},
 		},
 	}
@@ -85,7 +86,7 @@ func TestGetClusterAction(t *testing.T) {
 
 	// Test Case 3: Different WorkerGroupSpecs should lead to RolloutNew.
 	clusterSpec3 := clusterSpec1.DeepCopy()
-	clusterSpec3.WorkerGroupSpecs[0].MinReplicas = pointer.Int32(5)
+	clusterSpec3.WorkerGroupSpecs[0].GroupName = "worker-group-2"
 	action, err = getClusterAction(clusterSpec1, *clusterSpec3)
 	assert.Nil(t, err)
 	assert.Equal(t, RolloutNew, action)
@@ -145,7 +146,7 @@ func TestGetClusterAction(t *testing.T) {
 
 	// Test Case 9: Changing an existing WorkerGroupSpec outside of Replicas/WorkersToDelete *and* adding a new WorkerGroupSpec should lead to RolloutNew.
 	clusterSpec9 := clusterSpec1.DeepCopy()
-	clusterSpec9.WorkerGroupSpecs[0].MaxReplicas = pointer.Int32(5)
+	clusterSpec9.WorkerGroupSpecs[0].GroupName = "worker-group-3"
 	clusterSpec9.WorkerGroupSpecs = append(clusterSpec9.WorkerGroupSpecs, rayv1.WorkerGroupSpec{
 		Replicas:    pointer.Int32(2),
 		MinReplicas: pointer.Int32(1),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently, when updating RayService config, changing MinReplicas or MaxReplicas in the autoscaling config triggers an entirely new RayCluster to be instantiated.  In order to facilitate orchestrating canary deployments, we'd like to have the ability to scale those parameters on an existing cluster as we move traffic over.

## Related issue number

<!-- For example: "Closes #1234" -->
Currently no issue linked, but I can create one if needed.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
