### PR TITLE
[Feature][RayCluster]: introduce RayClusterSuspending and RayClusterSuspended conditions

### DIFF
--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -186,9 +186,9 @@ const (
 	HeadPodReady RayClusterConditionType = "HeadPodReady"
 	// RayClusterReplicaFailure is added in a RayCluster when one of its pods fails to be created or deleted.
 	RayClusterReplicaFailure RayClusterConditionType = "ReplicaFailure"
-	// RayClusterSuspending is added in a RayCluster when a user change its .Spec.Suspend to true.
+	// RayClusterSuspending is set to true when a user sets .Spec.Suspend to true, ensuring the atomicity of the suspend operation.
 	RayClusterSuspending RayClusterConditionType = "RayClusterSuspending"
-	// RayClusterSuspended is added in a RayCluster when it is suspended from the suspending condition.
+	// RayClusterSuspended is set to true when all Pods belonging to a suspending RayCluster are deleted. Note that RayClusterSuspending and RayClusterSuspended cannot both be true at the same time.
 	RayClusterSuspended RayClusterConditionType = "RayClusterSuspended"
 )
 

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -172,6 +172,8 @@ type RayClusterConditionType string
 const (
 	AllPodRunningAndReadyFirstTime = "AllPodRunningAndReadyFirstTime"
 	RayClusterPodsProvisioning     = "RayClusterPodsProvisioning"
+	RayClusterSuspended            = "RayClusterSuspended"
+	RayClusterSuspending           = "RayClusterSuspending"
 	HeadPodNotFound                = "HeadPodNotFound"
 	HeadPodRunningAndReady         = "HeadPodRunningAndReady"
 	// UnknownReason says that the reason for the condition is unknown.
@@ -186,6 +188,8 @@ const (
 	HeadPodReady RayClusterConditionType = "HeadPodReady"
 	// RayClusterReplicaFailure is added in a RayCluster when one of its pods fails to be created or deleted.
 	RayClusterReplicaFailure RayClusterConditionType = "ReplicaFailure"
+	// RayClusterSuspend is added in a RayCluster when a user change its .Spec.Suspend to true
+	RayClusterSuspend RayClusterConditionType = "RayClusterSuspend"
 )
 
 // HeadInfo gives info about head

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -172,8 +172,6 @@ type RayClusterConditionType string
 const (
 	AllPodRunningAndReadyFirstTime = "AllPodRunningAndReadyFirstTime"
 	RayClusterPodsProvisioning     = "RayClusterPodsProvisioning"
-	RayClusterSuspended            = "RayClusterSuspended"
-	RayClusterSuspending           = "RayClusterSuspending"
 	HeadPodNotFound                = "HeadPodNotFound"
 	HeadPodRunningAndReady         = "HeadPodRunningAndReady"
 	// UnknownReason says that the reason for the condition is unknown.
@@ -188,8 +186,10 @@ const (
 	HeadPodReady RayClusterConditionType = "HeadPodReady"
 	// RayClusterReplicaFailure is added in a RayCluster when one of its pods fails to be created or deleted.
 	RayClusterReplicaFailure RayClusterConditionType = "ReplicaFailure"
-	// RayClusterSuspend is added in a RayCluster when a user change its .Spec.Suspend to true
-	RayClusterSuspend RayClusterConditionType = "RayClusterSuspend"
+	// RayClusterSuspending is added in a RayCluster when a user change its .Spec.Suspend to true.
+	RayClusterSuspending RayClusterConditionType = "RayClusterSuspending"
+	// RayClusterSuspended is added in a RayCluster when it is suspended from the suspending condition.
+	RayClusterSuspended RayClusterConditionType = "RayClusterSuspended"
 )
 
 // HeadInfo gives info about head

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -370,8 +370,9 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 	} else {
 		err = updateErr
 	}
-	// Besides an error, we also requeue the reconciliation if status changed.
-	// This behavior is required by atomic operations that depend on status changes, such as suspending a RayCluster.
+	// If the custom resource's status is updated, requeue the reconcile key.
+	// Without this behavior, atomic operations such as the suspend operation would need to wait for `RAYCLUSTER_DEFAULT_REQUEUE_SECONDS` to delete Pods
+	// after the condition rayv1.RayClusterSuspending is set to true.
 	if err != nil || inconsistent {
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1269,7 +1269,8 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 			meta.SetStatusCondition(&newInstance.Status.Conditions, headPodReadyCondition)
 		}
 
-		if !meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterProvisioned)) {
+		suspendStatus := utils.FindRayClusterSuspendStatus(newInstance)
+		if !meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterProvisioned)) && suspendStatus != rayv1.RayClusterSuspended {
 			// RayClusterProvisioned indicates whether all Ray Pods are ready when the RayCluster is first created.
 			// Note RayClusterProvisioned StatusCondition will not be updated after all Ray Pods are ready for the first time. Unless the cluster has been suspended.
 			if utils.CheckAllPodsRunning(ctx, runtimePods) {
@@ -1289,7 +1290,6 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 			}
 		}
 
