### PR TITLE
some logs are not json format

### DIFF
--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -28,6 +28,7 @@ require (
 	k8s.io/client-go v0.29.6
 	k8s.io/code-generator v0.29.6
 	k8s.io/component-base v0.29.6
+	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	sigs.k8s.io/controller-runtime v0.17.5
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1
@@ -91,7 +92,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240228010128-51d4e06bde70 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240620174524-b456828f718b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 )

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -155,15 +155,15 @@ func main() {
 
 		ctrl.SetLogger(combineLoggerR)
 
-        // By default, the log from kubernetes/client-go is not json format.
-        // This will apply the logger to kubernetes/client-go and change it to json format.
-        klog.SetLogger(combineLoggerR)
+		// By default, the log from kubernetes/client-go is not json format.
+		// This will apply the logger to kubernetes/client-go and change it to json format.
+		klog.SetLogger(combineLoggerR)
 	} else {
 		k8sLogger := k8szap.New(k8szap.UseFlagOptions(&opts))
 		ctrl.SetLogger(k8sLogger)
 
-        // By default, the log from kubernetes/client-go is not json format.
-        // This will apply the logger to kubernetes/client-go and change it to json format.
+		// By default, the log from kubernetes/client-go is not json format.
+		// This will apply the logger to kubernetes/client-go and change it to json format.
 		klog.SetLogger(k8sLogger)
 	}
 

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -154,10 +154,16 @@ func main() {
 		combineLoggerR := zapr.NewLogger(combineLogger)
 
 		ctrl.SetLogger(combineLoggerR)
-		klog.SetLogger(combineLoggerR)
+
+        // By default, the log from kubernetes/client-go is not json format.
+        // This will apply the logger to kubernetes/client-go and change it to json format.
+        klog.SetLogger(combineLoggerR)
 	} else {
 		k8sLogger := k8szap.New(k8szap.UseFlagOptions(&opts))
 		ctrl.SetLogger(k8sLogger)
+
+        // By default, the log from kubernetes/client-go is not json format.
+        // This will apply the logger to kubernetes/client-go and change it to json format.
 		klog.SetLogger(k8sLogger)
 	}
 

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -159,7 +159,6 @@ func main() {
 		k8sLogger := k8szap.New(k8szap.UseFlagOptions(&opts))
 		ctrl.SetLogger(k8sLogger)
 		klog.SetLogger(k8sLogger)
-
 	}
 
 	if forcedClusterUpgrade {

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -21,6 +21,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -153,8 +154,12 @@ func main() {
 		combineLoggerR := zapr.NewLogger(combineLogger)
 
 		ctrl.SetLogger(combineLoggerR)
+		klog.SetLogger(combineLoggerR)
 	} else {
-		ctrl.SetLogger(k8szap.New(k8szap.UseFlagOptions(&opts)))
+		k8sLogger := k8szap.New(k8szap.UseFlagOptions(&opts))
+		ctrl.SetLogger(k8sLogger)
+		klog.SetLogger(k8sLogger)
+
 	}
 
 	if forcedClusterUpgrade {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some logs from client-go are not in JSON format.

According to https://github.com/kubernetes/client-go/issues/18#issuecomment-624162529, 
Calling `klog.SetLogger()` applies logs with JSON format from client-go.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/kuberay/issues/2512

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
