### PR TITLE
[kubectl-plugin] silence warnings when creating worker groups

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 
@@ -54,6 +55,9 @@ func NewCreateWorkerGroupOptions(streams genericclioptions.IOStreams) *CreateWor
 func NewCreateWorkerGroupCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	options := NewCreateWorkerGroupOptions(streams)
 	cmdFactory := cmdutil.NewFactory(options.configFlags)
+	// Silence warnings to avoid messages like 'unknown field "spec.headGroupSpec.template.metadata.creationTimestamp"'
+	// See https://github.com/kubernetes/kubernetes/issues/67610 for more details.
+	rest.SetDefaultWarningHandler(rest.NoWarnings{})
 
 	cmd := &cobra.Command{
 		Use:          "workergroup [WORKERGROUP]",


### PR DESCRIPTION
## Why are these changes needed?

When running `kubectl ray create workergroup`, there's a warning that occurs due to creationTimestamp being included in the type but not included in the CRD generation.
```
$ kubectl ray create workergroup gpu-group --ray-cluster sample-cluster --worker-gpu=1
W0121 19:24:22.913198 1950811 warnings.go:70] unknown field "spec.headGroupSpec.template.metadata.creationTimestamp"
W0121 19:24:22.913288 1950811 warnings.go:70] unknown field "spec.workerGroupSpecs[0].template.metadata.creationTimestamp"
W0121 19:24:22.913293 1950811 warnings.go:70] unknown field "spec.workerGroupSpecs[1].template.metadata.creationTimestamp"
W0121 19:24:22.913297 1950811 warnings.go:70] unknown field "spec.workerGroupSpecs[2].template.metadata.creationTimestamp"
```

As a temporary workaround,  we can hide the warnings.  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