-		suspendStatus := utils.FindRayClusterSuspendStatus(newInstance)
 		if suspendStatus == rayv1.RayClusterSuspending {
 			if len(runtimePods.Items) == 0 {
 				meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -488,7 +488,7 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*3, time.Millisecond*500).Should(Equal(rayv1.Suspended))
 			if withConditionEnabled {
 				Eventually(
-					func() string {
+					func() rayv1.RayClusterConditionType {
 						if err := getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster)(); err != nil {
 							return ""
 						}
@@ -554,7 +554,7 @@ var _ = Context("Inside the default namespace", func() {
 
 			if withConditionEnabled {
 				Eventually(
-					func() string {
+					func() rayv1.RayClusterConditionType {
 						if err := getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster)(); err != nil {
 							return ""
 						}
@@ -603,7 +603,7 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*3, time.Millisecond*500).Should(Equal(rayv1.Ready))
 			if withConditionEnabled {
 				Eventually(
-					func() string {
+					func() rayv1.RayClusterConditionType {
 						if err := getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster)(); err != nil {
 							return ""
 						}

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -37,7 +37,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/utils/ptr"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -416,6 +415,32 @@ var _ = Context("Inside the default namespace", func() {
 		})
 	})
 
+	updateRayClusterSuspendField := func(ctx context.Context, rayCluster *rayv1.RayCluster, suspend bool) error {
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			Eventually(
+				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: rayCluster.Namespace}, rayCluster),
+				time.Second*3, time.Millisecond*500).Should(BeNil(), "rayCluster = %v", rayCluster)
+			rayCluster.Spec.Suspend = &suspend
+			return k8sClient.Update(ctx, rayCluster)
+		})
+	}
+
+	findRayClusterSuspendStatus := func(ctx context.Context, rayCluster *rayv1.RayCluster) (rayv1.RayClusterConditionType, error) {
+		if err := getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: rayCluster.Namespace}, rayCluster)(); err != nil {
+			return "", err
+		}
+		suspending := meta.IsStatusConditionTrue(rayCluster.Status.Conditions, string(rayv1.RayClusterSuspending))
+		suspended := meta.IsStatusConditionTrue(rayCluster.Status.Conditions, string(rayv1.RayClusterSuspended))
+		if suspending && suspended {
+			return "invalid", errors.New("invalid: rayv1.RayClusterSuspending and rayv1.RayClusterSuspended should not be both true")
+		} else if suspending {
+			return rayv1.RayClusterSuspending, nil
+		} else if suspended {
+			return rayv1.RayClusterSuspended, nil
+		}
+		return "", nil
+	}
+
 	testSuspendRayCluster := func(withConditionEnabled bool) {
 		ctx := context.Background()
 		namespace := "default"
@@ -426,22 +451,6 @@ var _ = Context("Inside the default namespace", func() {
 		workerFilters := common.RayClusterGroupPodsAssociationOptions(rayCluster, rayCluster.Spec.WorkerGroupSpecs[0].GroupName).ToListOptions()
 		headFilters := common.RayClusterHeadPodsAssociationOptions(rayCluster).ToListOptions()
 		allFilters := common.RayClusterAllPodsAssociationOptions(rayCluster).ToListOptions()
-
-		findRayClusterSuspendStatus := func() (rayv1.RayClusterConditionType, error) {
-			if err := getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster)(); err != nil {
-				return "", err
-			}
-			suspending := meta.IsStatusConditionTrue(rayCluster.Status.Conditions, string(rayv1.RayClusterSuspending))
-			suspended := meta.IsStatusConditionTrue(rayCluster.Status.Conditions, string(rayv1.RayClusterSuspended))
-			if suspending && suspended {
-				return "", errors.New("invalid: rayv1.RayClusterSuspending and rayv1.RayClusterSuspended should not be both true")
-			} else if suspending {
-				return rayv1.RayClusterSuspending, nil
-			} else if suspended {
-				return rayv1.RayClusterSuspended, nil
-			}
-			return "", nil
-		}
 
 		BeforeAll(func() {
 			if withConditionEnabled {
@@ -474,69 +483,12 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				listResourceFunc(ctx, &workerPods, workerFilters...),
 				time.Second*3, time.Millisecond*500).Should(Equal(numWorkerPods), fmt.Sprintf("workerGroup %v", workerPods.Items))
-
-			if withConditionEnabled { // Add finalizers to worker Pods to prevent it from being deleted so that we can test if the status condition makes the suspending process atomic.
-				for _, pod := range workerPods.Items {
-					err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						pod.Finalizers = append(pod.Finalizers, "ray.io/deletion-blocker")
-						return k8sClient.Update(ctx, &pod)
-					})
-					Expect(err).NotTo(HaveOccurred(), "Failed to update worker Pods")
-				}
-			}
 		})
 
 		It("Should delete all head and worker Pods if suspended", func() {
 			// suspend a Raycluster and check that all Pods are deleted.
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				Eventually(
-					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "rayCluster: %v", rayCluster)
-				suspend := true
-				rayCluster.Spec.Suspend = &suspend
-				return k8sClient.Update(ctx, rayCluster)
-			})
+			err := updateRayClusterSuspendField(ctx, rayCluster, true)
 			Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster")
-
-			// Make sure the suspending process is atomic by removing finalizers one by one.
-			if withConditionEnabled {
-				// Make sure the cluster is now marked with RayClusterSuspending.
-				Eventually(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).Should(Equal(rayv1.RayClusterSuspending))
-				// Then turn the Spec.Suspend to false.
-				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-					Eventually(
-						getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-						time.Second*3, time.Millisecond*500).Should(BeNil(), "rayCluster: %v", rayCluster)
-					suspend := false
-					rayCluster.Spec.Suspend = &suspend
-					return k8sClient.Update(ctx, rayCluster)
-				})
-				Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster")
-
-				// Remove the finalizers one by one to make sure the suspending process is still ongoing.
-				Eventually(listResourceFunc(ctx, &workerPods, workerFilters...), time.Second*3, time.Millisecond*500).Should(Equal(3))
-				for i, pod := range workerPods.Items {
-					if i == len(workerPods.Items)-1 { // Turn the Spec.Suspend back to true before we remove the last finalizer.
-						err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-							Eventually(
-								getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-								time.Second*3, time.Millisecond*500).Should(BeNil(), "rayCluster: %v", rayCluster)
-							suspend := true
-							rayCluster.Spec.Suspend = &suspend
-							return k8sClient.Update(ctx, rayCluster)
-						})
-						Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster")
-					}
-					Eventually(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).Should(Equal(rayv1.RayClusterSuspending))
-					err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						Eventually(getResourceFunc(ctx, client.ObjectKey{Name: pod.Name, Namespace: namespace}, &pod), time.Second*3, time.Millisecond*500).Should(BeNil())
-						pod.Finalizers = nil
-						return k8sClient.Update(ctx, &pod)
-					})
-					Expect(err).NotTo(HaveOccurred(), "Failed to update the worker Pod")
-					Eventually(getResourceFunc(ctx, client.ObjectKey{Name: pod.Name, Namespace: namespace}, &pod), time.Second*3, time.Millisecond*500).Should(MatchError(k8serrors.NewNotFound(corev1.Resource("pods"), pod.Name)))
-				}
-			}
 
 			// Check that all Pods are deleted
 			Eventually(
@@ -555,9 +507,8 @@ var _ = Context("Inside the default namespace", func() {
 				getClusterState(ctx, namespace, rayCluster.Name),
 				time.Second*3, time.Millisecond*500).Should(Equal(rayv1.Suspended))
 			if withConditionEnabled {
-				Eventually(
-					findRayClusterSuspendStatus,
-					time.Second*3, time.Millisecond*500).Should(Equal(rayv1.RayClusterSuspended))
+				Eventually(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).
+					WithArguments(ctx, rayCluster).Should(Equal(rayv1.RayClusterSuspended))
 				Expect(meta.IsStatusConditionTrue(rayCluster.Status.Conditions, string(rayv1.RayClusterProvisioned))).To(BeFalse())
 				Expect(rayCluster.Status.Head.PodName).To(BeEmpty())
 			}
@@ -565,14 +516,7 @@ var _ = Context("Inside the default namespace", func() {
 
 		It("Set suspend to false and then revert it to true before all Pods are running", func() {
 			// set suspend to false
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				Eventually(
-					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "rayCluster = %v", rayCluster)
-				suspend := false
-				rayCluster.Spec.Suspend = &suspend
-				return k8sClient.Update(ctx, rayCluster)
-			})
+			err := updateRayClusterSuspendField(ctx, rayCluster, false)
 			Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster")
 
 			// check that all Pods are created
@@ -591,14 +535,7 @@ var _ = Context("Inside the default namespace", func() {
 			}
 
 			// change suspend to true before all Pods are Running.
-			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				Eventually(
-					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "rayCluster = %v", rayCluster)
-				suspend := true
-				rayCluster.Spec.Suspend = &suspend
-				return k8sClient.Update(ctx, rayCluster)
-			})
+			err = updateRayClusterSuspendField(ctx, rayCluster, true)
 			Expect(err).NotTo(HaveOccurred(), "Failed to update test RayCluster resource")
 
 			// check that all Pods are deleted
@@ -618,22 +555,14 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*3, time.Millisecond*500).Should(Equal(rayv1.Suspended))
 
 			if withConditionEnabled {
-				Eventually(
-					findRayClusterSuspendStatus,
-					time.Second*3, time.Millisecond*500).Should(Equal(rayv1.RayClusterSuspended))
+				Eventually(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).
+					WithArguments(ctx, rayCluster).Should(Equal(rayv1.RayClusterSuspended))
 			}
 		})
 
 		It("Should run all head and worker pods if un-suspended", func() {
 			// Resume the suspended RayCluster
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				Eventually(
-					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "rayCluster = %v", rayCluster)
-				suspend := false
-				rayCluster.Spec.Suspend = &suspend
-				return k8sClient.Update(ctx, rayCluster)
-			})
+			err := updateRayClusterSuspendField(ctx, rayCluster, false)
 			Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster")
 
 			// check that all pods are created
