### PR TITLE
[refactor][kubectl-plugin] make `--node-type` an enum flag

### DIFF
--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -32,12 +32,51 @@ import (
 
 const filePathInPod = "/tmp/ray/session_latest/logs/"
 
+type nodeTypeEnum string
+
+const (
+	allNodeType    nodeTypeEnum = "all"
+	headNodeType   nodeTypeEnum = "head"
+	workerNodeType nodeTypeEnum = "worker"
+)
+
+// String is used both by fmt.Print and by Cobra in help text
+func (e *nodeTypeEnum) String() string {
+	return string(*e)
+}
+
+// Set must have pointer receiver so it doesn't change the value of a copy
+func (e *nodeTypeEnum) Set(v string) error {
+	val := strings.ToLower(v)
+
+	switch val {
+	case string(allNodeType), string(headNodeType), string(workerNodeType):
+		*e = nodeTypeEnum(val)
+		return nil
+	default:
+		return fmt.Errorf("must be one of %q, %q, or %q", allNodeType, headNodeType, workerNodeType)
+	}
+}
+
+// Type is only used in help text
+func (e *nodeTypeEnum) Type() string {
+	return "enum"
+}
+
+func nodeTypeCompletion(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return []string{
+		fmt.Sprintf("%s\tdownload logs from %s Ray nodes", allNodeType, allNodeType),
+		fmt.Sprintf("%s\tdownload logs from %s Ray nodes", headNodeType, headNodeType),
+		fmt.Sprintf("%s\tdownload logs from %s Ray nodes", workerNodeType, workerNodeType),
+	}, cobra.ShellCompDirectiveDefault
+}
+
 type ClusterLogOptions struct {
 	configFlags  *genericclioptions.ConfigFlags
 	ioStreams    *genericclioptions.IOStreams
 	Executor     RemoteExecutor
 	outputDir    string
-	nodeType     string
+	nodeType     nodeTypeEnum
 	ResourceName string
 	ResourceType util.ResourceType
 }
@@ -73,6 +112,7 @@ func NewClusterLogOptions(streams genericclioptions.IOStreams) *ClusterLogOption
 		configFlags: genericclioptions.NewConfigFlags(true),
 		ioStreams:   &streams,
 		Executor:    &DefaultRemoteExecutor{},
+		nodeType:    allNodeType,
 	}
 }
 
@@ -100,7 +140,10 @@ func NewClusterLogCommand(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&options.outputDir, "out-dir", options.outputDir, "directory to save the logs to")
-	cmd.Flags().StringVar(&options.nodeType, "node-type", options.nodeType, "type of Ray node from which to download log, supports 'worker', 'head', or 'all'")
+	cmd.Flags().Var(&options.nodeType, "node-type", "type of Ray node from which to download logs, supports: 'worker', 'head', or 'all'")
+
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("node-type", nodeTypeCompletion))
+
 	options.configFlags.AddFlags(cmd.Flags())
 	return cmd
 }
@@ -135,12 +178,6 @@ func (options *ClusterLogOptions) Complete(cmd *cobra.Command, args []string) er
 		}
 
 		options.ResourceName = typeAndName[1]
-	}
-
-	if options.nodeType == "" {
-		options.nodeType = "all"
-	} else {
-		options.nodeType = strings.ToLower(options.nodeType)
 	}
 
 	return nil

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -117,18 +117,16 @@ func TestRayClusterLogComplete(t *testing.T) {
 
 	tests := []struct {
 		name                 string
-		nodeType             string
+		nodeType             nodeTypeEnum
 		expectedResourceType util.ResourceType
 		expectedResourceName string
-		expectedNodeType     string
 		args                 []string
 		hasErr               bool
 	}{
 		{
-			name:                 "valid request with RayCluster with empty nodetype input",
+			name:                 "valid request with RayCluster",
 			expectedResourceType: util.RayCluster,
 			expectedResourceName: "test-raycluster",
-			expectedNodeType:     "all",
 			args:                 []string{"test-raycluster"},
 			hasErr:               false,
 		},
@@ -137,7 +135,6 @@ func TestRayClusterLogComplete(t *testing.T) {
 			expectedResourceType: util.RayCluster,
 			expectedResourceName: "test-raycluster",
 			args:                 []string{"rayCluster/test-raycluster"},
-			expectedNodeType:     "all",
 			hasErr:               false,
 		},
 		{
@@ -145,7 +142,6 @@ func TestRayClusterLogComplete(t *testing.T) {
 			expectedResourceType: util.RayService,
 			expectedResourceName: "test-rayservice",
 			args:                 []string{"rayservice/test-rayservice"},
-			expectedNodeType:     "all",
 			hasErr:               false,
 		},
 		{
@@ -153,7 +149,6 @@ func TestRayClusterLogComplete(t *testing.T) {
 			expectedResourceType: util.RayJob,
 			expectedResourceName: "test-rayJob",
 			args:                 []string{"rayJob/test-rayJob"},
-			expectedNodeType:     "all",
 			hasErr:               false,
 		},
 		{
@@ -187,6 +182,7 @@ func TestRayClusterLogComplete(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
 			fakeClusterLogOptions := NewClusterLogOptions(testStreams)
+			fakeClusterLogOptions.nodeType = tc.nodeType
 			err := fakeClusterLogOptions.Complete(cmd, tc.args)
 			if tc.hasErr {
 				require.Error(t, err)
@@ -194,7 +190,6 @@ func TestRayClusterLogComplete(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tc.expectedResourceType, fakeClusterLogOptions.ResourceType)
 				assert.Equal(t, tc.expectedResourceName, fakeClusterLogOptions.ResourceName)
-				assert.Equal(t, tc.expectedNodeType, fakeClusterLogOptions.nodeType)
 			}
 		})
 	}
@@ -237,7 +232,7 @@ func TestRayClusterLogValidate(t *testing.T) {
 				},
 				outputDir:    fakeDir,
 				ResourceName: "fake-cluster",
-				nodeType:     "head",
+				nodeType:     headNodeType,
 				ioStreams:    &testStreams,
 			},
 			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
@@ -251,7 +246,7 @@ func TestRayClusterLogValidate(t *testing.T) {
 				},
 				outputDir:    fakeDir,
 				ResourceName: "fake-cluster",
-				nodeType:     "head",
+				nodeType:     workerNodeType,
 				ioStreams:    &testStreams,
 			},
 		},
