### PR TITLE
Remove default option for batch scheduler name

### DIFF
--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -78,10 +78,9 @@ batchScheduler:
   # Deprecated. This option will be removed in the future.
   # Note, for backwards compatibility. When it sets to true, it enables volcano scheduler integration.
   enabled: false
-  # Name of the scheduler, currently supported "default", "volcano" and "yunikorn",
-  # set the customized scheduler name, e.g "volcano" or "yunikorn", do not set
+  # Set the customized scheduler name, supported values are "volcano" or "yunikorn", do not set
   # "batchScheduler.enabled=true" at the same time as it will override this option.
-  name: default
+  name: ""
 
 featureGates:
   - name: RayClusterStatusConditions

--- a/ray-operator/apis/config/v1alpha1/config_utils.go
+++ b/ray-operator/apis/config/v1alpha1/config_utils.go
@@ -17,11 +17,6 @@ func ValidateBatchSchedulerConfig(logger logr.Logger, config Configuration) erro
 	}
 
 	if len(config.BatchScheduler) > 0 {
-		// default option, no-opt.
-		if config.BatchScheduler == "default" {
-			return nil
-		}
-
 		// if a customized scheduler is configured, check it is supported
 		if config.BatchScheduler == volcano.GetPluginName() || config.BatchScheduler == yunikorn.GetPluginName() {
 			logger.Info("Feature flag batch-scheduler is enabled",
@@ -30,5 +25,6 @@ func ValidateBatchSchedulerConfig(logger logr.Logger, config Configuration) erro
 			return fmt.Errorf("scheduler is not supported, name=%s", config.BatchScheduler)
 		}
 	}
+
 	return nil
 }

--- a/ray-operator/apis/config/v1alpha1/config_utils_test.go
+++ b/ray-operator/apis/config/v1alpha1/config_utils_test.go
@@ -71,6 +71,17 @@ func TestValidateBatchSchedulerConfig(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "invalid option, invalid scheduler name default",
+			args: args{
+				logger: testr.New(t),
+				config: Configuration{
+					EnableBatchScheduler: false,
+					BatchScheduler:       "default",
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -91,9 +91,9 @@ func main() {
 	flag.StringVar(&logStdoutEncoder, "log-stdout-encoder", "json",
 		"Encoder to use for logging stdout. Valid values are 'json' and 'console'. Defaults to 'json'")
 	flag.BoolVar(&enableBatchScheduler, "enable-batch-scheduler", false,
-		"(Deprecated) Enable batch scheduler. Currently is volcano, which supports gang scheduler policy.")
+		"(Deprecated) Enable batch scheduler. Currently is volcano, which supports gang scheduler policy. Please use --batch-scheduler instead.")
 	flag.StringVar(&batchScheduler, "batch-scheduler", "",
-		"Batch scheduler name, supported values are default, volcano, yunikorn.")
+		"Batch scheduler name, supported values are volcano and yunikorn.")
 	flag.StringVar(&configFile, "config", "", "Path to structured config file. Flags are ignored if config file is set.")
 	flag.BoolVar(&useKubernetesProxy, "use-kubernetes-proxy", false,
 		"Use Kubernetes proxy subresource when connecting to the Ray Head node.")

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -92,7 +92,7 @@ func main() {
 		"Encoder to use for logging stdout. Valid values are 'json' and 'console'. Defaults to 'json'")
 	flag.BoolVar(&enableBatchScheduler, "enable-batch-scheduler", false,
 		"(Deprecated) Enable batch scheduler. Currently is volcano, which supports gang scheduler policy.")
-	flag.StringVar(&batchScheduler, "batch-scheduler", "default",
+	flag.StringVar(&batchScheduler, "batch-scheduler", "",
 		"Batch scheduler name, supported values are default, volcano, yunikorn.")
 	flag.StringVar(&configFile, "config", "", "Path to structured config file. Flags are ignored if config file is set.")
 	flag.BoolVar(&useKubernetesProxy, "use-kubernetes-proxy", false,


### PR DESCRIPTION
Per review comment here: https://github.com/ray-project/kuberay/pull/2300#issuecomment-2337070070. Remove the redundant "default" option for the batch scheduler name.

How this was tested?

- UT (this PR added UT coverage for various cases)
- Local tests

```
// normal start up
./ray-operator/bin/manager -leader-election-namespace default -use-kubernetes-proxy

// batchscheduler.enabled=true
// this enables volcano integration
./ray-operator/bin/manager -enable-batch-scheduler -leader-election-namespace default -use-kubernetes-proxy

// batchscheduler.name=volcao
// this enables volcano integration
./ray-operator/bin/manager -batch-scheduler volcano -leader-election-namespace default -use-kubernetes-proxy
{"level":"info","ts":"2024-09-10T16:18:31.104-0700","logger":"setup","msg":"Feature flag batch-scheduler is enabled","scheduler name":"volcano"}
...

// batchscheduler.name=yunikorn
// this enables yunikorn integration
./ray-operator/bin/manager -batch-scheduler yunikorn -leader-election-namespace default -use-kubernetes-proxy
{"level":"info","ts":"2024-09-10T16:18:54.893-0700","logger":"setup","msg":"Feature flag batch-scheduler is enabled","scheduler name":"yunikorn"}
...
```