### PR TITLE
[Doc] Remove KubeRay CLI references and add Python client details

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ by some organizations to back user interfaces for KubeRay resource management.
 
 * **KubeRay Python client**: This Python client library provides APIs to handle RayCluster from your Python application.
 
-* **KubeRay CLI**: KubeRay CLI provides the ability to manage KubeRay resources through command-line interface.
-
 ## Documentation
 
 From September 2023, all user-facing KubeRay documentation will be hosted on the [Ray documentation](https://docs.ray.io/en/latest/cluster/kubernetes/index.html).

--- a/docs/components/pythonapiclient.md
+++ b/docs/components/pythonapiclient.md
@@ -1,0 +1,1 @@
+../../clients/python-apiserver-client/README.md

--- a/docs/components/pythonclient.md
+++ b/docs/components/pythonclient.md
@@ -1,0 +1,1 @@
+../../clients/python-client/README.md

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -13,10 +13,8 @@ To learn more about developing and testing the KubeRay Operator, please refer to
 The KubeRay APIServer is a central component that exposes the KubeRay API for managing Ray clusters.
 For more information about developing and testing the KubeRay APIServer, please refer to the [APIServer Development Guide](https://github.com/ray-project/kuberay/blob/master/apiserver/DEVELOPMENT.md).
 
-## KubeRay CLI
-
-The KubeRay CLI is a command-line interface for interacting with Ray clusters managed by KubeRay.
-For more information about developing and testing the KubeRay CLI, please refer to the [CLI Development Guide](https://github.com/ray-project/kuberay/blob/master/cli/README.md).
+## KubeRay Python client
+The KubeRay Python client library provides APIs to handle RayCluster from your Python application. For more information about developing and testing the KubeRay Python client, please refer to the [Python Client](https://github.com/ray-project/kuberay/blob/master/components/pythonclient.md), [Python API Client](https://github.com/ray-project/kuberay/blob/master/components/pythonapiclient.md).
 
 ## Proto and OpenAPI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,8 +41,6 @@ by some organizations to back user interfaces for KubeRay resource management.
 
 * **KubeRay Python client**: This Python client library provides APIs to handle RayCluster from your Python application.
 
-* **KubeRay CLI**: KubeRay CLI provides the ability to manage KubeRay resources through command-line interface.
-
 ## KubeRay ecosystem
 
 * [AWS Application Load Balancer](https://docs.ray.io/en/master/cluster/kubernetes/k8s-ecosystem/ingress.html#aws-application-load-balancer-alb-ingress-support-on-aws-eks)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,8 @@ nav:
   - Components:
     - KubeRay Operator: components/operator.md
     - KubeRay API Server: components/apiserver.md
-    - KubeRay CLI: components/cli.md
+    - KubeRay Python Client: components/pythonclient.md
+    - KubeRay Python API Client: components/pythonapiclient.md
   - Features:
     - RayService: guidance/rayservice.md
     - RayJob: guidance/rayjob.md


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- These changes fix broken links from deprecated CLI references and provide updated information on the KubeRay Python client.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
- #2520
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
