### PR TITLE
[RayJob] add Failing RayJob in HTTPMode e2e test for rayjob with retry

### DIFF
--- a/ray-operator/test/e2e/rayjob_retry_test.go
+++ b/ray-operator/test/e2e/rayjob_retry_test.go
@@ -152,11 +152,11 @@ func TestRayJobRetry(t *testing.T) {
 		// Assert that the RayJob deployment status has been updated.
 		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
-		
+
 		// Assert the Ray job has failed.
 		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
-		
+
 		// Check the RayJob reason has been updated.
 		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobReason, Equal(rayv1.AppFailed)))

--- a/ray-operator/test/e2e/rayjob_retry_test.go
+++ b/ray-operator/test/e2e/rayjob_retry_test.go
@@ -134,10 +134,6 @@ func TestRayJobRetry(t *testing.T) {
 	// })
 
 	test.T().Run("Failing RayJob in HTTPMode", func(_ *testing.T) {
-		// TODO: The RayJob in HTTPMode fails and retries. This test is similar to the
-		// "Failing RayJob without cluster shutdown after finished" test in rayjob_lightweight_test.go.
-		// The difference is that here we set RayJob.BackoffLimit.
-
 		// Set up the RayJob with HTTP mode and a BackoffLimit
 		rayJobAC := rayv1ac.RayJob("failing-rayjob-in-httpmode", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().

--- a/ray-operator/test/e2e/rayjob_retry_test.go
+++ b/ray-operator/test/e2e/rayjob_retry_test.go
@@ -133,9 +133,49 @@ func TestRayJobRetry(t *testing.T) {
 	// regardless of the value of backoffLimit. Refer to rayjob_test.go for an example.
 	// })
 
-	// test.T().Run("Failing RayJob in HTTPMode", func(_ *testing.T) {
-	// TODO: The RayJob in HTTPMode fails and retries. This test is similar to the
-	// "Failing RayJob without cluster shutdown after finished" test in rayjob_lightweight_test.go.
-	// The difference is that here we set RayJob.BackoffLimit.
-	// })
+	test.T().Run("Failing RayJob in HTTPMode", func(_ *testing.T) {
+		// TODO: The RayJob in HTTPMode fails and retries. This test is similar to the
+		// "Failing RayJob without cluster shutdown after finished" test in rayjob_lightweight_test.go.
+		// The difference is that here we set RayJob.BackoffLimit.
+
+		// Set up the RayJob with HTTP mode and a BackoffLimit
+		rayJobAC := rayv1ac.RayJob("failing-rayjob-in-httpmode", namespace.Name).
+			WithSpec(rayv1ac.RayJobSpec().
+				WithSubmissionMode(rayv1.HTTPMode).
+				WithBackoffLimit(2).
+				WithEntrypoint("python /home/ray/jobs/fail.py").
+				WithShutdownAfterJobFinishes(false).
+				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))))
+
+		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		test.T().Logf("Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+
+		// Assert the Ray job has failed
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
+
+		// Assert that the RayJob deployment status and RayJob reason have been updated accordingly.
+		test.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobReason, Equal(rayv1.AppFailed)))
+
+		// Check whether the controller respects the backoffLimit.
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			Should(WithTransform(RayJobFailed, Equal(int32(3)))) // 2 retries + 1 initial attempt = 3 failures
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			Should(WithTransform(RayJobSucceeded, Equal(int32(0))))
+		test.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobReason, Equal(rayv1.AppFailed)))
+
+		// Clean up
+		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		test.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+	})
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Add the "The RayJob in HTTPMode fails and retries" test.

https://github.com/ray-project/kuberay/blob/ea314d7ee780e840382f3de852918f69d7867f25/ray-operator/test/e2e/rayjob_retry_test.go#L89-L93

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

Testing was conducted on my Apply M2 Mac, with the RayImage changed to `rayproject/ray:2.9.0-aarch64` in the `ray-operator/test/support/defaults.go` file.

Below are the commands I used for the test and the resulting test logs. 
```
$ cd ray-operator
$ kind create cluster --image=kindest/node:v1.24.0
$ IMG=kuberay/operator:nightly make docker-build
$ kind load docker-image kuberay/operator:nightly
$ helm install kuberay-operator --set image.repository=kuberay/operator --set image.tag=nightly ../helm-chart/kuberay-operator
$ go test -timeout 30m -v ./test/e2e/rayjob_retry_test.go ./test/e2e/support.go 
```
```
--- PASS: TestRayJobRetry (283.95s)
    --- PASS: TestRayJobRetry/Failing_RayJob_without_cluster_shutdown_after_finished (134.35s)
    --- PASS: TestRayJobRetry/Failing_submitter_K8s_Job (76.77s)
    --- PASS: TestRayJobRetry/Failing_RayJob_in_HTTPMode (72.70s)
PASS
ok  	command-line-arguments	284.457s
```