### PR TITLE
[Feature] Add ManagedBy field to RayCluster

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -113,6 +113,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `suspend` _boolean_ | Suspend indicates whether a RayCluster should be suspended.<br />A suspended RayCluster will have head pods and worker pods deleted. |  |  |
+| `managedBy` _string_ | ManagedBy is an optional configuration for the controller or entity that manages a RayCluster.<br />The value must be either 'ray.io/kuberay-operator' or 'kueue.x-k8s.io/multikueue'.<br />The kuberay-operator reconciles a RayCluster which doesn't have this field at all or<br />the field value is the reserved string 'ray.io/kuberay-operator',<br />but delegates reconciling the RayCluster with 'kueue.x-k8s.io/multikueue' to the Kueue.<br />The field is immutable. |  |  |
 | `autoscalerOptions` _[AutoscalerOptions](#autoscaleroptions)_ | AutoscalerOptions specifies optional configuration for the Ray autoscaler. |  |  |
 | `headServiceAnnotations` _object (keys:string, values:string)_ |  |  |  |
 | `enableInTreeAutoscaling` _boolean_ | EnableInTreeAutoscaling indicates whether operator should create in tree autoscaling configs |  |  |

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -4107,6 +4107,14 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              managedBy:
+                type: string
+                x-kubernetes-validations:
+                - message: the managedBy field is immutable
+                  rule: self == oldSelf
+                - message: the managedBy field value must be either 'ray.io/kuberay-operator'
+                    or 'kueue.x-k8s.io/multikueue'
+                  rule: self in ['ray.io/kuberay-operator', 'kueue.x-k8s.io/multikueue']
               rayVersion:
                 type: string
               suspend:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -4127,6 +4127,14 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  managedBy:
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the managedBy field is immutable
+                      rule: self == oldSelf
+                    - message: the managedBy field value must be either 'ray.io/kuberay-operator'
+                        or 'kueue.x-k8s.io/multikueue'
+                      rule: self in ['ray.io/kuberay-operator', 'kueue.x-k8s.io/multikueue']
                   rayVersion:
                     type: string
                   suspend:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -4085,6 +4085,14 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  managedBy:
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the managedBy field is immutable
+                      rule: self == oldSelf
+                    - message: the managedBy field value must be either 'ray.io/kuberay-operator'
+                        or 'kueue.x-k8s.io/multikueue'
+                      rule: self in ['ray.io/kuberay-operator', 'kueue.x-k8s.io/multikueue']
                   rayVersion:
                     type: string
                   suspend:

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -14,6 +14,15 @@ type RayClusterSpec struct {
 	// Suspend indicates whether a RayCluster should be suspended.
 	// A suspended RayCluster will have head pods and worker pods deleted.
 	Suspend *bool `json:"suspend,omitempty"`
+	// ManagedBy is an optional configuration for the controller or entity that manages a RayCluster.
+	// The value must be either 'ray.io/kuberay-operator' or 'kueue.x-k8s.io/multikueue'.
+	// The kuberay-operator reconciles a RayCluster which doesn't have this field at all or
+	// the field value is the reserved string 'ray.io/kuberay-operator',
+	// but delegates reconciling the RayCluster with 'kueue.x-k8s.io/multikueue' to the Kueue.
+	// The field is immutable.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="the managedBy field is immutable"
+	// +kubebuilder:validation:XValidation:rule="self in ['ray.io/kuberay-operator', 'kueue.x-k8s.io/multikueue']",message="the managedBy field value must be either 'ray.io/kuberay-operator' or 'kueue.x-k8s.io/multikueue'"
+	ManagedBy *string `json:"managedBy,omitempty"`
 	// AutoscalerOptions specifies optional configuration for the Ray autoscaler.
 	AutoscalerOptions      *AutoscalerOptions `json:"autoscalerOptions,omitempty"`
 	HeadServiceAnnotations map[string]string  `json:"headServiceAnnotations,omitempty"`

--- a/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
@@ -217,6 +217,11 @@ func (in *RayClusterSpec) DeepCopyInto(out *RayClusterSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ManagedBy != nil {
+		in, out := &in.ManagedBy, &out.ManagedBy
+		*out = new(string)
+		**out = **in
+	}
 	if in.AutoscalerOptions != nil {
 		in, out := &in.AutoscalerOptions, &out.AutoscalerOptions
 		*out = new(AutoscalerOptions)

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -4107,6 +4107,14 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              managedBy:
+                type: string
+                x-kubernetes-validations:
+                - message: the managedBy field is immutable
+                  rule: self == oldSelf
+                - message: the managedBy field value must be either 'ray.io/kuberay-operator'
+                    or 'kueue.x-k8s.io/multikueue'
+                  rule: self in ['ray.io/kuberay-operator', 'kueue.x-k8s.io/multikueue']
               rayVersion:
                 type: string
               suspend:

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -4127,6 +4127,14 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  managedBy:
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the managedBy field is immutable
+                      rule: self == oldSelf
+                    - message: the managedBy field value must be either 'ray.io/kuberay-operator'
+                        or 'kueue.x-k8s.io/multikueue'
+                      rule: self in ['ray.io/kuberay-operator', 'kueue.x-k8s.io/multikueue']
                   rayVersion:
                     type: string
                   suspend:

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -4085,6 +4085,14 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  managedBy:
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the managedBy field is immutable
+                      rule: self == oldSelf
+                    - message: the managedBy field value must be either 'ray.io/kuberay-operator'
+                        or 'kueue.x-k8s.io/multikueue'
+                      rule: self in ['ray.io/kuberay-operator', 'kueue.x-k8s.io/multikueue']
                   rayVersion:
                     type: string
                   suspend:

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -226,6 +226,11 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 	var reconcileErr error
 	logger := ctrl.LoggerFrom(ctx)
 
+	if manager := utils.ManagedByExternalController(instance.Spec.ManagedBy); manager != nil {
+		logger.Info("Skipping RayCluster managed by a custom controller", "managed-by", manager)
+		return ctrl.Result{}, nil
+	}
+
 	if err := r.validateRayClusterStatus(instance); err != nil {
 		logger.Error(err, "The RayCluster status is invalid")
 		r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.InvalidRayClusterStatus),

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayclusterspec.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayclusterspec.go
@@ -6,6 +6,7 @@ package v1
 // with apply.
 type RayClusterSpecApplyConfiguration struct {
 	Suspend                 *bool                                `json:"suspend,omitempty"`
+	ManagedBy               *string                              `json:"managedBy,omitempty"`
 	AutoscalerOptions       *AutoscalerOptionsApplyConfiguration `json:"autoscalerOptions,omitempty"`
 	HeadServiceAnnotations  map[string]string                    `json:"headServiceAnnotations,omitempty"`
 	EnableInTreeAutoscaling *bool                                `json:"enableInTreeAutoscaling,omitempty"`
@@ -25,6 +26,14 @@ func RayClusterSpec() *RayClusterSpecApplyConfiguration {
 // If called multiple times, the Suspend field is set to the value of the last call.
 func (b *RayClusterSpecApplyConfiguration) WithSuspend(value bool) *RayClusterSpecApplyConfiguration {
 	b.Suspend = &value
+	return b
+}
+
+// WithManagedBy sets the ManagedBy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ManagedBy field is set to the value of the last call.
+func (b *RayClusterSpecApplyConfiguration) WithManagedBy(value string) *RayClusterSpecApplyConfiguration {
+	b.ManagedBy = &value
 	return b
 }
 

--- a/ray-operator/test/e2e/raycluster_test.go
+++ b/ray-operator/test/e2e/raycluster_test.go
@@ -1,0 +1,78 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
+	. "github.com/ray-project/kuberay/ray-operator/test/support"
+)
+
+func TestRayClusterManagedBy(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+
+	// Create a namespace
+	namespace := test.NewTestNamespace()
+	test.StreamKubeRayOperatorLogs()
+
+	test.T().Run("Successful creation of cluster, managed by Kuberay Operator", func(t *testing.T) {
+		t.Parallel()
+
+		rayClusterAC := rayv1ac.RayCluster("raycluster-ok", namespace.Name).
+			WithSpec(newRayClusterSpec().
+				WithManagedBy(utils.KubeRayController))
+
+		rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+		test.T().Logf("Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
+	})
+
+	test.T().Run("Creation of cluster skipped, managed by Kueue", func(t *testing.T) {
+		t.Parallel()
+
+		rayClusterAC := rayv1ac.RayCluster("raycluster-skip", namespace.Name).
+			WithSpec(newRayClusterSpec().
+				WithManagedBy("kueue.x-k8s.io/multikueue"))
+
+		rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		test.T().Logf("Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+		test.T().Logf("RayCluster %s/%s will not become ready - not reconciled", rayCluster.Namespace, rayCluster.Name)
+		g.Consistently(func(gg Gomega) {
+			rc, err := RayCluster(test, rayCluster.Namespace, rayCluster.Name)()
+			gg.Expect(err).NotTo(HaveOccurred())
+			gg.Expect(rc.Status.Conditions).To(BeEmpty())
+		}, time.Second*3, time.Millisecond*500).Should(Succeed())
+
+		// Should not to be able to change managedBy field as it's immutable
+		rayClusterAC.Spec.WithManagedBy(utils.KubeRayController)
+		rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).To(HaveOccurred())
+		g.Eventually(RayCluster(test, *rayClusterAC.Namespace, *rayClusterAC.Name)).
+			Should(WithTransform(RayClusterManagedBy, Equal(ptr.To("kueue.x-k8s.io/multikueue"))))
+	})
+
+	test.T().Run("Failed creation of cluster, managed by external non supported controller", func(t *testing.T) {
+		t.Parallel()
+
+		rayClusterAC := rayv1ac.RayCluster("raycluster-fail", namespace.Name).
+			WithSpec(newRayClusterSpec().
+				WithManagedBy("controller.com/not-supported"))
+
+		_, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(errors.IsInvalid(err)).To(BeTrue(), "error: %v", err)
+	})
+}

--- a/ray-operator/test/e2e/rayjob_cluster_selector_test.go
+++ b/ray-operator/test/e2e/rayjob_cluster_selector_test.go
@@ -103,7 +103,7 @@ env_vars:
   counter_name: test_counter
 `).
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()).
-				WithManagedBy(MultiKueueController))
+				WithManagedBy("kueue.x-k8s.io/multikueue"))
 
 		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())

--- a/ray-operator/test/e2e/rayjob_test.go
+++ b/ray-operator/test/e2e/rayjob_test.go
@@ -260,7 +260,7 @@ env_vars:
 `).
 				WithShutdownAfterJobFinishes(true).
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()).
-				WithManagedBy(MultiKueueController))
+				WithManagedBy("kueue.x-k8s.io/multikueue"))
 
 		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -271,7 +271,7 @@ env_vars:
 		_, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).To(HaveOccurred())
 		g.Eventually(RayJob(test, *rayJobAC.Namespace, *rayJobAC.Name)).
-			Should(WithTransform(RayJobManagedBy, Equal(ptr.To(MultiKueueController))))
+			Should(WithTransform(RayJobManagedBy, Equal(ptr.To("kueue.x-k8s.io/multikueue"))))
 
 		// Refresh the RayJob status and assert it has not been updated
 		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -132,6 +132,10 @@ func GetGroupPods(t Test, rayCluster *rayv1.RayCluster, group string) []corev1.P
 	return pods.Items
 }
 
+func RayClusterManagedBy(rayCluster *rayv1.RayCluster) *string {
+	return rayCluster.Spec.ManagedBy
+}
+
 func GetRayService(t Test, namespace, name string) (*rayv1.RayService, error) {
 	return t.Client().Ray().RayV1().RayServices(namespace).Get(t.Ctx(), name, metav1.GetOptions{})
 }

--- a/ray-operator/test/support/utils.go
+++ b/ray-operator/test/support/utils.go
@@ -16,8 +16,6 @@ type OutputType string
 
 const (
 	Log OutputType = "log"
-	// MultiKueueController represents the vaue of the MultiKueue controller
-	MultiKueueController = "kueue.x-k8s.io/multikueue"
 )
 
 func WriteToOutputDir(t Test, fileName string, fileType OutputType, data []byte) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As stated in https://github.com/ray-project/kuberay/issues/2544.
It allows for integration with [MultiKueue](https://kueue.sigs.k8s.io/docs/tasks/manage/setup_multikueue/) (multi-cluster Kueue), in specific it provides:
* simpler installation, otherwise only installation of RayCluster CRDs is required
* support for mixed setup in one cluster - some RayCluster instances could be run by MultiKueue and some by the default operator

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Relates to #2544 
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
