### PR TITLE
[Feature][kubectl-plugin] add KubeRay operator version query

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ exclude: _generated.go$|\.svg$|^third_party/|^proto/swagger/|^apiserver/pkg/swag
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/kubectl-plugin/pkg/cmd/ray.go
+++ b/kubectl-plugin/pkg/cmd/ray.go
@@ -30,6 +30,7 @@ func NewRayCommand(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd.AddCommand(session.NewSessionCommand(streams))
 	cmd.AddCommand(log.NewClusterLogCommand(streams))
 	cmd.AddCommand(job.NewJobCommand(streams))
-	cmd.AddCommand(version.NewVersionCommand())
+	cmd.AddCommand(version.NewVersionCommand(streams))
+
 	return cmd
 }

--- a/kubectl-plugin/pkg/cmd/version/version.go
+++ b/kubectl-plugin/pkg/cmd/version/version.go
@@ -3,18 +3,50 @@ package version
 import (
 	"fmt"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 var Version = "development"
 
-func NewVersionCommand() *cobra.Command {
+type VersionOptions struct {
+	configFlags *genericclioptions.ConfigFlags
+	ioStreams   *genericclioptions.IOStreams
+}
+
+func NewVersionOptions(streams genericclioptions.IOStreams) *VersionOptions {
+	return &VersionOptions{
+		configFlags: genericclioptions.NewConfigFlags(true),
+		ioStreams:   &streams,
+	}
+}
+
+func NewVersionCommand(streams genericclioptions.IOStreams) *cobra.Command {
+	options := NewVersionOptions(streams)
+	cmdFactory := cmdutil.NewFactory(options.configFlags)
+
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Output the version of the Ray kubectl plugin",
-		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Println(Version)
+		Short: "Output the version of the Ray kubectl plugin and KubeRay operator",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			fmt.Println("kubectl ray plugin version:", Version)
+
+			kubeClient, err := client.NewClient(cmdFactory)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			operatorVersion, err := kubeClient.GetKubeRayOperatorVersion(cmd.Context())
+			if err != nil {
+				fmt.Println("Warning: KubeRay operator installation cannot be found - did you install it with the name \"kuberay-operator\"?")
+			} else {
+				fmt.Println("KubeRay operator version:", operatorVersion)
+			}
+			return nil
 		},
 	}
+
 	return cmd
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Added the `kubectl ray version` feature to dynamically query the deployment version of the KubeRay operator. The `LabelSelector` used is `app.kubernetes.io/name in (kuberay-operator,kuberay)`, with the Helm Chart corresponding to the `kuberay-operator` and the Kustomize corresponding to `kuberay`.

However, there is a small issue: when users install using the Helm chart and modify `Values.nameOverride`, the CLI is unable to retrieve the version.

## Test Process:
```
$ ./kubectl-ray version
kubectl ray plugin version: development
Warning: KubeRay operator installation cannot be found - did you install it with the name "kuberay-operator"?

$ helm install kuberay-operator kuberay/kuberay-operator

$ ./kubectl-ray version
kubectl ray plugin version: development
KubeRay operator version: v1.2.2
```

```
$ helm install kuberay-operator kuberay/kuberay-operator --set nameOverride=test

$ ./kubectl-ray version
kubectl ray plugin version: development
Warning: KubeRay operator installation cannot be found - did you install it with the name "kuberay-operator"?
```

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/2439
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
