### PR TITLE
[RayCluster][Feature] reject redis username to head pod out side of GcsFaultToleranceOptions

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -236,13 +236,13 @@ func validateRayClusterSpec(instance *rayv1.RayCluster) error {
 		}
 	}
 
+	headContainer := instance.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex]
 	if instance.Spec.GcsFaultToleranceOptions != nil {
 		if redisPassword := instance.Spec.HeadGroupSpec.RayStartParams["redis-password"]; redisPassword != "" {
 			return fmt.Errorf("cannot set `redis-password` in rayStartParams when " +
 				"GcsFaultToleranceOptions is enabled - use GcsFaultToleranceOptions.RedisPassword instead")
 		}
 
-		headContainer := instance.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex]
 		if utils.EnvVarExists(utils.REDIS_PASSWORD, headContainer.Env) {
 			return fmt.Errorf("cannot set `REDIS_PASSWORD` env var in head Pod when " +
 				"GcsFaultToleranceOptions is enabled - use GcsFaultToleranceOptions.RedisPassword instead")
@@ -257,6 +257,10 @@ func validateRayClusterSpec(instance *rayv1.RayCluster) error {
 			return fmt.Errorf("cannot set `ray.io/external-storage-namespace` annotation when " +
 				"GcsFaultToleranceOptions is enabled - use GcsFaultToleranceOptions.ExternalStorageNamespace instead")
 		}
+	}
+	if instance.Spec.HeadGroupSpec.RayStartParams["redis-username"] != "" || utils.EnvVarExists(utils.REDIS_USERNAME, headContainer.Env) {
+		return fmt.Errorf("cannot set redis username in rayStartParams or environment variables" +
+			" - use GcsFaultToleranceOptions.RedisUsername instead")
 	}
 
 	if !features.Enabled(features.RayJobDeletionPolicy) {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3684,6 +3684,77 @@ func TestValidateRayClusterSpecRedisPassword(t *testing.T) {
 	}
 }
 
+func TestValidateRayClusterSpecRedisUsername(t *testing.T) {
+	errorMessageRedisUsername := "cannot set redis username in rayStartParams or environment variables - use GcsFaultToleranceOptions.RedisUsername instead"
+
+	tests := []struct {
+		gcsFaultToleranceOptions *rayv1.GcsFaultToleranceOptions
+		name                     string
+		errorMessage             string
+		rayStartParams           map[string]string
+		envVars                  []corev1.EnvVar
+		expectError              bool
+	}{
+		{
+			name: "`redis-username` is set in rayStartParams of the Head Pod",
+			rayStartParams: map[string]string{
+				"redis-username": "username",
+			},
+			expectError:  true,
+			errorMessage: errorMessageRedisUsername,
+		},
+		{
+			name: "`REDIS_USERNAME` env var is set in the Head Pod",
+			envVars: []corev1.EnvVar{
+				{
+					Name:  utils.REDIS_USERNAME,
+					Value: "username",
+				},
+			},
+			expectError:  true,
+			errorMessage: errorMessageRedisUsername,
+		},
+		{
+			name: "GcsFaultToleranceOptions.RedisUsername is set",
+			gcsFaultToleranceOptions: &rayv1.GcsFaultToleranceOptions{
+				RedisUsername: &rayv1.RedisCredential{
+					Value: "username",
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rayCluster := &rayv1.RayCluster{
+				Spec: rayv1.RayClusterSpec{
+					GcsFaultToleranceOptions: tt.gcsFaultToleranceOptions,
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						RayStartParams: tt.rayStartParams,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: tt.envVars,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			err := validateRayClusterSpec(rayCluster)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.errorMessage)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateRayClusterSpecEmptyContainers(t *testing.T) {
 	headGroupSpecWithOneContainer := rayv1.HeadGroupSpec{
 		Template: corev1.PodTemplateSpec{


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Addressing the comment https://github.com/ray-project/kuberay/pull/2760#discussion_r1921867783

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
