### PR TITLE
[Refactor] Move `validateRayServiceSpec` to `validation.go` and its unit test to `validation_test.go`

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -26,38 +26,6 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
-func TestValidateRayServiceSpec(t *testing.T) {
-	err := validateRayServiceSpec(&rayv1.RayService{
-		Spec: rayv1.RayServiceSpec{
-			RayClusterSpec: rayv1.RayClusterSpec{
-				HeadGroupSpec: rayv1.HeadGroupSpec{
-					HeadService: &corev1.Service{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "my-head-service",
-						},
-					},
-				},
-			},
-		},
-	})
-	assert.Error(t, err, "spec.rayClusterConfig.headGroupSpec.headService.metadata.name should not be set")
-
-	err = validateRayServiceSpec(&rayv1.RayService{
-		Spec: rayv1.RayServiceSpec{},
-	})
-	assert.NoError(t, err, "The RayService spec is valid.")
-
-	var upgradeStrat rayv1.RayServiceUpgradeType = "invalidStrategy"
-	err = validateRayServiceSpec(&rayv1.RayService{
-		Spec: rayv1.RayServiceSpec{
-			UpgradeStrategy: &rayv1.RayServiceUpgradeStrategy{
-				Type: &upgradeStrat,
-			},
-		},
-	})
-	assert.Error(t, err, "spec.UpgradeSpec.Type is invalid")
-}
-
 func TestGenerateHashWithoutReplicasAndWorkersToDelete(t *testing.T) {
 	// `generateRayClusterJsonHash` will mute fields that will not trigger new RayCluster preparation. For example,
 	// Autoscaler will update `Replicas` and `WorkersToDelete` when scaling up/down. Hence, `hash1` should be equal to

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -149,3 +149,18 @@ func ValidateRayJobSpec(rayJob *rayv1.RayJob) error {
 	}
 	return nil
 }
+
+func ValidateRayServiceSpec(rayService *rayv1.RayService) error {
+	if headSvc := rayService.Spec.RayClusterSpec.HeadGroupSpec.HeadService; headSvc != nil && headSvc.Name != "" {
+		return fmt.Errorf("spec.rayClusterConfig.headGroupSpec.headService.metadata.name should not be set")
+	}
+
+	// only NewCluster and None are valid upgradeType
+	if rayService.Spec.UpgradeStrategy != nil &&
+		rayService.Spec.UpgradeStrategy.Type != nil &&
+		*rayService.Spec.UpgradeStrategy.Type != rayv1.None &&
+		*rayService.Spec.UpgradeStrategy.Type != rayv1.NewCluster {
+		return fmt.Errorf("Spec.UpgradeStrategy.Type value %s is invalid, valid options are %s or %s", *rayService.Spec.UpgradeStrategy.Type, rayv1.NewCluster, rayv1.None)
+	}
+	return nil
+}

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -686,3 +686,35 @@ func TestValidateRayJobSpec(t *testing.T) {
 	})
 	assert.ErrorContains(t, err, "shutdownAfterJobFinshes is set to 'true' while deletion policy is 'DeleteNone'")
 }
+
+func TestValidateRayServiceSpec(t *testing.T) {
+	err := ValidateRayServiceSpec(&rayv1.RayService{
+		Spec: rayv1.RayServiceSpec{
+			RayClusterSpec: rayv1.RayClusterSpec{
+				HeadGroupSpec: rayv1.HeadGroupSpec{
+					HeadService: &corev1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "my-head-service",
+						},
+					},
+				},
+			},
+		},
+	})
+	assert.Error(t, err, "spec.rayClusterConfig.headGroupSpec.headService.metadata.name should not be set")
+
+	err = ValidateRayServiceSpec(&rayv1.RayService{
+		Spec: rayv1.RayServiceSpec{},
+	})
+	assert.NoError(t, err, "The RayService spec is valid.")
+
+	var upgradeStrat rayv1.RayServiceUpgradeType = "invalidStrategy"
+	err = ValidateRayServiceSpec(&rayv1.RayService{
+		Spec: rayv1.RayServiceSpec{
+			UpgradeStrategy: &rayv1.RayServiceUpgradeStrategy{
+				Type: &upgradeStrat,
+			},
+		},
+	})
+	assert.Error(t, err, "spec.UpgradeSpec.Type is invalid")
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Separate PR https://github.com/ray-project/kuberay/pull/2774 into small PRs
- Move the function `validateRayServiceSpec` to `validation.go`
- Move unit test `TestvalidateRayServiceSpec` to  `validation_test.go`
Refer to this https://github.com/ray-project/kuberay/pull/2774#issuecomment-2601501738
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #2740 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
