### PR TITLE
skip suspending worker groups if the RayJobDeletionPolicy feature flag is not enabled

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -356,7 +356,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `suspend` _boolean_ | Suspend indicates whether a worker group should be suspended.<br />A suspended worker group will have all pods deleted. |  |  |
+| `suspend` _boolean_ | Suspend indicates whether a worker group should be suspended.<br />A suspended worker group will have all pods deleted.<br />This is not a user-facing API and is only used by RayJob DeletionPolicy. |  |  |
 | `groupName` _string_ | we can have multiple worker groups, we distinguish them by name |  |  |
 | `replicas` _integer_ | Replicas is the number of desired Pods for this worker group. See https://github.com/ray-project/kuberay/pull/1443 for more details about the reason for making this field optional. | 0 |  |
 | `minReplicas` _integer_ | MinReplicas denotes the minimum number of desired Pods for this worker group. | 0 |  |

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -72,6 +72,7 @@ type HeadGroupSpec struct {
 type WorkerGroupSpec struct {
 	// Suspend indicates whether a worker group should be suspended.
 	// A suspended worker group will have all pods deleted.
+	// This is not a user-facing API and is only used by RayJob DeletionPolicy.
 	Suspend *bool `json:"suspend,omitempty"`
 	// we can have multiple worker groups, we distinguish them by name
 	GroupName string `json:"groupName"`

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -262,6 +262,14 @@ func validateRayClusterSpec(instance *rayv1.RayCluster) error {
 	// TODO (kevin85421): If GcsFaultToleranceOptions is set, users should use `GcsFaultToleranceOptions.ExternalStorageNamespace` instead of
 	// the annotation `ray.io/external-storage-namespace`.
 
+	if !features.Enabled(features.RayJobDeletionPolicy) {
+		for _, workerGroup := range instance.Spec.WorkerGroupSpecs {
+			if workerGroup.Suspend != nil && *workerGroup.Suspend {
+				return fmt.Errorf("suspending worker groups is currently available when the RayJobDeletionPolicy feature gate is enabled")
+			}
+		}
+	}
+
 	enableInTreeAutoscaling := (instance.Spec.EnableInTreeAutoscaling != nil) && (*instance.Spec.EnableInTreeAutoscaling)
 	if enableInTreeAutoscaling {
 		for _, workerGroup := range instance.Spec.WorkerGroupSpecs {

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -828,6 +828,10 @@ var _ = Context("Inside the default namespace", func() {
 		workerFilters := common.RayClusterGroupPodsAssociationOptions(rayCluster, rayCluster.Spec.WorkerGroupSpecs[0].GroupName).ToListOptions()
 		headFilters := common.RayClusterHeadPodsAssociationOptions(rayCluster).ToListOptions()
 
+		BeforeAll(func() {
+			DeferCleanup(features.SetFeatureGateDuringTest(GinkgoTB(), features.RayJobDeletionPolicy, true))
+		})
+
 		It("Create a RayCluster custom resource", func() {
 			err := k8sClient.Create(ctx, rayCluster)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
@@ -870,6 +874,10 @@ var _ = Context("Inside the default namespace", func() {
 		allFilters := common.RayClusterAllPodsAssociationOptions(rayCluster).ToListOptions()
 		workerFilters := common.RayClusterGroupPodsAssociationOptions(rayCluster, rayCluster.Spec.WorkerGroupSpecs[0].GroupName).ToListOptions()
 		headFilters := common.RayClusterHeadPodsAssociationOptions(rayCluster).ToListOptions()
+
+		BeforeAll(func() {
+			DeferCleanup(features.SetFeatureGateDuringTest(GinkgoTB(), features.RayJobDeletionPolicy, true))
+		})
 
 		It("Create a RayCluster custom resource", func() {
 			err := k8sClient.Create(ctx, rayCluster)

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -962,7 +962,6 @@ var _ = Context("RayJob with different submission modes", func() {
 	})
 
 	Describe("RayJob with DeletionPolicy=DeleteWorkers", Ordered, func() {
-
 		ctx := context.Background()
 		namespace := "default"
 		rayJob := rayJobTemplate("rayjob-test-deletionpolicy-deleteworkers", namespace)
@@ -1111,6 +1110,10 @@ var _ = Context("RayJob with different submission modes", func() {
 		rayJob.Spec.DeletionPolicy = &deletionPolicy
 		rayJob.Spec.ShutdownAfterJobFinishes = false
 		rayCluster := &rayv1.RayCluster{}
+
+		BeforeAll(func() {
+			DeferCleanup(features.SetFeatureGateDuringTest(GinkgoTB(), features.RayJobDeletionPolicy, true))
+		})
 
 		It("Create a RayJob custom resource", func() {
 			err := k8sClient.Create(ctx, rayJob)

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -838,8 +838,6 @@ var _ = Context("RayJob with different submission modes", func() {
 	})
 
 	Describe("RayJob with DeletionPolicy=DeleteCluster", Ordered, func() {
-		features.SetFeatureGateDuringTest(GinkgoTB(), features.RayJobDeletionPolicy, true)
-
 		ctx := context.Background()
 		namespace := "default"
 		rayJob := rayJobTemplate("rayjob-test-deletionpolicy-deletecluster", namespace)
@@ -847,6 +845,10 @@ var _ = Context("RayJob with different submission modes", func() {
 		rayJob.Spec.DeletionPolicy = &deletionPolicy
 		rayJob.Spec.ShutdownAfterJobFinishes = false
 		rayCluster := &rayv1.RayCluster{}
+
+		BeforeAll(func() {
+			DeferCleanup(features.SetFeatureGateDuringTest(GinkgoTB(), features.RayJobDeletionPolicy, true))
+		})
 
 		It("Verify RayJob spec", func() {
 			Expect(*rayJob.Spec.DeletionPolicy).To(Equal(rayv1.DeleteClusterDeletionPolicy))
@@ -960,7 +962,6 @@ var _ = Context("RayJob with different submission modes", func() {
 	})
 
 	Describe("RayJob with DeletionPolicy=DeleteWorkers", Ordered, func() {
-		features.SetFeatureGateDuringTest(GinkgoTB(), features.RayJobDeletionPolicy, true)
 
 		ctx := context.Background()
 		namespace := "default"
@@ -969,6 +970,10 @@ var _ = Context("RayJob with different submission modes", func() {
 		rayJob.Spec.DeletionPolicy = &deletionPolicy
 		rayJob.Spec.ShutdownAfterJobFinishes = false
 		rayCluster := &rayv1.RayCluster{}
+
+		BeforeAll(func() {
+			DeferCleanup(features.SetFeatureGateDuringTest(GinkgoTB(), features.RayJobDeletionPolicy, true))
+		})
 
 		It("Verify RayJob spec", func() {
 			Expect(*rayJob.Spec.DeletionPolicy).To(Equal(rayv1.DeleteWorkersDeletionPolicy))
@@ -1203,8 +1208,6 @@ var _ = Context("RayJob with different submission modes", func() {
 	})
 
 	Describe("RayJob with DeletionPolicy=DeleteNone", Ordered, func() {
-		features.SetFeatureGateDuringTest(GinkgoTB(), features.RayJobDeletionPolicy, true)
-
 		ctx := context.Background()
 		namespace := "default"
 		rayJob := rayJobTemplate("rayjob-test-deletionpolicy-deletenone", namespace)
@@ -1212,6 +1215,10 @@ var _ = Context("RayJob with different submission modes", func() {
 		rayJob.Spec.DeletionPolicy = &deletionPolicy
 		rayJob.Spec.ShutdownAfterJobFinishes = false
 		rayCluster := &rayv1.RayCluster{}
+
+		BeforeAll(func() {
+			DeferCleanup(features.SetFeatureGateDuringTest(GinkgoTB(), features.RayJobDeletionPolicy, true))
+		})
 
 		It("Verify RayJob spec", func() {
 			Expect(*rayJob.Spec.DeletionPolicy).To(Equal(rayv1.DeleteNoneDeletionPolicy))


### PR DESCRIPTION
## Why are these changes needed?

This is a follow-up RP for https://github.com/ray-project/kuberay/pull/2748.

We limit that the `suspend` field on a worker group is only available under the RayJobDeletionPolicy feature gate:
1. Add a comment saying that the field is not user-facing.
2. Add a validation on RayCluster to reject the suspend field if the feature gate is not enabled.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
