### PR TITLE
[feat][kubectl-plugin] support `get clusters` command alias

### DIFF
--- a/kubectl-plugin/pkg/cmd/get/get_cluster.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster.go
@@ -43,6 +43,7 @@ func NewGetClusterCommand(streams genericclioptions.IOStreams) *cobra.Command {
 		Use:               "cluster [NAME]",
 		Aliases:           []string{"clusters"},
 		Short:             "Get cluster information.",
+		Aliases:           []string{"clusters"},
 		SilenceUsage:      true,
 		ValidArgsFunction: completion.RayClusterCompletionFunc(cmdFactory),
 		Args:              cobra.MaximumNArgs(1),


### PR DESCRIPTION
You can only get RayClusters with `kubectl ray get cluster`. This one-line change lets you use the plural with `kubectl ray get clusters` as a convenience.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
