### PR TITLE
[RayService] Remove the dependencies between `constructRayClusterForRayService` and the reconciler to make it more unit testable

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -1099,3 +1099,113 @@ func TestCalculateConditions(t *testing.T) {
 		})
 	}
 }
+
+func TestConstructRayClusterForRayService(t *testing.T) {
+	tests := []struct {
+		name       string
+		rayService rayv1.RayService
+	}{
+		{
+			name: "RayClusterSpec with no worker groups",
+			rayService: rayv1.RayService{
+				Spec: rayv1.RayServiceSpec{
+					RayClusterSpec: rayv1.RayClusterSpec{
+						WorkerGroupSpecs: []rayv1.WorkerGroupSpec{},
+					},
+				},
+			},
+		},
+		{
+			name: "RayClusterSpec with two worker groups",
+			rayService: rayv1.RayService{
+				Spec: rayv1.RayServiceSpec{
+					RayClusterSpec: rayv1.RayClusterSpec{
+						WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+							{
+								GroupName: "worker-group-1",
+							},
+							{
+								GroupName: "worker-group-2",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "RayService with labels",
+			rayService: rayv1.RayService{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"label-1": "value-1",
+						"label-2": "value-2",
+					},
+				},
+				Spec: rayv1.RayServiceSpec{
+					RayClusterSpec: rayv1.RayClusterSpec{
+						WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+							{
+								GroupName: "worker-group-1",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "RayService with annotations",
+			rayService: rayv1.RayService{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"annotation-1": "value-1",
+						"annotation-2": "value-2",
+					},
+				},
+				Spec: rayv1.RayServiceSpec{
+					RayClusterSpec: rayv1.RayClusterSpec{
+						WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+							{
+								GroupName: "worker-group-1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rayService := tt.rayService
+			rayService.Name = "test-service"
+			rayService.Namespace = "test-namespace"
+			clusterName := "test-cluster"
+			rayCluster, err := constructRayClusterForRayService(&tt.rayService, clusterName)
+			assert.NoError(t, err)
+
+			// Check ObjectMeta of the RayCluster
+			assert.Equal(t, rayCluster.ObjectMeta.Name, clusterName)
+			assert.Equal(t, rayCluster.ObjectMeta.Namespace, tt.rayService.Namespace)
+
+			// Check labels for metadata
+			assert.Equal(t, rayCluster.Labels[utils.RayOriginatedFromCRNameLabelKey], tt.rayService.Name)
+			assert.Equal(t, rayCluster.Labels[utils.RayOriginatedFromCRDLabelKey], string(utils.RayServiceCRD))
+
+			// Check annotations for metadata
+			assert.NotEmpty(t, rayCluster.Annotations[utils.HashWithoutReplicasAndWorkersToDeleteKey])
+			expectedNumWorkerGroups := strconv.Itoa(len(tt.rayService.Spec.RayClusterSpec.WorkerGroupSpecs))
+			assert.Equal(t, rayCluster.Annotations[utils.NumWorkerGroupsKey], expectedNumWorkerGroups)
+			assert.Equal(t, rayCluster.Annotations[utils.KubeRayVersion], utils.KUBERAY_VERSION)
+
+			// Check whether the RayService's labels are copied to the RayCluster
+			for key, value := range tt.rayService.Labels {
+				assert.Equal(t, rayCluster.Labels[key], value)
+			}
+
+			// Check whether the RayService's annotations are copied to the RayCluster
+			for key, value := range tt.rayService.Annotations {
+				assert.Equal(t, rayCluster.Annotations[key], value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
