### PR TITLE
[Style] Fix golangci-lint rule: nolintlint

### DIFF
--- a/ray-operator/.golangci.yml
+++ b/ray-operator/.golangci.yml
@@ -7,6 +7,9 @@ linters-settings:
     local-prefixes: github.com/ray-project/kuberay/ray-operator
   misspell:
     locale: US
+  nolintlint:
+    require-explanation: true
+    require-specific: true
   revive:
     ignore-generated-header: true
     rules:
@@ -68,6 +71,7 @@ linters:
     - misspell
     - nilerr
     - noctx
+    - nolintlint
     - predeclared
     - revive
     - staticcheck

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -266,7 +266,7 @@ var _ = Context("RayJob in K8sJobMode", func() {
 
 		It("RayJobs's JobDeploymentStatus transitions from Running to Complete.", func() {
 			// Update fake dashboard client to return job info with "Succeeded" status.
-			getJobInfo := func(context.Context, string) (*utils.RayJobInfo, error) { //nolint:unparam
+			getJobInfo := func(context.Context, string) (*utils.RayJobInfo, error) { //nolint:unparam // This is a mock function so parameters are required
 				return &utils.RayJobInfo{JobStatus: rayv1.JobStatusSucceeded}, nil
 			}
 			fakeRayDashboardClient.GetJobInfoMock.Store(&getJobInfo)

--- a/ray-operator/test/support/meta.go
+++ b/ray-operator/test/support/meta.go
@@ -6,8 +6,7 @@ type labelSelector string
 
 var _ Option[*metav1.ListOptions] = (*labelSelector)(nil)
 
-// nolint: unused
-// To be removed when the false-positivity is fixed.
+//nolint:unused // To be removed when the false-positivity is fixed.
 func (l labelSelector) applyTo(options *metav1.ListOptions) error {
 	options.LabelSelector = string(l)
 	return nil

--- a/ray-operator/test/support/test.go
+++ b/ray-operator/test/support/test.go
@@ -33,8 +33,7 @@ type Option[T any] interface {
 
 type errorOption[T any] func(to T) error
 
-// nolint: unused
-// To be removed when the false-positivity is fixed.
+//nolint:unused // To be removed when the false-positivity is fixed.
 func (o errorOption[T]) applyTo(to T) error {
 	return o(to)
 }
@@ -60,7 +59,7 @@ func With(t *testing.T) Test {
 type T struct {
 	*gomega.WithT
 	t *testing.T
-	// nolint: containedctx
+	//nolint:containedctx //nolint:nolintlint // TODO: The reason for this lint is unknown
 	ctx       context.Context
 	client    Client
 	outputDir string


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Based on https://github.com/ray-project/kuberay/pull/2128, there are some rules that need manual fixing. This PR fixes the rule: `nolintlint`

See https://golangci-lint.run/usage/linters/ for details.

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
