### PR TITLE
[RayJob] add RayJob pass Deadline e2e-test with retry

### DIFF
--- a/ray-operator/test/e2e/rayjob_retry_test.go
+++ b/ray-operator/test/e2e/rayjob_retry_test.go
@@ -127,11 +127,32 @@ func TestRayJobRetry(t *testing.T) {
 		test.T().Logf("Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 	})
 
-	// test.T().Run("RayJob has passed ActiveDeadlineSeconds", func(_ *testing.T) {
-	// TODO: Add a test case to verify that the RayJob has passed ActiveDeadlineSeconds
-	// and ensure that the RayJob transitions to JobDeploymentStatusFailed
-	// regardless of the value of backoffLimit. Refer to rayjob_test.go for an example.
-	// })
+	test.T().Run("RayJob has passed ActiveDeadlineSeconds", func(_ *testing.T) {
+		// RayJob will transition to JobDeploymentStatusFailed
+		// regardless of the value of backoffLimit.
+		rayJobAC := rayv1ac.RayJob("long-running", namespace.Name).
+			WithSpec(rayv1ac.RayJobSpec().
+				WithBackoffLimit(2).
+				WithSubmitterConfig(rayv1ac.SubmitterConfig().
+					WithBackoffLimit(0)).
+				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).
+				WithEntrypoint("python /home/ray/jobs/long_running.py").
+				WithShutdownAfterJobFinishes(true).
+				WithTTLSecondsAfterFinished(600).
+				WithActiveDeadlineSeconds(5).
+				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()))
+
+		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		// The RayJob will transition to `Complete` because it has passed `ActiveDeadlineSeconds`.
+		test.T().Logf("Waiting for RayJob %s/%s to be 'Complete'", rayJob.Namespace, rayJob.Name)
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobReason, Equal(rayv1.DeadlineExceeded)))
+	})
 
 	// test.T().Run("Failing RayJob in HTTPMode", func(_ *testing.T) {
 	// TODO: The RayJob in HTTPMode fails and retries. This test is similar to the

--- a/ray-operator/test/e2e/rayjob_retry_test.go
+++ b/ray-operator/test/e2e/rayjob_retry_test.go
@@ -146,12 +146,18 @@ func TestRayJobRetry(t *testing.T) {
 		test.Expect(err).NotTo(HaveOccurred())
 		test.T().Logf("Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		// The RayJob will transition to `Complete` because it has passed `ActiveDeadlineSeconds`.
-		test.T().Logf("Waiting for RayJob %s/%s to be 'Complete'", rayJob.Namespace, rayJob.Name)
+		// The RayJob will transition to `Failed` because it has passed `ActiveDeadlineSeconds`.
+		test.T().Logf("Waiting for RayJob %s/%s to be 'Failed'", rayJob.Namespace, rayJob.Name)
+
 		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
 		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobReason, Equal(rayv1.DeadlineExceeded)))
+
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			Should(WithTransform(RayJobFailed, Equal(int32(1))))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			Should(WithTransform(RayJobSucceeded, Equal(int32(0))))
 	})
 
 	// test.T().Run("Failing RayJob in HTTPMode", func(_ *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add test for rayjob_retry_test.go.

https://github.com/ray-project/kuberay/blob/ea314d7ee780e840382f3de852918f69d7867f25/ray-operator/test/e2e/rayjob_retry_test.go#L83-L87

Make sure RayJob status reaches to JobDeploymentStatusFailed after ActiveDeadlineSeconds regardless of retry times.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

```
$ kind delete cluster

$ sudo rm -rf bin

$ cd ray-operator

$ kind create cluster --image=kindest/node:v1.24.0

$ IMG=kuberay/operator:nightly make docker-build

$ kind load docker-image kuberay/operator:nightly

$ helm install kuberay-operator --set image.repository=kuberay/operator --set image.tag=nightly ../helm-chart/kuberay-operator

$ go test -timeout 30m -v ./test/e2e/rayjob_retry_test.go ./test/e2e/support.go 2>&1 | tee e2e-rayjob-test.log
```
```
--- PASS: TestRayJobRetry (175.48s)
    --- PASS: TestRayJobRetry/Failing_RayJob_without_cluster_shutdown_after_finished (90.70s)
    --- PASS: TestRayJobRetry/Failing_submitter_K8s_Job (77.66s)
    --- PASS: TestRayJobRetry/RayJob_has_passed_ActiveDeadlineSeconds (7.05s)
PASS
ok      command-line-arguments  176.472s
```
