### PR TITLE
[CI][#2905] Improvement: enable `testifylint` `compares` rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,9 +55,6 @@ linters-settings:
       - fieldalignment
   lll:
     line-length: 120
-  # TODO: Enable all testifylint rules
-  testifylint:
-    disable:
 linters:
   enable:
     - asciicheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,6 @@ linters-settings:
   # TODO: Enable all testifylint rules
   testifylint:
     disable:
-      - compares
 linters:
   enable:
     - asciicheck

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -339,7 +339,7 @@ func TestRayClusterLogValidate(t *testing.T) {
 				if tc.opts.outputDir == "" {
 					assert.Equal(t, tc.opts.ResourceName, tc.opts.outputDir)
 				}
-				assert.True(t, err == nil)
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -389,10 +389,10 @@ func TestConfigureGCSFaultToleranceWithAnnotations(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// Validate the test input
 			if test.redisUsernameEnv != "" && test.redisUsernameRayStartParams != "" {
-				assert.Equal(t, test.redisUsernameRayStartParams, "$REDIS_USERNAME")
+				assert.Equal(t, "$REDIS_USERNAME", test.redisUsernameRayStartParams)
 			}
 			if test.redisPasswordEnv != "" && test.redisPasswordRayStartParams != "" {
-				assert.Equal(t, test.redisPasswordRayStartParams, "$REDIS_PASSWORD")
+				assert.Equal(t, "$REDIS_PASSWORD", test.redisPasswordRayStartParams)
 			}
 
 			// Prepare the cluster

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -389,10 +389,10 @@ func TestConfigureGCSFaultToleranceWithAnnotations(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// Validate the test input
 			if test.redisUsernameEnv != "" && test.redisUsernameRayStartParams != "" {
-				assert.True(t, test.redisUsernameRayStartParams == "$REDIS_USERNAME")
+				assert.Equal(t, test.redisUsernameRayStartParams, "$REDIS_USERNAME")
 			}
 			if test.redisPasswordEnv != "" && test.redisPasswordRayStartParams != "" {
-				assert.True(t, test.redisPasswordRayStartParams == "$REDIS_PASSWORD")
+				assert.Equal(t, test.redisPasswordRayStartParams, "$REDIS_PASSWORD")
 			}
 
 			// Prepare the cluster


### PR DESCRIPTION
## Why are these changes needed?

As title

## Related issue number

Closes: https://github.com/ray-project/kuberay/issues/2905

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
