### PR TITLE
[RayCluster][CI] add e2e tests for RayClusterStatusCondition

### DIFF
--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -26,7 +26,8 @@ spec:
       containers:
       - command:
         - /manager
-#        args:
+        args:
+        - --feature-gates=RayClusterStatusConditions=true
 #        - --enable-leader-election
         image: kuberay/operator
         imagePullPolicy: IfNotPresent

--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -27,7 +27,7 @@ spec:
       - command:
         - /manager
         args:
-        - --feature-gates=RayClusterStatusConditions=true
+        - --feature-gates=RayClusterStatusConditions=true # this argument can be removed for version >= v1.3 where the feature gate is enabled by default.
 #        - --enable-leader-election
         image: kuberay/operator
         imagePullPolicy: IfNotPresent

--- a/ray-operator/test/sampleyaml/raycluster_test.go
+++ b/ray-operator/test/sampleyaml/raycluster_test.go
@@ -8,6 +8,8 @@ import (
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestRayCluster(t *testing.T) {
@@ -77,6 +79,10 @@ func TestRayCluster(t *testing.T) {
 
 			test.T().Logf("Waiting for RayCluster %s/%s to be ready", namespace.Name, rayCluster.Name)
 			g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+				Should(WithTransform(StatusCondition(rayv1.HeadPodReady), MatchCondition(metav1.ConditionTrue, rayv1.HeadPodRunningAndReady)))
+			g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+				Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionTrue, rayv1.AllPodRunningAndReadyFirstTime)))
+			g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
 				Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
 			rayCluster, err = GetRayCluster(test, namespace.Name, rayCluster.Name)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -99,6 +105,19 @@ func TestRayCluster(t *testing.T) {
 
 			// Check that all pods can submit jobs
 			g.Eventually(SubmitJobsToAllPods(test, rayCluster), TestTimeoutShort).Should(Succeed())
+
+			// Delete all pods after setting quota to 0 to avoid recreating pods
+			KubectlApplyQuota(test, namespace.Name, "--hard=cpu=0,memory=0G,pods=0")
+			KubectlDeleteAllPods(test, namespace.Name)
+			// The HeadPodReady condition should now be False with a HeadPodNotFound reason.
+			g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+				Should(WithTransform(StatusCondition(rayv1.HeadPodReady), MatchCondition(metav1.ConditionFalse, rayv1.HeadPodNotFound)))
+			// The RayClusterProvisioned condition should still be True.
+			g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+				Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionTrue, rayv1.AllPodRunningAndReadyFirstTime)))
+			// The RayClusterReplicaFailure condition now be True with a FailedCreateHeadPod reason due to the quota limit.
+			g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+				Should(WithTransform(StatusCondition(rayv1.RayClusterReplicaFailure), MatchCondition(metav1.ConditionTrue, "FailedCreateHeadPod")))
 		})
 	}
 }

--- a/ray-operator/test/support/yaml.go
+++ b/ray-operator/test/support/yaml.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -28,7 +28,7 @@ func DeserializeRayClusterYAML(t Test, filename string) *rayv1.RayCluster {
 	t.T().Helper()
 	rayCluster := &rayv1.RayCluster{}
 	err := deserializeYAML(filename, rayCluster)
-	assert.NoError(t.T(), err)
+	require.NoError(t.T(), err)
 	return rayCluster
 }
 
@@ -36,7 +36,7 @@ func DeserializeRayJobYAML(t Test, filename string) *rayv1.RayJob {
 	t.T().Helper()
 	rayJob := &rayv1.RayJob{}
 	err := deserializeYAML(filename, rayJob)
-	assert.NoError(t.T(), err)
+	require.NoError(t.T(), err)
 	return rayJob
 }
 
@@ -44,7 +44,7 @@ func DeserializeRayServiceYAML(t Test, filename string) *rayv1.RayService {
 	t.T().Helper()
 	rayService := &rayv1.RayService{}
 	err := deserializeYAML(filename, rayService)
-	assert.NoError(t.T(), err)
+	require.NoError(t.T(), err)
 	return rayService
 }
 
@@ -52,9 +52,7 @@ func KubectlApplyYAML(t Test, filename string, namespace string) {
 	t.T().Helper()
 	kubectlCmd := exec.CommandContext(t.Ctx(), "kubectl", "apply", "-f", filename, "-n", namespace)
 	err := kubectlCmd.Run()
-	if err != nil {
-		t.T().Fatalf("Failed to apply %s to namespace %s: %v", filename, namespace, err)
-	}
+	require.NoError(t.T(), err)
 	t.T().Logf("Successfully applied %s to namespace %s", filename, namespace)
 }
 
@@ -62,7 +60,7 @@ func KubectlApplyQuota(t Test, namespace, quota string) {
 	t.T().Helper()
 	kubectlCmd := exec.CommandContext(t.Ctx(), "kubectl", "create", "quota", namespace, "-n", namespace, quota)
 	err := kubectlCmd.Run()
-	assert.NoError(t.T(), err)
+	require.NoError(t.T(), err)
 	t.T().Logf("Successfully applied quota %s in %s", quota, namespace)
 }
 
