### PR TITLE
[Chore] remove redundant var declaration

### DIFF
--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -40,7 +40,6 @@ func BuildIngressForHeadService(ctx context.Context, cluster rayv1.RayCluster) (
 		}
 	}
 
-	var paths []networkingv1.HTTPIngressPath
 	pathType := networkingv1.PathTypeExact
 	servicePorts := getServicePorts(cluster)
 	dashboardPort := int32(utils.DefaultDashboardPort)
@@ -52,7 +51,7 @@ func BuildIngressForHeadService(ctx context.Context, cluster rayv1.RayCluster) (
 	if err != nil {
 		return nil, err
 	}
-	paths = []networkingv1.HTTPIngressPath{
+	paths := []networkingv1.HTTPIngressPath{
 		{
 			Path:     "/" + cluster.Name + "/(.*)",
 			PathType: &pathType,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

To make code more concise, remove redundant var declaration, which is assigned with a value at:
https://github.com/ray-project/kuberay/blob/7e726277e8c7313bb79189b6b9004b89dba6cb13/ray-operator/controllers/ray/common/ingress.go#L55

And there is no other usage between the line of assignment and the line of declaration.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
