### PR TITLE
[RayCluster][Feature] skip suspending worker groups if the in-tree autoscaler is enabled

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -267,7 +267,7 @@ func validateRayClusterSpec(instance *rayv1.RayCluster) error {
 		for _, workerGroup := range instance.Spec.WorkerGroupSpecs {
 			if workerGroup.Suspend != nil && *workerGroup.Suspend {
 				// TODO (rueian): This can be supported in future Ray. We should check the RayVersion once we know the version.
-				return fmt.Errorf("suspending worker groups is not supported with Autoscaler enabled")
+				return fmt.Errorf("suspending worker groups is not currently supported with Autoscaler enabled")
 			}
 		}
 	}

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -878,7 +878,7 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
 		})
 
-		It("Check the number of Pods and add finalizers", func() {
+		It("Check the number of Pods", func() {
 			Eventually(listResourceFunc(ctx, &allPods, allFilters...), time.Second*3, time.Millisecond*500).
 				Should(Equal(4), fmt.Sprintf("all pods %v", allPods.Items))
 		})
@@ -889,7 +889,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster")
 		})
 
-		It("Worker pods should be not deleted and head pod should still be running", func() {
+		It("Worker pods should not be deleted and head pod should still be running", func() {
 			Consistently(listResourceFunc(ctx, &allPods, workerFilters...), time.Second*5, time.Millisecond*500).
 				Should(Equal(3), fmt.Sprintf("all pods %v", allPods.Items))
 			Consistently(listResourceFunc(ctx, &allPods, headFilters...), time.Second*5, time.Millisecond*500).

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3737,14 +3737,13 @@ func TestValidateRayClusterSpecSuspendingWorkerGroup(t *testing.T) {
 			},
 		},
 	}
-	workerGroupSpec := rayv1.WorkerGroupSpec{
+	workerGroupSpecSuspended := rayv1.WorkerGroupSpec{
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{{Name: "ray-worker"}},
 			},
 		},
 	}
-	workerGroupSpecSuspended := *workerGroupSpec.DeepCopy()
 	workerGroupSpecSuspended.Suspend = ptr.To[bool](true)
 
 	tests := []struct {
@@ -3774,7 +3773,7 @@ func TestValidateRayClusterSpecSuspendingWorkerGroup(t *testing.T) {
 				},
 			},
 			expectError:  true,
-			errorMessage: "suspending worker groups is not supported with Autoscaler enabled",
+			errorMessage: "suspending worker groups is not currently supported with Autoscaler enabled",
 		},
 	}
 


### PR DESCRIPTION
## Why are these changes needed?

Skip suspending worker groups if the in-tree autoscaler is enabled to prevent ray cluster from malfunctioning.

The old autoscaler can't know if a worker group has been suspended on the KubeRay side, therefore, it will keep making wrong scaling decisions if some of the worker groups have been suspended. Such as:
1. Always trying to scale up a suspended worker group to keep the min_workers requirement.
2. Always trying to scale up a suspended worker group for the current queuing Ray tasks.

To prevent a ray cluster from malfunctioning like that, we must forbid the usage of work group suspension on all old Ray versions that don't recognize the `suspend` field in the CR. However, we are unable to forbid usage by the controller without the validation webhook. In the case without the validation webhook, we can only fire a warning event `InvalidRayClusterSpec` to let users know that this is forbidden.

The validation webhook implementation will be in another PR.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
