### PR TITLE
fix: update ray-job.pytorch-image-classifier.yaml

### DIFF
--- a/ray-operator/config/samples/pytorch-resnet-image-classifier/ray-job.pytorch-image-classifier.yaml
+++ b/ray-operator/config/samples/pytorch-resnet-image-classifier/ray-job.pytorch-image-classifier.yaml
@@ -88,6 +88,7 @@ spec:
                 image: rayproject/ray-ml:2.9.0-gpu
                 resources:
                   limits:
+                    cpu: "1"
                     memory: "8G"
                     nvidia.com/gpu: "1"
                   requests:


### PR DESCRIPTION
add CPU limit to worker group.
Otherwise using this RayJob YAML might result in the error of Pod using more CPU requests than the default limit.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
