### PR TITLE
Fix/make helm and kustomize consistent

### DIFF
--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -11,11 +11,11 @@
     - IMG=kuberay/operator:nightly make docker-image
     - kind load docker-image kuberay/operator:nightly
     - IMG=kuberay/operator:nightly make deploy
-    - kubectl wait --timeout=90s --for=condition=Available=true deployment -n ray-system kuberay-operator
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run e2e tests
     - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2eautoscaler
     # Printing KubeRay operator logs
-    - kubectl logs -n ray-system --tail -1 -l app.kubernetes.io/name=kuberay
+    - kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay
 
 - label: 'Test Sample YAMLs (nightly operator)'
   instance_size: large
@@ -29,11 +29,11 @@
     - IMG=kuberay/operator:nightly make docker-image
     - kind load docker-image kuberay/operator:nightly
     - IMG=kuberay/operator:nightly make deploy
-    - kubectl wait --timeout=90s --for=condition=Available=true deployment -n ray-system kuberay-operator
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run sample YAML tests
     - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/sampleyaml
     # Printing KubeRay operator logs
-    - kubectl logs -n ray-system --tail -1 -l app.kubernetes.io/name=kuberay
+    - kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay
 
 - label: 'Test Sample YAMLs (latest release)'
   instance_size: large
@@ -45,8 +45,8 @@
     # Deploy KubeRay operator
     - pushd ray-operator
     - IMG=quay.io/kuberay/operator:v1.2.2 make deploy
-    - kubectl wait --timeout=90s --for=condition=Available=true deployment -n ray-system kuberay-operator
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run sample YAML tests
     - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/sampleyaml
     # Printing KubeRay operator logs
-    - kubectl logs -n ray-system --tail -1 -l app.kubernetes.io/name=kuberay
+    - kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay

--- a/.github/workflows/e2e-tests-reusable-workflow.yaml
+++ b/.github/workflows/e2e-tests-reusable-workflow.yaml
@@ -53,7 +53,7 @@ jobs:
             make docker-push -e IMG="${IMG}" -e ENGINE=podman
 
             make deploy -e IMG="${IMG}"
-            kubectl wait --timeout=90s --for=condition=Available=true deployment -n ray-system kuberay-operator
+            kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
 
         - name: Deploy Kuberay Cluster
           if: inputs.plugin-test
@@ -80,7 +80,7 @@ jobs:
           if: (!inputs.plugin-test) && always() && steps.deploy.outcome == 'success'
           run: |
             echo "Printing KubeRay operator logs"
-            kubectl logs -n ray-system --tail -1 -l app.kubernetes.io/name=kuberay | tee ${KUBERAY_TEST_OUTPUT_DIR}/kuberay-operator.log
+            kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee ${KUBERAY_TEST_OUTPUT_DIR}/kuberay-operator.log
 
         - name: Upload logs
           uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-tests-reusable-workflow.yaml
+++ b/.github/workflows/e2e-tests-reusable-workflow.yaml
@@ -61,7 +61,7 @@ jobs:
             echo Deploying Kuberay cluster
 
             kubectl apply -f ./ray-operator/config/samples/ray-cluster.sample.yaml
-            kubectl wait --timeout=300s --for=condition=ready  pod -l ray.io/cluster=raycluster-sample
+            kubectl wait --timeout=300s --for=condition=ready  pod -l ray.io/cluster=raycluster-kuberay
 
         - name: Run e2e tests
           run: |

