### PR TITLE
Add RayClusterProvisioned Condition Type

### DIFF
--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -168,7 +168,7 @@ type RayClusterConditionType string
 
 // Custom Reason for RayClusterCondition
 const (
-	AllPodRunningAndReady  = "AllPodRunningAndReady"
+	AllPodRunningAndReadyFirstTime  = "AllPodRunningAndReadyFirstTime"
 	HeadPodNotFound        = "HeadPodNotFound"
 	HeadPodRunningAndReady = "HeadPodRunningAndReady"
 	// UnknownReason says that the reason for the condition is unknown.
@@ -176,9 +176,9 @@ const (
 )
 
 const (
-	// RayClusterReady indicates whether all Ray Pods are ready when the RayCluster is first created.
-	// After RayClusterReady is set to true for the first time, it only indicates whether the RayCluster's head Pod is ready for requests.
-	RayClusterReady RayClusterConditionType = "RayClusterReady"
+	// RayClusterProvisioned indicates whether all Ray Pods are ready for the first time.
+	// After RayClusterProvisioned is set to true for the first time, it will not change anymore.
+	RayClusterProvisioned RayClusterConditionType = "RayClusterProvisioned"
 	// HeadPodReady indicates whether RayCluster's head Pod is ready for requests.
 	HeadPodReady RayClusterConditionType = "HeadPodReady"
 	// RayClusterReplicaFailure is added in a RayCluster when one of its pods fails to be created or deleted.

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -168,9 +168,9 @@ type RayClusterConditionType string
 
 // Custom Reason for RayClusterCondition
 const (
-	AllPodRunningAndReadyFirstTime  = "AllPodRunningAndReadyFirstTime"
-	HeadPodNotFound        = "HeadPodNotFound"
-	HeadPodRunningAndReady = "HeadPodRunningAndReady"
+	AllPodRunningAndReadyFirstTime = "AllPodRunningAndReadyFirstTime"
+	HeadPodNotFound                = "HeadPodNotFound"
+	HeadPodRunningAndReady         = "HeadPodRunningAndReady"
 	// UnknownReason says that the reason for the condition is unknown.
 	UnknownReason = "Unknown"
 )

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1210,25 +1210,17 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 			meta.SetStatusCondition(&newInstance.Status.Conditions, headPodReadyCondition)
 		}
 
-		if meta.FindStatusCondition(newInstance.Status.Conditions, string(rayv1.RayClusterReady)) == nil {
-			// RayClusterReady indicates whether all Ray Pods are ready when the RayCluster is first created.
-			// Note RayClusterReady StatusCondition will not be added to Raycluster until all Ray Pods are ready for the first time.
+		if meta.FindStatusCondition(newInstance.Status.Conditions, string(rayv1.RayClusterProvisioned)) == nil {
+			// RayClusterProvisioned indicates whether all Ray Pods are ready when the RayCluster is first created.
+			// Note RayClusterProvisioned StatusCondition will not be added to Raycluster until all Ray Pods are ready for the first time.
 			if utils.CheckAllPodsRunning(ctx, runtimePods) {
 				meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
-					Type:    string(rayv1.RayClusterReady),
+					Type:    string(rayv1.RayClusterProvisioned),
 					Status:  metav1.ConditionTrue,
-					Reason:  rayv1.AllPodRunningAndReady,
-					Message: "All Ray Pods are ready. Future checks focus on the head",
+					Reason:  rayv1.AllPodRunningAndReadyFirstTime,
+					Message: "All Ray Pods are ready for the first time",
 				})
 			}
-		} else { // After RayClusterReady is set to true for the first time, its meaning changes to be the same as HeadPodReady.
-			headPodReadyCondition := meta.FindStatusCondition(newInstance.Status.Conditions, string(rayv1.HeadPodReady))
-			meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
-				Type:    string(rayv1.RayClusterReady),
-				Status:  headPodReadyCondition.Status,
-				Reason:  headPodReadyCondition.Reason,
-				Message: "Only check head after all Ray Pods are initially ready",
-			})
 		}
 
 	}

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1833,7 +1833,7 @@ func TestRayClusterProvisionedCondition(t *testing.T) {
 	testRayCluster, _ = r.calculateStatus(ctx, testRayCluster, nil)
 	rayClusterProvisionedCondition = meta.FindStatusCondition(testRayCluster.Status.Conditions, string(rayv1.RayClusterProvisioned))
 	assert.Equal(t, rayClusterProvisionedCondition.Status, metav1.ConditionTrue)
-	assert.Equal(t, rayClusterProvisionedCondition.Reason, rayv1.AllPodRunningAndReadyFirstTime)	
+	assert.Equal(t, rayClusterProvisionedCondition.Reason, rayv1.AllPodRunningAndReadyFirstTime)
 
 	// After a while, head Pod also fails readiness, RayClusterProvisioned condition should still be true.
 	headPod.Status = UnReadyStatus


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See https://github.com/ray-project/kuberay/issues/2297 for the reason.

`RayClusterProvisioned` represents the first time all Ray pods are ready. So after `RayClusterProvisioned` is set to true for the first time, It will not change any more:

```yaml
    Last Transition Time:   2024-08-10T23:00:02Z
    Message:                All Ray Pods are ready for the first time
    Reason:                 AllPodRunningAndReadyFirstTime
    Status:                 True
    Type:                   RayClusterProvisioned
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #2297
<!-- For example: "Closes #2297" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
