### PR TITLE
[RayJob] UserMode -> InteractiveMode and check rayjob.spec.jobId instead of annotation

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -162,7 +162,7 @@ _Appears in:_
 | `entrypoint` _string_ | INSERT ADDITIONAL SPEC FIELDS - desired state of cluster<br />Important: Run "make" to regenerate code after modifying this file |  |  |
 | `runtimeEnvYAML` _string_ | RuntimeEnvYAML represents the runtime environment configuration<br />provided as a multi-line YAML string. |  |  |
 | `jobId` _string_ | If jobId is not set, a new jobId will be auto-generated. |  |  |
-| `submissionMode` _[JobSubmissionMode](#jobsubmissionmode)_ | SubmissionMode specifies how RayJob submits the Ray job to the RayCluster.<br />In "K8sJobMode", the KubeRay operator creates a submitter Kubernetes Job to submit the Ray job.<br />In "HTTPMode", the KubeRay operator sends a request to the RayCluster to create a Ray job. | K8sJobMode |  |
+| `submissionMode` _[JobSubmissionMode](#jobsubmissionmode)_ | SubmissionMode specifies how RayJob submits the Ray job to the RayCluster.<br />In "K8sJobMode", the KubeRay operator creates a submitter Kubernetes Job to submit the Ray job.<br />In "HTTPMode", the KubeRay operator sends a request to the RayCluster to create a Ray job.<br />In "InteractiveMode", the KubeRay operator waits for a user to submit a job to the Ray cluster. | K8sJobMode |  |
 | `entrypointResources` _string_ | EntrypointResources specifies the custom resources and quantities to reserve for the<br />entrypoint command. |  |  |
 | `entrypointNumCpus` _float_ | EntrypointNumCpus specifies the number of cpus to reserve for the entrypoint command. |  |  |
 | `entrypointNumGpus` _float_ | EntrypointNumGpus specifies the number of gpus to reserve for the entrypoint command. |  |  |

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -198,12 +198,11 @@ func (options *SubmitJobOptions) Validate() error {
 		return fmt.Errorf("RayJob does not have `submissionMode` field set")
 	}
 	if submissionMode != nil {
-		// Currently using string since latest release does not have `rayv1api.UserMode` yet
-		if submissionMode != "UserMode" {
+		if submissionMode != "InteractiveMode" {
 			return fmt.Errorf("Submission mode of the Ray Job is not supported")
 		}
 	} else {
-		return fmt.Errorf("Submission mode must be set to rayv1api.UserMode or `UserMode`")
+		return fmt.Errorf("Submission mode must be set to 'InteractiveMode'")
 	}
 
 	runtimeEnvYaml, ok := options.RayJob.Object["spec"].(map[string]interface{})["runtimeEnvYAML"].(string)

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -74,7 +74,7 @@ kind: RayJob
 metadata:
   name: rayjob-sample
 spec:
-  submissionMode: 'UserMode'`
+  submissionMode: 'InteractiveMode'`
 
 	rayJobYamlPath := filepath.Join(fakeDir, "rayjob-temp-*.yaml")
 
@@ -132,7 +132,7 @@ kind: RayJob
 metadata:
   name: rayjob-sample
 spec:
-  submissionMode: 'UserMode'`
+  submissionMode: 'InteractiveMode'`
 	_, err = rayjobtmpfile.Write([]byte(rayYaml))
 	assert.Nil(t, err)
 
@@ -145,7 +145,7 @@ spec:
 
 	submissionMode, ok := rayJobYamlActual.Object["spec"].(map[string]interface{})["submissionMode"]
 	assert.True(t, ok)
-	assert.Equal(t, "UserMode", submissionMode)
+	assert.Equal(t, "InteractiveMode", submissionMode)
 }
 
 func TestRuntimeEnvHasWorkingDir(t *testing.T) {

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -57,9 +57,9 @@ const (
 type JobSubmissionMode string
 
 const (
-	K8sJobMode JobSubmissionMode = "K8sJobMode" // Submit job via Kubernetes Job
-	HTTPMode   JobSubmissionMode = "HTTPMode"   // Submit job via HTTP request
-	UserMode   JobSubmissionMode = "UserMode"   // Don't submit job in KubeRay. Instead, wait for user to submit job and provide the job submission ID
+	K8sJobMode      JobSubmissionMode = "K8sJobMode"      // Submit job via Kubernetes Job
+	HTTPMode        JobSubmissionMode = "HTTPMode"        // Submit job via HTTP request
+	InteractiveMode JobSubmissionMode = "InteractiveMode" // Don't submit job in KubeRay. Instead, wait for user to submit job and provide the job submission ID.
 )
 
 type SubmitterConfig struct {
@@ -97,6 +97,7 @@ type RayJobSpec struct {
 	// SubmissionMode specifies how RayJob submits the Ray job to the RayCluster.
 	// In "K8sJobMode", the KubeRay operator creates a submitter Kubernetes Job to submit the Ray job.
 	// In "HTTPMode", the KubeRay operator sends a request to the RayCluster to create a Ray job.
+	// In "InteractiveMode", the KubeRay operator waits for a user to submit a job to the Ray cluster.
 	// +kubebuilder:default:=K8sJobMode
 	SubmissionMode JobSubmissionMode `json:"submissionMode,omitempty"`
 	// EntrypointResources specifies the custom resources and quantities to reserve for the

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -752,17 +752,17 @@ var _ = Context("RayJob with different submission modes", func() {
 		})
 	})
 
-	Context("RayJob in UserMode", func() {
+	Context("RayJob in InteractiveMode", func() {
 		Describe("Successful RayJob", Ordered, func() {
 			ctx := context.Background()
 			namespace := "default"
 			rayJob := rayJobTemplate("rayjob-test-none-mode", namespace)
-			rayJob.Spec.SubmissionMode = rayv1.UserMode
+			rayJob.Spec.SubmissionMode = rayv1.InteractiveMode
 			rayCluster := &rayv1.RayCluster{}
 			testRayJobId := "fake-id"
 
 			It("Verify RayJob spec", func() {
-				Expect(rayJob.Spec.SubmissionMode).To(Equal(rayv1.UserMode))
+				Expect(rayJob.Spec.SubmissionMode).To(Equal(rayv1.InteractiveMode))
 				Expect(rayJob.Spec.ShutdownAfterJobFinishes).To(BeTrue())
 				Expect(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs).To(HaveLen(1))
 			})
@@ -818,8 +818,8 @@ var _ = Context("RayJob with different submission modes", func() {
 					time.Second*3, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusWaiting), "JobDeploymentStatus = %v", rayJob.Status.JobDeploymentStatus)
 			})
 
-			It("sets annotation to RayJob", func() {
-				err := setAnnotationOnRayJob(ctx, rayJob, utils.RayJobSubmissionIdLabelKey, testRayJobId)
+			It("sets jobId in RayJob", func() {
+				err := setJobIdOnRayJob(ctx, rayJob, testRayJobId)
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/ray-operator/controllers/ray/suite_helpers_test.go
+++ b/ray-operator/controllers/ray/suite_helpers_test.go
@@ -6,8 +6,6 @@ import (
 	"reflect"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 
 	"github.com/onsi/gomega"
@@ -306,13 +304,13 @@ func updateRayJobSuspendField(ctx context.Context, rayJob *rayv1.RayJob, suspend
 	})
 }
 
-func setAnnotationOnRayJob(ctx context.Context, rayJob *rayv1.RayJob, key, value string) error {
+func setJobIdOnRayJob(ctx context.Context, rayJob *rayv1.RayJob, jobId string) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		err := k8sClient.Get(ctx, client.ObjectKey{Namespace: rayJob.Namespace, Name: rayJob.Name}, rayJob)
 		if err != nil {
 			return err
 		}
-		metav1.SetMetaDataAnnotation(&rayJob.ObjectMeta, key, value)
+		rayJob.Spec.JobId = jobId
 		return k8sClient.Update(ctx, rayJob)
 	})
 }

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -26,7 +26,6 @@ const (
 	HashWithoutReplicasAndWorkersToDeleteKey = "ray.io/hash-without-replicas-and-workers-to-delete"
 	NumWorkerGroupsKey                       = "ray.io/num-worker-groups"
 	KubeRayVersion                           = "ray.io/kuberay-version"
-	RayJobSubmissionIdLabelKey               = "ray.io/ray-job-submission-id"
 
 	// In KubeRay, the Ray container must be the first application container in a head or worker Pod.
 	RayContainerIndex = 0


### PR DESCRIPTION
## Why are these changes needed?

Update the experimental `UserMode` submission mode to `InteractiveMode`, which I think better expresses the intend of the API. 

Also updates the new interactive mode to check the existing field `rayjob.spec.jobId` for the submission ID instead of checking for a new annotation.  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
