### PR TITLE
Add Fake TPU e2e Autoscaling Test Cases

### DIFF
--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -140,6 +140,171 @@ func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
 	}
 }
 
+func TestRayClusterAutoscalerWithFakeSingleHostTPU(t *testing.T) {
+	// Enable the below multi-host indexing feature, even on single-host, to ensure
+	// stablity on TPU which commonly run in SPMD configurations.
+	features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, true)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := gomega.NewWithT(t)
+
+			// Create a namespace
+			namespace := test.NewTestNamespace()
+
+			// Scripts for creating and terminating detached actors to trigger autoscaling
+			scriptsAC := newConfigMap(namespace.Name, Files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
+			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
+
+			groupName := "tpu-group"
+			rayClusterSpecAC := rayv1ac.RayClusterSpec().
+				WithEnableInTreeAutoscaling(true).
+				WithRayVersion(GetRayVersion()).
+				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+					WithRayStartParams(map[string]string{"num-cpus": "0"}).
+					WithTemplate(tc.HeadPodTemplateGetter())).
+				WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
+					WithReplicas(0).
+					WithMinReplicas(0).
+					WithMaxReplicas(3).
+					WithNumOfHosts(1).
+					WithGroupName(groupName).
+					WithRayStartParams(map[string]string{"num-cpus": "1", "resources": `'{"TPU":4}'`}).
+					WithTemplate(tc.WorkerPodTemplateGetter()))
+			rayClusterAC := rayv1ac.RayCluster("ray-cluster", namespace.Name).
+				WithSpec(Apply(rayClusterSpecAC, MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](scripts, "/home/ray/test_scripts")))
+			
+			// Set required TPU specific Pod fields.
+			rayClusterAC.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector = map[string]string{
+				"cloud.google.com/gke-tpu-topology":    "2x2x1",
+				"cloud.google.com/gke-tpu-accelerator": "tpu-v4-podslice",
+			}
+			
+			rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+			// Wait for RayCluster to become ready and verify the number of available worker replicas.
+			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+				Should(gomega.WithTransform(RayClusterState, gomega.Equal(rayv1.Ready)))
+			g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
+
+			headPod, err := GetHeadPod(test, rayCluster)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
+
+			// Create a detached TPU actor, and a TPU worker Pod should be created.
+			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/create_detached_actor.py", "tpu_actor", "--custom-resource-name=TPU", "--num-custom-resources=4"})
+			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(1))))
+			g.Expect(GetGroupPods(test, rayCluster, groupName)).To(gomega.HaveLen(1))
+			LogWithTimestamp(test.T(), "Created TPU worker of group %s", groupName)
+
+			// Terminate the TPU actor to remove the allocated resource request.
+			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/terminate_detached_actor.py", "tpu_actor"})
+
+			// Set maxReplicas of the TPU worker group replica to 0 to force scale-down.
+			// It's not possible to wait on idle timeout since the required TPU nodeSelectors prevent scheduling.
+			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			rayCluster.Spec.WorkerGroupSpecs[0].MaxReplicas = ptr.To(int32(0))
+			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(test.Ctx(), rayCluster, metav1.UpdateOptions{})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Updated RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+			// Validate that the TPU slice is scaled down.
+			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutMedium).Should(gomega.BeEmpty())
+		})
+	}
+}
+
+func TestRayClusterAutoscalerWithFakeMultiHostTPU(t *testing.T) {
+	// Enable the below multi-host indexing feature to ensure stablity on TPU
+	// which commonly run in SPMD configurations.
+	features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, true)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := gomega.NewWithT(t)
+
+			// Create a namespace
+			namespace := test.NewTestNamespace()
+
+			// Scripts for creating and terminating detached actors to trigger autoscaling
+			scriptsAC := newConfigMap(namespace.Name, Files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
+			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
+
+			groupName := "tpu-multi-host-group"
+			rayClusterSpecAC := rayv1ac.RayClusterSpec().
+				WithEnableInTreeAutoscaling(true).
+				WithRayVersion(GetRayVersion()).
+				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+					WithRayStartParams(map[string]string{"num-cpus": "0"}).
+					WithTemplate(tc.HeadPodTemplateGetter())).
+				WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
+					WithReplicas(0).
+					WithMinReplicas(0).
+					WithMaxReplicas(3).
+					WithNumOfHosts(4). // Defines a multi-host worker group (4 Pods per replica)
+					WithGroupName(groupName).
+					WithRayStartParams(map[string]string{"num-cpus": "1", "resources": `'{"TPU":4}'`}).
+					WithTemplate(tc.WorkerPodTemplateGetter()))
+			rayClusterAC := rayv1ac.RayCluster("ray-cluster-multi-host", namespace.Name).
+				WithSpec(Apply(rayClusterSpecAC, MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](scripts, "/home/ray/test_scripts")))
+
+			// Set required multi-host TPU specific Pod fields.
+			rayClusterAC.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector = map[string]string{
+				"cloud.google.com/gke-tpu-topology":    "4x4",
+				"cloud.google.com/gke-tpu-accelerator": "tpu-v6e-slice",
+			}
+
+			rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+			// Wait for RayCluster to become ready and verify the number of available worker replicas.
+			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+				Should(gomega.WithTransform(RayClusterState, gomega.Equal(rayv1.Ready)))
+			g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
+
+			headPod, err := GetHeadPod(test, rayCluster)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
+
+			// Create a detached TPU actor requiring 16 TPUs (4 hosts * 4 TPUs/host) to trigger a full slice scale-up.
+			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/create_detached_actor.py", "tpu_actor", "--custom-resource-name=TPU", "--num-custom-resources=16"})
+			
+			// Autoscaler scales up desired replicas by 1 (which represents 1 group of 4 pods for multi-host)
+			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(1))))
+			
+			// Verify that scaling up 1 replica results in exactly 4 Pods being created for the multi-host group
+			g.Expect(GetGroupPods(test, rayCluster, groupName)).To(gomega.HaveLen(4))
+			LogWithTimestamp(test.T(), "Created multi-host TPU workers of group %s", groupName)
+
+			// Terminate the TPU actor to remove the allocated resource request.
+			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/terminate_detached_actor.py", "tpu_actor"})
+
+			// Set maxReplicas of the TPU worker group replica to 0 to force scale-down.
+			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			rayCluster.Spec.WorkerGroupSpecs[0].MaxReplicas = ptr.To(int32(0))
+			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(test.Ctx(), rayCluster, metav1.UpdateOptions{})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Updated RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+			// Validate that the entire multi-host TPU slice is scaled down.
+			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutMedium).Should(gomega.BeEmpty())
+		})
+	}
+}
+
 func TestRayClusterAutoscalerWithCustomResource(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -249,7 +249,7 @@ func TestRayClusterAutoscalerWithFakeTPU(t *testing.T) {
 				// It's not possible to wait on idle timeout since the required TPU nodeSelectors prevent scheduling.
 				rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(gomega.HaveOccurred())
-				rayCluster.Spec.WorkerGroupSpecs[0].MaxReplicas = ptr.To(int32(0))
+				rayCluster.Spec.WorkerGroupSpecs[0].MaxReplicas = Ptr(int32(0))
 				rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(test.Ctx(), rayCluster, metav1.UpdateOptions{})
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				LogWithTimestamp(test.T(), "Updated RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -143,7 +143,7 @@ func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
 
 func TestRayClusterAutoscalerWithFakeTPU(t *testing.T) {
 	// Enable the below multi-host indexing feature, even on single-host, to ensure
-	// stablity on TPU which commonly run in SPMD configurations.
+	// stability on TPU which commonly run in SPMD configurations.
 	features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, true)
 
 	tpuTestCases := []struct {

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -141,175 +141,123 @@ func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
 	}
 }
 
-func TestRayClusterAutoscalerWithFakeSingleHostTPU(t *testing.T) {
+func TestRayClusterAutoscalerWithFakeTPU(t *testing.T) {
 	// Enable the below multi-host indexing feature, even on single-host, to ensure
 	// stablity on TPU which commonly run in SPMD configurations.
 	features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, true)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			test := With(t)
-			g := gomega.NewWithT(t)
-
-			// Create a namespace
-			namespace := test.NewTestNamespace()
-
-			// Scripts for creating and terminating detached actors to trigger autoscaling
-			scriptsAC := newConfigMap(namespace.Name, Files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
-			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
-
-			groupName := "tpu-group"
-			rayClusterSpecAC := rayv1ac.RayClusterSpec().
-				WithEnableInTreeAutoscaling(true).
-				WithRayVersion(GetRayVersion()).
-				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
-					WithRayStartParams(map[string]string{"num-cpus": "0"}).
-					WithTemplate(tc.HeadPodTemplateGetter())).
-				WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
-					WithReplicas(0).
-					WithMinReplicas(0).
-					WithMaxReplicas(3).
-					WithNumOfHosts(1).
-					WithGroupName(groupName).
-					WithRayStartParams(map[string]string{"num-cpus": "1", "resources": `'{"TPU":4}'`}).
-					WithTemplate(tc.WorkerPodTemplateGetter()))
-			rayClusterAC := rayv1ac.RayCluster("ray-cluster", namespace.Name).
-				WithSpec(Apply(rayClusterSpecAC, MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](scripts, "/home/ray/test_scripts")))
-
-			// Set required TPU specific Pod fields.
-			rayClusterAC.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector = map[string]string{
+	tpuTestCases := []struct {
+		nodeSelector map[string]string
+		name         string
+		groupName    string
+		clusterName  string
+		numOfHosts   int32
+		maxReplicas  int32
+	}{
+		{
+			name:        "v4 2x2x1 single-host",
+			numOfHosts:  1,
+			maxReplicas: 3,
+			nodeSelector: map[string]string{
 				"cloud.google.com/gke-tpu-topology":    "2x2x1",
 				"cloud.google.com/gke-tpu-accelerator": "tpu-v4-podslice",
-			}
-
-			rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
-
-			// Wait for RayCluster to become ready and verify the number of available worker replicas.
-			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-				Should(gomega.WithTransform(RayClusterState, gomega.Equal(rayv1.Ready)))
-			g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
-
-			headPod, err := GetHeadPod(test, rayCluster)
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
-
-			// Create a detached TPU actor, and a TPU worker Pod should be created.
-			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/create_detached_actor.py", "tpu_actor", "--custom-resource-name=TPU", "--num-custom-resources=4"})
-			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(1))))
-			g.Expect(GetGroupPods(test, rayCluster, groupName)).To(gomega.HaveLen(1))
-			LogWithTimestamp(test.T(), "Created TPU worker of group %s", groupName)
-
-			// Terminate the TPU actor to remove the allocated resource request.
-			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/terminate_detached_actor.py", "tpu_actor"})
-
-			// Set maxReplicas of the TPU worker group replica to 0 to force scale-down.
-			// It's not possible to wait on idle timeout since the required TPU nodeSelectors prevent scheduling.
-			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			rayCluster.Spec.WorkerGroupSpecs[0].MaxReplicas = ptr.To(int32(0))
-			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(test.Ctx(), rayCluster, metav1.UpdateOptions{})
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			LogWithTimestamp(test.T(), "Updated RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
-
-			// Validate that the TPU slice is scaled down.
-			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutMedium).Should(gomega.BeEmpty())
-		})
-	}
-}
-
-func TestRayClusterAutoscalerWithFakeMultiHostTPU(t *testing.T) {
-	// Enable the below multi-host indexing feature to ensure stablity on TPU
-	// which commonly run in SPMD configurations.
-	features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, true)
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			test := With(t)
-			g := gomega.NewWithT(t)
-
-			// Create a namespace
-			namespace := test.NewTestNamespace()
-
-			// Scripts for creating and terminating detached actors to trigger autoscaling
-			scriptsAC := newConfigMap(namespace.Name, Files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
-			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
-
-			groupName := "tpu-multi-host-group"
-			rayClusterSpecAC := rayv1ac.RayClusterSpec().
-				WithEnableInTreeAutoscaling(true).
-				WithRayVersion(GetRayVersion()).
-				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
-					WithRayStartParams(map[string]string{"num-cpus": "0"}).
-					WithTemplate(tc.HeadPodTemplateGetter())).
-				WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
-					WithReplicas(0).
-					WithMinReplicas(0).
-					WithMaxReplicas(4).
-					WithNumOfHosts(4). // Defines a multi-host worker group (4 Pods per replica)
-					WithGroupName(groupName).
-					WithRayStartParams(map[string]string{"num-cpus": "1", "resources": `'{"TPU":4}'`}).
-					WithTemplate(tc.WorkerPodTemplateGetter()))
-			rayClusterAC := rayv1ac.RayCluster("ray-cluster-multi-host", namespace.Name).
-				WithSpec(Apply(rayClusterSpecAC, MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](scripts, "/home/ray/test_scripts")))
-
-			// Set required multi-host TPU specific Pod fields.
-			rayClusterAC.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector = map[string]string{
+			},
+			groupName:   "tpu-group",
+			clusterName: "ray-cluster",
+		},
+		{
+			name:        "v6e 4x4 multi-host",
+			numOfHosts:  4,
+			maxReplicas: 4,
+			nodeSelector: map[string]string{
 				"cloud.google.com/gke-tpu-topology":    "4x4",
 				"cloud.google.com/gke-tpu-accelerator": "tpu-v6e-slice",
-			}
+			},
+			groupName:   "tpu-multi-host-group",
+			clusterName: "ray-cluster-multi-host",
+		},
+	}
 
