### PR TITLE
[RayService] Rename Restarting to PreparingNewCluster

### DIFF
--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -13,7 +13,7 @@ type ServiceStatus string
 const (
 	WaitForServeDeploymentReady ServiceStatus = "WaitForServeDeploymentReady"
 	Running                     ServiceStatus = "Running"
-	Restarting                  ServiceStatus = "Restarting"
+	PreparingNewCluster         ServiceStatus = "PreparingNewCluster"
 )
 
 type RayServiceUpgradeType string

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -13,7 +13,7 @@ type ServiceStatus string
 const (
 	WaitForServeDeploymentReady ServiceStatus = "WaitForServeDeploymentReady"
 	Running                     ServiceStatus = "Running"
-	Restarting                  ServiceStatus = "Restarting"
+	PreparingNewCluster         ServiceStatus = "PreparingNewCluster"
 )
 
 // These statuses should match Ray Serve's application statuses

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -436,7 +436,7 @@ func (r *RayServiceReconciler) reconcileRayCluster(ctx context.Context, rayServi
 	clusterAction := decideClusterAction(ctx, rayServiceInstance, activeRayCluster, pendingRayCluster)
 	switch clusterAction {
 	case GeneratePendingClusterName:
-		markRestartAndAddPendingClusterName(ctx, rayServiceInstance)
+		markPreparingNewCluster(rayServiceInstance)
 		return activeRayCluster, nil, nil
 	case CreatePendingCluster:
 		logger.Info("Creating a new pending RayCluster instance.")
@@ -975,12 +975,8 @@ func (r *RayServiceReconciler) cacheServeConfig(rayServiceInstance *rayv1.RaySer
 	rayServiceServeConfigs.Set(clusterName, serveConfig)
 }
 
-func markRestartAndAddPendingClusterName(ctx context.Context, rayServiceInstance *rayv1.RayService) {
-	logger := ctrl.LoggerFrom(ctx)
-
-	// Generate RayCluster name for pending cluster.
-	logger.Info("Current cluster is unhealthy, prepare to restart.", "Status", rayServiceInstance.Status)
-	rayServiceInstance.Status.ServiceStatus = rayv1.Restarting
+func markPreparingNewCluster(rayServiceInstance *rayv1.RayService) {
+	rayServiceInstance.Status.ServiceStatus = rayv1.PreparingNewCluster
 	rayServiceInstance.Status.PendingServiceStatus = rayv1.RayServiceStatus{
 		RayClusterName: utils.GenerateRayClusterName(rayServiceInstance.Name),
 	}

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -366,7 +366,7 @@ func TestInconsistentRayServiceStatuses(t *testing.T) {
 				},
 			},
 		},
-		ServiceStatus: rayv1.Restarting,
+		ServiceStatus: rayv1.PreparingNewCluster,
 	}
 	ctx := context.Background()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

New cluster will only be created when there is no active cluster or RayCluster spec is updated and the upgrade is triggered. New cluster will not be created when current cluster is unhealthy.

It's weird that when a new RayService is created and marked "Restarting". Rename it to `PreparingNewCluster` is a workaround. The long term solution is to delete `Restarting` and use the conditions proposed by @MortalHappiness.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
