### PR TITLE
[CI] Change Pre-commit-shellcheck-to-shellcheck-py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,8 @@ repos:
     hooks:
       - id: gitleaks
 
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
     hooks:
       - id: shellcheck
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Use shellcheck-py instead of shellcheck so that pre-commit won't rely on docker.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#2933 
<!-- For example: "Closes #1234" -->
```
❯ pre-commit run shellcheck --all-files
shellcheck...............................................................Passed
```
## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
