### PR TITLE
[Chore][Minor] Add .gitignore to kubectl-plugin

### DIFF
--- a/kubectl-plugin/.gitignore
+++ b/kubectl-plugin/.gitignore
@@ -1,0 +1,1 @@
+kubectl-ray


### PR DESCRIPTION
## Why are these changes needed?

Add `.gitignore` to `kubectl-plugin` folder to ignore the `kubectl-ray` binary.

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
