### PR TITLE
[CI] Deflaky TestRayServiceGCSFaultTolerance

### DIFF
--- a/ray-operator/test/e2e/testdata/ray-service.ft.yaml
+++ b/ray-operator/test/e2e/testdata/ray-service.ft.yaml
@@ -15,7 +15,7 @@ spec:
         args:
           num_forwards: 0
         runtime_env:
-          working_dir: https://github.com/ray-project/serve_workloads/archive/a2e2405f3117f1b4134b6924b5f44c4ff0710c00.zip
+          working_dir: https://github.com/ray-project/serve_workloads/archive/a9f184f4d9ddb7f9a578502ae106470f87a702ef.zip
         deployments:
           - name: NoOp
             num_replicas: 1
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.9.0
+              image: rayproject/ray:2.40.0
               env:
                 - name: RAY_REDIS_ADDRESS
                   value: redis:6379
@@ -70,7 +70,7 @@ spec:
           spec:
             containers:
               - name: ray-worker
-                image: rayproject/ray:2.9.0
+                image: rayproject/ray:2.40.0
                 resources:
                   requests:
                     cpu: 300m

--- a/ray-operator/test/support/yaml.go
+++ b/ray-operator/test/support/yaml.go
@@ -52,6 +52,8 @@ func KubectlApplyYAML(t Test, filename string, namespace string) {
 	t.T().Helper()
 	kubectlCmd := exec.CommandContext(t.Ctx(), "kubectl", "apply", "-f", filename, "-n", namespace)
 	err := kubectlCmd.Run()
-	assert.NoError(t.T(), err)
-	t.T().Logf("Successfully applied %s", filename)
+	if err != nil {
+		t.T().Fatalf("Failed to apply %s to namespace %s: %v", filename, namespace, err)
+	}
+	t.T().Logf("Successfully applied %s to namespace %s", filename, namespace)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#2590 adds an e2e test for RayService HA with GCS FT. However, it is quite flaky. On my devbox, it has about a 50% chance of failing. 

The reason is that when the GCS process on the head Pod is killed, the readiness/liveness probes on the worker Pod will fail for a while, causing some requests to be dropped. I no longer observe the issue after upgrading from Ray 2.9.0 to Ray 2.40.0.

## Related issue number

Closes #2659

## Checks

I ran the test 10 times with this PR. All passed.

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
