### PR TITLE
[release][9/N] Update text summarizer RayService to Ray 2.41

### DIFF
--- a/ray-operator/config/samples/ray-cluster.gke-bucket.yaml
+++ b/ray-operator/config/samples/ray-cluster.gke-bucket.yaml
@@ -3,10 +3,9 @@ kind: RayCluster
 metadata:
   name: raycluster-mini
 spec:
-  rayVersion: '2.9.0'
+  rayVersion: '2.41.0'
   headGroupSpec:
-    rayStartParams:
-      dashboard-host: '0.0.0.0'
+    rayStartParams: {}
     template:
       spec:
         serviceAccountName: my-ksa
@@ -14,7 +13,7 @@ spec:
           iam.gke.io/gke-metadata-server-enabled: "true"
         containers:
         - name: ray-head
-          image: rayproject/ray:2.9.0
+          image: rayproject/ray:2.41.0
           resources:
             limits:
               cpu: 1

--- a/ray-operator/config/samples/ray-job.sample.yaml
+++ b/ray-operator/config/samples/ray-job.sample.yaml
@@ -102,7 +102,7 @@ spec:
   #     restartPolicy: Never
   #     containers:
   #       - name: my-custom-rayjob-submitter-pod
-  #         image: rayproject/ray:2.9.0
+  #         image: rayproject/ray:2.41.0
   #         # If Command is not specified, the correct command will be supplied at runtime using the RayJob spec `entrypoint` field.
   #         # Specifying Command is not recommended.
   #         # command: ["sh", "-c", "ray job submit --address=http://$RAY_DASHBOARD_ADDRESS --submission-id=$RAY_JOB_SUBMISSION_ID -- echo hello world"]

--- a/ray-operator/config/samples/ray-service.mobilenet.yaml
+++ b/ray-operator/config/samples/ray-service.mobilenet.yaml
@@ -16,21 +16,20 @@ spec:
             ray_actor_options:
               num_cpus: 1
   rayClusterConfig:
-    rayVersion: '2.9.0' # should match the Ray version in the image of the containers
+    rayVersion: '2.41.0' # should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
       # The `rayStartParams` are used to configure the `ray start` command.
       # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
       # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
-      rayStartParams:
-        dashboard-host: '0.0.0.0'
+      rayStartParams: {}
       #pod template
       template:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray-ml:2.9.0
+              image: rayproject/ray-ml:2.41.0.deprecated-py39-cpu
               resources:
                 limits:
                   cpu: 1
@@ -63,7 +62,7 @@ spec:
           spec:
             containers:
               - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-                image: rayproject/ray-ml:2.9.0
+                image: rayproject/ray-ml:2.41.0.deprecated-py39-cpu
                 resources:
                   limits:
                     cpu: 1

--- a/ray-operator/config/samples/ray-service.text-summarizer.yaml
+++ b/ray-operator/config/samples/ray-service.text-summarizer.yaml
@@ -8,7 +8,7 @@ spec:
       - name: text_summarizer
         import_path: text_summarizer.text_summarizer:deployment
         runtime_env:
-          working_dir: "https://github.com/kevin85421/serve_config_examples/archive/refs/heads/fix-text-summarizer.zip"
+          working_dir: "https://github.com/ray-project/serve_config_examples/archive/607d1264c2c998e4a85eaf5403efcd3bc9ed3039.zip"
   rayClusterConfig:
     rayVersion: '2.41.0' # Should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################

--- a/ray-operator/config/samples/ray-service.text-summarizer.yaml
+++ b/ray-operator/config/samples/ray-service.text-summarizer.yaml
@@ -8,23 +8,22 @@ spec:
       - name: text_summarizer
         import_path: text_summarizer.text_summarizer:deployment
         runtime_env:
-          working_dir: "https://github.com/ray-project/serve_config_examples/archive/refs/heads/master.zip"
+          working_dir: "https://github.com/kevin85421/serve_config_examples/archive/refs/heads/fix-text-summarizer.zip"
   rayClusterConfig:
-    rayVersion: '2.9.0' # Should match the Ray version in the image of the containers
+    rayVersion: '2.41.0' # Should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
       # The `rayStartParams` are used to configure the `ray start` command.
       # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
       # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
-      rayStartParams:
-        dashboard-host: '0.0.0.0'
+      rayStartParams: {}
       # Pod template
       template:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray-ml:2.9.0
+            image: rayproject/ray-ml:2.41.0.deprecated-py39-gpu
             ports:
             - containerPort: 6379
               name: gcs
@@ -59,7 +58,7 @@ spec:
         spec:
           containers:
           - name: ray-worker
-            image: rayproject/ray-ml:2.9.0
+            image: rayproject/ray-ml:2.41.0.deprecated-py39-gpu
             resources:
               limits:
                 cpu: 4


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?



1. [text summarizer](https://docs.ray.io/en/latest/cluster/kubernetes/examples/text-summarizer-rayservice.html):
 
<img width="869" alt="Screenshot 2025-02-06 at 4 52 11 PM" src="https://github.com/user-attachments/assets/c2459eef-35ac-4f64-983d-bd81115cabad" />

2. [mobilenet](https://docs.ray.io/en/latest/cluster/kubernetes/examples/mobilenet-rayservice.html): The input is the image generated by #2960

<img width="672" alt="image" src="https://github.com/user-attachments/assets/26ed5155-837a-4278-b084-84b239294133" />

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
