### PR TITLE
Add support for parsing neuron core resource limit and pass it as ray…

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -797,12 +797,12 @@ func addCustomAcceleratorToResourcesIfNotExists(rayStartParams map[string]string
 		resourcesMap[resourceName] = float64(resourceCount)
 	}
 
-	if updatedResourcesStr, err := json.Marshal(resourcesMap); err != nil {
+	updatedResourcesStr, err := json.Marshal(resourcesMap)
+	if err != nil {
 		return fmt.Errorf("failed to marshal resources map to string %w", err)
-	} else {
-		rayStartParams["resources"] = string(updatedResourcesStr)
 	}
 
+	rayStartParams["resources"] = string(updatedResourcesStr)
 	return nil
 }
 

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1158,11 +1158,11 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 
 func TestGenerateRayStartCommand(t *testing.T) {
 	tests := []struct {
-		name           string
-		nodeType       rayv1.RayNodeType
 		rayStartParams map[string]string
-		resource       corev1.ResourceRequirements
+		name           string
 		expected       string
+		nodeType       rayv1.RayNodeType
+		resource       corev1.ResourceRequirements
 	}{
 		{
 			name:           "WorkerNode with GPU",

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1197,20 +1197,7 @@ func TestGenerateRayStartCommand(t *testing.T) {
 					"aws.amazon.com/neuroncore": resource.MustParse("4"),
 				},
 			},
-			expected: `ray start --head  --resources={"custom_resource":2,"neuron_cores":4} `,
-		},
-		{
-			name:     "HeadNode with existing neuron_cores resources",
-			nodeType: rayv1.HeadNode,
-			rayStartParams: map[string]string{
-				"resources": `{"custom_resource":2,"neuron_cores":3}`,
-			},
-			resource: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					"aws.amazon.com/neuroncore": resource.MustParse("4"),
-				},
-			},
-			expected: `ray start --head  --resources={"custom_resource":2,"neuron_cores":3} `,
+			expected: `ray start --head  --resources={"custom_resource":2} `,
 		},
 		{
 			name:     "HeadNode with invalid resources string",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The PR is needed to parse the neuroncore resource limits fro the pod spec and pass them to `ray start` command as it expects.
Expected format: https://docs.ray.io/en/latest/ray-core/scheduling/accelerators.html

## Related issue number

https://github.com/ray-project/ray/issues/44361

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
