### PR TITLE
[RayJob] Unified checkBackoffLimitAndUpdateStatusIfNeeded codepath and add an e2e test for retry

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -388,12 +388,12 @@ func checkBackoffLimitAndUpdateStatusIfNeeded(ctx context.Context, rayJob *rayv1
 				"RayJob is not eligible for retry due to failure with DeadlineExceeded",
 				"backoffLimit", *rayJob.Spec.BackoffLimit,
 				"succeeded", *rayJob.Status.Succeeded,
-				"failed", rayJob.Status.Failed,
+				"failed", *rayJob.Status.Failed,
 			)
 			return
 		}
 		logger.Info("RayJob is eligible for retry, setting JobDeploymentStatus to Retrying",
-			"backoffLimit", *rayJob.Spec.BackoffLimit, "succeeded", *rayJob.Status.Succeeded, "failed", rayJob.Status.Failed)
+			"backoffLimit", *rayJob.Spec.BackoffLimit, "succeeded", *rayJob.Status.Succeeded, "failed", *rayJob.Status.Failed)
 		rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusRetrying
 	}
 }

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -206,8 +206,6 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 			}
 			if shouldUpdate := r.checkK8sJobAndUpdateStatusIfNeeded(ctx, rayJobInstance, job); shouldUpdate {
-				// check for retries and update deployment status to Retrying.
-				r.checkBackoffLimitAndUpdateStatusIfNeeded(ctx, rayJobInstance)
 				break
 			}
 		}
@@ -268,9 +266,6 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		rayJobInstance.Status.JobDeploymentStatus = jobDeploymentStatus
 		rayJobInstance.Status.Reason = reason
 		rayJobInstance.Status.Message = jobInfo.Message
-
-		// check for retries and update deployment status to Retrying.
-		r.checkBackoffLimitAndUpdateStatusIfNeeded(ctx, rayJobInstance)
 	case rayv1.JobDeploymentStatusSuspending, rayv1.JobDeploymentStatusRetrying:
 		// The `suspend` operation should be atomic. In other words, if users set the `suspend` flag to true and then immediately
 		// set it back to false, either all of the RayJob's associated resources should be cleaned up, or no resources should be
@@ -350,9 +345,10 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		logger.Info("Unknown JobDeploymentStatus", "JobDeploymentStatus", rayJobInstance.Status.JobDeploymentStatus)
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 	}
+	checkBackoffLimitAndUpdateStatusIfNeeded(ctx, rayJobInstance)
 
 	// This is the only place where we update the RayJob status. Please do NOT add any code
