### PR TITLE
[release] Update Volcano YAML files to Ray 2.41

### DIFF
--- a/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
+++ b/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
@@ -6,14 +6,14 @@ metadata:
     ray.io/scheduler-name: volcano
     volcano.sh/queue-name: kuberay-test-queue
 spec:
-  rayVersion: '2.9.0'
+  rayVersion: '2.41.0'
   headGroupSpec:
     rayStartParams: {}
     template:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.9.0
+          image: rayproject/ray:2.41.0
           resources:
             limits:
               cpu: "1"
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray:2.9.0
+            image: rayproject/ray:2.41.0
             resources:
               limits:
                 cpu: "1"

--- a/ray-operator/config/samples/ray-cluster.volcano-scheduler.yaml
+++ b/ray-operator/config/samples/ray-cluster.volcano-scheduler.yaml
@@ -5,14 +5,14 @@ metadata:
   labels:
     ray.io/scheduler-name: volcano
 spec:
-  rayVersion: '2.9.0'
+  rayVersion: '2.41.0'
   headGroupSpec:
     rayStartParams: {}
     template:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.9.0
+          image: rayproject/ray:2.41.0
           resources:
             limits:
               cpu: "1"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Update images to Ray 2.41 and then follow https://docs.ray.io/en/latest/cluster/kubernetes/k8s-ecosystem/volcano.html to check whether the doc still works or not.

### 1. Test [ray-cluster.volcano-scheduler.yaml](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.volcano-scheduler.yaml)
```
$ kubectl apply -f ray-operator/config/samples/ray-cluster.volcano-scheduler.yaml 
raycluster.ray.io/test-cluster-0 created

$ kubectl get pod -l ray.io/cluster=test-cluster-0
NAME                        READY   STATUS    RESTARTS   AGE
test-cluster-0-head-9wvn7   0/1     Running   0          9s
```

### 2.Test [ray-cluster.volcano-scheduler-queue.yaml](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml)
1. Create a queue with a capacity of 4 CPUs and 6Gi of RAM:
```
$ kubectl create -f - <<EOF
apiVersion: scheduling.volcano.sh/v1beta1
kind: Queue
metadata:
  name: kuberay-test-queue
spec:
  weight: 1
  capability:
    cpu: 4
    memory: 6Gi
EOF
```
2. create a RayCluster with a head node (1 CPU + 2Gi of RAM) and two workers (1 CPU + 1Gi of RAM each), for a total of 3 CPU and 4Gi of RAM
```
$ kubectl apply -f ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml 
raycluster.ray.io/test-cluster-0 created

$ kubectl get podgroup ray-test-cluster-0-pg -o yaml
apiVersion: scheduling.volcano.sh/v1beta1
kind: PodGroup
metadata:
  creationTimestamp: "2025-02-07T15:13:13Z"
  generation: 5
  name: ray-test-cluster-0-pg
  namespace: default
  ownerReferences:
  - apiVersion: ray.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: RayCluster
    name: test-cluster-0
    uid: 7c2d6bd5-19da-4146-8025-dd56c5ee06fe
  resourceVersion: "1858"
  uid: 9aec52f2-6f45-4101-a0ca-5645ba0c2edf
spec:
  minMember: 3
  minResources:
    cpu: "3"
    memory: 4Gi
  queue: kuberay-test-queue
status:
  conditions:
  - lastTransitionTime: "2025-02-07T15:15:03Z"
    reason: tasks in gang are ready to be scheduled
    status: "True"
    transitionID: 3ed1d6cd-db50-405b-82a9-baed48ef3a63
    type: Scheduled
  phase: Running
  running: 3
```
3. Check the status of the queue to see 1 running job:
```
$ kubectl get queue kuberay-test-queue -o yaml
apiVersion: scheduling.volcano.sh/v1beta1
kind: Queue
metadata:
  creationTimestamp: "2025-02-07T15:12:34Z"
  generation: 2
  name: kuberay-test-queue
  resourceVersion: "1861"
  uid: a65b1be2-a2c5-4c2c-afaa-1f088787e21d
spec:
  capability:
    cpu: 4
    memory: 6Gi
  parent: root
  reclaimable: true
  weight: 1
status:
  allocated:
    cpu: "3"
    memory: 4Gi
    pods: "3"
  reservation: {}
  state: Open
```

