### PR TITLE
[Fix][RayCluster] Make the RayClusterReplicaFailureReason to capture the correct reason

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -17,6 +17,7 @@ package ray
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -1707,7 +1708,7 @@ func TestCalculateStatus(t *testing.T) {
 	assert.Equal(t, newInstance.Status.LastUpdateTime, newInstance.Status.StateTransitionTimes[rayv1.Ready])
 
 	// Test reconcilePodsErr with the feature gate disabled
-	newInstance, err = r.calculateStatus(ctx, testRayCluster, utils.ErrFailedCreateHeadPod)
+	newInstance, err = r.calculateStatus(ctx, testRayCluster, errors.Join(utils.ErrFailedCreateHeadPod, errors.New("invalid")))
 	assert.Nil(t, err)
 	assert.Empty(t, newInstance.Status.Conditions)
 
@@ -1740,7 +1741,7 @@ func TestCalculateStatus(t *testing.T) {
 	assert.True(t, meta.IsStatusConditionPresentAndEqual(newInstance.Status.Conditions, string(rayv1.HeadPodReady), metav1.ConditionFalse))
 
 	// Test reconcilePodsErr with the feature gate enabled
-	newInstance, err = r.calculateStatus(ctx, testRayCluster, utils.ErrFailedCreateHeadPod)
+	newInstance, err = r.calculateStatus(ctx, testRayCluster, errors.Join(utils.ErrFailedCreateHeadPod, errors.New("invalid")))
 	assert.Nil(t, err)
 	assert.True(t, meta.IsStatusConditionPresentAndEqual(newInstance.Status.Conditions, string(rayv1.RayClusterReplicaFailure), metav1.ConditionTrue))
 }

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -197,22 +197,27 @@ func RayOriginatedFromCRDLabelValue(crdType CRDType) string {
 	return string(crdType)
 }
 
+type errRayClusterReplicaFailure struct {
+	reason string
+}
+
+func (e *errRayClusterReplicaFailure) Error() string {
+	return e.reason
+}
+
 // These are markers used by the calculateStatus() for setting the RayClusterReplicaFailure condition.
 var (
-	errRayClusterReplicaFailure = errors.New("RayClusterReplicaFailure")
-	ErrFailedDeleteAllPods      = errors.Join(errRayClusterReplicaFailure, errors.New("FailedDeleteAllPods"))
-	ErrFailedDeleteHeadPod      = errors.Join(errRayClusterReplicaFailure, errors.New("FailedDeleteHeadPod"))
-	ErrFailedCreateHeadPod      = errors.Join(errRayClusterReplicaFailure, errors.New("FailedCreateHeadPod"))
-	ErrFailedDeleteWorkerPod    = errors.Join(errRayClusterReplicaFailure, errors.New("FailedDeleteWorkerPod"))
-	ErrFailedCreateWorkerPod    = errors.Join(errRayClusterReplicaFailure, errors.New("FailedCreateWorkerPod"))
+	ErrFailedDeleteAllPods   = &errRayClusterReplicaFailure{reason: "FailedDeleteAllPods"}
+	ErrFailedDeleteHeadPod   = &errRayClusterReplicaFailure{reason: "FailedDeleteHeadPod"}
+	ErrFailedCreateHeadPod   = &errRayClusterReplicaFailure{reason: "FailedCreateHeadPod"}
+	ErrFailedDeleteWorkerPod = &errRayClusterReplicaFailure{reason: "FailedDeleteWorkerPod"}
+	ErrFailedCreateWorkerPod = &errRayClusterReplicaFailure{reason: "FailedCreateWorkerPod"}
 )
 
 func RayClusterReplicaFailureReason(err error) string {
-	if e, ok := err.(interface{ Unwrap() []error }); ok {
-		errs := e.Unwrap()
-		if len(errs) >= 2 && errors.Is(errs[0], errRayClusterReplicaFailure) {
-			return errs[1].Error()
-		}
+	var failure *errRayClusterReplicaFailure
+	if errors.As(err, &failure) {
+		return failure.reason
 	}
 	return ""
 }

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -655,5 +655,10 @@ func TestErrRayClusterReplicaFailureReason(t *testing.T) {
 	assert.Equal(t, RayClusterReplicaFailureReason(ErrFailedCreateHeadPod), "FailedCreateHeadPod")
 	assert.Equal(t, RayClusterReplicaFailureReason(ErrFailedDeleteWorkerPod), "FailedDeleteWorkerPod")
 	assert.Equal(t, RayClusterReplicaFailureReason(ErrFailedCreateWorkerPod), "FailedCreateWorkerPod")
+	assert.Equal(t, RayClusterReplicaFailureReason(errors.Join(ErrFailedDeleteAllPods, errors.New("other error"))), "FailedDeleteAllPods")
+	assert.Equal(t, RayClusterReplicaFailureReason(errors.Join(ErrFailedDeleteHeadPod, errors.New("other error"))), "FailedDeleteHeadPod")
+	assert.Equal(t, RayClusterReplicaFailureReason(errors.Join(ErrFailedCreateHeadPod, errors.New("other error"))), "FailedCreateHeadPod")
+	assert.Equal(t, RayClusterReplicaFailureReason(errors.Join(ErrFailedDeleteWorkerPod, errors.New("other error"))), "FailedDeleteWorkerPod")
+	assert.Equal(t, RayClusterReplicaFailureReason(errors.Join(ErrFailedCreateWorkerPod, errors.New("other error"))), "FailedCreateWorkerPod")
 	assert.Equal(t, RayClusterReplicaFailureReason(errors.New("other error")), "")
 }


### PR DESCRIPTION
@MortalHappiness found the previous implementation of `RayClusterReplicaFailureReason` failed to capture condition reasons correctly. It made a wrong positional assumption on the error tree passed in so it failed in integration. 

This PR removes the wrong assumption by using the `errors.As` function which traverses the whole tree and finds the first target by the specified pointer type (i.e. the *errRayClusterReplicaFailure). The `RayClusterReplicaFailureReason` can now return the correct condition reason no matter how the error is wrapped.


FailedCreateHeadPod Example:
<img width="1693" alt="image" src="https://github.com/user-attachments/assets/abe2416d-304b-4e49-991e-7aad1d0f55b7">

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
