### PR TITLE
[Feature] [Fix] Ensure Correct Logs Display for Go Test Logs in Buildkite Runner

### DIFF
--- a/.buildkite/format.awk
+++ b/.buildkite/format.awk
@@ -1,0 +1,16 @@
+/^=== RUN/ {
+    split($3, parts, "/")
+    if (length(parts) > 1) {
+        print
+    } else {
+        gsub(/===/, "---")
+        print
+    }
+    next
+}
+/---/ && !/RUN/ {
+    gsub(/---/, "###")
+    print
+    next
+}
+{ print }

--- a/.buildkite/format.awk
+++ b/.buildkite/format.awk
@@ -1,16 +1,50 @@
+###############################################################################
+# This AWK script processes lines from test logs.
+#
+# - If a line starts with "=== RUN":
+#     1) Split the third field on the "/" delimiter to check if it's a subtest.
+#        (e.g., $3 might be "Test/SomeSubtest")
+#     2) If it is a subtest, print as is.
+#        (=== RUN Test/SomeSubtest)
+#     3) Otherwise, replace "===" with "---" (indicating a main test).
+#        (--- RUN Test)
+#
+# - If a line contains "---" but does NOT contain "RUN", we interpret it as
+#   non-RUN log lines. We replace "---" with "###".
+#   ("--- PASS" to "### PASS")
+#
+# - All other lines are printed unchanged.
+###############################################################################
+
+# Match lines starting with "=== RUN"
 /^=== RUN/ {
+
+    # Split the 3rd field on "/"
     split($3, parts, "/")
+
+    # Check if more than one part was created after splitting on "/"
+    # This indicates it's a subtest (e.g., "Test/SomeSubtest").
     if (length(parts) > 1) {
+        # For subtests, print the line unchanged
         print
     } else {
+        # If not a subtest, it's the main test. Replace "===" with "---".
         gsub(/===/, "---")
         print
     }
+
+    # Skip any further rules for this line
     next
 }
+
+# Match lines containing "---" but not containing "RUN"
 /---/ && !/RUN/ {
+
+    # Replace "---" with "###"
     gsub(/---/, "###")
     print
     next
 }
+
+# Print all other lines unchanged
 { print }

--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -12,7 +12,9 @@
     - IMG=kuberay/operator:nightly make deploy
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run e2e tests and print KubeRay operator logs if tests fail
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2e || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
+    - echo "--- START:Running e2e rayservice (nightly operator) tests"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2e | awk -f ../.buildkite/format.awk || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
+    - echo "--- END:e2e rayservice (nightly operator) tests finished"
 
 - label: 'Test E2E rayservice (nightly operator)'
   instance_size: large
@@ -28,7 +30,9 @@
     - IMG=kuberay/operator:nightly make deploy
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run e2e tests and print KubeRay operator logs if tests fail
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2erayservice || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
+    - echo "--- START:Running e2e rayservice (nightly operator) tests"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2erayservice | awk -f ../.buildkite/format.awk || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
+    - echo "--- END:e2e rayservice (nightly operator) tests finished"
 
 - label: 'Test Autoscaler E2E (nightly operator)'
   instance_size: large
@@ -44,4 +48,6 @@
     - IMG=kuberay/operator:nightly make deploy
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run e2e tests and print KubeRay operator logs if tests fail
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2eautoscaler || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
+    - echo "--- START:Running Autoscaler e2e (nightly operator) tests"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2eautoscaler | awk -f ../.buildkite/format.awk || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
+    - echo "--- END:Autoscaler e2e (nightly operator) tests finished"

--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -12,7 +12,9 @@
     - IMG=kuberay/operator:nightly make deploy
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run sample YAML tests
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/sampleyaml
+    - echo "--- START:Running Sample YAMLs (nightly operator) tests"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/sampleyaml | awk -f ../.buildkite/format.awk
+    - echo "--- END:Sample YAMLs (nightly operator) tests finished"
     # Printing KubeRay operator logs
     - kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay
 
@@ -28,6 +30,8 @@
     - IMG=quay.io/kuberay/operator:v1.2.2 make deploy
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run sample YAML tests
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/sampleyaml
+    - echo "--- START:Running Sample YAMLs (latest release) tests"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/sampleyaml | awk -f ../.buildkite/format.awk
+    - echo "--- END:Sample YAMLs (latest release) tests finished"
     # Printing KubeRay operator logs
     - kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay

