### PR TITLE
[Fix][RayJob] Invalid quote for RayJob submitter

### DIFF
--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
-	"github.com/google/shlex"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/yaml"
@@ -60,7 +59,7 @@ func GetK8sJobCommand(rayJobInstance *rayv1.RayJob) ([]string, error) {
 	address := rayJobInstance.Status.DashboardURL
 	metadata := rayJobInstance.Spec.Metadata
 	jobId := rayJobInstance.Status.JobId
-	entrypoint := rayJobInstance.Spec.Entrypoint
+	entrypoint := strings.TrimSpace(rayJobInstance.Spec.Entrypoint)
 	entrypointNumCpus := rayJobInstance.Spec.EntrypointNumCpus
 	entrypointNumGpus := rayJobInstance.Spec.EntrypointNumGpus
 	entrypointResources := rayJobInstance.Spec.EntrypointResources
@@ -120,15 +119,7 @@ func GetK8sJobCommand(rayJobInstance *rayv1.RayJob) ([]string, error) {
 	}
 
 	// "--" is used to separate the entrypoint from the Ray Job CLI command and its arguments.
-	k8sJobCommand = append(k8sJobCommand, "--")
-
-	commandSlice, err := shlex.Split(entrypoint)
-	if err != nil {
-		return nil, err
-	}
-	k8sJobCommand = append(k8sJobCommand, commandSlice...)
-
-	k8sJobCommand = append(k8sJobCommand, ";", "fi")
+	k8sJobCommand = append(k8sJobCommand, "--", entrypoint, ";", "fi")
 
 	return k8sJobCommand, nil
 }

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -22,7 +22,7 @@ var testRayJob = &rayv1.RayJob{
 		RayClusterSpec: &rayv1.RayClusterSpec{
 			RayVersion: "2.6.0",
 		},
-		Entrypoint:          "echo hello",
+		Entrypoint:          "echo no quote 'single quote' \"double quote\"",
 		EntrypointNumCpus:   1,
 		EntrypointNumGpus:   0.5,
 		EntrypointResources: `{"Custom_1": 1, "Custom_2": 5.5}`,
@@ -86,7 +86,7 @@ func TestGetK8sJobCommand(t *testing.T) {
 		"--entrypoint-num-gpus", "0.500000",
 		"--entrypoint-resources", strconv.Quote(`{"Custom_1": 1, "Custom_2": 5.5}`),
 		"--",
-		"echo", "hello",
+		"echo no quote 'single quote' \"double quote\"",
 		";", "fi",
 	}
 	command, err := GetK8sJobCommand(testRayJob)
@@ -107,7 +107,7 @@ pip: ["python-multipart==0.0.6"]
 			RayClusterSpec: &rayv1.RayClusterSpec{
 				RayVersion: "2.6.0",
 			},
-			Entrypoint: "echo hello",
+			Entrypoint: "echo no quote 'single quote' \"double quote\"",
 		},
 		Status: rayv1.RayJobStatus{
 			DashboardURL: "http://127.0.0.1:8265",
@@ -125,7 +125,7 @@ pip: ["python-multipart==0.0.6"]
 		"--metadata-json", strconv.Quote(`{"testKey":"testValue"}`),
 		"--submission-id", "testJobId",
 		"--",
-		"echo", "hello",
+		"echo no quote 'single quote' \"double quote\"",
 		";", "fi",
 	}
 	command, err := GetK8sJobCommand(rayJobWithYAML)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -503,7 +503,7 @@ func getSubmitterTemplate(ctx context.Context, rayJobInstance *rayv1.RayJob, ray
 		if err != nil {
 			return corev1.PodTemplateSpec{}, err
 		}
-		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/sh"}
+		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/bash"}
 		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args = []string{"-c", strings.Join(k8sJobCommand, " ")}
 		logger.Info("No command is specified in the user-provided template. Default command is used", "command", k8sJobCommand)
 	} else {

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -97,7 +97,7 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	// RayJob instance with user-provided submitter pod template.
 	rayJobInstanceWithTemplate := &rayv1.RayJob{
 		Spec: rayv1.RayJobSpec{
-			Entrypoint: "echo hello world",
+			Entrypoint: "echo no quote 'single quote' \"double quote\"",
 			SubmitterPodTemplate: &corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -118,7 +118,7 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	// In this case we should use the image of the Ray Head, so specify the image so we can test it.
 	rayJobInstanceWithoutTemplate := &rayv1.RayJob{
 		Spec: rayv1.RayJobSpec{
-			Entrypoint: "echo hello world",
+			Entrypoint: "echo no quote 'single quote' \"double quote\"",
 			RayClusterSpec: &rayv1.RayClusterSpec{
 				HeadGroupSpec: rayv1.HeadGroupSpec{
 					Template: corev1.PodTemplateSpec{
@@ -165,14 +165,14 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	rayJobInstanceWithTemplate.Spec.SubmitterPodTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{}
 	submitterTemplate, err = getSubmitterTemplate(ctx, rayJobInstanceWithTemplate, nil)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"/bin/sh"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	assert.Equal(t, []string{"-c", "if ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job logs --address http://test-url --follow test-job-id ; else ray job submit --address http://test-url --submission-id test-job-id -- echo hello world ; fi"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
+	assert.Equal(t, []string{"/bin/bash"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
+	assert.Equal(t, []string{"-c", "if ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job logs --address http://test-url --follow test-job-id ; else ray job submit --address http://test-url --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 
 	// Test 3: User did not provide template, should use the image of the Ray Head
 	submitterTemplate, err = getSubmitterTemplate(ctx, rayJobInstanceWithoutTemplate, rayClusterInstance)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"/bin/sh"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	assert.Equal(t, []string{"-c", "if ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job logs --address http://test-url --follow test-job-id ; else ray job submit --address http://test-url --submission-id test-job-id -- echo hello world ; fi"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
+	assert.Equal(t, []string{"/bin/bash"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
+	assert.Equal(t, []string{"-c", "if ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job logs --address http://test-url --follow test-job-id ; else ray job submit --address http://test-url --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 	assert.Equal(t, "rayproject/ray:custom-version", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Image)
 
 	// Test 4: Check default PYTHONUNBUFFERED setting


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
1. Use `bash` instead of `sh`.
2. Don't split entrypoint, otherwise quotes will be omitted.

Before:

`if ray job status --address http://rayjob-sample-6qxdg-raycluster-b4crs-head-svc.default.svc.cluster.local:8265 rayjob-sample-6qxdg-gnc2m >/dev/null 2>&1 ; then ray job logs --address http://rayjob-sample-6qxdg-raycluster-b4crs-head-svc.default.svc.cluster.local:8265 --follow rayjob-sample-6qxdg-gnc2m ; else ray job submit --address http://rayjob-sample-6qxdg-raycluster-b4crs-head-svc.default.svc.cluster.local:8265 --submission-id rayjob-sample-6qxdg-gnc2m -- python -c import time; import ray; ray.init(); [print(f"iter: {i}, ray.cluster_resources(): {ray.cluster_resources()}") or time.sleep(1) for i in range(600)] ; fi`

After:

`if ray job status --address http://rayjob-sample-v66vm-raycluster-gzvpr-head-svc.default.svc.cluster.local:8265 rayjob-sample-v66vm-qm7cm >/dev/null 2>&1 ; then ray job logs --address http://rayjob-sample-v66vm-raycluster-gzvpr-head-svc.default.svc.cluster.local:8265 --follow rayjob-sample-v66vm-qm7cm ; else ray job submit --address http://rayjob-sample-v66vm-raycluster-gzvpr-head-svc.default.svc.cluster.local:8265 --submission-id rayjob-sample-v66vm-qm7cm -- python -c "import time; import ray; ray.init(); [print(f\"iter: {i}, ray.cluster_resources(): {ray.cluster_resources()}\") or time.sleep(1) for i in range(600)]" ; fi`

Note the quote after `python -c`

## Related issue number

<!-- For example: "Closes #1234" -->
Closes: ray-project/kuberay#2943

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
