### PR TITLE
[Refactor] Remove ingress in service controller

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -15,8 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/utils/lru"
 
-	networkingv1 "k8s.io/api/networking/v1"
-
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 
@@ -97,9 +95,6 @@ func NewRayServiceReconciler(_ context.Context, mgr manager.Manager, provider ut
 // +kubebuilder:rbac:groups=core,resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=services/proxy,verbs=get;update;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingressclasses,verbs=get;list;watch
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;delete;patch
-// +kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;delete
@@ -198,19 +193,19 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
 	}
 
-	// Get the ready Ray cluster instance for service and ingress update.
+	// Get the ready Ray cluster instance for service update.
 	var rayClusterInstance *rayv1.RayCluster
 	if pendingRayClusterInstance != nil {
 		rayClusterInstance = pendingRayClusterInstance
-		logger.Info("Reconciling the ingress and service resources " +
+		logger.Info("Reconciling the service resources " +
 			"on the pending Ray cluster.")
 	} else if activeRayClusterInstance != nil {
 		rayClusterInstance = activeRayClusterInstance
-		logger.Info("Reconciling the ingress and service resources " +
+		logger.Info("Reconciling the service resources " +
 			"on the active Ray cluster. No pending Ray cluster found.")
 	} else {
 		rayClusterInstance = nil
-		logger.Info("No Ray cluster found. Skipping ingress and service reconciliation.")
+		logger.Info("No Ray cluster found. Skipping service reconciliation.")
 	}
 
 	if rayClusterInstance != nil {
@@ -367,7 +362,6 @@ func (r *RayServiceReconciler) SetupWithManager(mgr ctrl.Manager, reconcileConcu
 		))).
 		Owns(&rayv1.RayCluster{}).
 		Owns(&corev1.Service{}).
-		Owns(&networkingv1.Ingress{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: reconcileConcurrency,
 			LogConstructor: func(request *reconcile.Request) logr.Logger {
@@ -487,7 +481,6 @@ func (r *RayServiceReconciler) cleanUpRayClusterInstance(ctx context.Context, ra
 	}
 
 	// Clean up RayCluster instances. Each instance is deleted 60 seconds
-	// after becoming inactive to give the ingress time to update.
 	for _, rayClusterInstance := range rayClusterList.Items {
 		if rayClusterInstance.Name != rayServiceInstance.Status.ActiveServiceStatus.RayClusterName && rayClusterInstance.Name != rayServiceInstance.Status.PendingServiceStatus.RayClusterName {
 			cachedTimestamp, exists := r.RayClusterDeletionTimestamps.Get(rayClusterInstance.Name)


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Refer to issue #2707 

## Related issue number
"Closes #2707"

## Checks
```
k get pods
NAME                                                          READY   STATUS    RESTARTS   AGE
kuberay-operator-696bc84cc4-vtrqs                             1/1     Running   0          3m14s
rayservice-sample-raycluster-bcb7b-head-5ppzt                 1/1     Running   0          2m51s
rayservice-sample-raycluster-bcb7b-small-group-worker-mzvck   1/1     Running   0          2m51s
```
<img width="1690" alt="image" src="https://github.com/user-attachments/assets/b7f26cc4-95cc-44d4-84ed-44e8af7a3432" />
Only RayCluster controllers logs are left.


- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
