### PR TITLE
[RayService] e2e for redeploying RayServe application after recreating a new Head Pod

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -295,8 +295,9 @@ func (r *RayServiceReconciler) calculateStatus(ctx context.Context, rayServiceIn
 				"newCluster", clusterName)
 			rayServiceInstance.Status.ActiveServiceStatus = rayServiceInstance.Status.PendingServiceStatus
 			rayServiceInstance.Status.PendingServiceStatus = rayv1.RayServiceStatus{}
-			rayServiceInstance.Status.ServiceStatus = rayv1.Running
 		}
+		// make ServiceStatus ready since headSvc and serveSvc are ready.
+		rayServiceInstance.Status.ServiceStatus = rayv1.Running
 	}
 
 	serveEndPoints := &corev1.Endpoints{}

--- a/ray-operator/test/e2erayservice/rayservice_redeploy_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_redeploy_test.go
@@ -77,7 +77,7 @@ func TestRedeployRayServe(t *testing.T) {
 		g.Expect(endpoints.Subsets).To(HaveLen(1))
 		g.Expect(endpoints.Subsets[0].Addresses).To(HaveLen(1))
 		g.Expect(endpoints.Subsets[0].Addresses[0].TargetRef.Name).NotTo(Equal(oldHeadPod.Name))
-	}, TestTimeoutShort).Should(Succeed())
+	}, TestTimeoutMedium).Should(Succeed())
 
 	test.T().Logf("Waiting for RayService %s/%s to running", rayService.Namespace, rayService.Name)
 	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).

--- a/ray-operator/test/e2erayservice/rayservice_redeploy_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_redeploy_test.go
@@ -1,0 +1,95 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/test/sampleyaml"
+	. "github.com/ray-project/kuberay/ray-operator/test/support"
+)
+
+func TestRedeployRayServe(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+
+	// Create a namespace
+	namespace := test.NewTestNamespace()
+	rayServiceName := "rayservice-sample"
+
+	rayServiceAC := rayv1ac.RayService(rayServiceName, namespace.Name).WithSpec(rayServiceSampleYamlApplyConfiguration())
+
+	rayService, err := test.Client().Ray().RayV1().RayServices(namespace.Name).Apply(test.Ctx(), rayServiceAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(rayService).NotTo(BeNil())
+
+	test.T().Logf("Waiting for RayService %s/%s to running", rayService.Namespace, rayService.Name)
+	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).
+		Should(WithTransform(RayServiceStatus, Equal(rayv1.Running)))
+
+	// Get the latest RayService
+	rayService, err = GetRayService(test, namespace.Name, rayServiceName)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(rayService).NotTo(BeNil())
+
+	curlPodName := "curl-pod"
+	curlContainerName := "curl-container"
+
+	test.T().Logf("Creating curl pod %s/%s", namespace.Name, curlPodName)
+
+	curlPod, err := CreateCurlPod(test, curlPodName, curlContainerName, namespace.Name)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Eventually(func(g Gomega) *corev1.Pod {
+		updatedCurlPod, err := test.Client().Core().CoreV1().Pods(curlPod.Namespace).Get(test.Ctx(), curlPod.Name, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		return updatedCurlPod
+	}, TestTimeoutShort).Should(WithTransform(sampleyaml.IsPodRunningAndReady, BeTrue()))
+	test.T().Logf("Curl pod %s/%s is running and ready", namespace.Name, curlPodName)
+
+	test.T().Logf("Sending requests to the RayService to make sure it is ready to serve requests")
+	g.Eventually(func(g Gomega) {
+		// curl /fruit
+		stdout, _ := curlRayServicePod(test, rayService, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)
+		g.Expect(stdout.String()).To(Equal("6"))
+		// curl /calc
+		stdout, _ = curlRayServicePod(test, rayService, curlPod, curlContainerName, "/calc", `["MUL", 3]`)
+		g.Expect(stdout.String()).To(Equal("15 pizzas please!"))
+	}, TestTimeoutShort).Should(Succeed())
+
+	test.T().Logf("Deleting the current Head for recreating a new one")
+	rayServiceUnderlyingRayCluster, err := GetRayCluster(test, namespace.Name, rayService.Status.ActiveServiceStatus.RayClusterName)
+	g.Expect(err).NotTo(HaveOccurred())
+	oldHeadPod, err := GetHeadPod(test, rayServiceUnderlyingRayCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = test.Client().Core().CoreV1().Pods(namespace.Name).Delete(test.Ctx(), oldHeadPod.Name, metav1.DeleteOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	test.T().Logf("Checking that the K8s serve service eventually has 1 endpoint and the endpoint is not the old head Pod")
+	g.Eventually(func(g Gomega) {
+		svcName := utils.GenerateServeServiceName(rayService.Name)
+		endpoints, err := test.Client().Core().CoreV1().Endpoints(namespace.Name).Get(test.Ctx(), svcName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(endpoints.Subsets).To(HaveLen(1))
+		g.Expect(endpoints.Subsets[0].Addresses).To(HaveLen(1))
+		g.Expect(endpoints.Subsets[0].Addresses[0].TargetRef.Name).NotTo(Equal(oldHeadPod.Name))
+	}, TestTimeoutShort).Should(Succeed())
+
+	test.T().Logf("Waiting for RayService %s/%s to running", rayService.Namespace, rayService.Name)
+	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).
+		Should(WithTransform(RayServiceStatus, Equal(rayv1.Running)))
+
+	test.T().Logf("Sending requests to the RayService to make sure it is ready to serve requests")
+	g.Eventually(func(g Gomega) {
+		// curl /fruit
+		stdout, _ := curlRayServicePod(test, rayService, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)
+		g.Expect(stdout.String()).To(Equal("6"))
+		// curl /calc
+		stdout, _ = curlRayServicePod(test, rayService, curlPod, curlContainerName, "/calc", `["MUL", 3]`)
+		g.Expect(stdout.String()).To(Equal("15 pizzas please!"))
+	}, TestTimeoutShort).Should(Succeed())
+}

--- a/ray-operator/test/e2erayservice/support.go
+++ b/ray-operator/test/e2erayservice/support.go
@@ -154,11 +154,11 @@ func rayServiceSampleYamlApplyConfiguration() *rayv1ac.RayServiceSpecApplyConfig
 							WithResources(corev1ac.ResourceRequirements().
 								WithRequests(corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("2"),
-									corev1.ResourceMemory: resource.MustParse("2Gi"),
+									corev1.ResourceMemory: resource.MustParse("3Gi"),
 								}).
 								WithLimits(corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("2"),
-									corev1.ResourceMemory: resource.MustParse("2Gi"),
+									corev1.ResourceMemory: resource.MustParse("3Gi"),
 								})))))),
 		)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. Deploy a RayService. Wait until all Ray Serve applications are running. The RayCluster should become the active cluster.
2. Send a request to the RayCluster
3. Delete the head Pod.
4. After the head Pod restarts, KubeRay should still submit a request to create the serve applications again.
5. Send a request to the RayCluster


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Resolves https://github.com/ray-project/kuberay/issues/2829

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
