### PR TITLE
[Refactor] Use constants for image tag, image repo, and versions in golang to avoid hard-coded strings

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -36,13 +36,13 @@ var (
 		Creates Ray Cluster from inputed file or generate one for user.
 	`)
 
-	createClusterExample = templates.Examples(`
+	createClusterExample = templates.Examples(fmt.Sprintf(`
 		# Create a Ray Cluster using default values
 		kubectl ray create cluster sample-cluster
-
+	
 		# Creates Ray Cluster from flags input
-		kubectl ray create cluster sample-cluster --ray-version 2.41.0 --image rayproject/ray:2.41.0 --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi
-	`)
+		kubectl ray create cluster sample-cluster --ray-version %s --image %s --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi
+	`, util.RayVersion, util.RayImage))
 )
 
 func NewCreateClusterOptions(streams genericclioptions.IOStreams) *CreateClusterOptions {
@@ -73,7 +73,7 @@ func NewCreateClusterCommand(streams genericclioptions.IOStreams) *cobra.Command
 		},
 	}
 
-	cmd.Flags().StringVar(&options.rayVersion, "ray-version", "2.41.0", "Ray version to use")
+	cmd.Flags().StringVar(&options.rayVersion, "ray-version", util.RayVersion, "Ray version to use")
 	cmd.Flags().StringVar(&options.image, "image", fmt.Sprintf("rayproject/ray:%s", options.rayVersion), "container image to use")
 	cmd.Flags().StringVar(&options.headCPU, "head-cpu", "2", "number of CPUs in the Ray head")
 	cmd.Flags().StringVar(&options.headMemory, "head-memory", "4Gi", "amount of memory in the Ray head")

--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -39,7 +39,7 @@ var (
 	createClusterExample = templates.Examples(fmt.Sprintf(`
 		# Create a Ray Cluster using default values
 		kubectl ray create cluster sample-cluster
-	
+
 		# Creates Ray Cluster from flags input
 		kubectl ray create cluster sample-cluster --ray-version %s --image %s --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi
 	`, util.RayVersion, util.RayImage))

--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -44,13 +44,13 @@ var (
 		Adds a worker group to an existing Ray cluster.
 	`)
 
-	createWorkerGroupExample = templates.Examples(`
+	createWorkerGroupExample = templates.Examples(fmt.Sprintf(`
 		# Create a worker group in an existing Ray cluster with defaults
 		kubectl ray create workergroup example-group --ray-cluster sample-cluster
-
+	
 		# Create a worker group in an existing Ray cluster
-		kubectl ray create workergroup example-group --ray-cluster sample-cluster --image rayproject/ray:2.41.0 --worker-cpu 2 --worker-memory 5Gi
-	`)
+		kubectl ray create workergroup example-group --ray-cluster sample-cluster --image %s --worker-cpu 2 --worker-memory 5Gi
+	`, util.RayImage))
 )
 
 func NewCreateWorkerGroupOptions(streams genericclioptions.IOStreams) *CreateWorkerGroupOptions {
@@ -85,7 +85,7 @@ func NewCreateWorkerGroupCommand(streams genericclioptions.IOStreams) *cobra.Com
 	}
 
 	cmd.Flags().StringVarP(&options.clusterName, "ray-cluster", "c", "", "Ray cluster to add a worker group to")
-	cmd.Flags().StringVar(&options.rayVersion, "ray-version", "2.41.0", "Ray version to use")
+	cmd.Flags().StringVar(&options.rayVersion, "ray-version", util.RayVersion, "Ray version to use")
 	cmd.Flags().StringVar(&options.image, "image", fmt.Sprintf("rayproject/ray:%s", options.rayVersion), "container image to use")
 	cmd.Flags().Int32Var(&options.workerReplicas, "worker-replicas", 1, "desired replicas")
 	cmd.Flags().Int32Var(&options.workerMinReplicas, "worker-min-replicas", 1, "minimum number of replicas")

