### PR TITLE
DELETE_RAYJOB_CR_AFTER_JOB_FINISHES doesn't work with Configuration API

### DIFF
--- a/ray-operator/apis/config/v1alpha1/configuration_types.go
+++ b/ray-operator/apis/config/v1alpha1/configuration_types.go
@@ -3,9 +3,6 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 )
 
 //+kubebuilder:object:root=true
@@ -66,12 +63,4 @@ type Configuration struct {
 
 	// DeleteRayJobAfterJobFinishes deletes the RayJob CR itself if shutdownAfterJobFinishes is set to true.
 	DeleteRayJobAfterJobFinishes bool `json:"deleteRayJobAfterJobFinishes,omitempty"`
-}
-
-func (config Configuration) GetDashboardClient(mgr manager.Manager) func() utils.RayDashboardClientInterface {
-	return utils.GetRayDashboardClientFunc(mgr, config.UseKubernetesProxy)
-}
-
-func (config Configuration) GetHttpProxyClient(mgr manager.Manager) func() utils.RayHttpProxyClientInterface {
-	return utils.GetRayHttpProxyClientFunc(mgr, config.UseKubernetesProxy)
 }

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -17,7 +17,6 @@ package ray
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -423,8 +422,11 @@ var _ = Context("RayJob in K8sJobMode", func() {
 		})
 
 		It("If DELETE_RAYJOB_CR_AFTER_JOB_FINISHES environement variable is set, RayJob should be deleted.", func() {
-			os.Setenv(utils.DELETE_RAYJOB_CR_AFTER_JOB_FINISHES, "true")
-			defer os.Unsetenv(utils.DELETE_RAYJOB_CR_AFTER_JOB_FINISHES)
+			rayJobReconciler.deleteRayJobAfterJobFinishes = true
+			defer func() {
+				rayJobReconciler.deleteRayJobAfterJobFinishes = false
+			}()
+
 			Eventually(
 				func() bool {
 					return apierrors.IsNotFound(getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob)())

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -14,11 +14,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/apimachinery/pkg/util/json"
 
+	configapi "github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
@@ -29,6 +31,18 @@ var (
 	// Job URL paths
 	JobPath = "/api/jobs/"
 )
+
+type RayClientProvider struct {
+	configapi.Configuration
+}
+
+func (r *RayClientProvider) GetDashboardClient(mgr manager.Manager) func() RayDashboardClientInterface {
+	return GetRayDashboardClientFunc(mgr, r.UseKubernetesProxy)
+}
+
+func (r *RayClientProvider) GetHttpProxyClient(mgr manager.Manager) func() RayHttpProxyClientInterface {
+	return GetRayHttpProxyClientFunc(mgr, r.UseKubernetesProxy)
+}
 
 type RayDashboardClientInterface interface {
 	InitClient(ctx context.Context, url string, rayCluster *rayv1.RayCluster) error


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is a follow-up to https://github.com/ray-project/kuberay/pull/2225 

The `deleteRayJobAfterJobFinishes` field in the Configuration API does not actually work because the controller only checks for environment variables. This PR changes the behavior so that KubeRay checks both environment variables and the Configuration API.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
