### PR TITLE
[RayService] Use `waitGroup` to ensure a goroutine's completion before the RayService HA test ends

### DIFF
--- a/ray-operator/test/e2e/rayservice_ha_test.go
+++ b/ray-operator/test/e2e/rayservice_ha_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -173,7 +174,12 @@ func TestRayServiceZeroDowntimeUpgrade(t *testing.T) {
 	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust"})
 
 	// Start a goroutine to perform zero-downtime upgrade
+	var wg sync.WaitGroup
+	wg.Add(1)
+
 	go func() {
+		defer wg.Done()
+
 		test.T().Logf("Waiting several seconds before updating RayService")
 		time.Sleep(30 * time.Second)
 
@@ -196,4 +202,6 @@ func TestRayServiceZeroDowntimeUpgrade(t *testing.T) {
 	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
 		"python", "/locust-runner/locust_runner.py", "-f", "/locustfile/locustfile.py", "--host", "http://test-rayservice-serve-svc:8000",
 	})
+
+	wg.Wait()
 }


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Ref: #2653

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #2653

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
