### PR TITLE
[Chore][CI] Upgrade ray version to 2.40 except for TestRayServiceInPlaceUpdate

### DIFF
--- a/ray-operator/test/e2e/rayservice_in_place_update_test.go
+++ b/ray-operator/test/e2e/rayservice_in_place_update_test.go
@@ -25,6 +25,10 @@ func TestRayServiceInPlaceUpdate(t *testing.T) {
 
 	rayServiceAC := rayv1ac.RayService(rayServiceName, namespace.Name).WithSpec(rayServiceSampleYamlApplyConfiguration())
 
+	// TODO: This test will fail on Ray 2.40.0. Pin the Ray version to 2.9.0 as a workaround. Need to remove this after the issue is fixed.
+	rayServiceAC.Spec.RayClusterSpec.WithRayVersion("2.9.0")
+	rayServiceAC.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].WithImage("rayproject/ray:2.9.0")
+
 	rayService, err := test.Client().Ray().RayV1().RayServices(namespace.Name).Apply(test.Ctx(), rayServiceAC, TestApplyOptions)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(rayService).NotTo(BeNil())

--- a/ray-operator/test/support/defaults.go
+++ b/ray-operator/test/support/defaults.go
@@ -1,6 +1,6 @@
 package support
 
 const (
-	RayVersion = "2.9.0"
-	RayImage   = "rayproject/ray:2.9.0"
+	RayVersion = "2.40.0"
+	RayImage   = "rayproject/ray:2.40.0"
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR upgrades ray version to `2.40.0`. However, `TestRayServiceInPlaceUpdate` fails for ray `2.40.0`, so currently pin it to `2.9.0` as a workaround.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
