### PR TITLE
[Fix][kubectl-plugin]: make `version` handle digests

### DIFF
--- a/kubectl-plugin/go.mod
+++ b/kubectl-plugin/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.5
 
 require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/novln/docker-parser v1.0.0
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
 	github.com/ray-project/kuberay/ray-operator v0.0.0

--- a/kubectl-plugin/go.sum
+++ b/kubectl-plugin/go.sum
@@ -114,6 +114,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/novln/docker-parser v1.0.0 h1:PjEBd9QnKixcWczNGyEdfUrP6GR0YUilAqG7Wksg3uc=
+github.com/novln/docker-parser v1.0.0/go.mod h1:oCeM32fsoUwkwByB5wVjsrsVQySzPWkl3JdlTn1txpE=
 github.com/onsi/ginkgo/v2 v2.20.2 h1:7NVCeyIWROIAheY21RLS+3j2bb52W0W82tkberYytp4=
 github.com/onsi/ginkgo/v2 v2.20.2/go.mod h1:K9gyxPIlb+aIvnZ8bd9Ak+YP18w3APlR+5coaZoE2ag=
 github.com/onsi/gomega v1.34.2 h1:pNCwDkzrsv7MS9kpaQvVb1aVLahQXyJ/Tv5oAZMI3i8=
@@ -147,6 +149,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
@@ -220,6 +223,7 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSP
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/kubectl-plugin/pkg/util/client/client_test.go
+++ b/kubectl-plugin/pkg/util/client/client_test.go
@@ -31,7 +31,7 @@ func TestGetKubeRayOperatorVersion(t *testing.T) {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
-								Image: "kuberay/operator:v0.5.0",
+								Image: "kuberay/operator:v0.5.0@sha256:cc8ce713f3b4be3c72cca1f63ee78e3733bc7283472ecae367b47a128f7e4478",
 							},
 						},
 					},
@@ -53,7 +53,51 @@ func TestGetKubeRayOperatorVersion(t *testing.T) {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
+								Image: "kuberay/operator:v0.6.0@sha256:cc8ce713f3b4be3c72cca1f63ee78e3733bc7283472ecae367b47a128f7e4478",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	kustomizeObjectsImageWithOnlyTag := []runtime.Object{
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kuberay-operator-kustomize",
+				Namespace: "test",
+				Labels: map[string]string{
+					"app.kubernetes.io/name": "kuberay",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
 								Image: "kuberay/operator:v0.6.0",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	kustomizeObjectsImageWithOnlyDigest := []runtime.Object{
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kuberay-operator-kustomize",
+				Namespace: "test",
+				Labels: map[string]string{
+					"app.kubernetes.io/name": "kuberay",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Image: "kuberay/operator@sha256:cc8ce713f3b4be3c72cca1f63ee78e3733bc7283472ecae367b47a128f7e4478",
 							},
 						},
 					},
@@ -69,22 +113,34 @@ func TestGetKubeRayOperatorVersion(t *testing.T) {
 		kubeObjects     []runtime.Object
 	}{
 		{
-			name:            "kubeRay operator not found",
+			name:            "KubeRay operator not found",
 			expectedVersion: "",
 			expectedError:   "no KubeRay operator deployments found in any namespace",
 			kubeObjects:     nil,
 		},
 		{
-			name:            "find kubeRay operator version for helm chart",
-			expectedVersion: "v0.5.0",
+			name:            "find KubeRay operator version for helm chart",
+			expectedVersion: "v0.5.0@sha256:cc8ce713f3b4be3c72cca1f63ee78e3733bc7283472ecae367b47a128f7e4478",
 			expectedError:   "",
 			kubeObjects:     helmKubeObjects,
 		},
 		{
-			name:            "find kubeRay operator version for Kustomize",
-			expectedVersion: "v0.6.0",
+			name:            "find KubeRay operator version for Kustomize",
+			expectedVersion: "v0.6.0@sha256:cc8ce713f3b4be3c72cca1f63ee78e3733bc7283472ecae367b47a128f7e4478",
 			expectedError:   "",
 			kubeObjects:     kustomizeObjects,
+		},
+		{
+			name:            "find KubeRay operator version for Kustomize",
+			expectedVersion: "v0.6.0",
+			expectedError:   "",
+			kubeObjects:     kustomizeObjectsImageWithOnlyTag,
+		},
+		{
+			name:            "find KubeRay operator version for Kustomize",
+			expectedVersion: "sha256:cc8ce713f3b4be3c72cca1f63ee78e3733bc7283472ecae367b47a128f7e4478",
+			expectedError:   "",
+			kubeObjects:     kustomizeObjectsImageWithOnlyDigest,
 		},
 	}
 
@@ -96,7 +152,7 @@ func TestGetKubeRayOperatorVersion(t *testing.T) {
 			version, err := client.GetKubeRayOperatorVersion(context.Background())
 
 			if tc.expectedVersion != "" {
-				assert.Equal(t, version, tc.expectedVersion)
+				assert.Equal(t, tc.expectedVersion, version)
 				assert.NoError(t, err)
 			} else {
 				assert.EqualError(t, err, tc.expectedError)


### PR DESCRIPTION
Right now `kubectl ray version` returns only the image digest if the KubeRay operator uses an image reference that contains both tag and digest. This change returns both and also handles the case where only the digest is present.

We depend on the https://github.com/novln/docker-parser library to simplify image reference parsing logic except in the case where both tag and digest are used which the library doesn't seem to handle. See [this issue][1].

[1]: https://github.com/novln/docker-parser/issues/3

Signed-off-by: David Xia <david@davidxia.com>

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
