### PR TITLE
[RayService] Passing serve applications to `calculateStatus` and avoid calling `Status().Update(...)` inside `reconcileServe`

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -179,7 +179,6 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	if pendingRayClusterInstance != nil {
 		logger.Info("Reconciling the Serve applications for pending cluster", "clusterName", pendingRayClusterInstance.Name)
 		if isPendingClusterReady, pendingClusterServeApplications, err = r.reconcileServe(ctx, rayServiceInstance, pendingRayClusterInstance); err != nil {
-			// TODO
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
 		}
 	}
@@ -188,7 +187,6 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 		// in-place update and updating the serve application status for the active cluster will not work.
 		logger.Info("Reconciling the Serve applications for active cluster", "clusterName", activeRayClusterInstance.Name)
 		if isActiveClusterReady, activeClusterServeApplications, err = r.reconcileServe(ctx, rayServiceInstance, activeRayClusterInstance); err != nil {
-			// TODO
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
 		}
 	}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -285,6 +285,7 @@ func (r *RayServiceReconciler) calculateStatus(ctx context.Context, rayServiceIn
 		}
 
 		// If services point to a different cluster than the active one, promote pending to active
+		logger.Info("calculateStatus", "clusterSvcPointingTo", clusterName, "pendingClusterName", pendingClusterName, "activeClusterName", activeClusterName)
 		if activeClusterName != clusterName {
 			logger.Info("Promoting pending cluster to active",
 				"oldCluster", rayServiceInstance.Status.ActiveServiceStatus.RayClusterName,

--- a/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
@@ -130,7 +130,7 @@ func TestOldHeadPodFailDuringUpgrade(t *testing.T) {
 		g.Expect(endpoints.Subsets).To(HaveLen(1))
 		g.Expect(endpoints.Subsets[0].Addresses).To(HaveLen(1))
 		g.Expect(endpoints.Subsets[0].Addresses[0].TargetRef.Name).NotTo(Equal(headPodName))
-	}, TestTimeoutShort).Should(Succeed())
+	}, TestTimeoutMedium).Should(Succeed())
 
 	test.T().Logf("Sending requests to the RayService to make sure it is ready to serve requests")
 	g.Eventually(func(g Gomega) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. `reconcileServe` returns serve application status.
2. Pass serve applications to `calculateStatus`
3. Remove `Status().Update(...)` inside `reconcileServe`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
