### PR TITLE
[kubectl-plugin] Validate resource values for negative and non-numeric inputs

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -114,6 +114,21 @@ func (options *CreateClusterOptions) Validate() error {
 		return fmt.Errorf("no context is currently set, use %q or %q to select a new one", "--context", "kubectl config use-context <context>")
 	}
 
+	resourceFields := map[string]string{
+		"head-cpu":      options.headCPU,
+		"head-gpu":      options.headGPU,
+		"head-memory":   options.headMemory,
+		"worker-cpu":    options.workerCPU,
+		"worker-gpu":    options.workerGPU,
+		"worker-memory": options.workerMemory,
+	}
+
+	for name, value := range resourceFields {
+		if err := util.ValidateResourceQuantity(value, name); err != nil {
+			return fmt.Errorf("%w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -249,6 +249,22 @@ func (options *SubmitJobOptions) Validate() error {
 
 	// Changed working dir clean to here instead of complete since calling Clean on empty string return "." and it would be dificult to determine if that is actually user input or not.
 	options.workingDir = filepath.Clean(options.workingDir)
+
+	resourceFields := map[string]string{
+		"head-cpu":      options.headCPU,
+		"head-gpu":      options.headGPU,
+		"head-memory":   options.headMemory,
+		"worker-cpu":    options.workerCPU,
+		"worker-gpu":    options.workerGPU,
+		"worker-memory": options.workerMemory,
+	}
+
+	for name, value := range resourceFields {
+		if err := util.ValidateResourceQuantity(value, name); err != nil {
+			return fmt.Errorf("%w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/kubectl-plugin/pkg/util/validation.go
+++ b/kubectl-plugin/pkg/util/validation.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func ValidateResourceQuantity(value string, name string) error {
+	if value == "" {
+		return nil
+	}
+
+	q, err := resource.ParseQuantity(value)
+	if err != nil {
+		return fmt.Errorf("%s is not a valid resource quantity: %w", name, err)
+	}
+	if q.Sign() < 0 {
+		return fmt.Errorf("%s cannot be negative", name)
+	}
+	return nil
+}

--- a/kubectl-plugin/pkg/util/validation_test.go
+++ b/kubectl-plugin/pkg/util/validation_test.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestValidateResourceQuantity(t *testing.T) {
+	tests := []struct {
+		value   string
+		name    string
+		wantErr bool
+	}{
+		{"500m", "cpu", false},
+		{"-500m", "cpu", true},
+		{"aaa", "cpu", true},
+		{"10Gi", "memory", false},
+		{"bbb", "memory", true},
+		{"", "memory", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			err := ValidateResourceQuantity(tt.value, tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateResourceQuantity() = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The [create cluster](https://github.com/ray-project/kuberay/blob/master/kubectl-plugin/pkg/cmd/create/create_cluster.go)  and [job submit](https://github.com/ray-project/kuberay/blob/master/kubectl-plugin/pkg/cmd/job/job_submit.go) command in the kubectl-plugin does not validate CPU, Memory, and GPU values properly. Since these values are passed as strings and directly used in resource definitions, users can input:
```
kubectl ray job submit --name rayjob-sample --head-cpu -1 --worker-cpu -2 --work-gpu xyz  --runtime-env path/to/runtimeEnv.yaml -- python my_script.py
```

- Negative values (-2, -1) should not be allowed.
- Non-numeric or malformed values (e.g., xyz) should trigger an error, instead of causing a panic, to ensure the program handles these gracefully.

After:
```
$ kubectl ray create cluster sample-cluster --head-cpu -2
Error: head-cpu cannot be negative

$ kubectl ray create cluster sample-cluster --head-memory aa
Error: head-memory is not a valid resource quantity: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'

$ kubectl ray job submit --name ray-job-sample  --working-dir ~/workdir --head-gpu -1 --runtime-env ~/workdir/runtimeEnv.yaml -- python sample_code.py
Error: head-gpu cannot be negative
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #3043
Closes #3041

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
