### PR TITLE
[Feat][Kubectl-Plugin] Implement kubectl session for RayJob and RayService

### DIFF
--- a/kubectl-plugin/go.mod
+++ b/kubectl-plugin/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
+	k8s.io/api v0.30.2
 	k8s.io/apimachinery v0.30.2
 	k8s.io/cli-runtime v0.30.2
 	k8s.io/client-go v0.30.2
@@ -76,7 +77,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.30.2 // indirect
 	k8s.io/component-base v0.30.2 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect

--- a/kubectl-plugin/pkg/cmd/session/session_test.go
+++ b/kubectl-plugin/pkg/cmd/session/session_test.go
@@ -58,6 +58,15 @@ func TestComplete(t *testing.T) {
 			hasErr:               false,
 		},
 		{
+			name:                 "no slash default to raycluster",
+			namespace:            "",
+			args:                 []string{"test-resource"},
+			expectedResourceType: util.RayCluster,
+			expectedNamespace:    "default",
+			expectedName:         "test-resource",
+			hasErr:               false,
+		},
+		{
 			name:   "invalid args (no args)",
 			args:   []string{},
 			hasErr: true,
@@ -65,11 +74,6 @@ func TestComplete(t *testing.T) {
 		{
 			name:   "invalid args (too many args)",
 			args:   []string{"raycluster/test-raycluster", "extra-arg"},
-			hasErr: true,
-		},
-		{
-			name:   "invalid args (no slash)",
-			args:   []string{"test-resource"},
 			hasErr: true,
 		},
 		{

--- a/kubectl-plugin/pkg/cmd/session/session_test.go
+++ b/kubectl-plugin/pkg/cmd/session/session_test.go
@@ -1,55 +1,91 @@
 package session
 
 import (
-	"context"
 	"testing"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestComplete(t *testing.T) {
 	cmd := &cobra.Command{Use: "session"}
 
 	tests := []struct {
-		name              string
-		namespace         string
-		expectedNamespace string
-		args              []string
-		hasErr            bool
+		name                 string
+		namespace            string
+		expectedResourceType util.ResourceType
+		expectedNamespace    string
+		expectedName         string
+		args                 []string
+		hasErr               bool
 	}{
 		{
-			name:              "valid args without namespace",
-			namespace:         "",
-			args:              []string{"test-cluster"},
-			expectedNamespace: "default",
-			hasErr:            false,
+			name:                 "valid raycluster without namespace",
+			namespace:            "",
+			args:                 []string{"raycluster/test-raycluster"},
+			expectedResourceType: util.RayCluster,
+			expectedNamespace:    "default",
+			expectedName:         "test-raycluster",
+			hasErr:               false,
 		},
 		{
-			name:              "valid args with namespace",
-			namespace:         "test-namespace",
-			args:              []string{"test-cluster"},
-			expectedNamespace: "test-namespace",
-			hasErr:            false,
+			name:                 "valid raycluster with namespace",
+			namespace:            "test-namespace",
+			args:                 []string{"raycluster/test-raycluster"},
+			expectedResourceType: util.RayCluster,
+			expectedNamespace:    "test-namespace",
+			expectedName:         "test-raycluster",
+			hasErr:               false,
 		},
 		{
-			name:              "invalid args (no args)",
-			namespace:         "",
-			args:              []string{},
-			expectedNamespace: "",
-			hasErr:            true,
+			name:                 "valid rayjob without namespace",
+			namespace:            "",
+			args:                 []string{"rayjob/test-rayjob"},
+			expectedResourceType: util.RayJob,
+			expectedNamespace:    "default",
+			expectedName:         "test-rayjob",
+			hasErr:               false,
 		},
 		{
-			name:              "invalid args (too many args)",
-			namespace:         "",
-			args:              []string{"test-cluster", "extra-arg"},
-			expectedNamespace: "",
-			hasErr:            true,
+			name:                 "valid rayservice without namespace",
+			namespace:            "",
+			args:                 []string{"rayservice/test-rayservice"},
+			expectedResourceType: util.RayService,
+			expectedNamespace:    "default",
+			expectedName:         "test-rayservice",
+			hasErr:               false,
+		},
+		{
+			name:   "invalid args (no args)",
+			args:   []string{},
+			hasErr: true,
+		},
+		{
+			name:   "invalid args (too many args)",
+			args:   []string{"raycluster/test-raycluster", "extra-arg"},
+			hasErr: true,
+		},
+		{
+			name:   "invalid args (no slash)",
+			args:   []string{"test-resource"},
+			hasErr: true,
+		},
+		{
+			name:   "invalid args (no resource type)",
+			args:   []string{"/test-resource"},
+			hasErr: true,
+		},
+		{
+			name:   "invalid args (no resource name)",
+			args:   []string{"raycluster/"},
+			hasErr: true,
+		},
+		{
+			name:   "invalid args (invalid resource type)",
+			args:   []string{"invalid-type/test-resource"},
+			hasErr: true,
 		},
 	}
 
@@ -64,81 +100,8 @@ func TestComplete(t *testing.T) {
 			} else {
 				assert.Nil(t, err)
 				assert.Equal(t, tc.expectedNamespace, fakeSessionOptions.Namespace)
-			}
-		})
-	}
-}
-
-func TestFindServiceName(t *testing.T) {
-	objects := []runtime.Object{
-		&corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "raycluster-default-head-svc",
-				Namespace: "default",
-				Labels: map[string]string{
-					"ray.io/cluster":   "raycluster-default",
-					"ray.io/node-type": "head",
-				},
-			},
-		},
-		&corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "raycluster-test-head-svc",
-				Namespace: "test",
-				Labels: map[string]string{
-					"ray.io/cluster":   "raycluster-test",
-					"ray.io/node-type": "head",
-				},
-			},
-		},
-		&corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "raycluster-non-related-head-svc",
-				Namespace: "test",
-				Labels: map[string]string{
-					"ray.io/cluster":   "raycluster-non-related",
-					"ray.io/node-type": "head",
-				},
-			},
-		},
-	}
-
-	kubeClientSet := fake.NewSimpleClientset(objects...)
-
-	tests := []struct {
-		name         string
-		namespace    string
-		resourceName string
-		serviceName  string
-	}{
-		{
-			name:         "find service name in default namespace",
-			namespace:    "default",
-			resourceName: "raycluster-default",
-			serviceName:  "service/raycluster-default-head-svc",
-		},
-		{
-			name:         "find service name in test namespace",
-			namespace:    "test",
-			resourceName: "raycluster-test",
-			serviceName:  "service/raycluster-test-head-svc",
-		},
-		{
-			name:         "resource not found",
-			namespace:    "default",
-			resourceName: "raycluster-not-found",
-			serviceName:  "",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			serviceName, err := findServiceName(context.Background(), kubeClientSet, tc.namespace, tc.resourceName)
-			if tc.serviceName == "" {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				assert.Equal(t, tc.serviceName, serviceName)
+				assert.Equal(t, tc.expectedResourceType, fakeSessionOptions.ResourceType)
+				assert.Equal(t, tc.expectedName, fakeSessionOptions.ResourceName)
 			}
 		})
 	}

