### PR TITLE
Fix logging issue for FetchHeadServiceURL

### DIFF
--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -104,7 +104,7 @@ func FetchHeadServiceURL(ctx context.Context, cli client.Client, rayCluster *ray
 		headSvc.Namespace,
 		domainName,
 		port)
-	log.Info("FetchHeadServiceURL", "head service URL", headServiceURL, "port", defaultPortName)
+	log.Info("FetchHeadServiceURL", "head service URL", headServiceURL)
 	return headServiceURL, nil
 }
 


### PR DESCRIPTION
## Why are these changes needed?

When logging the `FetchHeadServiceURL` function, the port field was included as a string `defaultPortName`. This caused issues in Logz.io, where the port field was expected to be a long integer. The port field from the log entry is removed to ensure only `headServiceURL` is logged.

## Related issue number

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
