### PR TITLE
[Refactor][RayCluster] Unify status update to single place

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1496,7 +1496,7 @@ func TestUpdateStatusObservedGeneration(t *testing.T) {
 	}
 
 	// Compare the values of `Generation` and `ObservedGeneration` to check if they match.
-	newInstance, err := testRayClusterReconciler.calculateStatus(ctx, testRayCluster)
+	newInstance, err := testRayClusterReconciler.calculateStatus(ctx, testRayCluster, nil)
 	assert.Nil(t, err)
 	err = fakeClient.Get(ctx, namespacedName, &cluster)
 	assert.Nil(t, err)
@@ -1676,7 +1676,7 @@ func TestCalculateStatus(t *testing.T) {
 	}
 
 	// Test head information
-	newInstance, err := r.calculateStatus(ctx, testRayCluster)
+	newInstance, err := r.calculateStatus(ctx, testRayCluster, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, headNodeIP, newInstance.Status.Head.PodIP)
 	assert.Equal(t, headServiceIP, newInstance.Status.Head.ServiceIP)
@@ -1729,7 +1729,7 @@ func TestStateTransitionTimes_NoStateChange(t *testing.T) {
 	preUpdateTime := metav1.Now()
 	testRayCluster.Status.State = rayv1.Ready
 	testRayCluster.Status.StateTransitionTimes = map[rayv1.ClusterState]*metav1.Time{rayv1.Ready: &preUpdateTime}
-	newInstance, err := r.calculateStatus(ctx, testRayCluster)
+	newInstance, err := r.calculateStatus(ctx, testRayCluster, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, preUpdateTime, *newInstance.Status.StateTransitionTimes[rayv1.Ready], "Cluster state transition timestamp should not be updated")
 }

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1257,7 +1257,9 @@ func TestReconcile_UpdateClusterReason(t *testing.T) {
 	}
 	reason := "test reason"
 
-	err = testRayClusterReconciler.updateClusterReason(ctx, testRayCluster, reason)
+	newTestRayCluster := testRayCluster.DeepCopy()
+	newTestRayCluster.Status.Reason = reason
+	err = testRayClusterReconciler.updateRayClusterStatus(ctx, testRayCluster, newTestRayCluster)
 	assert.Nil(t, err, "Fail to update cluster reason")
 
 	err = fakeClient.Get(ctx, namespacedName, &cluster)
@@ -1532,7 +1534,9 @@ func TestReconcile_UpdateClusterState(t *testing.T) {
 	}
 
 	state := rayv1.Ready
-	err = testRayClusterReconciler.updateClusterState(ctx, testRayCluster, state)
+	newTestRayCluster := testRayCluster.DeepCopy()
+	newTestRayCluster.Status.State = state
+	err = testRayClusterReconciler.updateRayClusterStatus(ctx, testRayCluster, newTestRayCluster)
 	assert.Nil(t, err, "Fail to update cluster state")
 
 	err = fakeClient.Get(ctx, namespacedName, &cluster)


### PR DESCRIPTION
## Why are these changes needed?

See the description in the corresponding issue for details.

Implementation details of this PR:
- `updateClusterState` and `updateClusterReason` functions are integrated into a single function `updateRayClusterStatus`.
- The `inconsistentRayClusterStatus` checking is moved into `updateRayClusterStatus`, so that the status will only be updated if it is inconsistent.
- `calculateStatus` function takes one more argument called `reconcileErr`. If it is a non-nil value, then the `Status.State` will be set to `Failed` and `Status.Reason` will be set to the string representation of the error.
- Reconcile functions for each resource:
  - Before: Calling each reconcile function and if there is an error, update the status and then return immediately.
  - Now: Stored reconcile functions into a slice and loop over it. If there is an error, then save it to `reconcileErr` variable for processing later.

## Related issue number

Resolves: ray-project/kuberay#2235

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
