### PR TITLE
Add Init Containers Definition to values.yaml for Clarity

### DIFF
--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -105,6 +105,9 @@ head:
   # sidecarContainers specifies additional containers to attach to the Ray pod.
   # Follows standard K8s container spec.
   sidecarContainers: []
+  # initContainers specifies init containers to attach to the Ray pod.
+  # Follows standard K8s container spec.
+  initContainers: []
   # See docs/guidance/pod-command.md for more details about how to specify
   # container command for head Pod.
   command: []
@@ -187,6 +190,9 @@ worker:
   # sidecarContainers specifies additional containers to attach to the Ray pod.
   # Follows standard K8s container spec.
   sidecarContainers: []
+  # initContainers specifies init containers to attach to the Ray pod.
+  # Follows standard K8s container spec.
+  initContainers: []
   # See docs/guidance/pod-command.md for more details about how to specify
   # container command for worker Pod.
   command: []


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, the raycluster-cluster.yaml template includes support for initContainers (as seen [here](https://github.com/ray-project/kuberay/blob/master/helm-chart/ray-cluster/templates/raycluster-cluster.yaml#L51)). However, the values.yaml file does not provide a corresponding section or example for users to understand whether initContainers are supported or what format is expected, similar to how sidecar containers are documented.

This omission can lead to confusion and limit users from leveraging initContainers effectively in their configurations.

## Checks
- [X] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
