### PR TITLE
[kubectl-plugin] fix worker resources in 'kubectl ray create cluster' command

### DIFF
--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -90,12 +90,12 @@ func (rayClusterSpecObject *RayClusterSpecObject) generateRayClusterSpec() *rayv
 						WithImage(rayClusterSpecObject.Image).
 						WithResources(corev1ac.ResourceRequirements().
 							WithRequests(corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse(rayClusterSpecObject.HeadCPU),
-								corev1.ResourceMemory: resource.MustParse(rayClusterSpecObject.HeadMemory),
+								corev1.ResourceCPU:    resource.MustParse(rayClusterSpecObject.WorkerCPU),
+								corev1.ResourceMemory: resource.MustParse(rayClusterSpecObject.WorkerMemory),
 							}).
 							WithLimits(corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse(rayClusterSpecObject.HeadCPU),
-								corev1.ResourceMemory: resource.MustParse(rayClusterSpecObject.HeadMemory),
+								corev1.ResourceCPU:    resource.MustParse(rayClusterSpecObject.WorkerCPU),
+								corev1.ResourceMemory: resource.MustParse(rayClusterSpecObject.WorkerMemory),
 							}))))))
 
 	// Lifecycle cannot be empty, an empty lifecycle will stop pod startup so this will add lifecycle if its not empty

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -21,8 +21,8 @@ func TestGenerateRayCluterApplyConfig(t *testing.T) {
 			HeadMemory:     "5Gi",
 			WorkerGrpName:  "worker-group1",
 			WorkerReplicas: 3,
-			WorkerCPU:      "1",
-			WorkerMemory:   "5Gi",
+			WorkerCPU:      "2",
+			WorkerMemory:   "10Gi",
 		},
 	}
 
@@ -52,8 +52,8 @@ func TestGenerateRayJobApplyConfig(t *testing.T) {
 			HeadMemory:     "5Gi",
 			WorkerGrpName:  "worker-group1",
 			WorkerReplicas: 3,
-			WorkerCPU:      "1",
-			WorkerMemory:   "5Gi",
+			WorkerCPU:      "2",
+			WorkerMemory:   "10Gi",
 		},
 	}
 
@@ -83,8 +83,8 @@ func TestConvertRayClusterApplyConfigToYaml(t *testing.T) {
 			HeadMemory:     "5Gi",
 			WorkerGrpName:  "worker-group1",
 			WorkerReplicas: 3,
-			WorkerCPU:      "1",
-			WorkerMemory:   "5Gi",
+			WorkerCPU:      "2",
+			WorkerMemory:   "10Gi",
 		},
 	}
 
@@ -133,11 +133,11 @@ spec:
           name: ray-worker
           resources:
             limits:
-              cpu: "1"
-              memory: 5Gi
+              cpu: "2"
+              memory: 10Gi
             requests:
-              cpu: "1"
-              memory: 5Gi`
+              cpu: "2"
+              memory: 10Gi`
 
 	assert.Equal(t, expectedResultYaml, strings.TrimSpace(resultString))
 }


### PR DESCRIPTION
## Why are these changes needed?

Fix a bug where worker group resources are not passed in correctly

## Related issue number

https://github.com/ray-project/kuberay/issues/2608

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [X] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
