### PR TITLE
[docs] move pre-commit instructions to main dev docs

### DIFF
--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -3,6 +3,13 @@
 This guide provides an overview of the different components in the KubeRay project and instructions for developing and testing each component.
 Most developers will be concerned with the KubeRay Operator; the other components are optional.
 
+## Pre-commit Hooks
+
+We use [pre-commit] to lint and format code before each commit.
+
+1. Install [pre-commit]
+1. Run `pre-commit install` to install the pre-commit hooks
+
 ## KubeRay Operator
 
 The KubeRay Operator is responsible for managing Ray clusters on Kubernetes.
@@ -36,3 +43,5 @@ docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
 - Open your web browser and navigate to <http://127.0.0.1:8000/kuberay/> to view the documentation.
 
 If you make any changes to the documentation files, the local preview will automatically update to reflect those changes.
+
+[pre-commit]: https://pre-commit.com/

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -203,8 +203,7 @@ helm uninstall kuberay-operator; helm install kuberay-operator --set image.repos
 
 ## pre-commit hooks
 
-1. Install [pre-commit](https://pre-commit.com/).
-2. Run `pre-commit install` to install the pre-commit hooks.
+See [main development documentation][main-dev-doc].
 
 ## CI/CD
 
@@ -299,3 +298,5 @@ docker buildx build --tag quay.io/<my org>/operator:latest --tag docker.io/<my o
 * --tag is a remote repo_name:tag to push.
 * --push/--load optionally Push to remote registry or Load into local docker.
 * Some registry such as Quay.io dashboard displays attestation manifests as unknown platforms. Setting --provenance=false to avoid this issue.
+
+[main-dev-doc]: ../docs/development/development.md#pre-commit-hooks


### PR DESCRIPTION
from ray-operator dev docs since pre-commit hooks are used in this repo's other components.