### PR TITLE
[Feat] Add support user-defined serve service ports

### DIFF
--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -238,7 +238,6 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 			if serveService.ObjectMeta.Annotations == nil {
 				serveService.ObjectMeta.Annotations = make(map[string]string)
 			}
-
 			// Add port with name "serve" if it is already not added and ignore any custom ports
 			// Keeping this consistentent with adding only serve port in serve service
 			if len(ports) != 0 {
@@ -248,7 +247,8 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 				ports := []corev1.ServicePort{}
 				for _, port := range serveService.Spec.Ports {
 					if port.Name == utils.ServingPortName {
-						svcPort := corev1.ServicePort{Name: port.Name, Port: port.Port}
+						svcPort := corev1.ServicePort{Name: port.Name, Port: port.Port, NodePort: port.NodePort,
+							TargetPort: port.TargetPort}
 						ports = append(ports, svcPort)
 						break
 					}


### PR DESCRIPTION
## Why are these changes needed?

Users may only need to customize the serve service to use the NodePort mode for external access, but currently, the implementation requires setting all ports in the cluster to NodePort mode.

## Related issue number


## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