4. add an additional RayCluster with the same configuration of head and worker nodes, but with a different name:
```
$ sed 's/test-cluster-0/test-cluster-1/' ray-operator/config/samples/ray-cluster.volcano
-scheduler-queue.yaml |  kubectl apply -f-
raycluster.ray.io/test-cluster-1 created

# Check the status of its PodGroup to see that its phase is Pending and the last status is Unschedulable:
$ kubectl get podgroup ray-test-cluster-1-pg -o yaml
apiVersion: scheduling.volcano.sh/v1beta1
kind: PodGroup
metadata:
  creationTimestamp: "2025-02-07T15:16:35Z"
  generation: 2
  name: ray-test-cluster-1-pg
  namespace: default
  ownerReferences:
  - apiVersion: ray.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: RayCluster
    name: test-cluster-1
    uid: e5008d52-eb6c-4555-9512-e81acb97ba69
  resourceVersion: "2050"
  uid: c458466a-80e1-4f8b-9ec6-65fe350bc4dc
spec:
  minMember: 3
  minResources:
    cpu: "3"
    memory: 4Gi
  queue: kuberay-test-queue
status:
  conditions:
  - lastTransitionTime: "2025-02-07T15:16:35Z"
    message: '3/3 tasks in gang unschedulable: pod group is not ready, 3 Pending,
      3 minAvailable; Pending: 3 Unschedulable'
    reason: NotEnoughResources
    status: "True"
    transitionID: f282a2e0-f113-4346-89cf-6944c0eb12bc
    type: Unschedulable
  phase: Pending

$ kubectl get pods
NAME                                 READY   STATUS    RESTARTS   AGE
kuberay-operator-685d587695-9xq5l    1/1     Running   0          5m8s
test-cluster-0-head-kdcbz            1/1     Running   0          4m14s
test-cluster-0-worker-worker-b7524   1/1     Running   0          4m14s
test-cluster-0-worker-worker-qcptz   1/1     Running   0          4m14s
test-cluster-1-head-vjpr7            0/1     Pending   0          52s
test-cluster-1-worker-worker-7fdmk   0/1     Pending   0          52s
test-cluster-1-worker-worker-kjsdc   0/1     Pending   0          52s
```

5. Delete the first RayCluster to make space in the queue:
```
$ kubectl delete raycluster test-cluster-0
raycluster.ray.io "test-cluster-0" deleted

$ kubectl get podgroup ray-test-cluster-1-pg -o yaml
apiVersion: scheduling.volcano.sh/v1beta1
kind: PodGroup
metadata:
  creationTimestamp: "2025-02-07T15:16:35Z"
  generation: 5
  name: ray-test-cluster-1-pg
  namespace: default
  ownerReferences:
  - apiVersion: ray.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: RayCluster
    name: test-cluster-1
    uid: e5008d52-eb6c-4555-9512-e81acb97ba69
  resourceVersion: "2293"
  uid: c458466a-80e1-4f8b-9ec6-65fe350bc4dc
spec:
  minMember: 3
  minResources:
    cpu: "3"
    memory: 4Gi
  queue: kuberay-test-queue
status:
  conditions:
  - lastTransitionTime: "2025-02-07T15:16:35Z"
    message: '3/3 tasks in gang unschedulable: pod group is not ready, 3 Pending,
      3 minAvailable; Pending: 3 Unschedulable'
    reason: NotEnoughResources
    status: "True"
    transitionID: f282a2e0-f113-4346-89cf-6944c0eb12bc
    type: Unschedulable
  - lastTransitionTime: "2025-02-07T15:17:59Z"
    reason: tasks in gang are ready to be scheduled
    status: "True"
    transitionID: d35adc53-e669-4ec1-8566-02d56ed79692
    type: Scheduled
  phase: Running
  running: 3

$ kubectl get pods
NAME                                 READY   STATUS    RESTARTS   AGE
kuberay-operator-685d587695-9xq5l    1/1     Running   0          5m58s
test-cluster-1-head-vjpr7            1/1     Running   0          102s
test-cluster-1-worker-worker-7fdmk   1/1     Running   0          102s
test-cluster-1-worker-worker-kjsdc   1/1     Running   0          102s
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #2967

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
