### PR TITLE
[RayJob] Add Failure Feedback (log and event) for Failed k8s Creation Task

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -513,7 +513,7 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 		return err
 	}
 	logger.Info("Kubernetes Job created", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)
-	r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, "Created", "Created Kubernetes Job %s", job.Name)
+	r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, "k8sJobCreationCreated", "Created Kubernetes Job %s", job.Name)
 	return nil
 }
 

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -508,6 +508,8 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 
 	// Create the Kubernetes Job
 	if err := r.Client.Create(ctx, job); err != nil {
+		logger.Error(err, "Failed to create new Kubernetes Job")
+		r.Recorder.Eventf(rayJobInstance, corev1.EventTypeWarning, "k8sJobCreationFailed", "Failed to create Kubernetes Job %s: %v", job.Name, err)
 		return err
 	}
 	logger.Info("Kubernetes Job created", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -509,7 +509,7 @@ func (r *RayJobReconciler) createNewK8sJob(ctx context.Context, rayJobInstance *
 	// Create the Kubernetes Job
 	if err := r.Client.Create(ctx, job); err != nil {
 		logger.Error(err, "Failed to create new Kubernetes Job")
-		r.Recorder.Eventf(rayJobInstance, corev1.EventTypeWarning, "k8sJobCreationFailed", "Failed to create Kubernetes Job %s: %v", job.Name, err)
+		r.Recorder.Eventf(rayJobInstance, corev1.EventTypeWarning, "k8sJobCreationFailed", "Failed to create new Kubernetes Job %s: %v", job.Name, err)
 		return err
 	}
 	logger.Info("Kubernetes Job created", "RayJob", rayJobInstance.Name, "Kubernetes Job", job.Name)

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -376,7 +376,6 @@ func TestValidateRayJobSpec(t *testing.T) {
 }
 
 func TestFailedCreatek8sJob(t *testing.T) {
-
 	rayJob := &rayv1.RayJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-rayjob",
@@ -386,7 +385,7 @@ func TestFailedCreatek8sJob(t *testing.T) {
 
 	submitterTemplate := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-submit-pod",
+			Name:      "test-submit-pod",
 			Namespace: "default",
 		},
 		Spec: corev1.PodSpec{
@@ -398,7 +397,7 @@ func TestFailedCreatek8sJob(t *testing.T) {
 			},
 		},
 	}
-	
+
 	fakeClient := clientFake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
 		Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
 			return utils.ErrFailedCreateWorkerPod
@@ -408,9 +407,9 @@ func TestFailedCreatek8sJob(t *testing.T) {
 	recorder := record.NewFakeRecorder(100)
 
 	reconciler := &RayJobReconciler{
-		Client: fakeClient,
+		Client:   fakeClient,
 		Recorder: recorder,
-		Scheme: scheme.Scheme,
+		Scheme:   scheme.Scheme,
 	}
 
 	err := reconciler.createNewK8sJob(context.Background(), rayJob, submitterTemplate)


### PR DESCRIPTION
## Why are these changes needed?
When a Kubernetes Job cannot be successfully created, it logs the error and generates an event for the failed job creation.

## Related issue number
Refer to https://github.com/ray-project/kuberay/issues/2210

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
