### PR TITLE
Update TPU Ray CR manifests to use Ray 2.41.0

### DIFF
--- a/ray-operator/config/samples/ray-cluster.tpu-v4-multihost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v4-multihost.yaml
@@ -4,24 +4,16 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  # Label required for TPU webhook to initialize environments.
-  labels:
-    app.kubernetes.io/name: kuberay
-  name: example-cluster-kuberay
+  name: raycluster-tpu-v4-multihost
 spec:
+  rayVersion: '2.41.0'
   headGroupSpec:
-    rayStartParams:
-      {}
+    rayStartParams: {}
     template:
       spec:
-        imagePullSecrets:
-          []
         containers:
-          - volumeMounts:
-            - mountPath: /tmp/ray
-              name: ray-logs
-            name: ray-head
-            image: rayproject/ray:2.9.0-py310
+          - name: ray-head
+            image: rayproject/ray:2.41.0
             imagePullPolicy: IfNotPresent
             resources:
               limits:
@@ -32,8 +24,6 @@ spec:
                 cpu: "8"
                 ephemeral-storage: 10Gi
                 memory: 40G
-            securityContext:
-              {}
             env:
               - name: RAY_memory_monitor_refresh_ms
                 value: "0"
@@ -56,33 +46,18 @@ spec:
                 name: slicebuilder
               - containerPort: 8081
                 name: mxla
-        volumes:
-          - emptyDir: {}
-            name: ray-logs
-      metadata:
-        labels:
-          cloud.google.com/gke-ray-node-type: head
-          app.kubernetes.io/name: kuberay
-          app.kubernetes.io/instance: example-cluster
-
   workerGroupSpecs:
-  - rayStartParams:
-      {}
+  - rayStartParams: {}
     replicas: 1
     minReplicas: 1
     maxReplicas: 1
     numOfHosts: 2
-    groupName: workergroup
+    groupName: tpu-group
     template:
       spec:
-        imagePullSecrets:
-          []
         containers:
-          - volumeMounts:
-            - mountPath: /tmp/ray
-              name: ray-logs
-            name: ray-worker
-            image: rayproject/ray:2.9.0-py310
+          - name: ray-worker
+            image: rayproject/ray:2.41.0
             imagePullPolicy: IfNotPresent
             resources:
               limits:
@@ -95,19 +70,6 @@ spec:
                 ephemeral-storage: 10Gi
                 google.com/tpu: "4"
                 memory: 40G
-            securityContext:
-              {}
-            env:
-            ports:
-              null
-        volumes:
-          - emptyDir: {}
-            name: ray-logs
         nodeSelector:
           cloud.google.com/gke-tpu-accelerator: tpu-v4-podslice
           cloud.google.com/gke-tpu-topology: 2x2x2
-      metadata:
-        labels:
-          cloud.google.com/gke-ray-node-type: worker
-          app.kubernetes.io/name: kuberay
-          app.kubernetes.io/instance: example-cluster

--- a/ray-operator/config/samples/ray-cluster.tpu-v4-singlehost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v4-singlehost.yaml
@@ -4,24 +4,16 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  # Label required for TPU webhook to initialize environments.
-  labels:
-    app.kubernetes.io/name: kuberay
-  name: example-cluster-kuberay
+  name: raycluster-tpu-v4-singlehost
 spec:
+  rayVersion: '2.41.0'
   headGroupSpec:
-    rayStartParams:
-      {}
+    rayStartParams: {}
     template:
       spec:
-        imagePullSecrets:
-          []
         containers:
-          - volumeMounts:
-            - mountPath: /tmp/ray
-              name: ray-logs
-            name: ray-head
-            image: rayproject/ray:2.9.0-py310
+          - name: ray-head
+            image: rayproject/ray:2.41.0
             imagePullPolicy: IfNotPresent
             resources:
               limits:
@@ -32,8 +24,6 @@ spec:
                 cpu: "8"
                 ephemeral-storage: 10Gi
                 memory: 40G
-            securityContext:
-              {}
             env:
               - name: RAY_memory_monitor_refresh_ms
                 value: "0"
@@ -52,33 +42,18 @@ spec:
                 name: client
               - containerPort: 8000
                 name: serve
-        volumes:
-          - emptyDir: {}
-            name: ray-logs
-      metadata:
-        labels:
-          cloud.google.com/gke-ray-node-type: head
-          app.kubernetes.io/name: kuberay
-          app.kubernetes.io/instance: example-cluster
-
   workerGroupSpecs:
