### PR TITLE
[Feature] Add ValidateRayClusterSpec to Webhook

### DIFF
--- a/ray-operator/apis/ray/v1/constant.go
+++ b/ray-operator/apis/ray/v1/constant.go
@@ -1,10 +1,12 @@
 package v1
 
-// In KubeRay, the Ray container must be the first application container in a head or worker Pod.
-const RayContainerIndex = 0
+const (
+	// In KubeRay, the Ray container must be the first application container in a head or worker Pod.
+	RayContainerIndex = 0
 
-// Use as container env variable
-const RAY_REDIS_ADDRESS = "RAY_REDIS_ADDRESS"
+	// Use as container env variable
+	RAY_REDIS_ADDRESS = "RAY_REDIS_ADDRESS"
 
-// Ray GCS FT related annotations
-const RayFTEnabledAnnotationKey = "ray.io/ft-enabled"
+	// Ray GCS FT related annotations
+	RayFTEnabledAnnotationKey = "ray.io/ft-enabled"
+)

--- a/ray-operator/apis/ray/v1/constant.go
+++ b/ray-operator/apis/ray/v1/constant.go
@@ -6,7 +6,7 @@ const (
 
 	// Use as container env variable
 	RAY_REDIS_ADDRESS = "RAY_REDIS_ADDRESS"
-
+	REDIS_PASSWORD    = "REDIS_PASSWORD"
 	// Ray GCS FT related annotations
 	RayFTEnabledAnnotationKey = "ray.io/ft-enabled"
 )

--- a/ray-operator/apis/ray/v1/constant.go
+++ b/ray-operator/apis/ray/v1/constant.go
@@ -1,0 +1,10 @@
+package v1
+
+// In KubeRay, the Ray container must be the first application container in a head or worker Pod.
+const RayContainerIndex = 0
+
+// Use as container env variable
+const RAY_REDIS_ADDRESS = "RAY_REDIS_ADDRESS"
+
+// Ray GCS FT related annotations
+const RayFTEnabledAnnotationKey = "ray.io/ft-enabled"

--- a/ray-operator/apis/ray/v1/pod.go
+++ b/ray-operator/apis/ray/v1/pod.go
@@ -1,0 +1,8 @@
+package v1
+
+import "strings"
+
+func IsGCSFaultToleranceEnabled(instance RayCluster) bool {
+	v, ok := instance.Annotations[RayFTEnabledAnnotationKey]
+	return (ok && strings.ToLower(v) == "true") || instance.Spec.GcsFaultToleranceOptions != nil
+}

