### PR TITLE
[Chore][precommit] Replace grep with awk in pre-commit hooks for BSD compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: check-golangci-lint-version
         name: golangci-lint version check
-        entry: sh -c 'version="1.60.3"; [ "$(golangci-lint --version | awk "/version/ {print \$4}")" = "$version" ] || { echo "golangci-lint version is not $version"; exit 1; }'
+        entry: bash -c 'version="1.60.3"; [ "$(golangci-lint --version | awk "/version/ {print \$4}")" = "$version" ] || { echo "golangci-lint version is not $version"; exit 1; }'
         language: system
         always_run: true
         fail_fast: true
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: check-kubeconform-version
         name: kubeconform version check
-        entry: sh -c 'version="0.6.7"; [ "$(kubeconform -v | awk -F"v" "{print \$2}")" = "$version" ] || { echo "kubeconform version is not $version"; exit 1; }'
+        entry: bash -c 'version="0.6.7"; [ "$(kubeconform -v | awk -F"v" "{print \$2}")" = "$version" ] || { echo "kubeconform version is not $version"; exit 1; }'
         language: system
         always_run: true
         fail_fast: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: check-golangci-lint-version
         name: golangci-lint version check
-        entry: bash -c 'version="1.60.3"; [ "$(golangci-lint --version | grep -oP "(?<=version )[\d\.]+")" = "$version" ] || { echo "golangci-lint version is not $version"; exit 1; }'
+        entry: sh -c 'version="1.60.3"; [ "$(golangci-lint --version | awk "/version/ {print \$4}")" = "$version" ] || { echo "golangci-lint version is not $version"; exit 1; }'
         language: system
         always_run: true
         fail_fast: true
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: check-kubeconform-version
         name: kubeconform version check
-        entry: bash -c 'version="0.6.7"; [ "$(kubeconform -v | grep -oP "(?<=v)[\d\.]+")" = "$version" ] || { echo "kubeconform version is not $version"; exit 1; }'
+        entry: sh -c 'version="0.6.7"; [ "$(kubeconform -v | awk -F"v" "{print \$2}")" = "$version" ] || { echo "kubeconform version is not $version"; exit 1; }'
         language: system
         always_run: true
         fail_fast: true


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- The current pre-commit configuration uses `grep -oP`, which is a feature specific to GNU grep. This option is not supported on BSD systems (such as macOS), causing potential compatibility issues.
- To address this, we need to replace these grep commands with a more universal alternative like awk, ensuring the hooks work consistently across different Unix-like operating systems.

### Example
<img width="637" alt="image" src="https://github.com/user-attachments/assets/48f0454e-7423-4778-9b9d-18333fcaca76">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
