### PR TITLE
Bump go to 1.22.4 to fix ray-operator vulnerabilities

### DIFF
--- a/apiserver/go.mod
+++ b/apiserver/go.mod
@@ -2,7 +2,7 @@ module github.com/ray-project/kuberay/apiserver
 
 go 1.22.0
 
-toolchain go1.22.3
+toolchain go1.22.4
 
 require (
 	github.com/go-openapi/runtime v0.28.0

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -2,7 +2,7 @@ module github.com/ray-project/kuberay/ray-operator
 
 go 1.22.0
 
-toolchain go1.22.3
+toolchain go1.22.4
 
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 
@@ -27,6 +27,7 @@ require (
 	k8s.io/apiserver v0.29.6
 	k8s.io/client-go v0.29.6
 	k8s.io/code-generator v0.29.6
+	k8s.io/component-base v0.29.6
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	sigs.k8s.io/controller-runtime v0.17.5
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1
@@ -85,7 +86,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/component-base v0.29.6 // indirect
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240228010128-51d4e06bde70 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Vulnerability scanning shows `Critical` and `Medium` severity vulnerabilities in ray-operator v1.2.0-rc.0 image due to go version 1.22.3. This PR bumps the go toolchain to 1.22.4 to fix these errors.

ray-operator image showing vulnerabilities: `gcr.io/gke-release-staging/ray-operator@sha256:56f36fe9a805a271b218f16df009f06a1d785d53ff4b27a5bb2e5c33f52e7d97`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [x] This PR is not tested :(
