### PR TITLE
[RayService] Deflaky RayService envtest

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -227,6 +227,7 @@ var _ = Context("RayService env tests", func() {
 		ctx := context.Background()
 		var rayService *rayv1.RayService
 		var rayCluster *rayv1.RayCluster
+		var endpoints *corev1.Endpoints
 		serveAppName := "app1"
 		namespace := "default"
 
@@ -304,7 +305,7 @@ var _ = Context("RayService env tests", func() {
 			// TODO: Verify the serve service by checking labels and annotations.
 
 			By("The RayServiceReady condition should be true when the number of endpoints is greater than 0")
-			endpoints := endpointsTemplate(utils.GenerateServeServiceName(rayService.Name), namespace)
+			endpoints = endpointsTemplate(utils.GenerateServeServiceName(rayService.Name), namespace)
 			err = k8sClient.Create(ctx, endpoints)
 			Expect(err).NotTo(HaveOccurred(), "failed to create Endpoints resource")
 			Eventually(func() int32 {
@@ -320,6 +321,9 @@ var _ = Context("RayService env tests", func() {
 			By(fmt.Sprintf("Delete the RayService custom resource %v", rayService.Name))
 			err := k8sClient.Delete(ctx, rayService)
 			Expect(err).NotTo(HaveOccurred(), "failed to delete the test RayService resource")
+			By(fmt.Sprintf("Delete the Endpoints %v", endpoints.Name))
+			err = k8sClient.Delete(ctx, endpoints)
+			Expect(err).NotTo(HaveOccurred(), "failed to delete the test Endpoints resource")
 		})
 
 		When("Testing in-place update: updating the serveConfigV2", Ordered, func() {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Endpoints are not cleaned up after a test, so if the name of the endpoint is the same in two different tests, the second test will fail when it tries to create the endpoint because it already exists.


* [CI failure example](https://github.com/ray-project/kuberay/actions/runs/13190875193/job/36823475912)
    <img width="944" alt="image" src="https://github.com/user-attachments/assets/2bd82380-9ab1-4f9b-ba7f-0a5b6482adf3" />
    <img width="1057" alt="image" src="https://github.com/user-attachments/assets/05fc7470-5b68-42a2-91f5-40744095bbe7" />



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
