### PR TITLE
[kubectl-plugin] Fix panic when working_dir is not set

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -573,8 +573,7 @@ func runtimeEnvHasWorkingDir(runtimePath string) (string, error) {
 		return "", err
 	}
 
-	workingDir := runtimeEnvYaml["working_dir"].(string)
-	if workingDir != "" {
+	if workingDir, ok := runtimeEnvYaml["working_dir"].(string); ok {
 		return workingDir, nil
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This change fixes the issue where `kubectl ray job submit` can execute even when `working_dir` is not set in the runtime environment.

User can choose to use the `working-dir` parameter directly or set `working_dir` in the runtime-env.

### Before:
```
$ kubectl ray job submit --name rayjob-sample --working-dir ./workdir/ --runtime-env ./workdir/runtimeEnv.yaml -- python sample_code.py
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/ray-project/kuberay/kubectl-plugin/pkg/cmd/job.runtimeEnvHasWorkingDir({0xc000596828?, 0x0?})
        /home/blocka/kuberay/kubectl-plugin/pkg/cmd/job/job_submit.go:576 +0x105
github.com/ray-project/kuberay/kubectl-plugin/pkg/cmd/job.(*SubmitJobOptions).Validate(0xc00022b680)
        /home/blocka/kuberay/kubectl-plugin/pkg/cmd/job/job_submit.go:200 +0x2ed
github.com/ray-project/kuberay/kubectl-plugin/pkg/cmd/job.NewJobSubmitCommand.func1(0xc00045d208, {0xc000157290, 0x2, 0x9})
        /home/blocka/kuberay/kubectl-plugin/pkg/cmd/job/job_submit.go:129 +0x145
github.com/spf13/cobra.(*Command).execute(0xc00045d208, {0xc000157200, 0x9, 0x9})
        /home/blocka/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0xc00045c008)
        /home/blocka/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(0x30cb260?)
        /home/blocka/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x13
main.main()
        /home/blocka/kuberay/kubectl-plugin/cmd/kubectl-ray.go:17 +0xf5
```

### After:
```
$ kubectl ray job submit --name ray-job-sample pip --working-dir ~/workdir --runtime-env ~/workdir/runtimeEnv.yaml -- python sample_code.py
Submitted RayJob ray-job-sample.
Waiting for RayCluster
Checking Cluster Status for cluster ray-job-sample-raycluster-r96hj...
Waiting for portforwarding...Port Forwarding service ray-job-sample-raycluster-r96hj-head-svc
Forwarding from 127.0.0.1:8265 -> 8265
Forwarding from [::1]:8265 -> 8265
Handling connection for 8265
Portforwarding started on http://localhost:8265
Ray command: [ray job submit --address http://localhost:8265 --runtime-env /home/ubuntu/workdir/runtimeEnv.yaml --working-dir /home/ubuntu/workdir -- python sample_code.py]
E0208 19:10:36.121991  554025 portforward.go:398] "Unhandled Error" err="error copying from local connection to remote stream: writeto tcp4 127.0.0.1:8265->127.0.0.1:41708: read tcp4 127.0.0.1:8265->127.0.0.1:41708: read: connection reset by peer" logger="UnhandledError"
Running Ray submit job command...
Handling connection for 8265
Handling connection for 8265
Handling connection for 8265
2025-02-08 19:10:37,453 INFO dashboard_sdk.py:338 -- Uploading package gcs://_ray_pkg_976e812a2a0b2a22.zip.
2025-02-08 19:10:37,453 INFO packaging.py:574 -- Creating a file package for local module '/home/ubuntu/workdir'.
Handling connection for 8265
Handling connection for 8265
Handling connection for 8265
Handling connection for 8265
Handling connection for 8265
2025-02-08 19:10:37,445 INFO cli.py:39 -- Job submission server address: http://localhost:8265
2025-02-08 19:10:38,077 SUCC cli.py:63 -- -------------------------------------------------------
2025-02-08 19:10:38,077 SUCC cli.py:64 -- Job 'raysubmit_UxU8Jyx1xjcRF44Z' submitted successfully
2025-02-08 19:10:38,077 SUCC cli.py:65 -- -------------------------------------------------------
2025-02-08 19:10:38,077 INFO cli.py:289 -- Next steps
2025-02-08 19:10:38,077 INFO cli.py:290 -- Query the logs of the job:
2025-02-08 19:10:38,077 INFO cli.py:292 -- ray job logs raysubmit_UxU8Jyx1xjcRF44Z
2025-02-08 19:10:38,078 INFO cli.py:294 -- Query the status of the job:
2025-02-08 19:10:38,078 INFO cli.py:296 -- ray job status raysubmit_UxU8Jyx1xjcRF44Z
2025-02-08 19:10:38,078 INFO cli.py:298 -- Request the job to be stopped:
2025-02-08 19:10:38,078 INFO cli.py:300 -- ray job stop raysubmit_UxU8Jyx1xjcRF44Z
2025-02-08 19:10:38,084 INFO cli.py:307 -- Tailing logs until the job exits (disable with --no-wait):
2025-02-08 11:10:37,816 INFO job_manager.py:530 -- Runtime env is setting up.
2025-02-08 11:10:43,104 INFO worker.py:1514 -- Using address 10.244.0.25:6379 set in the environment variable RAY_ADDRESS
2025-02-08 11:10:43,104 INFO worker.py:1654 -- Connecting to existing Ray cluster at address: 10.244.0.25:6379...
2025-02-08 11:10:43,120 INFO worker.py:1832 -- Connected to Ray cluster. View the dashboard at 10.244.0.25:8265 
test_counter got 1
test_counter got 2
test_counter got 3
test_counter got 4
test_counter got 5
2025-02-08 19:10:46,139 SUCC cli.py:63 -- ------------------------------------------
2025-02-08 19:10:46,139 SUCC cli.py:64 -- Job 'raysubmit_UxU8Jyx1xjcRF44Z' succeeded
2025-02-08 19:10:46,139 SUCC cli.py:65 -- ------------------------------------------
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
