### PR TITLE
[Helm] Enable leader election when leaderElectionEnabled is not set

### DIFF
--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -82,8 +82,8 @@ spec:
             {{- $argList = append $argList "--log-file-encoder" -}}
             {{- $argList = append $argList .Values.logging.fileEncoder -}}
             {{- end -}}
-            {{- if not .Values.leaderElectionEnabled -}}
-            {{- $argList = append $argList "--enable-leader-election=false" -}}
+            {{- if hasKey .Values "leaderElectionEnabled" -}}
+            {{- $argList = append $argList (printf "--enable-leader-election=%t" .Values.leaderElectionEnabled) -}}
             {{- end -}}
             {{- (printf "\n") -}}
             {{- $argList | toYaml | indent 12 }}

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -79,7 +79,7 @@ securityContext:
     type: RuntimeDefault
 
 
-# enabled by default, disable leader election to solve k8s api timeout when leader election occur and 1 replica exist.
+# If leaderElectionEnabled is set to true, the KubeRay operator will use leader election for high availability.
 leaderElectionEnabled: true
 
 # If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is a follow up for https://github.com/ray-project/kuberay/pull/2262#pullrequestreview-2217437641.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(


* Case 1: `leaderElectionEnabled: true` -> `helm template .`
  <img width="668" alt="Screenshot 2024-08-03 at 11 17 19 PM" src="https://github.com/user-attachments/assets/3f83eac6-526b-4d88-bff6-44ceb8607724">
* Case 2: `leaderElectionEnabled: false` -> `helm template .`
  <img width="584" alt="Screenshot 2024-08-03 at 11 17 32 PM" src="https://github.com/user-attachments/assets/8c85c8cf-4b5f-4ca8-9547-1d50f75dd23a">
* Case 3: `leaderElectionEnabled` is not set -> `helm template .`
  <img width="554" alt="Screenshot 2024-08-03 at 11 17 44 PM" src="https://github.com/user-attachments/assets/a9ec724f-79e3-4a30-952b-88d0accda47a">