--- a/kubectl-plugin/pkg/util/client/client.go
+++ b/kubectl-plugin/pkg/util/client/client.go
@@ -95,6 +95,13 @@ func (c *k8sClient) getRayHeadSvcNameByRayJob(ctx context.Context, namespace str
 	return svcName, nil
 }
 
+// There are 3 services associated with a RayService:
+// - <rayservice-name>-head-svc
+// - <rayservice-name>-serve-svc
+// - <raycluster-name>-head-svc
+// This function retrieves the name of the <raycluster-name>-head-svc service.
+// Actually there is no difference between which service to use, because kubectl port-forward source code first tries to find the underlying pod.
+// See https://github.com/kubernetes/kubectl/blob/262825a8a665c7cae467dfaa42b63be5a5b8e5a2/pkg/cmd/portforward/portforward.go#L345 for details.
 func (c *k8sClient) getRayHeadSvcNameByRayService(ctx context.Context, namespace string, name string) (string, error) {
 	rayService, err := c.DynamicClient().Resource(util.RayServiceGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {

--- a/kubectl-plugin/pkg/util/client/client.go
+++ b/kubectl-plugin/pkg/util/client/client.go
@@ -1,0 +1,129 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+type Client interface {
+	KubernetesClient() kubernetes.Interface
+	DynamicClient() dynamic.Interface
+	// GetRayHeadSvcName retrieves the name of RayHead service for the given RayCluster, RayJob, or RayService.
+	GetRayHeadSvcName(ctx context.Context, namespace string, resourceType util.ResourceType, name string) (string, error)
+}
+
+type k8sClient struct {
+	kubeClient    kubernetes.Interface
+	dynamicClient dynamic.Interface
+}
+
+func NewClient(factory cmdutil.Factory) (Client, error) {
+	kubeClient, err := factory.KubernetesClientSet()
+	if err != nil {
+		return nil, err
+	}
+	dynamicClient, err := factory.DynamicClient()
+	if err != nil {
+		return nil, err
+	}
+	return &k8sClient{
+		kubeClient:    kubeClient,
+		dynamicClient: dynamicClient,
+	}, nil
+}
+
+func NewClientForTesting(kubeClient kubernetes.Interface, dynamicClient dynamic.Interface) Client {
+	return &k8sClient{
+		kubeClient:    kubeClient,
+		dynamicClient: dynamicClient,
+	}
+}
+
+func (c *k8sClient) KubernetesClient() kubernetes.Interface {
+	return c.kubeClient
+}
+
+func (c *k8sClient) DynamicClient() dynamic.Interface {
+	return c.dynamicClient
+}
+
+func (c *k8sClient) GetRayHeadSvcName(ctx context.Context, namespace string, resourceType util.ResourceType, name string) (string, error) {
+	switch resourceType {
+	case util.RayCluster:
+		return c.getRayHeadSvcNameByRayCluster(ctx, namespace, name)
+	case util.RayJob:
+		return c.getRayHeadSvcNameByRayJob(ctx, namespace, name)
+	case util.RayService:
+		return c.getRayHeadSvcNameByRayService(ctx, namespace, name)
+	default:
+		return "", fmt.Errorf("unsupported resource type: %s", resourceType)
+	}
+}
+
+func (c *k8sClient) getRayHeadSvcNameByRayCluster(ctx context.Context, namespace string, name string) (string, error) {
+	rayCluster, err := c.DynamicClient().Resource(util.RayClusterGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("unable to find RayCluster %s: %w", name, err)
+	}
+	svcName, err := extractRayHeadSvcNameFromRayClusterStatus(rayCluster.Object["status"])
+	if err != nil {
+		return "", fmt.Errorf("unable to extract RayHead service name from RayCluster %s: %w", name, err)
+	}
+	return svcName, nil
+}
+
+func (c *k8sClient) getRayHeadSvcNameByRayJob(ctx context.Context, namespace string, name string) (string, error) {
+	rayJob, err := c.DynamicClient().Resource(util.RayJobGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("unable to find RayJob %s: %w", name, err)
+	}
+	status := rayJob.Object["status"]
+	rayClusterStatus, ok := status.(map[string]interface{})["rayClusterStatus"]
+	if !ok {
+		return "", fmt.Errorf("unable to find rayClusterStatus in status")
+	}
+	svcName, err := extractRayHeadSvcNameFromRayClusterStatus(rayClusterStatus)
+	if err != nil {
+		return "", fmt.Errorf("unable to extract RayHead service name from RayJob %s: %w", name, err)
+	}
+	return svcName, nil
+}
+
+func (c *k8sClient) getRayHeadSvcNameByRayService(ctx context.Context, namespace string, name string) (string, error) {
+	rayService, err := c.DynamicClient().Resource(util.RayServiceGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("unable to find RayService %s: %w", name, err)
+	}
+	status := rayService.Object["status"]
+	activeServiceStatus, ok := status.(map[string]interface{})["activeServiceStatus"]
+	if !ok {
+		return "", fmt.Errorf("unable to find activeServiceStatus in status")
+	}
+	rayClusterStatus, ok := activeServiceStatus.(map[string]interface{})["rayClusterStatus"]
+	if !ok {
+		return "", fmt.Errorf("unable to find rayClusterStatus in activeServiceStatus")
+	}
+	svcName, err := extractRayHeadSvcNameFromRayClusterStatus(rayClusterStatus)
+	if err != nil {
+		return "", fmt.Errorf("unable to extract RayHead service name from RayJob %s: %w", name, err)
+	}
+	return svcName, nil
+}
+
+func extractRayHeadSvcNameFromRayClusterStatus(status interface{}) (string, error) {
+	head, ok := status.(map[string]interface{})["head"]
+	if !ok {
+		return "", fmt.Errorf("unable to find head in status")
+	}
+	svcName, ok := head.(map[string]interface{})["serviceName"].(string)
+	if !ok {
+		return "", fmt.Errorf("unable to find serviceName in head")
+	}
+	return svcName, nil
+}

--- a/kubectl-plugin/pkg/util/client/client_test.go
+++ b/kubectl-plugin/pkg/util/client/client_test.go
@@ -1,0 +1,262 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicFake "k8s.io/client-go/dynamic/fake"
+	kubeFake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetRayHeadSvcNameByRayCluster(t *testing.T) {
+	kubeObjects := []runtime.Object{}
+
+	dynamicObjects := []runtime.Object{
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "ray.io/v1",
+				"kind":       "RayCluster",
+				"metadata": map[string]interface{}{
+					"name":      "raycluster-default",
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"head": map[string]interface{}{
+						"serviceName": "raycluster-default-head-svc",
+					},
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "ray.io/v1",
+				"kind":       "RayCluster",
+				"metadata": map[string]interface{}{
+					"name":      "raycluster-test",
+					"namespace": "test",
+				},
+				"status": map[string]interface{}{
+					"head": map[string]interface{}{
+						"serviceName": "raycluster-test-head-svc",
+					},
+				},
+			},
+		},
+	}
+
+	kubeClientSet := kubeFake.NewSimpleClientset(kubeObjects...)
+	dynamicClient := dynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), dynamicObjects...)
+	client := NewClientForTesting(kubeClientSet, dynamicClient)
+
+	tests := []struct {
+		name         string
+		namespace    string
+		resourceName string
+		serviceName  string
+	}{
+		{
+			name:         "find service name in default namespace",
+			namespace:    "default",
+			resourceName: "raycluster-default",
+			serviceName:  "raycluster-default-head-svc",
+		},
+		{
+			name:         "find service name in test namespace",
+			namespace:    "test",
+			resourceName: "raycluster-test",
+			serviceName:  "raycluster-test-head-svc",
+		},
+		{
+			name:         "resource not found",
+			namespace:    "default",
+			resourceName: "raycluster-not-found",
+			serviceName:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svcName, err := client.GetRayHeadSvcName(context.Background(), tc.namespace, util.RayCluster, tc.resourceName)
+			if tc.serviceName == "" {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tc.serviceName, svcName)
+			}
+		})
+	}
+}
+
+func TestGetRayHeadSvcNameByRayJob(t *testing.T) {
+	kubeObjects := []runtime.Object{}
+
+	dynamicObjects := []runtime.Object{
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "ray.io/v1",
+				"kind":       "RayJob",
+				"metadata": map[string]interface{}{
+					"name":      "rayjob-default",
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"rayClusterStatus": map[string]interface{}{
+						"head": map[string]interface{}{
+							"serviceName": "rayjob-default-raycluster-xxxxx-head-svc",
+						},
+					},
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "ray.io/v1",
+				"kind":       "RayJob",
+				"metadata": map[string]interface{}{
+					"name":      "rayjob-test",
+					"namespace": "test",
+				},
+				"status": map[string]interface{}{
+					"rayClusterStatus": map[string]interface{}{
+						"head": map[string]interface{}{
+							"serviceName": "rayjob-test-raycluster-xxxxx-head-svc",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	kubeClientSet := kubeFake.NewSimpleClientset(kubeObjects...)
+	dynamicClient := dynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), dynamicObjects...)
+	client := NewClientForTesting(kubeClientSet, dynamicClient)
+
+	tests := []struct {
+		name         string
+		namespace    string
+		resourceName string
+		serviceName  string
+	}{
+		{
+			name:         "find service name in default namespace",
+			namespace:    "default",
+			resourceName: "rayjob-default",
+			serviceName:  "rayjob-default-raycluster-xxxxx-head-svc",
+		},
+		{
+			name:         "find service name in test namespace",
+			namespace:    "test",
+			resourceName: "rayjob-test",
+			serviceName:  "rayjob-test-raycluster-xxxxx-head-svc",
+		},
+		{
+			name:         "resource not found",
+			namespace:    "default",
+			resourceName: "rayjob-not-found",
+			serviceName:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svcName, err := client.GetRayHeadSvcName(context.Background(), tc.namespace, util.RayJob, tc.resourceName)
+			if tc.serviceName == "" {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tc.serviceName, svcName)
+			}
+		})
+	}
+}
+
+func TestGetRayHeadSvcNameByRayService(t *testing.T) {
+	kubeObjects := []runtime.Object{}
+
+	dynamicObjects := []runtime.Object{
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "ray.io/v1",
+				"kind":       "RayService",
+				"metadata": map[string]interface{}{
+					"name":      "rayservice-default",
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"activeServiceStatus": map[string]interface{}{
+						"rayClusterStatus": map[string]interface{}{
+							"head": map[string]interface{}{
+								"serviceName": "rayservice-default-raycluster-xxxxx-head-svc",
+							},
+						},
+					},
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "ray.io/v1",
+				"kind":       "RayService",
+				"metadata": map[string]interface{}{
+					"name":      "rayservice-test",
+					"namespace": "test",
+				},
+				"status": map[string]interface{}{
+					"activeServiceStatus": map[string]interface{}{
+						"rayClusterStatus": map[string]interface{}{
+							"head": map[string]interface{}{
+								"serviceName": "rayservice-test-raycluster-xxxxx-head-svc",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	kubeClientSet := kubeFake.NewSimpleClientset(kubeObjects...)
+	dynamicClient := dynamicFake.NewSimpleDynamicClient(runtime.NewScheme(), dynamicObjects...)
+	client := NewClientForTesting(kubeClientSet, dynamicClient)
+
+	tests := []struct {
+		name         string
+		namespace    string
+		resourceName string
+		serviceName  string
+	}{
+		{
+			name:         "find service name in default namespace",
+			namespace:    "default",
+			resourceName: "rayservice-default",
+			serviceName:  "rayservice-default-raycluster-xxxxx-head-svc",
+		},
+		{
+			name:         "find service name in test namespace",
+			namespace:    "test",
+			resourceName: "rayservice-test",
+			serviceName:  "rayservice-test-raycluster-xxxxx-head-svc",
+		},
+		{
+			name:         "resource not found",
+			namespace:    "default",
+			resourceName: "rayservice-not-found",
+			serviceName:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svcName, err := client.GetRayHeadSvcName(context.Background(), tc.namespace, util.RayService, tc.resourceName)
+			if tc.serviceName == "" {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tc.serviceName, svcName)
+			}
+		})
+	}
+}

--- a/kubectl-plugin/pkg/util/types.go
+++ b/kubectl-plugin/pkg/util/types.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type ResourceType string
+
+const (
+	RayCluster ResourceType = "raycluster"
+	RayJob     ResourceType = "rayjob"
+	RayService ResourceType = "rayservice"
+)
+
+const (
+	RayGroup   = "ray.io"
+	RayVersion = "v1"
+)
+
+var RayClusterGVR = schema.GroupVersionResource{
+	Group:    RayGroup,
+	Version:  RayVersion,
+	Resource: "rayclusters",
+}
+
+var RayJobGVR = schema.GroupVersionResource{
+	Group:    RayGroup,
+	Version:  RayVersion,
+	Resource: "rayjobs",
+}
+
+var RayServiceGVR = schema.GroupVersionResource{
+	Group:    RayGroup,
+	Version:  RayVersion,
+	Resource: "rayservices",
+}


### PR DESCRIPTION
## Why are these changes needed?

https://github.com/ray-project/kuberay/pull/2298 only implemented `kubectl ray session` for `RayCluster`. This PR implements `kubectl session` for `RayJob` and `RayService`.

![image](https://github.com/user-attachments/assets/23d7495a-e49a-43d3-b7ef-f95897412ced)


## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
