### PR TITLE
increase memory limit for sample ray-cluster.complete.yaml

### DIFF
--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -54,14 +54,14 @@ spec:
           resources:
             limits:
               cpu: "1"
-              memory: "2G"
+              memory: "4G"
             requests:
               # For production use-cases, we recommend specifying integer CPU requests and limits.
               # We also recommend setting requests equal to limits for both CPU and memory.
               # For this example, we use a 500m CPU request to accomodate resource-constrained local
               # Kubernetes testing environments such as KinD and minikube.
               cpu: "500m"
-              memory: "2G"
+              memory: "4G"
         volumes:
           - name: ray-logs
             emptyDir: {}


### PR DESCRIPTION
## Why are these changes needed?

From my own testing, the ray-cluster.completel.yaml sample doesn't work due to memory issues from the head pod:
```
$ kubectl logs raycluster-complete-head-hfgm2
Traceback (most recent call last):
  File "/home/ray/anaconda3/bin/ray", line 8, in <module>
2024-08-12 19:59:15,403	INFO usage_lib.py:467 -- Usage stats collection is enabled by default without user confirmation because this terminal is detected to be non-interactive. To disable this, add `--disable-usage-stats` to the command that starts the cluster, or run the following command: `ray disable-usage-stats` before starting the cluster. See https://docs.ray.io/en/master/cluster/usage-stats.html for more details.
2024-08-12 19:59:15,403	INFO scripts.py:767 -- Local node IP: 10.244.0.11
    sys.exit(main())
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/scripts/scripts.py", line 2615, in main
    return cli()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ray/anaconda3/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/autoscaler/_private/cli_logger.py", line 856, in wrapper
    return f(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/scripts/scripts.py", line 794, in start
    node = ray._private.node.Node(
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/node.py", line 336, in __init__
    self.start_ray_processes()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/node.py", line 1406, in start_ray_processes
    ) = ray._private.services.determine_plasma_store_config(
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/services.py", line 2056, in determine_plasma_store_config
    raise ValueError(
ValueError: Attempting to cap object store memory usage at 24945868 bytes, but the minimum allowed is 78643200 bytes.
```

Increasing the memory limit to 4Gi to 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
