### PR TITLE
Add RayClusterReady Condition Type 

### DIFF
--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -168,14 +168,18 @@ type RayClusterConditionType string
 
 // Custom Reason for RayClusterCondition
 const (
-	// PodRunningAndReady says that the pod is running and ready.
-	PodRunningAndReady = "PodRunningAndReady"
+	AllPodRunningAndReady  = "AllPodRunningAndReady"
+	HeadPodNotFound        = "HeadPodNotFound"
+	HeadPodRunningAndReady = "HeadPodRunningAndReady"
 	// UnknownReason says that the reason for the condition is unknown.
 	UnknownReason = "Unknown"
 )
 
 const (
-	// HeadPodReady is added in a RayCluster when its Head Pod is ready for requests.
+	// RayClusterReady indicates whether all Ray Pods are ready when the RayCluster is first created.
+	// After RayClusterReady is set to true for the first time, it only indicates whether the RayCluster's head Pod is ready for requests.
+	RayClusterReady RayClusterConditionType = "RayClusterReady"
+	// HeadPodReady indicates whether RayCluster's head Pod is ready for requests.
 	HeadPodReady RayClusterConditionType = "HeadPodReady"
 	// RayClusterReplicaFailure is added in a RayCluster when one of its pods fails to be created or deleted.
 	RayClusterReplicaFailure RayClusterConditionType = "ReplicaFailure"

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1212,13 +1212,35 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 			meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
 				Type:    string(rayv1.HeadPodReady),
 				Status:  metav1.ConditionFalse,
-				Reason:  "HeadPodNotFound",
+				Reason:  rayv1.HeadPodNotFound,
 				Message: "Head Pod not found",
 			})
 		} else {
-			replicaHeadPodReadyCondition := utils.FindPodReadyCondition(headPod, rayv1.HeadPodReady)
-			meta.SetStatusCondition(&newInstance.Status.Conditions, replicaHeadPodReadyCondition)
+			headPodReadyCondition := utils.FindHeadPodReadyCondition(headPod)
+			meta.SetStatusCondition(&newInstance.Status.Conditions, headPodReadyCondition)
 		}
+
+		if meta.FindStatusCondition(newInstance.Status.Conditions, string(rayv1.RayClusterReady)) == nil {
+			// RayClusterReady indicates whether all Ray Pods are ready when the RayCluster is first created.
+			// Note RayClusterReady StatusCondition will not be added to Raycluster until all Ray Pods are ready for the first time.
+			if utils.CheckAllPodsRunning(ctx, runtimePods) {
+				meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
+					Type:    string(rayv1.RayClusterReady),
+					Status:  metav1.ConditionTrue,
+					Reason:  rayv1.AllPodRunningAndReady,
+					Message: "All Ray Pods are ready. Future checks focus on the head",
+				})
+			}
+		} else { // After RayClusterReady is set to true for the first time, its meaning changes to be the same as HeadPodReady.
+			headPodReadyCondition := meta.FindStatusCondition(newInstance.Status.Conditions, string(rayv1.HeadPodReady))
+			meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
+				Type:    string(rayv1.RayClusterReady),
+				Status:  headPodReadyCondition.Status,
+				Reason:  headPodReadyCondition.Reason,
+				Message: "Only check head after all Ray Pods are initially ready",
+			})
+		}
+
 	}
 
 	if newInstance.Spec.Suspend != nil && *newInstance.Spec.Suspend && len(runtimePods.Items) == 0 {

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -71,36 +71,36 @@ func IsCreated(pod *corev1.Pod) bool {
 	return pod.Status.Phase != ""
 }
 
-func FindPodReadyCondition(pod *corev1.Pod, condType rayv1.RayClusterConditionType) metav1.Condition {
-	replicaPodReadyCondition := metav1.Condition{
-		Type:   string(condType),
+func FindHeadPodReadyCondition(headPod *corev1.Pod) metav1.Condition {
+	headPodReadyCondition := metav1.Condition{
+		Type:   string(rayv1.HeadPodReady),
 		Status: metav1.ConditionFalse,
 		Reason: rayv1.UnknownReason,
 	}
 
-	for _, cond := range pod.Status.Conditions {
+	for _, cond := range headPod.Status.Conditions {
 		if cond.Type != corev1.PodReady {
 			continue
 		}
 		// Set the status based on the PodReady condition
-		replicaPodReadyCondition.Status = metav1.ConditionStatus(cond.Status)
-		replicaPodReadyCondition.Message = cond.Message
+		headPodReadyCondition.Status = metav1.ConditionStatus(cond.Status)
+		headPodReadyCondition.Message = cond.Message
 
-		// Determine the reason; default to PodRunningAndReady if the pod is ready but no specific reason is provided
+		// Determine the reason; default to HeadPodRunningAndReady if the headPod is ready but no specific reason is provided
 		reason := cond.Reason
 		if cond.Status == corev1.ConditionTrue && reason == "" {
-			reason = rayv1.PodRunningAndReady
+			reason = rayv1.HeadPodRunningAndReady
 		}
 
 		// Update the reason if it's not empty
 		if reason != "" {
-			replicaPodReadyCondition.Reason = reason
+			headPodReadyCondition.Reason = reason
 		}
 
 		// Since we're only interested in the PodReady condition, break after processing it
 		break
 	}
-	return replicaPodReadyCondition
+	return headPodReadyCondition
 }
 
 // IsRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -643,8 +643,8 @@ func TestFindHeadPodReadyCondition(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			replicaHeadPodReadyCondition := FindPodReadyCondition(tc.pod, rayv1.HeadPodReady)
-			assert.Equal(t, tc.expected.Status, replicaHeadPodReadyCondition.Status)
+			headPodReadyCondition := FindHeadPodReadyCondition(tc.pod)
+			assert.Equal(t, tc.expected.Status, headPodReadyCondition.Status)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please adds a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds RayClusterReady condition type. See here for the reason: https://docs.google.com/document/d/1bRL0cZa87eCX6SI7gqthN68CgmHaB6l3-vJuIse-BrY/edit.


RayClusterReady indicates whether all Ray Pods are ready when the RayCluster is first created.
```yaml
  Conditions:
    Last Transition Time:   2024-07-30T05:58:56Z
    Message:                
    Reason:                 HeadPodRunningAndReady
    Status:                 True
    Type:                   HeadPodReady
    Last Transition Time:   2024-07-30T05:58:56Z
    Message:                All Ray Pods are ready. Future checks focus on the head
    Reason:                 AllPodRunningAndReady
    Status:                 True
    Type:                   RayClusterReady
```

After RayClusterReady is set to true for the first time, it only indicates whether the RayCluster's Head Pod is ready for 
```yaml
    Last Transition Time:   2024-07-30T05:58:56Z
    Message:                
    Reason:                 HeadPodRunningAndReady
    Status:                 True
    Type:                   HeadPodReady
    Last Transition Time:   2024-07-30T05:58:56Z
    Message:                Only check head after all Ray Pods are initially ready
    Reason:                 HeadPodRunningAndReady
    Status:                 True
    Type:                   RayClusterReady
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks


- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
