### PR TITLE
Improve the logs before creating the ray cluster

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -692,6 +692,24 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		deleted := struct{}{}
 		numDeletedUnhealthyWorkerPods := 0
 		for _, workerPod := range workerPods.Items {
+			if workerPod.Status.Phase != "Running" {
+				if len(workerPod.Status.Conditions) > 0 {
+					for _, condition := range workerPod.Status.Conditions {
+						if condition.Message != "" {
+							logger.Info("reconcilePods",
+								"Worker Pod Name", workerPod.Name,
+								"Status", workerPod.Status.Phase,
+								"Condition Type", condition.Type,
+								"Condition Status", condition.Status,
+								"Message", condition.Message)
+						}
+					}
+				}
+			} else {
+				logger.Info("reconcilePods",
+					"Worker Pod Name", workerPod.Name,
+					"Status", workerPod.Status.Phase)
+			}
 			shouldDelete, reason := shouldDeletePod(workerPod, rayv1.WorkerNode)
 			logger.Info("reconcilePods", "worker Pod", workerPod.Name, "shouldDelete", shouldDelete, "reason", reason)
 			if shouldDelete {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Improved logs in case the network is very slow during the Ray cluster creation. Now, if the pods take hours to be created, a message about the status of the pods will appear. ref [2148](https://github.com/ray-project/kuberay/pull/2148)
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
