### PR TITLE
Allow configuration of restartPolicy

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -42,6 +42,9 @@ spec:
         {{- if .Values.head.serviceAccountName }}
         serviceAccountName: {{ .Values.head.serviceAccountName }}
         {{- end }}
+        {{- if .Values.head.restartPolicy }}
+        restartPolicy: {{ .Values.head.restartPolicy }}
+        {{- end }}
         {{- if .Values.head.initContainers }}
         initContainers: {{- toYaml .Values.head.initContainers | nindent 10 }}
         {{- end }}
@@ -136,6 +139,9 @@ spec:
         {{- if $values.serviceAccountName }}
         serviceAccountName: {{ $values.serviceAccountName }}
         {{- end }}
+        {{- if $values.restartPolicy }}
+        restartPolicy: {{ $values.restartPolicy }}
+        {{- end }}
         {{- if $values.initContainers }}
         initContainers: {{- toYaml $values.initContainers | nindent 10 }}
         {{- end }}
@@ -227,6 +233,9 @@ spec:
         imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
         {{- if .Values.worker.serviceAccountName }}
         serviceAccountName: {{ .Values.worker.serviceAccountName }}
+        {{- end }}
+        {{- if .Values.worker.restartPolicy }}
+        restartPolicy: {{ .Values.worker.restartPolicy }}
         {{- end }}
         {{- if .Values.worker.initContainers }}
         initContainers: {{- toYaml .Values.worker.initContainers | nindent 10 }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -56,6 +56,7 @@ head:
   # Note: From KubeRay v0.6.0, users need to create the ServiceAccount by themselves if they specify the `serviceAccountName`
   # in the headGroupSpec. See https://github.com/ray-project/kuberay/pull/1128 for more details.
   serviceAccountName: ""
+  restartPolicy: ""
   rayStartParams:
     dashboard-host: '0.0.0.0'
   # containerEnv specifies environment variables for the Ray container,
@@ -126,6 +127,7 @@ worker:
   maxReplicas: 3
   labels: {}
   serviceAccountName: ""
+  restartPolicy: ""
   rayStartParams: {}
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
@@ -189,6 +191,7 @@ additionalWorkerGroups:
     maxReplicas: 3
     labels: {}
     serviceAccountName: ""
+    restartPolicy: ""
     rayStartParams: {}
     # containerEnv specifies environment variables for the Ray container,
     # Follows standard K8s container env schema.


### PR DESCRIPTION
## Why are these changes needed?

For a correct configuration of the v2 autoscaler, it is necessary to override the restartPolicy. See: https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html#autoscaler-v2-with-kuberay

## Related issue number

No issue

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [x] This PR is not tested :(