--- a/ray-operator/apis/ray/v1/pod_test.go
+++ b/ray-operator/apis/ray/v1/pod_test.go
@@ -1,0 +1,70 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsGCSFaultToleranceEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance RayCluster
+		expected bool
+	}{
+		{
+			name: "ray.io/ft-enabled is true",
+			instance: RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						RayFTEnabledAnnotationKey: "true",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "ray.io/ft-enabled is false",
+			instance: RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						RayFTEnabledAnnotationKey: "false",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "ray.io/ft-enabled is nil, GcsFaultToleranceOptions is not nil",
+			instance: RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: RayClusterSpec{
+					GcsFaultToleranceOptions: &GcsFaultToleranceOptions{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "ray.io/ft-enabled is nil, GcsFaultToleranceOptions is nil",
+			instance: RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: RayClusterSpec{
+					GcsFaultToleranceOptions: nil,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsGCSFaultToleranceEnabled(tt.instance)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/ray-operator/apis/ray/v1/raycluster_webhook.go
+++ b/ray-operator/apis/ray/v1/raycluster_webhook.go
@@ -98,13 +98,10 @@ func (r *RayCluster) ValidateRayClusterSpec() *field.Error {
 		return field.Invalid(
 			field.NewPath("spec").Child("gcsFaultToleranceOptions"),
 			r.Spec.GcsFaultToleranceOptions,
-			fmt.Sprintf("GcsFaultToleranceOptions should be nil when %s is disabled", RayFTEnabledAnnotationKey),
+			fmt.Sprintf("GcsFaultToleranceOptions should be nil when %s annotation is set to false", RayFTEnabledAnnotationKey),
 		)
 	}
-	if r.Annotations[RayFTEnabledAnnotationKey] != "true" &&
-		len(r.Spec.HeadGroupSpec.Template.Spec.Containers) > 0 &&
-		r.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Env != nil {
-
+	if r.Annotations[RayFTEnabledAnnotationKey] != "true" && len(r.Spec.HeadGroupSpec.Template.Spec.Containers) > 0 {
 		if EnvVarExists(RAY_REDIS_ADDRESS, r.Spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Env) {
 			return field.Invalid(
 				field.NewPath("spec").Child("headGroupSpec").Child("template").Child("spec").Child("containers").Index(0).Child("env"),

--- a/ray-operator/apis/ray/v1/raycluster_webhook.go
+++ b/ray-operator/apis/ray/v1/raycluster_webhook.go
@@ -102,11 +102,11 @@ func (r *RayCluster) ValidateRayClusterSpec() *field.Error {
 		)
 	}
 
-	for _, workerGroup := range r.Spec.WorkerGroupSpecs {
+	for i, workerGroup := range r.Spec.WorkerGroupSpecs {
 		if len(workerGroup.Template.Spec.Containers) == 0 {
 			return field.Invalid(
-				field.NewPath("spec").Child("workerGroupSpecs"),
-				r.Spec.WorkerGroupSpecs,
+				field.NewPath("spec").Child("workerGroupSpecs").Index(i),
+				workerGroup,
 				"workerGroupSpec should have at least one container",
 			)
 		}

--- a/ray-operator/apis/ray/v1/raycluster_webhook_test.go
+++ b/ray-operator/apis/ray/v1/raycluster_webhook_test.go
@@ -13,10 +13,10 @@ import (
 func TestValidateRayClusterSpec(t *testing.T) {
 	tests := []struct {
 		gcsFaultToleranceOptions *GcsFaultToleranceOptions
-		name                     string
 		annotations              map[string]string
-		envVars                  []corev1.EnvVar
+		name                     string
 		errorMessage             string
+		envVars                  []corev1.EnvVar
 		expectError              bool
 	}{
 		{
@@ -152,14 +152,15 @@ func TestValidateRayClusterSpec(t *testing.T) {
 		})
 	}
 }
+
 func TestValidateRayCluster(t *testing.T) {
 	tests := []struct {
 		GcsFaultToleranceOptions *GcsFaultToleranceOptions
 		name                     string
+		errorMessage             string
 		ObjectMeta               metav1.ObjectMeta
 		WorkerGroupSpecs         []WorkerGroupSpec
 		expectError              bool
-		errorMessage             string
 	}{
 		{
 			name: "Invalid name",
@@ -241,8 +242,7 @@ func TestValidateRayCluster(t *testing.T) {
 			if tt.expectError {
 				assert.NotNil(t, err)
 				assert.IsType(t, &apierrors.StatusError{}, err)
-				statusErr := err.(*apierrors.StatusError)
-				assert.Contains(t, statusErr.ErrStatus.Details.Causes[0].Message, tt.errorMessage)
+				assert.Contains(t, err.Error(), tt.errorMessage)
 			} else {
 				assert.Nil(t, err)
 			}

--- a/ray-operator/apis/ray/v1/raycluster_webhook_test.go
+++ b/ray-operator/apis/ray/v1/raycluster_webhook_test.go
@@ -27,7 +27,7 @@ func TestValidateRayClusterSpec(t *testing.T) {
 			},
 			gcsFaultToleranceOptions: &GcsFaultToleranceOptions{},
 			expectError:              true,
-			errorMessage:             fmt.Sprintf("GcsFaultToleranceOptions should be nil when %s is disabled", RayFTEnabledAnnotationKey),
+			errorMessage:             fmt.Sprintf("GcsFaultToleranceOptions should be nil when %s annotation is set to false", RayFTEnabledAnnotationKey),
 		},
 		{
 			name: "FT disabled with RAY_REDIS_ADDRESS set",
@@ -197,7 +197,7 @@ func TestValidateRayCluster(t *testing.T) {
 			},
 			GcsFaultToleranceOptions: &GcsFaultToleranceOptions{},
 			expectError:              true,
-			errorMessage:             fmt.Sprintf("GcsFaultToleranceOptions should be nil when %s is disabled", RayFTEnabledAnnotationKey),
+			errorMessage:             fmt.Sprintf("GcsFaultToleranceOptions should be nil when %s annotation is set to false", RayFTEnabledAnnotationKey),
 		},
 		{
 			name: "Valid RayCluster",

--- a/ray-operator/apis/ray/v1/raycluster_webhook_test.go
+++ b/ray-operator/apis/ray/v1/raycluster_webhook_test.go
@@ -1,0 +1,251 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateRayClusterSpec(t *testing.T) {
+	tests := []struct {
+		gcsFaultToleranceOptions *GcsFaultToleranceOptions
+		name                     string
+		annotations              map[string]string
+		envVars                  []corev1.EnvVar
+		errorMessage             string
+		expectError              bool
+	}{
+		{
+			name: "FT disabled with GcsFaultToleranceOptions set",
+			annotations: map[string]string{
+				RayFTEnabledAnnotationKey: "false",
+			},
+			gcsFaultToleranceOptions: &GcsFaultToleranceOptions{},
+			expectError:              true,
+			errorMessage:             "GcsFaultToleranceOptions should be nil when ray.io/ft-enabled is disabled",
+		},
+		{
+			name: "FT disabled with RAY_REDIS_ADDRESS set",
+			annotations: map[string]string{
+				RayFTEnabledAnnotationKey: "false",
+			},
+			envVars: []corev1.EnvVar{
+				{
+					Name:  "RAY_REDIS_ADDRESS",
+					Value: "redis://127.0.0.1:6379",
+				},
+			},
+			expectError:  true,
+			errorMessage: "RAY_REDIS_ADDRESS should not be set when ray.io/ft-enabled is disabled",
+		},
+		{
+			name:        "FT not set with RAY_REDIS_ADDRESS set",
+			annotations: map[string]string{},
+			envVars: []corev1.EnvVar{
+				{
+					Name:  "RAY_REDIS_ADDRESS",
+					Value: "redis://127.0.0.1:6379",
+				},
+			},
+			expectError:  true,
+			errorMessage: "RAY_REDIS_ADDRESS should not be set when ray.io/ft-enabled is disabled",
+		},
+		{
+			name: "FT disabled with other environment variables set",
+			annotations: map[string]string{
+				RayFTEnabledAnnotationKey: "false",
+			},
+			envVars: []corev1.EnvVar{
+				{
+					Name:  "SOME_OTHER_ENV",
+					Value: "some-value",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "FT enabled, GcsFaultToleranceOptions not nil",
+			annotations: map[string]string{
+				RayFTEnabledAnnotationKey: "true",
+			},
+			gcsFaultToleranceOptions: &GcsFaultToleranceOptions{
+				RedisAddress: "redis://127.0.0.1:6379",
+			},
+			expectError: false,
+		},
+		{
+			name: "FT enabled, GcsFaultToleranceOptions is nil",
+			annotations: map[string]string{
+				RayFTEnabledAnnotationKey: "true",
+			},
+			expectError: false,
+		},
+		{
+			name: "FT enabled with with other environment variables set",
+			annotations: map[string]string{
+				RayFTEnabledAnnotationKey: "true",
+			},
+			envVars: []corev1.EnvVar{
+				{
+					Name:  "SOME_OTHER_ENV",
+					Value: "some-value",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "FT enabled with RAY_REDIS_ADDRESS set",
+			annotations: map[string]string{
+				RayFTEnabledAnnotationKey: "true",
+			},
+			envVars: []corev1.EnvVar{
+				{
+					Name:  "RAY_REDIS_ADDRESS",
+					Value: "redis://127.0.0.1:6379",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "FT disabled with no GcsFaultToleranceOptions and no RAY_REDIS_ADDRESS",
+			annotations: map[string]string{
+				RayFTEnabledAnnotationKey: "false",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+				Spec: RayClusterSpec{
+					GcsFaultToleranceOptions: tt.gcsFaultToleranceOptions,
+					HeadGroupSpec: HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "ray-head",
+										Env:  tt.envVars,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			err := r.ValidateRayClusterSpec()
+			if tt.expectError {
+				assert.NotNil(t, err)
+				assert.IsType(t, &field.Error{}, err)
+				assert.Equal(t, err.Detail, tt.errorMessage)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+func TestValidateRayCluster(t *testing.T) {
+	tests := []struct {
+		GcsFaultToleranceOptions *GcsFaultToleranceOptions
+		name                     string
+		ObjectMeta               metav1.ObjectMeta
+		WorkerGroupSpecs         []WorkerGroupSpec
+		expectError              bool
+		errorMessage             string
+	}{
+		{
+			name: "Invalid name",
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "Invalid_Name",
+			},
+			expectError:  true,
+			errorMessage: "name must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character",
+		},
+		{
+			name: "Duplicate worker group names",
+
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid-name",
+			},
+
+			WorkerGroupSpecs: []WorkerGroupSpec{
+				{GroupName: "group1"},
+				{GroupName: "group1"},
+			},
+
+			expectError:  true,
+			errorMessage: "worker group names must be unique",
+		},
+		{
+			name: "FT disabled with GcsFaultToleranceOptions set",
+
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid-name",
+				Annotations: map[string]string{
+					RayFTEnabledAnnotationKey: "false",
+				},
+			},
+			GcsFaultToleranceOptions: &GcsFaultToleranceOptions{},
+			expectError:              true,
+			errorMessage:             "GcsFaultToleranceOptions should be nil when ray.io/ft-enabled is disabled",
+		},
+		{
+			name: "Valid RayCluster",
+
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid-name",
+				Annotations: map[string]string{
+					RayFTEnabledAnnotationKey: "true",
+				},
+			},
+			GcsFaultToleranceOptions: &GcsFaultToleranceOptions{
+				RedisAddress: "redis://127.0.0.1:6379",
+			},
+			WorkerGroupSpecs: []WorkerGroupSpec{
+				{GroupName: "group1"},
+				{GroupName: "group2"},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rayCluster := &RayCluster{
+				ObjectMeta: tt.ObjectMeta,
+				Spec: RayClusterSpec{
+					GcsFaultToleranceOptions: tt.GcsFaultToleranceOptions,
+					HeadGroupSpec: HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "ray-head",
+									},
+								},
+							},
+						},
+					},
+					WorkerGroupSpecs: tt.WorkerGroupSpecs,
+				},
+			}
+			err := rayCluster.validateRayCluster()
+			if tt.expectError {
+				assert.NotNil(t, err)
+				assert.IsType(t, &apierrors.StatusError{}, err)
+				statusErr := err.(*apierrors.StatusError)
+				assert.Contains(t, statusErr.ErrStatus.Details.Causes[0].Message, tt.errorMessage)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}

--- a/ray-operator/apis/ray/v1/raycluster_webhook_test.go
+++ b/ray-operator/apis/ray/v1/raycluster_webhook_test.go
@@ -293,10 +293,10 @@ func TestValidateRayCluster(t *testing.T) {
 	workerGroupSpecs := []WorkerGroupSpec{workerGroupSpec}
 
 	tests := []struct {
-		name         string
 		rayCluster   *RayCluster
-		expectError  bool
+		name         string
 		errorMessage string
+		expectError  bool
 	}{
 		{
 			name: "valid RayCluster",

--- a/ray-operator/apis/ray/v1/raycluster_webhook_test.go
+++ b/ray-operator/apis/ray/v1/raycluster_webhook_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,7 @@ func TestValidateRayClusterSpec(t *testing.T) {
 			},
 			gcsFaultToleranceOptions: &GcsFaultToleranceOptions{},
 			expectError:              true,
-			errorMessage:             "GcsFaultToleranceOptions should be nil when ray.io/ft-enabled is disabled",
+			errorMessage:             fmt.Sprintf("GcsFaultToleranceOptions should be nil when %s is disabled", RayFTEnabledAnnotationKey),
 		},
 		{
 			name: "FT disabled with RAY_REDIS_ADDRESS set",
@@ -35,24 +36,24 @@ func TestValidateRayClusterSpec(t *testing.T) {
 			},
 			envVars: []corev1.EnvVar{
 				{
-					Name:  "RAY_REDIS_ADDRESS",
+					Name:  RAY_REDIS_ADDRESS,
 					Value: "redis://127.0.0.1:6379",
 				},
 			},
 			expectError:  true,
-			errorMessage: "RAY_REDIS_ADDRESS should not be set when ray.io/ft-enabled is disabled",
+			errorMessage: fmt.Sprintf("%s should not be set when %s is disabled", RAY_REDIS_ADDRESS, RayFTEnabledAnnotationKey),
 		},
 		{
 			name:        "FT not set with RAY_REDIS_ADDRESS set",
 			annotations: map[string]string{},
 			envVars: []corev1.EnvVar{
 				{
-					Name:  "RAY_REDIS_ADDRESS",
+					Name:  RAY_REDIS_ADDRESS,
 					Value: "redis://127.0.0.1:6379",
 				},
 			},
 			expectError:  true,
-			errorMessage: "RAY_REDIS_ADDRESS should not be set when ray.io/ft-enabled is disabled",
+			errorMessage: fmt.Sprintf("%s should not be set when %s is disabled", RAY_REDIS_ADDRESS, RayFTEnabledAnnotationKey),
 		},
 		{
 			name: "FT disabled with other environment variables set",
@@ -104,7 +105,7 @@ func TestValidateRayClusterSpec(t *testing.T) {
 			},
 			envVars: []corev1.EnvVar{
 				{
-					Name:  "RAY_REDIS_ADDRESS",
+					Name:  RAY_REDIS_ADDRESS,
 					Value: "redis://127.0.0.1:6379",
 				},
 			},
@@ -196,7 +197,7 @@ func TestValidateRayCluster(t *testing.T) {
 			},
 			GcsFaultToleranceOptions: &GcsFaultToleranceOptions{},
 			expectError:              true,
-			errorMessage:             "GcsFaultToleranceOptions should be nil when ray.io/ft-enabled is disabled",
+			errorMessage:             fmt.Sprintf("GcsFaultToleranceOptions should be nil when %s is disabled", RayFTEnabledAnnotationKey),
 		},
 		{
 			name: "Valid RayCluster",

--- a/ray-operator/apis/ray/v1/utils.go
+++ b/ray-operator/apis/ray/v1/utils.go
@@ -1,0 +1,12 @@
+package v1
+
+import corev1 "k8s.io/api/core/v1"
+
+func EnvVarExists(envName string, envVars []corev1.EnvVar) bool {
+	for _, env := range envVars {
+		if env.Name == envName {
+			return true
+		}
+	}
+	return false
+}

--- a/ray-operator/apis/ray/v1/utils_test.go
+++ b/ray-operator/apis/ray/v1/utils_test.go
@@ -1,0 +1,50 @@
+package v1
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestEnvVarExists(t *testing.T) {
+	tests := []struct {
+		name     string
+		envName  string
+		envVars  []corev1.EnvVar
+		expected bool
+	}{
+		{
+			name:    "env var exists",
+			envName: "EXISTING_ENV",
+			envVars: []corev1.EnvVar{
+				{Name: "EXISTING_ENV", Value: "value1"},
+				{Name: "ANOTHER_ENV", Value: "value2"},
+			},
+			expected: true,
+		},
+		{
+			name:    "env var does not exist",
+			envName: "NON_EXISTING_ENV",
+			envVars: []corev1.EnvVar{
+				{Name: "EXISTING_ENV", Value: "value1"},
+				{Name: "ANOTHER_ENV", Value: "value2"},
+			},
+			expected: false,
+		},
+		{
+			name:     "empty env vars",
+			envName:  "ANY_ENV",
+			envVars:  []corev1.EnvVar{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := EnvVarExists(tt.envName, tt.envVars)
+			if result != tt.expected {
+				t.Errorf("EnvVarExists(%s, %v) = %v; expected %v", tt.envName, tt.envVars, result, tt.expected)
+			}
+		})
+	}
+}

--- a/ray-operator/apis/ray/v1/webhook_suite_test.go
+++ b/ray-operator/apis/ray/v1/webhook_suite_test.go
@@ -136,11 +136,24 @@ var _ = Describe("RayCluster validating webhook", func() {
 						RayStartParams: map[string]string{"DEADBEEF": "DEADBEEF"},
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{},
+								Containers: []corev1.Container{
+									{Name: "ray-head"},
+								},
 							},
 						},
 					},
-					WorkerGroupSpecs: []WorkerGroupSpec{},
+					WorkerGroupSpecs: []WorkerGroupSpec{
+						{
+							GroupName: "worker-group-1",
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{Name: "ray-worker"},
+									},
+								},
+							},
+						},
+					},
 				},
 			}
 

--- a/ray-operator/apis/ray/v1/webhook_suite_test.go
+++ b/ray-operator/apis/ray/v1/webhook_suite_test.go
@@ -144,7 +144,8 @@ var _ = Describe("RayCluster validating webhook", func() {
 					},
 					WorkerGroupSpecs: []WorkerGroupSpec{
 						{
-							GroupName: "worker-group-1",
+							GroupName:      "worker-group-1",
+							RayStartParams: map[string]string{"DEADBEEF": "DEADBEEF"},
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -56,10 +56,7 @@ func GetHeadPort(headStartParams map[string]string) string {
 }
 
 // Check if the RayCluster has GCS fault tolerance enabled.
-func IsGCSFaultToleranceEnabled(instance rayv1.RayCluster) bool {
-	v, ok := instance.Annotations[utils.RayFTEnabledAnnotationKey]
-	return (ok && strings.ToLower(v) == "true") || instance.Spec.GcsFaultToleranceOptions != nil
-}
+var IsGCSFaultToleranceEnabled func(instance rayv1.RayCluster) bool = rayv1.IsGCSFaultToleranceEnabled
 
 // Check if overwrites the container command.
 func isOverwriteRayContainerCmd(instance rayv1.RayCluster) bool {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3533,7 +3533,7 @@ func TestValidateRayClusterSpecGcsFaultToleranceOptions(t *testing.T) {
 			errorMessage: errorMessageRedisAddressSet,
 		},
 		{
-			name: "FT is disabled and RAY_REDIS_ADDRESS is set",
+			name: "ray.io/ft-enabled is not set and RAY_REDIS_ADDRESS is set",
 			envVars: []corev1.EnvVar{
 				{
 					Name:  utils.RAY_REDIS_ADDRESS,

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -1,6 +1,10 @@
 package utils
 
-import "errors"
+import (
+	"errors"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+)
 
 const (
 
@@ -28,7 +32,7 @@ const (
 	KubeRayVersion                           = "ray.io/kuberay-version"
 
 	// In KubeRay, the Ray container must be the first application container in a head or worker Pod.
-	RayContainerIndex = 0
+	RayContainerIndex = rayv1.RayContainerIndex
 
 	// Batch scheduling labels
 	// TODO(tgaddair): consider making these part of the CRD
@@ -37,7 +41,7 @@ const (
 	RayClusterGangSchedulingEnabled = "ray.io/gang-scheduling-enabled"
 
 	// Ray GCS FT related annotations
-	RayFTEnabledAnnotationKey         = "ray.io/ft-enabled"
+	RayFTEnabledAnnotationKey         = rayv1.RayFTEnabledAnnotationKey
 	RayExternalStorageNSAnnotationKey = "ray.io/external-storage-namespace"
 
 	// If this annotation is set to "true", the KubeRay operator will not modify the container's command.
@@ -95,7 +99,7 @@ const (
 	FQ_RAY_IP                               = "FQ_RAY_IP"
 	RAY_PORT                                = "RAY_PORT"
 	RAY_ADDRESS                             = "RAY_ADDRESS"
-	RAY_REDIS_ADDRESS                       = "RAY_REDIS_ADDRESS"
+	RAY_REDIS_ADDRESS                       = rayv1.RAY_REDIS_ADDRESS
 	REDIS_PASSWORD                          = "REDIS_PASSWORD"
 	RAY_DASHBOARD_ENABLE_K8S_DISK_USAGE     = "RAY_DASHBOARD_ENABLE_K8S_DISK_USAGE"
 	RAY_EXTERNAL_STORAGE_NS                 = "RAY_external_storage_namespace"

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -100,7 +100,7 @@ const (
 	RAY_PORT                                = "RAY_PORT"
 	RAY_ADDRESS                             = "RAY_ADDRESS"
 	RAY_REDIS_ADDRESS                       = rayv1.RAY_REDIS_ADDRESS
-	REDIS_PASSWORD                          = "REDIS_PASSWORD"
+	REDIS_PASSWORD                          = rayv1.REDIS_PASSWORD
 	RAY_DASHBOARD_ENABLE_K8S_DISK_USAGE     = "RAY_DASHBOARD_ENABLE_K8S_DISK_USAGE"
 	RAY_EXTERNAL_STORAGE_NS                 = "RAY_external_storage_namespace"
 	RAY_GCS_RPC_SERVER_RECONNECT_TIMEOUT_S  = "RAY_gcs_rpc_server_reconnect_timeout_s"

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -589,14 +589,7 @@ func IsJobFinished(j *batchv1.Job) (batchv1.JobConditionType, bool) {
 	return "", false
 }
 
-func EnvVarExists(envName string, envVars []corev1.EnvVar) bool {
-	for _, env := range envVars {
-		if env.Name == envName {
-			return true
-		}
-	}
-	return false
-}
+var EnvVarExists func(envName string, envVars []corev1.EnvVar) bool = rayv1.EnvVarExists
 
 func UpsertEnvVar(envVars []corev1.EnvVar, newEnvVar corev1.EnvVar) []corev1.EnvVar {
 	overridden := false


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
ValidateRayClusterSpec validation should also be invoked in the optional validation webhook
- The validation webhook is usually the recommended way to validate a k8s CR, but users can choose not to enable it. That is the reason we need to validate both reconciliation and the webhook.
- Add `constant.go` to store some necessary variables which copy from `controllers/ray/utils`
- Add `utils.go` to store some necessary functions which copy from `controllers/ray/utils`

## Related issue number
Closes #2694 
### Related Discussion: 
- https://github.com/ray-project/kuberay/pull/2726#discussion_r1912207609
- https://github.com/ray-project/kuberay/pull/2726#discussion_r1912512345

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
   - [X] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
