### PR TITLE
[feat][kubectl-plugin] show last Condition and State

### DIFF
--- a/kubectl-plugin/pkg/cmd/get/get_cluster.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster.go
@@ -148,6 +148,8 @@ func printClusters(rayclusterList *rayv1.RayClusterList, output io.Writer) error
 			{Name: "GPUs", Type: "string"},
 			{Name: "TPUs", Type: "string"},
 			{Name: "Memory", Type: "string"},
+			{Name: "Condition", Type: "string"},
+			{Name: "Status", Type: "string"},
 			{Name: "Age", Type: "string"},
 		},
 	}
@@ -156,6 +158,11 @@ func printClusters(rayclusterList *rayv1.RayClusterList, output io.Writer) error
 		age := duration.HumanDuration(time.Since(raycluster.GetCreationTimestamp().Time))
 		if raycluster.GetCreationTimestamp().Time.IsZero() {
 			age = "<unknown>"
+		}
+		relevantConditionType := ""
+		relevantCondition := util.RelevantRayClusterCondition(raycluster)
+		if relevantCondition != nil {
+			relevantConditionType = relevantCondition.Type
 		}
 		resTable.Rows = append(resTable.Rows, v1.TableRow{
 			Cells: []interface{}{
@@ -167,6 +174,8 @@ func printClusters(rayclusterList *rayv1.RayClusterList, output io.Writer) error
 				raycluster.Status.DesiredGPU.String(),
 				raycluster.Status.DesiredTPU.String(),
 				raycluster.Status.DesiredMemory.String(),
+				relevantConditionType,
+				raycluster.Status.State, //nolint:staticcheck // Display State for now until it's removed from the CRD
 				age,
 			},
 		})

--- a/kubectl-plugin/pkg/util/conditions.go
+++ b/kubectl-plugin/pkg/util/conditions.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+)
+
+// RelevantRayClusterCondition returns a RayCluster's most relevant condition
+func RelevantRayClusterCondition(cluster rayv1.RayCluster) *metav1.Condition {
+	conditions := cluster.Status.Conditions
+
+	if len(conditions) == 0 {
+		return nil
+	}
+
+	// The order of precedence in which we return conditions is
+	// RayClusterProvisioned > HeadPodReady > RayClusterReplicaFailure > Suspended > Suspending.
+	if meta.IsStatusConditionTrue(conditions, string(rayv1.RayClusterProvisioned)) {
+		return meta.FindStatusCondition(conditions, string(rayv1.RayClusterProvisioned))
+	}
+	if meta.IsStatusConditionTrue(conditions, string(rayv1.HeadPodReady)) {
+		return meta.FindStatusCondition(conditions, string(rayv1.HeadPodReady))
+	}
+	if meta.IsStatusConditionTrue(conditions, string(rayv1.RayClusterReplicaFailure)) {
+		return meta.FindStatusCondition(conditions, string(rayv1.RayClusterReplicaFailure))
+	}
+	if meta.IsStatusConditionTrue(conditions, string(rayv1.RayClusterSuspended)) {
+		return meta.FindStatusCondition(conditions, string(rayv1.RayClusterSuspended))
+	}
+	if meta.IsStatusConditionTrue(conditions, string(rayv1.RayClusterSuspending)) {
+		return meta.FindStatusCondition(conditions, string(rayv1.RayClusterSuspending))
+	}
+
+	return nil
+}

