### PR TITLE
Add workflow to mark as and close stale issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,22 @@
+name: "Close inactive issues"
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."
+          stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."
+          days-before-stale: 60
+          days-before-close: 30
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
+          close-pr-message: "This pull request was closed because it has been inactive for 30 days since being marked as stale."


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
> This workflow would close issues and pull request as a bot `Named` github-actions
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

<!-- Please give a short summary of the change and the problem this solves. -->
## Why are these changes needed?

The addition of a stale bot will help automate the process of managing old PRs and issues in the KubeRay repo. This will simplify the management by automatically marking and closing PRs and issues that are inactive for a specified period, ensuring that the repository remains clean and up-to-date.


## Related issue number

<!-- For example: "Closes #1234" -->
Closes #681 
## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [x] This PR is not tested :(