### PR TITLE
[BUG] Fix Dockerfile WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match

### DIFF
--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.4-bullseye as builder
+FROM golang:1.22.4-bullseye AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When building the image, the following warning keeps appearing. This PR changes the `as` in the Dockerfile from lowercase to uppercase to resolve this warning.

https://docs.docker.com/reference/build-checks/from-as-casing/

```
$ IMG=kuberay/operator:nightly make docker-build
go fmt ./...
go vet ./...
go build                                    \
    -ldflags                                    \
    "                                           \
    -X 'main._buildTime_=2024-11-09 20:21:48'         \
    -X 'main._commitId_=95c3830b84997c87577f00c2ed0ebcb4472b443c'         \
    "                                           \
    -o bin/manager main.go
"docker" build -t kuberay/operator:nightly .
[+] Building 21.8s (19/19) FINISHED                                                                                 docker:default
 => [internal] load build definition from Dockerfile                                                                          0.0s
 => => transferring dockerfile: 739B                                                                                          0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)                                                0.0s
 => [internal] load metadata for gcr.io/distroless/base-debian12:nonroot                                                      0.3s
 => [internal] load metadata for docker.io/library/golang:1.22.4-bullseye                                                     2.9s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                 0.0s
 => [internal] load .dockerignore                                                                                             0.0s
 => => transferring context: 193B                                                                                             0.0s
 => [builder  1/10] FROM docker.io/library/golang:1.22.4-bullseye@sha256:a6a57082ab73381832e16682d4ebee7868b94ffbfbececbe10e  0.0s
 => [internal] load build context                                                                                             0.0s
 => => transferring context: 100.49kB                                                                                         0.0s
 => CACHED [stage-1 1/3] FROM gcr.io/distroless/base-debian12:nonroot@sha256:c3584d9160af7bbc6a0a6089dc954d0938bb7f755465bb4  0.0s
 => CACHED [builder  2/10] WORKDIR /workspace                                                                                 0.0s
 => CACHED [builder  3/10] COPY go.mod go.mod                                                                                 0.0s
 => CACHED [builder  4/10] COPY go.sum go.sum                                                                                 0.0s
 => CACHED [builder  5/10] RUN go mod download                                                                                0.0s
 => CACHED [builder  6/10] COPY main.go main.go                                                                               0.0s
 => CACHED [builder  7/10] COPY apis/ apis/                                                                                   0.0s
 => [builder  8/10] COPY controllers/ controllers/                                                                            0.0s
 => [builder  9/10] COPY pkg/features pkg/features                                                                            0.0s
 => [builder 10/10] RUN CGO_ENABLED=1 GOOS=linux go build -tags strictfipsruntime -a -o manager main.go                      18.5s
 => [stage-1 2/3] COPY --from=builder /workspace/manager .                                                                    0.1s
 => exporting to image                                                                                                        0.1s
 => => exporting layers                                                                                                       0.1s
 => => writing image sha256:d29930dd3344a1f8294f8abbc7ca211531185f24f93517963f1630139ed31d68                                  0.0s
 => => naming to docker.io/kuberay/operator:nightly                                                                           0.0s

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
