### PR TITLE
[no-op] Avoid implicit package import

### DIFF
--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -3,7 +3,7 @@ package e2eautoscaler
 import (
 	"testing"
 
-	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
@@ -13,7 +13,7 @@ import (
 
 func TestRayClusterAutoscaler(t *testing.T) {
 	test := With(t)
-	g := NewWithT(t)
+	g := gomega.NewWithT(t)
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
@@ -22,7 +22,7 @@ func TestRayClusterAutoscaler(t *testing.T) {
 	// Scripts for creating and terminating detached actors to trigger autoscaling
 	scriptsAC := newConfigMap(namespace.Name, "scripts", files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
 	scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 	test.T().Logf("Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
 	test.T().Run("Create a RayCluster with autoscaling enabled", func(_ *testing.T) {
@@ -43,43 +43,43 @@ func TestRayClusterAutoscaler(t *testing.T) {
 			WithSpec(apply(rayClusterSpecAC, mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](scripts, "/home/ray/test_scripts")))
 
 		rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
-		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(err).NotTo(gomega.HaveOccurred())
 		test.T().Logf("Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
 
 		// Wait for RayCluster to become ready and verify the number of available worker replicas.
 		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-			Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
-		g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(WithTransform(RayClusterDesiredWorkerReplicas, Equal(int32(0))))
+			Should(gomega.WithTransform(RayClusterState, gomega.Equal(rayv1.Ready)))
+		g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
 
 		headPod, err := GetHeadPod(test, rayCluster)
-		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(err).NotTo(gomega.HaveOccurred())
 		test.T().Logf("Found head pod %s/%s", headPod.Namespace, headPod.Name)
 
 		// Create a detached actor, and a worker should be created.
 		ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/create_detached_actor.py", "actor1"})
 		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-			Should(WithTransform(RayClusterDesiredWorkerReplicas, Equal(int32(1))))
+			Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(1))))
 
 		// Create a detached actor, and a worker should be created.
 		ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/create_detached_actor.py", "actor2"})
 		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-			Should(WithTransform(RayClusterDesiredWorkerReplicas, Equal(int32(2))))
+			Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(2))))
 
 		// Terminate a detached actor, and a worker should be deleted.
 		ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/terminate_detached_actor.py", "actor1"})
 		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-			Should(WithTransform(RayClusterDesiredWorkerReplicas, Equal(int32(1))))
+			Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(1))))
 
 		// Terminate a detached actor, and a worker should be deleted.
 		ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/terminate_detached_actor.py", "actor2"})
 		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-			Should(WithTransform(RayClusterDesiredWorkerReplicas, Equal(int32(0))))
+			Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
 	})
 }
 
 func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
 	test := With(t)
-	g := NewWithT(t)
+	g := gomega.NewWithT(t)
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
@@ -88,7 +88,7 @@ func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
 	// Scripts for creating and terminating detached actors to trigger autoscaling
 	scriptsAC := newConfigMap(namespace.Name, "scripts", files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
 	scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 	test.T().Logf("Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
 	test.T().Run("Create a RayCluster with autoscaling enabled", func(_ *testing.T) {
@@ -109,36 +109,36 @@ func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
 			WithSpec(apply(rayClusterSpecAC, mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](scripts, "/home/ray/test_scripts")))
 
 		rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
-		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(err).NotTo(gomega.HaveOccurred())
 		test.T().Logf("Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
 
 		// Wait for RayCluster to become ready and verify the number of available worker replicas.
 		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-			Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
-		g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(WithTransform(RayClusterDesiredWorkerReplicas, Equal(int32(0))))
+			Should(gomega.WithTransform(RayClusterState, gomega.Equal(rayv1.Ready)))
+		g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
 
 		headPod, err := GetHeadPod(test, rayCluster)
-		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(err).NotTo(gomega.HaveOccurred())
 		test.T().Logf("Found head pod %s/%s", headPod.Namespace, headPod.Name)
 
 		// Create a detached gpu actor, and a worker in the "gpu-group" should be created.
 		ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/create_detached_actor.py", "gpu_actor", "--num-gpus=1"})
 		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-			Should(WithTransform(RayClusterDesiredWorkerReplicas, Equal(int32(1))))
+			Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(1))))
 		// We don't use real GPU resources of Kubernetes here, therefore we can't test the RayClusterDesiredGPU.
 		// We test the Pods count of the "gpu-group" instead.
-		g.Expect(GetGroupPods(test, rayCluster, "gpu-group")).To(HaveLen(1))
+		g.Expect(GetGroupPods(test, rayCluster, "gpu-group")).To(gomega.HaveLen(1))
 
 		// Terminate the gpu detached actor, and the worker should be deleted.
 		ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/terminate_detached_actor.py", "gpu_actor"})
 		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-			Should(WithTransform(RayClusterDesiredWorkerReplicas, Equal(int32(0))))
+			Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
 	})
 }
 
 func TestRayClusterAutoscalerWithCustomResource(t *testing.T) {
 	test := With(t)
-	g := NewWithT(t)
+	g := gomega.NewWithT(t)
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
@@ -147,7 +147,7 @@ func TestRayClusterAutoscalerWithCustomResource(t *testing.T) {
 	// Scripts for creating and terminating detached actors to trigger autoscaling
 	scriptsAC := newConfigMap(namespace.Name, "scripts", files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
 	scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 	test.T().Logf("Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
 	test.T().Run("Create a RayCluster with autoscaling enabled", func(_ *testing.T) {
@@ -170,27 +170,27 @@ func TestRayClusterAutoscalerWithCustomResource(t *testing.T) {
 			WithSpec(apply(rayClusterSpecAC, mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](scripts, "/home/ray/test_scripts")))
 
 		rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
-		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(err).NotTo(gomega.HaveOccurred())
 		test.T().Logf("Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
 
 		// Wait for RayCluster to become ready and verify the number of available worker replicas.
 		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-			Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
-		g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(WithTransform(RayClusterDesiredWorkerReplicas, Equal(int32(0))))
+			Should(gomega.WithTransform(RayClusterState, gomega.Equal(rayv1.Ready)))
+		g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
 
 		headPod, err := GetHeadPod(test, rayCluster)
-		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(err).NotTo(gomega.HaveOccurred())
 		test.T().Logf("Found head pod %s/%s", headPod.Namespace, headPod.Name)
 
 		// Create a detached custom resource actor, and a worker in the "custom-resource-group" should be created.
 		ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/create_detached_actor.py", "custom_resource_actor", "--num-custom-resources=1"})
 		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-			Should(WithTransform(RayClusterDesiredWorkerReplicas, Equal(int32(1))))
-		g.Expect(GetGroupPods(test, rayCluster, groupName)).To(HaveLen(1))
+			Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(1))))
+		g.Expect(GetGroupPods(test, rayCluster, groupName)).To(gomega.HaveLen(1))
 
 		// Terminate the custom resource detached actor, and the worker should be deleted.
 		ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/terminate_detached_actor.py", "custom_resource_actor"})
 		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-			Should(WithTransform(RayClusterDesiredWorkerReplicas, Equal(int32(0))))
+			Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
 	})
 }


### PR DESCRIPTION
Currently we're importing several external packages into the current package, which is not a good practice since it's mixing a bunch of symbols together into one "namespace" (similar to `using namespace` in C++).