### PR TITLE
[Feature] Print KubeRay logs in Buildkite runner when tests fail

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -11,10 +11,8 @@
     - kind load docker-image kuberay/operator:nightly
     - IMG=kuberay/operator:nightly make deploy
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
-    # Run e2e tests
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2e
-    # Printing KubeRay operator logs
-    - kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay
+    # Run e2e tests and print KubeRay operator logs if tests fail
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2e || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
 
 - label: 'Test E2E rayservice (nightly operator)'
   instance_size: large
@@ -29,10 +27,8 @@
     - kind load docker-image kuberay/operator:nightly
     - IMG=kuberay/operator:nightly make deploy
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
-    # Run e2e tests
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2erayservice
-    # Printing KubeRay operator logs
-    - kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay
+    # Run e2e tests and print KubeRay operator logs if tests fail
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2erayservice || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
 
 - label: 'Test Autoscaler E2E (nightly operator)'
   instance_size: large
@@ -47,7 +43,5 @@
     - kind load docker-image kuberay/operator:nightly
     - IMG=kuberay/operator:nightly make deploy
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
-    # Run e2e tests
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2eautoscaler
-    # Printing KubeRay operator logs
-    - kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay
+    # Run e2e tests and print KubeRay operator logs if tests fail
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2eautoscaler || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
See #2652 

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #2652 

## Manual tests

I set the timeout to 1 second locally using the following command to make the test fail, and observed the logs to see if there was any output : 
```
go test -timeout 1s -v ./test/e2e || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1) >> ~/data/kuberay-operator.log
```

kuberay-operator.log : 
```
{"level":"info","ts":"2024-12-27T06:14:03.982Z","logger":"setup","msg":"Loaded feature gates","featureGates":{"RayClusterStatusConditions":true}}
{"level":"info","ts":"2024-12-27T06:14:03.983Z","logger":"setup","msg":"Flag watchNamespace is not set. Watch custom resources in all namespaces."}
{"level":"info","ts":"2024-12-27T06:14:03.983Z","logger":"setup","msg":"Setup manager"}
{"level":"info","ts":"2024-12-27T06:14:04.185Z","logger":"setup","msg":"starting manager"}
{"level":"info","ts":"2024-12-27T06:14:04.185Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2024-12-27T06:14:04.185Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
{"level":"info","ts":"2024-12-27T06:14:04.186Z","msg":"starting server","kind":"health probe","addr":"[::]:8082"}
{"level":"info","ts":"2024-12-27T06:14:04.387Z","msg":"attempting to acquire leader lease default/ray-operator-leader..."}
{"level":"info","ts":"2024-12-27T06:14:21.213Z","msg":"successfully acquired lease default/ray-operator-leader"}
...
```

And after setting it properly and passing the test using the following command, I observed the log output:
```
go test -timeout 30m -v ./test/e2e || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1) >> ~/data/kuberay-operator.log
```

kuberay-operator.log : 
```
(empty)
```

Therefore, it can be confirmed that the logs are printed only when the test fails.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
