### PR TITLE
[CI] Make kubectl plugin release only be triggered manually

### DIFF
--- a/.github/workflows/kubectl-plugin-release.yaml
+++ b/.github/workflows/kubectl-plugin-release.yaml
@@ -1,15 +1,18 @@
-name: release
+name: release-kubectl-plugin
 on:
-  push:
-    tags:
-      - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Desired release version tag (e.g. v1.1.0-rc.1).'
+        required: true
 jobs:
   release-kubectl-plugin:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -23,6 +26,5 @@ jobs:
           workdir: 'kubectl-plugin'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # TODO(MortalHappiness): This won't work now. The first version of plugin has to be submitted manually by use to the krew-index repo, so I'll submit a PR to the krew-index repo once a release candidate is created.
       - name: Update new version in krew-index
         uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.github/workflows/kubectl-plugin-release.yaml
+++ b/.github/workflows/kubectl-plugin-release.yaml
@@ -13,18 +13,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.tag }}
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22'
-      - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: 'goreleaser'
-          version: latest
-          args: release --clean
-          workdir: 'kubectl-plugin'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update new version in krew-index
-        uses: rajatjindal/krew-release-bot@v0.0.46
+          fetch-depth: 0
+      - name: Show tag
+        run: git show-ref --head --dereference | grep "$(git rev-parse HEAD)"
+#      - name: Setup Go
+#        uses: actions/setup-go@v5
+#        with:
+#          go-version: '1.22'
+#      - name: GoReleaser
+#        uses: goreleaser/goreleaser-action@v6
+#        with:
+#          distribution: 'goreleaser'
+#          version: latest
+#          args: release --clean
+#          workdir: 'kubectl-plugin'
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Update new version in krew-index
+#        uses: rajatjindal/krew-release-bot@v0.0.46


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As title.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
