### PR TITLE
kuberay autoscaler pod use same command and args as ray head container

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -415,14 +415,12 @@ func BuildAutoscalerContainer(autoscalerImage string) corev1.Container {
 			},
 		},
 		Command: []string{
-			"ray",
+			"/bin/bash",
+			"-lc",
+			"--",
 		},
 		Args: []string{
-			"kuberay-autoscaler",
-			"--cluster-name",
-			"$(RAY_CLUSTER_NAME)",
-			"--cluster-namespace",
-			"$(RAY_CLUSTER_NAMESPACE)",
+			"ray kuberay-autoscaler --cluster-name $(RAY_CLUSTER_NAME) --cluster-namespace $(RAY_CLUSTER_NAMESPACE)",
 		},
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -192,14 +192,12 @@ var autoscalerContainer = corev1.Container{
 		},
 	},
 	Command: []string{
-		"ray",
+		"/bin/bash",
+		"-lc",
+		"--",
 	},
 	Args: []string{
-		"kuberay-autoscaler",
-		"--cluster-name",
-		"$(RAY_CLUSTER_NAME)",
-		"--cluster-namespace",
-		"$(RAY_CLUSTER_NAMESPACE)",
+		"ray kuberay-autoscaler --cluster-name $(RAY_CLUSTER_NAME) --cluster-namespace $(RAY_CLUSTER_NAMESPACE)",
 	},
 	Resources: corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{


### PR DESCRIPTION
## Why are these changes needed?

kuberay autoscaler pod should use same command and args as ray head container
this is how we found this issue:
1. we have build image, which has .bashrc in /root, in .bashrc, we export PATH=/opt/miniconda/bin:PATH
2. for ray-head, it works well, since it use /bin/bash -lc to load .bashrc script, but for autoscaler container, it will fail with error: 'failed to create containerd task: failed to create shim task: Could
          not run process: container_linux.go:370: starting container process caused:
          exec: "ray": executable file not found in $PATH: unknown'
3. usually we build ray image to make sure  ray head works well, so we may missing the situation in autoscaler. so auotscaler container should be better to use same command and args as ray head container

## Related issue number


## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
