### PR TITLE
Add a util function to convert string and bytes array

### DIFF
--- a/ray-operator/pkg/utils/string_conversion.go
+++ b/ray-operator/pkg/utils/string_conversion.go
@@ -5,7 +5,7 @@
 //
 // func f() {
 //   s := "helloworld"
-//   TakeByteSlice(ConvertStringToByteArray(s))  // convert string to byte slice with zero-copy
+//   TakeByteSlice(ConvertStringToByteSlice(s))  // convert string to byte slice with zero-copy
 // }
 
 package utils
@@ -17,13 +17,13 @@ import (
 // Convert a byte array to string w/o copy.
 //
 // WARNING: The returned byte slice is not expected to change.
-func ConvertByteArrayToString(arr []byte) string {
+func ConvertByteSliceToString(arr []byte) string {
 	return unsafe.String(&arr[0], len(arr))
 }
 
 // Convert a string to byte array w/o copy.
 //
 // WARNING: The returned byte slice is not expected to change.
-func ConvertStringToByteArray(s string) (arr []byte) {
+func ConvertStringToByteSlice(s string) (arr []byte) {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }

--- a/ray-operator/pkg/utils/string_conversion.go
+++ b/ray-operator/pkg/utils/string_conversion.go
@@ -1,4 +1,12 @@
-// Util functions for type conversion between byte array and string.
+// Util functions for type conversion between byte array and string without copy.
+//
+// Example usage:
+// func TakeByteSlice(bs []byte) {...}
+//
+// func f() {
+//   s := "helloworld"
+//   TakeByteSlice(ConvertStringToByteArray(s))  // convert string to byte slice with zero-copy
+// }
 
 package utils
 
@@ -7,11 +15,15 @@ import (
 )
 
 // Convert a byte array to string w/o copy.
+//
+// WARNING: The returned byte slice is not expected to change.
 func ConvertByteArrayToString(arr []byte) string {
 	return unsafe.String(&arr[0], len(arr))
 }
 
 // Convert a string to byte array w/o copy.
+//
+// WARNING: The returned byte slice is not expected to change.
 func ConvertStringToByteArray(s string) (arr []byte) {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }

--- a/ray-operator/pkg/utils/string_conversion.go
+++ b/ray-operator/pkg/utils/string_conversion.go
@@ -16,7 +16,7 @@ import (
 
 // Convert a byte array to string w/o copy.
 //
-// WARNING: The returned byte slice is not expected to change.
+// WARNING: The input byte slice is not expected to change.
 func ConvertByteSliceToString(arr []byte) string {
 	return unsafe.String(&arr[0], len(arr))
 }

--- a/ray-operator/pkg/utils/string_conversion.go
+++ b/ray-operator/pkg/utils/string_conversion.go
@@ -1,11 +1,19 @@
 // Util functions for type conversion between byte array and string without copy.
 //
-// Example usage:
+// Example usage 1 (convert string to byte slice):
 // func TakeByteSlice(bs []byte) {...}
 //
 // func f() {
 //   s := "helloworld"
 //   TakeByteSlice(ConvertStringToByteSlice(s))  // convert string to byte slice with zero-copy
+// }
+//
+// Example usage 2 (convert byte slice to string):
+// func TakeString(s string) {...}
+//
+// func f() {
+//   bytes := []byte("helloworld")
+//   TakeByteSlice(ConvertByteSliceToString(bytes))  // convert byte slice to string with zero-copy
 // }
 
 package utils

--- a/ray-operator/pkg/utils/string_conversion.go
+++ b/ray-operator/pkg/utils/string_conversion.go
@@ -1,0 +1,17 @@
+// Util functions for type conversion between byte array and string.
+
+package utils
+
+import (
+	"unsafe"
+)
+
+// Convert a byte array to string w/o copy.
+func ConvertByteArrayToString(arr []byte) string {
+	return unsafe.String(&arr[0], len(arr))
+}
+
+// Convert a string to byte array w/o copy.
+func ConvertStringToByteArray(s string) (arr []byte) {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}

--- a/ray-operator/test/utils/string_conversion_test.go
+++ b/ray-operator/test/utils/string_conversion_test.go
@@ -2,6 +2,7 @@ package strconv
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/onsi/gomega"
 
@@ -16,8 +17,10 @@ func TestStringConversion(t *testing.T) {
 	// Test string to byte array conversion.
 	arr := utils.ConvertStringToByteSlice(str)
 	g.Expect(arr).Should(gomega.Equal([]byte(str)))
+	g.Expect(&arr[0]).Should(gomega.Equal(unsafe.StringData(str)))
 
 	// Test byte array to string conversion.
 	convStr := utils.ConvertByteSliceToString(arr)
 	g.Expect(str).Should(gomega.Equal(convStr))
+	g.Expect(unsafe.StringData(convStr)).Should(gomega.Equal(&arr[0]))
 }

--- a/ray-operator/test/utils/string_conversion_test.go
+++ b/ray-operator/test/utils/string_conversion_test.go
@@ -14,10 +14,10 @@ func TestStringConversion(t *testing.T) {
 	str := "hello world"
 
 	// Test string to byte array conversion.
-	arr := utils.ConvertStringToByteArray(str)
+	arr := utils.ConvertStringToByteSlice(str)
 	g.Expect(arr).Should(gomega.Equal([]byte(str)))
 
 	// Test byte array to string conversion.
-	convStr := utils.ConvertByteArrayToString(arr)
+	convStr := utils.ConvertByteSliceToString(arr)
 	g.Expect(str).Should(gomega.Equal(convStr))
 }

--- a/ray-operator/test/utils/string_conversion_test.go
+++ b/ray-operator/test/utils/string_conversion_test.go
@@ -1,0 +1,23 @@
+package strconv
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	utils "github.com/ray-project/kuberay/ray-operator/pkg/utils"
+)
+
+func TestStringConversion(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	str := "hello world"
+
+	// Test string to byte array conversion.
+	arr := utils.ConvertStringToByteArray(str)
+	g.Expect(arr).Should(gomega.Equal([]byte(str)))
+
+	// Test byte array to string conversion.
+	convStr := utils.ConvertByteArrayToString(arr)
+	g.Expect(str).Should(gomega.Equal(convStr))
+}


### PR DESCRIPTION
Reading through the code, I found we have several places converting between byte array and string type.
For example:
- https://github.com/ray-project/kuberay/blob/ece1d34448ee7763eea47ee5dc5f284d23f3f55a/ray-operator/controllers/ray/common/job.go#L29
- https://github.com/ray-project/kuberay/blob/ece1d34448ee7763eea47ee5dc5f284d23f3f55a/ray-operator/controllers/ray/common/job.go#L62

Add a util function to apply zero-copy strategy to these conversions.