### PR TITLE
Update v6e-256 KubeRay Sample

### DIFF
--- a/ray-operator/config/samples/ray-cluster.tpu-v6e-16-multihost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v6e-16-multihost.yaml
@@ -38,8 +38,6 @@ spec:
     rayStartParams: {}
     template:
       spec:
-        securityContext:
-          runAsUser: 0
         containers:
           - name: ray-worker
             image: rayproject/ray:2.37.0-py310

--- a/ray-operator/config/samples/ray-cluster.tpu-v6e-256-multihost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v6e-256-multihost.yaml
@@ -67,6 +67,8 @@ spec:
             ports:
             - containerPort: 8081
               name: mxla
+            securityContext:
+              privileged: true
         nodeSelector:
           cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
           cloud.google.com/gke-tpu-topology: 16x16

--- a/ray-operator/config/samples/ray-cluster.tpu-v6e-256-multihost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v6e-256-multihost.yaml
@@ -67,8 +67,6 @@ spec:
             ports:
             - containerPort: 8081
               name: mxla
-            securityContext:
-              privileged: true
         nodeSelector:
           cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
           cloud.google.com/gke-tpu-topology: 16x16

--- a/ray-operator/config/samples/ray-cluster.tpu-v6e-256-multihost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v6e-256-multihost.yaml
@@ -38,8 +38,6 @@ spec:
     rayStartParams: {}
     template:
       spec:
-        securityContext:
-          runAsUser: 0
         containers:
           - name: ray-worker
             image: rayproject/ray:2.37.0-py310

--- a/ray-operator/config/samples/ray-cluster.tpu-v6e-singlehost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v6e-singlehost.yaml
@@ -40,8 +40,6 @@ spec:
     rayStartParams: {}
     template:
       spec:
-        securityContext:
-          runAsUser: 0
         containers:
           - name: ray-worker
             image: rayproject/ray:2.37.0-py310

--- a/ray-operator/config/samples/ray-job.tpu-v6e-256-multihost.yaml
+++ b/ray-operator/config/samples/ray-job.tpu-v6e-256-multihost.yaml
@@ -44,8 +44,6 @@ spec:
           resources: '"{\"TPU\": 4}"'
         template:
           spec:
-            securityContext:
-              runAsUser: 0
             containers:
               - name: ray-worker
                 image: rayproject/ray:2.37.0-py310
@@ -61,8 +59,6 @@ spec:
                 env:
                 - name: JAX_PLATFORMS
                   value: tpu,cpu
-                securityContext:
-                  privileged: true
             nodeSelector:
               cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
               cloud.google.com/gke-tpu-topology: 16x16

--- a/ray-operator/config/samples/ray-job.tpu-v6e-256-multihost.yaml
+++ b/ray-operator/config/samples/ray-job.tpu-v6e-256-multihost.yaml
@@ -40,7 +40,8 @@ spec:
         maxReplicas: 1
         numOfHosts: 64
         groupName: tpu-group
-        rayStartParams: {}
+        rayStartParams:
+          resources: '"{\"TPU\": 4}"'
         template:
           spec:
             securityContext:
@@ -71,6 +72,8 @@ spec:
                 ports:
                 - containerPort: 8081
                   name: mxla
+                securityContext:
+                  privileged: true
             nodeSelector:
               cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
               cloud.google.com/gke-tpu-topology: 16x16

--- a/ray-operator/config/samples/ray-job.tpu-v6e-256-multihost.yaml
+++ b/ray-operator/config/samples/ray-job.tpu-v6e-256-multihost.yaml
@@ -59,19 +59,8 @@ spec:
                     google.com/tpu: "4"
                     memory: 200G
                 env:
-                - name: NODE_IP
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.hostIP
-                - name: VBAR_CONTROL_SERVICE_URL
-                  value: $(NODE_IP):8353
                 - name: JAX_PLATFORMS
                   value: tpu,cpu
-                - name: ENABLE_PJRT_COMPATIBILITY
-                  value: "true"
-                ports:
-                - containerPort: 8081
-                  name: mxla
                 securityContext:
                   privileged: true
             nodeSelector:

