### PR TITLE
[RayCluster] Validate RayClusterSpec for empty containers and GCS FT

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3474,6 +3474,12 @@ func Test_ReconcileManagedBy(t *testing.T) {
 }
 
 func TestValidateRayClusterSpecGcsFaultToleranceOptions(t *testing.T) {
+	errorMessageBothSet := fmt.Sprintf("%s annotation and GcsFaultToleranceOptions are both set. "+
+		"Please use only GcsFaultToleranceOptions to configure GCS fault tolerance", utils.RayFTEnabledAnnotationKey)
+	errorMessageRedisAddressSet := fmt.Sprintf("%s is set which implicitly enables GCS fault tolerance, "+
+		"but GcsFaultToleranceOptions is not set. Please set GcsFaultToleranceOptions "+
+		"to enable GCS fault tolerance", utils.RAY_REDIS_ADDRESS)
+
 	tests := []struct {
 		gcsFaultToleranceOptions *rayv1.GcsFaultToleranceOptions
 		annotations              map[string]string
@@ -3490,8 +3496,7 @@ func TestValidateRayClusterSpecGcsFaultToleranceOptions(t *testing.T) {
 			},
 			gcsFaultToleranceOptions: &rayv1.GcsFaultToleranceOptions{},
 			expectError:              true,
-			errorMessage: fmt.Sprintf("%s annotation and GcsFaultToleranceOptions are both set. "+
-				"Please use only GcsFaultToleranceOptions to configure GCS fault tolerance", utils.RayFTEnabledAnnotationKey),
+			errorMessage:             errorMessageBothSet,
 		},
 		{
 			name: "ray.io/ft-enabled is set to true and GcsFaultToleranceOptions is set",
@@ -3500,8 +3505,7 @@ func TestValidateRayClusterSpecGcsFaultToleranceOptions(t *testing.T) {
 			},
 			gcsFaultToleranceOptions: &rayv1.GcsFaultToleranceOptions{},
 			expectError:              true,
-			errorMessage: fmt.Sprintf("%s annotation and GcsFaultToleranceOptions are both set. "+
-				"Please use only GcsFaultToleranceOptions to configure GCS fault tolerance", utils.RayFTEnabledAnnotationKey),
+			errorMessage:             errorMessageBothSet,
 		},
 		{
 			name:                     "ray.io/ft-enabled is not set and GcsFaultToleranceOptions is set",
@@ -3525,10 +3529,8 @@ func TestValidateRayClusterSpecGcsFaultToleranceOptions(t *testing.T) {
 					Value: "redis:6379",
 				},
 			},
-			expectError: true,
-			errorMessage: fmt.Sprintf("%s is set which implicitly enables GCS fault tolerance, "+
-				"but GcsFaultToleranceOptions is not set. Please set GcsFaultToleranceOptions "+
-				"to enable GCS fault tolerance", utils.RAY_REDIS_ADDRESS),
+			expectError:  true,
+			errorMessage: errorMessageRedisAddressSet,
 		},
 		{
 			name: "FT is disabled and RAY_REDIS_ADDRESS is set",
@@ -3538,10 +3540,8 @@ func TestValidateRayClusterSpecGcsFaultToleranceOptions(t *testing.T) {
 					Value: "redis:6379",
 				},
 			},
-			expectError: true,
-			errorMessage: fmt.Sprintf("%s is set which implicitly enables GCS fault tolerance, "+
-				"but GcsFaultToleranceOptions is not set. Please set GcsFaultToleranceOptions "+
-				"to enable GCS fault tolerance", utils.RAY_REDIS_ADDRESS),
+			expectError:  true,
+			errorMessage: errorMessageRedisAddressSet,
 		},
 		{
 			name: "ray.io/ft-enabled is set to true and RAY_REDIS_ADDRESS is set",

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3591,6 +3591,25 @@ func TestValidateRayClusterSpecGcsFaultToleranceOptions(t *testing.T) {
 }
 
 func TestValidateRayClusterSpecEmptyContainers(t *testing.T) {
+	headGroupSpecWithOneContainer := rayv1.HeadGroupSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "ray-head"}},
+			},
+		},
+	}
+	workerGroupSpecWithOneContainer := rayv1.WorkerGroupSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "ray-worker"}},
+			},
+		},
+	}
+	headGroupSpecWithNoContainers := *headGroupSpecWithOneContainer.DeepCopy()
+	headGroupSpecWithNoContainers.Template.Spec.Containers = []corev1.Container{}
+	workerGroupSpecWithNoContainers := *workerGroupSpecWithOneContainer.DeepCopy()
+	workerGroupSpecWithNoContainers.Template.Spec.Containers = []corev1.Container{}
+
 	tests := []struct {
 		rayCluster   *rayv1.RayCluster
 		name         string
@@ -3601,11 +3620,7 @@ func TestValidateRayClusterSpecEmptyContainers(t *testing.T) {
 			name: "headGroupSpec has no containers",
 			rayCluster: &rayv1.RayCluster{
 				Spec: rayv1.RayClusterSpec{
-					HeadGroupSpec: rayv1.HeadGroupSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{}, // Empty containers slice
-						},
-					},
+					HeadGroupSpec: headGroupSpecWithNoContainers,
 				},
 			},
 			expectError:  true,
@@ -3615,18 +3630,8 @@ func TestValidateRayClusterSpecEmptyContainers(t *testing.T) {
 			name: "workerGroupSpec has no containers",
 			rayCluster: &rayv1.RayCluster{
 				Spec: rayv1.RayClusterSpec{
-					HeadGroupSpec: rayv1.HeadGroupSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{{Name: "ray-head"}},
-							},
-						},
-					},
-					WorkerGroupSpecs: []rayv1.WorkerGroupSpec{{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{}, // Empty containers slice
-						},
-					}},
+					HeadGroupSpec:    headGroupSpecWithOneContainer,
+					WorkerGroupSpecs: []rayv1.WorkerGroupSpec{workerGroupSpecWithNoContainers},
 				},
 			},
 			expectError:  true,
@@ -3636,30 +3641,8 @@ func TestValidateRayClusterSpecEmptyContainers(t *testing.T) {
 			name: "valid cluster with containers in both head and worker groups",
 			rayCluster: &rayv1.RayCluster{
 				Spec: rayv1.RayClusterSpec{
-					HeadGroupSpec: rayv1.HeadGroupSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name: "ray-head",
-									},
-								},
-							},
-						},
-					},
-					WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
-						{
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{
-											Name: "ray-worker",
-										},
-									},
-								},
-							},
-						},
-					},
+					HeadGroupSpec:    headGroupSpecWithOneContainer,
+					WorkerGroupSpecs: []rayv1.WorkerGroupSpec{workerGroupSpecWithOneContainer},
 				},
 			},
 			expectError: false,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. **Ensure PodSpec has at least one container**: OpenAPI only validates whether `containers` exists in the PodSpec or not. However, it doesn't validate whether the PodSpec has at least one container or not. In K8s, it is validated in the server side: https://sourcegraph.com/github.com/kubernetes/kubernetes/-/blob/pkg/apis/core/validation/validation.go?L3635. In KubeRay, we assume that the Ray container is the first container in the Pod. To avoid segfault in KubeRay, this PR checks whether all PodSpec have at least one container or not.

2. `GcsFaultToleranceOptions` and the annotation should not be set at the same time.

3. `RAY_REDIS_ADDRESS` should not be set if KubeRay doesn't aware of GCS FT is enabled.

4. Update error messages to encourage users to use new API `GcsFaultToleranceOptions`.

## Related issue number

Follow up #2726

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
