### PR TITLE
[kubectl-plugin] Support specifying number of head GPUs and worker GPUs for Rayjob

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -60,8 +60,10 @@ type SubmitJobOptions struct {
 	image              string
 	headCPU            string
 	headMemory         string
+	headGPU            string
 	workerCPU          string
 	workerMemory       string
+	workerGPU          string
 	entryPointCPU      float32
 	entryPointGPU      float32
 	entryPointMemory   int
@@ -94,7 +96,7 @@ var (
 		kubectl ray job submit --name rayjob-sample --working-dir /path/to/working-dir/ --runtime-env /runtimeEnv.yaml -- python my_script.py
 
 		# Generate Ray job with specifications and submit Ray job with runtime Env file and working directory
-		kubectl ray job submit --name rayjob-sample --ray-version %s --image %s --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
+		kubectl ray job submit --name rayjob-sample --ray-version %s --image %s --head-cpu 1 --head-memory 5Gi --head-gpu 1 --worker-replicas 3 --worker-cpu 1 --work-gpu 1 --worker-memory 5Gi --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
 
 		# Generate Ray job with specifications and print out the generated RayJob YAML
 		kubectl ray job submit --dry-run --name rayjob-sample --ray-version %s --image %s --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
@@ -153,9 +155,11 @@ func NewJobSubmitCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(&options.image, "image", fmt.Sprintf("rayproject/ray:%s", options.rayVersion), "container image to use")
 	cmd.Flags().StringVar(&options.headCPU, "head-cpu", "2", "number of CPUs in the Ray head")
 	cmd.Flags().StringVar(&options.headMemory, "head-memory", "4Gi", "amount of memory in the Ray head")
+	cmd.Flags().StringVar(&options.headGPU, "head-gpu", "0", "number of GPUs in the Ray head")
 	cmd.Flags().Int32Var(&options.workerReplicas, "worker-replicas", 1, "desired worker group replicas")
 	cmd.Flags().StringVar(&options.workerCPU, "worker-cpu", "2", "number of CPUs in each worker group replica")
 	cmd.Flags().StringVar(&options.workerMemory, "worker-memory", "4Gi", "amount of memory in each worker group replica")
+	cmd.Flags().StringVar(&options.workerGPU, "worker-gpu", "0", "number of GPUs in each worker group replica")
 	cmd.Flags().BoolVar(&options.dryRun, "dry-run", false, "print the generated YAML instead of creating the cluster. Only works when filename is not provided")
 
 	options.configFlags.AddFlags(cmd.Flags())
@@ -265,8 +269,10 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 				Image:          options.image,
 				HeadCPU:        options.headCPU,
 				HeadMemory:     options.headMemory,
+				HeadGPU:        options.headGPU,
 				WorkerCPU:      options.workerCPU,
 				WorkerMemory:   options.workerMemory,
+				WorkerGPU:      options.workerGPU,
 				WorkerReplicas: options.workerReplicas,
 			},
 		}

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -101,34 +101,28 @@ func (rayClusterSpecObject *RayClusterSpecObject) generateRayClusterSpec() *rayv
 								corev1.ResourceMemory: resource.MustParse(rayClusterSpecObject.WorkerMemory),
 							}))))))
 
-	// If the HeadGPU resource is set with a value, then proceed with parsing.
-	if rayClusterSpecObject.HeadGPU != "" {
-		headGPUResource := resource.MustParse(rayClusterSpecObject.HeadGPU)
-		if !headGPUResource.IsZero() {
-			var requests, limits corev1.ResourceList
-			requests = *rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests
-			limits = *rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits
-			requests[corev1.ResourceName(resourceNvidiaGPU)] = headGPUResource
-			limits[corev1.ResourceName(resourceNvidiaGPU)] = headGPUResource
+	headGPUResource := resource.MustParse(rayClusterSpecObject.HeadGPU)
+	if !headGPUResource.IsZero() {
+		var requests, limits corev1.ResourceList
+		requests = *rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests
+		limits = *rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits
+		requests[corev1.ResourceName(resourceNvidiaGPU)] = headGPUResource
+		limits[corev1.ResourceName(resourceNvidiaGPU)] = headGPUResource
 
-			rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests = &requests
-			rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits = &limits
-		}
+		rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests = &requests
+		rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits = &limits
 	}
 
-	// If the workerGPU resource is set with a value, then proceed with parsing.
-	if rayClusterSpecObject.WorkerGPU != "" {
-		workerGPUResource := resource.MustParse(rayClusterSpecObject.WorkerGPU)
-		if !workerGPUResource.IsZero() {
-			var requests, limits corev1.ResourceList
-			requests = *rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests
-			limits = *rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Limits
-			requests[corev1.ResourceName(resourceNvidiaGPU)] = workerGPUResource
-			limits[corev1.ResourceName(resourceNvidiaGPU)] = workerGPUResource
+	workerGPUResource := resource.MustParse(rayClusterSpecObject.WorkerGPU)
+	if !workerGPUResource.IsZero() {
+		var requests, limits corev1.ResourceList
+		requests = *rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests
+		limits = *rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Limits
+		requests[corev1.ResourceName(resourceNvidiaGPU)] = workerGPUResource
+		limits[corev1.ResourceName(resourceNvidiaGPU)] = workerGPUResource
 
-			rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests = &requests
-			rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Limits = &limits
-		}
+		rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests = &requests
+		rayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Limits = &limits
 	}
 
 	return rayClusterSpec

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -75,6 +75,7 @@ func TestGenerateRayJobApplyConfig(t *testing.T) {
 	assert.Equal(t, testRayJobYamlObject.Image, *result.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, resource.MustParse(testRayJobYamlObject.HeadCPU), *result.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests.Cpu())
 	assert.Equal(t, resource.MustParse(testRayJobYamlObject.HeadMemory), *result.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests.Memory())
+	assert.Equal(t, resource.MustParse(testRayJobYamlObject.HeadGPU), *result.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests.Name(corev1.ResourceName("nvidia.com/gpu"), resource.DecimalSI))
 	assert.Equal(t, "default-group", *result.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName)
 	assert.Equal(t, testRayJobYamlObject.WorkerReplicas, *result.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas)
 	assert.Equal(t, resource.MustParse(testRayJobYamlObject.WorkerCPU), *result.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests.Cpu())


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As title

### Manual Test
```
$ kubectl ray job submit --name ray-job-sample pip --working-dir ~/workdir --head-gpu 1 --worker-gpu 1 --runtime-env ~/workdir/runtimeEnv.yaml -- python sample_code.py
```
For worker pod:
![image](https://github.com/user-attachments/assets/fd0bbc3c-b361-4f9a-9801-26333cb05a0f)


For head pod:
![image](https://github.com/user-attachments/assets/955e3472-cbe5-4d4e-a1b3-49633386296d)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
