### PR TITLE
[Feature][kubectl-plugin] return usage error when no entrypoint input

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -104,6 +104,9 @@ func NewJobSubmitCommand(streams genericclioptions.IOStreams) *cobra.Command {
 		Example: jobSubmitExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			entryPointStart := cmd.ArgsLenAtDash()
+			if entryPointStart == -1 || len(args[entryPointStart:]) == 0 {
+				return cmdutil.UsageErrorf(cmd, "%s", cmd.Use)
+			}
 			options.entryPoint = strings.Join(args[entryPointStart:], " ")
 			if err := options.Complete(); err != nil {
 				return err


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Check for `ray job submit` entrypoint input from user. 

Currently if there is no "--", it will cause error with `panic: runtime error: slice bounds out of range [-1:]`. 
Or if there is no `entrypoint` input after "--", the command will run through the whole cluster setup process and job submission step and then fail. Adding a check will ensure that it won't need to go through the whole setup/submission process.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
