### PR TITLE
[chore][kubectl-plugin] use consistent capitalization

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -37,7 +37,7 @@ var (
 	`)
 
 	createClusterExample = templates.Examples(`
-		# Create a Ray cluster using default values
+		# Create a Ray Cluster using default values
 		kubectl ray create cluster sample-cluster
 
 		# Creates Ray Cluster from flags input

--- a/kubectl-plugin/pkg/cmd/delete/delete.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete.go
@@ -55,7 +55,7 @@ func NewDeleteCommand(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:               "delete (RAYCLUSTER | TYPE/NAME)",
-		Short:             "Delete Ray resoruce.",
+		Short:             "Delete Ray resource.",
 		Example:           deleteExample,
 		Long:              `Deletes Ray custom resources such as RayCluster, RayService, or RayJob`,
 		ValidArgsFunction: completion.RayClusterResourceNameCompletionFunc(factory),

--- a/kubectl-plugin/pkg/cmd/delete/delete_test.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete_test.go
@@ -49,7 +49,7 @@ func TestComplete(t *testing.T) {
 			hasErr:               false,
 		},
 		{
-			name:                 "valid rayjob with namespace",
+			name:                 "valid RayJob with namespace",
 			namespace:            "test-namespace",
 			expectedResourceType: util.RayJob,
 			expectedNamespace:    "test-namespace",

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -72,31 +72,31 @@ type SubmitJobOptions struct {
 
 var (
 	jobSubmitLong = templates.LongDesc(`
-		Submit ray job to ray cluster as one would using ray CLI e.g. 'ray job submit ENTRYPOINT'. Command supports all options that 'ray job submit' supports, except '--address'.
+		Submit Ray job to Ray cluster as one would using Ray CLI e.g. 'ray job submit ENTRYPOINT'. Command supports all options that 'ray job submit' supports, except '--address'.
 		If RayCluster is already setup, use 'kubectl ray session' instead.
 
-		If no rayjob yaml file is specified, the command will create a default rayjob for the user.
+		If no RayJob yaml file is specified, the command will create a default RayJob for the user.
 
-		Command will apply RayJob CR and also submit the ray job. RayJob CR is required.
+		Command will apply RayJob CR and also submit the Ray job. RayJob CR is required.
 	`)
 
 	jobSubmitExample = templates.Examples(`
-		# Submit ray job with working-directory
+		# Submit Ray job with working-directory
 		kubectl ray job submit -f rayjob.yaml --working-dir /path/to/working-dir/ -- python my_script.py
 
-		# Submit ray job with runtime Env file and working directory
+		# Submit Ray job with runtime Env file and working directory
 		kubectl ray job submit -f rayjob.yaml --working-dir /path/to/working-dir/ --runtime-env /runtimeEnv.yaml -- python my_script.py
 
-		# Submit ray job with runtime Env file assuming runtime-env has working_dir set
+		# Submit Ray job with runtime Env file assuming runtime-env has working_dir set
 		kubectl ray job submit -f rayjob.yaml --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
 
-		# Submit generated ray job with default values and with runtime Env file and working directory
+		# Submit generated Ray job with default values and with runtime Env file and working directory
 		kubectl ray job submit --name rayjob-sample --working-dir /path/to/working-dir/ --runtime-env /runtimeEnv.yaml -- python my_script.py
 
-		# Generate ray job with specifications and submit ray job with runtime Env file and working directory
+		# Generate Ray job with specifications and submit Ray job with runtime Env file and working directory
 		kubectl ray job submit --name rayjob-sample --ray-version 2.39.0 --image rayproject/ray:2.39.0 --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
 
-		# Generate ray job with specifications and print out the generated rayjob in yaml format
+		# Generate Ray job with specifications and print out the generated RayJob YAML
 		kubectl ray job submit --dry-run --name rayjob-sample --ray-version 2.39.0 --image rayproject/ray:2.39.0 --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
 	`)
 )
@@ -114,7 +114,7 @@ func NewJobSubmitCommand(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "submit [OPTIONS] -f/--filename RAYJOB_YAML -- ENTRYPOINT",
-		Short:   "Submit ray job to ray cluster",
+		Short:   "Submit Ray job to Ray cluster",
 		Long:    jobSubmitLong,
 		Example: jobSubmitExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -133,12 +133,12 @@ func NewJobSubmitCommand(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&options.fileName, "filename", "f", options.fileName, "Path and name of the Ray Job YAML file")
-	cmd.Flags().StringVar(&options.submissionID, "submission-id", options.submissionID, "ID to specify for the ray job. If not provided, one will be generated")
+	cmd.Flags().StringVar(&options.submissionID, "submission-id", options.submissionID, "ID to specify for the Ray job. If not provided, one will be generated")
 	cmd.Flags().StringVar(&options.runtimeEnv, "runtime-env", options.runtimeEnv, "Path and name to the runtime env YAML file.")
 	cmd.Flags().StringVar(&options.workingDir, "working-dir", options.workingDir, "Directory containing files that your job will run in")
 	cmd.Flags().StringVar(&options.headers, "headers", options.headers, "Used to pass headers through http/s to Ray Cluster. Must be JSON formatting")
-	cmd.Flags().StringVar(&options.runtimeEnvJson, "runtime-env-json", options.runtimeEnvJson, "JSON-serialized runtime_env dictionary. Precedence over ray job CR.")
-	cmd.Flags().StringVar(&options.verify, "verify", options.verify, "Boolean indication to verify the server’s TLS certificate or a path to a file or directory of trusted certificates.")
+	cmd.Flags().StringVar(&options.runtimeEnvJson, "runtime-env-json", options.runtimeEnvJson, "JSON-serialized runtime_env dictionary. Precedence over Ray job CR.")
+	cmd.Flags().StringVar(&options.verify, "verify", options.verify, "Boolean indication to verify the server's TLS certificate or a path to a file or directory of trusted certificates.")
 	cmd.Flags().StringVar(&options.entryPointResource, "entrypoint-resources", options.entryPointResource, "JSON-serialized dictionary mapping resource name to resource quantity")
 	cmd.Flags().StringVar(&options.metadataJson, "metadata-json", options.metadataJson, "JSON-serialized dictionary of metadata to attach to the job.")
 	cmd.Flags().StringVar(&options.logStyle, "log-style", options.logStyle, "Specific to 'ray job submit'. Options are 'auto | record | pretty'")
@@ -148,14 +148,14 @@ func NewJobSubmitCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().IntVar(&options.entryPointMemory, "entrypoint-memory", options.entryPointMemory, "Amount of memory reserved for the entrypoint command")
 	cmd.Flags().BoolVar(&options.noWait, "no-wait", options.noWait, "If present, will not stream logs and wait for job to finish")
 
-	cmd.Flags().StringVar(&options.rayjobName, "name", "", "Name of the ray job that will be generated")
+	cmd.Flags().StringVar(&options.rayjobName, "name", "", "Name of the Ray job that will be generated")
 	cmd.Flags().StringVar(&options.rayVersion, "ray-version", "2.39.0", "Ray Version to use in the Ray Cluster yaml.")
 	cmd.Flags().StringVar(&options.image, "image", "rayproject/ray:2.39.0", "Ray image to use in the Ray Cluster yaml")
-	cmd.Flags().StringVar(&options.headCPU, "head-cpu", "2", "Number of CPU for the ray head")
-	cmd.Flags().StringVar(&options.headMemory, "head-memory", "4Gi", "Amount of memory to use for the ray head")
+	cmd.Flags().StringVar(&options.headCPU, "head-cpu", "2", "Number of CPU for the Ray head")
+	cmd.Flags().StringVar(&options.headMemory, "head-memory", "4Gi", "Amount of memory to use for the Ray head")
 	cmd.Flags().Int32Var(&options.workerReplicas, "worker-replicas", 1, "Number of the worker group replicas")
-	cmd.Flags().StringVar(&options.workerCPU, "worker-cpu", "2", "Number of CPU for the ray worker")
-	cmd.Flags().StringVar(&options.workerMemory, "worker-memory", "4Gi", "Amount of memory to use for the ray worker")
+	cmd.Flags().StringVar(&options.workerCPU, "worker-cpu", "2", "Number of CPU for the Ray worker")
+	cmd.Flags().StringVar(&options.workerMemory, "worker-memory", "4Gi", "Amount of memory to use for the Ray worker")
 	cmd.Flags().BoolVar(&options.dryRun, "dry-run", false, "Will not apply the generated cluster and will print out the generated yaml. Only works when filename is not provided")
 
 	options.configFlags.AddFlags(cmd.Flags())
@@ -212,7 +212,7 @@ func (options *SubmitJobOptions) Validate() error {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("Ray Job file does not exist. Failed with: %w", err)
 		} else if err != nil {
-			return fmt.Errorf("Error occurred when checking ray job file: %w", err)
+			return fmt.Errorf("Error occurred when checking Ray job file: %w", err)
 		} else if !info.Mode().IsRegular() {
 			return fmt.Errorf("Filename given is not a regular file. Failed with: %w", err)
 		}
@@ -236,7 +236,7 @@ func (options *SubmitJobOptions) Validate() error {
 			options.runtimeEnvJson = string(runtimeJson)
 		}
 	} else if strings.TrimSpace(options.rayjobName) == "" {
-		return fmt.Errorf("Must set either yaml file (--filename) or set ray job name (--name)")
+		return fmt.Errorf("Must set either yaml file (--filename) or set Ray job name (--name)")
 	}
 
 	if options.workingDir == "" {
@@ -255,7 +255,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	}
 
 	if options.fileName == "" {
-		// Genarate the ray job.
+		// Genarate the Ray job.
 		rayJobObject := generation.RayJobYamlObject{
 			RayJobName:     options.rayjobName,
 			Namespace:      *options.configFlags.Namespace,
@@ -276,7 +276,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 		if options.dryRun {
 			resultYaml, err := generation.ConvertRayJobApplyConfigToYaml(rayJobApplyConfig)
 			if err != nil {
-				return fmt.Errorf("Failed to convert rayjob into yaml format: %w", err)
+				return fmt.Errorf("Failed to convert RayJob into yaml format: %w", err)
 			}
 
 			fmt.Printf("%s\n", resultYaml)
@@ -286,7 +286,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 		// Apply the generated yaml
 		rayJobApplyConfigResult, err := k8sClients.RayClient().RayV1().RayJobs(*options.configFlags.Namespace).Apply(ctx, rayJobApplyConfig, v1.ApplyOptions{FieldManager: "ray-kubectl-plugin"})
 		if err != nil {
-			return fmt.Errorf("Failed to apply generated yaml: %w", err)
+			return fmt.Errorf("Failed to apply generated YAML: %w", err)
 		}
 		options.RayJob = &rayv1.RayJob{}
 		options.RayJob.SetName(rayJobApplyConfigResult.Name)
@@ -336,7 +336,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 		fmt.Printf("Deleting RayJob...\n")
 		err = k8sClients.RayClient().RayV1().RayJobs(*options.configFlags.Namespace).Delete(ctx, options.RayJob.GetName(), v1.DeleteOptions{})
 		if err != nil {
-			return fmt.Errorf("Failed to clean up ray job after time out.: %w", err)
+			return fmt.Errorf("Failed to clean up Ray job after time out.: %w", err)
 		}
 		fmt.Printf("Cleaned Up RayJob: %s\n", options.RayJob.GetName())
 
@@ -412,7 +412,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	}
 
 	go func() {
-		fmt.Printf("Running ray submit job command...\n")
+		fmt.Printf("Running Ray submit job command...\n")
 		err := cmd.Start()
 		if err != nil {
 			log.Fatalf("error occurred while running command %s: %v", fmt.Sprint(raySubmitCmd), err)
@@ -434,7 +434,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 			// Running under assumption that scanner does not break up ray job name
 			if currStdToken != "" && rayJobID == "" && strings.Contains(currStdToken, "raysubmit") {
 				regexExp := regexp.MustCompile(`'([^']*raysubmit[^']*)'`)
-				// Search for rayjob name. Returns at least two string, first one has single quotes and second string does not have single quotes
+				// Search for RayJob name. Returns at least two string, first one has single quotes and second string does not have single quotes
 				match := regexExp.FindStringSubmatch(currStdToken)
 				if len(match) > 1 {
 					rayJobIDChan <- match[1]
@@ -466,23 +466,23 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	if rayJobID == "" {
 		rayJobID = <-rayJobIDChan
 	}
-	// Add annotation to RayJob with the correct ray job id and update the CR
+	// Add annotation to RayJob with the correct Ray job ID and update the CR
 	options.RayJob, err = k8sClients.RayClient().RayV1().RayJobs(*options.configFlags.Namespace).Get(ctx, options.RayJob.GetName(), v1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed to get latest version of Ray Job")
+		return fmt.Errorf("Failed to get latest version of Ray job")
 	}
 
 	options.RayJob.Spec.JobId = rayJobID
 
 	_, err = k8sClients.RayClient().RayV1().RayJobs(*options.configFlags.Namespace).Update(ctx, options.RayJob, v1.UpdateOptions{})
 	if err != nil {
-		return fmt.Errorf("Error occurred when trying to add job ID to rayJob: %w", err)
+		return fmt.Errorf("Error occurred when trying to add job ID to RayJob: %w", err)
 	}
 
-	// Wait for ray job submit to finish.
+	// Wait for Ray job submit to finish.
 	err = cmd.Wait()
 	if err != nil {
-		return fmt.Errorf("Error occurred with ray job submit: %w", err)
+		return fmt.Errorf("Error occurred with Ray job submit: %w", err)
 	}
 	return nil
 }
@@ -543,7 +543,7 @@ func (options *SubmitJobOptions) raySubmitCmd() ([]string, error) {
 	return raySubmitCmd, nil
 }
 
-// Decode rayjob yaml if we decide to submit job using kube client
+// Decode RayJob YAML if we decide to submit job using kube client
 func decodeRayJobYaml(rayJobFilePath string) (*rayv1.RayJob, error) {
 	decodedRayJob := &rayv1.RayJob{}
 

--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -203,13 +203,13 @@ func (options *ClusterLogOptions) Run(ctx context.Context, factory cmdutil.Facto
 	case util.RayJob:
 		rayJob, err := clientSet.RayClient().RayV1().RayJobs(*options.configFlags.Namespace).Get(ctx, options.ResourceName, v1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to retrieve rayjob info for %s: %w", options.ResourceName, err)
+			return fmt.Errorf("failed to retrieve RayJob info for %s: %w", options.ResourceName, err)
 		}
 		clusterName = rayJob.Status.RayClusterName
 	case util.RayService:
 		rayService, err := clientSet.RayClient().RayV1().RayServices(*options.configFlags.Namespace).Get(ctx, options.ResourceName, v1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to retrieve rayjob info for %s: %w", options.ResourceName, err)
+			return fmt.Errorf("failed to retrieve RayJob info for %s: %w", options.ResourceName, err)
 		}
 		clusterName = rayService.Status.ActiveServiceStatus.RayClusterName
 	default:

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -124,7 +124,7 @@ func TestRayClusterLogComplete(t *testing.T) {
 		hasErr               bool
 	}{
 		{
-			name:                 "valide request with raycluster with empty nodetype input",
+			name:                 "valid request with RayCluster with empty nodetype input",
 			expectedResourceType: util.RayCluster,
 			expectedResourceName: "test-raycluster",
 			expectedNodeType:     "all",
@@ -132,7 +132,7 @@ func TestRayClusterLogComplete(t *testing.T) {
 			hasErr:               false,
 		},
 		{
-			name:                 "valide request with raycluster",
+			name:                 "valid request with RayCluster",
 			expectedResourceType: util.RayCluster,
 			expectedResourceName: "test-raycluster",
 			args:                 []string{"rayCluster/test-raycluster"},
@@ -140,15 +140,15 @@ func TestRayClusterLogComplete(t *testing.T) {
 			hasErr:               false,
 		},
 		{
-			name:                 "valide request with rayservice",
+			name:                 "valid request with RayService",
 			expectedResourceType: util.RayService,
-			expectedResourceName: "test-rayService",
-			args:                 []string{"rayService/test-rayService"},
+			expectedResourceName: "test-rayservice",
+			args:                 []string{"rayservice/test-rayservice"},
 			expectedNodeType:     "all",
 			hasErr:               false,
 		},
 		{
-			name:                 "valide request with rayjob",
+			name:                 "valid request with RayJob",
 			expectedResourceType: util.RayJob,
 			expectedResourceName: "test-rayJob",
 			args:                 []string{"rayJob/test-rayJob"},

--- a/kubectl-plugin/pkg/cmd/session/session_test.go
+++ b/kubectl-plugin/pkg/cmd/session/session_test.go
@@ -31,7 +31,7 @@ func TestComplete(t *testing.T) {
 			hasErr:               false,
 		},
 		{
-			name:                 "valid raycluster with namespace",
+			name:                 "valid RayCluster with namespace",
 			namespace:            "test-namespace",
 			args:                 []string{"raycluster/test-raycluster"},
 			expectedResourceType: util.RayCluster,
@@ -40,7 +40,7 @@ func TestComplete(t *testing.T) {
 			hasErr:               false,
 		},
 		{
-			name:                 "valid rayjob without namespace",
+			name:                 "valid RayJob without namespace",
 			namespace:            "",
 			args:                 []string{"rayjob/test-rayjob"},
 			expectedResourceType: util.RayJob,
@@ -49,7 +49,7 @@ func TestComplete(t *testing.T) {
 			hasErr:               false,
 		},
 		{
-			name:                 "valid rayservice without namespace",
+			name:                 "valid RayService without namespace",
 			namespace:            "",
 			args:                 []string{"rayservice/test-rayservice"},
 			expectedResourceType: util.RayService,


### PR DESCRIPTION
in comments and console messages.

* capitalize "Ray" when used as a proper noun
* capitalize Ray K8s CRDs like "RayJob" and "RayCluster"
* capitalize acronyms like "YAML"
* fix some minor typos

No functional changes.

Signed-off-by: David Xia <david@davidxia.com>

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
