### PR TITLE
[RayService] Create k8s events after creating/updating k8s resources

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -720,7 +720,7 @@ func TestLabelHeadPodForServeStatus(t *testing.T) {
 				},
 			}
 
-			err := r.updateHeadPodServeLabel(ctx, &cluster, tc.excludeHeadPodFromServeSvc)
+			err := r.updateHeadPodServeLabel(ctx, &rayv1.RayService{}, &cluster, tc.excludeHeadPodFromServeSvc)
 			assert.NoError(t, err)
 			// Get latest headPod status
 			headPod, err = common.GetRayClusterHeadPod(ctx, r, &cluster)

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -271,7 +271,11 @@ const (
 	FailedToUpdateRayCluster      K8sEventType = "FailedToUpdateRayCluster"
 
 	// RayService event list
-	InvalidRayServiceSpec K8sEventType = "InvalidRayServiceSpec"
+	InvalidRayServiceSpec           K8sEventType = "InvalidRayServiceSpec"
+	UpdatedHeadPodServeLabel        K8sEventType = "UpdatedHeadPodServeLabel"
+	UpdatedServeApplications        K8sEventType = "UpdatedServeApplications"
+	FailedToUpdateHeadPodServeLabel K8sEventType = "FailedToUpdateHeadPodServeLabel"
+	FailedToUpdateServeApplications K8sEventType = "FailedToUpdateServeApplications"
 
 	// Generic Pod event list
 	DeletedPod                  K8sEventType = "DeletedPod"
@@ -288,7 +292,9 @@ const (
 
 	// Service event list
 	CreatedService        K8sEventType = "CreatedService"
+	UpdatedService        K8sEventType = "UpdatedService"
 	FailedToCreateService K8sEventType = "FailedToCreateService"
+	FailedToUpdateService K8sEventType = "FailedToUpdateService"
 
 	// ServiceAccount event list
 	CreatedServiceAccount            K8sEventType = "CreatedServiceAccount"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To improve RayService observability, we use the following k8s events to log RayService reconciliation actions:

* `CreatedRayCluster`/`FailedToCreateRayCluster`
* `UpdatedRayCluster`/`FailedToUpdateRayCluster`
* `DeletedRayCluster`/`FailedToDeleteRayCluster`
* `CreatedService`/`FailedToCreateService`

The above events are existing events in the code base. Below are newly added:

* `UpdatedService`/`FailedToUpdateService` (new)
* `UpdatedHeadPodServeLabel`/`FailedToUpdateHeadPodServeLabel` (new)
* `UpdatedServeApplications`/`FailedToUpdateServeApplications` (new)

While the last pair of events, `UpdatedServeApplications`/`FailedToUpdateServeApplications`, are actually not related to k8s, I think users may still need them to check if their apps have been updated.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