@@ -264,7 +259,7 @@ func TestRayClusterLogValidate(t *testing.T) {
 				},
 				outputDir:    fakeDir,
 				ResourceName: "fake-cluster",
-				nodeType:     "head",
+				nodeType:     allNodeType,
 				ioStreams:    &testStreams,
 			},
 		},
@@ -287,7 +282,7 @@ func TestRayClusterLogValidate(t *testing.T) {
 				configFlags:  fakeConfigFlags,
 				outputDir:    fakeDir,
 				ResourceName: "fake-cluster",
-				nodeType:     "head",
+				nodeType:     headNodeType,
 				ioStreams:    &testStreams,
 			},
 			expectError: "",
@@ -299,7 +294,7 @@ func TestRayClusterLogValidate(t *testing.T) {
 				configFlags:  fakeConfigFlags,
 				outputDir:    "",
 				ResourceName: "fake-cluster",
-				nodeType:     "head",
+				nodeType:     headNodeType,
 				ioStreams:    &testStreams,
 			},
 			expectError: "",
@@ -311,7 +306,7 @@ func TestRayClusterLogValidate(t *testing.T) {
 				configFlags:  fakeConfigFlags,
 				outputDir:    "randomPath-here",
 				ResourceName: "fake-cluster",
-				nodeType:     "head",
+				nodeType:     headNodeType,
 				ioStreams:    &testStreams,
 			},
 			expectError: "Directory does not exist. Failed with: stat randomPath-here: no such file or directory",
@@ -323,7 +318,7 @@ func TestRayClusterLogValidate(t *testing.T) {
 				configFlags:  fakeConfigFlags,
 				outputDir:    kubeConfigWithCurrentContext,
 				ResourceName: "fake-cluster",
-				nodeType:     "head",
+				nodeType:     headNodeType,
 				ioStreams:    &testStreams,
 			},
 			expectError: "Path is not a directory. Please input a directory and try again",


### PR DESCRIPTION
in the `kubectl ray log` command.

This is more complex but has several advantages.

* better help and error messages, e.g. shows the default "all" value in the
  help messages
* more type-safe
* can set the default value of "all" more easily
* supports shell completion

References

* https://stackoverflow.com/a/70541824/553994
* https://applejag.eu/blog/go-spf13-cobra-custom-flag-types/

## Before

```console
$ kubectl ray logs -h
...
      --node-type string               type of Ray node from which to download log, supports 'worker', 'head', or 'all'
...

$ kubectl ray logs dxia-test
No output directory specified, creating dir under current directory using resource name.
Command set to retrieve both head and worker node logs.
Downloading log for Ray Node dxia-test-default-group-worker-dgxsl
Downloading log for Ray Node dxia-test-head-xnh9r

$ kubectl ray logs dxia-test --node-type foo
No output directory specified, creating dir under current directory using resource name.
Error: unknown node type `foo`

$ kubectl ray logs dxia-test --node-type WORKER
No output directory specified, creating dir under current directory using resource name.
Command set to retrieve only worker node logs.
Downloading log for Ray Node dxia-test-default-group-worker-dgxsl
```

## After

```console
$ kubectl ray logs -h
...
      --node-type enum                 type of Ray node from which to download logs, supports: 'worker', 'head', or 'all' (default all)
...

$ kubectl ray logs dxia-test
No output directory specified, creating dir under current directory using resource name.
Command set to retrieve both head and worker node logs.
Downloading log for Ray Node dxia-test-default-group-worker-dgxsl
Downloading log for Ray Node dxia-test-head-xnh9r

$ kubectl ray logs dxia-test --node-type foo
Error: invalid argument "foo" for "--node-type" flag: must be one of "all", "head", or "worker"

$ kubectl ray logs dxia-test --node-type WORKER
No output directory specified, creating dir under current directory using resource name.
Command set to retrieve only worker node logs.
Downloading log for Ray Node dxia-test-default-group-worker-dgxsl
```

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