-  - rayStartParams:
-      {}
+  - rayStartParams: {}
     replicas: 1
     minReplicas: 1
     maxReplicas: 1
     numOfHosts: 1
-    groupName: workergroup
+    groupName: tpu-group
     template:
       spec:
-        imagePullSecrets:
-          []
         containers:
-          - volumeMounts:
-            - mountPath: /tmp/ray
-              name: ray-logs
-            name: ray-worker
-            image: rayproject/ray:2.9.0-py310
+          - name: ray-worker
+            image: rayproject/ray:2.41.0
             imagePullPolicy: IfNotPresent
             resources:
               limits:
@@ -91,19 +66,6 @@ spec:
                 ephemeral-storage: 10Gi
                 google.com/tpu: "4"
                 memory: 40G
-            securityContext:
-              {}
-            env:
-            ports:
-              null
-        volumes:
-          - emptyDir: {}
-            name: ray-logs
         nodeSelector:
           cloud.google.com/gke-tpu-accelerator: tpu-v4-podslice
           cloud.google.com/gke-tpu-topology: 2x2x1
-      metadata:
-        labels:
-          cloud.google.com/gke-ray-node-type: worker
-          app.kubernetes.io/name: kuberay
-          app.kubernetes.io/instance: example-cluster

--- a/ray-operator/config/samples/ray-cluster.tpu-v6e-16-multihost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v6e-16-multihost.yaml
@@ -1,15 +1,16 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  name: tpu-ray-cluster
+  name: raycluster-tpu-v6e-16-multihost
 spec:
+  rayVersion: '2.41.0'
   headGroupSpec:
     rayStartParams: {}
     template:
       spec:
         containers:
           - name: ray-head
-            image: rayproject/ray:2.37.0-py310
+            image: rayproject/ray:2.41.0
             imagePullPolicy: IfNotPresent
             resources:
               limits:
@@ -40,7 +41,7 @@ spec:
       spec:
         containers:
           - name: ray-worker
-            image: rayproject/ray:2.37.0-py310
+            image: rayproject/ray:2.41.0
             imagePullPolicy: IfNotPresent
             resources:
               limits:

--- a/ray-operator/config/samples/ray-cluster.tpu-v6e-16-multihost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v6e-16-multihost.yaml
@@ -1,7 +1,7 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  name: raycluster-tpu-v6e-16-multihost
+  name: raycluster-tpu-v6e-multihost
 spec:
   rayVersion: '2.41.0'
   headGroupSpec:

--- a/ray-operator/config/samples/ray-cluster.tpu-v6e-256-multihost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v6e-256-multihost.yaml
@@ -1,7 +1,7 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  name: raycluster-tpu-v6e-256-multihost
+  name: raycluster-tpu-v6e-multihost
 spec:
   rayVersion: '2.41.0'
   headGroupSpec:

--- a/ray-operator/config/samples/ray-cluster.tpu-v6e-256-multihost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v6e-256-multihost.yaml
@@ -1,15 +1,16 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  name: tpu-ray-cluster
+  name: raycluster-tpu-v6e-256-multihost
 spec:
+  rayVersion: '2.41.0'
   headGroupSpec:
     rayStartParams: {}
     template:
       spec:
         containers:
           - name: ray-head
-            image: rayproject/ray:2.37.0-py310
+            image: rayproject/ray:2.41.0
             imagePullPolicy: IfNotPresent
             resources:
               limits:
@@ -40,7 +41,7 @@ spec:
       spec:
         containers:
           - name: ray-worker
-            image: rayproject/ray:2.37.0-py310
+            image: rayproject/ray:2.41.0
             imagePullPolicy: IfNotPresent
             resources:
               limits:

--- a/ray-operator/config/samples/ray-cluster.tpu-v6e-singlehost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v6e-singlehost.yaml
@@ -1,15 +1,16 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  name: tpu-ray-cluster
+  name: raycluster-tpu-v6e-singlehost
 spec:
+  rayVersion: '2.41.0'
   headGroupSpec:
     rayStartParams: {}
     template:
       spec:
         containers:
           - name: ray-head
-            image: rayproject/ray:2.37.0-py310
+            image: rayproject/ray:2.41.0
             imagePullPolicy: IfNotPresent
             resources:
               limits:
@@ -42,7 +43,7 @@ spec:
       spec:
         containers:
           - name: ray-worker
-            image: rayproject/ray:2.37.0-py310
+            image: rayproject/ray:2.41.0
             imagePullPolicy: IfNotPresent
             resources:
               limits:

