### PR TITLE
fix: update cluster status failed when not all pods running

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1195,6 +1195,8 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 
 	if utils.CheckAllPodsRunning(ctx, runtimePods) {
 		newInstance.Status.State = rayv1.Ready
+	} else {
+		newInstance.Status.State = rayv1.Failed
 	}
 
 	if newInstance.Spec.Suspend != nil && *newInstance.Spec.Suspend && len(runtimePods.Items) == 0 {


### PR DESCRIPTION
## Why are these changes needed?

when not all the RayCluster's Pods running, the cluster status need to be updated with `Failed`

## Related issue number

#2188

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
