### PR TITLE
[Fix][Sample-Yaml] Increase ray head CPU resource for pytorch minst

### DIFF
--- a/ray-operator/config/samples/pytorch-mnist/ray-job.pytorch-mnist.yaml
+++ b/ray-operator/config/samples/pytorch-mnist/ray-job.pytorch-mnist.yaml
@@ -11,7 +11,7 @@ spec:
       - torchvision
     working_dir: "https://github.com/ray-project/kuberay/archive/master.zip"
     env_vars:
-      NUM_WORKERS: "4"
+      NUM_WORKERS: "2"
       CPUS_PER_WORKER: "2"
 
   # rayClusterSpec specifies the RayCluster instance to be created by the RayJob controller.
@@ -34,13 +34,13 @@ spec:
                   name: client
               resources:
                 limits:
-                  cpu: "2"
+                  cpu: "1"
                   memory: "4Gi"
                 requests:
-                  cpu: "2"
+                  cpu: "1"
                   memory: "4Gi"
     workerGroupSpecs:
-      - replicas: 4
+      - replicas: 2
         minReplicas: 1
         maxReplicas: 5
         groupName: small-group
@@ -53,8 +53,8 @@ spec:
                 image: rayproject/ray:2.34.0
                 resources:
                   limits:
-                    cpu: "2"
+                    cpu: "3"
                     memory: "4Gi"
                   requests:
-                    cpu: "2"
+                    cpu: "3"
                     memory: "4Gi"


### PR DESCRIPTION
## Why are these changes needed?

There is a breaking change from `ray:2.9` to `ray:2.34.0`, the reserved resources for CPUs increased from 2 to 3. So the CPU resource for the head pod needs to be increased to reflect this change.

See https://github.com/ray-project/ray/issues/47316 for details.

## Related issue number

Closes: ray-project/kuberay#2329

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
