### PR TITLE
Add TPU to Known Custom Accelerators for generated rayStartCommand

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -36,13 +36,13 @@ const (
 	EnableInitContainerInjectionEnvKey = "ENABLE_INIT_CONTAINER_INJECTION"
 	NeuronCoreContainerResourceName    = "aws.amazon.com/neuroncore"
 	NeuronCoreRayResourceName          = "neuron_cores"
-	TPUContainerResourceName    	   = "google.com/tpu"
-	TPURayResourceName          	   = "TPU"
+	TPUContainerResourceName           = "google.com/tpu"
+	TPURayResourceName                 = "TPU"
 )
 
 var customAcceleratorToRayResourceMap = map[string]string{
 	NeuronCoreContainerResourceName: NeuronCoreRayResourceName,
-	TPUContainerResourceName: TPURayResourceName,
+	TPUContainerResourceName:        TPURayResourceName,
 }
 
 // Get the port required to connect to the Ray cluster by worker nodes and drivers

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -36,10 +36,13 @@ const (
 	EnableInitContainerInjectionEnvKey = "ENABLE_INIT_CONTAINER_INJECTION"
 	NeuronCoreContainerResourceName    = "aws.amazon.com/neuroncore"
 	NeuronCoreRayResourceName          = "neuron_cores"
+	TPUContainerResourceName    	   = "google.com/tpu"
+	TPURayResourceName          	   = "TPU"
 )
 
 var customAcceleratorToRayResourceMap = map[string]string{
 	NeuronCoreContainerResourceName: NeuronCoreRayResourceName,
+	TPUContainerResourceName: TPURayResourceName,
 }
 
 // Get the port required to connect to the Ray cluster by worker nodes and drivers

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1235,6 +1235,17 @@ func TestGenerateRayStartCommand(t *testing.T) {
 			expected: "ray start  --num-gpus=1 ",
 		},
 		{
+			name:           "WorkerNode with TPU",
+			nodeType:       rayv1.WorkerNode,
+			rayStartParams: map[string]string{},
+			resource: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"google.com/tpu": resource.MustParse("4"),
+				},
+			},
+			expected: `ray start  --resources='{"TPU":4}' `,
+		},
+		{
 			name:           "HeadNode with Neuron Cores",
 			nodeType:       rayv1.HeadNode,
 			rayStartParams: map[string]string{},
@@ -1299,6 +1310,19 @@ func TestGenerateRayStartCommand(t *testing.T) {
 				},
 			},
 			expected: `ray start --head  --resources='{"custom_resource":2,"neuron_cores":3}' `,
+		},
+		{
+			name:     "HeadNode with existing TPU resources",
+			nodeType: rayv1.HeadNode,
+			rayStartParams: map[string]string{
+				"resources": `'{"custom_resource":2,"TPU":4}'`,
+			},
+			resource: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"google.com/tpu": resource.MustParse("8"),
+				},
+			},
+			expected: `ray start --head  --resources='{"custom_resource":2,"TPU":4}' `,
 		},
 		{
 			name:     "HeadNode with invalid resources string",

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1216,12 +1216,11 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 
 func TestGenerateRayStartCommand(t *testing.T) {
 	tests := []struct {
-		rayStartParams                        map[string]string
-		mockCustomAcceleratorToRayResourceMap map[string]string
-		name                                  string
-		expected                              string
-		nodeType                              rayv1.RayNodeType
-		resource                              corev1.ResourceRequirements
+		rayStartParams map[string]string
+		name           string
+		expected       string
+		nodeType       rayv1.RayNodeType
+		resource       corev1.ResourceRequirements
 	}{
 		{
 			name:           "WorkerNode with GPU",
@@ -1274,14 +1273,10 @@ func TestGenerateRayStartCommand(t *testing.T) {
 			rayStartParams: map[string]string{},
 			resource: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					"cloud-tpus.google.com/v3":  resource.MustParse("8"),
+					"google.com/tpu":            resource.MustParse("8"),
 					"aws.amazon.com/neuroncore": resource.MustParse("4"),
 					"nvidia.com/gpu":            resource.MustParse("1"),
 				},
-			},
-			mockCustomAcceleratorToRayResourceMap: map[string]string{
-				NeuronCoreContainerResourceName: NeuronCoreRayResourceName,
-				"cloud-tpus.google.com/v3":      "tpu",
 			},
 			expected: `ray start --head  --num-gpus=1  --resources='{"neuron_cores":4}' `,
 		},
@@ -1348,15 +1343,6 @@ func TestGenerateRayStartCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Mock the customAcceleratorToRayResourceMap with the value specified in the test
-			if tt.mockCustomAcceleratorToRayResourceMap != nil {
-				originalCustomAcceleratorToRayResourceMap := customAcceleratorToRayResourceMap
-				customAcceleratorToRayResourceMap = tt.mockCustomAcceleratorToRayResourceMap
-				defer func() {
-					customAcceleratorToRayResourceMap = originalCustomAcceleratorToRayResourceMap
-				}()
-			}
-
 			result := generateRayStartCommand(context.TODO(), tt.nodeType, tt.rayStartParams, tt.resource)
 			assert.Equal(t, tt.expected, result)
 		})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

This PR adds TPUs to the list of known custom accelerators in pod.go, allowing Ray to add the TPU custom resource to the generated `rayStartCommand` when `google.com/tpu` resources are specified in the K8s container.

Manually tested by creating a RayCluster with a TPU worker group and describing the created TPU worker Pod:
```
kubectl describe <tpu-pod-name>

# checked the part of the output with the generated rayStartCommand
...
ray-worker:
    Container ID:  containerd://70ace65d27a18aebbc0ae5d198e9cf8b5a95a216453adea0cbbb10104b0a82fe
    Image:         rayproject/ray:2.37.0-py310
    Image ID:      docker.io/rayproject/ray@sha256:0e96acf8740eb31f165c7851fa724c225d7938afbf65a73f50020c32faa3b474
    Ports:         8081/TCP, 8080/TCP
    Host Ports:    0/TCP, 0/TCP
    Command:
      /bin/bash
      -lc
      --
    Args:
      ulimit -n 65536; ray start  --address=tpu-ray-cluster-head-svc.default.svc.cluster.local:6379  --block  --dashboard-agent-listen-port=52365  --memory=200000000000  --metrics-export-port=8080  --num-cpus=24  --resources='{"TPU":4}' 
...
```

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #2494

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
