### PR TITLE
Add additional KubeRay autoscaler e2e tests

### DIFF
--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go
@@ -589,3 +589,67 @@ func TestRayClusterAutoscalerGCSFT(t *testing.T) {
 		})
 	}
 }
+
+func TestRayClusterAutoscalerUpscalingModeConservative(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := gomega.NewWithT(t)
+
+			// Create a namespace
+			namespace := test.NewTestNamespace()
+
+			// Script for creating detached actors to trigger autoscaling
+			scriptsAC := newConfigMap(namespace.Name, Files(test, "create_detached_actor.py"))
+			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
+
+			groupName := "test-group"
+			rayClusterSpecAC := rayv1ac.RayClusterSpec().
+				WithEnableInTreeAutoscaling(true).
+				WithRayVersion(GetRayVersion()).
+				WithAutoscalerOptions(rayv1ac.AutoscalerOptions().
+					WithUpscalingMode("Conservative")).
+				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+					WithRayStartParams(map[string]string{"num-cpus": "0"}).
+					WithTemplate(tc.HeadPodTemplateGetter())).
+				WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
+					WithReplicas(0).
+					WithMinReplicas(0).
+					WithMaxReplicas(10).
+					WithGroupName(groupName).
+					WithRayStartParams(map[string]string{"num-cpus": "1"}).
+					WithTemplate(tc.WorkerPodTemplateGetter()))
+			rayClusterAC := rayv1ac.RayCluster("ray-cluster", namespace.Name).
+				WithSpec(Apply(rayClusterSpecAC, MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](scripts, "/home/ray/test_scripts")))
+
+			rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+			// Wait for the RayCluster to become ready
+			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+				Should(gomega.WithTransform(RayClusterState, gomega.Equal(rayv1.Ready)))
+			g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
+
+			// Verify the Autoscaler's CRD patching behavior while scaling up 10 workers.
+			// In Default mode, replicas would jump straight to 10 to meet the demand.
+			// In Conservative mode, the initial batch is capped at max(5, num_running).
+			g.Expect(RateLimitedReplicas(test, rayCluster, 5, func() {
+				headPod, err := GetHeadPod(test, rayCluster)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
+				ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
+					"bash", "-c",
+					`for i in {0..9}; do python /home/ray/test_scripts/create_detached_actor.py "actor$i" & done; wait`,
+				})
+			})).To(gomega.BeTrue(), "Conservative mode should cap the initial scale-up to 5")
+
+			// Eventually, all worker Pods should connect to the RayCluster.
+			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutLong).
+				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(10))))
+			g.Eventually(GroupPods(test, rayCluster, groupName), TestTimeoutLong).Should(gomega.HaveLen(10))
+		})
+	}
+}

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go
@@ -634,6 +634,9 @@ func TestRayClusterAutoscalerUpscalingModeConservative(t *testing.T) {
 			g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(0))))
 
 			// Verify the Autoscaler's CRD patching behavior while scaling up 10 workers.
+			// We create all 10 actors in a single Python script invocation (--count=10) rather
+			// than asynchronous background bash jobs so that demand reaches 10 immediately
+			// without any partial demand intermediate state.
 			// In Default mode, replicas would jump straight to 10 to meet the demand.
 			// In Conservative mode, the initial batch is capped at max(5, num_running).
 			g.Expect(RateLimitedReplicas(test, rayCluster, 5, func() {
@@ -641,8 +644,7 @@ func TestRayClusterAutoscalerUpscalingModeConservative(t *testing.T) {
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
 				ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
-					"bash", "-c",
-					`for i in {0..9}; do python /home/ray/test_scripts/create_detached_actor.py "actor$i" & done; wait`,
+					"python", "/home/ray/test_scripts/create_detached_actor.py", "actor", "--count=10",
 				})
 			})).To(gomega.BeTrue(), "Conservative mode should cap the initial scale-up to 5")
 

--- a/ray-operator/test/support/create_detached_actor.py
+++ b/ray-operator/test/support/create_detached_actor.py
@@ -7,6 +7,7 @@ parser.add_argument('--num-cpus', type=float, default=1)
 parser.add_argument('--num-gpus', type=float, default=0)
 parser.add_argument('--custom-resource-name', type=str, default="CustomResource")
 parser.add_argument('--num-custom-resources', type=float, default=0)
+parser.add_argument('--count', type=int, default=1)
 args = parser.parse_args()
 
 @ray.remote(num_cpus=args.num_cpus, num_gpus=args.num_gpus, resources={args.custom_resource_name: args.num_custom_resources})
@@ -15,4 +16,6 @@ class Actor:
 
 
 ray.init(namespace="default_namespace")
-Actor.options(name=args.name, lifetime="detached").remote()
+for i in range(args.count):
+    name = f"{args.name}{i}" if args.count > 1 else args.name
+    Actor.options(name=name, lifetime="detached").remote()

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -1,8 +1,10 @@
 package support
 
 import (
+	"context"
 	"errors"
 	"strings"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
@@ -174,6 +176,51 @@ func GetWorkerPods(t Test, rayCluster *rayv1.RayCluster) ([]corev1.Pod, error) {
 		return nil, err
 	}
 	return pods.Items, err
+}
+
+// RateLimitedReplicas verifies that the initial scale-up batch size does not exceed limit.
+// We pass an action closure (such as triggering autoscaling via detached actors) to execute
+// concurrently while a background goroutine monitors the RayCluster.
+func RateLimitedReplicas(t Test, rayCluster *rayv1.RayCluster, limit int32, action func()) bool {
+	// The number of new launches must be less than or equal to the size of the RayCluster.
+	// The minimum number of pending launches is 5 regardless of RayCluster size and upscaling_speed.
+	initialReplicasChan := make(chan int32, 1)
+	ctx, cancel := context.WithCancel(t.Ctx())
+	defer cancel()
+
+	go func() {
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				cluster, err := GetRayCluster(t, rayCluster.Namespace, rayCluster.Name)
+				if err == nil {
+					replicas := GetRayClusterWorkerGroupReplicaSum(cluster)
+					if replicas > 0 {
+						select {
+						case initialReplicasChan <- replicas:
+						default:
+						}
+						return
+					}
+				}
+			}
+		}
+	}()
+
+	if action != nil {
+		action()
+	}
+
+	select {
+	case initialScale := <-initialReplicasChan:
+		return initialScale <= limit
+	case <-time.After(TestTimeoutMedium):
+		return false
+	}
 }
 
 func GetAllPods(t Test, rayCluster *rayv1.RayCluster) ([]corev1.Pod, error) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds two more test cases to cover autoscaler v1 and v2 behavior, specifically updating `MaxReplicas` and scaling Pods with `upscalingMode: Conservative`. For the second case, `Default` and `Aggressive` upscaling modes are already covered by the other tests. `TestRayClusterAutoscalerUpscalingModeConservative` is intermittently failing due to the the number of `Pending` worker Pods being greater than the number of worker Pods connected to the RayCluster at that time, potentially indicating a bug with the `upscalingMode` logic.

## Related issue number

#2561

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