-			rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+	for _, tc := range tests {
+		for _, tpuTc := range tpuTestCases {
+			t.Run(tc.name+"-"+tpuTc.name, func(t *testing.T) {
+				test := With(t)
+				g := gomega.NewWithT(t)
 
-			// Wait for RayCluster to become ready and verify the number of available worker replicas.
-			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-				Should(gomega.WithTransform(RayClusterState, gomega.Equal(rayv1.Ready)))
-			g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
+				// Create a namespace
+				namespace := test.NewTestNamespace()
 
-			headPod, err := GetHeadPod(test, rayCluster)
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
+				// Scripts for creating and terminating detached actors to trigger autoscaling
+				scriptsAC := newConfigMap(namespace.Name, Files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
+				scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
-			// Create 4 detached TPU actors concurrently using a single shell script execution.
-			// This ensures the Autoscaler sees the resource request on the same iteration.
-			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
-				"bash", "-c",
-				`for i in {0..3}; do python /home/ray/test_scripts/create_detached_actor.py "tpu_actor_$i" --custom-resource-name=TPU --num-custom-resources=4 & done; wait`,
+				workerTemplate := tc.WorkerPodTemplateGetter()
+				workerTemplate.Spec.WithNodeSelector(tpuTc.nodeSelector)
+
+				rayClusterSpecAC := rayv1ac.RayClusterSpec().
+					WithEnableInTreeAutoscaling(true).
+					WithRayVersion(GetRayVersion()).
+					WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+						WithRayStartParams(map[string]string{"num-cpus": "0"}).
+						WithTemplate(tc.HeadPodTemplateGetter())).
+					WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
+						WithReplicas(0).
+						WithMinReplicas(0).
+						WithMaxReplicas(tpuTc.maxReplicas).
+						WithNumOfHosts(tpuTc.numOfHosts).
+						WithGroupName(tpuTc.groupName).
+						WithRayStartParams(map[string]string{"num-cpus": "1", "resources": `'{"TPU":4}'`}).
+						WithTemplate(workerTemplate))
+				rayClusterAC := rayv1ac.RayCluster(tpuTc.clusterName, namespace.Name).
+					WithSpec(Apply(rayClusterSpecAC, MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](scripts, "/home/ray/test_scripts")))
+
+				rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+				// Wait for RayCluster to become ready and verify the number of available worker replicas.
+				g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+					Should(gomega.WithTransform(RayClusterState, gomega.Equal(rayv1.Ready)))
+				g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
+
+				headPod, err := GetHeadPod(test, rayCluster)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
+
+				// Create detached TPU actors concurrently using a single shell script execution.
+				// This ensures the Autoscaler sees the resource request on the same iteration.
+				ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
+					"bash", "-c",
+					fmt.Sprintf(`for i in {0..%d}; do python /home/ray/test_scripts/create_detached_actor.py "tpu_actor_$i" --custom-resource-name=TPU --num-custom-resources=4 & done; wait`, tpuTc.numOfHosts-1),
+				})
+
+				// Autoscaler scales up desired replicas by 1
+				g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutLong).
+					Should(gomega.WithTransform(GetRayClusterWorkerGroupReplicaSum, gomega.Equal(int32(1))))
+				g.Eventually(GroupPods(test, rayCluster, tpuTc.groupName), TestTimeoutLong).Should(gomega.HaveLen(int(tpuTc.numOfHosts)))
+				LogWithTimestamp(test.T(), "Created TPU workers of group %s", tpuTc.groupName)
+
+				// Terminate all TPU actors concurrently to remove the allocated resource requests.
+				ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
+					"bash", "-c",
+					fmt.Sprintf(`for i in {0..%d}; do python /home/ray/test_scripts/terminate_detached_actor.py "tpu_actor_$i" & done; wait`, tpuTc.numOfHosts-1),
+				})
+
+				// Set maxReplicas of the TPU worker group replica to 0 to force scale-down.
+				// It's not possible to wait on idle timeout since the required TPU nodeSelectors prevent scheduling.
+				rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				rayCluster.Spec.WorkerGroupSpecs[0].MaxReplicas = ptr.To(int32(0))
+				rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(test.Ctx(), rayCluster, metav1.UpdateOptions{})
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				LogWithTimestamp(test.T(), "Updated RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+				// Validate that the entire TPU slice is scaled down.
+				g.Eventually(WorkerPods(test, rayCluster), TestTimeoutMedium).Should(gomega.BeEmpty())
 			})
