### PR TITLE
Remove redundant log line that is failing golangci-lint

### DIFF
--- a/ray-operator/apis/config/v1alpha1/config_utils_test.go
+++ b/ray-operator/apis/config/v1alpha1/config_utils_test.go
@@ -75,7 +75,6 @@ func TestValidateBatchSchedulerConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Logf(tt.name)
 			if err := ValidateBatchSchedulerConfig(tt.args.logger, tt.args.config); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateBatchSchedulerConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
## Why are these changes needed?

golangci-lint is failing with this error:
```
apis/config/v1alpha1/config_utils_test.go:78:11: printf: non-constant format string in call to (*testing.common).Logf (govet)
			t.Logf(tt.name)
			       ^
```

This log line is not needed anyways since the test is wrapped with `t.Run(tt.name, func(t *testing.T)`. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
