### PR TITLE
[Fix][RayCluster] fix missing pod name in CreatedWorkerPod and Failed…

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1080,12 +1080,12 @@ func (r *RayClusterReconciler) createWorkerPod(ctx context.Context, instance ray
 
 	replica := pod
 	if err := r.Create(ctx, &replica); err != nil {
-		r.Recorder.Eventf(&instance, corev1.EventTypeWarning, string(utils.FailedToCreateWorkerPod), "Failed to create worker Pod %s/%s, %v", pod.Namespace, pod.Name, err)
+		r.Recorder.Eventf(&instance, corev1.EventTypeWarning, string(utils.FailedToCreateWorkerPod), "Failed to create worker Pod for the cluster %s/%s, %v", instance.Namespace, instance.Name, err)
 		return err
 	}
 	r.rayClusterScaleExpectation.ExpectScalePod(replica.Namespace, instance.Name, worker.GroupName, replica.Name, expectations.Create)
-	logger.Info("Created worker Pod for RayCluster", "name", pod.Name)
-	r.Recorder.Eventf(&instance, corev1.EventTypeNormal, string(utils.CreatedWorkerPod), "Created worker Pod %s/%s", pod.Namespace, pod.Name)
+	logger.Info("Created worker Pod for RayCluster", "name", replica.Name)
+	r.Recorder.Eventf(&instance, corev1.EventTypeNormal, string(utils.CreatedWorkerPod), "Created worker Pod %s/%s", replica.Namespace, replica.Name)
 	return nil
 }
 


### PR DESCRIPTION
## Why are these changes needed?

Fixes https://github.com/ray-project/kuberay/issues/3056

Before the fix:
```sh
Events:
  Type    Reason            Age   From                   Message
  ----    ------            ----  ----                   -------
  Normal  CreatedService    43m   raycluster-controller  Created service default/raycluster-kuberay-head-svc
  Normal  CreatedHeadPod    43m   raycluster-controller  Created head Pod default/raycluster-kuberay-head-l7v7q
  Normal  CreatedWorkerPod  43m   raycluster-controller  Created worker Pod default/
```

After the fix:
<img width="1088" alt="image" src="https://github.com/user-attachments/assets/ba5487d0-eabc-496a-a55c-fa3147af670f" />


## Related issue number

Fixes https://github.com/ray-project/kuberay/issues/3056

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
