### PR TITLE
[Fix] Standardize Buildkite Display Format Across All Tests

### DIFF
--- a/.buildkite/test-kubectl-plugin-e2e.yml
+++ b/.buildkite/test-kubectl-plugin-e2e.yml
@@ -19,5 +19,5 @@
     - cp ./kubectl-ray /usr/local/bin
     # Run e2e tests
     - echo "--- START:Running Test E2E (kubectl-plugin) tests"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2e
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2e  | awk -f ../.buildkite/format.awk
     - echo "--- END:Test E2E (kubectl-plugin) tests finished"

--- a/.buildkite/test-kubectl-plugin-e2e.yml
+++ b/.buildkite/test-kubectl-plugin-e2e.yml
@@ -12,15 +12,12 @@
     - kind load docker-image kuberay/operator:nightly
     - IMG=kuberay/operator:nightly make deploy
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
-    # Setup gotestfmt
     - popd && pushd kubectl-plugin
-    - curl -Lo gotestfmt.tar.gz https://github.com/GoTestTools/gotestfmt/releases/download/v2.5.0/gotestfmt_2.5.0_linux_amd64.tar.gz
-    - tar -zxvf gotestfmt.tar.gz
-    - cp ./gotestfmt /usr/local/bin
-    - set -euo pipefail
     # Build CLI and add to path
     - go mod download
     - go build -o kubectl-ray -a ./cmd/kubectl-ray.go
     - cp ./kubectl-ray /usr/local/bin
-    # Run e2e tests and pipe output to gotestfmt
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2e -json 2>&1 | gotestfmt
+    # Run e2e tests
+    - echo "--- START:Running Test E2E (kubectl-plugin) tests"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2e
+    - echo "--- END:Test E2E (kubectl-plugin) tests finished"


### PR DESCRIPTION
## Why are these changes needed?

This PR standardizes the go test verbose logs across all tests in the Buildkite runner. Currently, most tests use an awk script (format.awk) for log formatting, while only the Test E2E (kubectl-plugin) suite uses gotestfmt. Unifying all logs under a consistent formatting approach to ensure clear and standardized log outputs in Buildkite.

By applying format.awk to Test E2E (kubectl-plugin), the logs become consistent with other test logs:
1. `--- START`, `--- END`, and `--- RUN: TestName` are correctly added
<img width="953" alt="Screenshot 2025-02-10 at 23 11 33" src="https://github.com/user-attachments/assets/a9a9d3ce-495f-47db-8d96-0e4516d714a9" />
2. For non-run lines, for example `PASS` and `FAIL`, `---` is replaced by `###` 
<img width="791" alt="Screenshot 2025-02-10 at 23 11 45" src="https://github.com/user-attachments/assets/df5a4e48-767b-45af-9790-c82253f920b6" />

## Related issue number 
Resolves #3001 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
