### PR TITLE
[RayService][refactor] Remove `updateState`

### DIFF
--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -11,13 +11,9 @@ import (
 type ServiceStatus string
 
 const (
-	FailedToGetOrCreateRayCluster    ServiceStatus = "FailedToGetOrCreateRayCluster"
-	WaitForServeDeploymentReady      ServiceStatus = "WaitForServeDeploymentReady"
-	FailedToGetServeDeploymentStatus ServiceStatus = "FailedToGetServeDeploymentStatus"
-	Running                          ServiceStatus = "Running"
-	Restarting                       ServiceStatus = "Restarting"
-	FailedToUpdateServingPodLabel    ServiceStatus = "FailedToUpdateServingPodLabel"
-	FailedToUpdateService            ServiceStatus = "FailedToUpdateService"
+	WaitForServeDeploymentReady ServiceStatus = "WaitForServeDeploymentReady"
+	Running                     ServiceStatus = "Running"
+	Restarting                  ServiceStatus = "Restarting"
 )
 
 type RayServiceUpgradeStrategy string

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -11,14 +11,9 @@ import (
 type ServiceStatus string
 
 const (
-	FailedToGetOrCreateRayCluster    ServiceStatus = "FailedToGetOrCreateRayCluster"
-	WaitForServeDeploymentReady      ServiceStatus = "WaitForServeDeploymentReady"
-	FailedToGetServeDeploymentStatus ServiceStatus = "FailedToGetServeDeploymentStatus"
-	Running                          ServiceStatus = "Running"
-	Restarting                       ServiceStatus = "Restarting"
-	FailedToUpdateIngress            ServiceStatus = "FailedToUpdateIngress"
-	FailedToUpdateServingPodLabel    ServiceStatus = "FailedToUpdateServingPodLabel"
-	FailedToUpdateService            ServiceStatus = "FailedToUpdateService"
+	WaitForServeDeploymentReady ServiceStatus = "WaitForServeDeploymentReady"
+	Running                     ServiceStatus = "Running"
+	Restarting                  ServiceStatus = "Restarting"
 )
 
 // These statuses should match Ray Serve's application statuses

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -507,14 +507,13 @@ func (r *RayServiceReconciler) cleanUpRayClusterInstance(ctx context.Context, ra
 }
 
 func (r *RayServiceReconciler) getRayClusterByNamespacedName(ctx context.Context, clusterKey client.ObjectKey) (*rayv1.RayCluster, error) {
+	if clusterKey.Name == "" {
+		return nil, nil
+	}
+
 	rayCluster := &rayv1.RayCluster{}
-	if clusterKey.Name != "" {
-		// Ignore not found since in that case we should return RayCluster as nil.
-		if err := r.Get(ctx, clusterKey, rayCluster); client.IgnoreNotFound(err) != nil {
-			return nil, err
-		}
-	} else {
-		rayCluster = nil
+	if err := r.Get(ctx, clusterKey, rayCluster); client.IgnoreNotFound(err) != nil {
+		return nil, err
 	}
 
 	return rayCluster, nil


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It's not a good pattern to update the CR status from multiple places during a single reconciliation. This PR removes `updateState`, which is called in multiple locations and updates the status only for observability purposes. Additionally, these states are not fully mutually exclusive, making it impossible for users to determine the current state based on the status.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