--- a/ray-operator/test/e2e/raycluster_gcsft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcsft_test.go
@@ -113,7 +113,7 @@ func TestGcsFaultToleranceOptions(t *testing.T) {
 
 			g.Expect(utils.EnvVarExists(utils.RAY_REDIS_ADDRESS, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
 			g.Expect(utils.EnvVarExists(utils.RAY_EXTERNAL_STORAGE_NS, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
-			if tc.redisPassword != "" {
+			if tc.redisPassword == "" {
 				g.Expect(utils.EnvVarExists(utils.REDIS_PASSWORD, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeFalse())
 			} else {
 				g.Expect(utils.EnvVarExists(utils.REDIS_PASSWORD, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
@@ -225,7 +225,7 @@ func TestGcsFaultToleranceAnnotations(t *testing.T) {
 
 			g.Expect(utils.EnvVarExists(utils.RAY_REDIS_ADDRESS, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
 			g.Expect(utils.EnvVarExists(utils.RAY_EXTERNAL_STORAGE_NS, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
-			if redisPassword != "" {
+			if redisPassword == "" {
 				g.Expect(utils.EnvVarExists(utils.REDIS_PASSWORD, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeFalse())
 			} else {
 				g.Expect(utils.EnvVarExists(utils.REDIS_PASSWORD, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())

--- a/ray-operator/test/e2e/raycluster_gcsft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcsft_test.go
@@ -113,7 +113,7 @@ func TestGcsFaultToleranceOptions(t *testing.T) {
 
 			g.Expect(utils.EnvVarExists(utils.RAY_REDIS_ADDRESS, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
 			g.Expect(utils.EnvVarExists(utils.RAY_EXTERNAL_STORAGE_NS, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
-			if tc.redisPassword == "" {
+			if tc.redisPassword != "" {
 				g.Expect(utils.EnvVarExists(utils.REDIS_PASSWORD, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeFalse())
 			} else {
 				g.Expect(utils.EnvVarExists(utils.REDIS_PASSWORD, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
@@ -225,7 +225,7 @@ func TestGcsFaultToleranceAnnotations(t *testing.T) {
 
 			g.Expect(utils.EnvVarExists(utils.RAY_REDIS_ADDRESS, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
 			g.Expect(utils.EnvVarExists(utils.RAY_EXTERNAL_STORAGE_NS, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())
-			if redisPassword == "" {
+			if redisPassword != "" {
 				g.Expect(utils.EnvVarExists(utils.REDIS_PASSWORD, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeFalse())
 			} else {
 				g.Expect(utils.EnvVarExists(utils.REDIS_PASSWORD, headPod.Spec.Containers[utils.RayContainerIndex].Env)).Should(BeTrue())


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR includes changes to ensure the correct display of go test verbose logs in the Buildkite Runner. Previously, the `---` in the go test logs was interpreted as collapsible items, causing a mismatch between the toggle test name and the collapsed log's test. 

An awk script is used to solve this issue by:
1. Parsing the test logs: Assigning `--- RUN` for the main test making it a collapsable item, and `=== RUN` for subtests. 

For example ([TestGcsFaultToleranceOptions in Test E2E (nightly operator) in this run](https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/6782#0194e8eb-6033-4da0-9656-4ea588f75380/597)): 

The main test name, "TestGcsFaultToleranceOptions", follows `--- RUN`, while subtest names follow `=== RUN`.
<img width="1130" alt="Screenshot 2025-02-08 at 23 23 46" src="https://github.com/user-attachments/assets/697e5ee2-9d7d-4ccb-966e-9aa49a53c96d" />



3. Replacing `---` for `PASS` and `FAIL` (other than `RUN`) with `###`.

For example
PASS case [Line 743 in the TestRayClusterAutoscalerWithCustomResource in Test Autoscaler E2E (nightly operator)
](https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/6782#0194e8eb-6034-4f1d-ae89-290994bfc77a/703-743) 
<img width="1089" alt="Screenshot 2025-02-08 at 23 40 53" src="https://github.com/user-attachments/assets/8387e664-bcd2-4c2f-b471-1c26c4f510d7" />


FAIL case [Line 1311 in the TestGcsFaultToleranceAnnotations in Test E2E (nightly operator)](https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/6378#0194b090-54de-4d51-9e72-3bc145b67dc4/908-1311) :
<img width="1227" alt="Screenshot 2025-02-08 at 23 06 28" src="https://github.com/user-attachments/assets/fe7f8890-98a1-415f-8560-ffae09b3dfbf" />
(This fail case is for demonstration purpose only.)

## Related issue number

Resolves #2651 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
