### PR TITLE
[Refactor] Move `ValidateRayJobStatus` to `validation.go` and create its unit test

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -134,7 +134,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 	}
 
-	if err := validateRayJobStatus(rayJobInstance); err != nil {
+	if err := utils.ValidateRayJobStatus(rayJobInstance); err != nil {
 		logger.Error(err, "The RayJob status is invalid")
 		r.Recorder.Eventf(rayJobInstance, corev1.EventTypeWarning, string(utils.InvalidRayJobStatus),
 			"The RayJob status is invalid %s/%s: %v", rayJobInstance.Namespace, rayJobInstance.Name, err)
@@ -925,13 +925,5 @@ func validateRayJobSpec(rayJob *rayv1.RayJob) error {
 			return fmt.Errorf("shutdownAfterJobFinshes is set to 'true' while deletion policy is 'DeleteNone'")
 		}
 	}
-	return nil
-}
-
-func validateRayJobStatus(rayJob *rayv1.RayJob) error {
-	if rayJob.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusWaiting && rayJob.Spec.SubmissionMode != rayv1.InteractiveMode {
-		return fmt.Errorf("invalid RayJob State: JobDeploymentStatus cannot be `Waiting` when SubmissionMode is not InteractiveMode")
-	}
-
 	return nil
 }

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -89,3 +89,11 @@ func ValidateRayClusterSpec(instance *rayv1.RayCluster) error {
 	}
 	return nil
 }
+
+func ValidateRayJobStatus(rayJob *rayv1.RayJob) error {
+	if rayJob.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusWaiting && rayJob.Spec.SubmissionMode != rayv1.InteractiveMode {
+		return fmt.Errorf("invalid RayJob State: JobDeploymentStatus cannot be `Waiting` when SubmissionMode is not InteractiveMode")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why are these changes needed?
Separate PR https://github.com/ray-project/kuberay/pull/2774 into small PRs
- Move the `ValidateRayJobStatus` function to `validation.go
- Move unit test `TestValidateRayJobStatus` to  `validation_test.go`
Refer to this https://github.com/ray-project/kuberay/pull/2774#issuecomment-2601501738


## Related issue number
Closes #2740 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
