### PR TITLE
[Doc] Fix RayCluster auth sample to include --config-file in kube-rbac-proxy

### DIFF
--- a/ray-operator/config/samples/ray-cluster.auth.yaml
+++ b/ray-operator/config/samples/ray-cluster.auth.yaml
@@ -8,7 +8,8 @@ data:
     authorization:
       resourceAttributes:
         namespace: default
-        apiVersion: ray.io/v1
+        apiVersion: v1
+        apiGroup: ray.io
         resource: rayclusters
         name: ray-cluster-with-auth
 ---
@@ -105,6 +106,7 @@ spec:
           args:
             - "--insecure-listen-address=0.0.0.0:8265"
             - "--upstream=http://127.0.0.1:8443/"
+            - "--config-file=/etc/kube-rbac-proxy/config-file.yaml"
             - "--logtostderr=true"
           volumeMounts:
           - name: config


### PR DESCRIPTION
## Why are these changes needed?

Forgot to include --config-file in kube-rbac-proxy and fix apiGroup and apiVersion in kube-rbac-proxy config file

## Related issue number

N/A

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
