### PR TITLE
[RayCluster][Refactor] use RayClusterAllPodsAssociationOptions instead

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1331,8 +1331,7 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	newInstance.Status.ObservedGeneration = newInstance.ObjectMeta.Generation
 
 	runtimePods := corev1.PodList{}
-	filterLabels := client.MatchingLabels{utils.RayClusterLabelKey: newInstance.Name}
-	if err := r.List(ctx, &runtimePods, client.InNamespace(newInstance.Namespace), filterLabels); err != nil {
+	if err := r.List(ctx, &runtimePods, common.RayClusterAllPodsAssociationOptions(newInstance).ToListOptions()...); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Move `client.MatchingLabels{utils.RayClusterLabelKey: string}` to the association.go to maintain the consistency in the association methods.

This PR includes the third one of https://github.com/ray-project/kuberay/issues/2732: 
https://github.com/ray-project/kuberay/blob/9068102246eeb5ab9d9e0b9a7480618d3f348686/ray-operator/controllers/ray/raycluster_controller.go#L1283

The first and second have been made in https://github.com/ray-project/kuberay/pull/2734 

## Related issue number

<!-- For example: "Closes #1234" -->

Resolves https://github.com/ray-project/kuberay/issues/2732

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
