### PR TITLE
[CI] Generate CRD json schema separately in pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@
 
 # Any file with a .log extension
 **/*.log
+
+# Ignore generated CRD schema files
+schema/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,9 +39,15 @@ repos:
         pass_filenames: false
         additional_dependencies:
           - github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
-
-  - repo: local
-    hooks:
+      - id: generate-crd-schema
+        name: generate CRD schemas for use of kubeconform
+        entry: ./scripts/generate-crd-schema.sh
+        language: python
+        require_serial: true
+        always_run: true
+        pass_filenames: false
+        additional_dependencies:
+          - PyYAML==6.0.1
       - id: validate-helm-charts
         name: validate helm charts with kubeconform
         entry: bash scripts/validate-helm.sh

--- a/scripts/generate-crd-schema.sh
+++ b/scripts/generate-crd-schema.sh
@@ -12,5 +12,5 @@ crd_files=$(find ray-operator/config/crd/bases -name "*.yaml" -exec realpath {} 
 cd schema
 
 for crd_file in $crd_files; do
-  $convert_script $crd_file
+  $convert_script "$crd_file"
 done

--- a/scripts/generate-crd-schema.sh
+++ b/scripts/generate-crd-schema.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ ! -d "schema" ]; then
+  mkdir schema
+fi
+
+convert_script=$(realpath scripts/openapi2jsonschema.py)
+crd_files=$(find ray-operator/config/crd/bases -name "*.yaml" -exec realpath {} \;)
+
+cd schema
+
+for crd_file in $crd_files; do
+  $convert_script $crd_file
+done

--- a/scripts/validate-helm.sh
+++ b/scripts/validate-helm.sh
@@ -12,6 +12,6 @@ fi
 
 charts=("kuberay-apiserver" "kuberay-operator" "ray-cluster")
 
-for chart in $charts; do
-  helm template ./helm-chart/$chart | kubeconform --summary -schema-location default -schema-location "$raycluster_crd_schema"
+for chart in "${charts[@]}"; do
+  helm template ./helm-chart/"$chart" | kubeconform --summary -schema-location default -schema-location "$raycluster_crd_schema"
 done

--- a/scripts/validate-helm.sh
+++ b/scripts/validate-helm.sh
@@ -1,19 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -euo pipefail
-export KUBERAY_HOME=$(git rev-parse --show-toplevel)
-SCRIPT_PATH="${KUBERAY_HOME}/scripts/openapi2jsonschema.py"
-RAYCLUSTER_CRD_PATH="$KUBERAY_HOME/ray-operator/config/crd/bases/ray.io_rayclusters.yaml"
-tmp=$(mktemp -d)
-trap 'rm -rf "$tmp"' EXIT
 
-# Convert CRD YAML to JSON Schema
-pushd "${tmp}" > /dev/null
-"$SCRIPT_PATH" "$RAYCLUSTER_CRD_PATH"
-popd > /dev/null
-RAYCLUSTER_CRD_SCHEMA="${tmp}/raycluster_v1.json"
+raycluster_crd_schema=./schema/raycluster_v1.json
 
-# Validate Helm charts with kubeconform
-echo "Validating Helm Charts with kubeconform..."
-helm template "$KUBERAY_HOME/helm-chart/kuberay-apiserver" | kubeconform --summary -schema-location default
-helm template "$KUBERAY_HOME/helm-chart/kuberay-operator" | kubeconform --summary -schema-location default
-helm template "$KUBERAY_HOME/helm-chart/ray-cluster" | kubeconform --summary -schema-location default -schema-location "$RAYCLUSTER_CRD_SCHEMA"
+if [ ! -f "$raycluster_crd_schema" ]; then
+  echo "CRD schema not found: $raycluster_crd_schema"
+  echo 'Please run "pre-commit genearete-crd-schema --all-files" first'
+  exit 1
+fi
+
+charts=("kuberay-apiserver" "kuberay-operator" "ray-cluster")
+
+for chart in $charts; do
+  helm template ./helm-chart/$chart | kubeconform --summary -schema-location default -schema-location "$raycluster_crd_schema"
+done


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
`openapi2jsonschema.py` requires the `PyYAML` dependency, while `scripts/validate-helm.sh` requires the `kubeconform` dependency. Since they are from two different languages, this PR separates schema generation and Helm validation into two separate hooks to properly handle dependencies.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
