### PR TITLE
[refactor][kubectl-plugin] simplify cobra `Validate()` tests

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -19,6 +19,7 @@ import (
 type CreateClusterOptions struct {
 	configFlags    *genericclioptions.ConfigFlags
 	ioStreams      *genericclioptions.IOStreams
+	kubeContexter  util.KubeContexter
 	clusterName    string
 	rayVersion     string
 	image          string
@@ -48,8 +49,9 @@ var (
 
 func NewCreateClusterOptions(streams genericclioptions.IOStreams) *CreateClusterOptions {
 	return &CreateClusterOptions{
-		configFlags: genericclioptions.NewConfigFlags(true),
-		ioStreams:   &streams,
+		configFlags:   genericclioptions.NewConfigFlags(true),
+		ioStreams:     &streams,
+		kubeContexter: &util.DefaultKubeContexter{},
 	}
 }
 
@@ -112,7 +114,7 @@ func (options *CreateClusterOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("error retrieving raw config: %w", err)
 	}
-	if !util.HasKubectlContext(config, options.configFlags) {
+	if !options.kubeContexter.HasContext(config, options.configFlags) {
 		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 

--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -23,80 +23,24 @@ func TestRayCreateClusterComplete(t *testing.T) {
 }
 
 func TestRayCreateClusterValidate(t *testing.T) {
-	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-	testNS, testContext, testBT, testImpersonate := "test-namespace", "test-context", "test-bearer-token", "test-person"
-
-	kubeConfigWithCurrentContext, err := util.CreateTempKubeConfigFile(t, testContext)
-	require.NoError(t, err)
-
-	kubeConfigWithoutCurrentContext, err := util.CreateTempKubeConfigFile(t, "")
-	require.NoError(t, err)
-
 	tests := []struct {
 		name        string
 		opts        *CreateClusterOptions
 		expectError string
 	}{
 		{
-			name: "Test validation when no context is set",
+			name: "should error when no K8s context is set",
 			opts: &CreateClusterOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-				},
-				ioStreams: &testStreams,
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				kubeContexter: util.NewMockKubeContexter(false),
 			},
 			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
 		},
 		{
-			name: "no error when kubeconfig has current context and --context switch isn't set",
+			name: "should not error when K8s context is set",
 			opts: &CreateClusterOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithCurrentContext,
-				},
-				ioStreams: &testStreams,
-			},
-		},
-		{
-			name: "no error when kubeconfig has no current context and --context switch is set",
-			opts: &CreateClusterOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-					Context:    &testContext,
-				},
-				ioStreams: &testStreams,
-			},
-		},
-		{
-			name: "no error when kubeconfig has current context and --context switch is set",
-			opts: &CreateClusterOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithCurrentContext,
-					Context:    &testContext,
-				},
-				ioStreams: &testStreams,
-			},
-		},
-		{
-			name: "Successful submit job validation with RayJob",
-			opts: &CreateClusterOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					Namespace:        &testNS,
-					Context:          &testContext,
-					KubeConfig:       &kubeConfigWithCurrentContext,
-					BearerToken:      &testBT,
-					Impersonate:      &testImpersonate,
-					ImpersonateGroup: &[]string{"fake-group"},
-				},
-				ioStreams:      &testStreams,
-				clusterName:    "fakeclustername",
-				rayVersion:     "ray-version",
-				image:          "ray-image",
-				headCPU:        "5",
-				headGPU:        "1",
-				headMemory:     "5Gi",
-				workerReplicas: 3,
-				workerCPU:      "4",
-				workerMemory:   "5Gi",
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				kubeContexter: util.NewMockKubeContexter(true),
 			},
 		},
 	}

