### PR TITLE
[Chore][CI] Remove StreamKubeRayOperatorLogs

### DIFF
--- a/ray-operator/test/e2e/raycluster_test.go
+++ b/ray-operator/test/e2e/raycluster_test.go
@@ -20,7 +20,6 @@ func TestRayClusterManagedBy(t *testing.T) {
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
-	test.StreamKubeRayOperatorLogs()
 
 	test.T().Run("Successful creation of cluster, managed by Kuberay Operator", func(t *testing.T) {
 		t.Parallel()

--- a/ray-operator/test/e2e/rayjob_cluster_selector_test.go
+++ b/ray-operator/test/e2e/rayjob_cluster_selector_test.go
@@ -19,7 +19,6 @@ func TestRayJobWithClusterSelector(t *testing.T) {
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
-	test.StreamKubeRayOperatorLogs()
 
 	// Job scripts
 	jobsAC := newConfigMap(namespace.Name, "jobs", files(test, "counter.py", "fail.py"))

--- a/ray-operator/test/e2e/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2e/rayjob_lightweight_test.go
@@ -21,7 +21,6 @@ func TestRayJobLightWeightMode(t *testing.T) {
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
-	test.StreamKubeRayOperatorLogs()
 
 	// Job scripts
 	jobsAC := newConfigMap(namespace.Name, "jobs", files(test, "counter.py", "fail.py", "stop.py"))

--- a/ray-operator/test/e2e/rayjob_retry_test.go
+++ b/ray-operator/test/e2e/rayjob_retry_test.go
@@ -19,7 +19,6 @@ func TestRayJobRetry(t *testing.T) {
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
-	test.StreamKubeRayOperatorLogs()
 
 	// Job scripts
 	jobsAC := newConfigMap(namespace.Name, "jobs", files(test, "fail.py"))

--- a/ray-operator/test/e2e/rayjob_suspend_test.go
+++ b/ray-operator/test/e2e/rayjob_suspend_test.go
@@ -21,7 +21,6 @@ func TestRayJobSuspend(t *testing.T) {
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
-	test.StreamKubeRayOperatorLogs()
 
 	// Job scripts
 	jobsAC := newConfigMap(namespace.Name, "jobs", files(test, "long_running.py", "counter.py"))

--- a/ray-operator/test/e2e/rayjob_test.go
+++ b/ray-operator/test/e2e/rayjob_test.go
@@ -22,7 +22,6 @@ func TestRayJob(t *testing.T) {
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
-	test.StreamKubeRayOperatorLogs()
 
 	// Job scripts
 	jobsAC := newConfigMap(namespace.Name, "jobs", files(test, "counter.py", "fail.py", "stop.py", "long_running.py"))

--- a/ray-operator/test/e2e/rayservice_ha_test.go
+++ b/ray-operator/test/e2e/rayservice_ha_test.go
@@ -22,7 +22,6 @@ func TestStaticRayService(t *testing.T) {
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
-	test.StreamKubeRayOperatorLogs()
 
 	// Create a ConfigMap with Locust runner script
 	configMapAC := newConfigMap(namespace.Name, "locust-runner-script", files(test, "locust_runner.py"))
@@ -73,7 +72,6 @@ func TestAutoscalingRayService(t *testing.T) {
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
-	test.StreamKubeRayOperatorLogs()
 
 	// Create a ConfigMap with Locust runner script
 	configMapAC := newConfigMap(namespace.Name, "locust-runner-script", files(test, "locust_runner.py"))
@@ -140,7 +138,6 @@ func TestRayServiceZeroDowntimeUpgrade(t *testing.T) {
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
-	test.StreamKubeRayOperatorLogs()
 
 	// Create a ConfigMap with Locust runner script
 	configMapAC := newConfigMap(namespace.Name, "locust-runner-script", files(test, "locust_runner.py"))

--- a/ray-operator/test/e2e/rayservice_in_place_update_test.go
+++ b/ray-operator/test/e2e/rayservice_in_place_update_test.go
@@ -21,7 +21,6 @@ func TestRayServiceInPlaceUpdate(t *testing.T) {
 	// Create a namespace
 	namespace := test.NewTestNamespace()
 	rayServiceName := "rayservice-sample"
-	test.StreamKubeRayOperatorLogs()
 
 	rayServiceAC := rayv1ac.RayService(rayServiceName, namespace.Name).WithSpec(rayServiceSampleYamlApplyConfiguration())
 

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -37,7 +37,6 @@ func TestRayClusterAutoscaler(t *testing.T) {
 
 		// Create a namespace
 		namespace := test.NewTestNamespace()
-		test.StreamKubeRayOperatorLogs()
 
 		// Scripts for creating and terminating detached actors to trigger autoscaling
 		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
@@ -106,7 +105,6 @@ func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
 
 		// Create a namespace
 		namespace := test.NewTestNamespace()
-		test.StreamKubeRayOperatorLogs()
 
 		// Scripts for creating and terminating detached actors to trigger autoscaling
 		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
@@ -168,7 +166,6 @@ func TestRayClusterAutoscalerWithCustomResource(t *testing.T) {
 
 		// Create a namespace
 		namespace := test.NewTestNamespace()
-		test.StreamKubeRayOperatorLogs()
 
 		// Scripts for creating and terminating detached actors to trigger autoscaling
 		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
@@ -233,7 +230,6 @@ func TestRayClusterAutoscalerWithDesiredState(t *testing.T) {
 
 		// Create a namespace
 		namespace := test.NewTestNamespace()
-		test.StreamKubeRayOperatorLogs()
 
 		// Scripts for creating and terminating detached actors to trigger autoscaling
 		scriptsAC := newConfigMap(namespace.Name, files(test, "create_concurrent_tasks.py"))
@@ -294,7 +290,6 @@ func TestRayClusterAutoscalerMinReplicasUpdate(t *testing.T) {
 
 		// Create a namespace
 		namespace := test.NewTestNamespace()
-		test.StreamKubeRayOperatorLogs()
 
 		// Script for creating detached actors to trigger autoscaling
 		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py"))

--- a/ray-operator/test/sampleyaml/raycluster_test.go
+++ b/ray-operator/test/sampleyaml/raycluster_test.go
@@ -68,7 +68,6 @@ func TestRayCluster(t *testing.T) {
 
 			yamlFilePath := path.Join(GetSampleYAMLDir(test), tt.name)
 			namespace := test.NewTestNamespace()
-			test.StreamKubeRayOperatorLogs()
 			rayClusterFromYaml := DeserializeRayClusterYAML(test, yamlFilePath)
 			KubectlApplyYAML(test, yamlFilePath, namespace.Name)
 

--- a/ray-operator/test/sampleyaml/rayjob_test.go
+++ b/ray-operator/test/sampleyaml/rayjob_test.go
@@ -38,7 +38,6 @@ func TestRayJob(t *testing.T) {
 
 			yamlFilePath := path.Join(GetSampleYAMLDir(test), tt.name)
 			namespace := test.NewTestNamespace()
-			test.StreamKubeRayOperatorLogs()
 			rayJobFromYaml := DeserializeRayJobYAML(test, yamlFilePath)
 			KubectlApplyYAML(test, yamlFilePath, namespace.Name)
 

--- a/ray-operator/test/sampleyaml/rayservice_test.go
+++ b/ray-operator/test/sampleyaml/rayservice_test.go
@@ -35,7 +35,6 @@ func TestRayService(t *testing.T) {
 
 			yamlFilePath := path.Join(GetSampleYAMLDir(test), tt.name)
 			namespace := test.NewTestNamespace()
-			test.StreamKubeRayOperatorLogs()
 			rayServiceFromYaml := DeserializeRayServiceYAML(test, yamlFilePath)
 			KubectlApplyYAML(test, yamlFilePath, namespace.Name)
 

--- a/ray-operator/test/support/test.go
+++ b/ray-operator/test/support/test.go
@@ -1,17 +1,11 @@
 package support
 
 import (
-	"bufio"
 	"context"
 	"os"
 	"path"
 	"sync"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -23,7 +17,6 @@ type Test interface {
 	OutputDir() string
 
 	NewTestNamespace(...Option[*corev1.Namespace]) *corev1.Namespace
-	StreamKubeRayOperatorLogs()
 }
 
 type Option[T any] interface {
@@ -119,36 +112,4 @@ func (t *T) NewTestNamespace(options ...Option[*corev1.Namespace]) *corev1.Names
 		deleteTestNamespace(t, namespace)
 	})
 	return namespace
-}
-
-func (t *T) StreamKubeRayOperatorLogs() {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.T().Cleanup(cancel)
-	// By using `.Pods("")`, we list kuberay-operators from all namespaces
-	// because they may not always be installed in the "ray-system" namespace.
-	pods, err := t.Client().Core().CoreV1().Pods("").List(ctx, metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/component=kuberay-operator",
-	})
-	assert.NoError(t.T(), err)
-	now := metav1.NewTime(time.Now())
-	for _, pod := range pods.Items {
-		go func(pod corev1.Pod, ts *metav1.Time) {
-			req := t.Client().Core().CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
-				Follow:    true,
-				SinceTime: ts,
-			})
-			stream, err := req.Stream(ctx)
-			if err != nil {
-				t.T().Logf("Fail to tail logs from the pod %s/%s", pod.Namespace, pod.Name)
-				return
-			}
-			t.T().Logf("Start tailing logs from the pod %s/%s", pod.Namespace, pod.Name)
-			defer stream.Close()
-			scanner := bufio.NewScanner(stream)
-			for scanner.Scan() {
-				t.T().Log(scanner.Text())
-			}
-			t.T().Logf("Stop tailing logs from the pod %s/%s: %v", pod.Namespace, pod.Name, scanner.Err())
-		}(pod, &now)
-	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Remove `StreamKubeRayOperatorLogs` to reduce messy logs in CI. We can use the `kuberay-operator.log` in artifacts instead to debug.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
