### PR TITLE
feat: add InvalidRayJobSpec, InvalidRayJobStatus, InvalidRayServiceSpec and InvalidRayClusterStatus events

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -225,6 +225,8 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request 
 
 	if err := r.validateRayClusterStatus(instance); err != nil {
 		logger.Error(err, "The RayCluster status is invalid")
+		r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.InvalidRayClusterStatus),
+			"The RayCluster status is invalid %s/%s, %v", instance.Namespace, instance.Name, err)
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
 

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -126,11 +126,15 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 
 	if err := validateRayJobSpec(rayJobInstance); err != nil {
 		logger.Error(err, "The RayJob spec is invalid")
+		r.Recorder.Eventf(rayJobInstance, corev1.EventTypeWarning, string(utils.InvalidRayJobSpec),
+			"The RayJob spec is invalid %s/%s: %v", rayJobInstance.Namespace, rayJobInstance.Name, err)
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 	}
 
 	if err := validateRayJobStatus(rayJobInstance); err != nil {
 		logger.Error(err, "The RayJob status is invalid")
+		r.Recorder.Eventf(rayJobInstance, corev1.EventTypeWarning, string(utils.InvalidRayJobStatus),
+			"The RayJob status is invalid %s/%s: %v", rayJobInstance.Namespace, rayJobInstance.Name, err)
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 	}
 

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -127,6 +127,8 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 
 	if err := validateRayServiceSpec(rayServiceInstance); err != nil {
 		logger.Error(err, "The RayService spec is invalid")
+		r.Recorder.Eventf(rayServiceInstance, corev1.EventTypeWarning, string(utils.InvalidRayServiceSpec),
+			"The RayService spec is invalid %s/%s: %v", rayServiceInstance.Namespace, rayServiceInstance.Name, err)
 		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
 	}
 

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -233,6 +233,8 @@ func RayClusterReplicaFailureReason(err error) string {
 type K8sEventType string
 
 const (
+	// RayCluster event list
+	InvalidRayClusterStatus K8sEventType = "InvalidRayClusterStatus"
 	// Head Pod event list
 	CreatedHeadPod        K8sEventType = "CreatedHeadPod"
 	FailedToCreateHeadPod K8sEventType = "FailedToCreateHeadPod"
@@ -250,6 +252,8 @@ const (
 	FailedToCreateRedisCleanupJob K8sEventType = "FailedToCreateRedisCleanupJob"
 
 	// RayJob event list
+	InvalidRayJobSpec             K8sEventType = "InvalidRayJobSpec"
+	InvalidRayJobStatus           K8sEventType = "InvalidRayJobStatus"
 	CreatedRayJobSubmitter        K8sEventType = "CreatedRayJobSubmitter"
 	DeletedRayJobSubmitter        K8sEventType = "DeletedRayJobSubmitter"
 	FailedToCreateRayJobSubmitter K8sEventType = "FailedToCreateRayJobSubmitter"
@@ -258,6 +262,9 @@ const (
 	DeletedRayCluster             K8sEventType = "DeletedRayCluster"
 	FailedToCreateRayCluster      K8sEventType = "FailedToCreateRayCluster"
 	FailedToDeleteRayCluster      K8sEventType = "FailedToDeleteRayCluster"
+
+	// RayService event list
+	InvalidRayServiceSpec K8sEventType = "InvalidRayServiceSpec"
 
 	// Generic Pod event list
 	DeletedPod        K8sEventType = "DeletedPod"


### PR DESCRIPTION
## Why are these changes needed?

This PR adds `InvalidRayJobSpec`, `InvalidRayJobStatus`, `InvalidRayServiceSpec`, and `InvalidRayClusterStatus` events.

These are existing validations that only have logs, but no event has been produced. Thus we add events for them for better CR observability. For example:

<img width="1516" alt="image" src="https://github.com/user-attachments/assets/092df4ea-5eb1-4f61-9944-d6800a71e8ea">


## Related issue number

Closes https://github.com/ray-project/kuberay/issues/2437

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
