### PR TITLE
[CI][Hotfix] Increase the timeout of `Test E2E` from 30m to 1h

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -12,7 +12,7 @@
     - IMG=kuberay/operator:nightly make deploy
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run e2e tests
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2e
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2e
     # Printing KubeRay operator logs
     - kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As we add more and more end-to-end tests, 30 minutes is no longer sufficient. This PR increases the timeout from 30 minutes to 1 hour.

There is an example timeout failure: https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/5725#_


This is just a hotfix. For long-term, we should separate the e2e tests into different Buildkite runners.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
