### PR TITLE
[Feature] REP 54: Add PodName to the HeadInfo

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -7831,6 +7831,8 @@ spec:
                 properties:
                   podIP:
                     type: string
+                  podName:
+                    type: string
                   serviceIP:
                     type: string
                   serviceName:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -11487,6 +11487,8 @@ spec:
                     properties:
                       podIP:
                         type: string
+                      podName:
+                        type: string
                       serviceIP:
                         type: string
                       serviceName:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -8040,6 +8040,8 @@ spec:
                         properties:
                           podIP:
                             type: string
+                          podName:
+                            type: string
                           serviceIP:
                             type: string
                           serviceName:
@@ -8187,6 +8189,8 @@ spec:
                       head:
                         properties:
                           podIP:
+                            type: string
+                          podName:
                             type: string
                           serviceIP:
                             type: string

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -177,6 +177,7 @@ const (
 type HeadInfo struct {
 	PodIP       string `json:"podIP,omitempty"`
 	ServiceIP   string `json:"serviceIP,omitempty"`
+	PodName     string `json:"podName,omitempty"`
 	ServiceName string `json:"serviceName,omitempty"`
 }
 

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -7831,6 +7831,8 @@ spec:
                 properties:
                   podIP:
                     type: string
+                  podName:
+                    type: string
                   serviceIP:
                     type: string
                   serviceName:

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -11487,6 +11487,8 @@ spec:
                     properties:
                       podIP:
                         type: string
+                      podName:
+                        type: string
                       serviceIP:
                         type: string
                       serviceName:

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -8040,6 +8040,8 @@ spec:
                         properties:
                           podIP:
                             type: string
+                          podName:
+                            type: string
                           serviceIP:
                             type: string
                           serviceName:
@@ -8187,6 +8189,8 @@ spec:
                       head:
                         properties:
                           podIP:
+                            type: string
+                          podName:
                             type: string
                           serviceIP:
                             type: string

--- a/ray-operator/controllers/ray/common/association.go
+++ b/ray-operator/controllers/ray/common/association.go
@@ -1,6 +1,10 @@
 package common
 
 import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -158,4 +162,15 @@ func RayJobRayClusterNamespacedName(rayJob *rayv1.RayJob) types.NamespacedName {
 		Name:      rayJob.Status.RayClusterName,
 		Namespace: rayJob.Namespace,
 	}
+}
+
+func GetRayClusterHeadPod(ctx context.Context, reader client.Reader, instance *rayv1.RayCluster) (*corev1.Pod, error) {
+	if instance.Status.Head.PodName == "" {
+		return nil, fmt.Errorf("RayCluster %s in the namespace %s did not contain .Status.Head.PodName", instance.Name, instance.Namespace)
+	}
+	pod := &corev1.Pod{}
+	if err := reader.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Status.Head.PodName}, pod); err != nil {
+		return nil, err
+	}
+	return pod, nil
 }

--- a/ray-operator/controllers/ray/common/association.go
+++ b/ray-operator/controllers/ray/common/association.go
@@ -165,7 +165,7 @@ func RayJobRayClusterNamespacedName(rayJob *rayv1.RayJob) types.NamespacedName {
 	}
 }
 
-// GetRayClusterHeadPod get a *corev1.Pod from a *rayv1.RayCluster. Note that it returns (nil, nil) in the case of no head pod exists.
+// GetRayClusterHeadPod gets a *corev1.Pod from a *rayv1.RayCluster. Note that it returns (nil, nil) in the case of no head pod exists.
 func GetRayClusterHeadPod(ctx context.Context, reader client.Reader, instance *rayv1.RayCluster) (*corev1.Pod, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
@@ -175,12 +175,12 @@ func GetRayClusterHeadPod(ctx context.Context, reader client.Reader, instance *r
 		return nil, err
 	}
 	if len(runtimePods.Items) == 0 {
-		logger.Info(fmt.Sprintf("Found %d head pods. cluster name %s, filter labels %v", len(runtimePods.Items), instance.Name, filterLabels))
+		logger.Info("Found 0 head pod", "filter labels", filterLabels)
 		return nil, nil
 	}
 	if len(runtimePods.Items) > 1 {
-		logger.Info(fmt.Sprintf("Found %d head pods. cluster name %s, filter labels %v", len(runtimePods.Items), instance.Name, filterLabels))
-		return nil, fmt.Errorf("found multiple heads. cluster name %s, filter labels %v", instance.Name, filterLabels)
+		logger.Info("Found multiple head pods", "count", len(runtimePods.Items), "filter labels", filterLabels)
+		return nil, fmt.Errorf("found multiple heads. filter labels %v", filterLabels)
 	}
 	return &runtimePods.Items[0], nil
 }

