### PR TITLE
[RayService] Mark `ServiceStatus` as deprecated

### DIFF
--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -11,8 +11,12 @@ import (
 type ServiceStatus string
 
 const (
-	Running             ServiceStatus = "Running"
-	PreparingNewCluster ServiceStatus = "PreparingNewCluster"
+	// `Running` means the RayService is ready to serve requests. `NotRunning` means it is not ready.
+	// The naming is a bit confusing, but to maintain backward compatibility, we use `Running` instead of `Ready`.
+	// Since KubeRay v1.3.0, `ServiceStatus` is equivalent to the `RayServiceReady` condition.
+	// `ServiceStatus` is deprecated - please use conditions instead.
+	Running    ServiceStatus = "Running"
+	NotRunning ServiceStatus = ""
 )
 
 type RayServiceUpgradeType string
@@ -87,7 +91,9 @@ type RayServiceStatuses struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// LastUpdateTime represents the timestamp when the RayService status was last updated.
 	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty"`
-	// ServiceStatus indicates the current RayService status.
+	// Deprecated: `ServiceStatus` is deprecated - use `Conditions` instead. `Running` means the RayService is ready to
+	// serve requests. An empty `ServiceStatus` means the RayService is not ready to serve requests. The definition of
+	// `ServiceStatus` is equivalent to the `RayServiceReady` condition.
 	ServiceStatus       ServiceStatus    `json:"serviceStatus,omitempty"`
 	ActiveServiceStatus RayServiceStatus `json:"activeServiceStatus,omitempty"`
 	// Pending Service Status indicates a RayCluster will be created or is being created.

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -11,8 +11,7 @@ import (
 type ServiceStatus string
 
 const (
-	Running             ServiceStatus = "Running"
-	PreparingNewCluster ServiceStatus = "PreparingNewCluster"
+	Running ServiceStatus = "Running"
 )
 
 // These statuses should match Ray Serve's application statuses

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -92,13 +92,13 @@ func TestInconsistentRayServiceStatuses(t *testing.T) {
 				},
 			},
 		},
-		ServiceStatus: rayv1.PreparingNewCluster,
+		ServiceStatus: rayv1.NotRunning,
 	}
 	ctx := context.Background()
 
 	// Test 1: Update ServiceStatus only.
 	newStatus := oldStatus.DeepCopy()
-	newStatus.ServiceStatus = rayv1.Running
+	newStatus.ServiceStatus = rayv1.Running //nolint:staticcheck // `ServiceStatus` is deprecated
 	assert.True(t, inconsistentRayServiceStatuses(ctx, oldStatus, *newStatus))
 
 	// Test 2: Test RayServiceStatus

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -192,7 +192,7 @@ func RayService(t Test, namespace, name string) func() (*rayv1.RayService, error
 }
 
 func RayServiceStatus(service *rayv1.RayService) rayv1.ServiceStatus {
-	return service.Status.ServiceStatus
+	return service.Status.ServiceStatus //nolint:staticcheck // `ServiceStatus` is deprecated
 }
 
 func IsRayServiceReady(service *rayv1.RayService) bool {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For KubeRay v1.3.0, we define `ServiceStatus` to be equivalent to the ready condition. Mark `ServiceStatus` as deprecated to encourage users to use `Conditions`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
