### PR TITLE
add feature gate mechanism to ray-operator

### DIFF
--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
+COPY pkg/features pkg/features
 
 # Build
 USER root

--- a/ray-operator/pkg/features/features.go
+++ b/ray-operator/pkg/features/features.go
@@ -1,0 +1,48 @@
+package features
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+)
+
+const (
+	// owner: @rueian @kevin85421 @andrewsykim
+	// rep: https://github.com/ray-project/enhancements/pull/54
+	// alpha: v1.2
+	//
+	// Enables new conditions in RayCluster status
+	RayClusterStatusConditions featuregate.Feature = "RayClusterStatusConditions"
+)
+
+func init() {
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultFeatureGates))
+}
+
+var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	RayClusterStatusConditions: {Default: false, PreRelease: featuregate.Alpha},
+}
+
+// SetFeatureGateDuringTest is a helper method to override feature gates in tests.
+func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) func() {
+	return featuregatetesting.SetFeatureGateDuringTest(tb, utilfeature.DefaultFeatureGate, f, value)
+}
+
+// Enabled is helper for `utilfeature.DefaultFeatureGate.Enabled()`
+func Enabled(f featuregate.Feature) bool {
+	return utilfeature.DefaultFeatureGate.Enabled(f)
+}
+
+func LogFeatureGates(log logr.Logger) {
+	features := make(map[featuregate.Feature]bool, len(defaultFeatureGates))
+	for f := range utilfeature.DefaultMutableFeatureGate.GetAll() {
+		if _, ok := defaultFeatureGates[f]; ok {
+			features[f] = Enabled(f)
+		}
+	}
+	log.Info("Loaded feature gates", "featureGates", features)
+}


### PR DESCRIPTION
## Why are these changes needed?

Add feature gating to KubeRay. This uses standard feature gate implementation used by Kubernetes components. 

## Related issue number

None

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
