### PR TITLE
add support for pipeline-parallel-size in vLLM example

### DIFF
--- a/ray-operator/config/samples/vllm/ray-service.vllm.yaml
+++ b/ray-operator/config/samples/vllm/ray-service.vllm.yaml
@@ -20,6 +20,7 @@ spec:
         env_vars:
           MODEL_ID: "meta-llama/Meta-Llama-3-8B-Instruct"
           TENSOR_PARALLELISM: "2"
+          PIPELINE_PARALLELISM: "1"
   rayClusterConfig:
     headGroupSpec:
       rayStartParams:

--- a/ray-operator/config/samples/vllm/serve.py
+++ b/ray-operator/config/samples/vllm/serve.py
@@ -122,4 +122,4 @@ def build_app(cli_args: Dict[str, str]) -> serve.Application:
 
 
 model = build_app(
-    {"model": os.environ['MODEL_ID'], "tensor-parallel-size": os.environ['TENSOR_PARALLELISM']})
+    {"model": os.environ['MODEL_ID'], "tensor-parallel-size": os.environ['TENSOR_PARALLELISM'], "pipeline-parallel-size": os.environ['PIPELINE_PARALLELISM']})


### PR DESCRIPTION
## Why are these changes needed?

Allow pipeline-parallel-size to be configurable in the vLLM example

## Related issue number

Related to https://github.com/ray-project/kuberay/issues/2354

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
