### PR TITLE
[chore][kubectl-plugin] use better test assertions

### DIFF
--- a/kubectl-plugin/pkg/cmd/delete/delete_test.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete_test.go
@@ -188,7 +188,7 @@ func TestRayDeleteValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.opts.Validate()
 			if tc.expectError != "" {
-				assert.Error(t, err, tc.expectError)
+				assert.EqualError(t, err, tc.expectError)
 			} else {
 				require.NoError(t, err)
 			}

--- a/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
@@ -217,7 +217,5 @@ func TestRayClusterGetRun(t *testing.T) {
 	err = fakeClusterGetOptions.Run(context.Background(), k8sClients)
 	require.NoError(t, err)
 
-	if e, a := resbuffer.String(), resBuf.String(); e != a {
-		t.Errorf("\nexpected\n%v\ngot\n%v", e, a)
-	}
+	assert.Equal(t, resbuffer.String(), resBuf.String())
 }


### PR DESCRIPTION
Fix two places.

* use `assert.EqualError()` instead of `assert.Error()` to check the error string is what we expect
* use testify assertion instead of string checking for better error output

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
