### PR TITLE
[docs][kubectl-plugin] improve help messages

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -73,16 +73,16 @@ func NewCreateClusterCommand(streams genericclioptions.IOStreams) *cobra.Command
 		},
 	}
 
-	cmd.Flags().StringVar(&options.rayVersion, "ray-version", "2.41.0", "Ray Version to use in the Ray Cluster yaml. Default to 2.41.0")
-	cmd.Flags().StringVar(&options.image, "image", options.image, "Ray image to use in the Ray Cluster yaml")
-	cmd.Flags().StringVar(&options.headCPU, "head-cpu", "2", "Number of CPU for the ray head. Default to 2")
-	cmd.Flags().StringVar(&options.headMemory, "head-memory", "4Gi", "Amount of memory to use for the ray head. Default to 4Gi")
-	cmd.Flags().StringVar(&options.headGPU, "head-gpu", "0", "Number of GPUs for the ray head. Default to 0")
-	cmd.Flags().Int32Var(&options.workerReplicas, "worker-replicas", 1, "Number of the worker group replicas. Default of 1")
-	cmd.Flags().StringVar(&options.workerCPU, "worker-cpu", "2", "Number of CPU for the ray worker. Default to 2")
-	cmd.Flags().StringVar(&options.workerMemory, "worker-memory", "4Gi", "Amount of memory to use for the ray worker. Default to 4Gi")
-	cmd.Flags().StringVar(&options.workerGPU, "worker-gpu", "0", "Number of GPUs for the ray worker. Default to 0")
-	cmd.Flags().BoolVar(&options.dryRun, "dry-run", false, "Will not apply the generated cluster and will print out the generated yaml")
+	cmd.Flags().StringVar(&options.rayVersion, "ray-version", "2.41.0", "Ray version to use")
+	cmd.Flags().StringVar(&options.image, "image", fmt.Sprintf("rayproject/ray:%s", options.rayVersion), "container image to use")
+	cmd.Flags().StringVar(&options.headCPU, "head-cpu", "2", "number of CPUs in the Ray head")
+	cmd.Flags().StringVar(&options.headMemory, "head-memory", "4Gi", "amount of memory in the Ray head")
+	cmd.Flags().StringVar(&options.headGPU, "head-gpu", "0", "number of GPUs in the Ray head")
+	cmd.Flags().Int32Var(&options.workerReplicas, "worker-replicas", 1, "desired worker group replicas")
+	cmd.Flags().StringVar(&options.workerCPU, "worker-cpu", "2", "number of CPUs in each worker group replica")
+	cmd.Flags().StringVar(&options.workerMemory, "worker-memory", "4Gi", "amount of memory in each worker group replica")
+	cmd.Flags().StringVar(&options.workerGPU, "worker-gpu", "0", "number of GPUs in each worker group replica")
+	cmd.Flags().BoolVar(&options.dryRun, "dry-run", false, "print the generated YAML instead of creating the cluster")
 
 	options.configFlags.AddFlags(cmd.Flags())
 	return cmd