--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -23,6 +23,7 @@ import (
 type CreateWorkerGroupOptions struct {
 	configFlags       *genericclioptions.ConfigFlags
 	ioStreams         *genericclioptions.IOStreams
+	kubeContexter     util.KubeContexter
 	clusterName       string
 	groupName         string
 	rayVersion        string
@@ -51,8 +52,9 @@ var (
 
 func NewCreateWorkerGroupOptions(streams genericclioptions.IOStreams) *CreateWorkerGroupOptions {
 	return &CreateWorkerGroupOptions{
-		configFlags: genericclioptions.NewConfigFlags(true),
-		ioStreams:   &streams,
+		configFlags:   genericclioptions.NewConfigFlags(true),
+		ioStreams:     &streams,
+		kubeContexter: &util.DefaultKubeContexter{},
 	}
 }
 
@@ -117,7 +119,7 @@ func (options *CreateWorkerGroupOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving raw config: %w", err)
 	}
-	if !util.HasKubectlContext(config, options.configFlags) {
+	if !options.kubeContexter.HasContext(config, options.configFlags) {
 		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 

--- a/kubectl-plugin/pkg/cmd/delete/delete.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete.go
@@ -20,11 +20,12 @@ import (
 )
 
 type DeleteOptions struct {
-	configFlags  *genericclioptions.ConfigFlags
-	ioStreams    *genericiooptions.IOStreams
-	ResourceType util.ResourceType
-	ResourceName string
-	Namespace    string
+	configFlags   *genericclioptions.ConfigFlags
+	ioStreams     *genericiooptions.IOStreams
+	kubeContexter util.KubeContexter
+	ResourceType  util.ResourceType
+	ResourceName  string
+	Namespace     string
 }
 
 var deleteExample = templates.Examples(`
@@ -44,8 +45,9 @@ var deleteExample = templates.Examples(`
 func NewDeleteOptions(streams genericiooptions.IOStreams) *DeleteOptions {
 	configFlags := genericclioptions.NewConfigFlags(true)
 	return &DeleteOptions{
-		ioStreams:   &streams,
-		configFlags: configFlags,
+		ioStreams:     &streams,
+		configFlags:   configFlags,
+		kubeContexter: &util.DefaultKubeContexter{},
 	}
 }
 
@@ -118,7 +120,7 @@ func (options *DeleteOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving raw config: %w", err)
 	}
-	if !util.HasKubectlContext(config, options.configFlags) {
+	if !options.kubeContexter.HasContext(config, options.configFlags) {
 		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 	return nil

--- a/kubectl-plugin/pkg/cmd/delete/delete_test.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete_test.go
@@ -113,75 +113,24 @@ func TestComplete(t *testing.T) {
 }
 
 func TestRayDeleteValidate(t *testing.T) {
-	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-
-	testNS, testContext, testBT, testImpersonate := "test-namespace", "test-context", "test-bearer-token", "test-person"
-
-	kubeConfigWithCurrentContext, err := util.CreateTempKubeConfigFile(t, testContext)
-	require.NoError(t, err)
-
-	kubeConfigWithoutCurrentContext, err := util.CreateTempKubeConfigFile(t, "")
-	require.NoError(t, err)
-
 	tests := []struct {
 		name        string
 		opts        *DeleteOptions
 		expectError string
 	}{
 		{
-			name: "Test validation when no context is set",
+			name: "should error when no K8s context is set",
 			opts: &DeleteOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-				},
-				ioStreams: &testStreams,
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				kubeContexter: util.NewMockKubeContexter(false),
 			},
 			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
 		},
 		{
-			name: "no error when kubeconfig has current context and --context switch isn't set",
+			name: "should not error when K8s context is set",
 			opts: &DeleteOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithCurrentContext,
-				},
-				ioStreams: &testStreams,
-			},
-		},
-		{
-			name: "no error when kubeconfig has no current context and --context switch is set",
-			opts: &DeleteOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-					Context:    &testContext,
-				},
-				ioStreams: &testStreams,
-			},
-		},
-		{
-			name: "no error when kubeconfig has current context and --context switch is set",
-			opts: &DeleteOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithCurrentContext,
-					Context:    &testContext,
-				},
-				ioStreams: &testStreams,
-			},
-		},
-		{
-			name: "Successful submit job validation with RayJob",
-			opts: &DeleteOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					Namespace:        &testNS,
-					Context:          &testContext,
-					KubeConfig:       &kubeConfigWithCurrentContext,
-					BearerToken:      &testBT,
-					Impersonate:      &testImpersonate,
-					ImpersonateGroup: &[]string{"fake-group"},
-				},
-				ioStreams:    &testStreams,
-				ResourceType: util.RayJob,
-				ResourceName: "test-rayjob",
-				Namespace:    testNS,
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				kubeContexter: util.NewMockKubeContexter(true),
 			},
 		},
 	}

