### PR TITLE
Fix v6e TPU Scripts and RayJob CRs

### DIFF
--- a/ray-operator/config/samples/ray-job.tpu-v6e-multihost.yaml
+++ b/ray-operator/config/samples/ray-job.tpu-v6e-multihost.yaml
@@ -3,7 +3,7 @@ kind: RayJob
 metadata:
   name: v6e-256-job
 spec:
-  entrypoint: python ray-operator/config/samples/ray-tpu-scripts/tpu_list_devices.py
+  entrypoint: python ray-operator/config/samples/tpu/tpu_list_devices.py
   runtimeEnvYAML: |
     working_dir: "https://github.com/ray-project/kuberay/archive/master.zip"
     pip:

--- a/ray-operator/config/samples/ray-job.tpu-v6e-multihost.yaml
+++ b/ray-operator/config/samples/ray-job.tpu-v6e-multihost.yaml
@@ -1,7 +1,7 @@
 apiVersion: ray.io/v1
 kind: RayJob
 metadata:
-  name: ray-multi-host-job
+  name: v6e-256-job
 spec:
   entrypoint: python ray-operator/config/samples/ray-tpu-scripts/tpu_list_devices.py
   runtimeEnvYAML: |
@@ -9,8 +9,6 @@ spec:
     pip:
       - jax[tpu]==0.4.33
       - -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
-    env_vars:
-      TPU_HOSTS: "64"
   rayClusterSpec:
     rayVersion: '2.37.0'
     headGroupSpec:

--- a/ray-operator/config/samples/ray-job.tpu-v6e-multihost.yaml
+++ b/ray-operator/config/samples/ray-job.tpu-v6e-multihost.yaml
@@ -48,10 +48,6 @@ spec:
             containers:
               - name: ray-worker
                 image: rayproject/ray:2.37.0-py310
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: [ "/bin/sh","-c","ray stop" ]
                 resources:
                   limits:
                     cpu: "100"

--- a/ray-operator/config/samples/ray-job.tpu-v6e-singlehost.yaml
+++ b/ray-operator/config/samples/ray-job.tpu-v6e-singlehost.yaml
@@ -3,7 +3,7 @@ kind: RayJob
 metadata:
   name: v6e-4-job
 spec:
-  entrypoint: python ray-operator/config/samples/ray-tpu-scripts/tpu_list_devices.py
+  entrypoint: python ray-operator/config/samples/tpu/tpu_list_devices.py
   runtimeEnvYAML: |
     working_dir: "https://github.com/ray-project/kuberay/archive/master.zip"
     pip:

--- a/ray-operator/config/samples/ray-job.tpu-v6e-singlehost.yaml
+++ b/ray-operator/config/samples/ray-job.tpu-v6e-singlehost.yaml
@@ -1,7 +1,7 @@
 apiVersion: ray.io/v1
 kind: RayJob
 metadata:
-  name: ray-single-host-job
+  name: v6e-4-job
 spec:
   entrypoint: python ray-operator/config/samples/ray-tpu-scripts/tpu_list_devices.py
   runtimeEnvYAML: |
@@ -9,8 +9,6 @@ spec:
     pip:
       - jax[tpu]==0.4.33
       - -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
-    env_vars:
-      TPU_HOSTS: "1"
   rayClusterSpec:
     rayVersion: '2.37.0'
     headGroupSpec:

--- a/ray-operator/config/samples/ray-job.tpu-v6e-singlehost.yaml
+++ b/ray-operator/config/samples/ray-job.tpu-v6e-singlehost.yaml
@@ -48,10 +48,6 @@ spec:
             containers:
               - name: ray-worker
                 image: rayproject/ray:2.37.0-py310
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: [ "/bin/sh","-c","ray stop" ]
                 resources:
                   limits:
                     cpu: "100"

--- a/ray-operator/config/samples/tpu/tpu_list_devices.py
+++ b/ray-operator/config/samples/tpu/tpu_list_devices.py
@@ -7,6 +7,6 @@ ray.init()
 def tpu_cores():
     return "TPU cores:" + str(jax.device_count())
 
-num_workers = int(ray.available_resources()["TPU"])
+num_workers = int(ray.available_resources()["TPU"]) // 4
 result = [tpu_cores.remote() for _ in range(num_workers)]
 print(ray.get(result))

--- a/ray-operator/config/samples/tpu/tpu_list_devices.py
+++ b/ray-operator/config/samples/tpu/tpu_list_devices.py
@@ -1,19 +1,12 @@
 import ray
+import jax
 
-ray.init(
-    runtime_env={
-        "pip": [
-            "jax[tpu]==0.4.33",
-            "-f https://storage.googleapis.com/jax-releases/libtpu_releases.html",
-        ]
-    }
-)
+ray.init()
 
 @ray.remote(resources={"TPU": 4})
 def tpu_cores():
-    import jax
     return "TPU cores:" + str(jax.device_count())
 
-num_workers = int(os.environ['TPU_HOSTS']) # Set in env of RayJob or RayCluster.
+num_workers = int(ray.available_resources()["TPU"])
 result = [tpu_cores.remote() for _ in range(num_workers)]
 print(ray.get(result))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Follow up to https://github.com/ray-project/kuberay/pull/2445, this PR modifies `tpu_list_devices.py` to get the number of TPU devices from `ray.available_resources` rather than a runtime environment variable. Additionally, this PR renames the RayJob CRs to include the accelerator and chip size (in case we add more single or multi-host examples).
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