-
-			// Autoscaler scales up desired replicas by 1 (which represents 1 group of 4 pods for multi-host)
-			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutLong).
-				Should(gomega.WithTransform(GetRayClusterWorkerGroupReplicaSum, gomega.BeNumerically(">=", int32(1))))
-
-			// Verify that exactly 4 Pods are created for the multi-host group
-			g.Eventually(GroupPods(test, rayCluster, groupName), TestTimeoutLong).Should(gomega.HaveLen(4))
-			LogWithTimestamp(test.T(), "Created multi-host TPU workers of group %s", groupName)
-
-			// Terminate all 4 TPU actors concurrently to remove the allocated resource requests.
-			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
-				"bash", "-c",
-				`for i in {0..3}; do python /home/ray/test_scripts/terminate_detached_actor.py "tpu_actor_$i" & done; wait`,
-			})
-
-			// Set maxReplicas of the TPU worker group replica to 0 to force scale-down.
-			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			rayCluster.Spec.WorkerGroupSpecs[0].MaxReplicas = ptr.To(int32(0))
-			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(test.Ctx(), rayCluster, metav1.UpdateOptions{})
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-			LogWithTimestamp(test.T(), "Updated RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
-
-			// Validate that the entire multi-host TPU slice is scaled down.
-			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutMedium).Should(gomega.BeEmpty())
-		})
+		}
 	}
 }
 

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -10,6 +10,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
@@ -176,13 +177,13 @@ func TestRayClusterAutoscalerWithFakeSingleHostTPU(t *testing.T) {
 					WithTemplate(tc.WorkerPodTemplateGetter()))
 			rayClusterAC := rayv1ac.RayCluster("ray-cluster", namespace.Name).
 				WithSpec(Apply(rayClusterSpecAC, MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](scripts, "/home/ray/test_scripts")))
