### PR TITLE
[RayService][Feature] support eager exposes services

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -188,7 +188,9 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 
 	if !isReady {
 		logger.Info("Ray Serve applications are not ready to serve requests")
-		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
+		if !isEagerExposesServicesEnabled() {
+			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
+		}
 	}
 
 	// Get the ready Ray cluster instance for service update.
@@ -216,6 +218,10 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 		if err := r.reconcileServices(ctx, rayServiceInstance, rayClusterInstance, utils.ServingService); err != nil {
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
 		}
+	}
+
+	if !isReady {
+		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
 	}
 
 	if err := r.calculateStatus(ctx, rayServiceInstance); err != nil {
@@ -247,6 +253,10 @@ func validateRayServiceSpec(rayService *rayv1.RayService) error {
 		return fmt.Errorf("Spec.UpgradeStrategy.Type value %s is invalid, valid options are %s or %s", *rayService.Spec.UpgradeStrategy.Type, rayv1.NewCluster, rayv1.None)
 	}
 	return nil
+}
+
+func isEagerExposesServicesEnabled() bool {
+	return strings.ToLower(os.Getenv(utils.ENABLE_RAYSERVICE_EAGER_EXPOSES_SERVICES)) == "true"
 }
 
 func (r *RayServiceReconciler) calculateStatus(ctx context.Context, rayServiceInstance *rayv1.RayService) error {

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -142,6 +142,9 @@ const (
 	// If set to true, the RayJob CR itself will be deleted if shutdownAfterJobFinishes is set to true. Note that all resources created by the RayJob CR will be deleted, including the K8s Job.
 	DELETE_RAYJOB_CR_AFTER_JOB_FINISHES = "DELETE_RAYJOB_CR_AFTER_JOB_FINISHES"
 
+	// If set to true, publish exposing HeadService before Serve application is ready
+	ENABLE_RAYSERVICE_EAGER_EXPOSES_SERVICES = "ENABLE_RAYSERVICE_EAGER_EXPOSES_SERVICES"
+
 	// Ray core default configurations
 	DefaultWorkerRayGcsReconnectTimeoutS = "600"
 


### PR DESCRIPTION
## Search before asking
- [x]  I had searched in the [issues](https://github.com/ray-project/kuberay/issues) and found no similar feature requirement.

## Description
Currently, when serve is not ready, `head service` and `serving service` cannot be exposed externally, which affects Ray Dashboard's external access. This PR adds a switch to allow users to expose the Service in advance.

## Use case

No response

## Related issues

No response

## Are you willing to submit a PR?

- [x] Yes I am willing to submit a PR!