### PR TITLE
[RayService] Calculate status based on K8s resources

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -552,7 +552,7 @@ func TestReconcileServices_UpdateService(t *testing.T) {
 
 	ctx := context.TODO()
 	// Create a head service.
-	err := r.reconcileServices(ctx, &rayService, &cluster, utils.HeadService)
+	_, err := r.reconcileServices(ctx, &rayService, &cluster, utils.HeadService)
 	assert.Nil(t, err, "Fail to reconcile service")
 
 	svcList := corev1.ServiceList{}
@@ -568,7 +568,7 @@ func TestReconcileServices_UpdateService(t *testing.T) {
 			ContainerPort: 9999,
 		},
 	}
-	err = r.reconcileServices(ctx, &rayService, &cluster, utils.HeadService)
+	_, err = r.reconcileServices(ctx, &rayService, &cluster, utils.HeadService)
 	assert.Nil(t, err, "Fail to reconcile service")
 
 	svcList = corev1.ServiceList{}
@@ -579,7 +579,7 @@ func TestReconcileServices_UpdateService(t *testing.T) {
 
 	// Test 2: When the RayCluster switches, the service should be updated.
 	cluster.Name = "new-cluster"
-	err = r.reconcileServices(ctx, &rayService, &cluster, utils.HeadService)
+	_, err = r.reconcileServices(ctx, &rayService, &cluster, utils.HeadService)
 	assert.Nil(t, err, "Fail to reconcile service")
 
 	svcList = corev1.ServiceList{}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -639,3 +639,11 @@ func IsGCSFaultToleranceEnabled(instance rayv1.RayCluster) bool {
 	v, ok := instance.Annotations[RayFTEnabledAnnotationKey]
 	return (ok && strings.ToLower(v) == "true") || instance.Spec.GcsFaultToleranceOptions != nil
 }
+
+// GetRayClusterNameFromService returns the name of the RayCluster that the service points to
+func GetRayClusterNameFromService(svc *corev1.Service) string {
+	if svc == nil || svc.Spec.Selector == nil {
+		return ""
+	}
+	return svc.Spec.Selector[RayClusterLabelKey]
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Try to calculate CR status only based on K8s resources which is the source of the truth. This PR passes K8s services into `calculateStatus` to determine whether update active / pending cluster status or not.

This is a follow up for #2805.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
