### PR TITLE
[Fix][kubectl-plugin] make tests use a temporary kube config

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -39,8 +39,10 @@ func TestRayCreateClusterValidate(t *testing.T) {
 		{
 			name: "Test validation when no context is set",
 			opts: &CreateClusterOptions{
-				configFlags: genericclioptions.NewConfigFlags(false),
-				ioStreams:   &testStreams,
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithoutCurrentContext,
+				},
+				ioStreams: &testStreams,
 			},
 			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
 		},

--- a/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
@@ -59,7 +59,9 @@ func TestRayClusterGetValidate(t *testing.T) {
 		{
 			name: "Test validation when no context is set",
 			opts: &GetClusterOptions{
-				configFlags:   genericclioptions.NewConfigFlags(false),
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithoutCurrentContext,
+				},
 				AllNamespaces: false,
 				args:          []string{"random_arg"},
 				ioStreams:     &testStreams,

--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -183,7 +183,7 @@ func (options *ClusterLogOptions) Validate() error {
 	} else if err != nil {
 		return fmt.Errorf("Error occurred will checking directory: %w", err)
 	} else if !info.IsDir() {
-		return fmt.Errorf("Path is Not a directory. Please input a directory and try again")
+		return fmt.Errorf("Path is not a directory. Please input a directory and try again")
 	}
 
 	return nil

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -231,7 +231,9 @@ func TestRayClusterLogValidate(t *testing.T) {
 		{
 			name: "Test validation when no context is set",
 			opts: &ClusterLogOptions{
-				configFlags:  genericclioptions.NewConfigFlags(false),
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithoutCurrentContext,
+				},
 				outputDir:    fakeDir,
 				ResourceName: "fake-cluster",
 				nodeType:     "head",
@@ -323,7 +325,7 @@ func TestRayClusterLogValidate(t *testing.T) {
 				nodeType:     "head",
 				ioStreams:    &testStreams,
 			},
-			expectError: "Path is Not a directory. Please input a directory and try again",
+			expectError: "Path is not a directory. Please input a directory and try again",
 		},
 	}
 


### PR DESCRIPTION
file that's not at the default path. Right now tests fail if there's a K8s
current context set with a command like `kubectl config use-context
my-context`.

This change allows tests to pass regardless of current context.

Signed-off-by: David Xia <david@davidxia.com>

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
