### PR TITLE
[chore] add Markdown linting pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,3 +57,13 @@ repos:
         pass_filenames: false
         additional_dependencies:
           - github.com/yannh/kubeconform/cmd/kubeconform@v0.6.7
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.44.0
+    hooks:
+      - id: markdownlint
+        name: Markdown linting
+        args:
+          - --config
+          - ci/markdownlint.yaml
+          - --fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,7 +417,7 @@ The following individuals contributed to KubeRay 0.5.0. This list is alphabetica
 * [Feature][Hotfix] Add observedGeneration to the status of CRDs ([#979](https://github.com/ray-project/kuberay/pull/979), @kevin85421)
 * Customize the Prometheus export port ([#954](https://github.com/ray-project/kuberay/pull/954), @Yicheng-Lu-llll)
 * [Feature] The default ImagePullPolicy should be IfNotPresent ([#947](https://github.com/ray-project/kuberay/pull/947), @kevin85421)
-*  Inject the --block option to ray start command automatically ([#932](https://github.com/ray-project/kuberay/pull/932), @Yicheng-Lu-llll)
+* Inject the --block option to ray start command automatically ([#932](https://github.com/ray-project/kuberay/pull/932), @Yicheng-Lu-llll)
 * Inject cluster name as an environment variable into head and worker pods ([#934](https://github.com/ray-project/kuberay/pull/934), @Yicheng-Lu-llll)
 * Ensure container ports without names are also included in the head node service ([#891](https://github.com/ray-project/kuberay/pull/891), @Yicheng-Lu-llll)
 * fix: `.status.availableWorkerReplicas` ([#887](https://github.com/ray-project/kuberay/pull/887), @davidxia)

--- a/ci/markdownlint.yaml
+++ b/ci/markdownlint.yaml
@@ -1,0 +1,23 @@
+---
+# Default state for all rules
+default: true
+
+MD004: false
+MD005: false
+MD007: false
+MD010: false
+MD012: false
+MD013: false
+MD022: false
+MD024: false
+MD025: false
+MD026: false
+MD031: false
+MD032: false
+MD033: false
+MD034: false
+MD036: false
+MD040: false
+MD041: false
+MD050: false
+MD052: false

--- a/clients/python-client/README.md
+++ b/clients/python-client/README.md
@@ -103,13 +103,13 @@ make sure you have installed setuptool
 
 `pip install -U pip setuptools`
 
-#### run the pip command
+### run the pip command
 
 from the directory `path/to/kuberay/clients/python-client`
 
 `pip install -e .`
 
-#### to uninstall the module run
+### to uninstall the module run
 
 `pip uninstall python-client`
 


### PR DESCRIPTION
Ignore most rules we violate for now.
Fix these two violations.

```
pre-commit run markdownlint --all-files --show-diff-on-failure

...
clients/python-client/README.md:106 MD001/heading-increment Heading levels should only increment by one level at a time [Expected: h3; Actual: h4]
CHANGELOG.md:420:1 MD030/list-marker-space Spaces after list markers [Expected: 1; Actual: 2]
```

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
