### PR TITLE
[scheduler] Setting both EnableBatchScheduler and BatchScheduler at the same time is not allowed

### DIFF
--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -61,6 +61,8 @@ readinessProbe:
 #  * "name" is the standard option, expecting a scheduler name, supported values are
 #    "default", "volcano", and "yunikorn".
 #
+# Note: "enabled" and "name" should not be set at the same time. If both are set, an error will be thrown.
+#
 # Examples:
 #  1. Use volcano (deprecated)
 #       batchScheduler:

--- a/ray-operator/apis/config/v1alpha1/config_utils.go
+++ b/ray-operator/apis/config/v1alpha1/config_utils.go
@@ -10,6 +10,10 @@ import (
 )
 
 func ValidateBatchSchedulerConfig(logger logr.Logger, config Configuration) error {
+	if config.EnableBatchScheduler && len(config.BatchScheduler) > 0 {
+		return fmt.Errorf("both feature flags enable-batch-scheduler (deprecated) and batch-scheduler are set. Please use batch-scheduler only")
+	}
+
 	if config.EnableBatchScheduler {
 		logger.Info("Feature flag enable-batch-scheduler is deprecated and will not be supported soon. " +
 			"Use batch-scheduler instead. ")

--- a/ray-operator/apis/config/v1alpha1/config_utils_test.go
+++ b/ray-operator/apis/config/v1alpha1/config_utils_test.go
@@ -82,6 +82,17 @@ func TestValidateBatchSchedulerConfig(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "both enable-batch-scheduler and batch-scheduler are set",
+			args: args{
+				logger: testr.New(t),
+				config: Configuration{
+					EnableBatchScheduler: true,
+					BatchScheduler:       "volcano",
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/ray-operator/controllers/ray/batchscheduler/schedulermanager.go
+++ b/ray-operator/controllers/ray/batchscheduler/schedulermanager.go
@@ -13,9 +13,7 @@ import (
 
 	"k8s.io/client-go/rest"
 
-	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	schedulerinterface "github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/interface"
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 )
 
 type SchedulerManager struct {
@@ -71,7 +69,7 @@ func getSchedulerFactory(rayConfigs configapi.Configuration) (schedulerinterface
 	}
 
 	// legacy option, if this is enabled, register volcano
-	// this is for backwards compatibility
+	// this is for backward compatibility
 	if rayConfigs.EnableBatchScheduler {
 		factory = &volcano.VolcanoBatchSchedulerFactory{}
 	}
@@ -79,16 +77,7 @@ func getSchedulerFactory(rayConfigs configapi.Configuration) (schedulerinterface
 	return factory, nil
 }
 
-func (batch *SchedulerManager) GetSchedulerForCluster(app *rayv1.RayCluster) (schedulerinterface.BatchScheduler, error) {
-	// for backwards compatibility
-	if batch.rayConfigs.EnableBatchScheduler {
-		if schedulerName, ok := app.ObjectMeta.Labels[utils.RaySchedulerName]; ok {
-			if schedulerName == volcano.GetPluginName() {
-				return batch.scheduler, nil
-			}
-		}
-	}
-
+func (batch *SchedulerManager) GetSchedulerForCluster() (schedulerinterface.BatchScheduler, error) {
 	return batch.scheduler, nil
 }
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -670,7 +670,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	// check if the batch scheduler integration is enabled
 	// call the scheduler plugin if so
 	if r.BatchSchedulerMgr != nil {
-		if scheduler, err := r.BatchSchedulerMgr.GetSchedulerForCluster(instance); err == nil {
+		if scheduler, err := r.BatchSchedulerMgr.GetSchedulerForCluster(); err == nil {
 			if err := scheduler.DoBatchSchedulingOnSubmission(ctx, instance); err != nil {
 				return err
 			}
@@ -1006,7 +1006,7 @@ func (r *RayClusterReconciler) createHeadPod(ctx context.Context, instance rayv1
 	// check if the batch scheduler integration is enabled
 	// call the scheduler plugin if so
 	if r.BatchSchedulerMgr != nil {
-		if scheduler, err := r.BatchSchedulerMgr.GetSchedulerForCluster(&instance); err == nil {
+		if scheduler, err := r.BatchSchedulerMgr.GetSchedulerForCluster(); err == nil {
 			scheduler.AddMetadataToPod(&instance, utils.RayNodeHeadGroupLabelValue, &pod)
 		} else {
 			return err
@@ -1028,7 +1028,7 @@ func (r *RayClusterReconciler) createWorkerPod(ctx context.Context, instance ray
 	// build the pod then create it
 	pod := r.buildWorkerPod(ctx, instance, worker)
 	if r.BatchSchedulerMgr != nil {
-		if scheduler, err := r.BatchSchedulerMgr.GetSchedulerForCluster(&instance); err == nil {
+		if scheduler, err := r.BatchSchedulerMgr.GetSchedulerForCluster(); err == nil {
 			scheduler.AddMetadataToPod(&instance, worker.GroupName, &pod)
 		} else {
 			return err


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`--enable-batch-scheduler` is deprecated. If both `--enable-batch-scheduler` and `--batch-scheduler` are set at the same time, the behavior is undefined. For example, users can set `--enable-batch-scheduler=true` and `--batch-scheduler=yunikorn`. However, Volcano will be used in this case.

This PR throws an error if both configs are set.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(


* Update `values.yaml`
  ```yaml
  batchScheduler:
    # Deprecated. This option will be removed in the future.
    # Note, for backwards compatibility. When it sets to true, it enables volcano scheduler integration.
    enabled: true
    # Set the customized scheduler name, supported values are "volcano" or "yunikorn", do not set
    # "batchScheduler.enabled=true" at the same time as it will override this option.
    name: "volcano"
  ```
* Install the KubeRay operator
* Check the KubeRay operator's log
  <img width="1440" alt="Screenshot 2024-10-24 at 1 47 31 PM" src="https://github.com/user-attachments/assets/1866e87a-554a-4f6b-97b1-dc563af2974d">