### PR TITLE
[chore] Refactor GetHeadPort

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -49,15 +49,10 @@ var customAcceleratorToRayResourceMap = map[string]string{
 // started within the cluster.
 // For Ray >= 1.11.0 this is the GCS server port. For Ray < 1.11.0 it is the Redis port.
 func GetHeadPort(headStartParams map[string]string) string {
-	var headPort string
-	if value, ok := headStartParams["port"]; !ok {
-		// using default port
-		headPort = strconv.Itoa(utils.DefaultRedisPort)
-	} else {
-		// setting port from the params
-		headPort = value
+	if value, ok := headStartParams["port"]; ok {
+		return value
 	}
-	return headPort
+	return strconv.Itoa(utils.DefaultGcsServerPort)
 }
 
 // Check if the RayCluster has GCS fault tolerance enabled.

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -409,7 +409,7 @@ func getPortsFromCluster(cluster rayv1.RayCluster) map[string]int32 {
 func getDefaultPorts() map[string]int32 {
 	return map[string]int32{
 		utils.ClientPortName:    utils.DefaultClientPort,
-		utils.RedisPortName:     utils.DefaultRedisPort,
+		utils.GcsServerPortName: utils.DefaultGcsServerPort,
 		utils.DashboardPortName: utils.DefaultDashboardPort,
 		utils.MetricsPortName:   utils.DefaultMetricsPort,
 		utils.ServingPortName:   utils.DefaultServingPort,

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1327,11 +1327,11 @@ func TestUpdateEndpoints(t *testing.T) {
 	}
 
 	expected := map[string]string{
-		"client":    "10001",
-		"dashboard": "8265",
-		"metrics":   "8080",
-		"redis":     "6379",
-		"serve":     "8000",
+		"client":     "10001",
+		"dashboard":  "8265",
+		"metrics":    "8080",
+		"gcs-server": "6379",
+		"serve":      "8000",
 	}
 	assert.Equal(t, expected, testRayCluster.Status.Endpoints, "RayCluster status endpoints not updated")
 }

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -63,18 +63,15 @@ const (
 	DashSymbol = "-"
 
 	// Use as default port
-	DefaultClientPort = 10001
-	// For Ray >= 1.11.0, "DefaultRedisPort" actually refers to the GCS server port.
-	// However, the role of this port is unchanged in Ray APIs like ray.init and ray start.
-	// This is the port used by Ray workers and drivers inside the Ray cluster to connect to the Ray head.
-	DefaultRedisPort                = 6379
+	DefaultClientPort               = 10001
+	DefaultGcsServerPort            = 6379
 	DefaultDashboardPort            = 8265
 	DefaultMetricsPort              = 8080
 	DefaultDashboardAgentListenPort = 52365
 	DefaultServingPort              = 8000
 
 	ClientPortName    = "client"
-	RedisPortName     = "redis"
+	GcsServerPortName = "gcs-server"
 	DashboardPortName = "dashboard"
 	MetricsPortName   = "metrics"
 	ServingPortName   = "serve"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, `GetHeadPort` always returns GCS server port for all Ray versions that KubeRay supports. Rename it and do some minor refactors.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
