### PR TITLE
Remove failed reason if reconciliation was successful

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -352,6 +352,11 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
 
+	// Reconciliation was successful, clear the reason
+	if updateErr := r.updateClusterReason(ctx, instance, ""); updateErr != nil {
+		logger.Error(updateErr, "RayCluster update reason error", "cluster name", request.Name)
+	}
+
 	// Calculate the new status for the RayCluster. Note that the function will deep copy `instance` instead of mutating it.
 	newInstance, err := r.calculateStatus(ctx, instance)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
At the moment reason is set only on error, and is not removed even if the error is fixed.

This should clear the reason if error does not exist

My issue was another operator adding the ServiceAccount to the RayCluster and creating the said ServiceAccount a moment later but if KubeRay reconcile in between the reason about forbidden serviceaccount will be added and never removed even though the service account was created almost at the same time and does exist.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