-			
+
 			// Set required TPU specific Pod fields.
 			rayClusterAC.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector = map[string]string{
 				"cloud.google.com/gke-tpu-topology":    "2x2x1",
 				"cloud.google.com/gke-tpu-accelerator": "tpu-v4-podslice",
 			}
-			
+
 			rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 			LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
@@ -279,11 +280,11 @@ func TestRayClusterAutoscalerWithFakeMultiHostTPU(t *testing.T) {
 
 			// Create a detached TPU actor requiring 16 TPUs (4 hosts * 4 TPUs/host) to trigger a full slice scale-up.
 			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/create_detached_actor.py", "tpu_actor", "--custom-resource-name=TPU", "--num-custom-resources=16"})
-			
+
 			// Autoscaler scales up desired replicas by 1 (which represents 1 group of 4 pods for multi-host)
 			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
 				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(1))))
-			
+
 			// Verify that scaling up 1 replica results in exactly 4 Pods being created for the multi-host group
 			g.Expect(GetGroupPods(test, rayCluster, groupName)).To(gomega.HaveLen(4))
 			LogWithTimestamp(test.T(), "Created multi-host TPU workers of group %s", groupName)

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -251,7 +251,7 @@ func TestRayClusterAutoscalerWithFakeMultiHostTPU(t *testing.T) {
 				WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
 					WithReplicas(0).
 					WithMinReplicas(0).
-					WithMaxReplicas(3).
+					WithMaxReplicas(4).
 					WithNumOfHosts(4). // Defines a multi-host worker group (4 Pods per replica)
 					WithGroupName(groupName).
 					WithRayStartParams(map[string]string{"num-cpus": "1", "resources": `'{"TPU":4}'`}).
@@ -278,19 +278,26 @@ func TestRayClusterAutoscalerWithFakeMultiHostTPU(t *testing.T) {
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 			LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
 
-			// Create a detached TPU actor requiring 16 TPUs (4 hosts * 4 TPUs/host) to trigger a full slice scale-up.
-			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/create_detached_actor.py", "tpu_actor", "--custom-resource-name=TPU", "--num-custom-resources=16"})
+			// Create 4 detached TPU actors concurrently using a single shell script execution.
+			// This ensures the Autoscaler sees the resource request on the same iteration.
+			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
+				"bash", "-c",
+				`for i in {0..3}; do python /home/ray/test_scripts/create_detached_actor.py "tpu_actor_$i" --custom-resource-name=TPU --num-custom-resources=4 & done; wait`,
+			})
 
 			// Autoscaler scales up desired replicas by 1 (which represents 1 group of 4 pods for multi-host)
