### PR TITLE
[Fix][kubectl-plugin] ray job submit runtime-env-json null error

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -232,7 +232,7 @@ func (options *SubmitJobOptions) Validate() error {
 		}
 
 		runtimeEnvYaml := options.RayJob.Spec.RuntimeEnvYAML
-		if options.runtimeEnv == "" && options.runtimeEnvJson == "" {
+		if options.runtimeEnv == "" && options.runtimeEnvJson == "" && runtimeEnvYaml != "" {
 			runtimeJson, err := yaml.YAMLToJSON([]byte(runtimeEnvYaml))
 			if err != nil {
 				return fmt.Errorf("Failed to convert runtime env to json: %w", err)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The following command is wrongly constructed if `RayJob.Spec.RuntimeEnvYAML`, `runtimeEnv`, and `runtimeEnvJson` are all empty string.

```sh
ray job submit --address http://localhost:8265 --runtime-env-json null --working-dir . -- python sample_code.py
```

Correct command should be

```sh
ray job submit --address http://localhost:8265 --working-dir . -- python sample_code.py
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
