### PR TITLE
[Feature] Support ARM image for test

### DIFF
--- a/ray-operator/test/support/environment.go
+++ b/ray-operator/test/support/environment.go
@@ -1,7 +1,10 @@
 package support
 
 import (
+	"fmt"
 	"os"
+	"runtime"
+	"strings"
 )
 
 const (
@@ -20,7 +23,15 @@ func GetRayVersion() string {
 }
 
 func GetRayImage() string {
-	return lookupEnvOrDefault(KuberayTestRayImage, RayImage)
+	rayImage := lookupEnvOrDefault(KuberayTestRayImage, RayImage)
+	// detect if we are running on arm64 machine, most likely apple silicon
+	// the os name is not checked as it also possible that it might be linux
+	// also check if the image does not have the `-aarch64` suffix
+	if runtime.GOARCH == "arm64" && !strings.HasSuffix(rayImage, "-aarch64") {
+		rayImage = rayImage + "-aarch64"
+		fmt.Printf("Modified Ray Image to: %s for ARM chips\n", rayImage)
+	}
+	return rayImage
 }
 
 func lookupEnvOrDefault(key, value string) string {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I found developers may need to have arm chip support for better development experience.
Change the GetRayImage handler will support most unit tests and e2e tests to use arm image.

## Test Results ## 

Test Log Format
![CleanShot 2024-12-30 at 23 11 42@2x](https://github.com/user-attachments/assets/c9957583-fa6a-4179-aa89-6d1c4dd08c19)

Success logs for all related references.
- Unit Test
```
test -s /Users/simo/Codes/kuberay/ray-operator/bin/controller-gen || GOBIN=/Users/simo/Codes/kuberay/ray-operator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0
/Users/simo/Codes/kuberay/ray-operator/bin/controller-gen "crd:maxDescLen=0,generateEmbeddedObjectMeta=true,allowDangerousTypes=true" rbac:roleName=kuberay-operator webhook paths="./..." output:crd:artifacts:config=config/crd/bases
go fmt ./...
go vet ./...
test -s /Users/simo/Codes/kuberay/ray-operator/bin/setup-envtest || GOBIN=/Users/simo/Codes/kuberay/ray-operator/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240201105228-4000e996a202
KUBEBUILDER_ASSETS="/Users/simo/Codes/kuberay/ray-operator/bin/k8s/1.24.2-darwin-arm64" go test github.com/ray-project/kuberay/ray-operator github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1 github.com/ray-project/kuberay/ray-operator/apis/ray/v1 github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1 github.com/ray-project/kuberay/ray-operator/controllers/ray github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/interface github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/volcano github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/yunikorn github.com/ray-project/kuberay/ray-operator/controllers/ray/common github.com/ray-project/kuberay/ray-operator/controllers/ray/expectations github.com/ray-project/kuberay/ray-operator/controllers/ray/utils github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/internal github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1 github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/fake github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1 github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1/fake github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions/internalinterfaces github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions/ray github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions/ray/v1 github.com/ray-project/kuberay/ray-operator/pkg/client/listers/ray/v1 github.com/ray-project/kuberay/ray-operator/pkg/features github.com/ray-project/kuberay/ray-operator/pkg/utils -coverprofile cover.out
	github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/interface		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/internal		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1		coverage: 0.0% of statements
ok  	github.com/ray-project/kuberay/ray-operator	1.261s	coverage: 8.3% of statements
ok  	github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1	0.366s	coverage: 21.8% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/fake		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1/fake		coverage: 0.0% of statements
?   	github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions/internalinterfaces	[no test files]
	github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions/ray		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/features		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions/ray/v1		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/listers/ray/v1		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/utils		coverage: 0.0% of statements
ok  	github.com/ray-project/kuberay/ray-operator/apis/ray/v1	11.100s	coverage: 12.9% of statements
ok  	github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1	0.564s	coverage: 0.9% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray	181.344s	coverage: 53.7% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler	0.908s	coverage: 37.0% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/volcano	1.570s	coverage: 8.5% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/yunikorn	2.137s	coverage: 61.1% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray/common	2.445s	coverage: 89.3% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray/expectations	3.846s	coverage: 81.1% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray/utils	2.610s	coverage: 35.3% of statements
```
- E2E Test
```
test -s /Users/simo/Codes/kuberay/ray-operator/bin/controller-gen || GOBIN=/Users/simo/Codes/kuberay/ray-operator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0
/Users/simo/Codes/kuberay/ray-operator/bin/controller-gen "crd:maxDescLen=0,generateEmbeddedObjectMeta=true,allowDangerousTypes=true" rbac:roleName=kuberay-operator webhook paths="./..." output:crd:artifacts:config=config/crd/bases
go fmt ./...
go vet ./...
go test -timeout 30m -v ./test/e2e
=== RUN   TestRayClusterManagedBy
=== RUN   TestRayClusterManagedBy/Successful_creation_of_cluster,_managed_by_Kuberay_Operator
=== PAUSE TestRayClusterManagedBy/Successful_creation_of_cluster,_managed_by_Kuberay_Operator
=== RUN   TestRayClusterManagedBy/Creation_of_cluster_skipped,_managed_by_Kueue
=== PAUSE TestRayClusterManagedBy/Creation_of_cluster_skipped,_managed_by_Kueue
=== RUN   TestRayClusterManagedBy/Failed_creation_of_cluster,_managed_by_external_non_supported_controller
=== PAUSE TestRayClusterManagedBy/Failed_creation_of_cluster,_managed_by_external_non_supported_controller
=== CONT  TestRayClusterManagedBy/Successful_creation_of_cluster,_managed_by_Kuberay_Operator
=== CONT  TestRayClusterManagedBy/Failed_creation_of_cluster,_managed_by_external_non_supported_controller
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== CONT  TestRayClusterManagedBy/Creation_of_cluster_skipped,_managed_by_Kueue
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayClusterManagedBy
    raycluster_test.go:34: Created RayCluster test-ns-5l5vd/raycluster-ok successfully
    raycluster_test.go:36: Waiting for RayCluster test-ns-5l5vd/raycluster-ok to become ready
    raycluster_test.go:50: Created RayCluster test-ns-5l5vd/raycluster-skip successfully
    raycluster_test.go:52: RayCluster test-ns-5l5vd/raycluster-skip will not become ready - not reconciled
    test.go:110: Retrieving Pod Container test-ns-5l5vd/raycluster-ok-head-74fsw/ray-head logs
    test.go:98: Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:101: Output directory has been created at: /var/folders/3k/5dtq_7lj7kn05h0cjw0gqy2m0000gn/T/TestRayClusterManagedBy3865228158/001
    test.go:110: Retrieving Pod Container test-ns-5l5vd/raycluster-ok-small-group-worker-24xw7/ray-worker logs
--- PASS: TestRayClusterManagedBy (0.04s)
    --- PASS: TestRayClusterManagedBy/Failed_creation_of_cluster,_managed_by_external_non_supported_controller (0.01s)
    --- PASS: TestRayClusterManagedBy/Creation_of_cluster_skipped,_managed_by_Kueue (3.02s)
    --- PASS: TestRayClusterManagedBy/Successful_creation_of_cluster,_managed_by_Kuberay_Operator (21.15s)
=== RUN   TestRayClusterSuspend
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
    raycluster_test.go:90: Created RayCluster test-ns-llj65/raycluster-suspend successfully
    raycluster_test.go:92: Waiting for RayCluster test-ns-llj65/raycluster-suspend to become ready
    raycluster_test.go:101: Suspend RayCluster test-ns-llj65/raycluster-suspend successfully
    raycluster_test.go:103: Waiting for RayCluster test-ns-llj65/raycluster-suspend to be suspended
    raycluster_test.go:114: Resume RayCluster test-ns-llj65/raycluster-suspend successfully
    raycluster_test.go:116: Waiting for RayCluster test-ns-llj65/raycluster-suspend to be resumed
    test.go:110: Retrieving Pod Container test-ns-llj65/raycluster-suspend-head-pc4fz/ray-head logs
    test.go:98: Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:101: Output directory has been created at: /var/folders/3k/5dtq_7lj7kn05h0cjw0gqy2m0000gn/T/TestRayClusterSuspend4171967734/001
    test.go:110: Retrieving Pod Container test-ns-llj65/raycluster-suspend-small-group-worker-dmq5j/ray-worker logs
--- PASS: TestRayClusterSuspend (42.38s)
=== RUN   TestRayJobWithClusterSelector
    rayjob_cluster_selector_test.go:27: Created ConfigMap test-ns-clnzr/jobs successfully
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
    rayjob_cluster_selector_test.go:35: Created RayCluster test-ns-clnzr/raycluster successfully
    rayjob_cluster_selector_test.go:37: Waiting for RayCluster test-ns-clnzr/raycluster to become ready
=== RUN   TestRayJobWithClusterSelector/Successful_RayJob
=== PAUSE TestRayJobWithClusterSelector/Successful_RayJob
=== RUN   TestRayJobWithClusterSelector/Failing_RayJob
=== PAUSE TestRayJobWithClusterSelector/Failing_RayJob
=== RUN   TestRayJobWithClusterSelector/RayJob_should_be_created_but_not_to_be_updated_when_managed_externally
=== PAUSE TestRayJobWithClusterSelector
=== RUN   TestRayJobLightWeightMode
    rayjob_lightweight_test.go:29: Created ConfigMap test-ns-kcrsn/jobs successfully
=== RUN   TestRayJobLightWeightMode/Successful_RayJob
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJobLightWeightMode
    rayjob_lightweight_test.go:58: Created RayJob test-ns-kcrsn/counter successfully
    rayjob_lightweight_test.go:60: Waiting for RayJob test-ns-kcrsn/counter to complete
=== RUN   TestRayJobLightWeightMode/Failing_RayJob_without_cluster_shutdown_after_finished
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJobLightWeightMode
    rayjob_lightweight_test.go:92: Created RayJob test-ns-kcrsn/fail successfully
    rayjob_lightweight_test.go:94: Waiting for RayJob test-ns-kcrsn/fail to complete
=== RUN   TestRayJobLightWeightMode/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped.
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJobLightWeightMode
    rayjob_lightweight_test.go:123: Created RayJob test-ns-kcrsn/stop successfully
    rayjob_lightweight_test.go:125: Waiting for RayJob test-ns-kcrsn/stop to be 'Running'
    rayjob_lightweight_test.go:129: Waiting for RayJob test-ns-kcrsn/stop to be 'Complete'
    rayjob_lightweight_test.go:139: Deleted RayJob test-ns-kcrsn/stop successfully
    test.go:110: Retrieving Pod Container test-ns-kcrsn/fail-raycluster-bvczm-head-wtq49/ray-head logs
    test.go:98: Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:101: Output directory has been created at: /var/folders/3k/5dtq_7lj7kn05h0cjw0gqy2m0000gn/T/TestRayJobLightWeightMode2943593109/001
    test.go:110: Retrieving Pod Container test-ns-kcrsn/fail-raycluster-bvczm-small-group-worker-m54fk/ray-worker logs
    test.go:110: Retrieving Pod Container test-ns-kcrsn/stop-raycluster-xrknd-head-nh7g7/ray-head logs
    test.go:110: Retrieving Pod Container test-ns-kcrsn/stop-raycluster-xrknd-small-group-worker-69mqd/ray-worker logs
--- PASS: TestRayJobLightWeightMode (84.59s)
    --- PASS: TestRayJobLightWeightMode/Successful_RayJob (21.12s)
    --- PASS: TestRayJobLightWeightMode/Failing_RayJob_without_cluster_shutdown_after_finished (21.13s)
    --- PASS: TestRayJobLightWeightMode/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped. (42.28s)
=== RUN   TestRayJobRecovery
    rayjob_recovery_test.go:28: Created ConfigMap test-ns-hnzb9/jobs successfully
=== RUN   TestRayJobRecovery/RayJob_should_recover_after_pod_deletion
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJobRecovery
    rayjob_recovery_test.go:44: Created RayJob test-ns-hnzb9/counter successfully
    rayjob_recovery_test.go:46: Waiting for RayJob test-ns-hnzb9/counter to start running
    rayjob_recovery_test.go:49: Find RayJob test-ns-hnzb9/counter running
    rayjob_recovery_test.go:51: Sleep RayJob test-ns-hnzb9/counter 15 seconds
    rayjob_recovery_test.go:63: Delete Pod counter-lp8p9 from namespace  test-ns-hnzb9
    rayjob_recovery_test.go:70: Waiting for new pod to be created and running for RayJob test-ns-hnzb9/counter
    rayjob_recovery_test.go:89: Found new running pod test-ns-hnzb9/counter-lp8p9
    test.go:110: Retrieving Pod Container test-ns-hnzb9/counter-xr5tc/ray-job-submitter logs
    test.go:98: Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:101: Output directory has been created at: /var/folders/3k/5dtq_7lj7kn05h0cjw0gqy2m0000gn/T/TestRayJobRecovery4270027822/001
    test.go:110: Retrieving Pod Container test-ns-hnzb9/counter-raycluster-g9dhz-head-ckm2t/ray-head logs
    test.go:110: Retrieving Pod Container test-ns-hnzb9/counter-raycluster-g9dhz-small-group-worker-rsmzk/ray-worker logs
--- PASS: TestRayJobRecovery (85.55s)
    --- PASS: TestRayJobRecovery/RayJob_should_recover_after_pod_deletion (85.52s)
=== RUN   TestRayJobRetry
    rayjob_retry_test.go:27: Created ConfigMap test-ns-f8z2n/jobs successfully
=== RUN   TestRayJobRetry/Failing_RayJob_without_cluster_shutdown_after_finished
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJobRetry
    rayjob_retry_test.go:43: Created RayJob test-ns-f8z2n/fail successfully
    rayjob_retry_test.go:45: Waiting for RayJob test-ns-f8z2n/fail to complete
    rayjob_retry_test.go:70: Deleted RayJob test-ns-f8z2n/fail successfully
=== RUN   TestRayJobRetry/Failing_submitter_K8s_Job
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJobRetry
    rayjob_retry_test.go:101: Created RayJob test-ns-f8z2n/fail-submitter-k8s-job successfully
    rayjob_retry_test.go:102: Waiting for RayJob test-ns-f8z2n/fail-submitter-k8s-job to complete
    rayjob_retry_test.go:135: Deleted RayJob test-ns-f8z2n/fail-submitter-k8s-job successfully
=== RUN   TestRayJobRetry/RayJob_has_passed_ActiveDeadlineSeconds
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJobRetry
    rayjob_retry_test.go:155: Created RayJob test-ns-f8z2n/long-running successfully
    rayjob_retry_test.go:158: Waiting for RayJob test-ns-f8z2n/long-running to be 'Failed'
=== RUN   TestRayJobRetry/Failing_RayJob_with_HttpMode_submission_mode
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJobRetry
    rayjob_retry_test.go:183: Created RayJob test-ns-f8z2n/failing-rayjob-in-httpmode successfully
    rayjob_retry_test.go:185: Waiting for RayJob test-ns-f8z2n/failing-rayjob-in-httpmode to complete
    rayjob_retry_test.go:208: Deleted RayJob test-ns-f8z2n/failing-rayjob-in-httpmode successfully
    test.go:110: Retrieving Pod Container test-ns-f8z2n/long-running-raycluster-t5qd9-head-nf46d/ray-head logs
    test.go:98: Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:101: Output directory has been created at: /var/folders/3k/5dtq_7lj7kn05h0cjw0gqy2m0000gn/T/TestRayJobRetry1030587021/001
    test.go:110: Retrieving Pod Container test-ns-f8z2n/long-running-raycluster-t5qd9-small-group-worker-bsxfj/ray-worker logs
    test.go:110: Retrieving Pod Container test-ns-f8z2n/failing-rayjob-in-httpmode-raycluster-wkfm5-head-n5kss/ray-head logs
    test.go:110: Retrieving Pod Container test-ns-f8z2n/failing-rayjob-in-httpmode-raycluster-wkfm5-small--worker-b8dq4/ray-worker logs
--- PASS: TestRayJobRetry (233.59s)
    --- PASS: TestRayJobRetry/Failing_RayJob_without_cluster_shutdown_after_finished (90.58s)
    --- PASS: TestRayJobRetry/Failing_submitter_K8s_Job (66.44s)
    --- PASS: TestRayJobRetry/RayJob_has_passed_ActiveDeadlineSeconds (7.04s)
    --- PASS: TestRayJobRetry/Failing_RayJob_with_HttpMode_submission_mode (69.46s)
=== RUN   TestRayJobSuspend
    rayjob_suspend_test.go:29: Created ConfigMap test-ns-x7crk/jobs successfully
=== RUN   TestRayJobSuspend/Suspend_the_RayJob_when_its_status_is_'Running',_and_then_resume_it.
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJobSuspend
    rayjob_suspend_test.go:43: Created RayJob test-ns-x7crk/long-running successfully
    rayjob_suspend_test.go:45: Waiting for RayJob test-ns-x7crk/long-running to be 'Running'
    rayjob_suspend_test.go:49: Suspend the RayJob test-ns-x7crk/long-running
    rayjob_suspend_test.go:54: Waiting for RayJob test-ns-x7crk/long-running to be 'Suspended'
    rayjob_suspend_test.go:70: Resume the RayJob by updating `suspend` to false.
    rayjob_suspend_test.go:80: Deleted RayJob test-ns-x7crk/long-running successfully
=== RUN   TestRayJobSuspend/Create_a_suspended_RayJob,_and_then_resume_it.
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJobSuspend
    rayjob_suspend_test.go:99: Created RayJob test-ns-x7crk/counter successfully
    rayjob_suspend_test.go:101: Waiting for RayJob test-ns-x7crk/counter to be 'Suspended'
    rayjob_suspend_test.go:105: Resume the RayJob by updating `suspend` to false.
    rayjob_suspend_test.go:110: Waiting for RayJob test-ns-x7crk/counter to complete
    rayjob_suspend_test.go:125: Deleted RayJob test-ns-x7crk/counter successfully
    test.go:110: Retrieving Pod Container test-ns-x7crk/long-running-q6ntl/ray-job-submitter logs
    test.go:98: Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:101: Output directory has been created at: /var/folders/3k/5dtq_7lj7kn05h0cjw0gqy2m0000gn/T/TestRayJobSuspend3125970771/001
--- PASS: TestRayJobSuspend (62.47s)
    --- PASS: TestRayJobSuspend/Suspend_the_RayJob_when_its_status_is_'Running',_and_then_resume_it. (33.23s)
    --- PASS: TestRayJobSuspend/Create_a_suspended_RayJob,_and_then_resume_it. (29.20s)
=== RUN   TestRayJob
    rayjob_test.go:30: Created ConfigMap test-ns-kqc24/jobs successfully
=== RUN   TestRayJob/Successful_RayJob
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJob
    rayjob_test.go:47: Created RayJob test-ns-kqc24/counter successfully
    rayjob_test.go:49: Waiting for RayJob test-ns-kqc24/counter to complete
    rayjob_test.go:77: Update `suspend` to true. However, since the RayJob is completed, the status should not be updated to `Suspended`.
    rayjob_test.go:87: Deleted RayJob test-ns-kqc24/counter successfully
=== RUN   TestRayJob/Failing_RayJob_without_cluster_shutdown_after_finished
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJob
    rayjob_test.go:101: Created RayJob test-ns-kqc24/fail successfully
    rayjob_test.go:103: Waiting for RayJob test-ns-kqc24/fail to complete
    rayjob_test.go:126: Deleted RayJob test-ns-kqc24/fail successfully
=== RUN   TestRayJob/Failing_submitter_K8s_Job
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJob
    rayjob_test.go:154: Created RayJob test-ns-kqc24/fail-k8s-job successfully
    rayjob_test.go:156: Waiting for RayJob test-ns-kqc24/fail-k8s-job to complete
    rayjob_test.go:179: Deleted RayJob test-ns-kqc24/fail-k8s-job successfully
=== RUN   TestRayJob/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped.
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJob
    rayjob_test.go:193: Created RayJob test-ns-kqc24/stop successfully
    rayjob_test.go:195: Waiting for RayJob test-ns-kqc24/stop to be 'Running'
    rayjob_test.go:199: Waiting for RayJob test-ns-kqc24/stop to be 'Complete'
    rayjob_test.go:209: Deleted RayJob test-ns-kqc24/stop successfully
=== RUN   TestRayJob/RuntimeEnvYAML_is_not_a_valid_YAML_string
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJob
    rayjob_test.go:221: Created RayJob test-ns-kqc24/invalid-yamlstr successfully
=== RUN   TestRayJob/RayJob_has_passed_ActiveDeadlineSeconds
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJob
    rayjob_test.go:240: Created RayJob test-ns-kqc24/long-running successfully
    rayjob_test.go:243: Waiting for RayJob test-ns-kqc24/long-running to be 'Complete'
=== RUN   TestRayJob/RayJob_should_be_created,_but_not_updated_when_managed_externally
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJob
    rayjob_test.go:266: Created RayJob test-ns-kqc24/managed-externally successfully
    rayjob_test.go:292: Deleted RayJob test-ns-kqc24/managed-externally successfully
    test.go:110: Retrieving Pod Container test-ns-kqc24/long-running-raycluster-tvcf2-head-kln99/ray-head logs
    test.go:98: Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:101: Output directory has been created at: /var/folders/3k/5dtq_7lj7kn05h0cjw0gqy2m0000gn/T/TestRayJob4219379599/001
    test.go:110: Retrieving Pod Container test-ns-kqc24/long-running-raycluster-tvcf2-small-group-worker-jpv2z/ray-worker logs
    test.go:110: Error getting logs from container test-ns-kqc24/long-running-raycluster-tvcf2-small-group-worker-jpv2z/ray-worker
--- PASS: TestRayJob (224.63s)
    --- PASS: TestRayJob/Successful_RayJob (61.23s)
    --- PASS: TestRayJob/Failing_RayJob_without_cluster_shutdown_after_finished (44.36s)
    --- PASS: TestRayJob/Failing_submitter_K8s_Job (54.47s)
    --- PASS: TestRayJob/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped. (53.46s)
    --- PASS: TestRayJob/RuntimeEnvYAML_is_not_a_valid_YAML_string (5.01s)
    --- PASS: TestRayJob/RayJob_has_passed_ActiveDeadlineSeconds (6.04s)
    --- PASS: TestRayJob/RayJob_should_be_created,_but_not_updated_when_managed_externally (0.03s)
=== CONT  TestRayJobWithClusterSelector
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
    rayjob_cluster_selector_test.go:109: Created RayJob test-ns-clnzr/managed-externally successfully
=== RUN   TestRayJobWithClusterSelector/RayJob_should_not_be_created_due_to_managedBy_invalid_value
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== CONT  TestRayJobWithClusterSelector/Successful_RayJob
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== CONT  TestRayJobWithClusterSelector/Failing_RayJob
Modified Ray Image to: rayproject/ray:2.40.0-aarch64 for ARM chips
=== NAME  TestRayJobWithClusterSelector
    rayjob_cluster_selector_test.go:57: Created RayJob test-ns-clnzr/counter successfully
    rayjob_cluster_selector_test.go:59: Waiting for RayJob test-ns-clnzr/counter to complete
    rayjob_cluster_selector_test.go:81: Created RayJob test-ns-clnzr/fail successfully
    rayjob_cluster_selector_test.go:83: Waiting for RayJob test-ns-clnzr/fail to complete
    test.go:110: Retrieving Pod Container test-ns-clnzr/raycluster-head-f7pgq/ray-head logs
    test.go:98: Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:101: Output directory has been created at: /var/folders/3k/5dtq_7lj7kn05h0cjw0gqy2m0000gn/T/TestRayJobWithClusterSelector1204191175/001
    test.go:110: Retrieving Pod Container test-ns-clnzr/raycluster-small-group-worker-br5cq/ray-worker logs
    test.go:110: Retrieving Pod Container test-ns-clnzr/counter-tl525/ray-job-submitter logs
    test.go:110: Retrieving Pod Container test-ns-clnzr/fail-lc9sn/ray-job-submitter logs
--- PASS: TestRayJobWithClusterSelector (24.19s)
    --- PASS: TestRayJobWithClusterSelector/RayJob_should_be_created_but_not_to_be_updated_when_managed_externally (693.83s)
    --- PASS: TestRayJobWithClusterSelector/RayJob_should_not_be_created_due_to_managedBy_invalid_value (0.01s)
    --- PASS: TestRayJobWithClusterSelector/Failing_RayJob (8.04s)
    --- PASS: TestRayJobWithClusterSelector/Successful_RayJob (11.08s)
PASS
ok  	github.com/ray-project/kuberay/ray-operator/test/e2e	790.105s
```
- E2E Autoscaler Test 
```
test -s /Users/simo/Codes/kuberay/ray-operator/bin/controller-gen || GOBIN=/Users/simo/Codes/kuberay/ray-operator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0
/Users/simo/Codes/kuberay/ray-operator/bin/controller-gen "crd:maxDescLen=0,generateEmbeddedObjectMeta=true,allowDangerousTypes=true" rbac:roleName=kuberay-operator webhook paths="./..." output:crd:artifacts:config=config/crd/bases
go fmt ./...
go vet ./...
test -s /Users/simo/Codes/kuberay/ray-operator/bin/setup-envtest || GOBIN=/Users/simo/Codes/kuberay/ray-operator/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240201105228-4000e996a202
KUBEBUILDER_ASSETS="/Users/simo/Codes/kuberay/ray-operator/bin/k8s/1.24.2-darwin-arm64" go test github.com/ray-project/kuberay/ray-operator github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1 github.com/ray-project/kuberay/ray-operator/apis/ray/v1 github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1 github.com/ray-project/kuberay/ray-operator/controllers/ray github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/interface github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/volcano github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/yunikorn github.com/ray-project/kuberay/ray-operator/controllers/ray/common github.com/ray-project/kuberay/ray-operator/controllers/ray/expectations github.com/ray-project/kuberay/ray-operator/controllers/ray/utils github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/internal github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1 github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/fake github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1 github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1/fake github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions/internalinterfaces github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions/ray github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions/ray/v1 github.com/ray-project/kuberay/ray-operator/pkg/client/listers/ray/v1 github.com/ray-project/kuberay/ray-operator/pkg/features github.com/ray-project/kuberay/ray-operator/pkg/utils -coverprofile cover.out
	github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/interface		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/internal		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1		coverage: 0.0% of statements
ok  	github.com/ray-project/kuberay/ray-operator	1.261s	coverage: 8.3% of statements
ok  	github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1	0.366s	coverage: 21.8% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/fake		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1/fake		coverage: 0.0% of statements
?   	github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions/internalinterfaces	[no test files]
	github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions/ray		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/features		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/informers/externalversions/ray/v1		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/client/listers/ray/v1		coverage: 0.0% of statements
	github.com/ray-project/kuberay/ray-operator/pkg/utils		coverage: 0.0% of statements
ok  	github.com/ray-project/kuberay/ray-operator/apis/ray/v1	11.100s	coverage: 12.9% of statements
ok  	github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1	0.564s	coverage: 0.9% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray	181.344s	coverage: 53.7% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler	0.908s	coverage: 37.0% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/volcano	1.570s	coverage: 8.5% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/yunikorn	2.137s	coverage: 61.1% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray/common	2.445s	coverage: 89.3% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray/expectations	3.846s	coverage: 81.1% of statements
ok  	github.com/ray-project/kuberay/ray-operator/controllers/ray/utils	2.610s	coverage: 35.3% of statements
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
