### PR TITLE
[Bug] TestRayServiceInPlaceUpdate is flaky

### DIFF
--- a/.github/workflows/e2e-tests-reusable-workflow.yaml
+++ b/.github/workflows/e2e-tests-reusable-workflow.yaml
@@ -74,7 +74,7 @@ jobs:
 
             set -euo pipefail
             cd ${{ inputs.dir-to-test }}
-            go test -timeout 30m -v ./test/e2e -json 2>&1 | tee ${KUBERAY_TEST_OUTPUT_DIR}/gotest.log | gotestfmt
+            go test -timeout 60m -v ./test/e2e -json 2>&1 | tee ${KUBERAY_TEST_OUTPUT_DIR}/gotest.log | gotestfmt
 
         - name: Print KubeRay operator logs
           if: (!inputs.plugin-test) && always() && steps.deploy.outcome == 'success'

--- a/ray-operator/test/e2e/rayservice_in_place_update_test.go
+++ b/ray-operator/test/e2e/rayservice_in_place_update_test.go
@@ -52,12 +52,14 @@ func TestRayServiceInPlaceUpdate(t *testing.T) {
 	}, TestTimeoutShort).Should(WithTransform(sampleyaml.IsPodRunningAndReady, BeTrue()))
 
 	// test the default curl result
-	// curl /fruit
-	stdout, _ := curlRayServicePod(test, rayService, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)
-	g.Expect(stdout.String()).To(Equal("6"))
-	// curl /calc
-	stdout, _ = curlRayServicePod(test, rayService, curlPod, curlContainerName, "/calc", `["MUL", 3]`)
-	g.Expect(stdout.String()).To(Equal("15 pizzas please!"))
+	g.Eventually(func(g Gomega) {
+		// curl /fruit
+		stdout, _ := curlRayServicePod(test, rayService, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)
+		g.Expect(stdout.String()).To(Equal("6"))
+		// curl /calc
+		stdout, _ = curlRayServicePod(test, rayService, curlPod, curlContainerName, "/calc", `["MUL", 3]`)
+		g.Expect(stdout.String()).To(Equal("15 pizzas please!"))
+	}, TestTimeoutShort).Should(Succeed())
 
 	// In-place update
 	// Parse ServeConfigV2 and replace the string in the simplest way to update it.
@@ -79,7 +81,7 @@ func TestRayServiceInPlaceUpdate(t *testing.T) {
 	// Test the new price and factor
 	g.Eventually(func(g Gomega) {
 		// curl /fruit
-		stdout, _ = curlRayServicePod(test, rayService, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)
+		stdout, _ := curlRayServicePod(test, rayService, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)
 		g.Expect(stdout.String()).To(Equal("8"))
 		// curl /calc
 		stdout, _ = curlRayServicePod(test, rayService, curlPod, curlContainerName, "/calc", `["MUL", 3]`)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. Increase the timeout from 30m to 60m because the time for a normal run needs around 27 ~ 30m. We should divide these tests into different runners in the future.

2. Add `Eventually` to check the request's response. The reason is that Ray Serve initially launches with its [default values](https://github.com/ray-project/test_dag/blob/4d2c9a59d9eabfd4c8a9e04a7aae44fc8f5b416f/conditional_dag.py#L36-L48), which are then overwritten by [serveConfigV2](https://github.com/ray-project/kuberay/blob/master/ray-operator/test/e2e/support.go#L237).

## Related issue number

Closes #2617 

## Checks

I ran `TestRayServiceInPlaceUpdate` three times for https://github.com/ray-project/kuberay/pull/2611. It failed the first two times. Additionally, the test failed three times in https://github.com/ray-project/kuberay/pull/2588. Hence, the tests failed 5 times out of 6 runs.

I triggered this PR's CI three times, and all runs passed.

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
