### PR TITLE
[Chore] Use safe YAML for helm-chart-verify-rbac

### DIFF
--- a/scripts/rbac-check.py
+++ b/scripts/rbac-check.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from yaml import load, CLoader as Loader
+from yaml import load, CSafeLoader
 from deepdiff import DeepDiff
 
 def compare_two_yaml(yaml1, yaml2):
@@ -19,8 +19,8 @@ if __name__ == "__main__":
 	diff_files = []
 
 	for f in files:
-		yaml1 = load(open(helm_rbac_dir + f, 'r'), Loader=Loader)
-		yaml2 = load(open(kustomize_rbac_dir + f, 'r'), Loader=Loader)
+		yaml1 = load(open(helm_rbac_dir + f, 'r'), Loader=CSafeLoader)
+		yaml2 = load(open(kustomize_rbac_dir + f, 'r'), Loader=CSafeLoader)
 		if not compare_two_yaml(yaml1, yaml2):
 			diff_files.append(f)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The default PyYAML loaders are not safe for all inputs. This change switches the helm RBAC verification script from CLoader to CSafeLoader.

While I doubt this is being abused currently, there's no reason not to switch to a loader that disallows arbitrary Python object construction. 

From the PyYAML [documentation](https://pyyaml.org/wiki/PyYAMLDocumentation):

> Loader supports all predefined tags and may construct an arbitrary Python object. Therefore it is not safe to use Loader to load a document received from an untrusted source.

See also the unsafe loader [deprecation notice](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation).

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests - I ran the rbac checker script
   - [ ] This PR is not tested :(
