### PR TITLE
RayClusterProvisioned status should be set while cluster is being provisioned for the first time

### DIFF
--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -169,6 +169,7 @@ type RayClusterConditionType string
 // Custom Reason for RayClusterCondition
 const (
 	AllPodRunningAndReadyFirstTime = "AllPodRunningAndReadyFirstTime"
+	RayClusterPodsProvisioning     = "RayClusterPodsProvisioning"
 	HeadPodNotFound                = "HeadPodNotFound"
 	HeadPodRunningAndReady         = "HeadPodRunningAndReady"
 	// UnknownReason says that the reason for the condition is unknown.

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -898,15 +898,15 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*3, time.Millisecond*500).Should(BeTrue())
 
 			By("Check RayCluster RayClusterProvisioned condition is false")
-			// But the worker pod is not ready yet, RayClusterProvisioned condition should still be absent.
+			// But the worker pod is not ready yet, RayClusterProvisioned condition should be false.
 			Consistently(
-				func() *metav1.Condition {
+				func() bool {
 					if err := getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster)(); err != nil {
-						return nil
+						return false
 					}
-					return meta.FindStatusCondition(rayCluster.Status.Conditions, string(rayv1.RayClusterProvisioned))
+					return meta.IsStatusConditionFalse(rayCluster.Status.Conditions, string(rayv1.RayClusterProvisioned))
 				},
-				time.Second*3, time.Millisecond*500).Should(BeNil())
+				time.Second*3, time.Millisecond*500).Should(BeTrue())
 
 			By("Update the worker pod to Running")
 			workerPod.Status.Phase = corev1.PodRunning

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1814,7 +1814,9 @@ func TestRayClusterProvisionedCondition(t *testing.T) {
 	_ = fakeClient.Status().Update(ctx, headPod)
 	_ = fakeClient.Status().Update(ctx, workerPod)
 	testRayCluster, _ = r.calculateStatus(ctx, testRayCluster, nil)
-	assert.Nil(t, meta.FindStatusCondition(testRayCluster.Status.Conditions, string(rayv1.RayClusterProvisioned)))
+	rayClusterProvisionedCondition := meta.FindStatusCondition(testRayCluster.Status.Conditions, string(rayv1.RayClusterProvisioned))
+	assert.Equal(t, rayClusterProvisionedCondition.Status, metav1.ConditionFalse)
+	assert.Equal(t, rayClusterProvisionedCondition.Reason, rayv1.RayClusterPodsProvisioning)
 
 	// After a while, all Ray Pods are ready for the first time, RayClusterProvisioned condition should be added and set to True.
 	headPod.Status = ReadyStatus
@@ -1822,7 +1824,7 @@ func TestRayClusterProvisionedCondition(t *testing.T) {
 	_ = fakeClient.Status().Update(ctx, headPod)
 	_ = fakeClient.Status().Update(ctx, workerPod)
 	testRayCluster, _ = r.calculateStatus(ctx, testRayCluster, nil)
-	rayClusterProvisionedCondition := meta.FindStatusCondition(testRayCluster.Status.Conditions, string(rayv1.RayClusterProvisioned))
+	rayClusterProvisionedCondition = meta.FindStatusCondition(testRayCluster.Status.Conditions, string(rayv1.RayClusterProvisioned))
 	assert.Equal(t, rayClusterProvisionedCondition.Status, metav1.ConditionTrue)
 	assert.Equal(t, rayClusterProvisionedCondition.Reason, rayv1.AllPodRunningAndReadyFirstTime)
 


### PR DESCRIPTION
## Why are these changes needed?

Follow-up to https://github.com/ray-project/kuberay/pull/2301, we should also set set the RayClusterProvisioned status with condition `False` while the cluster is being provisioned for the first time.

The new condition when cluster is provisioning:
```
  status:
    conditions:
    - lastTransitionTime: "2024-08-13T02:50:44Z"
      message: 'containers with unready status: [ray-head]'
      reason: ContainersNotReady
      status: "False"
      type: HeadPodReady
    - lastTransitionTime: "2024-08-13T02:50:44Z"
      message: RayCluster Pods are provisioning
      reason: RayClusterPodsProvisioning
      status: "False"
      type: RayClusterProvisioned
```

## Related issue number

Related to https://github.com/ray-project/kuberay/issues/2297

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