-			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(1))))
+			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutLong).
+				Should(gomega.WithTransform(GetRayClusterWorkerGroupReplicaSum, gomega.BeNumerically(">=", int32(1))))
 
-			// Verify that scaling up 1 replica results in exactly 4 Pods being created for the multi-host group
-			g.Eventually(GroupPods(test, rayCluster, groupName), TestTimeoutMedium).Should(gomega.HaveLen(4))
+			// Verify that exactly 4 Pods are created for the multi-host group
+			g.Eventually(GroupPods(test, rayCluster, groupName), TestTimeoutLong).Should(gomega.HaveLen(4))
 			LogWithTimestamp(test.T(), "Created multi-host TPU workers of group %s", groupName)
 
-			// Terminate the TPU actor to remove the allocated resource request.
-			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/terminate_detached_actor.py", "tpu_actor"})
+			// Terminate all 4 TPU actors concurrently to remove the allocated resource requests.
+			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
+				"bash", "-c",
+				`for i in {0..3}; do python /home/ray/test_scripts/terminate_detached_actor.py "tpu_actor_$i" & done; wait`,
+			})
 
 			// Set maxReplicas of the TPU worker group replica to 0 to force scale-down.
 			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -286,7 +286,7 @@ func TestRayClusterAutoscalerWithFakeMultiHostTPU(t *testing.T) {
 				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(1))))
 
 			// Verify that scaling up 1 replica results in exactly 4 Pods being created for the multi-host group