--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -47,7 +47,7 @@ var (
 	createWorkerGroupExample = templates.Examples(fmt.Sprintf(`
 		# Create a worker group in an existing Ray cluster with defaults
 		kubectl ray create workergroup example-group --ray-cluster sample-cluster
-	
+
 		# Create a worker group in an existing Ray cluster
 		kubectl ray create workergroup example-group --ray-cluster sample-cluster --image %s --worker-cpu 2 --worker-memory 5Gi
 	`, util.RayImage))

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -83,19 +83,19 @@ var (
 	jobSubmitExample = templates.Examples(fmt.Sprintf(`
 		# Submit Ray job with working-directory
 		kubectl ray job submit -f rayjob.yaml --working-dir /path/to/working-dir/ -- python my_script.py
-	
+
 		# Submit Ray job with runtime Env file and working directory
 		kubectl ray job submit -f rayjob.yaml --working-dir /path/to/working-dir/ --runtime-env /runtimeEnv.yaml -- python my_script.py
-	
+
 		# Submit Ray job with runtime Env file assuming runtime-env has working_dir set
 		kubectl ray job submit -f rayjob.yaml --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
-	
+
 		# Submit generated Ray job with default values and with runtime Env file and working directory
 		kubectl ray job submit --name rayjob-sample --working-dir /path/to/working-dir/ --runtime-env /runtimeEnv.yaml -- python my_script.py
-	
+
 		# Generate Ray job with specifications and submit Ray job with runtime Env file and working directory
 		kubectl ray job submit --name rayjob-sample --ray-version %s --image %s --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
-	
+
 		# Generate Ray job with specifications and print out the generated RayJob YAML
 		kubectl ray job submit --dry-run --name rayjob-sample --ray-version %s --image %s --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
 	`, util.RayVersion, util.RayImage, util.RayVersion, util.RayImage))

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -80,25 +80,25 @@ var (
 		Command will apply RayJob CR and also submit the Ray job. RayJob CR is required.
 	`)
 
-	jobSubmitExample = templates.Examples(`
+	jobSubmitExample = templates.Examples(fmt.Sprintf(`
 		# Submit Ray job with working-directory
 		kubectl ray job submit -f rayjob.yaml --working-dir /path/to/working-dir/ -- python my_script.py
-
+	
 		# Submit Ray job with runtime Env file and working directory
 		kubectl ray job submit -f rayjob.yaml --working-dir /path/to/working-dir/ --runtime-env /runtimeEnv.yaml -- python my_script.py
-
+	
 		# Submit Ray job with runtime Env file assuming runtime-env has working_dir set
 		kubectl ray job submit -f rayjob.yaml --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
-
+	
 		# Submit generated Ray job with default values and with runtime Env file and working directory
 		kubectl ray job submit --name rayjob-sample --working-dir /path/to/working-dir/ --runtime-env /runtimeEnv.yaml -- python my_script.py
-
+	
 		# Generate Ray job with specifications and submit Ray job with runtime Env file and working directory
-		kubectl ray job submit --name rayjob-sample --ray-version 2.41.0 --image rayproject/ray:2.41.0 --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
-
+		kubectl ray job submit --name rayjob-sample --ray-version %s --image %s --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
+	
 		# Generate Ray job with specifications and print out the generated RayJob YAML
-		kubectl ray job submit --dry-run --name rayjob-sample --ray-version 2.41.0 --image rayproject/ray:2.41.0 --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
-	`)
+		kubectl ray job submit --dry-run --name rayjob-sample --ray-version %s --image %s --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
+	`, util.RayVersion, util.RayImage, util.RayVersion, util.RayImage))
 )
 
 func NewJobSubmitOptions(streams genericiooptions.IOStreams) *SubmitJobOptions {
@@ -149,7 +149,7 @@ func NewJobSubmitCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVar(&options.noWait, "no-wait", options.noWait, "If present, will not stream logs and wait for job to finish")
 
 	cmd.Flags().StringVar(&options.rayjobName, "name", "", "Ray job name")
-	cmd.Flags().StringVar(&options.rayVersion, "ray-version", "2.41.0", "Ray version to use")
+	cmd.Flags().StringVar(&options.rayVersion, "ray-version", util.RayVersion, "Ray version to use")
 	cmd.Flags().StringVar(&options.image, "image", fmt.Sprintf("rayproject/ray:%s", options.rayVersion), "container image to use")
 	cmd.Flags().StringVar(&options.headCPU, "head-cpu", "2", "number of CPUs in the Ray head")
 	cmd.Flags().StringVar(&options.headMemory, "head-memory", "4Gi", "amount of memory in the Ray head")

--- a/kubectl-plugin/pkg/util/constant.go
+++ b/kubectl-plugin/pkg/util/constant.go
@@ -1,0 +1,6 @@
+package util
+
+const (
+	RayVersion = "2.41.0"
+	RayImage   = "rayproject/ray:" + RayVersion
+)

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
@@ -17,8 +18,8 @@ func TestGenerateRayCluterApplyConfig(t *testing.T) {
 		ClusterName: "test-ray-cluster",
 		Namespace:   "default",
 		RayClusterSpecObject: RayClusterSpecObject{
-			RayVersion:     "2.41.0",
-			Image:          "rayproject/ray:2.41.0",
+			RayVersion:     util.RayVersion,
+			Image:          util.RayImage,
 			HeadCPU:        "1",
 			HeadMemory:     "5Gi",
 			HeadGPU:        "1",
@@ -51,8 +52,8 @@ func TestGenerateRayJobApplyConfig(t *testing.T) {
 		Namespace:      "default",
 		SubmissionMode: "InteractiveMode",
 		RayClusterSpecObject: RayClusterSpecObject{
-			RayVersion:     "2.41.0",
-			Image:          "rayproject/ray:2.41.0",
+			RayVersion:     util.RayVersion,
+			Image:          util.RayImage,
 			HeadCPU:        "1",
 			HeadGPU:        "1",
 			HeadMemory:     "5Gi",
@@ -83,8 +84,8 @@ func TestConvertRayClusterApplyConfigToYaml(t *testing.T) {
 		ClusterName: "test-ray-cluster",
 		Namespace:   "default",
 		RayClusterSpecObject: RayClusterSpecObject{
-			RayVersion:     "2.41.0",
-			Image:          "rayproject/ray:2.41.0",
+			RayVersion:     util.RayVersion,
+			Image:          util.RayImage,
 			HeadCPU:        "1",
 			HeadMemory:     "5Gi",
 			HeadGPU:        "1",
@@ -111,7 +112,7 @@ spec:
     template:
       spec:
         containers:
-        - image: rayproject/ray:2.41.0
+        - image: %s
           name: ray-head
           ports:
           - containerPort: 6379
@@ -129,7 +130,7 @@ spec:
               cpu: "1"
               memory: 5Gi
               nvidia.com/gpu: "1"
-  rayVersion: 2.41.0
+  rayVersion: %s
   workerGroupSpecs:
   - groupName: default-group
     rayStartParams:
@@ -138,7 +139,7 @@ spec:
     template:
       spec:
         containers:
-        - image: rayproject/ray:2.41.0
+        - image: %s
           name: ray-worker
           resources:
             limits:

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -1,6 +1,7 @@
 package generation
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
+
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
@@ -100,7 +102,7 @@ func TestConvertRayClusterApplyConfigToYaml(t *testing.T) {
 
 	resultString, err := ConvertRayClusterApplyConfigToYaml(result)
 	require.NoError(t, err)
-	expectedResultYaml := `apiVersion: ray.io/v1
+	expectedResultYaml := fmt.Sprintf(`apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
   name: test-ray-cluster
@@ -147,7 +149,7 @@ spec:
               memory: 10Gi
             requests:
               cpu: "2"
-              memory: 10Gi`
+              memory: 10Gi`, util.RayImage, util.RayVersion, util.RayImage)
 
-	assert.Equal(t, expectedResultYaml, strings.TrimSpace(resultString))
+	assert.Equal(t, strings.TrimSpace(expectedResultYaml), strings.TrimSpace(resultString))
 }


### PR DESCRIPTION
## Why are these changes needed?
Currently, many golang files uses hard-coded strings to represent images and Ray versions. To avoid updating images / Ray versions in multiple places, use constant variables to replace hard-coded strings.

## Related issue number
Closes: #2939 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
