### PR TITLE
[Feat][kubectl-plugin] Add instructions for static shell completion

### DIFF
--- a/kubectl-plugin/README.md
+++ b/kubectl-plugin/README.md
@@ -2,56 +2,25 @@
 
 Kubectl plugin/extension for Kuberay CLI that provides the ability to manage ray resources.
 
-## Installation
-
-<!-- 1. Check [release page](https://github.com/ray-project/kuberay/releases) and download the necessary binaries. -->
-1. Run `go build cmd/kubectl-ray.go`
-2. Move the binary, which will be named `kubectl-ray` to your `PATH`
-
 ## Prerequisites
 
 1. Make sure there is a Kubernetes cluster running with KubeRay installed.
 2. Make sure `kubectl` has the right context.
 
-## Usage
+## Installation
 
-### Retrieve Ray Clusters
+### Compiling from source
 
-    Usage:
-    ray cluster get [flags]
+1. Run `go build cmd/kubectl-ray.go`
+2. Move the binary, which will be named `kubectl-ray` to your `PATH`
 
-    Aliases:
-    get, list
+### Using Krew
 
-    Description:
-    Retrieves the ray cluster information.
+1. Install [Krew](https://krew.sigs.k8s.io/docs/user-guide/setup/install/).
+2. (TODO: Replace this step with the installation command).
 
-    ```
-    $ kubectl ray cluster get
-    NAME                       NAMESPACE   DESIRED WORKERS   AVAILABLE WORKERS   CPUS   GPUS   TPUS   MEMORY   AGE
-    random-kuberay-cluster   default     1                 1                   5      1      0      24Gi     13d
-    ```
+## Shell Completion
 
-### Retrieve Ray Cluster Head Logs
-
-    Usage:
-    log (RAY_CLUSTER_NAME) [--out-dir directory] [--node-type all|head|worker]
-    **Currently only `head` is supported**
-
-    Aliases:
-    log, logs
-
-    Description:
-    Retrieves ray cluster head pod logs and all the logs under `/tmp/ray/session_latest/logs/`
-
-    ```
-    $ kubectl ray cluster logs --out-dir temp-dir
-    ...
-    $ ls temp-dir/
-    stable-diffusion-cluster-head-hqcxt
-    $ ls temp-dir/stable-diffusion-cluster-head-hqcxt
-    agent-424238335.err dashboard_agent.log gcs_server.err      monitor.err     old                     raylet.out              stdout.log
-    agent-424238335.out debug_state.txt     gcs_server.out      monitor.log     ray_client_server.err   runtime_env_agent.err
-    dashboard.err       debug_state_gcs.txt log_monitor.err     monitor.out     ray_client_server.out   runtime_env_agent.log
-    dashboard.log       events              log_monitor.log     nsight          raylet.err              runtime_env_agent.out
-    ```
+1. Install [kubectl plugin-completion](https://github.com/marckhouzam/kubectl-plugin_completion) plugin.
+2. Run `kubectl plugin-completion generate`.
+3. Add `$HOME/.kubectl-plugin-completion` to `PATH` in your shell profile.

--- a/kubectl-plugin/pkg/cmd/ray.go
+++ b/kubectl-plugin/pkg/cmd/ray.go
@@ -19,6 +19,9 @@ func NewRayCommand(streams genericiooptions.IOStreams) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
+		CompletionOptions: cobra.CompletionOptions{
+			DisableDefaultCmd: true,
+		},
 	}
 
 	cmd.AddCommand(cluster.NewClusterCommand(streams))


### PR DESCRIPTION
## Why are these changes needed?

This PR updates README.md to add instruction for static shell completion for kubectl ray plugin. Static means that we haven't implemented [Dynamic completion of nouns](https://github.com/spf13/cobra/blob/main/site/content/completions/_index.md#dynamic-completion-of-nouns) yet.

Also the default `completion` command in `cobra` is disabled because the shell completion for `kubectl` plugin works differently from normal commands. Therefore this command is useless. I removed it to avoid confusion. See https://github.com/kubernetes/kubernetes/issues/74178 and https://github.com/kubernetes/kubernetes/pull/105867 for details.

Screenshot (my shell is fish shell):

![image](https://github.com/user-attachments/assets/ccdba9aa-da8c-4acd-989f-8a9276d51a33)

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
