### PR TITLE
[RayCluster][Fix] leave .Status.State untouched when there is a reconcile error

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1284,11 +1284,7 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	newInstance.Status.DesiredGPU = sumGPUs(totalResources)
 	newInstance.Status.DesiredTPU = totalResources[corev1.ResourceName("google.com/tpu")]
 
-	if reconcileErr != nil {
-		// newInstance.Status.State = rayv1.Failed <- we don't do this because rayv1.Failed has been gone since v1.2.
-		// See https://github.com/ray-project/kuberay/issues/2357 for more details.
-		newInstance.Status.Reason = reconcileErr.Error()
-	} else {
+	if reconcileErr == nil && len(runtimePods.Items) == int(newInstance.Status.DesiredWorkerReplicas)+1 { // workers + 1 head
 		if utils.CheckAllPodsRunning(ctx, runtimePods) {
 			newInstance.Status.State = rayv1.Ready //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
 			newInstance.Status.Reason = ""

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1284,8 +1284,15 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	newInstance.Status.DesiredGPU = sumGPUs(totalResources)
 	newInstance.Status.DesiredTPU = totalResources[corev1.ResourceName("google.com/tpu")]
 
-	if utils.CheckAllPodsRunning(ctx, runtimePods) {
-		newInstance.Status.State = rayv1.Ready //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	if reconcileErr != nil {
+		// newInstance.Status.State = rayv1.Failed <- we don't do this because rayv1.Failed has been gone since v1.2.
+		// See https://github.com/ray-project/kuberay/issues/2357 for more details.
+		newInstance.Status.Reason = reconcileErr.Error()
+	} else {
+		if utils.CheckAllPodsRunning(ctx, runtimePods) {
+			newInstance.Status.State = rayv1.Ready //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+			newInstance.Status.Reason = ""
+		}
 	}
 
 	// Check if the head node is running and ready by checking the head pod's status or if the cluster has been suspended.


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We accidentally set the `.State` of RayCluster CR to `rayv1.Ready` even if there was a reconcile error in PR #2258 where we removed `rayv1.Failed`. This made users unable to deal with `false ready` RayClusters with no pod actually created, see #2357.

But since #2258 has been released and the `rayv1.Failed` has gone, I think we can't bring back `rayv1.Failed` either now. This PR fixes the issue by leaving the `.State` field untouched when there is a reconcile error but setting the error message in the `.Reason` field. That means the initial `.State` for case #2357 will be `blank` and the pod creation error will be in the `.Reason` field. The new unit test case in this PR also tests this behavior.

Example result:

```sh
▶ kubectl describe raycluster raycluster-mini
Name:         raycluster-mini
Namespace:    default
Labels:       <none>
Annotations:  <none>
API Version:  ray.io/v1
Kind:         RayCluster
Metadata:
  Creation Timestamp:  2024-12-06T22:53:44Z
  Generation:          1
  Resource Version:    1393
  UID:                 da4d6b0d-c3a3-4f00-9b9b-e4c411e2d6be
Spec:
  Head Group Spec:
    ...
  Ray Version:       2.9.0
  Suspend:           false
  Worker Group Specs:
    ...
Status:
  Desired CPU:              2
  Desired GPU:              0
  Desired Memory:           2G
  Desired TPU:              0
  Desired Worker Replicas:  1
  Endpoints:
    Client:     10001
    Dashboard:  8265
    Metrics:    8080
    Redis:      6379
  Head:
    Service Name:       raycluster-mini-head-svc
  Last Update Time:     2024-12-06T22:53:46Z
  Max Worker Replicas:  1
  Min Worker Replicas:  1
  Observed Generation:  1
  Reason:               FailedCreateHeadPod
pods "raycluster-mini-head-v6zqb" is forbidden: exceeded quota: demoquota, requested: cpu=1,memory=1G, used: cpu=100m,memory=512Mi, limited: cpu=1,memory=1G
Events:
  Type     Reason                 Age   From                   Message
  ----     ------                 ----  ----                   -------
  Normal   CreatedService         3s    raycluster-controller  Created service default/raycluster-mini-head-svc
  Warning  FailedToCreateHeadPod  3s    raycluster-controller  Failed to create head Pod default/, pods "raycluster-mini-head-tqljd" is forbidden: exceeded quota: demoquota, requested: cpu=1,memory=1G, used: cpu=100m,memory=512Mi, limited: cpu=1,memory=1G
  Warning  FailedToCreateHeadPod  3s    raycluster-controller  Failed to create head Pod default/, pods "raycluster-mini-head-gt52b" is forbidden: exceeded quota: demoquota, requested: cpu=1,memory=1G, used: cpu=100m,memory=512Mi, limited: cpu=1,memory=1G
```

## Related issue number

Closes #2357

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
