### PR TITLE
feat: support calculate custom gpu resource

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -41,7 +41,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	controller "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -1619,8 +1619,16 @@ func (r *RayClusterReconciler) updateRayClusterStatus(ctx context.Context, origi
 func sumGPUs(resources map[corev1.ResourceName]resource.Quantity) resource.Quantity {
 	totalGPUs := resource.Quantity{}
 
+	var customKeys []string
+	if accelerators := os.Getenv(utils.CUSTOM_GPU_ACCELERATOR); accelerators != "" {
+		customKeys = strings.Split(accelerators, ",")
+	}
+
 	for key, val := range resources {
 		if strings.HasSuffix(string(key), "gpu") && !val.IsZero() {
+			totalGPUs.Add(val)
+		}
+		if utils.Contains(customKeys, string(key)) && !val.IsZero() {
 			totalGPUs.Add(val)
 		}
 	}

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -144,6 +144,9 @@ const (
 	// If set to true, the RayJob CR itself will be deleted if shutdownAfterJobFinishes is set to true. Note that all resources created by the RayJob CR will be deleted, including the K8s Job.
 	DELETE_RAYJOB_CR_AFTER_JOB_FINISHES = "DELETE_RAYJOB_CR_AFTER_JOB_FINISHES"
 
+	// If not empty, the value will use to calculate ray cluster gpu status. The value must be some valid GPU resource keys, separated by commas.
+	CUSTOM_GPU_ACCELERATOR = "CUSTOM_GPU_ACCELERATOR"
+
 	// Ray core default configurations
 	DefaultWorkerRayGcsReconnectTimeoutS = "600"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- intel use some gpu resource key like `gpu.intel.com/i915`
- some gpu scheduler like [HAMi](https://github.com/Project-HAMi/HAMi) support set custom gpu resource key

The above two GPU settings cannot be counted in the `desiredGPU` field of the raycluster status.

<!-- Please give a short summary of the change and the problem this solves. -->

So I added an environment variable `CUSTOM_GPU_ACCELERATOR`, using commas to separate the custom gpu resource key that needs to be counted.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