--- a/kubectl-plugin/pkg/cmd/get/get_nodes.go
+++ b/kubectl-plugin/pkg/cmd/get/get_nodes.go
@@ -23,6 +23,7 @@ import (
 type GetNodesOptions struct {
 	configFlags   *genericclioptions.ConfigFlags
 	ioStreams     *genericclioptions.IOStreams
+	kubeContexter util.KubeContexter
 	namespace     string
 	cluster       string
 	node          string
@@ -64,8 +65,9 @@ var getNodesExample = templates.Examples(`
 
 func NewGetNodesOptions(streams genericclioptions.IOStreams) *GetNodesOptions {
 	return &GetNodesOptions{
-		configFlags: genericclioptions.NewConfigFlags(true),
-		ioStreams:   &streams,
+		configFlags:   genericclioptions.NewConfigFlags(true),
+		ioStreams:     &streams,
+		kubeContexter: &util.DefaultKubeContexter{},
 	}
 }
 
@@ -126,7 +128,7 @@ func (options *GetNodesOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("error retrieving raw config: %w", err)
 	}
-	if !util.HasKubectlContext(config, options.configFlags) {
+	if !options.kubeContexter.HasContext(config, options.configFlags) {
 		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 	return nil

--- a/kubectl-plugin/pkg/cmd/get/get_nodes_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_nodes_test.go
@@ -91,14 +91,6 @@ func TestRayNodesGetComplete(t *testing.T) {
 }
 
 func TestRayNodesGetValidate(t *testing.T) {
-	testContext := "test-context"
-
-	kubeConfigWithCurrentContext, err := util.CreateTempKubeConfigFile(t, testContext)
-	require.NoError(t, err)
-
-	kubeConfigWithoutCurrentContext, err := util.CreateTempKubeConfigFile(t, "")
-	require.NoError(t, err)
-
 	tests := []struct {
 		name        string
 		opts        *GetNodesOptions
@@ -106,38 +98,18 @@ func TestRayNodesGetValidate(t *testing.T) {
 		expectError string
 	}{
 		{
-			name: "should error when no context is set",
+			name: "should error when no K8s context is set",
 			opts: &GetNodesOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-				},
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				kubeContexter: util.NewMockKubeContexter(false),
 			},
 			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
 		},
 		{
-			name: "no error when kubeconfig has current context and --context switch isn't set",
+			name: "should not error when K8s context is set",
 			opts: &GetNodesOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithCurrentContext,
-				},
-			},
-		},
-		{
-			name: "no error when kubeconfig has no current context and --context switch is set",
-			opts: &GetNodesOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-					Context:    &testContext,
-				},
-			},
-		},
-		{
-			name: "no error when kubeconfig has current context and --context switch is set",
-			opts: &GetNodesOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithCurrentContext,
-					Context:    &testContext,
-				},
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				kubeContexter: util.NewMockKubeContexter(true),
 			},
 		},
 	}

--- a/kubectl-plugin/pkg/cmd/get/get_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/get/get_workergroup.go
@@ -23,6 +23,7 @@ import (
 type GetWorkerGroupsOptions struct {
 	configFlags   *genericclioptions.ConfigFlags
 	ioStreams     *genericclioptions.IOStreams
+	kubeContexter util.KubeContexter
 	namespace     string
 	cluster       string
 	workerGroup   string
@@ -69,8 +70,9 @@ var getWorkerGroupsExample = templates.Examples(`
 
 func NewGetWorkerGroupOptions(streams genericclioptions.IOStreams) *GetWorkerGroupsOptions {
 	return &GetWorkerGroupsOptions{
-		configFlags: genericclioptions.NewConfigFlags(true),
-		ioStreams:   &streams,
+		configFlags:   genericclioptions.NewConfigFlags(true),
+		ioStreams:     &streams,
+		kubeContexter: &util.DefaultKubeContexter{},
 	}
 }
 
@@ -131,7 +133,7 @@ func (options *GetWorkerGroupsOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("error retrieving raw config: %w", err)
 	}
-	if !util.HasKubectlContext(config, options.configFlags) {
+	if !options.kubeContexter.HasContext(config, options.configFlags) {
 		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 	return nil

--- a/kubectl-plugin/pkg/cmd/get/get_workergroup_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_workergroup_test.go
@@ -92,14 +92,6 @@ func TestRayWorkerGroupGetComplete(t *testing.T) {
 }
 
 func TestRayWorkerGroupsGetValidate(t *testing.T) {
-	testContext := "test-context"
-
-	kubeConfigWithCurrentContext, err := util.CreateTempKubeConfigFile(t, testContext)
-	require.NoError(t, err)
-
-	kubeConfigWithoutCurrentContext, err := util.CreateTempKubeConfigFile(t, "")
-	require.NoError(t, err)
-
 	tests := []struct {
 		name        string
 		opts        *GetWorkerGroupsOptions
@@ -107,38 +99,18 @@ func TestRayWorkerGroupsGetValidate(t *testing.T) {
 		expectError string
 	}{
 		{
-			name: "should error when no context is set",
+			name: "should error when no K8s context is set",
 			opts: &GetWorkerGroupsOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-				},
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				kubeContexter: util.NewMockKubeContexter(false),
 			},
 			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
 		},
 		{
-			name: "no error when kubeconfig has current context and --context switch isn't set",
+			name: "should not error when K8s context is set",
 			opts: &GetWorkerGroupsOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithCurrentContext,
-				},
-			},
-		},
-		{
-			name: "no error when kubeconfig has no current context and --context switch is set",
-			opts: &GetWorkerGroupsOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-					Context:    &testContext,
-				},
-			},
-		},
-		{
-			name: "no error when kubeconfig has current context and --context switch is set",
-			opts: &GetWorkerGroupsOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithCurrentContext,
-					Context:    &testContext,
-				},
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				kubeContexter: util.NewMockKubeContexter(true),
 			},
 		},
 	}

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -41,6 +41,7 @@ const (
 type SubmitJobOptions struct {
 	ioStreams          *genericiooptions.IOStreams
 	configFlags        *genericclioptions.ConfigFlags
+	kubeContexter      util.KubeContexter
 	RayJob             *rayv1.RayJob
 	submissionID       string
 	entryPoint         string
@@ -105,8 +106,9 @@ var (
 
 func NewJobSubmitOptions(streams genericiooptions.IOStreams) *SubmitJobOptions {
 	return &SubmitJobOptions{
-		ioStreams:   &streams,
-		configFlags: genericclioptions.NewConfigFlags(true),
+		ioStreams:     &streams,
+		configFlags:   genericclioptions.NewConfigFlags(true),
+		kubeContexter: &util.DefaultKubeContexter{},
 	}
 }
 
@@ -187,7 +189,7 @@ func (options *SubmitJobOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving raw config: %w", err)
 	}
-	if !util.HasKubectlContext(config, options.configFlags) {
+	if !options.kubeContexter.HasContext(config, options.configFlags) {
 		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -29,8 +29,6 @@ func TestRayJobSubmitComplete(t *testing.T) {
 func TestRayJobSubmitValidate(t *testing.T) {
 	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
 
-	testNS, testContext, testBT, testImpersonate := "test-namespace", "test-context", "test-bearer-token", "test-person"
-
 	fakeDir := t.TempDir()
 
 	rayYaml := `apiVersion: ray.io/v1
@@ -48,66 +46,27 @@ spec:
 	_, err = file.Write([]byte(rayYaml))
 	require.NoError(t, err)
 
-	kubeConfigWithCurrentContext, err := util.CreateTempKubeConfigFile(t, testContext)
-	require.NoError(t, err)
-
-	kubeConfigWithoutCurrentContext, err := util.CreateTempKubeConfigFile(t, "")
-	require.NoError(t, err)
-
 	tests := []struct {
 		name        string
 		opts        *SubmitJobOptions
 		expectError string
 	}{
 		{
-			name: "Test validation when no context is set",
+			name: "should error when no K8s context is set",
 			opts: &SubmitJobOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-				},
-				ioStreams:  &testStreams,
-				fileName:   rayJobYamlPath,
-				workingDir: "Fake/File/Path",
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				kubeContexter: util.NewMockKubeContexter(false),
 			},
 			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
 		},
 		{
-			name: "no error when kubeconfig has current context and --context switch isn't set",
-			opts: &SubmitJobOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithCurrentContext,
-				},
-				ioStreams:  &testStreams,
-				fileName:   rayJobYamlPath,
-				workingDir: "Fake/File/Path",
-			},
-		},
-		{
-			name: "no error when kubeconfig has no current context and --context switch is set",
-			opts: &SubmitJobOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-					Context:    &testContext,
-				},
-				ioStreams:  &testStreams,
-				fileName:   rayJobYamlPath,
-				workingDir: "Fake/File/Path",
-			},
-		},
-		{
 			name: "Successful submit job validation with RayJob",
 			opts: &SubmitJobOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					Namespace:        &testNS,
-					Context:          &testContext,
-					KubeConfig:       &kubeConfigWithCurrentContext,
-					BearerToken:      &testBT,
-					Impersonate:      &testImpersonate,
-					ImpersonateGroup: &[]string{"fake-group"},
-				},
-				ioStreams:  &testStreams,
-				fileName:   rayJobYamlPath,
-				workingDir: "Fake/File/Path",
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				ioStreams:     &testStreams,
+				kubeContexter: util.NewMockKubeContexter(true),
+				fileName:      rayJobYamlPath,
+				workingDir:    "Fake/File/Path",
 			},
 		},
 	}

--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -72,13 +72,14 @@ func nodeTypeCompletion(_ *cobra.Command, _ []string, _ string) ([]string, cobra
 }
 
 type ClusterLogOptions struct {
-	configFlags  *genericclioptions.ConfigFlags
-	ioStreams    *genericclioptions.IOStreams
-	Executor     RemoteExecutor
-	outputDir    string
-	nodeType     nodeTypeEnum
-	ResourceName string
-	ResourceType util.ResourceType
+	configFlags   *genericclioptions.ConfigFlags
+	ioStreams     *genericclioptions.IOStreams
+	kubeContexter util.KubeContexter
+	Executor      RemoteExecutor
+	outputDir     string
+	nodeType      nodeTypeEnum
+	ResourceName  string
+	ResourceType  util.ResourceType
 }
 
 var (
@@ -109,10 +110,11 @@ var (
 
 func NewClusterLogOptions(streams genericclioptions.IOStreams) *ClusterLogOptions {
 	return &ClusterLogOptions{
-		configFlags: genericclioptions.NewConfigFlags(true),
-		ioStreams:   &streams,
-		Executor:    &DefaultRemoteExecutor{},
-		nodeType:    allNodeType,
+		configFlags:   genericclioptions.NewConfigFlags(true),
+		ioStreams:     &streams,
+		kubeContexter: &util.DefaultKubeContexter{},
+		Executor:      &DefaultRemoteExecutor{},
+		nodeType:      allNodeType,
 	}
 }
 
@@ -191,7 +193,7 @@ func (options *ClusterLogOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving raw config: %w", err)
 	}
-	if !util.HasKubectlContext(config, options.configFlags) {
+	if !options.kubeContexter.HasContext(config, options.configFlags) {
 		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 

--- a/kubectl-plugin/pkg/cmd/session/session.go
+++ b/kubectl-plugin/pkg/cmd/session/session.go
@@ -26,6 +26,7 @@ type appPort struct {
 type SessionOptions struct {
 	configFlags    *genericclioptions.ConfigFlags
 	ioStreams      *genericiooptions.IOStreams
+	kubeContexter  util.KubeContexter
 	currentContext string
 	ResourceType   util.ResourceType
 	ResourceName   string
@@ -73,8 +74,9 @@ var (
 func NewSessionOptions(streams genericiooptions.IOStreams) *SessionOptions {
 	configFlags := genericclioptions.NewConfigFlags(true)
 	return &SessionOptions{
-		ioStreams:   &streams,
-		configFlags: configFlags,
+		ioStreams:     &streams,
+		configFlags:   configFlags,
+		kubeContexter: &util.DefaultKubeContexter{},
 	}
 }
 
@@ -150,7 +152,7 @@ func (options *SessionOptions) Validate() error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving raw config: %w", err)
 	}
-	if !util.HasKubectlContext(config, options.configFlags) {
+	if !options.kubeContexter.HasContext(config, options.configFlags) {
 		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 	options.currentContext = config.CurrentContext

--- a/kubectl-plugin/pkg/cmd/version/version.go
+++ b/kubectl-plugin/pkg/cmd/version/version.go
@@ -16,14 +16,16 @@ import (
 var Version = "development"
 
 type VersionOptions struct {
-	configFlags *genericclioptions.ConfigFlags
-	ioStreams   *genericclioptions.IOStreams
+	configFlags   *genericclioptions.ConfigFlags
+	ioStreams     *genericclioptions.IOStreams
+	kubeContexter util.KubeContexter
 }
 
 func NewVersionOptions(streams genericclioptions.IOStreams) *VersionOptions {
 	return &VersionOptions{
-		configFlags: genericclioptions.NewConfigFlags(true),
-		ioStreams:   &streams,
+		configFlags:   genericclioptions.NewConfigFlags(true),
+		ioStreams:     &streams,
+		kubeContexter: &util.DefaultKubeContexter{},
 	}
 }
 
@@ -75,7 +77,7 @@ func (options *VersionOptions) checkContext() error {
 		return fmt.Errorf("error retrieving raw config: %w", err)
 	}
 
-	if !util.HasKubectlContext(config, options.configFlags) {
+	if !options.kubeContexter.HasContext(config, options.configFlags) {
 		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 	return nil

--- a/kubectl-plugin/pkg/cmd/version/version_test.go
+++ b/kubectl-plugin/pkg/cmd/version/version_test.go
@@ -17,57 +17,24 @@ import (
 )
 
 func TestRayVersionCheckContext(t *testing.T) {
-	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-	testContext := "test-context"
-
-	kubeConfigWithCurrentContext, err := util.CreateTempKubeConfigFile(t, "my-fake-context")
-	require.NoError(t, err)
-
-	kubeConfigWithoutCurrentContext, err := util.CreateTempKubeConfigFile(t, "")
-	require.NoError(t, err)
-
 	tests := []struct {
 		name        string
 		opts        *VersionOptions
 		expectError string
 	}{
 		{
-			name: "Test validation when no context is set",
+			name: "should error when no K8s context is set",
 			opts: &VersionOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-				},
-				ioStreams: &testStreams,
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				kubeContexter: util.NewMockKubeContexter(false),
 			},
 			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
 		},
 		{
-			name: "no error when kubeconfig has current context and --context switch isn't set",
+			name: "should not error when K8s context is set",
 			opts: &VersionOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithCurrentContext,
-				},
-				ioStreams: &testStreams,
-			},
-		},
-		{
-			name: "no error when kubeconfig has no current context and --context switch is set",
-			opts: &VersionOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-					Context:    &testContext,
-				},
-				ioStreams: &testStreams,
-			},
-		},
-		{
-			name: "no error when kubeconfig has current context and --context switch is set",
-			opts: &VersionOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithCurrentContext,
-					Context:    &testContext,
-				},
-				ioStreams: &testStreams,
+				configFlags:   genericclioptions.NewConfigFlags(true),
+				kubeContexter: util.NewMockKubeContexter(true),
 			},
 		},
 	}
@@ -112,15 +79,9 @@ func (c fakeClient) RayClient() rayclient.Interface {
 
 // Tests the Run() step of the command and checks the output.
 func TestRayVersionRun(t *testing.T) {
-	testContext := "test-context"
-
-	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-
 	fakeVersionOptions := &VersionOptions{
-		configFlags: &genericclioptions.ConfigFlags{
-			Context: &testContext,
-		},
-		ioStreams: &testStreams,
+		configFlags:   genericclioptions.NewConfigFlags(true),
+		kubeContexter: util.NewMockKubeContexter(true),
 	}
 
 	tests := []struct {

--- a/kubectl-plugin/pkg/util/kubeconfig.go
+++ b/kubectl-plugin/pkg/util/kubeconfig.go
@@ -1,47 +1,31 @@
 package util
 
 import (
-	"path/filepath"
-	"testing"
-
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
+// KubeContexter is an interface that checks if the kubeconfig has a current context or if the --context switch is set.
+type KubeContexter interface {
+	HasContext(config api.Config, configFlags *genericclioptions.ConfigFlags) bool
+}
+
+type DefaultKubeContexter struct{}
+
 // HasKubectlContext checks if the kubeconfig has a current context or if the --context switch is set.
-func HasKubectlContext(config api.Config, configFlags *genericclioptions.ConfigFlags) bool {
+func (d *DefaultKubeContexter) HasContext(config api.Config, configFlags *genericclioptions.ConfigFlags) bool {
 	return config.CurrentContext != "" || (configFlags.Context != nil && *configFlags.Context != "")
 }
 
-// CreateTempKubeConfigFile creates a temporary kubeconfig file with the given current context.
-// This function should only be used in tests.
-func CreateTempKubeConfigFile(t *testing.T, currentContext string) (string, error) {
-	tmpDir := t.TempDir()
+// MockKubeContexter is a mock implementation of KubeContexter that should be used only in tests.
+type MockKubeContexter struct {
+	returnValue bool
+}
 
-	// Set up fake config for kubeconfig
-	config := &api.Config{
-		Clusters: map[string]*api.Cluster{
-			"test-cluster": {
-				Server:                "https://fake-kubernetes-cluster.example.com",
-				InsecureSkipTLSVerify: true, // For testing purposes
-			},
-		},
-		Contexts: map[string]*api.Context{
-			"my-fake-context": {
-				Cluster:  "my-fake-cluster",
-				AuthInfo: "my-fake-user",
-			},
-		},
-		CurrentContext: currentContext,
-		AuthInfos: map[string]*api.AuthInfo{
-			"my-fake-user": {
-				Token: "", // Empty for testing without authentication
-			},
-		},
-	}
+func (m *MockKubeContexter) HasContext(_ api.Config, _ *genericclioptions.ConfigFlags) bool {
+	return m.returnValue
+}
 
-	fakeFile := filepath.Join(tmpDir, ".kubeconfig")
-
-	return fakeFile, clientcmd.WriteToFile(*config, fakeFile)
+func NewMockKubeContexter(returnValue bool) *MockKubeContexter {
+	return &MockKubeContexter{returnValue: returnValue}
 }

--- a/kubectl-plugin/pkg/util/kubeconfig_test.go
+++ b/kubectl-plugin/pkg/util/kubeconfig_test.go
@@ -1,0 +1,64 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/ptr"
+)
+
+func TestHasKubectlContext(t *testing.T) {
+	sut := &DefaultKubeContexter{}
+
+	tests := []struct {
+		config      api.Config
+		configFlags *genericclioptions.ConfigFlags
+		name        string
+		expected    bool
+	}{
+		{
+			name:        "should return false if there's no current context and no --context flag",
+			configFlags: &genericclioptions.ConfigFlags{},
+			expected:    false,
+		},
+		{
+			name: "should return false if there's no current context and the --context flag is an empty string",
+			configFlags: &genericclioptions.ConfigFlags{
+				Context: ptr.To(""),
+			},
+			expected: false,
+		},
+		{
+			name: "should return true if there's no current context but the --context flag is set",
+			configFlags: &genericclioptions.ConfigFlags{
+				Context: ptr.To("my-context"),
+			},
+			expected: true,
+		},
+		{
+			name: "should return true if there's a current context but no --context flag",
+			config: api.Config{
+				CurrentContext: "my-context",
+			},
+			expected: true,
+		},
+		{
+			name: "should return true if there's a current context and the --context flag is set",
+			config: api.Config{
+				CurrentContext: "my-context",
+			},
+			configFlags: &genericclioptions.ConfigFlags{
+				Context: ptr.To("my-context"),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, sut.HasContext(tc.config, tc.configFlags))
+		})
+	}
+}


### PR DESCRIPTION
We were duplicating logic in each command's `Validate()` test.

1. Abstract away K8s context detection logic with a new interface `KubeContexter`.
1. Consolidate tests for this logic in a separate test for `DefaultKubeContexter`.
1. Mock `KubeContexter` in `Validate()` tests with `MockKubeContexter` to simplify the `Validate()` tests.


## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