--- a/ray-operator/config/samples/ray-job.tpu-v6e-16-multihost.yaml
+++ b/ray-operator/config/samples/ray-job.tpu-v6e-16-multihost.yaml
@@ -10,14 +10,14 @@ spec:
       - jax[tpu]==0.4.33
       - -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
   rayClusterSpec:
-    rayVersion: '2.37.0'
+    rayVersion: '2.41.0'
     headGroupSpec:
       rayStartParams: {}
       template:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.37.0-py310
+              image: rayproject/ray:2.41.0
               ports:
                 - containerPort: 6379
                   name: gcs-server
@@ -47,7 +47,7 @@ spec:
               runAsUser: 0
             containers:
               - name: ray-worker
-                image: rayproject/ray:2.37.0-py310
+                image: rayproject/ray:2.41.0
                 resources:
                   limits:
                     cpu: "24"

--- a/ray-operator/config/samples/ray-job.tpu-v6e-256-multihost.yaml
+++ b/ray-operator/config/samples/ray-job.tpu-v6e-256-multihost.yaml
@@ -10,14 +10,14 @@ spec:
       - jax[tpu]==0.4.33
       - -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
   rayClusterSpec:
-    rayVersion: '2.37.0'
+    rayVersion: '2.41.0'
     headGroupSpec:
       rayStartParams: {}
       template:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.37.0-py310
+              image: rayproject/ray:2.41.0
               ports:
                 - containerPort: 6379
                   name: gcs-server
@@ -46,7 +46,7 @@ spec:
           spec:
             containers:
               - name: ray-worker
-                image: rayproject/ray:2.37.0-py310
+                image: rayproject/ray:2.41.0
                 resources:
                   limits:
                     cpu: "24"

--- a/ray-operator/config/samples/ray-job.tpu-v6e-singlehost.yaml
+++ b/ray-operator/config/samples/ray-job.tpu-v6e-singlehost.yaml
@@ -10,14 +10,14 @@ spec:
       - jax[tpu]==0.4.33
       - -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
   rayClusterSpec:
-    rayVersion: '2.37.0'
+    rayVersion: '2.41.0'
     headGroupSpec:
       rayStartParams: {}
       template:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.37.0-py310
+              image: rayproject/ray:2.41.0
               ports:
                 - containerPort: 6379
                   name: gcs-server
@@ -45,7 +45,7 @@ spec:
               runAsUser: 0
             containers:
               - name: ray-worker
-                image: rayproject/ray:2.37.0-py310
+                image: rayproject/ray:2.41.0
                 resources:
                   limits:
                     cpu: "24"

--- a/ray-operator/config/samples/ray-service.tpu-single-host.yaml
+++ b/ray-operator/config/samples/ray-service.tpu-single-host.yaml
@@ -21,20 +21,14 @@ spec:
             - -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
             - fastapi
   rayClusterConfig:
-    rayVersion: '2.9.0' # Should match the Ray version in the image of the containers
-    ######################headGroupSpecs#################################
-    # Ray head pod template.
+    rayVersion: '2.41.0'
     headGroupSpec:
-      # The `rayStartParams` are used to configure the `ray start` command.
-      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
-      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
       rayStartParams: {}
-      # Pod template
       template:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray:2.9.0-py310
+            image: rayproject/ray:2.41.0
             ports:
             - containerPort: 6379
               name: gcs
@@ -52,19 +46,17 @@ spec:
                 cpu: "2"
                 memory: "8G"
     workerGroupSpecs:
-    # The pod replicas in this group typed worker
     - replicas: 1
       minReplicas: 1
       maxReplicas: 10
       numOfHosts: 1
       groupName: tpu-group
       rayStartParams: {}
-      # Pod template
       template:
         spec:
           containers:
           - name: ray-worker
-            image: rayproject/ray:2.9.0-py310
+            image: rayproject/ray:2.41.0
             resources:
               limits:
                 # ct4p-hightpu-4t (v4) TPUs have 240 vCPUs, adjust this value based on your resource needs


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR updates TPU related manifests in `ray-operator/config/samples` to use the Ray 2.41.0 image, since they're currently using much older images. I also cleaned up some of the other fields in these manifests that are not needed/recommended (unnecessary labels, ray-logs volumes, etc.). This PR was tested by applying the manifests, verifying they were created successfully, and (for the Ray Jobs/Services) checking that they run successfully once scheduled.

## Related issue number

Closes #2944

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
