### PR TITLE
Allow setting the appProtocol on the serve Service

### DIFF
--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -248,7 +248,7 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 				ports := []corev1.ServicePort{}
 				for _, port := range serveService.Spec.Ports {
 					if port.Name == utils.ServingPortName {
-						svcPort := corev1.ServicePort{Name: port.Name, Port: port.Port}
+						svcPort := corev1.ServicePort{Name: port.Name, Port: port.Port, AppProtocol: port.AppProtocol}
 						ports = append(ports, svcPort)
 						break
 					}

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -248,7 +248,11 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 				ports := []corev1.ServicePort{}
 				for _, port := range serveService.Spec.Ports {
 					if port.Name == utils.ServingPortName {
-						svcPort := corev1.ServicePort{Name: port.Name, Port: port.Port, AppProtocol: port.AppProtocol}
+						appProtocol := utils.DefaultServiceAppProtocol
+						if port.AppProtocol != nil {
+							appProtocol = *port.AppProtocol
+						}
+						svcPort := corev1.ServicePort{Name: port.Name, Port: port.Port, AppProtocol: &appProtocol}
 						ports = append(ports, svcPort)
 						break
 					}


### PR DESCRIPTION
When using gRPC and istio gateways to get proper protocol selection we need to be able either change the name of the port which it seems there is an opinion that it should be called serve or we need to be able to set appProtocol https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/ to keep the naming consistent I propose opening up setting the appProtocl on the serveService. 