### PR TITLE
[Refactor] move validateRayClusterStatus out of RayClusterReconciler

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -211,7 +211,7 @@ func (r *RayClusterReconciler) deleteAllPods(ctx context.Context, filters common
 	return pods, nil
 }
 
-func (r *RayClusterReconciler) validateRayClusterStatus(instance *rayv1.RayCluster) error {
+func validateRayClusterStatus(instance *rayv1.RayCluster) error {
 	suspending := meta.IsStatusConditionTrue(instance.Status.Conditions, string(rayv1.RayClusterSuspending))
 	suspended := meta.IsStatusConditionTrue(instance.Status.Conditions, string(rayv1.RayClusterSuspended))
 	if suspending && suspended {
@@ -229,7 +229,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.validateRayClusterStatus(instance); err != nil {
+	if err := validateRayClusterStatus(instance); err != nil {
 		logger.Error(err, "The RayCluster status is invalid")
 		r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.InvalidRayClusterStatus),
 			"The RayCluster status is invalid %s/%s, %v", instance.Namespace, instance.Name, err)

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3404,3 +3404,82 @@ func Test_ReconcileManagedBy(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRayClusterStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		conditions  []metav1.Condition
+		expectError bool
+	}{
+		{
+			name: "Both suspending and suspended are true",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(rayv1.RayClusterSuspending),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(rayv1.RayClusterSuspended),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Only suspending is true",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(rayv1.RayClusterSuspending),
+					Status: metav1.ConditionTrue,
+				},
+				{
+					Type:   string(rayv1.RayClusterSuspended),
+					Status: metav1.ConditionFalse,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Only suspended is true",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(rayv1.RayClusterSuspending),
+					Status: metav1.ConditionFalse,
+				},
+				{
+					Type:   string(rayv1.RayClusterSuspended),
+					Status: metav1.ConditionTrue,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Both suspending and suspended are false",
+			conditions: []metav1.Condition{
+				{
+					Type:   string(rayv1.RayClusterSuspending),
+					Status: metav1.ConditionFalse,
+				},
+				{
+					Type:   string(rayv1.RayClusterSuspended),
+					Status: metav1.ConditionFalse,
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &rayv1.RayCluster{
+				Status: rayv1.RayClusterStatus{
+					Conditions: tt.conditions,
+				},
+			}
+			err := validateRayClusterStatus(instance)
+			if (err != nil) != tt.expectError {
+				t.Errorf("validateRayClusterStatus() error = %v, wantErr %v", err, tt.expectError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->
`RayClusterReconciler` doesn't need to be the member function of RayClusterReconciler
Relate to https://github.com/ray-project/kuberay/pull/2726#discussion_r1912559951

## Related issue number
Closes #2694 
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
   - [X] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