--- a/ray-operator/config/samples/tpu/tpu_list_devices.py
+++ b/ray-operator/config/samples/tpu/tpu_list_devices.py
@@ -8,7 +8,7 @@ ray.init()
 @ray.remote(resources={"TPU": 4})
 def tpu_cores():
     multihost_utils.sync_global_devices("sync")
-    return "TPU cores:" + str(jax.device_count())
+    return "TPU Worker: " + os.environ.get("TPU_WORKER_ID") + "TPU cores:" + str(jax.device_count())
 
 num_workers = int(ray.available_resources()["TPU"]) // 4
 printf("Number of TPU Workers: %d" + num_workers)

--- a/ray-operator/config/samples/tpu/tpu_list_devices.py
+++ b/ray-operator/config/samples/tpu/tpu_list_devices.py
@@ -9,6 +9,7 @@ ray.init()
 
 @ray.remote(resources={"TPU": 4})
 def tpu_cores():
+    multihost_utils.sync_global_devices("sync")
     cores = "TPU cores:" + str(jax.device_count())
     print("TPU Worker: " + os.environ.get("TPU_WORKER_ID"))
     return cores

--- a/ray-operator/config/samples/tpu/tpu_list_devices.py
+++ b/ray-operator/config/samples/tpu/tpu_list_devices.py
@@ -11,6 +11,6 @@ def tpu_cores():
     return "TPU Worker: " + os.environ.get("TPU_WORKER_ID") + "TPU cores:" + str(jax.device_count())
 
 num_workers = int(ray.available_resources()["TPU"]) // 4
-printf("Number of TPU Workers: %d" + num_workers)
+print(f"Number of TPU Workers: {num_workers}")
 result = [tpu_cores.remote() for _ in range(num_workers)]
 print(ray.get(result))

--- a/ray-operator/config/samples/tpu/tpu_list_devices.py
+++ b/ray-operator/config/samples/tpu/tpu_list_devices.py
@@ -1,6 +1,7 @@
 import os
 import ray
 import jax
+import time
 
 from jax.experimental import multihost_utils
 
@@ -10,7 +11,8 @@ ray.init()
 def tpu_cores():
     cores = "TPU cores:" + str(jax.device_count())
     print("TPU Worker: " + os.environ.get("TPU_WORKER_ID"))
-    multihost_utils.sync_global_devices("sync")
+    time.sleep(10)
+    # multihost_utils.sync_global_devices("sync")
     return cores
 
 num_workers = int(ray.available_resources()["TPU"]) // 4

--- a/ray-operator/config/samples/tpu/tpu_list_devices.py
+++ b/ray-operator/config/samples/tpu/tpu_list_devices.py
@@ -5,6 +5,7 @@ ray.init()
 
 @ray.remote(resources={"TPU": 4})
 def tpu_cores():
+    multihost_utils.sync_global_devices("sync")
     return "TPU cores:" + str(jax.device_count())
 
 num_workers = int(ray.available_resources()["TPU"]) // 4

--- a/ray-operator/config/samples/tpu/tpu_list_devices.py
+++ b/ray-operator/config/samples/tpu/tpu_list_devices.py
@@ -1,3 +1,4 @@
+import os
 import ray
 import jax
 

--- a/ray-operator/config/samples/tpu/tpu_list_devices.py
+++ b/ray-operator/config/samples/tpu/tpu_list_devices.py
@@ -7,8 +7,10 @@ ray.init()
 
 @ray.remote(resources={"TPU": 4})
 def tpu_cores():
+    cores = "TPU cores:" + str(jax.device_count())
+    print("TPU Worker: " + os.environ.get("TPU_WORKER_ID"))
     multihost_utils.sync_global_devices("sync")
-    return "TPU Worker: " + os.environ.get("TPU_WORKER_ID") + "TPU cores:" + str(jax.device_count())
+    return cores
 
 num_workers = int(ray.available_resources()["TPU"]) // 4
 print(f"Number of TPU Workers: {num_workers}")

--- a/ray-operator/config/samples/tpu/tpu_list_devices.py
+++ b/ray-operator/config/samples/tpu/tpu_list_devices.py
@@ -11,5 +11,6 @@ def tpu_cores():
     return "TPU cores:" + str(jax.device_count())
 
 num_workers = int(ray.available_resources()["TPU"]) // 4