-			g.Expect(GetGroupPods(test, rayCluster, groupName)).To(gomega.HaveLen(4))
+			g.Eventually(GroupPods(test, rayCluster, groupName), TestTimeoutMedium).Should(gomega.HaveLen(4))
 			LogWithTimestamp(test.T(), "Created multi-host TPU workers of group %s", groupName)
 
 			// Terminate the TPU actor to remove the allocated resource request.

--- a/ray-operator/test/e2eautoscaler/support.go
+++ b/ray-operator/test/e2eautoscaler/support.go
@@ -67,7 +67,6 @@ func headPodTemplateApplyConfigurationV2() *corev1ac.PodTemplateSpecApplyConfigu
 
 func workerPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfiguration {
 	return corev1ac.PodTemplateSpec().
-		WithLabels(make(map[string]string)).
 		WithSpec(corev1ac.PodSpec().
 			WithContainers(corev1ac.Container().
 				WithName("ray-worker").
@@ -85,7 +84,6 @@ func workerPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfigu
 
 func workerPodTemplateApplyConfigurationV2() *corev1ac.PodTemplateSpecApplyConfiguration {
 	return corev1ac.PodTemplateSpec().
-		WithLabels(make(map[string]string)).
 		WithSpec(corev1ac.PodSpec().
 			WithRestartPolicy(corev1.RestartPolicyNever).
 			WithContainers(corev1ac.Container().

--- a/ray-operator/test/e2eautoscaler/support.go
+++ b/ray-operator/test/e2eautoscaler/support.go
@@ -67,6 +67,7 @@ func headPodTemplateApplyConfigurationV2() *corev1ac.PodTemplateSpecApplyConfigu
 
 func workerPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfiguration {
 	return corev1ac.PodTemplateSpec().
+		WithLabels(make(map[string]string)).
 		WithSpec(corev1ac.PodSpec().
 			WithContainers(corev1ac.Container().
 				WithName("ray-worker").
@@ -84,6 +85,7 @@ func workerPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfigu
 
 func workerPodTemplateApplyConfigurationV2() *corev1ac.PodTemplateSpecApplyConfiguration {
 	return corev1ac.PodTemplateSpec().
+		WithLabels(make(map[string]string)).
 		WithSpec(corev1ac.PodSpec().
 			WithRestartPolicy(corev1.RestartPolicyNever).
 			WithContainers(corev1ac.Container().

--- a/ray-operator/test/support/create_detached_actor.py
+++ b/ray-operator/test/support/create_detached_actor.py
@@ -10,7 +10,7 @@ parser.add_argument('--custom-resource-name', type=str, default="CustomResource"
 parser.add_argument('--num-custom-resources', type=float, default=0)
 args = parser.parse_args()
 
-@ray.remote(num_cpus=args.num_cpus, num_gpus=args.num_gpus, resources={"CustomResource": args.num_custom_resources})
+@ray.remote(num_cpus=args.num_cpus, num_gpus=args.num_gpus, resources={args.custom_resource_name: args.num_custom_resources})
 class Actor:
     pass
 

--- a/ray-operator/test/support/create_detached_actor.py
+++ b/ray-operator/test/support/create_detached_actor.py
@@ -6,6 +6,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('name')
 parser.add_argument('--num-cpus', type=float, default=1)
 parser.add_argument('--num-gpus', type=float, default=0)
+parser.add_argument('--custom-resource-name', type=str, default="CustomResource")
 parser.add_argument('--num-custom-resources', type=float, default=0)
 args = parser.parse_args()
 

--- a/ray-operator/test/support/create_detached_actor.py
+++ b/ray-operator/test/support/create_detached_actor.py
@@ -1,5 +1,4 @@
 import ray
-import sys
 import argparse
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds a fake TPU test case, similar to the existing fake GPU test case for autoscaling, that uses detached actors to verify that single-host and multi-host autoscaling behaves as expected. The behaviors tested included:
- (1) Creating a detached actor that requests `resources: {"TPU": 4}` will scale up a Ray TPU worker
- (2) For a worker group, the number of workers created should equal `replicas * numOfHosts`
- (2) Terminating detached actors scheduled on a TPU worker group replica will cause the entire replica to be scaled down   - not tested due to constraints listed in https://github.com/ray-project/kuberay/pull/2279#discussion_r3576667626

These tests are ran with the `RayMultiHostIndexing` feature enabled which adds replica and host indices to the created Pods, and atomically scales up/down multi-host slices. These tests can be part of promoting the feature to Beta.

## Related issue number

https://github.com/ray-project/kuberay/issues/2173

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
