### PR TITLE
[Feat][RayCluster] Use a new RayClusterReplicaFailure condition to reflect the result of reconcilePods

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -605,7 +605,7 @@ var reconcilePodsErr = errstd.New("reconcile pods error")
 
 func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv1.RayCluster) error {
 	if err := r.doReconcilePods(ctx, instance); err != nil {
-		return fmt.Errorf("%w: %w", reconcilePodsErr, err)
+		return errstd.Join(reconcilePodsErr, err)
 	}
 	return nil
 }

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -395,9 +395,7 @@ func (r *RayClusterReconciler) inconsistentRayClusterStatus(ctx context.Context,
 		return true
 	}
 	if !reflect.DeepEqual(oldStatus.Conditions, newStatus.Conditions) {
-		logger.Info("inconsistentRayClusterStatus", "detect inconsistency", fmt.Sprintf(
-			"old Conditions: %v, new Conditions: %v",
-			oldStatus.Conditions, newStatus.Conditions))
+		logger.Info("inconsistentRayClusterStatus", "old conditions", oldStatus.Conditions, "new conditions", newStatus.Conditions)
 		return true
 	}
 	return false

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -1,5 +1,10 @@
 package utils
 
+import (
+	"errors"
+	"go.uber.org/multierr"
+)
+
 const (
 
 	// Default application name
@@ -193,4 +198,25 @@ const (
 // This is also the only function to construct label filter of resources originated from a given CRDType.
 func RayOriginatedFromCRDLabelValue(crdType CRDType) string {
 	return string(crdType)
+}
+
+// These are markers used by the calculateStatus() for setting the RayClusterReplicaFailure condition.
+var (
+	ErrRayClusterReplicaFailure = errors.New("RayClusterReplicaFailure")
+	ErrFailedDeleteAllPods      = errors.Join(ErrRayClusterReplicaFailure, errors.New("FailedDeleteAllPods"))
+	ErrFailedDeleteHeadPod      = errors.Join(ErrRayClusterReplicaFailure, errors.New("FailedDeleteHeadPod"))
+	ErrFailedCreateHeadPod      = errors.Join(ErrRayClusterReplicaFailure, errors.New("FailedCreateHeadPod"))
+	ErrFailedDeleteWorkerPod    = errors.Join(ErrRayClusterReplicaFailure, errors.New("FailedDeleteWorkerPod"))
+	ErrFailedCreateWorkerPod    = errors.Join(ErrRayClusterReplicaFailure, errors.New("FailedCreateWorkerPod"))
+)
+
+func RayClusterReplicaFailureReason(err error) string {
+	errs := multierr.Errors(err)
+	if len(errs) < 2 {
+		return ""
+	}
+	if !errors.Is(errs[0], ErrRayClusterReplicaFailure) {
+		return ""
+	}
+	return errs[1].Error()
 }

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -199,18 +199,18 @@ func RayOriginatedFromCRDLabelValue(crdType CRDType) string {
 
 // These are markers used by the calculateStatus() for setting the RayClusterReplicaFailure condition.
 var (
-	ErrRayClusterReplicaFailure = errors.New("RayClusterReplicaFailure")
-	ErrFailedDeleteAllPods      = errors.Join(ErrRayClusterReplicaFailure, errors.New("FailedDeleteAllPods"))
-	ErrFailedDeleteHeadPod      = errors.Join(ErrRayClusterReplicaFailure, errors.New("FailedDeleteHeadPod"))
-	ErrFailedCreateHeadPod      = errors.Join(ErrRayClusterReplicaFailure, errors.New("FailedCreateHeadPod"))
-	ErrFailedDeleteWorkerPod    = errors.Join(ErrRayClusterReplicaFailure, errors.New("FailedDeleteWorkerPod"))
-	ErrFailedCreateWorkerPod    = errors.Join(ErrRayClusterReplicaFailure, errors.New("FailedCreateWorkerPod"))
+	errRayClusterReplicaFailure = errors.New("RayClusterReplicaFailure")
+	ErrFailedDeleteAllPods      = errors.Join(errRayClusterReplicaFailure, errors.New("FailedDeleteAllPods"))
+	ErrFailedDeleteHeadPod      = errors.Join(errRayClusterReplicaFailure, errors.New("FailedDeleteHeadPod"))
+	ErrFailedCreateHeadPod      = errors.Join(errRayClusterReplicaFailure, errors.New("FailedCreateHeadPod"))
+	ErrFailedDeleteWorkerPod    = errors.Join(errRayClusterReplicaFailure, errors.New("FailedDeleteWorkerPod"))
+	ErrFailedCreateWorkerPod    = errors.Join(errRayClusterReplicaFailure, errors.New("FailedCreateWorkerPod"))
 )
 
 func RayClusterReplicaFailureReason(err error) string {
 	if e, ok := err.(interface{ Unwrap() []error }); ok {
 		errs := e.Unwrap()
-		if len(errs) >= 2 && errors.Is(errs[0], ErrRayClusterReplicaFailure) {
+		if len(errs) >= 2 && errors.Is(errs[0], errRayClusterReplicaFailure) {
 			return errs[1].Error()
 		}
 	}

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -1,9 +1,6 @@
 package utils
 
-import (
-	"errors"
-	"go.uber.org/multierr"
-)
+import "errors"
 
 const (
 
@@ -211,12 +208,11 @@ var (
 )
 
 func RayClusterReplicaFailureReason(err error) string {
-	errs := multierr.Errors(err)
-	if len(errs) < 2 {
-		return ""
+	if e, ok := err.(interface{ Unwrap() []error }); ok {
+		errs := e.Unwrap()
+		if len(errs) >= 2 && errors.Is(errs[0], ErrRayClusterReplicaFailure) {
+			return errs[1].Error()
+		}
 	}
-	if !errors.Is(errs[0], ErrRayClusterReplicaFailure) {
-		return ""
-	}
-	return errs[1].Error()
+	return ""
 }

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -523,3 +523,11 @@ env_vars:
 		})
 	}
 }
+
+func TestErrRayClusterReplicaFailureReason(t *testing.T) {
+	assert.Equal(t, RayClusterReplicaFailureReason(ErrFailedDeleteAllPods), "FailedDeleteAllPods")
+	assert.Equal(t, RayClusterReplicaFailureReason(ErrFailedDeleteHeadPod), "FailedDeleteHeadPod")
+	assert.Equal(t, RayClusterReplicaFailureReason(ErrFailedCreateHeadPod), "FailedCreateHeadPod")
+	assert.Equal(t, RayClusterReplicaFailureReason(ErrFailedDeleteWorkerPod), "FailedDeleteWorkerPod")
+	assert.Equal(t, RayClusterReplicaFailureReason(ErrFailedCreateWorkerPod), "FailedCreateWorkerPod")
+}

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -530,4 +531,5 @@ func TestErrRayClusterReplicaFailureReason(t *testing.T) {
 	assert.Equal(t, RayClusterReplicaFailureReason(ErrFailedCreateHeadPod), "FailedCreateHeadPod")
 	assert.Equal(t, RayClusterReplicaFailureReason(ErrFailedDeleteWorkerPod), "FailedDeleteWorkerPod")
 	assert.Equal(t, RayClusterReplicaFailureReason(ErrFailedCreateWorkerPod), "FailedCreateWorkerPod")
+	assert.Equal(t, RayClusterReplicaFailureReason(errors.New("other error")), "")
 }


### PR DESCRIPTION
This is a revised draft of https://github.com/ray-project/kuberay/pull/2245 based on the review.

In this version, a `RayClusterReplicaFailure` condition will be set whenever the `reconcilePods()` returns a `reconcileErr`. This is done by the `calculateStatus()` based on the `reconcileErr` solely. It assumes the `reconcilePods()` is the last reconciliation function.

We also consolidate the fine-grained condition reasons in the previous draft into one `FailedReconcilePods` for simplicity.

Tests are conducted in three parts:
1. Assert the `reconcilePods()` will return a `reconcileErr`.
2. Assert the `calculateStatus()` will set the condition only when the feature gate is enabled.
3. Assert the `inconsistentRayClusterStatus()` will report `true` when conditions are changed.

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
