### PR TITLE
[feat][kubectl-plugin] forward GCS 6379 port

### DIFF
--- a/kubectl-plugin/pkg/cmd/session/session.go
+++ b/kubectl-plugin/pkg/cmd/session/session.go
@@ -32,6 +32,10 @@ type SessionOptions struct {
 }
 
 var (
+	gcsPort = appPort{
+		name: "Ray GCS Server",
+		port: 6379,
+	}
 	dashboardPort = appPort{
 		name: "Ray Dashboard",
 		port: 8265,
@@ -164,7 +168,7 @@ func (options *SessionOptions) Run(ctx context.Context, factory cmdutil.Factory)
 	var appPorts []appPort
 	switch options.ResourceType {
 	case util.RayCluster:
-		appPorts = []appPort{dashboardPort, clientPort}
+		appPorts = []appPort{gcsPort, dashboardPort, clientPort}
 	case util.RayJob:
 		appPorts = []appPort{dashboardPort}
 	case util.RayService:


### PR DESCRIPTION
in `kubectl ray session` command for RayClusters
so we can use the `ray` CLI, e.g. `ray status --address localhost:6379`.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
