### PR TITLE
[Bug] Issue with glibc version GLIBC_2.34 and GLIBC_2.32 not found in earlier operator tags

### DIFF
--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -19,7 +19,7 @@ COPY pkg/features pkg/features
 USER root
 RUN CGO_ENABLED=1 GOOS=linux go build -tags strictfipsruntime -a -o manager main.go
 
-FROM gcr.io/distroless/base-debian11:nonroot
+FROM gcr.io/distroless/base-debian12:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/ray-operator/Dockerfile.buildx
+++ b/ray-operator/Dockerfile.buildx
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base-debian11:nonroot
+FROM gcr.io/distroless/base-debian12:nonroot
 ARG TARGETARCH
 WORKDIR /
 COPY ./manager-${TARGETARCH} ./manager


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#2205 changes the base image of `Dockerfile.buildx` from `registry.access.redhat.com/ubi9/ubi-minimal:9.3` to `gcr.io/distroless/base-debian11:nonroot` which uses GLIBC_2.31. However, KubeRay operator requires GLIBC_2.32 and GLIBC_2.34. KubeRay operator Pod will fail with the following logs:

```
/manager: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /manager)
/manager: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /manager)
```

This issue is similar to https://github.com/GoogleContainerTools/distroless/issues/1342, so this PR upgrades the base image from `debian11` to `debian12`.

I can reproduce the issue by pulling images that are built by GitHub Actions. However, when I build the image following the same steps as GitHub Actions and then publish it to Quay, the issue does not occur.

```sh
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -tags strictfipsruntime -a -o manager-amd64 main.go
CC=aarch64-linux-gnu-gcc CGO_ENABLED=1 GOOS=linux GOARCH=arm64 go build -tags strictfipsruntime -a -o manager-arm64 main.go
docker buildx build --push --platform linux/amd64,linux/arm64 --attest type=provenance,disabled=true -t quay.io/kevin85421/kuberay:test --file Dockerfile.buildx .
```

In order to reproduce the issue, I used https://github.com/ray-project/kuberay/blob/master/.github/workflows/image-release.yaml to build multi-arch images and publish to my Quay account.



## Related issue number

<!-- For example: "Closes #1234" -->
Closes #2270

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
