### PR TITLE
[metrics] Add ray_io_cluster to all Ray metrics

### DIFF
--- a/config/prometheus/podMonitor.yaml
+++ b/config/prometheus/podMonitor.yaml
@@ -19,3 +19,6 @@ spec:
   # A list of endpoints allowed as part of this PodMonitor.
   podMetricsEndpoints:
   - port: metrics
+    relabelings:
+    - sourceLabels: [__meta_kubernetes_pod_label_ray_io_cluster]
+      targetLabel: ray_io_cluster


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Both metrics from ServiceMonitor and PodMonitor have the label `ray_io_cluster` after this PR. Before this PR, only metrics from ServiceMonitor have the label.

![Screenshot 2024-11-08 at 10 26 28 AM](https://github.com/user-attachments/assets/654ad7f9-fc97-420e-9ffe-77055f5f51ad)
![Screenshot 2024-11-08 at 10 26 35 AM](https://github.com/user-attachments/assets/d054659c-9002-4025-bf2c-19256fc37247)


## Related issue number

Part of #2502

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
