### PR TITLE
[fix][kubectl-plugin] return error when getting a non-existent cluster

### DIFF
--- a/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
@@ -3,14 +3,18 @@ package get
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -218,4 +222,201 @@ func TestRayClusterGetRun(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, resbuffer.String(), resBuf.String())
+}
+
+func TestGetRayClusters(t *testing.T) {
+	testStreams := genericiooptions.NewTestIOStreamsDiscard()
+
+	namespace := "my-namespace"
+	rayCluster := &rayv1.RayCluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "raycluster-kuberay",
+			Namespace: namespace,
+		},
+	}
+
+	tests := []struct {
+		namespace      *string
+		name           string
+		expectedError  string
+		expectedOutput string
+		args           []string
+		rayClusters    []runtime.Object
+	}{
+		{
+			name:        "should not error if no cluster name is provided, searching all namespaces, and no clusters are found",
+			args:        []string{},
+			namespace:   nil,
+			rayClusters: []runtime.Object{},
+		},
+		{
+			name:          "should error if a cluster name is provided, searching all namespaces, and no clusters are found",
+			args:          []string{"my-cluster"},
+			namespace:     nil,
+			rayClusters:   []runtime.Object{},
+			expectedError: "Ray cluster my-cluster not found",
+		},
+		{
+			name:        "should not error if no cluster name is provided, searching one namespace, and no clusters are found",
+			args:        []string{},
+			namespace:   &namespace,
+			rayClusters: []runtime.Object{},
+		},
+		{
+			name:          "should error if a cluster name is provided, searching one namespace, and no clusters are found",
+			args:          []string{"my-cluster"},
+			namespace:     &namespace,
+			rayClusters:   []runtime.Object{},
+			expectedError: fmt.Sprintf("Ray cluster my-cluster not found in namespace %s", namespace),
+		},
+		{
+			name:        "should not error if no cluster name is provided, searching all namespaces, and clusters are found",
+			args:        []string{},
+			namespace:   nil,
+			rayClusters: []runtime.Object{rayCluster},
+		},
+		{
+			name:        "should not error if a cluster name is provided, searching all namespaces, and clusters are found",
+			args:        []string{"my-cluster"},
+			namespace:   nil,
+			rayClusters: []runtime.Object{rayCluster},
+		},
+		{
+			name:        "should not error if no cluster name is provided, searching one namespace, and clusters are found",
+			args:        []string{},
+			namespace:   &namespace,
+			rayClusters: []runtime.Object{rayCluster},
+		},
+		{
+			name:        "should not error if a cluster name is provided, searching one namespace, and clusters are found",
+			args:        []string{"my-cluster"},
+			namespace:   &namespace,
+			rayClusters: []runtime.Object{rayCluster},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClusterGetOptions := GetClusterOptions{
+				configFlags: genericclioptions.NewConfigFlags(true),
+				ioStreams:   &testStreams,
+				args:        tc.args,
+			}
+			if tc.namespace != nil {
+				*fakeClusterGetOptions.configFlags.Namespace = *tc.namespace
+			}
+
+			kubeClientSet := kubefake.NewClientset()
+			rayClient := rayClientFake.NewSimpleClientset(tc.rayClusters...)
+			k8sClients := client.NewClientForTesting(kubeClientSet, rayClient)
+
+			rayClusters, err := getRayClusters(context.Background(), &fakeClusterGetOptions, k8sClients)
+
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, len(tc.rayClusters), len(rayClusters.Items))
+		})
+	}
+}
+
+func TestPrintClusters(t *testing.T) {
+	rayClusterList := &rayv1.RayClusterList{
+		Items: []rayv1.RayCluster{
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "barista",
+					Namespace: "cafe",
+					CreationTimestamp: v1.Time{
+						Time: time.Now().Add(-24 * time.Hour),
+					},
+				},
+				Status: rayv1.RayClusterStatus{
+					DesiredWorkerReplicas:   2,
+					AvailableWorkerReplicas: 2,
+					DesiredCPU:              resource.MustParse("6"),
+					DesiredGPU:              resource.MustParse("1"),
+					DesiredTPU:              resource.MustParse("1"),
+					DesiredMemory:           resource.MustParse("24Gi"),
+					State:                   rayv1.Ready,
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "bartender",
+					Namespace: "speakeasy",
+				},
+				Status: rayv1.RayClusterStatus{
+					DesiredWorkerReplicas:   3,
+					AvailableWorkerReplicas: 4,
+					DesiredCPU:              resource.MustParse("8"),
+					DesiredGPU:              resource.MustParse("2"),
+					DesiredTPU:              resource.MustParse("0"),
+					DesiredMemory:           resource.MustParse("12Gi"),
+					State:                   rayv1.Ready,
+				},
+			},
+		},
+	}
+
+	// Initialize the printer with an empty print options since we are setting the column definition later
+	expectedTestResultTable := printers.NewTablePrinter(printers.PrintOptions{})
+
+	// Define the column names and types
+	testResTable := &v1.Table{
+		ColumnDefinitions: []v1.TableColumnDefinition{
+			{Name: "Name", Type: "string"},
+			{Name: "Namespace", Type: "string"},
+			{Name: "Desired Workers", Type: "string"},
+			{Name: "Available Workers", Type: "string"},
+			{Name: "CPUs", Type: "string"},
+			{Name: "GPUs", Type: "string"},
+			{Name: "TPUs", Type: "string"},
+			{Name: "Memory", Type: "string"},
+			{Name: "Age", Type: "string"},
+		},
+	}
+
+	testResTable.Rows = append(testResTable.Rows,
+		v1.TableRow{
+			Cells: []interface{}{
+				"barista",
+				"cafe",
+				"2",
+				"2",
+				"6",
+				"1",
+				"1",
+				"24Gi",
+				"24h",
+			},
+		},
+		v1.TableRow{
+			Cells: []interface{}{
+				"bartender",
+				"speakeasy",
+				"3",
+				"4",
+				"8",
+				"2",
+				"0",
+				"12Gi",
+				"<unknown>",
+			},
+		},
+	)
+
+	// Result buffer for the expected table result
+	var expectedOutput bytes.Buffer
+	err := expectedTestResultTable.PrintObj(testResTable, &expectedOutput)
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	err = printClusters(rayClusterList, &output)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedOutput.String(), output.String())
 }


### PR DESCRIPTION
Right now `kubectl ray get cluster CLUSTER_NAME` exits 0 when no clusters are found.

```console
$ kubectl ray get cluster NON_EXISTENT_CLUSTER

$ echo $?
0
```

This change makes the command exit 1 with these errors.

```console
$ kubectl ray get cluster NON_EXISTENT_CLUSTER
Error: Ray cluster NON_EXISTENT_CLUSTER not found in any namespace

$ echo $?
1

$ kubectl ray get cluster -n hyperkube NON_EXISTENT_CLUSTER
Error: Ray cluster NON_EXISTENT_CLUSTER not found in namespace hyperkube

$ echo $?
1
```

We move table formatting logic from `GetClusterOptions.Run()` into a separate `printClusters()` function for ease of unit testing.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
