### PR TITLE
prioritize memory limits over requests for /dev/shm size

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -959,12 +959,12 @@ func checkIfVolumeExists(pod *corev1.Pod, volumeName string) bool {
 
 func findMemoryReqOrLimit(container corev1.Container) (res *resource.Quantity) {
 	var mem *resource.Quantity
-	// check the requests, if they are not set, check the limits.
-	if q, ok := container.Resources.Requests[corev1.ResourceMemory]; ok {
+	// check the limits, if they are not set, check the requests.
+	if q, ok := container.Resources.Limits[corev1.ResourceMemory]; ok {
 		mem = &q
 		return mem
 	}
-	if q, ok := container.Resources.Limits[corev1.ResourceMemory]; ok {
+	if q, ok := container.Resources.Requests[corev1.ResourceMemory]; ok {
 		mem = &q
 		return mem
 	}


### PR DESCRIPTION
## Why are these changes needed?

When determining the size of `/dev/shm` volume mount, we check requests and limits. However, limits should take priority since limits is used for the `--memory` flag in `ray start` and it's always larger than requests. 

## Related issue number

See https://github.com/ray-project/kuberay/issues/2640

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
