### PR TITLE
[RayService] Add zero-downtime triggered test after rayVersion is updated

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -233,7 +233,7 @@ var _ = Context("RayService env tests", func() {
 
 		It("Should perform a zero-downtime update after rayVersion updated.", func() {
 			initialClusterName, _ := getRayClusterNameFunc(ctx, rayService)()
-			const mockRayVersion = "2.40.0" // Current rayVersion is 2.41.0, so set the rayVersio to 2.40.0 to test if zero-downtime is triggered.
+			const mockRayVersion = "2.40.0" // Current rayVersion is 2.41.0, so set the rayVersion to 2.40.0 to test if zero-downtime is triggered.
 
 			// The cluster shouldn't switch until deployments are finished updating
 			updatingStatus := generateServeStatus(rayv1.DeploymentStatusEnum.UPDATING, rayv1.ApplicationStatusEnum.DEPLOYING)

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -233,7 +233,7 @@ var _ = Context("RayService env tests", func() {
 
 		It("Should perform a zero-downtime update after rayVersion updated.", func() {
 			initialClusterName, _ := getRayClusterNameFunc(ctx, rayService)()
-			const mockRayVersion = "2.40.0" // Current rayVersion is 2.41.0, so set the rayVersiob to 2.40.0 to test if zero-downtime is triggered.
+			const mockRayVersion = "2.40.0" // Current rayVersion is 2.41.0, so set the rayVersio to 2.40.0 to test if zero-downtime is triggered.
 
 			// The cluster shouldn't switch until deployments are finished updating
 			updatingStatus := generateServeStatus(rayv1.DeploymentStatusEnum.UPDATING, rayv1.ApplicationStatusEnum.DEPLOYING)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#2878 
Test 2
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
