### PR TITLE
[RayService] Trim Redis Cleanup job less than 63 chars

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1147,7 +1147,6 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instanc
 	pod := r.buildHeadPod(ctx, instance)
 	pod.Labels[utils.RayNodeTypeLabelKey] = string(rayv1.RedisCleanupNode)
 
-
 	// Only keep the Ray container in the Redis cleanup Job.
 	pod.Spec.Containers = []corev1.Container{pod.Spec.Containers[utils.RayContainerIndex]}
 	pod.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/bash", "-lc", "--"}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1220,8 +1220,6 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instanc
 			},
 			// Make this job best-effort only for 5 minutes.
 			ActiveDeadlineSeconds: ptr.To[int64](300),
-			// Keep the Job for 3 minutes after it completes for debugging
-			TTLSecondsAfterFinished: ptr.To[int32](180),
 		},
 	}
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1123,8 +1123,7 @@ func (r *RayClusterReconciler) buildWorkerPod(ctx context.Context, instance rayv
 	podName := utils.PodGenerateName(fmt.Sprintf("%s-%s", instance.Name, worker.GroupName), rayv1.WorkerNode)
 	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, instance, instance.Namespace) // Fully Qualified Domain Name
 
-	// The Ray head p
-	//ort used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
+	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
 	autoscalingEnabled := utils.IsAutoscalingEnabled(&instance)
 	podTemplateSpec := common.DefaultWorkerPodTemplate(ctx, instance, worker, podName, fqdnRayIP, headPort)

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1147,10 +1147,6 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instanc
 	pod := r.buildHeadPod(ctx, instance)
 	pod.Labels[utils.RayNodeTypeLabelKey] = string(rayv1.RedisCleanupNode)
 
-	// Trim labels to meet Kubernetes naming constraints
-	for key, value := range pod.Labels {
-		pod.Labels[key] = utils.CheckLabel(value)
-	}
 
 	// Only keep the Ray container in the Redis cleanup Job.
 	pod.Spec.Containers = []corev1.Container{pod.Spec.Containers[utils.RayContainerIndex]}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -205,6 +205,11 @@ func CheckName(s string) string {
 	return s
 }
 
+// TrimJobName uses CheckLabel to trim Kubernetes job to constrains
+func TrimJobName(jobName string) string {
+	return CheckLabel(jobName)
+}
+
 // CheckLabel makes sure the label value does not start with a punctuation and the total length is < 63 char
 func CheckLabel(s string) string {
 	maxLenght := 63

--- a/ray-operator/test/e2e/raycluster_gcsft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcsft_test.go
@@ -74,6 +74,20 @@ func TestGcsFaultToleranceOptions(t *testing.T) {
 			},
 			createSecret: true,
 		},
+		{
+			name:          "Long RayCluster Name",
+			redisPassword: "",
+			rayClusterFn: func(namespace string) *rayv1ac.RayClusterApplyConfiguration {
+				// Intentionally using a long name to test job name trimming
+				return rayv1ac.RayCluster("raycluster-with-a-very-long-name-exceeding-k8s-limit", namespace).WithSpec(
+					newRayClusterSpec().WithGcsFaultToleranceOptions(
+						rayv1ac.GcsFaultToleranceOptions().
+							WithRedisAddress("redis:6379"),
+					),
+				)
+			},
+			createSecret: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Why are these changes needed?

When the RayCluster name is too long, the Redis cleanup job name and associated labels exceed Kubernetes' 63-character limit. This causes the cleanup job to fail during creation with the following error:
```
Warning  FailedToCreateRedisCleanupJob  raycluster/text-translation-model-rayservice-raycluster-g9gps        Failed to create Redis cleanup Job text-translation-model/text-translation-model-rayservice-raycluster-g9gps-redis-cleanup, Job.batch "text-translation-model-rayservice-raycluster-g9gps-redis-cleanup" is invalid: spec.template.labels: Invalid value: "text-translation-model-rayservice-raycluster-g9gps-redis-cleanup": must be no more than 63 characters
```
## Related issue number

Closes #2845

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
<img width="1152" alt="image" src="https://github.com/user-attachments/assets/9d35d6b5-e981-4437-88d6-876a3cc550e2" />

Update: Tested ✅ , great development doc! 🥇 
