### PR TITLE
[CI][GitHub-Actions] Upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/actions/compatibility/action.yaml
+++ b/.github/workflows/actions/compatibility/action.yaml
@@ -37,7 +37,7 @@ runs:
     uses: docker-practice/actions-setup-docker@master
 
   - name: Download Artifact Operator
-    uses: actions/download-artifact@v2
+    uses: actions/download-artifact@v4
     with:
       name: operator_img
       path: /tmp

--- a/.github/workflows/e2e-tests-reusable-workflow.yaml
+++ b/.github/workflows/e2e-tests-reusable-workflow.yaml
@@ -83,7 +83,7 @@ jobs:
             kubectl logs -n ray-system --tail -1 -l app.kubernetes.io/name=kuberay | tee ${KUBERAY_TEST_OUTPUT_DIR}/kuberay-operator.log
 
         - name: Upload logs
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           if: (!inputs.plugin-test) && always() && steps.deploy.outcome == 'success'
           with:
             name: logs

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -76,7 +76,7 @@ jobs:
           docker save -o /tmp/apiserver.tar kuberay/apiserver:${{ steps.vars.outputs.sha_short }}
 
       - name: Upload Artifact Apiserver
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: apiserver_img
           path: /tmp/apiserver.tar
@@ -150,7 +150,7 @@ jobs:
         working-directory: ${{env.working-directory}}
 
       - name: Upload security proxy artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: security-proxy_img
           path: /tmp/security-proxy.tar
@@ -228,7 +228,7 @@ jobs:
       working-directory: ${{env.working-directory}}
 
     - name: Upload Artifact Operator
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: operator_img
         path: /tmp/operator.tar


### PR DESCRIPTION
## Why are these changes needed?

See the description in the corresponding issue for details.

## Related issue number

Closes: ray-project/kuberay#2372

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
