### PR TITLE
[RayService] Use original ClusterIP for new head service

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -989,9 +989,7 @@ func (r *RayServiceReconciler) reconcileServices(ctx context.Context, rayService
 		// ClusterIP is immutable. Starting from Kubernetes v1.21.5, if the new service does not specify a ClusterIP,
 		// Kubernetes will assign the ClusterIP of the old service to the new one. However, to maintain compatibility
 		// with older versions of Kubernetes, we need to assign the ClusterIP here.
-		if newSvc.Spec.ClusterIP == "" {
-			newSvc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
-		}
+		newSvc.Spec.ClusterIP = oldSvc.Spec.ClusterIP
 
 		// TODO (kevin85421): Consider not only the updates of the Spec but also the ObjectMeta.
 		oldSvc.Spec = *newSvc.Spec.DeepCopy()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The comment at https://github.com/ray-project/kuberay/issues/2088#issuecomment-2319156015 mentioned that when upgrading from KubeRay v1.1.1 to KubeRay v1.2.0, updating the RayService CR will trigger the zero downtime upgrade as expected. The old RayCluster will eventually be torn down. However, the K8s service for serving will not point to the new RayCluster.

The reason is that the head service defaults to be headless from KubeRay v1.2.0. However, `ClusterIP` is immutable, so K8s API server will report error. Hence, the reconciliation will exit at L209 because of the head service error, so the serve K8s service's reconcile function L215 will not be executed.

https://github.com/ray-project/kuberay/blob/a69252e6cc90995a3b3085f14af5bcc6869a2d93/ray-operator/controllers/ray/rayservice_controller.go#L206-L219

## Related issue number

#2088 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(

```sh
helm install kuberay-operator kuberay/kuberay-operator --version 1.1.1
kubectl apply -f ray-service.sample.yaml
# Send some requests

kubectl replace -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.2.0"
# Install KubeRay with this PR.
helm upgrade kuberay-operator . --set image.repository=controller,image.tag=latest

# Update `ray-service.sample.yaml` to trigger zero-downtime upgrade.

# Send some requests after the old RayCluster is deleted.
```