--- a/ray-operator/controllers/ray/common/association_test.go
+++ b/ray-operator/controllers/ray/common/association_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
@@ -255,4 +257,40 @@ func TestRayJobRayClusterNamespacedName(t *testing.T) {
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
 	}
+}
+
+func TestGetRayClusterHeadPod(t *testing.T) {
+	// Create a new scheme with CRDs, Pod, Service schemes.
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	// Mock data
+	cluster := rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Status: rayv1.RayClusterStatus{
+			Head: rayv1.HeadInfo{
+				PodName: "head-pod",
+			},
+		},
+	}
+
+	headPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "head-pod",
+			Namespace: cluster.ObjectMeta.Namespace,
+		},
+	}
+
+	// Initialize a fake client with newScheme and runtimeObjects.
+	runtimeObjects := []runtime.Object{headPod}
+	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
+	ctx := context.TODO()
+
+	ret, err := GetRayClusterHeadPod(ctx, fakeClient, &cluster)
+	assert.Nil(t, err)
+	assert.Equal(t, ret, headPod)
 }

--- a/ray-operator/controllers/ray/common/association_test.go
+++ b/ray-operator/controllers/ray/common/association_test.go
@@ -271,17 +271,16 @@ func TestGetRayClusterHeadPod(t *testing.T) {
 			Name:      "test-cluster",
 			Namespace: "default",
 		},
-		Status: rayv1.RayClusterStatus{
-			Head: rayv1.HeadInfo{
-				PodName: "head-pod",
-			},
-		},
 	}
 
 	headPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "head-pod",
 			Namespace: cluster.ObjectMeta.Namespace,
