### PR TITLE
[Chore] init map with size

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -771,14 +771,14 @@ func (r *RayServiceReconciler) createRayClusterInstance(ctx context.Context, ray
 
 func constructRayClusterForRayService(rayService *rayv1.RayService, rayClusterName string, scheme *runtime.Scheme) (*rayv1.RayCluster, error) {
 	var err error
-	rayClusterLabel := make(map[string]string)
+	rayClusterLabel := make(map[string]string, len(rayService.Labels)+2)
 	for k, v := range rayService.Labels {
 		rayClusterLabel[k] = v
 	}
 	rayClusterLabel[utils.RayOriginatedFromCRNameLabelKey] = rayService.Name
 	rayClusterLabel[utils.RayOriginatedFromCRDLabelKey] = utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD)
 
-	rayClusterAnnotations := make(map[string]string)
+	rayClusterAnnotations := make(map[string]string, len(rayService.Annotations)+3)
 	for k, v := range rayService.Annotations {
 		rayClusterAnnotations[k] = v
 	}


### PR DESCRIPTION
## Why are these changes needed?

It would be better to initialize a map with the size if it could be estimated.

For `rayClusterLabels`, there are two additional assignments besides `rayService.Labels`.
https://github.com/ray-project/kuberay/blob/f123a44b92299a4db23ccc61e6193ba0cf0e8f10/ray-operator/controllers/ray/rayservice_controller.go#L774-L779

For `rayClusterAnnotations`, there are three additional assignments besides `rayService.Annotations`.
https://github.com/ray-project/kuberay/blob/f123a44b92299a4db23ccc61e6193ba0cf0e8f10/ray-operator/controllers/ray/rayservice_controller.go#L781-L792

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
