### PR TITLE
[Docs] add sample RayCluster with FluentBit sidecar to persist Ray logs

### DIFF
--- a/ray-operator/config/samples/ray-cluster-fluentbit-sidecar.yaml
+++ b/ray-operator/config/samples/ray-cluster-fluentbit-sidecar.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentbit-config
+data:
+  fluent-bit.conf: |
+    [INPUT]
+        Name tail
+        Path /tmp/ray/session_latest/logs/*
+        Tag ray
+        Path_Key true
+        Refresh_Interval 5
+    [FILTER]
+        Name modify
+        Match ray
+        Add POD_LABELS ${POD_LABELS}
+    [OUTPUT]
+        Name loki
+        Match *
+        Host loki-gateway
+        Port 80
+        Labels RayCluster=${POD_LABELS}
+        tenant_id test
+---
+# RayCluster CR with a FluentBit sidecar
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: raycluster-fluentbit-sidecar-logs
+spec:
+  rayVersion: '2.9.0'
+  headGroupSpec:
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.9.0
+          # This config is meant for demonstration purposes only.
+          # Use larger Ray containers in production!
+          resources:
+            limits:
+              cpu: 1
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 1Gi
+          # Share logs with Fluent Bit
+          volumeMounts:
+          - mountPath: /tmp/ray
+            name: ray-logs
+        # Fluent Bit sidecar
+        - name: fluentbit
+          image: fluent/fluent-bit:3.2.2
+          # Get Kubernetes metadata via downward API
+          env:
+          - name: POD_LABELS
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['ray.io/cluster']
+          # These resource requests for Fluent Bit should be sufficient in production.
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+          - mountPath: /tmp/ray
+            name: ray-logs
+          - mountPath: /fluent-bit/etc/fluent-bit.conf
+            subPath: fluent-bit.conf
+            name: fluentbit-config
+        # Log and config volumes
+        volumes:
+        - name: ray-logs
+          emptyDir: {}
+        - name: fluentbit-config
+          configMap:
+            name: fluentbit-config


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Adds an example RayCluster with Fluent-Bit sidecar mode to persist Ray logs. and reference the YAML in this [PR](https://github.com/ray-project/ray/pull/49038).

Using [downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/) to get kubernetes metadata.
```yaml
        - name: fluentbit
          image: fluent/fluent-bit:3.2.2
          # Get Kubernetes metadata via downward API
          env:
          - name: POD_LABELS
            valueFrom:
              fieldRef:
                fieldPath: metadata.labels['ray.io/cluster']
```

![image](https://github.com/user-attachments/assets/64e06277-1d8e-4e84-ac05-c0631a07979b)



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/pull/49038


<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
