### PR TITLE
Fix FromAsCasing warning.

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -1,5 +1,5 @@
 # Build the backend service
-FROM golang:1.22.4-bullseye as builder
+FROM golang:1.22.4-bullseye AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/experimental/Dockerfile
+++ b/experimental/Dockerfile
@@ -1,5 +1,5 @@
 # Build security proxy
-FROM golang:1.22.4-bullseye as builder
+FROM golang:1.22.4-bullseye AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -1,5 +1,5 @@
 # Generate client code (go & json) from API protocol buffers
-FROM golang:1.22.4-bullseye as generator
+FROM golang:1.22.4-bullseye AS generator
 
 ENV PROTOC_VERSION 3.17.3
 ENV GOLANG_PROTOBUF_VERSION v1.5.2

--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.4-bullseye as builder
+FROM golang:1.22.4-bullseye AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When running `make docker-build` with a newer version of Docker, the following warning appears:

```
...
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
```

According to the Docker documentation (https://docs.docker.com/reference/build-checks/from-as-casing/), the `FROM` and `AS` keywords must use consistent casing, either both uppercase or both lowercase.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
