### PR TITLE
[chore] remove redundant interface check

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -129,8 +129,6 @@ func NewReconciler(ctx context.Context, mgr manager.Manager, options RayClusterR
 	}
 }
 
-var _ reconcile.Reconciler = &RayClusterReconciler{}
-
 // RayClusterReconciler reconciles a RayCluster object
 type RayClusterReconciler struct {
 	client.Client


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

According to [Effetive Go inteface check](https://go.dev/doc/effective_go#blank_implements)
`
The appearance of the blank identifier in this construct indicates that the declaration exists only for the type checking, not to create a variable. Don't do this for every type that satisfies an interface, though. By convention, such declarations are only used when there are no static conversions already present in the code, which is a rare event.
`

The `complete()` function call has ensured that.
https://github.com/ray-project/kuberay/blob/f2d7c1f2b019034d0d194be7f9edc5d7a61fee94/ray-operator/controllers/ray/raycluster_controller.go#L1253

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