@@ -662,9 +591,8 @@ var _ = Context("Inside the default namespace", func() {
 				getClusterState(ctx, namespace, rayCluster.Name),
 				time.Second*3, time.Millisecond*500).Should(Equal(rayv1.Ready))
 			if withConditionEnabled {
-				Eventually(
-					findRayClusterSuspendStatus,
-					time.Second*3, time.Millisecond*500).Should(BeEmpty())
+				Eventually(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).
+					WithArguments(ctx, rayCluster).Should(BeEmpty())
 				Expect(meta.IsStatusConditionTrue(rayCluster.Status.Conditions, string(rayv1.RayClusterProvisioned))).To(BeTrue())
 				Expect(rayCluster.Status.Head.PodName).NotTo(BeEmpty())
 			}
@@ -682,6 +610,105 @@ var _ = Context("Inside the default namespace", func() {
 
 	Describe("Suspend RayCluster with Condition", Ordered, func() {
 		testSuspendRayCluster(true)
+	})
+
+	Describe("Suspend RayCluster atomically with Condition", Ordered, func() {
+		ctx := context.Background()
+		namespace := "default"
+		rayCluster := rayClusterTemplate("raycluster-suspend-atomically", namespace)
+		allPods := corev1.PodList{}
+		allFilters := common.RayClusterAllPodsAssociationOptions(rayCluster).ToListOptions()
+		numPods := 4 // 1 Head + 3 Workers
+
+		BeforeAll(func() {
+			cleanUpFunc := features.SetFeatureGateDuringTest(GinkgoTB(), features.RayClusterStatusConditions, true)
+			DeferCleanup(cleanUpFunc)
+		})
+
+		It("Create a RayCluster custom resource", func() {
+			err := k8sClient.Create(ctx, rayCluster)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
+			Eventually(getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
+				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+		})
+
+		It("Check the number of Pods and add finalizers", func() {
+			Eventually(listResourceFunc(ctx, &allPods, allFilters...), time.Second*3, time.Millisecond*500).
+				Should(Equal(numPods), fmt.Sprintf("all pods %v", allPods.Items))
+			// Add finalizers to worker Pods to prevent it from being deleted so that we can test if the status condition makes the suspending process atomic.
+			for _, pod := range allPods.Items {
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					pod.Finalizers = append(pod.Finalizers, "ray.io/deletion-blocker")
+					return k8sClient.Update(ctx, &pod)
+				})
+				Expect(err).NotTo(HaveOccurred(), "Failed to update Pods")
+			}
+		})
+
+		It("Should turn on the RayClusterSuspending if we set `.Spec.Suspend` back to true", func() {
+			// suspend a Raycluster.
+			err := updateRayClusterSuspendField(ctx, rayCluster, true)
+			Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster")
+
+			Eventually(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).
+				WithArguments(ctx, rayCluster).Should(Equal(rayv1.RayClusterSuspending))
+		})
+
+		It("Should keep RayClusterSuspending consistently if we set `.Spec.Suspend` back to false", func() {
+			err := updateRayClusterSuspendField(ctx, rayCluster, false)
+			Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster")
+
+			Consistently(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).
+				WithArguments(ctx, rayCluster).Should(Equal(rayv1.RayClusterSuspending))
+		})
+
+		It("Pods should be deleted and new Pods should created back after we remove those finalizers", func() {
+			Eventually(listResourceFunc(ctx, &allPods, allFilters...), time.Second*3, time.Millisecond*500).
+				Should(Equal(numPods), fmt.Sprintf("all pods %v", allPods.Items))
+
+			var oldNames []string
+			for _, pod := range allPods.Items {
+				oldNames = append(oldNames, pod.Name)
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					pod.Finalizers = nil
+					return k8sClient.Update(ctx, &pod)
+				})
+				Expect(err).NotTo(HaveOccurred(), "Failed to update Pods")
+			}
+			// RayClusterSuspending and RayClusterSuspended should be both false.
+			Eventually(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).
+				WithArguments(ctx, rayCluster).Should(BeEmpty())
+			Consistently(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).
+				WithArguments(ctx, rayCluster).Should(BeEmpty())
+
+			// New Pods should be created.
+			Eventually(listResourceFunc(ctx, &allPods, allFilters...), time.Second*3, time.Millisecond*500).
+				Should(Equal(numPods), fmt.Sprintf("all pods %v", allPods.Items))
+
+			var newNames []string
+			for _, pod := range allPods.Items {
+				newNames = append(newNames, pod.Name)
+			}
+			Expect(newNames).NotTo(ConsistOf(oldNames))
+		})
+
+		It("Set suspend to true and all Pods should be deleted again", func() {
+			err := updateRayClusterSuspendField(ctx, rayCluster, true)
+			Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster")
+
+			Eventually(listResourceFunc(ctx, &allPods, allFilters...), time.Second*3, time.Millisecond*500).
+				Should(Equal(0), fmt.Sprintf("all pods %v", allPods.Items))
+
+			Eventually(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).
+				WithArguments(ctx, rayCluster).Should(Equal(rayv1.RayClusterSuspended))
+			Consistently(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).
+				WithArguments(ctx, rayCluster).Should(Equal(rayv1.RayClusterSuspended))
+		})
+
+		It("Delete the cluster", func() {
+			err := k8sClient.Delete(ctx, rayCluster)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 
 	Describe("RayCluster with a multi-host worker group", Ordered, func() {

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -510,6 +510,8 @@ var _ = Context("Inside the default namespace", func() {
 				Eventually(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).
 					WithArguments(ctx, rayCluster).Should(Equal(rayv1.RayClusterSuspended))
 				Expect(meta.IsStatusConditionTrue(rayCluster.Status.Conditions, string(rayv1.RayClusterProvisioned))).To(BeFalse())
+				// rayCluster.Status.Head.PodName will be cleared.
+				// rayCluster.Status.Head.PodIP will also be cleared, but we don't test it here since we don't have IPs in tests.
 				Expect(rayCluster.Status.Head.PodName).To(BeEmpty())
 			}
 		})
@@ -594,6 +596,8 @@ var _ = Context("Inside the default namespace", func() {
 				Eventually(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).
 					WithArguments(ctx, rayCluster).Should(BeEmpty())
 				Expect(meta.IsStatusConditionTrue(rayCluster.Status.Conditions, string(rayv1.RayClusterProvisioned))).To(BeTrue())
+				// rayCluster.Status.Head.PodName should have a value now.
+				// rayCluster.Status.Head.PodIP should also have a value now, but we don't test it here since we don't have IPs in tests.
 				Expect(rayCluster.Status.Head.PodName).NotTo(BeEmpty())
 			}
 		})

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1283,8 +1283,9 @@ func TestReconcile_UpdateClusterReason(t *testing.T) {
 
 	newTestRayCluster := testRayCluster.DeepCopy()
 	newTestRayCluster.Status.Reason = reason
-	err = testRayClusterReconciler.updateRayClusterStatus(ctx, testRayCluster, newTestRayCluster)
+	inconsistent, err := testRayClusterReconciler.updateRayClusterStatus(ctx, testRayCluster, newTestRayCluster)
 	assert.Nil(t, err, "Fail to update cluster reason")
+	assert.True(t, inconsistent)
 
 	err = fakeClient.Get(ctx, namespacedName, &cluster)
 	assert.Nil(t, err, "Fail to get RayCluster after updating reason")
@@ -1563,8 +1564,9 @@ func TestReconcile_UpdateClusterState(t *testing.T) {
 	state := rayv1.Ready
 	newTestRayCluster := testRayCluster.DeepCopy()
 	newTestRayCluster.Status.State = state //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
-	err = testRayClusterReconciler.updateRayClusterStatus(ctx, testRayCluster, newTestRayCluster)
+	inconsistent, err := testRayClusterReconciler.updateRayClusterStatus(ctx, testRayCluster, newTestRayCluster)
 	assert.Nil(t, err, "Fail to update cluster state")
+	assert.True(t, inconsistent)
 
 	err = fakeClient.Get(ctx, namespacedName, &cluster)
 	assert.Nil(t, err, "Fail to get RayCluster after updating state")

--- a/ray-operator/controllers/ray/suite_helpers_test.go
+++ b/ray-operator/controllers/ray/suite_helpers_test.go
@@ -33,7 +33,7 @@ func listResourceFunc(ctx context.Context, workerPods *corev1.PodList, opt ...cl
 
 		count := 0
 		for _, aPod := range workerPods.Items {
-			if (reflect.DeepEqual(aPod.Status.Phase, corev1.PodRunning) || reflect.DeepEqual(aPod.Status.Phase, corev1.PodPending)) && aPod.DeletionTimestamp == nil {
+			if (reflect.DeepEqual(aPod.Status.Phase, corev1.PodRunning) || reflect.DeepEqual(aPod.Status.Phase, corev1.PodPending)) && (aPod.DeletionTimestamp == nil || len(aPod.Finalizers) != 0) {
 				count++
 			}
 		}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -102,13 +102,12 @@ func FindHeadPodReadyCondition(headPod *corev1.Pod) metav1.Condition {
 	return headPodReadyCondition
 }
 
-func FindRayClusterSuspendStatus(instance *rayv1.RayCluster) string {
+func FindRayClusterSuspendStatus(instance *rayv1.RayCluster) rayv1.RayClusterConditionType {
 	for _, cond := range instance.Status.Conditions {
-		if cond.Type == string(rayv1.RayClusterSuspend) {
+		if cond.Type == string(rayv1.RayClusterSuspending) || cond.Type == string(rayv1.RayClusterSuspended) {
 			if cond.Status == metav1.ConditionTrue {
-				return cond.Reason
+				return rayv1.RayClusterConditionType(cond.Type)
 			}
-			break
 		}
 	}
 	return ""

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -102,6 +102,18 @@ func FindHeadPodReadyCondition(headPod *corev1.Pod) metav1.Condition {
 	return headPodReadyCondition
 }
 
+func FindRayClusterSuspendStatus(instance *rayv1.RayCluster) string {
+	for _, cond := range instance.Status.Conditions {
+		if cond.Type == string(rayv1.RayClusterSuspend) {
+			if cond.Status == metav1.ConditionTrue {
+				return cond.Reason
+			}
+			break
+		}
+	}
+	return ""
+}
+
 // IsRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.
 func IsRunningAndReady(pod *corev1.Pod) bool {
 	if pod.Status.Phase != corev1.PodRunning {

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -110,12 +110,12 @@ func FindHeadPodReadyCondition(headPod *corev1.Pod) metav1.Condition {
 //
 //	rayv1.RayClusterSuspending:
 //	  False by default
-//	  False -> True: when Spec.Suspend is true.
-//	  True -> False: when all Pods are deleted, and also set rayv1.RayClusterSuspended from False to True.
+//	  False -> True: when `spec.Suspend` is true.
+//	  True -> False: when all Pods are deleted, set rayv1.RayClusterSuspended from False to True.
 //	rayv1.RayClusterSuspended
 //	  False by default
 //	  False -> True: when suspending transitions from True to False
-//	  True -> False: when spec.Suspend is false.
+//	  True -> False: when `spec.Suspend` is false.
 //
 // If both rayv1.RayClusterSuspending and rayv1.RayClusterSuspended are False, FindRayClusterSuspendStatus returns "".
 func FindRayClusterSuspendStatus(instance *rayv1.RayCluster) rayv1.RayClusterConditionType {


### PR DESCRIPTION
## Why are these changes needed?

Resolves https://github.com/ray-project/kuberay/issues/2277

~~This PR introduces a new status condition: `RayClusterSuspend` with two variations, `RayClusterSuspending` and `RayClusterSuspended`.~~

This PR introduces two new status conditions: `RayClusterSuspending` and `RayClusterSuspended`.

The new conditions will populated by default with `metav1.ConditionFalse` if the `features.Enabled(features.RayClusterStatusConditions)` is enabled.

When the gate is enabled, we rely on the new `RayClusterSuspending` to suspend a RayCluster atomically. When a user turns on the `.Spec.Suspend` of a RayCluster, we will enable the `RayClusterSuspending` and persist it before actually stopping all Pods. We will stop all Pods in the next reconciliation and do not consider the `.Spec.Suspend` again before switching to the `RayClusterSuspend`.

If the condition `RayClusterSuspend` is enabled and the `.Spec.Suspend` is turned off by the user, we will disable the condition by setting it to `metav1.ConditionFalse`, so that we can preserve the transition timestamp for more observability.

In summary, this is the status BEFORE suspending a RayCluster:

<img width="504" alt="image" src="https://github.com/user-attachments/assets/579328b9-db4b-4d82-a218-bded91c8e7dd">


This is the status DURING suspending a RayCluster:

<img width="495" alt="image" src="https://github.com/user-attachments/assets/6b9b28c7-293e-4c0c-a188-ed55226bd227">


This is the status AFTER it is suspended:

<img width="413" alt="image" src="https://github.com/user-attachments/assets/038a7fdf-1c48-4946-b4bd-caa4a47b514e">


This is the status AFTER the cluster is resumed:

<img width="513" alt="image" src="https://github.com/user-attachments/assets/451a2783-81d8-4ffe-ae25-91bcf5be5315">


## Related issue number
https://github.com/ray-project/kuberay/issues/2277

## Checks
- [x] I've made sure the tests are passing.
* Testing Strategy
  - [x] Unit tests
  - [x] Manual tests


