### PR TITLE
[refactor][CI] automatically install required Python packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,5 +72,7 @@ repos:
       - id: validate-helm-charts
         name: validate helm charts with kubeconform
         entry: bash scripts/validate-helm.sh
-        language: system
+        language: python
         pass_filenames: false
+        additional_dependencies:
+          - PyYAML==6.0.1


### PR DESCRIPTION
when running pre-commit hook `validate-helm-charts`.

Right now this hook requires PyYAML to be installed in the current Python
environment. By using `language: python` instead of `language: system`,
pre-commit will install the specified `additional_dependencies` into a virtual
environment it manages. This allows contributors to get started faster because
they no longer need to think about this dependency if they want to run the
hook.

We use PyYAML==6.0.1 because 6.0 resulted in a Cython compatibility error.
[See here][1].

[1]: https://stackoverflow.com/a/76710304/553994

Signed-off-by: David Xia <dxia@spotify.com>


## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
