### PR TITLE
Fix for deploy error with deprecated cli

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -7,7 +7,6 @@ on:
       - 'release-*'
     paths-ignore:
       - 'apiserver/**'
-      - 'cli/**'
       - 'docs/**'
       - '**.adoc'
       - '**.md'
@@ -18,7 +17,6 @@ on:
       - 'release-*'
     paths-ignore:
       - 'apiserver/**'
-      - 'cli/**'
       - 'docs/**'
       - '**.adoc'
       - '**.md'

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -1,1 +1,0 @@
-../../cli/README.md


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

CLI is being deprecated and this removes the file that was causing the deploy ci step to fail. Also removed residual `cli/` mentions in the repo.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
