### PR TITLE
[CI] dump failed test k8s resources

### DIFF
--- a/ray-operator/test/sampleyaml/rayjob_test.go
+++ b/ray-operator/test/sampleyaml/rayjob_test.go
@@ -46,6 +46,7 @@ func TestRayJob(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(rayJob).NotTo(BeNil())
 
+			// Wait for RayCluster name to be populated
 			g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
 				Should(WithTransform(RayJobClusterName, Not(BeEmpty())))
 

--- a/ray-operator/test/sampleyaml/rayjob_test.go
+++ b/ray-operator/test/sampleyaml/rayjob_test.go
@@ -42,22 +42,22 @@ func TestRayJob(t *testing.T) {
 			KubectlApplyYAML(test, yamlFilePath, namespace.Name)
 
 			rayJob, err := GetRayJob(test, namespace.Name, rayJobFromYaml.Name)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(rayJob).NotTo(BeNil())
+			g.Expect(err).NotTo(HaveOccurred(), LogRayJobRelatedResources(test))
+			g.Expect(rayJob).NotTo(BeNil(), LogRayJobRelatedResources(test))
 
 			// Wait for RayCluster name to be populated
 			g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
 				Should(WithTransform(RayJobClusterName, Not(BeEmpty())), LogRayJobRelatedResources(test))
 
 			rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(rayJob).NotTo(BeNil())
+			g.Expect(err).NotTo(HaveOccurred(), LogRayJobRelatedResources(test))
+			g.Expect(rayJob).NotTo(BeNil(), LogRayJobRelatedResources(test))
 
 			test.T().Logf("Waiting for RayCluster %s/%s to be ready", namespace.Name, rayJob.Status.RayClusterName)
 			g.Eventually(RayCluster(test, namespace.Name, rayJob.Status.RayClusterName), TestTimeoutMedium).
 				Should(WithTransform(RayClusterState, Equal(rayv1.Ready)), LogRayJobRelatedResources(test))
 			rayCluster, err := GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
-			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred(), LogRayJobRelatedResources(test))
 
 			// Check if the RayCluster created correct number of pods
 			var desiredWorkerReplicas int32
@@ -67,7 +67,7 @@ func TestRayJob(t *testing.T) {
 				}
 			}
 			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutShort).Should(HaveLen(int(desiredWorkerReplicas)), LogRayJobRelatedResources(test))
-			g.Expect(GetRayCluster(test, namespace.Name, rayCluster.Name)).To(WithTransform(RayClusterDesiredWorkerReplicas, Equal(desiredWorkerReplicas)))
+			g.Expect(GetRayCluster(test, namespace.Name, rayCluster.Name)).To(WithTransform(RayClusterDesiredWorkerReplicas, Equal(desiredWorkerReplicas)), LogRayJobRelatedResources(test))
 
 			// Check if the head pod is ready
 			g.Eventually(HeadPod(test, rayCluster), TestTimeoutShort).Should(WithTransform(IsPodRunningAndReady, BeTrue()), LogRayJobRelatedResources(test))

--- a/ray-operator/test/sampleyaml/rayjob_test.go
+++ b/ray-operator/test/sampleyaml/rayjob_test.go
@@ -47,7 +47,7 @@ func TestRayJob(t *testing.T) {
 
 			// Wait for RayCluster name to be populated
 			g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
-				Should(WithTransform(RayJobClusterName, Not(BeEmpty())))
+				Should(WithTransform(RayJobClusterName, Not(BeEmpty())), LogRayJobRelatedResources(test))
 
 			rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -55,7 +55,7 @@ func TestRayJob(t *testing.T) {
 
 			test.T().Logf("Waiting for RayCluster %s/%s to be ready", namespace.Name, rayJob.Status.RayClusterName)
 			g.Eventually(RayCluster(test, namespace.Name, rayJob.Status.RayClusterName), TestTimeoutMedium).
-				Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
+				Should(WithTransform(RayClusterState, Equal(rayv1.Ready)), LogRayJobRelatedResources(test))
 			rayCluster, err := GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
 			g.Expect(err).NotTo(HaveOccurred())
 
@@ -66,18 +66,18 @@ func TestRayJob(t *testing.T) {
 					desiredWorkerReplicas += *workerGroupSpec.Replicas
 				}
 			}
-			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutShort).Should(HaveLen(int(desiredWorkerReplicas)))
+			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutShort).Should(HaveLen(int(desiredWorkerReplicas)), LogRayJobRelatedResources(test))
 			g.Expect(GetRayCluster(test, namespace.Name, rayCluster.Name)).To(WithTransform(RayClusterDesiredWorkerReplicas, Equal(desiredWorkerReplicas)))
 
 			// Check if the head pod is ready
