### PR TITLE
Allow overriding just the args in submitter pod

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -382,8 +382,8 @@ func (r *RayJobReconciler) getSubmitterTemplate(ctx context.Context, rayJobInsta
 		logger.Info("user-provided submitter template is used; the first container is assumed to be the submitter")
 	}
 
-	// If the command in the submitter pod template isn't set, use the default command.
-	if len(submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command) == 0 {
+	// If neither the command nor the args are set in the submitter pod template, use the default command.
+	if len(submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command) == 0 && len(submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args) == 0 {
 		k8sJobCommand, err := common.GetK8sJobCommand(rayJobInstance)
 		if err != nil {
 			return corev1.PodTemplateSpec{}, err


### PR DESCRIPTION
## Why are these changes needed?

My submitter Pod's docker image has configured an ENTRYPOINT which I do not wish to override. I just want to set the `args` but kuberay will override the `command` when unspecified. 

## Related issue number

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [x] This PR is not tested :(
