### PR TITLE
[RayService] Always create RayService services and remove RayServiceInitializing

### DIFF
--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -138,7 +138,6 @@ const (
 )
 
 const (
-	RayServiceInitializing         RayServiceConditionReason = "Initializing"
 	ZeroServeEndpoints             RayServiceConditionReason = "ZeroServeEndpoints"
 	NonZeroServeEndpoints          RayServiceConditionReason = "NonZeroServeEndpoints"
 	BothActivePendingClustersExist RayServiceConditionReason = "BothActivePendingClustersExist"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, the RayService controller only creates k8s services for RayService when the RayServe is ready. This PR changes the behavior to create k8s services first even when the RayServe is not ready, and later, the selector is updated to the ready RayServe. The new behaivor will help users expose k8s services as soon as possible.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