+			Labels: map[string]string{
+				utils.RayClusterLabelKey:  cluster.Name,
+				utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
+			},
 		},
 	}
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1241,12 +1241,12 @@ func (r *RayClusterReconciler) getHeadServiceIPAndName(ctx context.Context, inst
 		return "", "", fmt.Errorf("head service IP is empty. cluster name %s, filter labels %v", instance.Name, common.RayClusterHeadServiceListOptions(instance))
 	} else if runtimeServices.Items[0].Spec.ClusterIP == corev1.ClusterIPNone {
 		// We return Head Pod IP if the Head service is headless.
-		head, err := common.GetRayClusterHeadPod(ctx, r, instance)
+		headPod, err := common.GetRayClusterHeadPod(ctx, r, instance)
 		if err != nil {
 			return "", "", err
 		}
-		if head != nil {
-			return head.Status.PodIP, runtimeServices.Items[0].Name, nil
+		if headPod != nil {
+			return headPod.Status.PodIP, runtimeServices.Items[0].Name, nil
 		}
 		return "", runtimeServices.Items[0].Name, nil
 	}
@@ -1296,13 +1296,13 @@ func (r *RayClusterReconciler) updateEndpoints(ctx context.Context, instance *ra
 }
 
 func (r *RayClusterReconciler) updateHeadInfo(ctx context.Context, instance *rayv1.RayCluster) error {
-	head, err := common.GetRayClusterHeadPod(ctx, r, instance)
+	headPod, err := common.GetRayClusterHeadPod(ctx, r, instance)
 	if err != nil {
 		return err
 	}
-	if head != nil {
-		instance.Status.Head.PodIP = head.Status.PodIP
-		instance.Status.Head.PodName = head.Name
+	if headPod != nil {
+		instance.Status.Head.PodIP = headPod.Status.PodIP
+		instance.Status.Head.PodName = headPod.Name
 	}
 
 	ip, name, err := r.getHeadServiceIPAndName(ctx, instance)

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1331,7 +1331,7 @@ func TestGetHeadPodIPAndName(t *testing.T) {
 		"no error if there's more than one head node": {
 			pods:         append(testPods, extraHeadPod),
 			expectedIP:   "",
-			returnsError: false,
+			returnsError: true,
 		},
 		"no error if head pod ip is not yet set": {
 			pods:         testPodsNoHeadIP,

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1346,10 +1346,10 @@ func TestGetHeadPodIPAndNameFromGetRayClusterHeadPod(t *testing.T) {
 			fakeClient := clientFake.NewClientBuilder().WithRuntimeObjects(tc.pods...).Build()
 
 			ip, name := "", ""
-			head, err := common.GetRayClusterHeadPod(context.TODO(), fakeClient, testRayCluster)
-			if head != nil {
-				ip = head.Status.PodIP
-				name = head.Name
+			headPod, err := common.GetRayClusterHeadPod(context.TODO(), fakeClient, testRayCluster)
+			if headPod != nil {
+				ip = headPod.Status.PodIP
+				name = headPod.Name
 			}
 
 			if tc.returnsError {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1296,7 +1296,7 @@ func TestUpdateEndpoints(t *testing.T) {
 	assert.Equal(t, expected, testRayCluster.Status.Endpoints, "RayCluster status endpoints not updated")
 }
 
-func TestGetHeadPodIPAndName(t *testing.T) {
+func TestGetHeadPodIPAndNameFromGetRayClusterHeadPod(t *testing.T) {
 	setupTest(t)
 
 	extraHeadPod := &corev1.Pod{
@@ -1345,22 +1345,21 @@ func TestGetHeadPodIPAndName(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			fakeClient := clientFake.NewClientBuilder().WithRuntimeObjects(tc.pods...).Build()
 
-			testRayClusterReconciler := &RayClusterReconciler{
-				Client:   fakeClient,
-				Recorder: &record.FakeRecorder{},
-				Scheme:   scheme.Scheme,
+			ip, name := "", ""
+			head, err := common.GetRayClusterHeadPod(context.TODO(), fakeClient, testRayCluster)
+			if head != nil {
+				ip = head.Status.PodIP
+				name = head.Name
 			}
-
-			ip, name, err := testRayClusterReconciler.getHeadPodIPAndName(context.TODO(), testRayCluster)
 
 			if tc.returnsError {
-				assert.NotNil(t, err, "getHeadPodIPAndName should return error")
+				assert.NotNil(t, err, "GetRayClusterHeadPod should return error")
 			} else {
-				assert.Nil(t, err, "getHeadPodIPAndName should not return error")
+				assert.Nil(t, err, "GetRayClusterHeadPod should not return error")
 			}
 
-			assert.Equal(t, tc.expectedIP, ip, "getHeadPodIPAndName returned unexpected IP")
-			assert.Equal(t, tc.expectedName, name, "getHeadPodIPAndName returned unexpected name")
+			assert.Equal(t, tc.expectedIP, ip, "GetRayClusterHeadPod returned unexpected IP")
+			assert.Equal(t, tc.expectedName, name, "GetRayClusterHeadPod returned unexpected name")
 		})
 	}
 }

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1225,7 +1225,7 @@ func isServeAppUnhealthyOrDeployedFailed(appStatus string) bool {
 // TODO: Move this function to util.go and always use this function to retrieve the head Pod.
 func (r *RayServiceReconciler) getHeadPod(ctx context.Context, instance *rayv1.RayCluster) (*corev1.Pod, error) {
 	if instance.Status.Head.PodName == "" {
-		return nil, fmt.Errorf("Found 0 head pods for RayCluster %s in the namespace %s", instance.Name, instance.Namespace)
+		return nil, fmt.Errorf("RayCluster %s in the namespace %s did not contain .Status.Head.PodName", instance.Name, instance.Namespace)
 	}
 	pod := &corev1.Pod{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Status.Head.PodName}, pod); err != nil {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1224,12 +1224,12 @@ func isServeAppUnhealthyOrDeployedFailed(appStatus string) bool {
 
 // TODO: Move this function to util.go and always use this function to retrieve the head Pod.
 func (r *RayServiceReconciler) getHeadPod(ctx context.Context, instance *rayv1.RayCluster) (*corev1.Pod, error) {
-	if instance.Status.Head.PodName != "" {
-		pod := &corev1.Pod{}
-		if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Status.Head.PodName}, pod); err != nil {
-			return nil, err
-		}
-		return pod, nil
+	if instance.Status.Head.PodName == "" {
+		return nil, fmt.Errorf("Found 0 head pods for RayCluster %s in the namespace %s", instance.Name, instance.Namespace)
 	}
-	return nil, fmt.Errorf("Found 0 head pods for RayCluster %s in the namespace %s", instance.Name, instance.Namespace)
+	pod := &corev1.Pod{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Status.Head.PodName}, pod); err != nil {
+		return nil, err
+	}
+	return pod, nil
 }

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1114,6 +1114,9 @@ func (r *RayServiceReconciler) labelHeadPodForServeStatus(ctx context.Context, r
 	if err != nil {
 		return err
 	}
+	if headPod == nil {
+		return fmt.Errorf("found 0 head. cluster name %s, namespace %v", rayClusterInstance.Name, rayClusterInstance.Namespace)
+	}
 
 	httpProxyClient := r.httpProxyClientFunc()
 	httpProxyClient.InitClient()
@@ -1213,6 +1216,9 @@ func (r *RayServiceReconciler) isHeadPodRunningAndReady(ctx context.Context, ins
 	headPod, err := common.GetRayClusterHeadPod(ctx, r, instance)
 	if err != nil {
 		return false, err
+	}
+	if headPod == nil {
+		return false, fmt.Errorf("found 0 head. cluster name %s, namespace %v", instance.Name, instance.Namespace)
 	}
 	return utils.IsRunningAndReady(headPod), nil
 }

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -266,6 +266,11 @@ func TestIsHeadPodRunningAndReady(t *testing.T) {
 			Name:      "test-cluster",
 			Namespace: "default",
 		},
+		Status: rayv1.RayClusterStatus{
+			Head: rayv1.HeadInfo{
+				PodName: "head-pod",
+			},
+		},
 	}
 
 	headPod := &corev1.Pod{

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -266,11 +266,6 @@ func TestIsHeadPodRunningAndReady(t *testing.T) {
 			Name:      "test-cluster",
 			Namespace: "default",
 		},
-		Status: rayv1.RayClusterStatus{
-			Head: rayv1.HeadInfo{
-				PodName: "head-pod",
-			},
-		},
 	}
 
 	headPod := &corev1.Pod{

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/headinfo.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/headinfo.go
@@ -7,6 +7,7 @@ package v1
 type HeadInfoApplyConfiguration struct {
 	PodIP       *string `json:"podIP,omitempty"`
 	ServiceIP   *string `json:"serviceIP,omitempty"`
+	PodName     *string `json:"podName,omitempty"`
 	ServiceName *string `json:"serviceName,omitempty"`
 }
 
@@ -29,6 +30,14 @@ func (b *HeadInfoApplyConfiguration) WithPodIP(value string) *HeadInfoApplyConfi
 // If called multiple times, the ServiceIP field is set to the value of the last call.
 func (b *HeadInfoApplyConfiguration) WithServiceIP(value string) *HeadInfoApplyConfiguration {
 	b.ServiceIP = &value
+	return b
+}
+
+// WithPodName sets the PodName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PodName field is set to the value of the last call.
+func (b *HeadInfoApplyConfiguration) WithPodName(value string) *HeadInfoApplyConfiguration {
+	b.PodName = &value
 	return b
 }
 


### PR DESCRIPTION
## Why are these changes needed?

Closes https://github.com/ray-project/kuberay/issues/2236

This PR adds the new `PodName` to the `HeadInfo` status. And make RayService use the field to fetch the Head Pod.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
