### PR TITLE
[refactor][kubectl-plugin] require cluster in `create workergroup`

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -85,6 +85,7 @@ func NewCreateWorkerGroupCommand(streams genericclioptions.IOStreams) *cobra.Com
 	}
 
 	cmd.Flags().StringVarP(&options.clusterName, "ray-cluster", "c", "", "Ray cluster to add a worker group to")
+	cobra.CheckErr(cmd.MarkFlagRequired("ray-cluster"))
 	cmd.Flags().StringVar(&options.rayVersion, "ray-version", util.RayVersion, "Ray version to use")
 	cmd.Flags().StringVar(&options.image, "image", fmt.Sprintf("rayproject/ray:%s", options.rayVersion), "container image to use")
 	cmd.Flags().Int32Var(&options.workerReplicas, "worker-replicas", 1, "desired replicas")


### PR DESCRIPTION
command in the Cobra way.

## Before

```console
$ kubectl ray --context gke_kubeflow-platform_europe-west4-b_ml-compute-1 create workergroup -n hyperkube other-group
Error: error getting Ray cluster: resource name may not be empty
```

## After

```console
$ kubectl ray create workergroup other-group
Error: required flag(s) "ray-cluster" not set
```

Signed-off-by: David Xia <david@davidxia.com>

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
