### PR TITLE
[Fix] Consistent parsing of custom accelerator resources

### DIFF
--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1272,7 +1272,7 @@ func TestGenerateRayStartCommand(t *testing.T) {
 				NeuronCoreContainerResourceName: NeuronCoreRayResourceName,
 				"cloud-tpus.google.com/v3":      "tpu",
 			},
-			expected: `ray start --head  --num-gpus=1  --resources='{"tpu":8}' `,
+			expected: `ray start --head  --num-gpus=1  --resources='{"neuron_cores":4}' `,
 		},
 		{
 			name:     "HeadNode with existing resources",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

- Consistent parsing of custom accelerator resources and adding them to ray start params, by sorting the resource limits.
- This makes sure that the first custom accelerator resource gets picked up from the resource limits
- Also fixes a flaky test case.

## Related issue number

<!-- For example: "Closes #1234" -->
Address comment: https://github.com/ray-project/kuberay/pull/2425#issuecomment-2417035317

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
