### PR TITLE
[RayJob][Refactor] use `ray job status` and `ray jog lobs` to be tolerant of duplicated job submissions

### DIFF
--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -119,6 +119,8 @@ func GetK8sJobCommand(rayJobInstance *rayv1.RayJob) ([]string, error) {
 	}
 	k8sJobCommand = append(k8sJobCommand, commandSlice...)
 
+	k8sJobCommand = append(k8sJobCommand, "2>&1", "|", "grep", "-zv", "'Please use a different submission_id'")
+
 	k8sJobCommand = append(k8sJobCommand, ";", "ray", "job", "logs", "--address", address, "--follow", jobId)
 
 	return k8sJobCommand, nil

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -88,6 +88,7 @@ func TestGetK8sJobCommand(t *testing.T) {
 		"--no-wait",
 		"--",
 		"echo", "hello",
+		"2>&1", "|", "grep", "-zv", "'Please use a different submission_id'",
 		";",
 		"ray", "job", "logs", "--address", "http://127.0.0.1:8265", "--follow", "testJobId",
 	}
@@ -124,6 +125,7 @@ pip: ["python-multipart==0.0.6"]
 		"--no-wait",
 		"--",
 		"echo", "hello",
+		"2>&1", "|", "grep", "-zv", "'Please use a different submission_id'",
 		";",
 		"ray", "job", "logs", "--address", "http://127.0.0.1:8265", "--follow", "testJobId",
 	}

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -471,7 +471,8 @@ func (r *RayJobReconciler) getSubmitterTemplate(ctx context.Context, rayJobInsta
 		if err != nil {
 			return corev1.PodTemplateSpec{}, err
 		}
-		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = k8sJobCommand
+		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/sh"}
+		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args = []string{"-c", strings.Join(k8sJobCommand, " ")}
 		logger.Info("No command is specified in the user-provided template. Default command is used", "command", k8sJobCommand)
 	} else {
 		logger.Info("User-provided command is used", "command", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -167,13 +167,13 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	submitterTemplate, err = r.getSubmitterTemplate(ctx, rayJobInstanceWithTemplate, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"/bin/sh"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	assert.Equal(t, []string{"-c", "ray job submit --address http://test-url --submission-id test-job-id --no-wait -- echo hello world ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
+	assert.Equal(t, []string{"-c", "ray job submit --address http://test-url --submission-id test-job-id --no-wait -- echo hello world 2>&1 | grep -zv 'Please use a different submission_id' ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 
 	// Test 3: User did not provide template, should use the image of the Ray Head
 	submitterTemplate, err = r.getSubmitterTemplate(ctx, rayJobInstanceWithoutTemplate, rayClusterInstance)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"/bin/sh"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	assert.Equal(t, []string{"-c", "ray job submit --address http://test-url --submission-id test-job-id --no-wait -- echo hello world ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
+	assert.Equal(t, []string{"-c", "ray job submit --address http://test-url --submission-id test-job-id --no-wait -- echo hello world 2>&1 | grep -zv 'Please use a different submission_id' ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 	assert.Equal(t, "rayproject/ray:custom-version", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Image)
 
 	// Test 4: Check default PYTHONUNBUFFERED setting

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -167,13 +167,13 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	submitterTemplate, err = r.getSubmitterTemplate(ctx, rayJobInstanceWithTemplate, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"/bin/sh"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	assert.Equal(t, []string{"-c", "ray job submit --address http://test-url --submission-id test-job-id --no-wait -- echo hello world 2>&1 | grep -zv 'Please use a different submission_id' ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
+	assert.Equal(t, []string{"-c", "if ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job logs --address http://test-url --follow test-job-id ; else ray job submit --address http://test-url --submission-id test-job-id -- echo hello world ; fi"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 
 	// Test 3: User did not provide template, should use the image of the Ray Head
 	submitterTemplate, err = r.getSubmitterTemplate(ctx, rayJobInstanceWithoutTemplate, rayClusterInstance)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"/bin/sh"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	assert.Equal(t, []string{"-c", "ray job submit --address http://test-url --submission-id test-job-id --no-wait -- echo hello world 2>&1 | grep -zv 'Please use a different submission_id' ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
+	assert.Equal(t, []string{"-c", "if ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job logs --address http://test-url --follow test-job-id ; else ray job submit --address http://test-url --submission-id test-job-id -- echo hello world ; fi"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 	assert.Equal(t, "rayproject/ray:custom-version", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Image)
 
 	// Test 4: Check default PYTHONUNBUFFERED setting

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -166,12 +166,14 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	rayJobInstanceWithTemplate.Spec.SubmitterPodTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{}
 	submitterTemplate, err = r.getSubmitterTemplate(ctx, rayJobInstanceWithTemplate, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"ray", "job", "submit", "--address", "http://test-url", "--submission-id", "test-job-id", "--", "echo", "hello", "world"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
+	assert.Equal(t, []string{"/bin/sh"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
+	assert.Equal(t, []string{"-c", "ray job submit --address http://test-url --submission-id test-job-id --no-wait -- echo hello world ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 
 	// Test 3: User did not provide template, should use the image of the Ray Head
 	submitterTemplate, err = r.getSubmitterTemplate(ctx, rayJobInstanceWithoutTemplate, rayClusterInstance)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"ray", "job", "submit", "--address", "http://test-url", "--submission-id", "test-job-id", "--", "echo", "hello", "world"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
+	assert.Equal(t, []string{"/bin/sh"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
+	assert.Equal(t, []string{"-c", "ray job submit --address http://test-url --submission-id test-job-id --no-wait -- echo hello world ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 	assert.Equal(t, "rayproject/ray:custom-version", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Image)
 
 	// Test 4: Check default PYTHONUNBUFFERED setting


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Use `ray job submit --no-wait + ray job logs --follow` to be tolerant of duplicated job submissions.

In summary, we can use this shell script to submit to workaround duplicated submissions issue:

```sh
ray job submit --address http://test-url --submission-id test-job-id --no-wait -- echo hello world 2>&1 | grep -zv 'Please use a different submission_id';
ray job logs --address http://test-url --follow test-job-id
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