--- a/kubectl-plugin/test/e2e/kubectl_ray_cluster_get_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_cluster_get_test.go
@@ -33,14 +33,14 @@ var _ = Describe("Calling ray plugin `get` command", Ordered, func() {
 
 		expectedTestResultTable.Rows = append(expectedTestResultTable.Rows, v1.TableRow{
 			Cells: []interface{}{
-				"raycluster-sample",
+				"raycluster-kuberay",
 				"default",
 				"1",
 				"1",
-				"1",
+				"2",
 				"0",
 				"0",
-				"3Gi",
+				"3G",
 			},
 		})
 

--- a/kubectl-plugin/test/e2e/kubectl_ray_log_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_log_test.go
@@ -17,10 +17,10 @@ var requiredFileSet = map[string]string{
 
 var _ = Describe("Calling ray plugin `log` command on Ray Cluster", Ordered, func() {
 	It("succeed in retrieving all ray cluster logs", func() {
-		expectedDirPath := "./raycluster-sample"
-		expectedOutputStringFormat := `No output directory specified, creating dir under current directory using resource name\.\nCommand set to retrieve both head and worker node logs\.\nDownloading log for Ray Node raycluster-sample-head-\w+\nDownloading log for Ray Node raycluster-sample-small-group-worker-\w+`
+		expectedDirPath := "./raycluster-kuberay"
+		expectedOutputStringFormat := `No output directory specified, creating dir under current directory using resource name\.\nCommand set to retrieve both head and worker node logs\.\nDownloading log for Ray Node raycluster-kuberay-head-\w+\nDownloading log for Ray Node raycluster-kuberay-workergroup-worker-\w+`
 
-		cmd := exec.Command("kubectl", "ray", "log", "raycluster-sample", "--node-type", "all")
+		cmd := exec.Command("kubectl", "ray", "log", "raycluster-kuberay", "--node-type", "all")
 		output, err := cmd.CombinedOutput()
 
 		Expect(err).NotTo(HaveOccurred())
@@ -72,10 +72,10 @@ var _ = Describe("Calling ray plugin `log` command on Ray Cluster", Ordered, fun
 	})
 
 	It("succeed in retrieving ray cluster head logs", func() {
-		expectedDirPath := "./raycluster-sample"
-		expectedOutputStringFormat := `No output directory specified, creating dir under current directory using resource name\.\nCommand set to retrieve only head node logs\.\nDownloading log for Ray Node raycluster-sample-head-\w+`
+		expectedDirPath := "./raycluster-kuberay"
+		expectedOutputStringFormat := `No output directory specified, creating dir under current directory using resource name\.\nCommand set to retrieve only head node logs\.\nDownloading log for Ray Node raycluster-kuberay-head-\w+`
 
-		cmd := exec.Command("kubectl", "ray", "log", "raycluster-sample", "--node-type", "head")
+		cmd := exec.Command("kubectl", "ray", "log", "raycluster-kuberay", "--node-type", "head")
 		output, err := cmd.CombinedOutput()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strings.TrimSpace(string(output))).Should(MatchRegexp(expectedOutputStringFormat))
@@ -125,10 +125,10 @@ var _ = Describe("Calling ray plugin `log` command on Ray Cluster", Ordered, fun
 	})
 
 	It("succeed in retrieving ray cluster worker logs", func() {
-		expectedDirPath := "./raycluster-sample"
-		expectedOutputStringFormat := `No output directory specified, creating dir under current directory using resource name\.\nCommand set to retrieve only worker node logs\.\nDownloading log for Ray Node raycluster-sample-small-group-worker-\w+`
+		expectedDirPath := "./raycluster-kuberay"
+		expectedOutputStringFormat := `No output directory specified, creating dir under current directory using resource name\.\nCommand set to retrieve only worker node logs\.\nDownloading log for Ray Node raycluster-kuberay-workergroup-worker-\w+`
 
-		cmd := exec.Command("kubectl", "ray", "log", "raycluster-sample", "--node-type", "worker")
+		cmd := exec.Command("kubectl", "ray", "log", "raycluster-kuberay", "--node-type", "worker")
 		output, err := cmd.CombinedOutput()
 
 		Expect(err).NotTo(HaveOccurred())
@@ -180,12 +180,12 @@ var _ = Describe("Calling ray plugin `log` command on Ray Cluster", Ordered, fun
 
 	It("succeed in retrieving ray cluster logs within designated directory", func() {
 		expectedDirPath := "./temporary-directory"
-		expectedOutputStringFormat := `Command set to retrieve both head and worker node logs\.\nDownloading log for Ray Node raycluster-sample-head-\w+\nDownloading log for Ray Node raycluster-sample-small-group-worker-\w+`
+		expectedOutputStringFormat := `Command set to retrieve both head and worker node logs\.\nDownloading log for Ray Node raycluster-kuberay-head-\w+\nDownloading log for Ray Node raycluster-kuberay-workergroup-worker-\w+`
 
 		err := os.MkdirAll(expectedDirPath, 0o755)
 		Expect(err).NotTo(HaveOccurred())
 
-		cmd := exec.Command("kubectl", "ray", "log", "raycluster-sample", "--node-type", "all", "--out-dir", expectedDirPath)
+		cmd := exec.Command("kubectl", "ray", "log", "raycluster-kuberay", "--node-type", "all", "--out-dir", expectedDirPath)
 		output, err := cmd.CombinedOutput()
 
 		Expect(err).NotTo(HaveOccurred())
@@ -210,7 +210,7 @@ var _ = Describe("Calling ray plugin `log` command on Ray Cluster", Ordered, fun
 	})
 
 	It("should not succeed with non-existent directory set", func() {
-		cmd := exec.Command("kubectl", "ray", "log", "raycluster-sample", "--out-dir", "./fake-directory")
+		cmd := exec.Command("kubectl", "ray", "log", "raycluster-kuberay", "--out-dir", "./fake-directory")
 		output, err := cmd.CombinedOutput()
 
 		Expect(err).To(HaveOccurred())

--- a/ray-operator/config/default/kustomization.yaml
+++ b/ray-operator/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: ray-system
+namespace: default
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
@@ -25,4 +25,3 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
-- namespace.yaml

--- a/ray-operator/config/default/namespace.yaml
+++ b/ray-operator/config/default/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: ray-operator
-  name: ray-system

--- a/ray-operator/config/samples/ray-cluster.sample.yaml
+++ b/ray-operator/config/samples/ray-cluster.sample.yaml
@@ -5,7 +5,7 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  name: raycluster-sample
+  name: raycluster-kuberay
 spec:
   rayVersion: '2.9.0' # should match the Ray version in the image of the containers
   # Ray head pod template
@@ -37,7 +37,7 @@ spec:
       minReplicas: 1
       maxReplicas: 5
       # logical group name, for this called small-group, also can be functional
-      groupName: small-group
+      groupName: workergroup
       rayStartParams: {}
       #pod template
       template:

--- a/ray-operator/config/samples/ray-cluster.sample.yaml
+++ b/ray-operator/config/samples/ray-cluster.sample.yaml
@@ -20,10 +20,10 @@ spec:
           resources:
             limits:
               cpu: 1
-              memory: 2Gi
+              memory: 2G
             requests:
-              cpu: 500m
-              memory: 2Gi
+              cpu: 1
+              memory: 2G
           ports:
           - containerPort: 6379
             name: gcs-server
@@ -48,7 +48,7 @@ spec:
               resources:
                 limits:
                   cpu: 1
-                  memory: 1Gi
+                  memory: 1G
                 requests:
-                  cpu: 500m
-                  memory: 1Gi
+                  cpu: 1
+                  memory: 1G


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In https://anyscale-ray--49085.com.readthedocs.build/en/49085/cluster/kubernetes/getting-started/raycluster-quick-start.html some instructions in helm part are not consistent with Kustomize part. 
To make them consistent for a better user experience.

Related doc PR: https://github.com/ray-project/ray/pull/49167

Executing the Kustomize instructions get results as follow:
`kubectl get pods`
<img width="565" alt="kubectl get po" src="https://github.com/user-attachments/assets/f83b4b3f-1c00-4b3a-91f4-de47cb2e39eb">


`kubectl get rayclusters`
<img width="772" alt="kubectl get rayclusters" src="https://github.com/user-attachments/assets/3db3402d-3c87-4293-96e5-1f43933bf4b4">

`kubectl get pods --selector=ray.io/cluster=raycluster-kuberay`
<img width="655" alt="kubectl get pods selector" src="https://github.com/user-attachments/assets/d66d7415-e973-4c42-a698-6e52279ec5d0">



## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/kuberay/issues/2616

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
