### PR TITLE
[kubectl-plugin] support general `kubectl` switches like `--context`

### DIFF
--- a/kubectl-plugin/pkg/cmd/version/version.go
+++ b/kubectl-plugin/pkg/cmd/version/version.go
@@ -1,8 +1,12 @@
 package version
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"os"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -25,28 +29,54 @@ func NewVersionOptions(streams genericclioptions.IOStreams) *VersionOptions {
 
 func NewVersionCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	options := NewVersionOptions(streams)
+	// Initialize the factory for later use with the current config flag
 	cmdFactory := cmdutil.NewFactory(options.configFlags)
 
 	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "Output the version of the Ray kubectl plugin and KubeRay operator",
+		Use:          "version",
+		Short:        "Output the version of the Ray kubectl plugin and KubeRay operator",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			fmt.Println("kubectl ray plugin version:", Version)
-
-			kubeClient, err := client.NewClient(cmdFactory)
+			// running cmd.Execute or cmd.ExecuteE sets the context, which will be done by root
+			k8sClient, err := client.NewClient(cmdFactory)
 			if err != nil {
 				return fmt.Errorf("failed to create client: %w", err)
 			}
-
-			operatorVersion, err := kubeClient.GetKubeRayOperatorVersion(cmd.Context())
-			if err != nil {
-				fmt.Println("Warning: KubeRay operator installation cannot be found - did you install it with the name \"kuberay-operator\"?")
-			} else {
-				fmt.Println("KubeRay operator version:", operatorVersion)
-			}
-			return nil
+			return options.Run(cmd.Context(), k8sClient, os.Stdout)
 		},
 	}
 
+	options.configFlags.AddFlags(cmd.Flags())
 	return cmd
+}
+
+func (options *VersionOptions) Run(ctx context.Context, k8sClient client.Client, writer io.Writer) error {
+	fmt.Fprintln(writer, "kubectl ray plugin version:", Version)
+
+	if err := options.checkContext(); err != nil {
+		return err
+	}
+
+	operatorVersion, err := k8sClient.GetKubeRayOperatorVersion(ctx)
+	if err != nil {
+		wrappedError := fmt.Errorf(`warning: KubeRay operator installation cannot be found: %w. Did you install it with the name "kuberay-operator"?`, err)
+		fmt.Fprintln(writer, wrappedError)
+	} else {
+		fmt.Fprintln(writer, "KubeRay operator version:", operatorVersion)
+	}
+	return nil
+}
+
+// checkContext checks if a context is set in the kube config or with the --context flag
+func (options *VersionOptions) checkContext() error {
+	// Overrides and binds the kube config then retrieves the merged result
+	config, err := options.configFlags.ToRawKubeConfigLoader().RawConfig()
+	if err != nil {
+		return fmt.Errorf("error retrieving raw config: %w", err)
+	}
+
+	if !util.HasKubectlContext(config, options.configFlags) {
+		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
+	}
+	return nil
 }

--- a/kubectl-plugin/pkg/cmd/version/version_test.go
+++ b/kubectl-plugin/pkg/cmd/version/version_test.go
@@ -1,0 +1,155 @@
+package version
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+
+	rayclient "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned"
+)
+
+func TestRayVersionCheckContext(t *testing.T) {
+	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	testContext := "test-context"
+
+	kubeConfigWithCurrentContext, err := util.CreateTempKubeConfigFile(t, "my-fake-context")
+	assert.NoError(t, err)
+
+	kubeConfigWithoutCurrentContext, err := util.CreateTempKubeConfigFile(t, "")
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		opts        *VersionOptions
+		expectError string
+	}{
+		{
+			name: "Test validation when no context is set",
+			opts: &VersionOptions{
+				configFlags: genericclioptions.NewConfigFlags(false),
+				ioStreams:   &testStreams,
+			},
+			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
+		},
+		{
+			name: "no error when kubeconfig has current context and --context switch isn't set",
+			opts: &VersionOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithCurrentContext,
+				},
+				ioStreams: &testStreams,
+			},
+		},
+		{
+			name: "no error when kubeconfig has no current context and --context switch is set",
+			opts: &VersionOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithoutCurrentContext,
+					Context:    &testContext,
+				},
+				ioStreams: &testStreams,
+			},
+		},
+		{
+			name: "no error when kubeconfig has current context and --context switch is set",
+			opts: &VersionOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithCurrentContext,
+					Context:    &testContext,
+				},
+				ioStreams: &testStreams,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.opts.checkContext()
+			fmt.Printf("err: %v\n", err)
+			if tc.expectError != "" {
+				assert.Equal(t, tc.expectError, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+type fakeClient struct {
+	err                 error
+	kuberayImageVersion string
+}
+
+func (c fakeClient) GetKubeRayOperatorVersion(_ context.Context) (string, error) {
+	return c.kuberayImageVersion, c.err
+}
+
+func (c fakeClient) GetRayHeadSvcName(_ context.Context, _ string, _ util.ResourceType, _ string) (string, error) {
+	return "", nil
+}
+
+func (c fakeClient) KubernetesClient() kubernetes.Interface {
+	return nil
+}
+
+func (c fakeClient) RayClient() rayclient.Interface {
+	return nil
+}
+
+// Tests the Run() step of the command and checks the output.
+func TestRayVersionRun(t *testing.T) {
+	testContext := "test-context"
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+
+	fakeVersionOptions := &VersionOptions{
+		configFlags: &genericclioptions.ConfigFlags{
+			Context: &testContext,
+		},
+		ioStreams: &testStreams,
+	}
+
+	tests := []struct {
+		name                           string
+		kuberayImageVersion            string
+		getKubeRayOperatorVersionError error
+		expected                       string
+	}{
+		{
+			name:                           "Test when we can successfully get the KubeRay operator image version",
+			kuberayImageVersion:            "v0.0.1",
+			getKubeRayOperatorVersionError: nil,
+			expected: fmt.Sprintf("kubectl ray plugin version: %s\n"+
+				"KubeRay operator version: %s\n", Version, "v0.0.1"),
+		},
+		{
+			name:                           "Test when we cannot get the KubeRay operator image version",
+			kuberayImageVersion:            "",
+			getKubeRayOperatorVersionError: fmt.Errorf("something went wrong"),
+			expected: fmt.Sprintf("kubectl ray plugin version: %s\n"+
+				"warning: KubeRay operator installation cannot be found: something went wrong. "+
+				"Did you install it with the name \"kuberay-operator\"?\n", Version),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fClient := fakeClient{kuberayImageVersion: tc.kuberayImageVersion, err: tc.getKubeRayOperatorVersionError}
+
+			var buf bytes.Buffer
+			err := fakeVersionOptions.Run(context.Background(), fClient, &buf)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.expected, buf.String())
+		})
+	}
+}


### PR DESCRIPTION
in the `kubectl ray version` sub-command. Right now `kubectl ray version` doesn't allow `--context my-context`. It should like the other `kubectl ray` sub-commands.

Add tests

Signed-off-by: David Xia <david@davidxia.com>

[Slack thread](https://ray.slack.com/archives/C02GFQ82JPM/p1738608216456149)

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