--- a/kubectl-plugin/pkg/util/conditions_test.go
+++ b/kubectl-plugin/pkg/util/conditions_test.go
@@ -1,0 +1,76 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+)
+
+func TestRelevantRayClusterCondition(t *testing.T) {
+	provisionedCondition := metav1.Condition{
+		Type:   string(rayv1.RayClusterProvisioned),
+		Status: metav1.ConditionTrue,
+	}
+	headPodReadyCondition := metav1.Condition{
+		Type:   string(rayv1.HeadPodReady),
+		Status: metav1.ConditionTrue,
+	}
+	replicaFailureCondition := metav1.Condition{
+		Type:   string(rayv1.RayClusterReplicaFailure),
+		Status: metav1.ConditionTrue,
+	}
+	suspendedCondition := metav1.Condition{
+		Type:   string(rayv1.RayClusterSuspended),
+		Status: metav1.ConditionTrue,
+	}
+	suspendingCondition := metav1.Condition{
+		Type:   string(rayv1.RayClusterSuspending),
+		Status: metav1.ConditionTrue,
+	}
+
+	tests := []struct {
+		expectedCondition *metav1.Condition
+		name              string
+		conditions        []metav1.Condition
+	}{
+		{
+			name:              "passing no conditions should return nil pointer",
+			conditions:        []metav1.Condition{},
+			expectedCondition: nil,
+		},
+		{
+			name:              "RayClusterProvisioned precedence",
+			conditions:        []metav1.Condition{suspendingCondition, suspendedCondition, replicaFailureCondition, headPodReadyCondition, provisionedCondition},
+			expectedCondition: &provisionedCondition,
+		},
+		{
+			name:              "HeadPodReady precedence",
+			conditions:        []metav1.Condition{suspendingCondition, suspendedCondition, replicaFailureCondition, headPodReadyCondition},
+			expectedCondition: &headPodReadyCondition,
+		},
+		{
+			name:              "RayClusterReplicaFailure precedence",
+			conditions:        []metav1.Condition{suspendingCondition, suspendedCondition, replicaFailureCondition},
+			expectedCondition: &replicaFailureCondition,
+		},
+		{
+			name:              "RayClusterSuspended precedence",
+			conditions:        []metav1.Condition{suspendingCondition, suspendedCondition},
+			expectedCondition: &suspendedCondition,
+		},
+		{
+			name:              "RayClusterSuspending precedence",
+			conditions:        []metav1.Condition{suspendingCondition},
+			expectedCondition: &suspendingCondition,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedCondition, RelevantRayClusterCondition(rayv1.RayCluster{Status: rayv1.RayClusterStatus{Conditions: tc.conditions}}))
+		})
+	}
+}

--- a/kubectl-plugin/test/e2e/kubectl_ray_cluster_get_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_cluster_get_test.go
@@ -9,6 +9,8 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/printers"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
 var _ = Describe("Calling ray plugin `get` command", func() {
@@ -38,6 +40,8 @@ var _ = Describe("Calling ray plugin `get` command", func() {
 				{Name: "GPUs", Type: "string"},
 				{Name: "TPUs", Type: "string"},
 				{Name: "Memory", Type: "string"},
+				{Name: "Condition", Type: "string"},
+				{Name: "Status", Type: "string"},
 				{Name: "Age", Type: "string"},
 			},
 		}
@@ -52,6 +56,8 @@ var _ = Describe("Calling ray plugin `get` command", func() {
 				"0",
 				"0",
 				"3G",
+				rayv1.RayClusterProvisioned,
+				rayv1.Ready,
 			},
 		})
 


### PR DESCRIPTION
in `kubectl ray [get|list] cluster` output.

## Before

```console
$ kubectl ray get cluster

NAME                            NAMESPACE   DESIRED WORKERS   AVAILABLE WORKERS   CPUS   GPUS   TPUS   MEMORY    AGE
vectors-test                    deep-end    68                68                  2048   0      0      13624Gi   21h
rayjob-b8ghp-raycluster-g2xvh   hulk        2                 2                   24     1      0      92Gi      15m
rayjob-8pnlm-raycluster-768x8   deadbeef    1                 1                   16     1      0      96Gi      8m35s
```

## After

```console
$ kubectl ray get cluster

NAME                            NAMESPACE   DESIRED WORKERS   AVAILABLE WORKERS   CPUS   GPUS   TPUS   MEMORY    CONDITION              STATUS   AGE
vectors-test                    deep-end    68                68                  2048   0      0      13624Gi   RayClusterProvisioned  ready    21h
rayjob-z6j96-raycluster-lgdh7   hulk        2                 2                   24     1      0      92Gi      HeadPodReady           ready    19m
rayjob-8pnlm-raycluster-768x8   deadbeef    1                 1                   16     1      0      96Gi                             ready    8m35s
```

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
