### PR TITLE
add kubectl-plugin directory to kuberay.code-workspace

### DIFF
--- a/kuberay.code-workspace
+++ b/kuberay.code-workspace
@@ -10,7 +10,7 @@
 			"path": "apiserver"
 		},
 		{
-			"path": "cli"
+			"path": "kubectl-plugin"
 		},
 		{
 			"path": "proto"


### PR DESCRIPTION
## Why are these changes needed?

The cli directry was removed in favor of kubectl-plugin

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
