### PR TITLE
Remove preStop hooks from Ray CR Samples

### DIFF
--- a/ray-operator/config/samples/ray-cluster.autoscaler-v2.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler-v2.yaml
@@ -41,10 +41,6 @@ spec:
             name: dashboard
           - containerPort: 10001
             name: client
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           resources:
             limits:
               cpu: "1"

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -91,10 +91,6 @@ spec:
             name: dashboard
           - containerPort: 10001
             name: client
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
   workerGroupSpecs:
   # the pod replicas in this group typed worker
   - replicas: 1
@@ -139,7 +135,4 @@ spec:
             requests:
               cpu: 14
               memory: 54Gi
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
+

--- a/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.large.yaml
@@ -135,4 +135,3 @@ spec:
             requests:
               cpu: 14
               memory: 54Gi
-

--- a/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-cluster.autoscaler.yaml
@@ -63,10 +63,6 @@ spec:
             name: dashboard
           - containerPort: 10001
             name: client
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           resources:
             limits:
               cpu: "1"
@@ -109,10 +105,6 @@ spec:
         containers:
         - name: ray-worker
           image: rayproject/ray:2.9.0
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           resources:
             limits:
               cpu: "1"

--- a/ray-operator/config/samples/ray-cluster.complete.large.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.large.yaml
@@ -52,10 +52,6 @@ spec:
             name: dashboard
           - containerPort: 10001
             name: client
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           volumeMounts:
             - mountPath: /tmp/ray
               name: ray-logs
@@ -100,10 +96,6 @@ spec:
             requests:
               cpu: 14
               memory: 54Gi
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           # use volumeMounts.Optional.
           # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
           volumeMounts:

--- a/ray-operator/config/samples/ray-cluster.complete.yaml
+++ b/ray-operator/config/samples/ray-cluster.complete.yaml
@@ -38,10 +38,6 @@ spec:
             name: dashboard
           - containerPort: 10001
             name: client
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           volumeMounts:
             - mountPath: /tmp/ray
               name: ray-logs
@@ -92,10 +88,6 @@ spec:
         containers:
         - name: ray-worker
           image: rayproject/ray:2.9.0
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           # use volumeMounts.Optional.
           # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
           volumeMounts:

--- a/ray-operator/config/samples/ray-cluster.embed-grafana.yaml
+++ b/ray-operator/config/samples/ray-cluster.embed-grafana.yaml
@@ -32,10 +32,6 @@ spec:
             name: as-metrics # autoscaler
           - containerPort: 44227
             name: dash-metrics # dashboard
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           volumeMounts:
             - mountPath: /tmp/ray
               name: ray-logs
@@ -69,10 +65,6 @@ spec:
         containers:
         - name: ray-worker
           image: rayproject/ray:2.9.0
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           volumeMounts:
             - mountPath: /tmp/ray
               name: ray-logs

--- a/ray-operator/config/samples/ray-cluster.tls.yaml
+++ b/ray-operator/config/samples/ray-cluster.tls.yaml
@@ -79,10 +79,6 @@ spec:
             name: dashboard
           - containerPort: 10001
             name: client
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           volumeMounts:
             - mountPath: /tmp/ray
               name: ray-logs
@@ -160,10 +156,6 @@ spec:
         containers:
         - name: ray-worker
           image: rayproject/ray:2.9.0
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","ray stop"]
           # use volumeMounts.Optional.
           # Refer to https://kubernetes.io/docs/concepts/storage/volumes/
           volumeMounts:

--- a/ray-operator/config/samples/ray-job.custom-head-svc.yaml
+++ b/ray-operator/config/samples/ray-job.custom-head-svc.yaml
@@ -76,10 +76,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.9.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: [ "/bin/sh","-c","ray stop" ]
                 resources:
                   limits:
                     cpu: "1"

--- a/ray-operator/config/samples/ray-job.resources.yaml
+++ b/ray-operator/config/samples/ray-job.resources.yaml
@@ -88,10 +88,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.5.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: [ "/bin/sh","-c","ray stop" ]
                 resources:
                   requests:
                     cpu: "200m"

