### PR TITLE
[kubectl-plugin] Fix panic when GPU resource is not set

### DIFF
--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -101,28 +101,34 @@ func (rayClusterSpecObject *RayClusterSpecObject) generateRayClusterSpec() *rayv
 								corev1.ResourceMemory: resource.MustParse(rayClusterSpecObject.WorkerMemory),
 							}))))))
 
-	headGPUResource := resource.MustParse(rayClusterSpecObject.HeadGPU)
-	if !headGPUResource.IsZero() {
-		var requests, limits corev1.ResourceList
-		requests = *rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests
-		limits = *rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits
-		requests[corev1.ResourceName(resourceNvidiaGPU)] = headGPUResource
-		limits[corev1.ResourceName(resourceNvidiaGPU)] = headGPUResource
+	// If the HeadGPU resource is set with a value, then proceed with parsing.
+	if rayClusterSpecObject.HeadGPU != "" {
+		headGPUResource := resource.MustParse(rayClusterSpecObject.HeadGPU)
+		if !headGPUResource.IsZero() {
+			var requests, limits corev1.ResourceList
+			requests = *rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests
+			limits = *rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits
+			requests[corev1.ResourceName(resourceNvidiaGPU)] = headGPUResource
+			limits[corev1.ResourceName(resourceNvidiaGPU)] = headGPUResource
 
-		rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests = &requests
-		rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits = &limits
+			rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests = &requests
+			rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits = &limits
+		}
 	}
 
-	workerGPUResource := resource.MustParse(rayClusterSpecObject.WorkerGPU)
-	if !workerGPUResource.IsZero() {
-		var requests, limits corev1.ResourceList
-		requests = *rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests
-		limits = *rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Limits
-		requests[corev1.ResourceName(resourceNvidiaGPU)] = workerGPUResource
-		limits[corev1.ResourceName(resourceNvidiaGPU)] = workerGPUResource
+	// If the workerGPU resource is set with a value, then proceed with parsing.
+	if rayClusterSpecObject.WorkerGPU != "" {
+		workerGPUResource := resource.MustParse(rayClusterSpecObject.WorkerGPU)
+		if !workerGPUResource.IsZero() {
+			var requests, limits corev1.ResourceList
+			requests = *rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests
+			limits = *rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Limits
+			requests[corev1.ResourceName(resourceNvidiaGPU)] = workerGPUResource
+			limits[corev1.ResourceName(resourceNvidiaGPU)] = workerGPUResource
 
-		rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests = &requests
-		rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Limits = &limits
+			rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests = &requests
+			rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Limits = &limits
+		}
 	}
 
 	return rayClusterSpec


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This change fixes a panic issue encountered while testing `ray job submit`. The issue occurs when the GPU resources are not set. Previously, an empty string would cause the `MustParse` function to fail, triggering a panic. 

This update adds a check to ensure that the GPU fields are only parsed when they contain valid values, preventing the panic.

### Before:
```
$ kubectl ray job submit --name rayjob-sample --working-dir ./workdir/ --runtime-env ./workdir/runtimeEnv.yaml -- python sample_code.py
panic: cannot parse '': quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'

goroutine 1 [running]:
k8s.io/apimachinery/pkg/api/resource.MustParse({0x0, 0x0})
        /home/blocka/go/pkg/mod/k8s.io/apimachinery@v0.31.1/pkg/api/resource/quantity.go:141 +0x173
github.com/ray-project/kuberay/kubectl-plugin/pkg/util/generation.(*RayClusterSpecObject).generateRayClusterSpec(0xc0007358d0)
        /home/blocka/kuberay/kubectl-plugin/pkg/util/generation/generation.go:104 +0x186f
github.com/ray-project/kuberay/kubectl-plugin/pkg/util/generation.(*RayJobYamlObject).GenerateRayJobApplyConfig(0xc0007358a0)
        /home/blocka/kuberay/kubectl-plugin/pkg/util/generation/generation.go:55 +0x2a5
github.com/ray-project/kuberay/kubectl-plugin/pkg/cmd/job.(*SubmitJobOptions).Run(0xc000205500, {0x30e99b8, 0x4324440}, {0x30fa2c0, 0xc0001a1400})
        /home/blocka/kuberay/kubectl-plugin/pkg/cmd/job/job_submit.go:273 +0x34c
github.com/ray-project/kuberay/kubectl-plugin/pkg/cmd/job.NewJobSubmitCommand.func1(0xc000053b08, {0xc0000fd170, 0x2, 0x9})
        /home/blocka/kuberay/kubectl-plugin/pkg/cmd/job/job_submit.go:132 +0x177
github.com/spf13/cobra.(*Command).execute(0xc000053b08, {0xc0000fd0e0, 0x9, 0x9})
        /home/blocka/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0xc000052908)
        /home/blocka/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(0x30cb260?)
        /home/blocka/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x13
main.main()
        /home/blocka/kuberay/kubectl-plugin/cmd/kubectl-ray.go:17 +0xf5
```

### After:
```
kubectl ray job submit --name rayjob-sample --working-dir ./workdir/ --runtime-env ./workdir/runtimeEnv.yaml -- python sample_code.py
Submitted RayJob rayjob-sample.
Waiting for RayCluster
Checking Cluster Status for cluster rayjob-sample-raycluster-lz2t7...
```



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
