### PR TITLE
Drop unused permission + configurable binary path

### DIFF
--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               mountPath: "{{ .Values.logging.baseDir }}"
           {{- end }}
           command:
-            - /manager
+            - {{ .Values.operatorComand }}
           args:
             {{- $argList := list -}}
             {{- $argList = append $argList (include "kuberay.featureGates" . | trim) -}}

--- a/helm-chart/kuberay-operator/templates/leader_election_role.yaml
+++ b/helm-chart/kuberay-operator/templates/leader_election_role.yaml
@@ -20,14 +20,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -88,6 +88,8 @@ featureGates:
   - name: RayClusterStatusConditions
     enabled: false
 
+# Path to the operator binary
+operatorComand: /manager
 
 # Set up `securityContext` to improve Pod security.
 # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md for further guidance.

--- a/ray-operator/config/rbac/leader_election_role.yaml
+++ b/ray-operator/config/rbac/leader_election_role.yaml
@@ -19,14 +19,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Configmaps have no status (see eg https://github.com/kubernetes/kubernetes/blob/v1.31.2/pkg/apis/core/types.go#L1722-L1743) ; omiting this to avoid operator having to be explicitly granted that non existing subresource to apply the chart
* Supporting overriding the operator's binary path can be useful for custom rebuilds, or using a wrapper.

```
$ kubectl get configmap --subresource status myconfigmap        # k8s v1.28
Error from server (NotFound): the server could not find the requested resource
```

## Checks

That's chart only change:

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x ] Manual tests
   - [ ] This PR is not tested :(
