### PR TITLE
[RayService] Merge `initConditions` into `calculateConditions`

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -729,6 +729,24 @@ func TestCalculateConditions(t *testing.T) {
 		rayServiceInstance      rayv1.RayService
 	}{
 		{
+			name:                    "initial RayServiceReady",
+			rayServiceInstance:      rayv1.RayService{},
+			conditionType:           rayv1.RayServiceReady,
+			originalConditionStatus: metav1.ConditionFalse,
+			originalReason:          string(rayv1.RayServiceInitializing),
+			expectedConditionStatus: metav1.ConditionFalse,
+			expectedReason:          string(rayv1.RayServiceInitializing),
+		},
+		{
+			name:                    "initial RayServiceInitializing",
+			rayServiceInstance:      rayv1.RayService{},
+			conditionType:           rayv1.UpgradeInProgress,
+			originalConditionStatus: metav1.ConditionFalse,
+			originalReason:          string(rayv1.RayServiceInitializing),
+			expectedConditionStatus: metav1.ConditionFalse,
+			expectedReason:          string(rayv1.RayServiceInitializing),
+		},
+		{
 			name: "Ready condition remains false unchanged",
 			rayServiceInstance: rayv1.RayService{
 				Status: rayv1.RayServiceStatuses{
@@ -841,7 +859,6 @@ func TestCalculateConditions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			initConditions(&tt.rayServiceInstance)
 			meta.SetStatusCondition(&tt.rayServiceInstance.Status.Conditions, metav1.Condition{
 				Type:   string(tt.conditionType),
 				Status: tt.originalConditionStatus,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Merge initConditions into calculateConditions so that we have only one place to update the CR status.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
