### PR TITLE
[RayCluster] e2e test for GCS FT with Redis Username

### DIFF
--- a/ray-operator/test/e2e/raycluster_gcsft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcsft_test.go
@@ -54,6 +54,21 @@ func TestGcsFaultToleranceOptions(t *testing.T) {
 			createSecret: false,
 		},
 		{
+			name:          "Redis Password and Username",
+			redisPassword: "5241590000000000",
+			rayClusterFn: func(namespace string) *rayv1ac.RayClusterApplyConfiguration {
+				return rayv1ac.RayCluster("raycluster-gcsft", namespace).WithSpec(
+					newRayClusterSpec().WithGcsFaultToleranceOptions(
+						rayv1ac.GcsFaultToleranceOptions().
+							WithRedisAddress("redis:6379").
+							WithRedisUsername(rayv1ac.RedisCredential().WithValue("default")).
+							WithRedisPassword(rayv1ac.RedisCredential().WithValue("5241590000000000")),
+					),
+				)
+			},
+			createSecret: false,
+		},
+		{
 			name:          "Redis Password In Secret",
 			redisPassword: "5241590000000000",
 			rayClusterFn: func(namespace string) *rayv1ac.RayClusterApplyConfiguration {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A follow-up for https://github.com/ray-project/kuberay/issues/2696.

We are using Ray 2.41.0 now, which supports Redis usernames. Therefore, we need to add an e2e test for the case.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
