### PR TITLE
[Chore] Modify pre-commit yaml to allow golangci-lint version with prefix "v"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: check-golangci-lint-version
         name: golangci-lint version check
-        entry: bash -c 'version="1.60.3"; [ "$(golangci-lint --version | awk "/version/ {print \$4}")" = "$version" ] || { echo "golangci-lint version is not $version"; exit 1; }'
+        entry: bash -c 'version="1.60.3"; [ "$(golangci-lint --version | awk "/version/ {print \$4}" | sed "s/^v//")" = "$version" ] || { echo "golangci-lint version is not $version"; exit 1; }'
         language: system
         always_run: true
         fail_fast: true


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Some people will get `v1.60.3` instead of  `1.60.3` in golangci-lint --version and will cause pre-commit failed.
So modified the validation part to allow it.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
