### PR TITLE
[feat][kubectl-plugin] Implement kubectl ray job submit with Deletion Policy API for RayJob Cleanup

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -164,6 +164,9 @@ func NewJobSubmitCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(&options.workerGPU, "worker-gpu", "0", "number of GPUs in each worker group replica")
 	cmd.Flags().BoolVar(&options.dryRun, "dry-run", false, "print the generated YAML instead of creating the cluster. Only works when filename is not provided")
 
+	cmd.Flags().BoolVar(&options.shutdownAfterJobFinishes, "shutdown-after-job-finishes", false, "Automatically shutdown resources after job finishes")
+	cmd.Flags().StringVar(&options.deletionPolicy, "deletion-policy", "", "Policy for deleting resources after job completion. Valid values: 'DeleteCluster', 'DeleteWorkers', 'DeleteSelf', 'DeleteNone'")
+
 	options.configFlags.AddFlags(cmd.Flags())
 	return cmd
 }
@@ -279,9 +282,11 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	if options.fileName == "" {
 		// Genarate the Ray job.
 		rayJobObject := generation.RayJobYamlObject{
-			RayJobName:     options.rayjobName,
-			Namespace:      *options.configFlags.Namespace,
-			SubmissionMode: "InteractiveMode",
+			RayJobName:               options.rayjobName,
+			Namespace:                *options.configFlags.Namespace,
+			SubmissionMode:           "InteractiveMode",
+			DeletionPolicy:           options.deletionPolicy,
+			ShutdownAfterJobFinishes: options.shutdownAfterJobFinishes,
 			RayClusterSpecObject: generation.RayClusterSpecObject{
 				RayVersion:     options.rayVersion,
 				Image:          options.image,

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -335,8 +335,8 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	}
 	fmt.Printf("Submitted RayJob %s.\n", options.RayJob.GetName())
 
-	// Check for events in a goroutine with timeout
-	// If RayJobDeletionPolicy feature gate is not enabled, throw an error and delete the RayJob
+	// Continuously checks for Kubernetes events related to the RayJobDeletionPolicy.
+	// If an event indicates that the RayJobDeletionPolicy feature gate must be enabled, throw an error and delete the RayJob.
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -284,6 +285,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 		return fmt.Errorf("failed to initialize clientset: %w", err)
 	}
 
+	startTime := time.Now()
 	if options.fileName == "" {
 		// Genarate the Ray job.
 		rayJobObject := generation.RayJobYamlObject{
@@ -333,7 +335,44 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	}
 	fmt.Printf("Submitted RayJob %s.\n", options.RayJob.GetName())
 
-	// TODO: Check if there are any events related to RayJobDeletionPolicy
+	// Check for events in a goroutine with timeout
+	// If RayJobDeletionPolicy feature gate is not enabled, throw an error and delete the RayJob
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-time.After(clusterTimeout * time.Second):
+				return
+			case <-ticker.C:
+				eventList, err := k8sClients.KubernetesClient().CoreV1().Events(*options.configFlags.Namespace).List(ctx, metav1.ListOptions{
+					FieldSelector: fmt.Sprintf("involvedObject.name=%s", options.RayJob.GetName()),
+				})
+				if err != nil {
+					fmt.Printf("Error listing events: %v\n", err)
+					return
+				}
+
+				// Check for error events related to RayJobDeletionPolicy feature gate
+				for _, event := range eventList.Items {
+					if strings.Contains(event.Message, "RayJobDeletionPolicy feature gate must be enabled to use the DeletionPolicy feature") {
+						if event.FirstTimestamp.Time.After(startTime) || event.LastTimestamp.Time.After(startTime) {
+							fmt.Printf("Deleting RayJob...\n")
+							err = k8sClients.RayClient().RayV1().RayJobs(*options.configFlags.Namespace).Delete(ctx, options.RayJob.GetName(), v1.DeleteOptions{})
+							if err != nil {
+								fmt.Printf("Failed to clean up Ray job: %v\n", err)
+							} else {
+								fmt.Printf("Cleaned Up RayJob: %s\n", options.RayJob.GetName())
+							}
+							log.Fatalf("%s", event.Message)
+						}
+					}
+				}
+				return
+			}
+		}
+	}()
 
 	if len(options.RayJob.GetName()) > 0 {
 		// Add timeout?

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -40,38 +40,41 @@ const (
 )
 
 type SubmitJobOptions struct {
-	ioStreams          *genericiooptions.IOStreams
-	configFlags        *genericclioptions.ConfigFlags
-	kubeContexter      util.KubeContexter
-	RayJob             *rayv1.RayJob
-	submissionID       string
-	entryPoint         string
-	fileName           string
-	workingDir         string
-	runtimeEnv         string
-	headers            string
-	verify             string
-	cluster            string
-	runtimeEnvJson     string
-	entryPointResource string
-	metadataJson       string
-	logStyle           string
-	logColor           string
-	rayjobName         string
-	rayVersion         string
-	image              string
-	headCPU            string
-	headMemory         string
-	headGPU            string
-	workerCPU          string
-	workerMemory       string
-	workerGPU          string
-	entryPointCPU      float32
-	entryPointGPU      float32
-	entryPointMemory   int
-	workerReplicas     int32
-	noWait             bool
-	dryRun             bool
+	ioStreams                *genericiooptions.IOStreams
+	configFlags              *genericclioptions.ConfigFlags
+	kubeContexter            util.KubeContexter
+	RayJob                   *rayv1.RayJob
+	deletionPolicy           string
+	submissionID             string
+	entryPoint               string
+	fileName                 string
+	workingDir               string
+	runtimeEnv               string
+	headers                  string
+	verify                   string
+	cluster                  string
+	runtimeEnvJson           string
+	entryPointResource       string
+	metadataJson             string
+	logStyle                 string
+	logColor                 string
+	rayjobName               string
+	rayVersion               string
+	image                    string
+	headCPU                  string
+	headMemory               string
+	headGPU                  string
+	workerCPU                string
+	workerMemory             string
+	workerGPU                string
+	entryPointCPU            float32
+	entryPointGPU            float32
+	entryPointMemory         int
+	workerReplicas           int32
+	ttlSecondsAfterFinished  int32
+	noWait                   bool
+	dryRun                   bool
+	shutdownAfterJobFinishes bool
 }
 
 var (

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -60,40 +60,11 @@ spec:
 			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
 		},
 		{
-			name: "no error when kubeconfig has current context and --context switch isn't set",
-			opts: &SubmitJobOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithCurrentContext,
-				},
-				ioStreams:  &testStreams,
-				fileName:   rayJobYamlPath,
-				workingDir: "Fake/File/Path",
-			},
-		},
-		{
-			name: "no error when kubeconfig has no current context and --context switch is set",
-			opts: &SubmitJobOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					KubeConfig: &kubeConfigWithoutCurrentContext,
-					Context:    &testContext,
-				},
-				ioStreams:  &testStreams,
-				fileName:   rayJobYamlPath,
-				workingDir: "Fake/File/Path",
-			},
-		},
-		{
 			name: "TTLSecondsAfterFinished with shutdownAfterJobFinishes disabled should error",
 			opts: &SubmitJobOptions{
-				configFlags: &genericclioptions.ConfigFlags{
-					Namespace:        &testNS,
-					Context:          &testContext,
-					KubeConfig:       &kubeConfigWithCurrentContext,
-					BearerToken:      &testBT,
-					Impersonate:      &testImpersonate,
-					ImpersonateGroup: &[]string{"fake-group"},
-				},
+				configFlags:              genericclioptions.NewConfigFlags(true),
 				ioStreams:                &testStreams,
+				kubeContexter:            util.NewMockKubeContexter(true),
 				fileName:                 rayJobYamlPath,
 				workingDir:               "Fake/File/Path",
 				shutdownAfterJobFinishes: false,

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -60,6 +60,48 @@ spec:
 			expectError: "no context is currently set, use \"--context\" or \"kubectl config use-context <context>\" to select a new one",
 		},
 		{
+			name: "no error when kubeconfig has current context and --context switch isn't set",
+			opts: &SubmitJobOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithCurrentContext,
+				},
+				ioStreams:  &testStreams,
+				fileName:   rayJobYamlPath,
+				workingDir: "Fake/File/Path",
+			},
+		},
+		{
+			name: "no error when kubeconfig has no current context and --context switch is set",
+			opts: &SubmitJobOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					KubeConfig: &kubeConfigWithoutCurrentContext,
+					Context:    &testContext,
+				},
+				ioStreams:  &testStreams,
+				fileName:   rayJobYamlPath,
+				workingDir: "Fake/File/Path",
+			},
+		},
+		{
+			name: "TTLSecondsAfterFinished with shutdownAfterJobFinishes disabled should error",
+			opts: &SubmitJobOptions{
+				configFlags: &genericclioptions.ConfigFlags{
+					Namespace:        &testNS,
+					Context:          &testContext,
+					KubeConfig:       &kubeConfigWithCurrentContext,
+					BearerToken:      &testBT,
+					Impersonate:      &testImpersonate,
+					ImpersonateGroup: &[]string{"fake-group"},
+				},
+				ioStreams:                &testStreams,
+				fileName:                 rayJobYamlPath,
+				workingDir:               "Fake/File/Path",
+				shutdownAfterJobFinishes: false,
+				ttlSecondsAfterFinished:  100,
+			},
+			expectError: "TTLSecondsAfterFinished only working when ShutdownAfterJobFinishes set to true when ShutdownAfterJobFinishes is set to true",
+		},
+		{
 			name: "Successful submit job validation with RayJob",
 			opts: &SubmitJobOptions{
 				configFlags:   genericclioptions.NewConfigFlags(true),

--- a/kubectl-plugin/pkg/cmd/version/version_test.go
+++ b/kubectl-plugin/pkg/cmd/version/version_test.go
@@ -77,6 +77,10 @@ func (c fakeClient) RayClient() rayclient.Interface {
 	return nil
 }
 
+func (c fakeClient) WaitRayJobDeletionPolicyEnabled(_ context.Context, _, _ string, _ time.Time, _ time.Duration) error {
+	return nil
+}
+
 // Tests the Run() step of the command and checks the output.
 func TestRayVersionRun(t *testing.T) {
 	fakeVersionOptions := &VersionOptions{

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -38,6 +38,7 @@ type RayJobYamlObject struct {
 	SubmissionMode string
 	DeletionPolicy string
 	RayClusterSpecObject
+	TTLSecondsAfterFinished  int32
 	ShutdownAfterJobFinishes bool
 }
 
@@ -53,6 +54,7 @@ func (rayJobObject *RayJobYamlObject) GenerateRayJobApplyConfig() *rayv1ac.RayJo
 		WithSpec(rayv1ac.RayJobSpec().
 			WithSubmissionMode(rayv1.JobSubmissionMode(rayJobObject.SubmissionMode)).
 			WithShutdownAfterJobFinishes(rayJobObject.ShutdownAfterJobFinishes).
+			WithTTLSecondsAfterFinished(rayJobObject.TTLSecondsAfterFinished).
 			WithRayClusterSpec(rayJobObject.generateRayClusterSpec()))
 
 	if rayJobObject.DeletionPolicy != "" {

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -36,7 +36,9 @@ type RayJobYamlObject struct {
 	RayJobName     string
 	Namespace      string
 	SubmissionMode string
+	DeletionPolicy string
 	RayClusterSpecObject
+	ShutdownAfterJobFinishes bool
 }
 
 func (rayClusterObject *RayClusterYamlObject) GenerateRayClusterApplyConfig() *rayv1ac.RayClusterApplyConfiguration {
@@ -50,8 +52,12 @@ func (rayJobObject *RayJobYamlObject) GenerateRayJobApplyConfig() *rayv1ac.RayJo
 	rayJobApplyConfig := rayv1ac.RayJob(rayJobObject.RayJobName, rayJobObject.Namespace).
 		WithSpec(rayv1ac.RayJobSpec().
 			WithSubmissionMode(rayv1.JobSubmissionMode(rayJobObject.SubmissionMode)).
+			WithShutdownAfterJobFinishes(rayJobObject.ShutdownAfterJobFinishes).
 			WithRayClusterSpec(rayJobObject.generateRayClusterSpec()))
 
+	if rayJobObject.DeletionPolicy != "" {
+		rayJobApplyConfig.Spec.WithDeletionPolicy(rayv1.DeletionPolicy(rayJobObject.DeletionPolicy))
+	}
 	return rayJobApplyConfig
 }
 

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -50,9 +50,12 @@ func TestGenerateRayCluterApplyConfig(t *testing.T) {
 
 func TestGenerateRayJobApplyConfig(t *testing.T) {
 	testRayJobYamlObject := RayJobYamlObject{
-		RayJobName:     "test-ray-job",
-		Namespace:      "default",
-		SubmissionMode: "InteractiveMode",
+		RayJobName:               "test-ray-job",
+		Namespace:                "default",
+		SubmissionMode:           "InteractiveMode",
+		DeletionPolicy:           "DeleteCluster",
+		TTLSecondsAfterFinished:  100,
+		ShutdownAfterJobFinishes: true,
 		RayClusterSpecObject: RayClusterSpecObject{
 			RayVersion:     util.RayVersion,
 			Image:          util.RayImage,
@@ -80,6 +83,9 @@ func TestGenerateRayJobApplyConfig(t *testing.T) {
 	assert.Equal(t, testRayJobYamlObject.WorkerReplicas, *result.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas)
 	assert.Equal(t, resource.MustParse(testRayJobYamlObject.WorkerCPU), *result.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests.Cpu())
 	assert.Equal(t, resource.MustParse(testRayJobYamlObject.WorkerMemory), *result.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests.Memory())
+	assert.Equal(t, rayv1.DeletionPolicy(testRayJobYamlObject.DeletionPolicy), *result.Spec.DeletionPolicy)
+	assert.Equal(t, testRayJobYamlObject.TTLSecondsAfterFinished, *result.Spec.TTLSecondsAfterFinished)
+	assert.Equal(t, testRayJobYamlObject.ShutdownAfterJobFinishes, *result.Spec.ShutdownAfterJobFinishes)
 }
 
 func TestConvertRayClusterApplyConfigToYaml(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Adds the `shutdown-after-job-finishes`, `deletion-policy` and `ttl-seconds-after-finished` flag to the `kubectl ray job submit` that allow users to manage RayJob CRs cleanup more easily by configuring deletion policies.

This behavior relies on ray-operator enable `RayJobDeletionPolicy` feature gate.

If the user has not enabled the RayJobDeletionPolicy
```
$ kubectl ray job submit --name ray-job-sample --deletion-policy DeleteCluster --working-dir ~/workdir --runtime-env ~/workdir/runtimeEnv.yaml -- python sample_code.py
Submitted RayJob ray-job-sample.
Deleting RayJob...
Cleaned Up RayJob: ray-job-sample
2025/02/16 15:06:14 The RayJob spec is invalid default/ray-job-sample: RayJobDeletionPolicy feature gate must be enabled to use the DeletionPolicy feature
```

--------
- Set `ttl-seconds-after-finished` but not set `shutdown-after-job-finishes`
```
$ kubectl ray job submit --name ray-job-sample --ttl-seconds-after-finished 10  --working-dir ~/workdir --runtime-env ~/workdir/runtimeEnv.yaml  -- python sample_code.py
Error: TTLSecondsAfterFinished only works when shutdown-after-job-finishes is set to true
```

- Set `ttl-seconds-after-finished` and `shutdown-after-job-finishes`
```
$ kubectl ray job submit --name ray-job-sample --shutdown-after-job-finishes --ttl-seconds-after-finished 10  --working-dir ~/workdir --runtime-env ~/workdir/runtimeEnv.yaml -- python sample_code.py
Submitted RayJob ray-job-sample.

$ k get rayjob
NAME             JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME                  START TIME             END TIME               AGE
ray-job-sample   SUCCEEDED    Complete            ray-job-sample-raycluster-5lvzq   2025-02-15T04:06:52Z   2025-02-15T04:07:36Z   62s

$ k get raycluster
No resources found in default namespace.
```

- Set `deletion-policy` to DeleteSelf
```
$ kubectl ray job submit --name ray-job-sample --deletion-policy DeleteSelf  --working-dir ~/workdir --runtime-env ~/workdir/runtimeEnv.yaml -- python sample_code.py
Submitted RayJob ray-job-sample.

$ k get raycluster
No resources found in default namespace.

$ k get rayjob
No resources found in default namespace.
```

- Set `deletion-policy` to DeleteCluster
```
kubectl ray job submit --name ray-job-sample --deletion-policy DeleteCluster  --working-dir ~/workdir --runtime-env ~/workdir/runtimeEnv.yaml -- python sample_code.py
Submitted RayJob ray-job-sample.

$ k get rayjob
NAME             JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME                  START TIME             END TIME               AGE
ray-job-sample   SUCCEEDED    Complete            ray-job-sample-raycluster-krkv5   2025-02-15T04:14:04Z   2025-02-15T04:14:51Z   66s

$ k get raycluster
No resources found in default namespace.
```

- Set `deletion-policy` to DeleteWorkers
```
$ kubectl ray job submit --name ray-job-sample --deletion-policy DeleteWorkers  --working-dir ~/workdir --runtime-env ~/workdir/runtimeEnv.yaml -- python sample_code.py
Submitted RayJob ray-job-sample.

$ k get rayjob
NAME             JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME                  START TIME             END TIME               AGE
ray-job-sample   SUCCEEDED    Complete            ray-job-sample-raycluster-w5j8m   2025-02-15T04:16:23Z   2025-02-15T04:17:11Z   80s

$ k get raycluster
NAME                              DESIRED WORKERS   AVAILABLE WORKERS   CPUS   MEMORY   GPUS   STATUS   AGE
ray-job-sample-raycluster-w5j8m                                         2      4Gi      0      ready    66s

$ k get pod
NAME                                         READY   STATUS    RESTARTS   AGE
kuberay-operator-f95d56cc6-txxwd             1/1     Running   0          101m
ray-job-sample-raycluster-w5j8m-head-qhdn7   1/1     Running   0          97s
```

- Set `deletion-policy` to DeleteNone
```
$ kubectl ray job submit --name ray-job-sample --deletion-policy DeleteNone  --working-dir ~/workdir --runtime-env ~/workdir/runtimeEnv.yaml -- python sample_code.py
Submitted RayJob ray-job-sample.

$ k get rayjob
NAME             JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME                  START TIME             END TIME               AGE
ray-job-sample   SUCCEEDED    Complete            ray-job-sample-raycluster-rdx6h   2025-02-15T05:06:04Z   2025-02-15T05:06:47Z   52s

$ k get rayclusters
NAME                              DESIRED WORKERS   AVAILABLE WORKERS   CPUS   MEMORY   GPUS   STATUS   AGE
ray-job-sample-raycluster-rdx6h   1                 1                   4      8Gi      0      ready    56s

$ k get pod
NAME                                                         READY   STATUS    RESTARTS   AGE
kuberay-operator-f95d56cc6-l8b26                             1/1     Running   0          3m12s
ray-job-sample-raycluster-rdx6h-default-group-worker-xx9qt   1/1     Running   0          59s
ray-job-sample-raycluster-rdx6h-head-2h4l9                   1/1     Running   0          59s
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