-			g.Eventually(HeadPod(test, rayCluster), TestTimeoutShort).Should(WithTransform(IsPodRunningAndReady, BeTrue()))
+			g.Eventually(HeadPod(test, rayCluster), TestTimeoutShort).Should(WithTransform(IsPodRunningAndReady, BeTrue()), LogRayJobRelatedResources(test))
 
 			// Check if all worker pods are ready
-			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutShort).Should(WithTransform(AllPodsRunningAndReady, BeTrue()))
+			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutShort).Should(WithTransform(AllPodsRunningAndReady, BeTrue()), LogRayJobRelatedResources(test))
 
-			g.Eventually(RayJob(test, namespace.Name, rayJobFromYaml.Name), TestTimeoutMedium).Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
+			g.Eventually(RayJob(test, namespace.Name, rayJobFromYaml.Name), TestTimeoutMedium).Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)), LogRayJobRelatedResources(test))
 
-			g.Eventually(RayJob(test, namespace.Name, rayJobFromYaml.Name), TestTimeoutMedium).Should(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)))
+			g.Eventually(RayJob(test, namespace.Name, rayJobFromYaml.Name), TestTimeoutMedium).Should(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)), LogRayJobRelatedResources(test))
 		})
 	}
 }

--- a/ray-operator/test/sampleyaml/support.go
+++ b/ray-operator/test/sampleyaml/support.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types" // needed for GomegaTestingT
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -113,65 +114,80 @@ func QueryDashboardGetAppStatus(t Test, rayCluster *rayv1.RayCluster) func(Gomeg
 	}
 }
 
