### PR TITLE
[Refactor]: Move `IsGCSFaultToleranceEnabled` to `utils.go`

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -55,12 +55,6 @@ func GetHeadPort(headStartParams map[string]string) string {
 	return strconv.Itoa(utils.DefaultGcsServerPort)
 }
 
-// Check if the RayCluster has GCS fault tolerance enabled.
-func IsGCSFaultToleranceEnabled(instance rayv1.RayCluster) bool {
-	v, ok := instance.Annotations[utils.RayFTEnabledAnnotationKey]
-	return (ok && strings.ToLower(v) == "true") || instance.Spec.GcsFaultToleranceOptions != nil
-}
-
 // Check if overwrites the container command.
 func isOverwriteRayContainerCmd(instance rayv1.RayCluster) bool {
 	v, ok := instance.Annotations[utils.RayOverwriteContainerCmdAnnotationKey]
@@ -80,7 +74,7 @@ func initTemplateAnnotations(instance rayv1.RayCluster, podTemplate *corev1.PodT
 func configureGCSFaultTolerance(podTemplate *corev1.PodTemplateSpec, instance rayv1.RayCluster, rayNodeType rayv1.RayNodeType) {
 	// Configure environment variables, annotations, and rayStartParams for GCS fault tolerance.
 	// Note that both `podTemplate` and `instance` will be modified.
-	ftEnabled := IsGCSFaultToleranceEnabled(instance)
+	ftEnabled := utils.IsGCSFaultToleranceEnabled(instance)
 	if podTemplate.Annotations == nil {
 		podTemplate.Annotations = make(map[string]string)
 	}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -237,7 +237,7 @@ func validateRayClusterSpec(instance *rayv1.RayCluster) error {
 			"Please use only GcsFaultToleranceOptions to configure GCS fault tolerance", utils.RayFTEnabledAnnotationKey)
 	}
 
-	if !common.IsGCSFaultToleranceEnabled(*instance) {
+	if !utils.IsGCSFaultToleranceEnabled(*instance) {
 		if utils.EnvVarExists(utils.RAY_REDIS_ADDRESS, instance.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Env) {
 			return fmt.Errorf("%s is set which implicitly enables GCS fault tolerance, "+
 				"but GcsFaultToleranceOptions is not set. Please set GcsFaultToleranceOptions "+
@@ -319,7 +319,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 	// manually after the RayCluster CR deletion.
 	enableGCSFTRedisCleanup := strings.ToLower(os.Getenv(utils.ENABLE_GCS_FT_REDIS_CLEANUP)) != "false"
 
-	if enableGCSFTRedisCleanup && common.IsGCSFaultToleranceEnabled(*instance) {
+	if enableGCSFTRedisCleanup && utils.IsGCSFaultToleranceEnabled(*instance) {
 		if instance.DeletionTimestamp.IsZero() {
 			if !controllerutil.ContainsFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer) {
 				logger.Info(

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -633,3 +633,9 @@ func IsAutoscalingEnabled[T *rayv1.RayCluster | *rayv1.RayJob | *rayv1.RayServic
 		panic(fmt.Sprintf("unsupported type: %T", obj))
 	}
 }
+
+// Check if the RayCluster has GCS fault tolerance enabled.
+func IsGCSFaultToleranceEnabled(instance rayv1.RayCluster) bool {
+	v, ok := instance.Annotations[RayFTEnabledAnnotationKey]
+	return (ok && strings.ToLower(v) == "true") || instance.Spec.GcsFaultToleranceOptions != nil
+}

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -752,3 +752,70 @@ func TestIsAutoscalingEnabled(t *testing.T) {
 	}
 	assert.True(t, IsAutoscalingEnabled(service))
 }
+
+func TestIsGCSFaultToleranceEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance rayv1.RayCluster
+		expected bool
+	}{
+		{
+			name: "ray.io/ft-enabled is true",
+			instance: rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						RayFTEnabledAnnotationKey: "true",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "ray.io/ft-enabled is not set and GcsFaultToleranceOptions is set",
+			instance: rayv1.RayCluster{
+				Spec: rayv1.RayClusterSpec{
+					GcsFaultToleranceOptions: &rayv1.GcsFaultToleranceOptions{},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "ray.io/ft-enabled is false",
+			instance: rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						RayFTEnabledAnnotationKey: "false",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "ray.io/ft-enabled is not set and GcsFaultToleranceOptions is not set",
+			instance: rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "ray.io/ft-enabled is using uppercase true",
+			instance: rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						RayFTEnabledAnnotationKey: "TRUE",
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := IsGCSFaultToleranceEnabled(test.instance)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Separate PR #2774 into small PRs, We started by moving `IsGCSFaultToleranceEnabled` to `ray-operator/controllers/ray/utils/util.go`
Refer to this https://github.com/ray-project/kuberay/pull/2774#issuecomment-2601501738

## Related issue number
Closes #2740 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
