### PR TITLE
[RayCluster] Adds `aliyun.com/gpu-mem` to known custom accelerators

### DIFF
--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1245,6 +1245,17 @@ func TestGenerateRayStartCommand(t *testing.T) {
 			expected: `ray start  --resources='{"TPU":4}' `,
 		},
 		{
+			name:           "WorkerNode with Aliyun's GPU Share",
+			nodeType:       rayv1.WorkerNode,
+			rayStartParams: map[string]string{},
+			resource: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"aliyun.com/gpu-mem": resource.MustParse("4"),
+				},
+			},
+			expected: `ray start  --num-gpus=4 `,
+		},
+		{
 			name:           "HeadNode with Neuron Cores",
 			nodeType:       rayv1.HeadNode,
 			rayStartParams: map[string]string{},
@@ -1261,11 +1272,12 @@ func TestGenerateRayStartCommand(t *testing.T) {
 			rayStartParams: map[string]string{},
 			resource: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
+					"aliyun.com/gpu-mem":        resource.MustParse("3"),
 					"aws.amazon.com/neuroncore": resource.MustParse("4"),
 					"nvidia.com/gpu":            resource.MustParse("1"),
 				},
 			},
-			expected: `ray start --head  --num-gpus=1  --resources='{"neuron_cores":4}' `,
+			expected: `ray start --head  --num-gpus=4  --resources='{"neuron_cores":4}' `,
 		},
 		{
 			name:           "HeadNode with multiple custom accelerators",
@@ -1273,12 +1285,13 @@ func TestGenerateRayStartCommand(t *testing.T) {
 			rayStartParams: map[string]string{},
 			resource: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
+					"aliyun.com/gpu-mem":        resource.MustParse("4"),
 					"google.com/tpu":            resource.MustParse("8"),
 					"aws.amazon.com/neuroncore": resource.MustParse("4"),
 					"nvidia.com/gpu":            resource.MustParse("1"),
 				},
 			},
-			expected: `ray start --head  --num-gpus=1  --resources='{"neuron_cores":4}' `,
+			expected: `ray start --head  --num-gpus=5  --resources='{"neuron_cores":4}' `,
 		},
 		{
 			name:     "HeadNode with existing resources",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

if use aliyun k8s gpu share, gpu key is `aliyun.com/gpu-mem`
```yaml
    workerGroupSpecs:
            resources:
              limits:
                aliyun.com/gpu-mem: "1"
                cpu: "1"
                memory: 2Gi
              requests:
                aliyun.com/gpu-mem: "1"
                cpu: "1"
                memory: 2Gi
```
autoscaler will not work when request gpu resource
```
(autoscaler +3m13s) Error: No available node types can fulfill resource request {'GPU': 1.0, 'CPU': 1.0}. Add suitable node types to this cluster to resolve this issue.
```


Adds aliyun's gpu share to the list of known custom accelerators in `pod.go`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #2484

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
