### PR TITLE
Revert "[BUG] Fix Dockerfile Error: WARN: FromAsCasing: 'as' and 'FROM' Keywords' Casing Do Not match (#2527)"

### DIFF
--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.4-bullseye AS builder
+FROM golang:1.22.4-bullseye as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION

This reverts commit 9c55794fc01aedfe6cb0138936b836baaff1e1b8.

This PR makes the CI pipeline `buildkite/ray-ecosystem-ci-kuberay-ci/test-sample-yamls-latest-release` stuck forever. I haven't investigated it. Revert the commit.


![image](https://github.com/user-attachments/assets/29a71eee-78eb-4592-9254-942bb2bfe928)

https://github.com/ray-project/kuberay/pull/2530

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
