### PR TITLE
[refactor][kubectl-plugin] require one posarg in `session`

### DIFF
--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -82,12 +82,18 @@ func NewClusterLogCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmdFactory := cmdutil.NewFactory(options.configFlags)
 
 	cmd := &cobra.Command{
-		Use:               "log (RAYCLUSTER | TYPE/NAME) [--out-dir DIR_PATH] [--node-type all|head|worker]",
-		Short:             "Get Ray cluster logs",
-		Long:              logLong,
-		Example:           logExample,
-		Aliases:           []string{"logs"},
-		SilenceUsage:      true,
+		Use:          "log (RAYCLUSTER | TYPE/NAME) [--out-dir DIR_PATH] [--node-type all|head|worker]",
+		Short:        "Get Ray cluster logs",
+		Long:         logLong,
+		Example:      logExample,
+		Aliases:      []string{"logs"},
+		SilenceUsage: true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return cmdutil.UsageErrorf(cmd, "accepts 1 arg, received %d\n%s", len(args), cmd.Use)
+			}
+			return nil
+		},
 		ValidArgsFunction: completion.RayClusterResourceNameCompletionFunc(cmdFactory),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.Complete(cmd, args); err != nil {
@@ -106,10 +112,6 @@ func NewClusterLogCommand(streams genericclioptions.IOStreams) *cobra.Command {
 }
 
 func (options *ClusterLogOptions) Complete(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return cmdutil.UsageErrorf(cmd, "%s", cmd.Use)
-	}
-
 	if *options.configFlags.Namespace == "" {
 		*options.configFlags.Namespace = "default"
 	}

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -157,16 +157,6 @@ func TestRayClusterLogComplete(t *testing.T) {
 			hasErr:               false,
 		},
 		{
-			name:   "invalid args (no args)",
-			args:   []string{},
-			hasErr: true,
-		},
-		{
-			name:   "invalid args (too many args)",
-			args:   []string{"raycluster/test-raycluster", "extra-arg"},
-			hasErr: true,
-		},
-		{
 			name:   "invalid args (no resource type)",
 			args:   []string{"/test-resource"},
 			hasErr: true,

--- a/kubectl-plugin/pkg/cmd/session/session.go
+++ b/kubectl-plugin/pkg/cmd/session/session.go
@@ -83,10 +83,16 @@ func NewSessionCommand(streams genericiooptions.IOStreams) *cobra.Command {
 	factory := cmdutil.NewFactory(options.configFlags)
 
 	cmd := &cobra.Command{
-		Use:               "session (RAYCLUSTER | TYPE/NAME)",
-		Short:             "Forward local ports to the Ray resources.",
-		Long:              sessionLong,
-		Example:           sessionExample,
+		Use:     "session (RAYCLUSTER | TYPE/NAME)",
+		Short:   "Forward local ports to the Ray resources.",
+		Long:    sessionLong,
+		Example: sessionExample,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return cmdutil.UsageErrorf(cmd, "accepts 1 arg, received %d\n%s", len(args), cmd.Use)
+			}
+			return nil
+		},
 		ValidArgsFunction: completion.RayClusterResourceNameCompletionFunc(factory),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := options.Complete(cmd, args); err != nil {
@@ -106,10 +112,6 @@ func NewSessionCommand(streams genericiooptions.IOStreams) *cobra.Command {
 }
 
 func (options *SessionOptions) Complete(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return cmdutil.UsageErrorf(cmd, "%s", cmd.Use)
-	}
-
 	typeAndName := strings.Split(args[0], "/")
 	if len(typeAndName) == 1 {
 		options.ResourceType = util.RayCluster

--- a/kubectl-plugin/pkg/cmd/session/session_test.go
+++ b/kubectl-plugin/pkg/cmd/session/session_test.go
@@ -68,16 +68,6 @@ func TestComplete(t *testing.T) {
 			hasErr:               false,
 		},
 		{
-			name:   "invalid args (no args)",
-			args:   []string{},
-			hasErr: true,
-		},
-		{
-			name:   "invalid args (too many args)",
-			args:   []string{"raycluster/test-raycluster", "extra-arg"},
-			hasErr: true,
-		},
-		{
 			name:   "invalid args (no resource type)",
 			args:   []string{"/test-resource"},
 			hasErr: true,


### PR DESCRIPTION
command with a custom Cobra `Command.Args` function instead of writing our own
logic in `Complete()`.

## Before

```console
$ kubectl ray session

Error: session (RAYCLUSTER | TYPE/NAME)
See 'ray session -h' for help and examples

$ kubectl ray logs

Error: log (RAYCLUSTER | TYPE/NAME) [--out-dir DIR_PATH] [--node-type all|head|worker]
See 'ray log -h' for help and examples
```

## After

```console
$ kubectl ray session

Error: accepts 1 arg, received 0
session (RAYCLUSTER | TYPE/NAME)
See 'ray session -h' for help and examples

$ kubectl ray logs

Error: accepts 1 arg, received 0
log (RAYCLUSTER | TYPE/NAME) [--out-dir DIR_PATH] [--node-type all|head|worker]
See 'ray log -h' for help and examples
```

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