-func LogRayJobRelatedResources(t Test) string {
-	t.T().Helper()
-	var message strings.Builder
+func WithRayJobResourceLogger(t Test) types.GomegaTestingT {
+	return &RayJobResourceLogger{t: t}
+}
 
-	if pods, err := t.Client().Core().CoreV1().Pods("").List(t.Ctx(), metav1.ListOptions{}); err == nil {
-		fmt.Fprintf(&message, "\n=== Pods across all namespaces ===\n")
+type RayJobResourceLogger struct {
+	t Test
+}
+
+func (l *RayJobResourceLogger) Helper() {
+	l.t.T().Helper()
+}
+
+func (l *RayJobResourceLogger) Fatalf(format string, args ...interface{}) {
+	l.Helper()
+	var sb strings.Builder
+
+	// Log the original failure message
+	fmt.Fprintf(&sb, format, args...)
+
+	if pods, err := l.t.Client().Core().CoreV1().Pods("").List(l.t.Ctx(), metav1.ListOptions{}); err == nil {
+		fmt.Fprintf(&sb, "\n=== Pods across all namespaces ===\n")
 		for _, pod := range pods.Items {
 			podJSON, err := json.MarshalIndent(pod, "", "    ")
 			if err != nil {
-				fmt.Fprintf(&message, "Error marshaling pod %s/%s: %v\n", pod.Namespace, pod.Name, err)
+				fmt.Fprintf(&sb, "Error marshaling pod %s/%s: %v\n", pod.Namespace, pod.Name, err)
 				continue
 			}
-			fmt.Fprintf(&message, "---\n# Pod: %s/%s\n%s\n", pod.Namespace, pod.Name, string(podJSON))
+			fmt.Fprintf(&sb, "---\n# Pod: %s/%s\n%s\n", pod.Namespace, pod.Name, string(podJSON))
 		}
 	} else {
-		fmt.Fprintf(&message, "Failed to get pods: %v\n", err)
+		fmt.Fprintf(&sb, "Failed to get pods: %v\n", err)
 	}
 
-	if jobs, err := t.Client().Core().BatchV1().Jobs("").List(t.Ctx(), metav1.ListOptions{}); err == nil {
-		fmt.Fprintf(&message, "\n=== Jobs across all namespaces ===\n")
+	if jobs, err := l.t.Client().Core().BatchV1().Jobs("").List(l.t.Ctx(), metav1.ListOptions{}); err == nil {
+		fmt.Fprintf(&sb, "\n=== Jobs across all namespaces ===\n")
 		for _, job := range jobs.Items {
 			jobJSON, err := json.MarshalIndent(job, "", "    ")
 			if err != nil {
-				fmt.Fprintf(&message, "Error marshaling job %s/%s: %v\n", job.Namespace, job.Name, err)
+				fmt.Fprintf(&sb, "Error marshaling job %s/%s: %v\n", job.Namespace, job.Name, err)
 				continue
 			}
-			fmt.Fprintf(&message, "---\n# Job: %s/%s\n%s\n", job.Namespace, job.Name, string(jobJSON))
+			fmt.Fprintf(&sb, "---\n# Job: %s/%s\n%s\n", job.Namespace, job.Name, string(jobJSON))
 		}
 	} else {
-		fmt.Fprintf(&message, "Failed to get jobs: %v\n", err)
+		fmt.Fprintf(&sb, "Failed to get jobs: %v\n", err)
 	}
 
-	if services, err := t.Client().Core().CoreV1().Services("").List(t.Ctx(), metav1.ListOptions{}); err == nil {
-		fmt.Fprintf(&message, "\n=== Services across all namespaces ===\n")
+	if services, err := l.t.Client().Core().CoreV1().Services("").List(l.t.Ctx(), metav1.ListOptions{}); err == nil {
+		fmt.Fprintf(&sb, "\n=== Services across all namespaces ===\n")
 		for _, svc := range services.Items {
 			serviceJSON, err := json.MarshalIndent(svc, "", "    ")
 			if err != nil {
-				fmt.Fprintf(&message, "Error marshaling service %s/%s: %v\n", svc.Namespace, svc.Name, err)
+				fmt.Fprintf(&sb, "Error marshaling service %s/%s: %v\n", svc.Namespace, svc.Name, err)
 				continue
 			}
-			fmt.Fprintf(&message, "---\n# Service: %s/%s\n%s\n", svc.Namespace, svc.Name, string(serviceJSON))
+			fmt.Fprintf(&sb, "---\n# Service: %s/%s\n%s\n", svc.Namespace, svc.Name, string(serviceJSON))
 		}
 	} else {
-		fmt.Fprintf(&message, "Failed to get services: %v\n", err)
+		fmt.Fprintf(&sb, "Failed to get services: %v\n", err)
 	}
 
-	if rayJobs, err := t.Client().Ray().RayV1().RayJobs("").List(t.Ctx(), metav1.ListOptions{}); err == nil {
-		fmt.Fprintf(&message, "\n=== RayJobs across all namespaces ===\n")
+	if rayJobs, err := l.t.Client().Ray().RayV1().RayJobs("").List(l.t.Ctx(), metav1.ListOptions{}); err == nil {
+		fmt.Fprintf(&sb, "\n=== RayJobs across all namespaces ===\n")
 		for _, rayJob := range rayJobs.Items {
 			rayJobJSON, err := json.MarshalIndent(rayJob, "", "    ")
 			if err != nil {
-				fmt.Fprintf(&message, "Error marshaling rayjob %s/%s: %v\n", rayJob.Namespace, rayJob.Name, err)
+				fmt.Fprintf(&sb, "Error marshaling rayjob %s/%s: %v\n", rayJob.Namespace, rayJob.Name, err)
 				continue
 			}
-			fmt.Fprintf(&message, "---\n# RayJob: %s/%s\n%s\n", rayJob.Namespace, rayJob.Name, string(rayJobJSON))
+			fmt.Fprintf(&sb, "---\n# RayJob: %s/%s\n%s\n", rayJob.Namespace, rayJob.Name, string(rayJobJSON))
 		}
 	} else {
-		fmt.Fprintf(&message, "Failed to get rayjobs: %v\n", err)
+		fmt.Fprintf(&sb, "Failed to get rayjobs: %v\n", err)
 	}
 
-	return message.String()
+	l.t.T().Fatal(sb.String())
 }

--- a/ray-operator/test/sampleyaml/support.go
+++ b/ray-operator/test/sampleyaml/support.go
@@ -1,15 +1,18 @@
 package sampleyaml
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
@@ -108,4 +111,67 @@ func QueryDashboardGetAppStatus(t Test, rayCluster *rayv1.RayCluster) func(Gomeg
 			g.Expect(value.ServeApplicationStatus.Status).To(Equal(rayv1.ApplicationStatusEnum.RUNNING))
 		}
 	}
+}
+
+func LogRayJobRelatedResources(t Test) string {
+	t.T().Helper()
+	var message strings.Builder
+
+	if pods, err := t.Client().Core().CoreV1().Pods("").List(t.Ctx(), metav1.ListOptions{}); err == nil {
+		fmt.Fprintf(&message, "\n=== Pods across all namespaces ===\n")
+		for _, pod := range pods.Items {
+			podJSON, err := json.MarshalIndent(pod, "", "    ")
+			if err != nil {
+				fmt.Fprintf(&message, "Error marshaling pod %s/%s: %v\n", pod.Namespace, pod.Name, err)
+				continue
+			}
+			fmt.Fprintf(&message, "---\n# Pod: %s/%s\n%s\n", pod.Namespace, pod.Name, string(podJSON))
+		}
+	} else {
+		fmt.Fprintf(&message, "Failed to get pods: %v\n", err)
+	}
+
+	if jobs, err := t.Client().Core().BatchV1().Jobs("").List(t.Ctx(), metav1.ListOptions{}); err == nil {
+		fmt.Fprintf(&message, "\n=== Jobs across all namespaces ===\n")
+		for _, job := range jobs.Items {
+			jobJSON, err := json.MarshalIndent(job, "", "    ")
+			if err != nil {
+				fmt.Fprintf(&message, "Error marshaling job %s/%s: %v\n", job.Namespace, job.Name, err)
+				continue
+			}
+			fmt.Fprintf(&message, "---\n# Job: %s/%s\n%s\n", job.Namespace, job.Name, string(jobJSON))
+		}
+	} else {
+		fmt.Fprintf(&message, "Failed to get jobs: %v\n", err)
+	}
+
+	if services, err := t.Client().Core().CoreV1().Services("").List(t.Ctx(), metav1.ListOptions{}); err == nil {
+		fmt.Fprintf(&message, "\n=== Services across all namespaces ===\n")
+		for _, svc := range services.Items {
+			serviceJSON, err := json.MarshalIndent(svc, "", "    ")
+			if err != nil {
+				fmt.Fprintf(&message, "Error marshaling service %s/%s: %v\n", svc.Namespace, svc.Name, err)
+				continue
+			}
+			fmt.Fprintf(&message, "---\n# Service: %s/%s\n%s\n", svc.Namespace, svc.Name, string(serviceJSON))
+		}
+	} else {
+		fmt.Fprintf(&message, "Failed to get services: %v\n", err)
+	}
+
+	if rayJobs, err := t.Client().Ray().RayV1().RayJobs("").List(t.Ctx(), metav1.ListOptions{}); err == nil {
+		fmt.Fprintf(&message, "\n=== RayJobs across all namespaces ===\n")
+		for _, rayJob := range rayJobs.Items {
+			rayJobJSON, err := json.MarshalIndent(rayJob, "", "    ")
+			if err != nil {
+				fmt.Fprintf(&message, "Error marshaling rayjob %s/%s: %v\n", rayJob.Namespace, rayJob.Name, err)
+				continue
+			}
+			fmt.Fprintf(&message, "---\n# RayJob: %s/%s\n%s\n", rayJob.Namespace, rayJob.Name, string(rayJobJSON))
+		}
+	} else {
+		fmt.Fprintf(&message, "Failed to get rayjobs: %v\n", err)
+	}
+
+	return message.String()
 }

--- a/ray-operator/test/sampleyaml/support.go
+++ b/ray-operator/test/sampleyaml/support.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types" // needed for GomegaTestingT
+	"github.com/onsi/gomega/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Dump k8s resources including pods, jobs, services, rayjobs when sampleyaml test failed.
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Better logs for debugging.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#2979
<!-- For example: "Closes #1234" -->
## Result
### collapsed format with default error message
![CleanShot 2025-02-13 at 16 50 48@2x](https://github.com/user-attachments/assets/a8e8b034-d357-464c-8407-b9b47a3628da)

### json content
![CleanShot 2025-02-13 at 16 51 18@2x](https://github.com/user-attachments/assets/99b90132-3913-413c-817a-4db80f51cdf7)

### end of logs with collapsed format
![CleanShot 2025-02-13 at 16 48 54@2x](https://github.com/user-attachments/assets/7ff6662a-d696-4f38-9692-1b9e25891324)


file size with error logs: 2.3MB


## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
