### PR TITLE
[Feature]: Add a new event type FailedToDeleteWorkerPodCollection

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -779,7 +779,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		// Delete all workers if worker group is suspended and skip reconcile
 		if worker.Suspend != nil && *worker.Suspend {
 			if _, err := r.deleteAllPods(ctx, common.RayClusterGroupPodsAssociationOptions(instance, worker.GroupName)); err != nil {
-				r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.FailedToDeleteWorkerPod),
+				r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.FailedToDeleteWorkerPodCollection),
 					"Failed deleting worker Pods for suspended group %s in RayCluster %s/%s, %v", worker.GroupName, instance.Namespace, instance.Name, err)
 				return errstd.Join(utils.ErrFailedDeleteWorkerPod, err)
 			}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -668,7 +668,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	if suspendStatus == rayv1.RayClusterSuspending ||
 		(!statusConditionGateEnabled && instance.Spec.Suspend != nil && *instance.Spec.Suspend) {
 		if _, err := r.deleteAllPods(ctx, common.RayClusterAllPodsAssociationOptions(instance)); err != nil {
-			r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.FailedToDeletePod),
+			r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.FailedToDeletePodCollection),
 				"Failed deleting Pods due to suspension for RayCluster %s/%s, %v",
 				instance.Namespace, instance.Name, err)
 			return errstd.Join(utils.ErrFailedDeleteAllPods, err)

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -272,8 +272,9 @@ const (
 	InvalidRayServiceSpec K8sEventType = "InvalidRayServiceSpec"
 
 	// Generic Pod event list
-	DeletedPod        K8sEventType = "DeletedPod"
-	FailedToDeletePod K8sEventType = "FailedToDeletePod"
+	DeletedPod                  K8sEventType = "DeletedPod"
+	FailedToDeletePod           K8sEventType = "FailedToDeletePod"
+	FailedToDeletePodCollection K8sEventType = "FailedToDeletePodCollection"
 
 	// Ingress event list
 	CreatedIngress        K8sEventType = "CreatedIngress"

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -246,10 +246,11 @@ const (
 	FailedToDeleteHeadPod K8sEventType = "FailedToDeleteHeadPod"
 
 	// Worker Pod event list
-	CreatedWorkerPod        K8sEventType = "CreatedWorkerPod"
-	FailedToCreateWorkerPod K8sEventType = "FailedToCreateWorkerPod"
-	DeletedWorkerPod        K8sEventType = "DeletedWorkerPod"
-	FailedToDeleteWorkerPod K8sEventType = "FailedToDeleteWorkerPod"
+	CreatedWorkerPod                  K8sEventType = "CreatedWorkerPod"
+	FailedToCreateWorkerPod           K8sEventType = "FailedToCreateWorkerPod"
+	DeletedWorkerPod                  K8sEventType = "DeletedWorkerPod"
+	FailedToDeleteWorkerPod           K8sEventType = "FailedToDeleteWorkerPod"
+	FailedToDeleteWorkerPodCollection K8sEventType = "FailedToDeleteWorkerPodCollection"
 
 	// Redis Cleanup Job event list
 	CreatedRedisCleanupJob        K8sEventType = "CreatedRedisCleanupJob"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, we are reusing the `FailedToDeleteWorkerPod` event type for scenarios where both `Delete` (requiring the `delete` verb in `Role` or `ClusterRole`) and `DeleteAllOf` (requiring the `deletecollection` verb) are involved. However, this reuse may lead to confusion because these operations rely on different verbs and permissions.

To improve clarity and maintainability, we should consider introducing a new event type specific to the `DeleteAllOf` operation.
## Related issue number

<!-- For example: "Closes #1234" -->
Closes #2672 
## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
