### PR TITLE
remove autoscaler's permission of patch pods

### DIFF
--- a/ray-operator/controllers/ray/common/rbac.go
+++ b/ray-operator/controllers/ray/common/rbac.go
@@ -42,7 +42,7 @@ func BuildRole(cluster *rayv1.RayCluster) (*rbacv1.Role, error) {
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list", "watch", "patch"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{"ray.io"},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Currently the autoscaler only need to patch rayCluster for scaling up and down. 
So it is better to remove the permission of patch pods, which is a useless permission.
We created a rayCluster with autoscaler, and after testing we found removing the permission will not affect the behavior of the autoscaler.

<!-- Please give a short summary of the change and the problem this solves. -->

#2551

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