-	// between the above switch statement and the following code.
+	// between `checkBackoffLimitAndUpdateStatusIfNeeded` and the following code.
 	if err = r.updateRayJobStatus(ctx, originalRayJobInstance, rayJobInstance); err != nil {
 		logger.Info("Failed to update RayJob status", "error", err)
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
@@ -362,7 +358,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 
 // checkBackoffLimitAndUpdateStatusIfNeeded determines if a RayJob is eligible for retry based on the configured backoff limit,
 // the job's success status, and its failure status. If eligible, sets the JobDeploymentStatus to Retrying.
-func (r *RayJobReconciler) checkBackoffLimitAndUpdateStatusIfNeeded(ctx context.Context, rayJob *rayv1.RayJob) {
+func checkBackoffLimitAndUpdateStatusIfNeeded(ctx context.Context, rayJob *rayv1.RayJob) {
 	logger := ctrl.LoggerFrom(ctx)
 
 	failedCount := int32(0)
@@ -387,6 +383,15 @@ func (r *RayJobReconciler) checkBackoffLimitAndUpdateStatusIfNeeded(ctx context.
 	rayJob.Status.Succeeded = ptr.To[int32](succeededCount)
 
 	if rayJob.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailed && rayJob.Spec.BackoffLimit != nil && *rayJob.Status.Failed < *rayJob.Spec.BackoffLimit+1 {
+		if rayJob.Status.Reason == rayv1.DeadlineExceeded {
+			logger.Info(
+				"RayJob is not eligible for retry due to failure with DeadlineExceeded",
+				"backoffLimit", *rayJob.Spec.BackoffLimit,
+				"succeeded", *rayJob.Status.Succeeded,
+				"failed", rayJob.Status.Failed,
+			)
+			return
+		}
 		logger.Info("RayJob is eligible for retry, setting JobDeploymentStatus to Retrying",
 			"backoffLimit", *rayJob.Spec.BackoffLimit, "succeeded", *rayJob.Status.Succeeded, "failed", rayJob.Status.Failed)
 		rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusRetrying

--- a/ray-operator/test/e2e/rayjob_retry_test.go
+++ b/ray-operator/test/e2e/rayjob_retry_test.go
@@ -1,0 +1,88 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
+	. "github.com/ray-project/kuberay/ray-operator/test/support"
+)
+
+func TestRayJobRetry(t *testing.T) {
+	test := With(t)
+
+	// Create a namespace
+	namespace := test.NewTestNamespace()
+	test.StreamKubeRayOperatorLogs()
+
+	// Job scripts
+	jobsAC := newConfigMap(namespace.Name, "jobs", files(test, "fail.py"))
+	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), jobsAC, TestApplyOptions)
+	test.Expect(err).NotTo(HaveOccurred())
+	test.T().Logf("Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
+
+	test.T().Run("Failing RayJob without cluster shutdown after finished", func(_ *testing.T) {
+		// RayJob: Set RayJob.BackoffLimit to 2
+		rayJobAC := rayv1ac.RayJob("fail", namespace.Name).
+			WithSpec(rayv1ac.RayJobSpec().
+				WithBackoffLimit(2).
+				WithSubmitterConfig(rayv1ac.SubmitterConfig().
+					WithBackoffLimit(0)).
+				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).
+				WithEntrypoint("python /home/ray/jobs/fail.py").
+				WithShutdownAfterJobFinishes(false).
+				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()))
+
+		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		test.T().Logf("Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+
+		// Assert that the RayJob deployment status and RayJob reason have been updated accordingly.
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutLong).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobReason, Equal(rayv1.AppFailed)))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
+
+		// Check whether the controller respects the backoffLimit.
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			Should(WithTransform(RayJobFailed, Equal(int32(3))))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			Should(WithTransform(RayJobSucceeded, Equal(int32(0))))
+
+		// Refresh the RayJob status
+		rayJob = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+
+		// Delete the RayJob
+		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		// Assert the RayCluster has been cascade deleted
+		test.Eventually(NotFound(RayClusterOrError(test, namespace.Name, rayJob.Status.RayClusterName))).
+			Should(BeTrue())
+
+		// Assert the submitter Job has been cascade deleted
+		test.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
+	})
+
+	// test.T().Run("Failing submitter K8s Job", func(_ *testing.T) {
+	// 	// TODO: Add a test case to verify that the RayJob has passed ActiveDeadlineSeconds
+	// 	// and ensure that the RayJob transitions to JobDeploymentStatusFailed
+	// 	// regardless of the value of backoffLimit. Refer to rayjob_test.go for an example.
+	// })
+
+	// test.T().Run("RayJob has passed ActiveDeadlineSeconds", func(_ *testing.T) {
+	// 	// TODO: Add a test case to verify that the RayJob has passed ActiveDeadlineSeconds
+	// 	// and ensure that the RayJob transitions to JobDeploymentStatusFailed
+	// 	// regardless of the value of backoffLimit. Refer to rayjob_test.go for an example.
+	// })
+}

--- a/ray-operator/test/e2e/rayjob_retry_test.go
+++ b/ray-operator/test/e2e/rayjob_retry_test.go
@@ -75,14 +75,20 @@ func TestRayJobRetry(t *testing.T) {
 	})
 
 	// test.T().Run("Failing submitter K8s Job", func(_ *testing.T) {
