### PR TITLE
[Fix][kubectl-plugin] Don't print wrapped error for job submit startup

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -332,8 +332,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 		}
 		clusterReady = isRayClusterReady(currCluster)
 		if !clusterReady {
-			err = fmt.Errorf("Cluster is not ready: %w", err)
-			fmt.Println(err)
+			fmt.Println("Cluster is not ready")
 		}
 		currTime = time.Now()
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`err` is not releated to `isRayClusterReady`. Don't print it.

Before:

![Image](https://github.com/user-attachments/assets/f4c09e5a-3ddb-4203-a0e3-24ccf2ace858)

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
