### PR TITLE
feat: support default function for containerEnv on additionalWorkerGroups in ray-cluster helm chart

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -169,7 +169,7 @@ spec:
             resources: {{- toYaml $values.resources | nindent 14 }}
             securityContext:
             {{- toYaml $values.securityContext | nindent 14 }}
-            {{- with concat $.Values.common.containerEnv $values.containerEnv }}
+            {{- with concat $.Values.common.containerEnv ($values.containerEnv | default list) }}
             env:
             {{- toYaml . | nindent 14 }}
             {{- end }}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Make the deployment of ray-cluster helm chart with containerEnv not being specified easier using Terraform.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #2569

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
