### PR TITLE
[Helm] add sizeLimit for emptyDir

### DIFF
--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -37,7 +37,12 @@ spec:
       {{- if and (.Values.logging.baseDir) (.Values.logging.fileName) }}
       volumes:
         - name: kuberay-logs
+          {{- if .Values.logging.sizeLimit }}
+          emptyDir:
+            sizeLimit: {{ .Values.logging.sizeLimit }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -44,6 +44,8 @@ logging:
   baseDir: ""
   # File name for kuberay-operator log file
   fileName: ""
+  # EmptyDir volume size limit for kuberay-operator log file
+  sizeLimit: ""
 
 livenessProbe:
   initialDelaySeconds: 10


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When a Pod requests an emptyDir, by default it does not have a size limit which may allow it to consume excess or all of the space in the medium backing the volume. This can quickly overrun a Node and may result in a denial of service for other workloads. This PR adds a sizeLimit field to KubeRay-Operator mounting emptyDir volumes

## Test Process:
```
helm install kuberay-operator --version 1.2.2 --set logging.sizeLimit="1Gi" --set logging.baseDir="/tmp/kuberay-operator" --set logging.fileName="kuberay-operator.log"  ../helm-chart/kuberay-operator
```
![image](https://github.com/user-attachments/assets/14f10722-abe2-408e-8048-8a252e002e4e)

```
helm install kuberay-operator --version 1.2.2 --set logging.baseDir="/tmp/kuberay-operator" --set logging.fileName="kuberay-operator.log"  ../helm-chart/kuberay-operator
```
![image](https://github.com/user-attachments/assets/80ecaba4-5871-4511-acf0-e19bd3a3442f)



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
