### PR TITLE
Support disable leader election for manager go binary via Values.yaml to mitigate kuberay restarts

### DIFF
--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
             {{- $argList = append $argList "--log-file-encoder" -}}
             {{- $argList = append $argList .Values.logging.fileEncoder -}}
             {{- end -}}
-            {{- if not .Values.leaderElection.enabled -}}
+            {{- if not .Values.leaderElectionEnabled -}}
             {{- $argList = append $argList "--enable-leader-election=false" -}}
             {{- end -}}
             {{- (printf "\n") -}}

--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -81,6 +81,9 @@ spec:
             {{- $argList = append $argList "--log-file-encoder" -}}
             {{- $argList = append $argList .Values.logging.fileEncoder -}}
             {{- end -}}
+            {{- if not .Values.leaderElection.enabled -}}
+            {{- $argList = append $argList "--enable-leader-election=false" -}}
+            {{- end -}}
             {{- (printf "\n") -}}
             {{- $argList | toYaml | indent 12 }}
           ports:

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -75,8 +75,7 @@ securityContext:
 
 
 # enabled by default, disable leader election to solve k8s api timeout when leader election occur and 1 replica exist.
-leaderElection:
-  enabled: true
+leaderElectionEnabled: true
 
 # If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on.
 rbacEnable: true

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -74,6 +74,10 @@ securityContext:
     type: RuntimeDefault
 
 
+# enabled by default, disable leader election to solve k8s api timeout when leader election occur and 1 replica exist.
+leaderElection:
+  enabled: true
+
 # If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on.
 rbacEnable: true
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, we don't have support to disable leader election via kuberay values.yaml
to disable leader election and prevent leader election lost errors:
```
leaderElectionEnabled: false
```

true is the default, so there is no need to check if enabled

https://github.com/ray-project/kuberay/issues/2252
https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1717181822513479

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/kuberay/issues/2252
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
