### PR TITLE
[Feature] Add an e2e test for Autoscaler to scale up by manually updating `minReplicas` 

### DIFF
--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -1,10 +1,14 @@
 package e2eautoscaler
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/onsi/gomega"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/utils/ptr"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
@@ -279,5 +283,80 @@ func TestRayClusterAutoscalerWithDesiredState(t *testing.T) {
 			g.Expect(pods).To(gomega.HaveLen(maxReplica))
 		})
 
+	}
+}
+
+func TestRayClusterAutoscalerMinReplicasUpdate(t *testing.T) {
+	for name, tc := range tests {
+
+		test := With(t)
+		g := gomega.NewWithT(t)
+
+		// Create a namespace
+		namespace := test.NewTestNamespace()
+		test.StreamKubeRayOperatorLogs()
+
+		// Script for creating detached actors to trigger autoscaling
+		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py"))
+		scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		test.T().Logf("Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
+
+		test.T().Run(name, func(_ *testing.T) {
+			groupName := "test-group"
+
+			rayClusterSpecAC := rayv1ac.RayClusterSpec().
+				WithEnableInTreeAutoscaling(true).
+				WithRayVersion(GetRayVersion()).
+				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+					WithRayStartParams(map[string]string{"num-cpus": "0"}).
+					WithTemplate(tc.HeadPodTemplateGetter())).
+				WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
+					WithReplicas(1).
+					WithMinReplicas(0).
+					WithMaxReplicas(5).
+					WithGroupName(groupName).
+					WithRayStartParams(map[string]string{"num-cpus": "1"}).
+					WithTemplate(tc.WorkerPodTemplateGetter()))
+			rayClusterAC := rayv1ac.RayCluster("ray-cluster", namespace.Name).
+				WithSpec(apply(rayClusterSpecAC, mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](scripts, "/home/ray/test_scripts")))
+
+			rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			test.T().Logf("Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+			// Wait for RayCluster to become ready
+			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+				Should(gomega.WithTransform(RayClusterState, gomega.Equal(rayv1.Ready)))
+			g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(1))))
+
+			// Update minReplicas from 0 to 2
+			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			rayCluster.Spec.WorkerGroupSpecs[0].MinReplicas = ptr.To(int32(2))
+			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(test.Ctx(), rayCluster, metav1.UpdateOptions{})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			test.T().Logf("Updated RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+			// Verify that KubeRay creates an additional Pod
+			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(2))))
+
+			// Create detached actors to trigger autoscaling to 5 Pods
+			headPod, err := GetHeadPod(test, rayCluster)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			test.T().Logf("Found head pod %s/%s", headPod.Namespace, headPod.Name)
+
+			for i := 0; i < 5; i++ {
+				ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/create_detached_actor.py", fmt.Sprintf("actor%d", i)})
+			}
+
+			// Verify that the Autoscaler scales up to 5 Pods
+			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(5))))
+
+			// Check that replicas is set to 5
+			g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(GetRayClusterWorkerGroupReplicaSum, gomega.Equal(int32(5))))
+		})
 	}
 }

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -145,3 +145,11 @@ func RayService(t Test, namespace, name string) func() (*rayv1.RayService, error
 func RayServiceStatus(service *rayv1.RayService) rayv1.ServiceStatus {
 	return service.Status.ServiceStatus
 }
+
+func GetRayClusterWorkerGroupReplicaSum(cluster *rayv1.RayCluster) int32 {
+	var replicas int32
+	for _, workerGroup := range cluster.Spec.WorkerGroupSpecs {
+		replicas += *workerGroup.Replicas
+	}
+	return replicas
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
See #2576 

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #2576 

## Test Log
This test follows these sequential steps:
* Create a RayCluster with the Autoscaler enabled, containing a worker group with replicas: 1 and minReplicas: 0.

```
{"msg": "reconcilePods", "desired workerReplicas": 1, "maxReplicas": 5, "minReplicas": 0, "replicas": 1}
```

* Update minReplicas from 0 to 2.
* KubeRay should create an additional Pod.

```
{"msg": "reconcilePods", "desired workerReplicas": 2, "maxReplicas": 5, "minReplicas": 2, "replicas": 1}
{"msg": "Number workers to add": 1, "Worker group": "test-group"}
{"msg": "Created worker Pod for RayCluster"}
```

* Submit some Ray detached actors to trigger autoscaling to 5 Pods.

```
"Executing command: [python /home/ray/test_scripts/create_detached_actor.py actor0]"
"Executing command: [python /home/ray/test_scripts/create_detached_actor.py actor1]"
"Executing command: [python /home/ray/test_scripts/create_detached_actor.py actor2]"
"Executing command: [python /home/ray/test_scripts/create_detached_actor.py actor3]"
"Executing command: [python /home/ray/test_scripts/create_detached_actor.py actor4]"
```

* Verify whether the Autoscaler successfully scales up to 5 Pods.

```
{"msg": "reconcilePods", "workerReplicas": 5, "NumOfHosts": 1, "runningPods": 2, "diff": 3}
{"msg": "Number workers to add": 3, "Worker group": "test-group"}
```

* Check whether replicas is set to 5.

```
"new status": {
    "desiredWorkerReplicas": 5,
    "minWorkerReplicas": 2,
    "maxWorkerReplicas": 5,
    "observedGeneration": 3
}
```
# Screenshot
![image](https://github.com/user-attachments/assets/ea5c0c36-9777-4b2b-adc8-2795e1aa77bb)


## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
