### PR TITLE
[Feature][RayJob]: Generate submitter and RayCluster creation/deletion events

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme"
 )
 
-func TestCreateK8sJobIfNeed(t *testing.T) {
+func TestCreateRayJobSubmitterIfNeed(t *testing.T) {
 	newScheme := runtime.NewScheme()
 	_ = rayv1.AddToScheme(newScheme)
 	_ = batchv1.AddToScheme(newScheme)
@@ -376,7 +376,7 @@ func TestValidateRayJobSpec(t *testing.T) {
 	assert.Error(t, err, "The RayJob is invalid because the backoffLimit must be a positive integer.")
 }
 
-func TestFailedCreatek8sJobEvent(t *testing.T) {
+func TestFailedToCreateRayJobSubmitterEvent(t *testing.T) {
 	rayJob := &rayv1.RayJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-rayjob",

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -248,6 +248,16 @@ const (
 	CreatedRedisCleanupJob        K8sEventType = "CreatedRedisCleanupJob"
 	FailedToCreateRedisCleanupJob K8sEventType = "FailedToCreateRedisCleanupJob"
 
+	// RayJob event list
+	CreatedRayJobSubmitter        K8sEventType = "CreatedRayJobSubmitter"
+	DeletedRayJobSubmitter        K8sEventType = "DeletedRayJobSubmitter"
+	FailedToCreateRayJobSubmitter K8sEventType = "FailedToCreateRayJobSubmitter"
+	FailedToDeleteRayJobSubmitter K8sEventType = "FailedToDeleteRayJobSubmitter"
+	CreatedRayCluster             K8sEventType = "CreatedRayCluster"
+	DeletedRayCluster             K8sEventType = "DeletedRayCluster"
+	FailedToCreateRayCluster      K8sEventType = "FailedToCreateRayCluster"
+	FailedToDeleteRayCluster      K8sEventType = "FailedToDeleteRayCluster"
+
 	// Generic Pod event list
 	DeletedPod        K8sEventType = "DeletedPod"
 	FailedToDeletePod K8sEventType = "FailedToDeletePod"


### PR DESCRIPTION
## Why are these changes needed?

This PR first continues @tinaxfwu's work on https://github.com/ray-project/kuberay/pull/2306 with new event naming and centralization of events to the `constant.go` file.

And following [the RayCluster status improvement workstream](https://docs.google.com/document/d/1NCX3fCTiE817AV4chvR46bkNHR7q0zy4QXQfDu-dqF4/edit), we also add events for RayCluster creation and deletion. Resulting in these 8 new events for RayJob controller:

```go
	CreatedRayJobSubmitter        K8sEventType = "CreatedRayJobSubmitter"
	DeletedRayJobSubmitter        K8sEventType = "DeletedRayJobSubmitter"
	FailedToCreateRayJobSubmitter K8sEventType = "FailedToCreateRayJobSubmitter"
	FailedToDeleteRayJobSubmitter K8sEventType = "FailedToDeleteRayJobSubmitter"
	CreatedRayCluster             K8sEventType = "CreatedRayCluster"
	DeletedRayCluster             K8sEventType = "DeletedRayCluster"
	FailedToCreateRayCluster      K8sEventType = "FailedToCreateRayCluster"
	FailedToDeleteRayCluster      K8sEventType = "FailedToDeleteRayCluster"
```

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
