### PR TITLE
[Chore] specify the capacity on calling make

### DIFF
--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -211,7 +211,7 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 
 	// `portsInt` is a map of port names to port numbers, while `ports` is a list of ServicePort objects
 	portsInt := getServicePorts(rayCluster)
-	ports := []corev1.ServicePort{}
+	ports := make([]corev1.ServicePort, 0, 1)
 	for name, port := range portsInt {
 		if name == utils.ServingPortName {
 			svcPort := corev1.ServicePort{Name: name, Port: port}
@@ -245,7 +245,7 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 				log.Info("port with name 'serve' already added. Ignoring user provided ports for serve service")
 				serveService.Spec.Ports = ports
 			} else {
-				ports := []corev1.ServicePort{}
+				ports := make([]corev1.ServicePort, 0, 1)
 				for _, port := range serveService.Spec.Ports {
 					if port.Name == utils.ServingPortName {
 						svcPort := corev1.ServicePort{Name: port.Name, Port: port.Port}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The slice only appends at most one time because the following loop breaks once condition matched. It would be better to specify the capacity in advance.

https://github.com/ray-project/kuberay/blob/7bb5877a032c68fe02bf42d39b8883d8d28352c3/ray-operator/controllers/ray/common/service.go#L214-L221

https://github.com/ray-project/kuberay/blob/7bb5877a032c68fe02bf42d39b8883d8d28352c3/ray-operator/controllers/ray/common/service.go#L248-L255

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