@@ -70,6 +68,6 @@ func KubectlDeleteAllPods(t Test, namespace string) {
 	t.T().Helper()
 	kubectlCmd := exec.CommandContext(t.Ctx(), "kubectl", "delete", "--all", "pods", "-n", namespace)
 	err := kubectlCmd.Run()
-	assert.NoError(t.T(), err)
+	require.NoError(t.T(), err)
 	t.T().Logf("Successfully delete pods in %s", namespace)
 }

--- a/ray-operator/test/support/yaml.go
+++ b/ray-operator/test/support/yaml.go
@@ -57,3 +57,19 @@ func KubectlApplyYAML(t Test, filename string, namespace string) {
 	}
 	t.T().Logf("Successfully applied %s to namespace %s", filename, namespace)
 }
+
+func KubectlApplyQuota(t Test, namespace, quota string) {
+	t.T().Helper()
+	kubectlCmd := exec.CommandContext(t.Ctx(), "kubectl", "create", "quota", namespace, "-n", namespace, quota)
+	err := kubectlCmd.Run()
+	assert.NoError(t.T(), err)
+	t.T().Logf("Successfully applied quota %s in %s", quota, namespace)
+}
+
+func KubectlDeleteAllPods(t Test, namespace string) {
+	t.T().Helper()
+	kubectlCmd := exec.CommandContext(t.Ctx(), "kubectl", "delete", "--all", "pods", "-n", namespace)
+	err := kubectlCmd.Run()
+	assert.NoError(t.T(), err)
+	t.T().Logf("Successfully delete pods in %s", namespace)
+}

--- a/ray-operator/test/support/yaml.go
+++ b/ray-operator/test/support/yaml.go
@@ -28,7 +28,7 @@ func DeserializeRayClusterYAML(t Test, filename string) *rayv1.RayCluster {
 	t.T().Helper()
 	rayCluster := &rayv1.RayCluster{}
 	err := deserializeYAML(filename, rayCluster)
-	require.NoError(t.T(), err)
+	require.NoError(t.T(), err, "Fail to deserialize yaml file %s", filename)
 	return rayCluster
 }
 
@@ -36,7 +36,7 @@ func DeserializeRayJobYAML(t Test, filename string) *rayv1.RayJob {
 	t.T().Helper()
 	rayJob := &rayv1.RayJob{}
 	err := deserializeYAML(filename, rayJob)
-	require.NoError(t.T(), err)
+	require.NoError(t.T(), err, "Fail to deserialize yaml file %s", filename)
 	return rayJob
 }
 
@@ -44,7 +44,7 @@ func DeserializeRayServiceYAML(t Test, filename string) *rayv1.RayService {
 	t.T().Helper()
 	rayService := &rayv1.RayService{}
 	err := deserializeYAML(filename, rayService)
-	require.NoError(t.T(), err)
+	require.NoError(t.T(), err, "Fail to deserialize yaml file %s", filename)
 	return rayService
 }
 
@@ -52,7 +52,7 @@ func KubectlApplyYAML(t Test, filename string, namespace string) {
 	t.T().Helper()
 	kubectlCmd := exec.CommandContext(t.Ctx(), "kubectl", "apply", "-f", filename, "-n", namespace)
 	err := kubectlCmd.Run()
-	require.NoError(t.T(), err)
+	require.NoError(t.T(), err, "Failed to apply %s to namespace %s", filename, namespace)
 	t.T().Logf("Successfully applied %s to namespace %s", filename, namespace)
 }
 
@@ -60,7 +60,7 @@ func KubectlApplyQuota(t Test, namespace, quota string) {
 	t.T().Helper()
 	kubectlCmd := exec.CommandContext(t.Ctx(), "kubectl", "create", "quota", namespace, "-n", namespace, quota)
 	err := kubectlCmd.Run()
-	require.NoError(t.T(), err)
+	require.NoError(t.T(), err, "Failed to apply quota %s in %s", quota, namespace)
 	t.T().Logf("Successfully applied quota %s in %s", quota, namespace)
 }
 
@@ -68,6 +68,6 @@ func KubectlDeleteAllPods(t Test, namespace string) {
 	t.T().Helper()
 	kubectlCmd := exec.CommandContext(t.Ctx(), "kubectl", "delete", "--all", "pods", "-n", namespace)
 	err := kubectlCmd.Run()
-	require.NoError(t.T(), err)
+	require.NoError(t.T(), err, "Failed to delete pods in %s", namespace)
 	t.T().Logf("Successfully delete pods in %s", namespace)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Continue https://github.com/ray-project/kuberay/issues/2645.

This PR adds e2e tests for the `HeadPodReady`, `RayClusterProvisioned`, and `ReplicaFailure` status conditions.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
