### PR TITLE
[Logging] Remove duplicate info in CR logs

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -179,7 +179,7 @@ func (r *RayClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	// Try to fetch the RayCluster instance
 	instance := &rayv1.RayCluster{}
 	if err = r.Get(ctx, request.NamespacedName, instance); err == nil {
-		return r.rayClusterReconcile(ctx, request, instance)
+		return r.rayClusterReconcile(ctx, instance)
 	}
 
 	// No match found
@@ -219,7 +219,7 @@ func (r *RayClusterReconciler) validateRayClusterStatus(instance *rayv1.RayClust
 	return nil
 }
 
-func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, request ctrl.Request, instance *rayv1.RayCluster) (ctrl.Result, error) {
+func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance *rayv1.RayCluster) (ctrl.Result, error) {
 	var reconcileErr error
 	logger := ctrl.LoggerFrom(ctx)
 

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -47,7 +47,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -2390,8 +2389,7 @@ func Test_RedisCleanupFeatureFlag(t *testing.T) {
 			assert.Equal(t, 1, len(rayClusterList.Items))
 			assert.Equal(t, 0, len(rayClusterList.Items[0].Finalizers))
 
-			request := ctrl.Request{NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}}
-			_, err = testRayClusterReconciler.rayClusterReconcile(ctx, request, cluster)
+			_, err = testRayClusterReconciler.rayClusterReconcile(ctx, cluster)
 			if tc.enableGCSFTRedisCleanup == "false" {
 				assert.Nil(t, err)
 				podList := corev1.PodList{}
@@ -2419,7 +2417,7 @@ func Test_RedisCleanupFeatureFlag(t *testing.T) {
 				assert.Equal(t, 0, len(podList.Items))
 
 				// Reconcile the RayCluster again. The controller should create Pods.
-				_, err = testRayClusterReconciler.rayClusterReconcile(ctx, request, cluster)
+				_, err = testRayClusterReconciler.rayClusterReconcile(ctx, cluster)
 				assert.Nil(t, err)
 
 				err = fakeClient.List(ctx, &podList, client.InNamespace(namespaceStr))
@@ -2498,8 +2496,7 @@ func TestEvents_RedisCleanup(t *testing.T) {
 				Scheme:   newScheme,
 			}
 
-			request := ctrl.Request{NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}}
-			_, err := testRayClusterReconciler.rayClusterReconcile(ctx, request, cluster)
+			_, err := testRayClusterReconciler.rayClusterReconcile(ctx, cluster)
 			assert.ErrorIs(t, err, tc.errInjected)
 
 			var foundEvent bool
@@ -2642,8 +2639,7 @@ func Test_RedisCleanup(t *testing.T) {
 			assert.Nil(t, err, "Fail to get Job list")
 			assert.Equal(t, 0, len(jobList.Items))
 
-			request := ctrl.Request{NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}}
-			_, err = testRayClusterReconciler.rayClusterReconcile(ctx, request, cluster)
+			_, err = testRayClusterReconciler.rayClusterReconcile(ctx, cluster)
 			assert.Nil(t, err)
 
 			// Check Job
@@ -2670,7 +2666,7 @@ func Test_RedisCleanup(t *testing.T) {
 
 				// Reconcile the RayCluster again. The controller should remove the finalizer and the RayCluster will be deleted.
 				// See https://github.com/kubernetes-sigs/controller-runtime/blob/release-0.11/pkg/client/fake/client.go#L308-L310 for more details.
-				_, err = testRayClusterReconciler.rayClusterReconcile(ctx, request, cluster)
+				_, err = testRayClusterReconciler.rayClusterReconcile(ctx, cluster)
 				assert.Nil(t, err, "Fail to reconcile RayCluster")
 				err = fakeClient.List(ctx, &rayClusterList, client.InNamespace(namespaceStr))
 				assert.Nil(t, err, "Fail to get RayCluster list")

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -635,7 +635,7 @@ func (r *RayServiceReconciler) createRayClusterInstanceIfNeeded(ctx context.Cont
 	} else {
 		clusterAction, err = getClusterAction(pendingRayCluster.Spec, rayServiceInstance.Spec.RayClusterSpec)
 		if err != nil {
-			err = fmt.Errorf("Fail to generate hash for RayClusterSpec: %w", err)
+			err = fmt.Errorf("fail to generate hash for RayClusterSpec: %w", err)
 			return nil, err
 		}
 	}
@@ -672,7 +672,7 @@ func (r *RayServiceReconciler) updateRayClusterInstance(ctx context.Context, ray
 		Name:      rayClusterInstance.Name,
 	})
 	if err != nil {
-		err = fmt.Errorf("Failed to get the current state of RayCluster, namespace: %s, name: %s: %w", rayClusterInstance.Namespace, rayClusterInstance.Name, err)
+		err = fmt.Errorf("failed to get the current state of RayCluster, namespace: %s, name: %s: %w", rayClusterInstance.Namespace, rayClusterInstance.Name, err)
 		return err
 	}
 
@@ -843,12 +843,12 @@ func (r *RayServiceReconciler) updateServeDeployment(ctx context.Context, raySer
 
 	configJson, err := json.Marshal(serveConfig)
 	if err != nil {
-		return fmt.Errorf("Failed to marshal converted serve config into bytes: %w", err)
+		return fmt.Errorf("failed to marshal converted serve config into bytes: %w", err)
 	}
 	logger.Info("updateServeDeployment", "MULTI_APP json config", string(configJson))
 	if err := rayDashboardClient.UpdateDeployments(ctx, configJson); err != nil {
 		err = fmt.Errorf(
-			"Fail to create / update Serve applications. If you observe this error consistently, "+
+			"fail to create / update Serve applications. If you observe this error consistently, "+
 				"please check \"Issue 5: Fail to create / update Serve applications.\" in "+
 				"https://docs.ray.io/en/master/cluster/kubernetes/troubleshooting/rayservice-troubleshooting.html#kuberay-raysvc-troubleshoot for more details. "+
 				"err: %v", err)
@@ -873,7 +873,7 @@ func (r *RayServiceReconciler) getAndCheckServeStatus(ctx context.Context, dashb
 	var err error
 	if serveAppStatuses, err = dashboardClient.GetMultiApplicationStatus(ctx); err != nil {
 		err = fmt.Errorf(
-			"Failed to get Serve application statuses from the dashboard. "+
+			"failed to get Serve application statuses from the dashboard. "+
 				"If you observe this error consistently, please check https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayservice-troubleshooting.md for more details. "+
 				"err: %v", err)
 		return false, err
@@ -979,7 +979,6 @@ func (r *RayServiceReconciler) reconcileServices(ctx context.Context, rayService
 	logger := ctrl.LoggerFrom(ctx)
 	logger.Info(
 		"reconcileServices", "serviceType", serviceType,
-		"RayService name", rayServiceInstance.Name, "RayService namespace", rayServiceInstance.Namespace,
 	)
 
 	var newSvc *corev1.Service


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR addresses redundant context information in KubeRay logs and improves log message formatting.

Key changes:

1. Removed duplicate context information:
   - Each CR's logger already includes name and namespace in its context.
   - Eliminated redundant output of this information in some log messages.
   - For example, removed the duplicate 'rayClusterName' field in RayCluster CR logs.

2. Improved error log message format:
   - Modified error log messages to start with lowercase letters for consistency.

## Related issue number

Closes #2514

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
