### PR TITLE
[GCS FT] Add e2e tests for configuring GCS FT with annotations

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -145,8 +145,8 @@ func configureGCSFaultTolerance(podTemplate *corev1.PodTemplateSpec, instance ra
 					redisPasswordEnv := corev1.EnvVar{Name: utils.REDIS_PASSWORD}
 					if value, ok := instance.Spec.HeadGroupSpec.RayStartParams["redis-password"]; ok {
 						redisPasswordEnv.Value = value
+						container.Env = append(container.Env, redisPasswordEnv)
 					}
-					container.Env = append(container.Env, redisPasswordEnv)
 				}
 			}
 		}

--- a/ray-operator/test/e2e/raycluster_gcsft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcsft_test.go
@@ -119,3 +119,120 @@ func TestGcsFaultToleranceOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestGcsFaultToleranceAnnotations(t *testing.T) {
+	tests := []struct {
+		name                          string
+		storageNS                     string
+		redisPasswordEnv              string
+		redisPasswordInRayStartParams string
+	}{
+		{
+			name:                          "GCS FT without redis password",
+			storageNS:                     "",
+			redisPasswordEnv:              "",
+			redisPasswordInRayStartParams: "",
+		},
+		{
+			name:                          "GCS FT with redis password in ray start params",
+			storageNS:                     "",
+			redisPasswordEnv:              "",
+			redisPasswordInRayStartParams: "5241590000000000",
+		},
+		{
+			name:                          "GCS FT with redis password in ray start params referring to env",
+			storageNS:                     "",
+			redisPasswordEnv:              "5241590000000000",
+			redisPasswordInRayStartParams: "$REDIS_PASSWORD",
+		},
+		{
+			name:                          "GCS FT with storage namespace",
+			storageNS:                     "test-storage-ns",
+			redisPasswordEnv:              "5241590000000000",
+			redisPasswordInRayStartParams: "$REDIS_PASSWORD",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := NewWithT(t)
+			namespace := test.NewTestNamespace()
+
+			redisPassword := ""
+			if tc.redisPasswordEnv != "" && tc.redisPasswordInRayStartParams != "" && tc.redisPasswordInRayStartParams != "$REDIS_PASSWORD" {
+				t.Fatalf("redisPasswordEnv and redisPasswordInRayStartParams are mutually exclusive")
+			}
+
+			switch {
+			case tc.redisPasswordEnv != "":
+				redisPassword = tc.redisPasswordEnv
+			case tc.redisPasswordInRayStartParams != "":
+				redisPassword = tc.redisPasswordInRayStartParams
+			}
+
+			deployRedis(test, namespace.Name, redisPassword)
+
+			podTemplateAC := podTemplateSpecApplyConfiguration(headPodTemplateApplyConfiguration(),
+				injectRayContainerEnv(
+					func() []corev1ac.EnvVarApplyConfiguration {
+						envs := []corev1ac.EnvVarApplyConfiguration{
+							*corev1ac.EnvVar().WithName("RAY_REDIS_ADDRESS").WithValue("redis:6379"),
+						}
+						if tc.redisPasswordEnv != "" {
+							envs = append(envs, *corev1ac.EnvVar().WithName("REDIS_PASSWORD").WithValue(tc.redisPasswordEnv))
+						}
+						return envs
+					}(),
+				),
+			)
+
+			rayClusterAC := rayv1ac.RayCluster("raycluster-gcsft", namespace.Name).WithAnnotations(
+				func() map[string]string {
+					annotations := map[string]string{
+						utils.RayFTEnabledAnnotationKey: "true",
+					}
+					if tc.storageNS != "" {
+						annotations[utils.RayExternalStorageNSAnnotationKey] = tc.storageNS
+					}
+					return annotations
+				}(),
+			).WithSpec(
+				rayClusterSpecWith(
+					rayv1ac.RayClusterSpec().
+						WithRayVersion(GetRayVersion()).
+						WithHeadGroupSpec(rayv1ac.HeadGroupSpec().WithTemplate(podTemplateAC)), injectRayStartParams(
+						func() map[string]string {
+							if tc.redisPasswordInRayStartParams != "" {
+								return map[string]string{"redis-password": tc.redisPasswordInRayStartParams}
+							}
+							// RayStartParams are not allowed to be empty.
+							return map[string]string{"dashboard-host": "0.0.0.0"}
+						}()),
+				),
+			)
+
+			rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+			g.Expect(err).NotTo(HaveOccurred())
+			test.T().Logf("Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+			test.T().Logf("Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+			g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+				Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionTrue, rayv1.AllPodRunningAndReadyFirstTime)))
+
+			test.T().Logf("Verifying environment variables on Head Pod")
+			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+			headPod, err := test.Client().Core().CoreV1().Pods(namespace.Name).Get(test.Ctx(), rayCluster.Status.Head.PodName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(utils.EnvVarExists(utils.RAY_REDIS_ADDRESS, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
+			g.Expect(utils.EnvVarExists(utils.RAY_EXTERNAL_STORAGE_NS, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
+			if redisPassword == "" {
+				g.Expect(utils.EnvVarExists(utils.REDIS_PASSWORD, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeFalse())
+			} else {
+				g.Expect(utils.EnvVarExists(utils.REDIS_PASSWORD, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
+			}
+		})
+	}
+}

--- a/ray-operator/test/e2e/raycluster_gcsft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcsft_test.go
@@ -173,19 +173,15 @@ func TestGcsFaultToleranceAnnotations(t *testing.T) {
 
 			deployRedis(test, namespace.Name, redisPassword)
 
-			podTemplateAC := podTemplateSpecApplyConfiguration(headPodTemplateApplyConfiguration(),
-				injectRayContainerEnv(
-					func() []corev1ac.EnvVarApplyConfiguration {
-						envs := []corev1ac.EnvVarApplyConfiguration{
-							*corev1ac.EnvVar().WithName("RAY_REDIS_ADDRESS").WithValue("redis:6379"),
-						}
-						if tc.redisPasswordEnv != "" {
-							envs = append(envs, *corev1ac.EnvVar().WithName("REDIS_PASSWORD").WithValue(tc.redisPasswordEnv))
-						}
-						return envs
-					}(),
-				),
+			podTemplateAC := headPodTemplateApplyConfiguration()
+			podTemplateAC.Spec.Containers[utils.RayContainerIndex].WithEnv(
+				corev1ac.EnvVar().WithName("RAY_REDIS_ADDRESS").WithValue("redis:6379"),
 			)
+			if tc.redisPasswordEnv != "" {
+				podTemplateAC.Spec.Containers[utils.RayContainerIndex].WithEnv(
+					corev1ac.EnvVar().WithName("REDIS_PASSWORD").WithValue(tc.redisPasswordEnv),
+				)
+			}
 
 			rayClusterAC := rayv1ac.RayCluster("raycluster-gcsft", namespace.Name).WithAnnotations(
 				func() map[string]string {

--- a/ray-operator/test/e2e/raycluster_gcsft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcsft_test.go
@@ -161,7 +161,7 @@ func TestGcsFaultToleranceAnnotations(t *testing.T) {
 
 			redisPassword := ""
 			if tc.redisPasswordEnv != "" && tc.redisPasswordInRayStartParams != "" && tc.redisPasswordInRayStartParams != "$REDIS_PASSWORD" {
-				t.Fatalf("redisPasswordEnv and redisPasswordInRayStartParams are mutually exclusive")
+				t.Fatalf("redisPasswordEnv and redisPasswordInRayStartParams are both set")
 			}
 
 			switch {

--- a/ray-operator/test/e2e/support.go
+++ b/ray-operator/test/e2e/support.go
@@ -100,13 +100,6 @@ func mountConfigMap[T rayv1ac.RayClusterSpecApplyConfiguration | corev1ac.PodTem
 	}
 }
 
-func injectRayStartParams(params map[string]string) option[rayv1ac.RayClusterSpecApplyConfiguration] {
-	return func(t *rayv1ac.RayClusterSpecApplyConfiguration) *rayv1ac.RayClusterSpecApplyConfiguration {
-		t.HeadGroupSpec.RayStartParams = params
-		return t
-	}
-}
-
 func rayClusterSpec() *rayv1ac.RayClusterSpecApplyConfiguration {
 	return rayv1ac.RayClusterSpec().
 		WithRayVersion(GetRayVersion()).

--- a/ray-operator/test/e2e/support.go
+++ b/ray-operator/test/e2e/support.go
@@ -107,13 +107,6 @@ func injectRayStartParams(params map[string]string) option[rayv1ac.RayClusterSpe
 	}
 }
 
-func injectRayContainerEnv(envs []corev1ac.EnvVarApplyConfiguration) option[corev1ac.PodTemplateSpecApplyConfiguration] {
-	return func(t *corev1ac.PodTemplateSpecApplyConfiguration) *corev1ac.PodTemplateSpecApplyConfiguration {
-		t.Spec.Containers[0].Env = envs
-		return t
-	}
-}
-
 func rayClusterSpec() *rayv1ac.RayClusterSpecApplyConfiguration {
 	return rayv1ac.RayClusterSpec().
 		WithRayVersion(GetRayVersion()).

--- a/ray-operator/test/e2e/support.go
+++ b/ray-operator/test/e2e/support.go
@@ -100,6 +100,20 @@ func mountConfigMap[T rayv1ac.RayClusterSpecApplyConfiguration | corev1ac.PodTem
 	}
 }
 
+func injectRayStartParams(params map[string]string) option[rayv1ac.RayClusterSpecApplyConfiguration] {
+	return func(t *rayv1ac.RayClusterSpecApplyConfiguration) *rayv1ac.RayClusterSpecApplyConfiguration {
+		t.HeadGroupSpec.RayStartParams = params
+		return t
+	}
+}
+
+func injectRayContainerEnv(envs []corev1ac.EnvVarApplyConfiguration) option[corev1ac.PodTemplateSpecApplyConfiguration] {
+	return func(t *corev1ac.PodTemplateSpecApplyConfiguration) *corev1ac.PodTemplateSpecApplyConfiguration {
+		t.Spec.Containers[0].Env = envs
+		return t
+	}
+}
+
 func rayClusterSpec() *rayv1ac.RayClusterSpecApplyConfiguration {
 	return rayv1ac.RayClusterSpec().
 		WithRayVersion(GetRayVersion()).


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Old GCS FT API uses annotations to configure GCS FT behavior. This PR adds e2e tests for it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
