### PR TITLE
[Fix] Use go 1.22 on Buildkite autoscaler e2e tests

### DIFF
--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -62,7 +62,7 @@
 
 - label: 'Test Autoscaler E2E (nightly operator)'
   instance_size: large
-  image: golang:1.20
+  image: golang:1.22
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./tests/framework/config/kind-config-buildkite.yml


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
