### PR TITLE
Use HTTP probes for Ray readiness and liviness probes

### DIFF
--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -151,21 +151,17 @@ const (
 	// Ray FT default readiness probe values
 	DefaultReadinessProbeInitialDelaySeconds = 10
 	DefaultReadinessProbeTimeoutSeconds      = 2
-	// Probe timeout for Head pod needs to be longer as it queries two endpoints (api/local_raylet_healthz & api/gcs_healthz)
-	DefaultHeadReadinessProbeTimeoutSeconds = 5
-	DefaultReadinessProbePeriodSeconds      = 5
-	DefaultReadinessProbeSuccessThreshold   = 1
-	DefaultReadinessProbeFailureThreshold   = 10
-	ServeReadinessProbeFailureThreshold     = 1
+	DefaultReadinessProbePeriodSeconds       = 5
+	DefaultReadinessProbeSuccessThreshold    = 1
+	DefaultReadinessProbeFailureThreshold    = 10
+	ServeReadinessProbeFailureThreshold      = 1
 
 	// Ray FT default liveness probe values
 	DefaultLivenessProbeInitialDelaySeconds = 30
 	DefaultLivenessProbeTimeoutSeconds      = 2
-	// Probe timeout for Head pod needs to be longer as it queries two endpoints (api/local_raylet_healthz & api/gcs_healthz)
-	DefaultHeadLivenessProbeTimeoutSeconds = 5
-	DefaultLivenessProbePeriodSeconds      = 5
-	DefaultLivenessProbeSuccessThreshold   = 1
-	DefaultLivenessProbeFailureThreshold   = 120
+	DefaultLivenessProbePeriodSeconds       = 5
+	DefaultLivenessProbeSuccessThreshold    = 1
+	DefaultLivenessProbeFailureThreshold    = 120
 
 	// Ray health check related configurations
 	// Note: Since the Raylet process and the dashboard agent process are fate-sharing,


### PR DESCRIPTION
## Why are these changes needed?

HTTP probes are considered lighter-weight than exec probes. However, exec probes have the advantage of doing multiple health checks. In KubeRay, we use exec probes to execute "wget" commands against multiple endpoints. Use of exec probes seems to be causing some issues, as shown in https://github.com/ray-project/kuberay/issues/2264 and from KubeRay scalability testing.  

This PR explores using HTTP probes instead. This PR needs more consideration as using HTTP probes means we can only health check 1 end point per probe. Marking WIP for now until that quesiton is resolved.  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
