### PR TITLE
[Fix][CI] E2E tests do not reflect error

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -13,7 +13,8 @@
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run e2e tests and print KubeRay operator logs if tests fail
     - echo "--- START:Running e2e rayservice (nightly operator) tests"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2e | awk -f ../.buildkite/format.awk || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
+    - set -o pipefail
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2e 2>&1 | awk -f ../.buildkite/format.awk || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
     - echo "--- END:e2e rayservice (nightly operator) tests finished"
 
 - label: 'Test E2E rayservice (nightly operator)'
@@ -31,7 +32,8 @@
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run e2e tests and print KubeRay operator logs if tests fail
     - echo "--- START:Running e2e rayservice (nightly operator) tests"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2erayservice | awk -f ../.buildkite/format.awk || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
+    - set -o pipefail
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2erayservice 2>&1 | awk -f ../.buildkite/format.awk || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
     - echo "--- END:e2e rayservice (nightly operator) tests finished"
 
 - label: 'Test Autoscaler E2E (nightly operator)'
@@ -49,5 +51,6 @@
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run e2e tests and print KubeRay operator logs if tests fail
     - echo "--- START:Running Autoscaler e2e (nightly operator) tests"
+    - set -o pipefail
     - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2eautoscaler | awk -f ../.buildkite/format.awk || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
     - echo "--- END:Autoscaler e2e (nightly operator) tests finished"

--- a/.buildkite/test-kubectl-plugin-e2e.yml
+++ b/.buildkite/test-kubectl-plugin-e2e.yml
@@ -19,5 +19,6 @@
     - cp ./kubectl-ray /usr/local/bin
     # Run e2e tests
     - echo "--- START:Running Test E2E (kubectl-plugin) tests"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2e  | awk -f ../.buildkite/format.awk
+    - set -o pipefail
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2e 2>&1 | awk -f ../.buildkite/format.awk
     - echo "--- END:Test E2E (kubectl-plugin) tests finished"

--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -13,7 +13,8 @@
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run sample YAML tests
     - echo "--- START:Running Sample YAMLs (nightly operator) tests"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/sampleyaml | awk -f ../.buildkite/format.awk
+    - set -o pipefail
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/sampleyaml 2>&1 | awk -f ../.buildkite/format.awk
     - echo "--- END:Sample YAMLs (nightly operator) tests finished"
     # Printing KubeRay operator logs
     - kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay
@@ -31,7 +32,8 @@
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run sample YAML tests
     - echo "--- START:Running Sample YAMLs (latest release) tests"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/sampleyaml | awk -f ../.buildkite/format.awk
+    - set -o pipefail
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/sampleyaml 2>&1 | awk -f ../.buildkite/format.awk
     - echo "--- END:Sample YAMLs (latest release) tests finished"
     # Printing KubeRay operator logs
     - kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/6857#0194f71f-8691-49cf-9279-cfc00c5e82fc

e2e tests failed but displayed success.

![image](https://github.com/user-attachments/assets/60c5de85-3085-4c21-ad8b-fa8365b6891f)

After this PR:

https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/6859#0194f740-3433-43ad-aaf1-f81de55661b5

![image](https://github.com/user-attachments/assets/1096acaf-751f-4613-a7fe-df40dbb000fe)

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
