### PR TITLE
[Refactor][kubectl-plugin] Rename filenames and variables based on kubectl repo

### DIFF
--- a/kubectl-plugin/pkg/cmd/cluster/cluster_get.go
+++ b/kubectl-plugin/pkg/cmd/cluster/cluster_get.go
@@ -16,22 +16,22 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
-type ClusterOptions struct {
+type ClusterGetOptions struct {
 	configFlags   *genericclioptions.ConfigFlags
 	ioStreams     *genericclioptions.IOStreams
 	args          []string
 	AllNamespaces bool
 }
 
-func NewClusterOptions(streams genericclioptions.IOStreams) *ClusterOptions {
-	return &ClusterOptions{
+func NewClusterGetOptions(streams genericclioptions.IOStreams) *ClusterGetOptions {
+	return &ClusterGetOptions{
 		configFlags: genericclioptions.NewConfigFlags(true),
 		ioStreams:   &streams,
 	}
 }
 
 func NewClusterGetCommand(streams genericclioptions.IOStreams) *cobra.Command {
-	options := NewClusterOptions(streams)
+	options := NewClusterGetOptions(streams)
 	// Initialize the factory for later use with the current config flag
 	cmdFactory := cmdutil.NewFactory(options.configFlags)
 
@@ -56,7 +56,7 @@ func NewClusterGetCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	return cmd
 }
 
-func (options *ClusterOptions) Complete(args []string) error {
+func (options *ClusterGetOptions) Complete(args []string) error {
 	if *options.configFlags.Namespace == "" {
 		options.AllNamespaces = true
 	}
@@ -65,7 +65,7 @@ func (options *ClusterOptions) Complete(args []string) error {
 	return nil
 }
 
-func (options *ClusterOptions) Validate() error {
+func (options *ClusterGetOptions) Validate() error {
 	// Overrides and binds the kube config then retrieves the merged result
 	config, err := options.configFlags.ToRawKubeConfigLoader().RawConfig()
 	if err != nil {
@@ -80,7 +80,7 @@ func (options *ClusterOptions) Validate() error {
 	return nil
 }
 
-func (options *ClusterOptions) Run(ctx context.Context, factory cmdutil.Factory) error {
+func (options *ClusterGetOptions) Run(ctx context.Context, factory cmdutil.Factory) error {
 	// Retrieves the dynamic client with factory.
 	dynamicClient, err := factory.DynamicClient()
 	if err != nil {

--- a/kubectl-plugin/pkg/cmd/cluster/cluster_get_test.go
+++ b/kubectl-plugin/pkg/cmd/cluster/cluster_get_test.go
@@ -24,7 +24,7 @@ import (
 func TestRayClusterGetComplete(t *testing.T) {
 	// Initialize members of the cluster get option struct and the struct itself
 	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-	fakeClusterGetOptions := NewClusterOptions(testStreams)
+	fakeClusterGetOptions := NewClusterGetOptions(testStreams)
 	fakeArgs := []string{"Expected", "output"}
 
 	*fakeClusterGetOptions.configFlags.Namespace = ""
@@ -87,13 +87,13 @@ func TestRayClusterGetValidate(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		opts        *ClusterOptions
+		opts        *ClusterGetOptions
 		expect      string
 		expectError string
 	}{
 		{
 			name: "Test validation when no context is set",
-			opts: &ClusterOptions{
+			opts: &ClusterGetOptions{
 				configFlags:   genericclioptions.NewConfigFlags(false),
 				AllNamespaces: false,
 				args:          []string{"random_arg"},
@@ -103,7 +103,7 @@ func TestRayClusterGetValidate(t *testing.T) {
 		},
 		{
 			name: "Test validation when more than 1 arg",
-			opts: &ClusterOptions{
+			opts: &ClusterGetOptions{
 				// Use fake config to bypass the config flag checks
 				configFlags:   fakeConfigFlags,
 				AllNamespaces: false,
@@ -114,7 +114,7 @@ func TestRayClusterGetValidate(t *testing.T) {
 		},
 		{
 			name: "Successful validation call",
-			opts: &ClusterOptions{
+			opts: &ClusterGetOptions{
 				// Use fake config to bypass the config flag checks
 				configFlags:   fakeConfigFlags,
 				AllNamespaces: false,
@@ -144,7 +144,7 @@ func TestRayClusterGetRun(t *testing.T) {
 
 	testStreams, _, resBuf, _ := genericclioptions.NewTestIOStreams()
 
-	fakeClusterGetOptions := NewClusterOptions(testStreams)
+	fakeClusterGetOptions := NewClusterGetOptions(testStreams)
 
 	// Create fake ray cluster unstructured object for fake rest response
 	raycluster := &unstructured.Unstructured{


### PR DESCRIPTION
## Why are these changes needed?

This PR renames filenames and variables using the [top command in the kubectl repo](https://github.com/kubernetes/kubectl/tree/master/pkg/cmd/top) as a reference.

I find some variable naming will cause problem when implementing sub-commands of the `kubectl ray cluster` command. For example, because here

https://github.com/ray-project/kuberay/blob/6c1c16e03370bcc98c08d5e91479f2ddff69a55d/kubectl-plugin/pkg/cmd/cluster/get.go#L19-L24

the options struct is named `ClusterOptions`, if a new command `kubectl ray cluster session` needs to be implemented, it cannot use the name `ClusterOptions` because they both belong to the same package `cluster`. By renaming this to `ClusterGetOptions`, the `session` command can name its options as `ClusterSessionOptions`, which prevents the naming conflict and ensures consistent variable naming style.

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
