### PR TITLE
[fix][kubectl-plugin] incorrect console message

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -223,7 +223,7 @@ func (options *SubmitJobOptions) Validate() error {
 
 		options.RayJob, err = decodeRayJobYaml(options.fileName)
 		if err != nil {
-			return fmt.Errorf("Failed to decode RayJob Yaml: %w", err)
+			return fmt.Errorf("Failed to decode RayJob YAML: %w", err)
 		}
 
 		submissionMode := options.RayJob.Spec.SubmissionMode
@@ -240,7 +240,7 @@ func (options *SubmitJobOptions) Validate() error {
 			options.runtimeEnvJson = string(runtimeJson)
 		}
 	} else if strings.TrimSpace(options.rayjobName) == "" {
-		return fmt.Errorf("Must set either yaml file (--filename) or set Ray job name (--name)")
+		return fmt.Errorf("Must set either YAML file (--filename) or set Ray job name (--name)")
 	}
 
 	if options.workingDir == "" {
@@ -332,7 +332,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 		}
 		clusterReady = isRayClusterReady(currCluster)
 		if !clusterReady {
-			err = fmt.Errorf("Cluster is not ready: %w", err)
+			err = fmt.Errorf("cluster %s is not ready", options.cluster)
 			fmt.Println(err)
 		}
 		currTime = time.Now()


### PR DESCRIPTION
in `kubectl ray job submit` command.

There's no error details we can show so remove them. Currently console messages show.

```console
$ kubectl ray job submit -f /tmp/test/ray-job.sample.yaml --working-dir /tmp/test -- python /tmp/test/script.py

Submitted RayJob dxia-rayjob.
Waiting for RayCluster
Checking Cluster Status for cluster dxia-rayjob-raycluster-sslzr...
Cluster is not ready: %!w(<nil>)
Cluster is not ready: %!w(<nil>)
Cluster is not ready: %!w(<nil>)
...
```

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
