### PR TITLE
[autoscaler] Bump Ray e2e test image

### DIFF
--- a/ray-operator/test/support/defaults.go
+++ b/ray-operator/test/support/defaults.go
@@ -1,6 +1,6 @@
 package support
 
 const (
-	RayVersion = "2.40.0"
-	RayImage   = "rayproject/ray:2.40.0"
+	RayVersion = "2.41.0"
+	RayImage   = "rayproject/ray:2.41.0"
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR bumps the default Ray image used for e2e autoscaler tests to 2.41.0. The newer Ray images contains several fixes for autoscaler issues that currently cause these tests to fail.

## Related issue number

Closes #2759

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