@@ -146,7 +146,7 @@ func (options *CreateClusterOptions) Run(ctx context.Context, factory cmdutil.Fa
 	if options.dryRun {
 		rayClusterYaml, err := generation.ConvertRayClusterApplyConfigToYaml(rayClusterac)
 		if err != nil {
-			return fmt.Errorf("Error when converting RayClusterApplyConfig to yaml: %w", err)
+			return fmt.Errorf("Error when converting RayClusterApplyConfig to YAML: %w", err)
 		}
 		fmt.Printf("%s\n", rayClusterYaml)
 		return nil
@@ -157,7 +157,7 @@ func (options *CreateClusterOptions) Run(ctx context.Context, factory cmdutil.Fa
 	// Applying the YAML
 	result, err := k8sClient.RayClient().RayV1().RayClusters(*options.configFlags.Namespace).Apply(ctx, rayClusterac, metav1.ApplyOptions{FieldManager: "kubectl-plugin"})
 	if err != nil {
-		return fmt.Errorf("Failed to create Ray Cluster with: %w", err)
+		return fmt.Errorf("Failed to create Ray cluster with: %w", err)
 	}
 	fmt.Printf("Created Ray Cluster: %s\n", result.GetName())
 	return nil

--- a/kubectl-plugin/pkg/cmd/delete/delete.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete.go
@@ -28,10 +28,10 @@ type DeleteOptions struct {
 }
 
 var deleteExample = templates.Examples(`
-		# Delete RayCluster
+		# Delete Ray cluster
 		kubectl ray delete sample-raycluster
 
-		# Delete RayCluster with specificed ray resource
+		# Delete Ray cluster with specificed Ray resource
 		kubectl ray delete raycluster/sample-raycluster
 
 		# Delete RayJob
@@ -55,7 +55,7 @@ func NewDeleteCommand(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:               "delete (RAYCLUSTER | TYPE/NAME)",
-		Short:             "Delete Ray resource.",
+		Short:             "Delete Ray resource",
 		Example:           deleteExample,
 		Long:              `Deletes Ray custom resources such as RayCluster, RayService, or RayJob`,
 		ValidArgsFunction: completion.RayClusterResourceNameCompletionFunc(factory),

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -73,9 +73,9 @@ type SubmitJobOptions struct {
 var (
 	jobSubmitLong = templates.LongDesc(`
 		Submit Ray job to Ray cluster as one would using Ray CLI e.g. 'ray job submit ENTRYPOINT'. Command supports all options that 'ray job submit' supports, except '--address'.
-		If RayCluster is already setup, use 'kubectl ray session' instead.
+		If Ray cluster is already setup, use 'kubectl ray session' instead.
 
-		If no RayJob yaml file is specified, the command will create a default RayJob for the user.
+		If no RayJob YAML file is specified, the command will create a default RayJob for the user.
 
 		Command will apply RayJob CR and also submit the Ray job. RayJob CR is required.
 	`)
@@ -143,20 +143,20 @@ func NewJobSubmitCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(&options.metadataJson, "metadata-json", options.metadataJson, "JSON-serialized dictionary of metadata to attach to the job.")
 	cmd.Flags().StringVar(&options.logStyle, "log-style", options.logStyle, "Specific to 'ray job submit'. Options are 'auto | record | pretty'")
 	cmd.Flags().StringVar(&options.logColor, "log-color", options.logColor, "Specific to 'ray job submit'. Options are 'auto | false | true'")
-	cmd.Flags().Float32Var(&options.entryPointCPU, "entrypoint-num-cpus", options.entryPointCPU, "Number of CPU reserved for the for the entrypoint command")
-	cmd.Flags().Float32Var(&options.entryPointGPU, "entrypoint-num-gpus", options.entryPointGPU, "Number of GPU reserved for the for the entrypoint command")
+	cmd.Flags().Float32Var(&options.entryPointCPU, "entrypoint-num-cpus", options.entryPointCPU, "Number of CPUs reserved for the for the entrypoint command")
+	cmd.Flags().Float32Var(&options.entryPointGPU, "entrypoint-num-gpus", options.entryPointGPU, "Number of GPUs reserved for the for the entrypoint command")
 	cmd.Flags().IntVar(&options.entryPointMemory, "entrypoint-memory", options.entryPointMemory, "Amount of memory reserved for the entrypoint command")
 	cmd.Flags().BoolVar(&options.noWait, "no-wait", options.noWait, "If present, will not stream logs and wait for job to finish")
 
-	cmd.Flags().StringVar(&options.rayjobName, "name", "", "Name of the Ray job that will be generated")
-	cmd.Flags().StringVar(&options.rayVersion, "ray-version", "2.41.0", "Ray Version to use in the Ray Cluster yaml.")
-	cmd.Flags().StringVar(&options.image, "image", "rayproject/ray:2.41.0", "Ray image to use in the Ray Cluster yaml")
-	cmd.Flags().StringVar(&options.headCPU, "head-cpu", "2", "Number of CPU for the Ray head")
-	cmd.Flags().StringVar(&options.headMemory, "head-memory", "4Gi", "Amount of memory to use for the Ray head")
-	cmd.Flags().Int32Var(&options.workerReplicas, "worker-replicas", 1, "Number of the worker group replicas")
-	cmd.Flags().StringVar(&options.workerCPU, "worker-cpu", "2", "Number of CPU for the Ray worker")
-	cmd.Flags().StringVar(&options.workerMemory, "worker-memory", "4Gi", "Amount of memory to use for the Ray worker")
-	cmd.Flags().BoolVar(&options.dryRun, "dry-run", false, "Will not apply the generated cluster and will print out the generated yaml. Only works when filename is not provided")
+	cmd.Flags().StringVar(&options.rayjobName, "name", "", "Ray job name")
+	cmd.Flags().StringVar(&options.rayVersion, "ray-version", "2.41.0", "Ray version to use")
+	cmd.Flags().StringVar(&options.image, "image", fmt.Sprintf("rayproject/ray:%s", options.rayVersion), "container image to use")
+	cmd.Flags().StringVar(&options.headCPU, "head-cpu", "2", "number of CPUs in the Ray head")
+	cmd.Flags().StringVar(&options.headMemory, "head-memory", "4Gi", "amount of memory in the Ray head")
+	cmd.Flags().Int32Var(&options.workerReplicas, "worker-replicas", 1, "desired worker group replicas")
+	cmd.Flags().StringVar(&options.workerCPU, "worker-cpu", "2", "number of CPUs in each worker group replica")
+	cmd.Flags().StringVar(&options.workerMemory, "worker-memory", "4Gi", "amount of memory in each worker group replica")
+	cmd.Flags().BoolVar(&options.dryRun, "dry-run", false, "print the generated YAML instead of creating the cluster. Only works when filename is not provided")
 
 	options.configFlags.AddFlags(cmd.Flags())
 	return cmd

--- a/kubectl-plugin/pkg/cmd/ray.go
+++ b/kubectl-plugin/pkg/cmd/ray.go
@@ -18,7 +18,7 @@ func NewRayCommand(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "ray",
 		Short:        "ray kubectl plugin",
-		Long:         "Manage RayCluster resources.",
+		Long:         "Manage Ray resources on Kubernetes",
 		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)

--- a/kubectl-plugin/pkg/cmd/session/session.go
+++ b/kubectl-plugin/pkg/cmd/session/session.go
@@ -54,16 +54,16 @@ var (
 	`)
 
 	sessionExample = templates.Examples(`
-		# Without specifying the resource type, forward local ports to the RayCluster resource
+		# Without specifying the resource type, forward local ports to the Ray cluster
 		kubectl ray session my-raycluster
 
-		# Forward local ports to the RayCluster resource
+		# Forward local ports to the Ray cluster
 		kubectl ray session raycluster/my-raycluster
 
-		# Forward local ports to the RayCluster used for the RayJob resource
+		# Forward local ports to the Ray cluster used for the Ray job
 		kubectl ray session rayjob/my-rayjob
 
-		# Forward local ports to the RayCluster used for the RayService resource
+		# Forward local ports to the Ray cluster used for the RayService resource
 		kubectl ray session rayservice/my-rayservice
 	`)
 )


### PR DESCRIPTION
by making them more concise and accurate.

Other changes include

* capitalize "Ray" when used as a proper noun
* capitalize acronyms like "YAML"
* prefer non-K8s-specific words like "Ray cluster" instead of "RayCluster" in user-facing messages to abstract away K8s when we can
* remove info about default flag values since Cobra automatically adds them in the help messages
* follow https://clig.dev/ style guide where it makes sense

No functional changes