### PR TITLE
[kubectl-plugin] update context error messages

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/generation"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -109,8 +110,8 @@ func (options *CreateClusterOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving raw config: %w", err)
 	}
-	if len(config.CurrentContext) == 0 {
-		return fmt.Errorf("no context is currently set, use %q to select a new one", "kubectl config use-context <context>")
+	if !util.HasKubectlContext(config, options.configFlags) {
+		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 
 	return nil

--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -1,15 +1,12 @@
 package create
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestRayCreateClusterComplete(t *testing.T) {
@@ -26,49 +23,13 @@ func TestRayCreateClusterComplete(t *testing.T) {
 
 func TestRayCreateClusterValidate(t *testing.T) {
 	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-
 	testNS, testContext, testBT, testImpersonate := "test-namespace", "test-context", "test-bearer-token", "test-person"
 
-	// Fake directory for kubeconfig
-	fakeDir, err := os.MkdirTemp("", "fake-dir")
-	assert.NoError(t, err)
-	defer os.RemoveAll(fakeDir)
-
-	// Set up fake config for kubeconfig
-	config := &api.Config{
-		Clusters: map[string]*api.Cluster{
-			"test-cluster": {
-				Server:                "https://fake-kubernetes-cluster.example.com",
-				InsecureSkipTLSVerify: true, // For testing purposes
-			},
-		},
-		Contexts: map[string]*api.Context{
-			"my-fake-context": {
-				Cluster:  "my-fake-cluster",
-				AuthInfo: "my-fake-user",
-			},
-		},
-		CurrentContext: "my-fake-context",
-		AuthInfos: map[string]*api.AuthInfo{
-			"my-fake-user": {
-				Token: "", // Empty for testing without authentication
-			},
-		},
-	}
-
-	fakeFile := filepath.Join(fakeDir, ".kubeconfig")
-
-	err = clientcmd.WriteToFile(*config, fakeFile)
+	kubeConfigWithCurrentContext, err := util.CreateTempKubeConfigFile(t, testContext)
 	assert.NoError(t, err)
 
-	fakeConfigFlags := &genericclioptions.ConfigFlags{
-		Namespace:        &testNS,
-		Context:          &testContext,
-		KubeConfig:       &fakeFile,
-		BearerToken:      &testBT,
-		Impersonate:      &testImpersonate,
-		ImpersonateGroup: &[]string{"fake-group"},
-	}
+	kubeConfigWithoutCurrentContext, err := util.CreateTempKubeConfigFile(t, "")
+	assert.NoError(t, err)
 
 	tests := []struct {
 		name        string
@@ -81,12 +42,48 @@ func TestRayCreateClusterValidate(t *testing.T) {
 				configFlags: genericclioptions.NewConfigFlags(false),
 				ioStreams:   &testStreams,
 			},
-			expectError: "no context is currently set, use \"kubectl config use-context <context>\" to select a new one",
+			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
+		},
+		{
+			name: "no error when kubeconfig has current context and --context switch isn't set",
+			opts: &CreateClusterOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithCurrentContext,
+				},
+				ioStreams: &testStreams,
+			},
+		},
+		{
+			name: "no error when kubeconfig has no current context and --context switch is set",
+			opts: &CreateClusterOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithoutCurrentContext,
+					Context:    &testContext,
+				},
+				ioStreams: &testStreams,
+			},
+		},
+		{
+			name: "no error when kubeconfig has current context and --context switch is set",
+			opts: &CreateClusterOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithCurrentContext,
+					Context:    &testContext,
+				},
+				ioStreams: &testStreams,
+			},
 		},
 		{
 			name: "Successful submit job validation with RayJob",
 			opts: &CreateClusterOptions{
-				configFlags:    fakeConfigFlags,
+				configFlags: &genericclioptions.ConfigFlags{
+					Namespace:        &testNS,
+					Context:          &testContext,
+					KubeConfig:       &kubeConfigWithCurrentContext,
+					BearerToken:      &testBT,
+					Impersonate:      &testImpersonate,
+					ImpersonateGroup: &[]string{"fake-group"},
+				},
 				ioStreams:      &testStreams,
 				clusterName:    "fakeclustername",
 				rayVersion:     "ray-version",

--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -112,8 +113,8 @@ func (options *CreateWorkerGroupOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving raw config: %w", err)
 	}
-	if len(config.CurrentContext) == 0 {
-		return fmt.Errorf("no context is currently set, use %q to select a new one", "kubectl config use-context <context>")
+	if !util.HasKubectlContext(config, options.configFlags) {
+		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 
 	return nil

--- a/kubectl-plugin/pkg/cmd/delete/delete.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete.go
@@ -118,8 +118,8 @@ func (options *DeleteOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving raw config: %w", err)
 	}
-	if len(config.CurrentContext) == 0 {
-		return fmt.Errorf("no context is currently set, use %q to select a new one", "kubectl config use-context <context>")
+	if !util.HasKubectlContext(config, options.configFlags) {
+		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 	return nil
 }

--- a/kubectl-plugin/pkg/cmd/delete/delete_test.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete_test.go
@@ -110,3 +110,87 @@ func TestComplete(t *testing.T) {
 		})
 	}
 }
+
+func TestRayDeleteValidate(t *testing.T) {
+	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+
+	testNS, testContext, testBT, testImpersonate := "test-namespace", "test-context", "test-bearer-token", "test-person"
+
+	kubeConfigWithCurrentContext, err := util.CreateTempKubeConfigFile(t, testContext)
+	assert.NoError(t, err)
+
+	kubeConfigWithoutCurrentContext, err := util.CreateTempKubeConfigFile(t, "")
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		opts        *DeleteOptions
+		expectError string
+	}{
+		{
+			name: "Test validation when no context is set",
+			opts: &DeleteOptions{
+				configFlags: genericclioptions.NewConfigFlags(false),
+				ioStreams:   &testStreams,
+			},
+			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
+		},
+		{
+			name: "no error when kubeconfig has current context and --context switch isn't set",
+			opts: &DeleteOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithCurrentContext,
+				},
+				ioStreams: &testStreams,
+			},
+		},
+		{
+			name: "no error when kubeconfig has no current context and --context switch is set",
+			opts: &DeleteOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithoutCurrentContext,
+					Context:    &testContext,
+				},
+				ioStreams: &testStreams,
+			},
+		},
+		{
+			name: "no error when kubeconfig has current context and --context switch is set",
+			opts: &DeleteOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithCurrentContext,
+					Context:    &testContext,
+				},
+				ioStreams: &testStreams,
+			},
+		},
+		{
+			name: "Successful submit job validation with RayJob",
+			opts: &DeleteOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					Namespace:        &testNS,
+					Context:          &testContext,
+					KubeConfig:       &kubeConfigWithCurrentContext,
+					BearerToken:      &testBT,
+					Impersonate:      &testImpersonate,
+					ImpersonateGroup: &[]string{"fake-group"},
+				},
+				ioStreams:    &testStreams,
+				ResourceType: util.RayJob,
+				ResourceName: "test-rayjob",
+				Namespace:    testNS,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.opts.Validate()
+			if tc.expectError != "" {
+				assert.Error(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/kubectl-plugin/pkg/cmd/get/get_cluster.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/completion"
 	"github.com/spf13/cobra"
@@ -77,8 +78,8 @@ func (options *GetClusterOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving raw config: %w", err)
 	}
-	if len(config.CurrentContext) == 0 {
-		return fmt.Errorf("no context is currently set, use %q to select a new one", "kubectl config use-context <context>")
+	if !util.HasKubectlContext(config, options.configFlags) {
+		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 	if len(options.args) > 1 {
 		return fmt.Errorf("too many arguments, either one or no arguments are allowed")

--- a/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
@@ -3,18 +3,15 @@ package get
 import (
 	"bytes"
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
@@ -47,47 +44,11 @@ func TestRayClusterGetValidate(t *testing.T) {
 
 	testNS, testContext, testBT, testImpersonate := "test-namespace", "test-context", "test-bearer-token", "test-person"
 
-	// Fake directory for kubeconfig
-	fakeDir, err := os.MkdirTemp("", "fake-config")
-	assert.NoError(t, err)
-	defer os.RemoveAll(fakeDir)
-
-	// Set up fake config for kubeconfig
-	config := &api.Config{
-		Clusters: map[string]*api.Cluster{
-			"test-cluster": {
-				Server:                "https://fake-kubernetes-cluster.example.com",
-				InsecureSkipTLSVerify: true, // For testing purposes
-			},
-		},
-		Contexts: map[string]*api.Context{
-			"my-fake-context": {
-				Cluster:  "my-fake-cluster",
-				AuthInfo: "my-fake-user",
-			},
-		},
-		CurrentContext: "my-fake-context",
-		AuthInfos: map[string]*api.AuthInfo{
-			"my-fake-user": {
-				Token: "", // Empty for testing without authentication
-			},
-		},
-	}
-
-	fakeFile := filepath.Join(fakeDir, ".kubeconfig")
-
-	err = clientcmd.WriteToFile(*config, fakeFile)
+	kubeConfigWithCurrentContext, err := util.CreateTempKubeConfigFile(t, testContext)
 	assert.NoError(t, err)
 
-	// Initialize the fake config flag with the fake kubeconfig and values
-	fakeConfigFlags := &genericclioptions.ConfigFlags{
-		Namespace:        &testNS,
-		Context:          &testContext,
-		KubeConfig:       &fakeFile,
-		BearerToken:      &testBT,
-		Impersonate:      &testImpersonate,
-		ImpersonateGroup: &[]string{"fake-group"},
-	}
+	kubeConfigWithoutCurrentContext, err := util.CreateTempKubeConfigFile(t, "")
+	assert.NoError(t, err)
 
 	tests := []struct {
 		name        string
@@ -103,13 +64,49 @@ func TestRayClusterGetValidate(t *testing.T) {
 				args:          []string{"random_arg"},
 				ioStreams:     &testStreams,
 			},
-			expectError: "no context is currently set, use \"kubectl config use-context <context>\" to select a new one",
+			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
+		},
+		{
+			name: "no error when kubeconfig has current context and --context switch isn't set",
+			opts: &GetClusterOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithCurrentContext,
+				},
+				ioStreams: &testStreams,
+			},
+		},
+		{
+			name: "no error when kubeconfig has no current context and --context switch is set",
+			opts: &GetClusterOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithoutCurrentContext,
+					Context:    &testContext,
+				},
+				ioStreams: &testStreams,
+			},
+		},
+		{
+			name: "no error when kubeconfig has current context and --context switch is set",
+			opts: &GetClusterOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithCurrentContext,
+					Context:    &testContext,
+				},
+				ioStreams: &testStreams,
+			},
 		},
 		{
 			name: "Test validation when more than 1 arg",
 			opts: &GetClusterOptions{
 				// Use fake config to bypass the config flag checks
-				configFlags:   fakeConfigFlags,
+				configFlags: &genericclioptions.ConfigFlags{
+					Namespace:        &testNS,
+					Context:          &testContext,
+					KubeConfig:       &kubeConfigWithCurrentContext,
+					BearerToken:      &testBT,
+					Impersonate:      &testImpersonate,
+					ImpersonateGroup: &[]string{"fake-group"},
+				},
 				AllNamespaces: false,
 				args:          []string{"fake", "args"},
 				ioStreams:     &testStreams,
@@ -120,7 +117,14 @@ func TestRayClusterGetValidate(t *testing.T) {
 			name: "Successful validation call",
 			opts: &GetClusterOptions{
 				// Use fake config to bypass the config flag checks
-				configFlags:   fakeConfigFlags,
+				configFlags: &genericclioptions.ConfigFlags{
+					Namespace:        &testNS,
+					Context:          &testContext,
+					KubeConfig:       &kubeConfigWithCurrentContext,
+					BearerToken:      &testBT,
+					Impersonate:      &testImpersonate,
+					ImpersonateGroup: &[]string{"fake-group"},
+				},
 				AllNamespaces: false,
 				args:          []string{"random_arg"},
 				ioStreams:     &testStreams,

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -183,8 +183,8 @@ func (options *SubmitJobOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving raw config: %w", err)
 	}
-	if len(config.CurrentContext) == 0 {
-		return fmt.Errorf("no context is currently set, use %q to select a new one", "kubectl config use-context <context>")
+	if !util.HasKubectlContext(config, options.configFlags) {
+		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 
 	if len(options.runtimeEnv) > 0 {

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
@@ -30,46 +30,7 @@ func TestRayJobSubmitValidate(t *testing.T) {
 
 	testNS, testContext, testBT, testImpersonate := "test-namespace", "test-context", "test-bearer-token", "test-person"
 
-	// Fake directory for kubeconfig
-	fakeDir, err := os.MkdirTemp("", "fake-dir")
-	assert.NoError(t, err)
-	defer os.RemoveAll(fakeDir)
-
-	// Set up fake config for kubeconfig
-	config := &api.Config{
-		Clusters: map[string]*api.Cluster{
-			"test-cluster": {
-				Server:                "https://fake-kubernetes-cluster.example.com",
-				InsecureSkipTLSVerify: true, // For testing purposes
-			},
-		},
-		Contexts: map[string]*api.Context{
-			"my-fake-context": {
-				Cluster:  "my-fake-cluster",
-				AuthInfo: "my-fake-user",
-			},
-		},
-		CurrentContext: "my-fake-context",
-		AuthInfos: map[string]*api.AuthInfo{
-			"my-fake-user": {
-				Token: "", // Empty for testing without authentication
-			},
-		},
-	}
-
-	fakeFile := filepath.Join(fakeDir, ".kubeconfig")
-
-	err = clientcmd.WriteToFile(*config, fakeFile)
-	assert.NoError(t, err)
-
-	fakeConfigFlags := &genericclioptions.ConfigFlags{
-		Namespace:        &testNS,
-		Context:          &testContext,
-		KubeConfig:       &fakeFile,
-		BearerToken:      &testBT,
-		Impersonate:      &testImpersonate,
-		ImpersonateGroup: &[]string{"fake-group"},
-	}
+	fakeDir := t.TempDir()
 
 	rayYaml := `apiVersion: ray.io/v1
 kind: RayJob
@@ -82,9 +43,14 @@ spec:
 
 	file, err := os.Create(rayJobYamlPath)
 	assert.NoError(t, err)
-	defer file.Close()
 
 	_, err = file.Write([]byte(rayYaml))
+	assert.NoError(t, err)
+
+	kubeConfigWithCurrentContext, err := util.CreateTempKubeConfigFile(t, testContext)
+	assert.NoError(t, err)
+
+	kubeConfigWithoutCurrentContext, err := util.CreateTempKubeConfigFile(t, "")
 	assert.NoError(t, err)
 
 	tests := []struct {
@@ -98,15 +64,45 @@ spec:
 				configFlags: genericclioptions.NewConfigFlags(false),
 				ioStreams:   &testStreams,
 			},
-			expectError: "no context is currently set, use \"kubectl config use-context <context>\" to select a new one",
+			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
+		},
+		{
+			name: "no error when kubeconfig has current context and --context switch isn't set",
+			opts: &SubmitJobOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithCurrentContext,
+				},
+				ioStreams:  &testStreams,
+				fileName:   rayJobYamlPath,
+				workingDir: "Fake/File/Path",
+			},
+		},
+		{
+			name: "no error when kubeconfig has no current context and --context switch is set",
+			opts: &SubmitJobOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithoutCurrentContext,
+					Context:    &testContext,
+				},
+				ioStreams:  &testStreams,
+				fileName:   rayJobYamlPath,
+				workingDir: "Fake/File/Path",
+			},
 		},
 		{
 			name: "Successful submit job validation with RayJob",
 			opts: &SubmitJobOptions{
-				configFlags: fakeConfigFlags,
-				ioStreams:   &testStreams,
-				fileName:    rayJobYamlPath,
-				workingDir:  "Fake/File/Path",
+				configFlags: &genericclioptions.ConfigFlags{
+					Namespace:        &testNS,
+					Context:          &testContext,
+					KubeConfig:       &kubeConfigWithCurrentContext,
+					BearerToken:      &testBT,
+					Impersonate:      &testImpersonate,
+					ImpersonateGroup: &[]string{"fake-group"},
+				},
+				ioStreams:  &testStreams,
+				fileName:   rayJobYamlPath,
+				workingDir: "Fake/File/Path",
 			},
 		},
 	}

--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -152,8 +152,8 @@ func (options *ClusterLogOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving raw config: %w", err)
 	}
-	if len(config.CurrentContext) == 0 {
-		return fmt.Errorf("no context is currently set, use %q to select a new one", "kubectl config use-context <context>")
+	if !util.HasKubectlContext(config, options.configFlags) {
+		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 
 	if options.outputDir == "" {

--- a/kubectl-plugin/pkg/cmd/session/session.go
+++ b/kubectl-plugin/pkg/cmd/session/session.go
@@ -143,8 +143,8 @@ func (options *SessionOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving raw config: %w", err)
 	}
-	if len(config.CurrentContext) == 0 {
-		return fmt.Errorf("no context is currently set, use %q to select a new one", "kubectl config use-context <context>")
+	if !util.HasKubectlContext(config, options.configFlags) {
+		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 	return nil
 }

--- a/kubectl-plugin/pkg/util/kubeconfig.go
+++ b/kubectl-plugin/pkg/util/kubeconfig.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"path/filepath"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// HasKubectlContext checks if the kubeconfig has a current context or if the --context switch is set.
+func HasKubectlContext(config api.Config, configFlags *genericclioptions.ConfigFlags) bool {
+	return config.CurrentContext != "" || (configFlags.Context != nil && *configFlags.Context != "")
+}
+
+// CreateTempKubeConfigFile creates a temporary kubeconfig file with the given current context.
+// This function should only be used in tests.
+func CreateTempKubeConfigFile(t *testing.T, currentContext string) (string, error) {
+	tmpDir := t.TempDir()
+
+	// Set up fake config for kubeconfig
+	config := &api.Config{
+		Clusters: map[string]*api.Cluster{
+			"test-cluster": {
+				Server:                "https://fake-kubernetes-cluster.example.com",
+				InsecureSkipTLSVerify: true, // For testing purposes
+			},
+		},
+		Contexts: map[string]*api.Context{
+			"my-fake-context": {
+				Cluster:  "my-fake-cluster",
+				AuthInfo: "my-fake-user",
+			},
+		},
+		CurrentContext: currentContext,
+		AuthInfos: map[string]*api.AuthInfo{
+			"my-fake-user": {
+				Token: "", // Empty for testing without authentication
+			},
+		},
+	}
+
+	fakeFile := filepath.Join(tmpDir, ".kubeconfig")
+
+	return fakeFile, clientcmd.WriteToFile(*config, fakeFile)
+}


### PR DESCRIPTION
to tell user they can use `--context` to set the K8s context.

Signed-off-by: David Xia <david@davidxia.com>

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