--- a/ray-operator/config/samples/ray-job.sample.yaml
+++ b/ray-operator/config/samples/ray-job.sample.yaml
@@ -91,10 +91,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.9.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: [ "/bin/sh","-c","ray stop" ]
                 resources:
                   limits:
                     cpu: "1"

--- a/ray-operator/config/samples/ray-job.shutdown.yaml
+++ b/ray-operator/config/samples/ray-job.shutdown.yaml
@@ -84,10 +84,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.9.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: [ "/bin/sh","-c","ray stop" ]
                 resources:
                   limits:
                     cpu: "1"

--- a/ray-operator/config/samples/ray-service.autoscaler.yaml
+++ b/ray-operator/config/samples/ray-service.autoscaler.yaml
@@ -97,10 +97,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.9.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: ["/bin/sh","-c","ray stop"]
                 resources:
                   limits:
                     cpu: "1"

--- a/ray-operator/config/samples/ray-service.custom-serve-service.yaml
+++ b/ray-operator/config/samples/ray-service.custom-serve-service.yaml
@@ -96,10 +96,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.9.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: ["/bin/sh","-c","ray stop"]
                 resources:
                   limits:
                     cpu: "1"

--- a/ray-operator/config/samples/ray-service.different-port.yaml
+++ b/ray-operator/config/samples/ray-service.different-port.yaml
@@ -83,10 +83,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.9.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: ["/bin/sh","-c","ray stop"]
                 resources:
                   limits:
                     cpu: "1"

--- a/ray-operator/config/samples/ray-service.gke-model-configmap.yaml
+++ b/ray-operator/config/samples/ray-service.gke-model-configmap.yaml
@@ -67,10 +67,6 @@ spec:
           containers:
           - name: llm
             image: anyscale/ray-llm:0.5.0
-            lifecycle:
-              preStop:
-                exec:
-                  command: ["/bin/sh","-c","ray stop"]
             resources:
               limits:
                 cpu: "20"

--- a/ray-operator/config/samples/ray-service.high-availability-locust.yaml
+++ b/ray-operator/config/samples/ray-service.high-availability-locust.yaml
@@ -78,10 +78,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.9.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: ["/bin/sh","-c","ray stop"]
                 resources:
                   limits:
                     cpu: 1

--- a/ray-operator/config/samples/ray-service.high-availability.yaml
+++ b/ray-operator/config/samples/ray-service.high-availability.yaml
@@ -96,10 +96,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.9.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: ["/bin/sh","-c","ray stop"]
                 resources:
                   limits:
                     cpu: 1

--- a/ray-operator/config/samples/ray-service.mobilenet.yaml
+++ b/ray-operator/config/samples/ray-service.mobilenet.yaml
@@ -64,10 +64,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray-ml:2.9.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: ["/bin/sh","-c","ray stop"]
                 resources:
                   limits:
                     cpu: 1

--- a/ray-operator/config/samples/ray-service.sample.yaml
+++ b/ray-operator/config/samples/ray-service.sample.yaml
@@ -108,10 +108,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.9.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: ["/bin/sh","-c","ray stop"]
                 resources:
                   limits:
                     cpu: "1"

--- a/ray-operator/config/samples/ray-service.text-ml.yaml
+++ b/ray-operator/config/samples/ray-service.text-ml.yaml
@@ -78,10 +78,6 @@ spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                 image: rayproject/ray:2.9.0
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: ["/bin/sh","-c","ray stop"]
                 resources:
                   limits:
                     cpu: "1"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR removes unnecessary `preStop` hooks from sample yamls in the KubeRay repo. The `preStop` hooks that call `ray stop` are not needed and can cause issues when deleting the k8s Pod.

For example, if a Ray Pod sidecar container fails and exits before the main container, the pre-stop hook is unable to exec into the Ray container to issue the stop command, causing the Pods to hang rather than gracefully terminate. Tasks/Actors are already gracefully terminated when a Ray Pod is marked for deletion, and the additional `ray stop` command is not needed.

## Related issue number

Closes #2606
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
