### PR TITLE
default RayClusterStatusConditions=true in helm-chart

### DIFF
--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -88,7 +88,7 @@ batchScheduler:
 
 featureGates:
   - name: RayClusterStatusConditions
-    enabled: false
+    enabled: true
 
 # Path to the operator binary
 operatorComand: /manager


### PR DESCRIPTION
## Why are these changes needed?

This feature gate is graduating to Beta (and on by default) in v1.3, the helm-chart default values should reflect that.

## Related issue number


## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
