### PR TITLE
Add KubeRay e2e Test for custom idleTimeoutSeconds with v2 Autoscaler

### DIFF
--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -72,6 +72,9 @@ test-e2e: WHAT ?= ./test/e2e
 test-e2e: manifests fmt vet ## Run e2e tests.
 	go test -timeout 30m -v $(WHAT)
 
+test-e2e-autoscaler: WHAT ?= ./test/e2eautoscaler
+test-e2e-autoscaler: manifests fmt vet ## Run e2e tests.
+	go test -timeout 30m -v $(WHAT)
 
 test-sampleyaml: WHAT ?= ./test/sampleyaml
 test-sampleyaml: manifests fmt vet

--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -73,7 +73,7 @@ test-e2e: manifests fmt vet ## Run e2e tests.
 	go test -timeout 30m -v $(WHAT)
 
 test-e2e-autoscaler: WHAT ?= ./test/e2eautoscaler
-test-e2e-autoscaler: manifests fmt vet ## Run e2e tests.
+test-e2e-autoscaler: manifests fmt vet ## Run e2e autoscaler tests.
 	go test -timeout 30m -v $(WHAT)
 
 test-sampleyaml: WHAT ?= ./test/sampleyaml

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -2,7 +2,9 @@ package e2eautoscaler
 
 import (
 	"fmt"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
@@ -354,4 +356,72 @@ func TestRayClusterAutoscalerMinReplicasUpdate(t *testing.T) {
 			g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(GetRayClusterWorkerGroupReplicaSum, gomega.Equal(int32(5))))
 		})
 	}
+}
+
+func TestRayClusterAutoscalerV2IdleTimeout(t *testing.T) {
+	// Only test with the V2 Autoscaler
+	name := "Create a RayCluster with autoscaler v2 enabled"
+	tc := tests["Create a RayCluster with autoscaler v2 enabled"]
+
+	test := With(t)
+	g := gomega.NewWithT(t)
+
+	// Create a namespace
+	namespace := test.NewTestNamespace()
+
+	// Minimum Ray Version for custom idleTimeoutSeconds
+	IDLE_TIMEOUT_MIN_RAY_VERSION := "2.40.0"
+	os.Setenv(KuberayTestRayImage, IDLE_TIMEOUT_MIN_RAY_VERSION)
+
+	customIdleTimeoutSeconds := 30
+	defaultIdleTimeoutSeconds := 60
+
+	test.T().Run(name, func(_ *testing.T) {
+		rayClusterSpecAC := rayv1ac.RayClusterSpec().
+			WithEnableInTreeAutoscaling(true).
+			WithRayVersion(IDLE_TIMEOUT_MIN_RAY_VERSION).
+			WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+				WithRayStartParams(map[string]string{"num-cpus": "0"}).
+				WithTemplate(tc.HeadPodTemplateGetter())).
+			WithWorkerGroupSpecs(
+				rayv1ac.WorkerGroupSpec().
+					WithReplicas(2).
+					WithMinReplicas(0).
+					WithMaxReplicas(4).
+					WithGroupName("no-idle-timeout-group").
+					WithRayStartParams(map[string]string{"num-cpus": "1"}).
+					WithTemplate(tc.WorkerPodTemplateGetter()),
+				rayv1ac.WorkerGroupSpec().
+					WithReplicas(2).
+					WithMinReplicas(0).
+					WithMaxReplicas(4).
+					WithIdleTimeoutSeconds(int32(customIdleTimeoutSeconds)).
+					WithGroupName("custom-idle-timeout-group").
+					WithRayStartParams(map[string]string{"num-cpus": "1"}).
+					WithTemplate(tc.WorkerPodTemplateGetter()),
+			)
+		rayClusterAC := rayv1ac.RayCluster("ray-cluster", namespace.Name).WithSpec(apply(rayClusterSpecAC))
+		rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		test.T().Logf("Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+		// Wait for RayCluster to become ready and verify the number of available worker replicas.
+		// Each worker group should scale up two initial replicas before idle timeout.
+		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+			Should(gomega.WithTransform(RayClusterState, gomega.Equal(rayv1.Ready)))
+		g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(4))))
+
+		headPod, err := GetHeadPod(test, rayCluster)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		test.T().Logf("Found head pod %s/%s", headPod.Namespace, headPod.Name)
+
+		// After customIdleTimeoutSeconds, both replicas in the worker group with custom idleTimeoutSeconds set
+		// should be scaled down.
+		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), time.Duration(customIdleTimeoutSeconds)*time.Second).
+			Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(2))))
+
+		// After the default idleTimeoutSeconds applied by Ray, all worker replicas should be scaled down.
+		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), time.Duration(defaultIdleTimeoutSeconds)*time.Second).
+			Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
+	})
 }

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -370,16 +370,16 @@ func TestRayClusterAutoscalerV2IdleTimeout(t *testing.T) {
 	namespace := test.NewTestNamespace()
 
 	// Minimum Ray Version for custom idleTimeoutSeconds
-	IDLE_TIMEOUT_MIN_RAY_VERSION := "2.40.0"
-	os.Setenv(KuberayTestRayImage, IDLE_TIMEOUT_MIN_RAY_VERSION)
+	idleTimeoutMinRayVersion := "2.40.0"
+	os.Setenv(KuberayTestRayImage, idleTimeoutMinRayVersion)
 
-	customIdleTimeoutSeconds := 30
-	defaultIdleTimeoutSeconds := 60
+	customIdleTimeoutSeconds := int32(30)
+	defaultIdleTimeoutSeconds := int32(60)
 
 	test.T().Run(name, func(_ *testing.T) {
 		rayClusterSpecAC := rayv1ac.RayClusterSpec().
 			WithEnableInTreeAutoscaling(true).
-			WithRayVersion(IDLE_TIMEOUT_MIN_RAY_VERSION).
+			WithRayVersion(idleTimeoutMinRayVersion).
 			WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 				WithRayStartParams(map[string]string{"num-cpus": "0"}).
 				WithTemplate(tc.HeadPodTemplateGetter())).
@@ -395,7 +395,7 @@ func TestRayClusterAutoscalerV2IdleTimeout(t *testing.T) {
 					WithReplicas(2).
 					WithMinReplicas(0).
 					WithMaxReplicas(4).
-					WithIdleTimeoutSeconds(int32(customIdleTimeoutSeconds)).
+					WithIdleTimeoutSeconds(customIdleTimeoutSeconds).
 					WithGroupName("custom-idle-timeout-group").
 					WithRayStartParams(map[string]string{"num-cpus": "1"}).
 					WithTemplate(tc.WorkerPodTemplateGetter()),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds a test case for custom `idleTimeoutSeconds` per worker group supported by the V2 Autoscaler starting in ray 2.40.0. The test case verifies that `idleTimeoutSeconds` for a worker group override the default `idleTimeoutSeconds` set in the `autoscalerOptions` by scaling up replicas of each type and then checking that they are terminated within the expected period.

This PR was tested by running `go test -timeout 30m -v ./test/e2eautoscaler` with the nightly version of the KubeRay operator installed, since the [change adding this field to the WorkerGroupSpec api](https://github.com/ray-project/kuberay/pull/2558) is not yet part of a release.

## Related issue number

#2561

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
