### PR TITLE
[RayService][Refactor] Avoid flooding Kubernetes events

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -193,8 +193,7 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	}
 
 	if !isReady {
-		logger.Info("Ray Serve applications are not ready to serve requests", "requeue_duration", ServiceDefaultRequeueDuration.String())
-		r.Recorder.Eventf(rayServiceInstance, "Normal", "ServiceNotReady", "The service is not ready yet. Controller will perform a round of actions in %s.", ServiceDefaultRequeueDuration)
+		logger.Info("Ray Serve applications are not ready to serve requests")
 		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
 	}
 
@@ -1124,9 +1123,6 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 			err = r.updateState(ctx, rayServiceInstance, rayv1.WaitForServeDeploymentReady, err)
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, false, err
 		}
-
-		r.Recorder.Eventf(rayServiceInstance, "Normal", "SubmittedServeDeployment",
-			"Controller sent API request to update Serve deployments on cluster %s", rayClusterInstance.Name)
 	}
 
 	var isReady bool
@@ -1140,7 +1136,6 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 	if isReady {
 		rayServiceInstance.Status.ServiceStatus = rayv1.Running
 		r.updateRayClusterInfo(ctx, rayServiceInstance, rayClusterInstance.Name)
-		r.Recorder.Event(rayServiceInstance, "Normal", "Running", "The Serve application is now running and healthy.")
 	} else {
 		rayServiceInstance.Status.ServiceStatus = rayv1.WaitForServeDeploymentReady
 		if err := r.Status().Update(ctx, rayServiceInstance); err != nil {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We only file events for the following two cases:

1. Interactions with the Kubernetes API server: For example, successfully creating Pods or creation failures.
2. Spec/Status validation failures.

However, before this PR, each reconciliation of a RayService CR would create at least one event in most cases. Although `EventCorrelator` has a rate limit and aggregates events to prevent scalability issues, it can introduce a significant delay in filing events to the Kubernetes API server if KubeRay manages multiple RayService CRs.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/7ca67a9e-eda5-4d54-b717-15a11c8bfcef">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
