### PR TITLE
[release blocker][v1.2.0] Fix HA OOM issue

### DIFF
--- a/ray-operator/config/samples/ray-service.high-availability.yaml
+++ b/ray-operator/config/samples/ray-service.high-availability.yaml
@@ -85,7 +85,7 @@ spec:
         import_path: fruit.deployment_graph
         route_prefix: /fruit
         runtime_env:
-          working_dir: "https://github.com/ray-project/test_dag/archive/41d09119cbdf8450599f993f51318e9e27c59098.zip"
+          working_dir: "https://github.com/ray-project/test_dag/archive/4d2c9a59d9eabfd4c8a9e04a7aae44fc8f5b416f.zip"
         deployments:
           - name: MangoStand
             num_replicas: 2
@@ -109,11 +109,6 @@ spec:
             ray_actor_options:
               num_cpus: 0.1
           - name: FruitMarket
-            num_replicas: 2
-            max_replicas_per_node: 1
-            ray_actor_options:
-              num_cpus: 0.1
-          - name: DAGDriver
             num_replicas: 2
             max_replicas_per_node: 1
             ray_actor_options:
@@ -144,10 +139,10 @@ spec:
               resources:
                 limits:
                   cpu: 1
-                  memory: 1Gi
+                  memory: 2Gi
                 requests:
                   cpu: 1
-                  memory: 1Gi
+                  memory: 2Gi
               ports:
                 - containerPort: 6379
                   name: gcs-server


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* `DAGDriver` has been completely removed from Ray Serve since Ray 2.9. Therefore, this PR removes `DAGDriver` from the YAML.
  * https://github.com/ray-project/kuberay/pull/1649#issuecomment-1813282187



* OOM issue: This PR increases the memory request / limit from 1GB to 2GB.
  * KubeRay operator fails to receive the response from the `GET` ("context deadline exceeded") request. 
    ```json
    {"level":"error","ts":"2024-08-19T23:53:21.930Z","logger":"controllers.RayService","msg":"Fail to reconcileServe.","RayService":{"name":"rayservice-ha","namespace":"default"},"reconcileID":"7edec0fb-a933-4f1b-8498-f2596888869c","error":"Failed to get Serve application statuses from the dashboard. If you observe this error consistently, please check https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayservice-troubleshooting.md for more details. err: Failed to get serve details: Get \"http://rayservice-ha-raycluster-bn48b-head-svc.default.svc.cluster.local:8265/api/serve/applications/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","stacktrace":"github.com/ray-project/kuberay/ray-operator/controllers/ray.(*RayServiceReconciler).Reconcile\n\t/home/runner/work/kuberay/kuberay/ray-operator/controllers/ray/rayservice_controller.go:176\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.5/pkg/internal/controller/controller.go:227"}
    ```
    <img width="1889" alt="Screenshot 2024-08-19 at 4 17 29 PM" src="https://github.com/user-attachments/assets/a1f0b9d8-e428-4f86-bb59-0498da07f9a4">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(


I followed [the HA doc](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/rayservice-high-availability.html) to test this PR. In Step 6, I sent 5000 requests, and no request failed. 

<img width="801" alt="image" src="https://github.com/user-attachments/assets/26da5ce4-0859-4042-917c-6a846cb97570">