+printf("Number of TPU Workers: %d" + num_workers)
 result = [tpu_cores.remote() for _ in range(num_workers)]
 print(ray.get(result))

--- a/ray-operator/config/samples/tpu/tpu_list_devices.py
+++ b/ray-operator/config/samples/tpu/tpu_list_devices.py
@@ -1,6 +1,8 @@
 import ray
 import jax
 
+from jax.experimental import multihost_utils
+
 ray.init()
 
 @ray.remote(resources={"TPU": 4})

--- a/ray-operator/config/samples/tpu/tpu_list_devices.py
+++ b/ray-operator/config/samples/tpu/tpu_list_devices.py
@@ -11,8 +11,6 @@ ray.init()
 def tpu_cores():
     cores = "TPU cores:" + str(jax.device_count())
     print("TPU Worker: " + os.environ.get("TPU_WORKER_ID"))
-    time.sleep(10)
-    # multihost_utils.sync_global_devices("sync")
     return cores
 
 num_workers = int(ray.available_resources()["TPU"]) // 4


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR adds recommended fields to the v6e-256 RayCluster and RayJob sample manifests. For the larger slice size, adding `privileged: true`  resolves a `UNKNOWN: TPU initialization failed: open(/dev/vfio/vfio): No such file or directory: No such file or directory; Couldn't open vfio container /dev/vfio/vfio` error while adding `resources: '"{\"TPU\": 4}"'` to the rayStartParams resolves a race condition that sometimes occurs in RayServices and RayJobs  where Python script execution begins before TPU device detection by the Raylets, causing `ray.available_resources()["TPU"]` to return 0.

This PR was manually tested as follows:
1. Create the RayJob CR
```
kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-job.tpu-v6e-256-multihost.yaml
```
2. View the Job output:
```
kubectl logs -l=job-name=v6e-256-job

2024-10-23 02:37:52,871 INFO cli.py:39 -- Job submission server address: http://v6e-256-job-raycluster-xj4wj-head-svc.default.svc.cluster.local:8265
2024-10-23 02:37:53,716 SUCC cli.py:63 -- ----------------------------------------------
2024-10-23 02:37:53,716 SUCC cli.py:64 -- Job 'v6e-256-job-4mhms' submitted successfully
2024-10-23 02:37:53,716 SUCC cli.py:65 -- ----------------------------------------------
2024-10-23 02:37:53,716 INFO cli.py:289 -- Next steps
2024-10-23 02:37:53,716 INFO cli.py:290 -- Query the logs of the job:
2024-10-23 02:37:53,716 INFO cli.py:292 -- ray job logs v6e-256-job-4mhms
2024-10-23 02:37:53,716 INFO cli.py:294 -- Query the status of the job:
2024-10-23 02:37:53,716 INFO cli.py:296 -- ray job status v6e-256-job-4mhms
2024-10-23 02:37:53,716 INFO cli.py:298 -- Request the job to be stopped:
2024-10-23 02:37:53,716 INFO cli.py:300 -- ray job stop v6e-256-job-4mhms
2024-10-23 02:37:53,742 INFO cli.py:307 -- Tailing logs until the job exits (disable with --no-wait):
2024-10-23 02:37:53,447 INFO job_manager.py:528 -- Runtime env is setting up.
2024-10-23 02:38:14,855 INFO worker.py:1461 -- Using address 10.96.6.73:6379 set in the environment variable RAY_ADDRESS
2024-10-23 02:38:14,856 INFO worker.py:1601 -- Connecting to existing Ray cluster at address: 10.96.6.73:6379...
2024-10-23 02:38:14,870 INFO worker.py:1777 -- Connected to Ray cluster. View the dashboard at 10.96.6.73:8265 
['TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256', 'TPU cores:256']
2024-10-23 02:38:44,974 SUCC cli.py:63 -- ---------------------------------
2024-10-23 02:38:44,974 SUCC cli.py:64 -- Job 'v6e-256-job-4mhms' succeeded
2024-10-23 02:38:44,974 SUCC cli.py:65 -- ---------------------------------
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