-	// 	// TODO: Add a test case to verify that the RayJob has passed ActiveDeadlineSeconds
-	// 	// and ensure that the RayJob transitions to JobDeploymentStatusFailed
-	// 	// regardless of the value of backoffLimit. Refer to rayjob_test.go for an example.
+	// TODO: The K8s submitter Job fails to connect to the RayCluster due to misconfiguration.
+	// This test is similar to the "Failing submitter K8s Job" test in rayjob_test.go. The difference
+	// is that here we set RayJob.BackoffLimit.
 	// })
 
 	// test.T().Run("RayJob has passed ActiveDeadlineSeconds", func(_ *testing.T) {
-	// 	// TODO: Add a test case to verify that the RayJob has passed ActiveDeadlineSeconds
-	// 	// and ensure that the RayJob transitions to JobDeploymentStatusFailed
-	// 	// regardless of the value of backoffLimit. Refer to rayjob_test.go for an example.
+	// TODO: Add a test case to verify that the RayJob has passed ActiveDeadlineSeconds
+	// and ensure that the RayJob transitions to JobDeploymentStatusFailed
+	// regardless of the value of backoffLimit. Refer to rayjob_test.go for an example.
+	// })
+
+	// test.T().Run("", func(_ *testing.T) {
+	// TODO: The RayJob in HTTPMode fails and retries. This test is similar to the
+	// "Failing RayJob without cluster shutdown after finished" test in rayjob_lightweight_test.go.
+	// The difference is that here we set RayJob.BackoffLimit.
 	// })
 }

--- a/ray-operator/test/e2e/rayjob_retry_test.go
+++ b/ray-operator/test/e2e/rayjob_retry_test.go
@@ -86,7 +86,7 @@ func TestRayJobRetry(t *testing.T) {
 	// regardless of the value of backoffLimit. Refer to rayjob_test.go for an example.
 	// })
 
-	// test.T().Run("", func(_ *testing.T) {
+	// test.T().Run("Failing RayJob in HTTPMode", func(_ *testing.T) {
 	// TODO: The RayJob in HTTPMode fails and retries. This test is similar to the
 	// "Failing RayJob without cluster shutdown after finished" test in rayjob_lightweight_test.go.
 	// The difference is that here we set RayJob.BackoffLimit.

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -35,6 +35,20 @@ func RayJobReason(job *rayv1.RayJob) rayv1.JobFailedReason {
 	return job.Status.Reason
 }
 
+func RayJobFailed(job *rayv1.RayJob) int32 {
+	if job.Status.Failed == nil {
+		return 0
+	}
+	return *job.Status.Failed
+}
+
+func RayJobSucceeded(job *rayv1.RayJob) int32 {
+	if job.Status.Succeeded == nil {
+		return 0
+	}
+	return *job.Status.Succeeded
+}
+
 func GetRayJobId(t Test, namespace, name string) string {
 	t.T().Helper()
 	job := RayJob(t, namespace, name)(t)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Unified the code path of `checkBackoffLimitAndUpdateStatusIfNeeded` to avoid forgetting to call the function when we have a new case to fail the RayJob in the future.

## Related issue number


## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

I manually tested the case that RayJob exceeded `ActiveDeadlineSeconds`.

* Create a RayJob with [this YAML](https://gist.github.com/kevin85421/37ef825a826129dd94797f5dcf86b4f2). The RayJob sets `activeDeadlineSeconds` to 1 second and the `backoffLimit` to 2. The expected behavior is that the RayJob should not retry although the `backoffLimit` is not 0 because it fails due to timeout.

```
{"level":"info","ts":"2024-07-02T17:02:22.504Z","logger":"controllers.RayJob","msg":"RayJob is not eligible for retry due to failure with DeadlineExceeded","RayJob":{"name":"rayjob-sample","namespace":"default"},"reconcileID":"6d29d711-507a-4f21-b8de-d5a45bf394cf","backoffLimit":2,"succeeded":0,"failed":1}
```

<img width="1258" alt="Screenshot 2024-07-02 at 10 07 20 AM" src="https://github.com/ray-project/kuberay/assets/20109646/66bd2a82-7595-4989-969f-9e08b3456345">
