### PR TITLE
[CI] Composable kube resource logger when test failed

### DIFF
--- a/ray-operator/test/support/resource_logger.go
+++ b/ray-operator/test/support/resource_logger.go
@@ -1,0 +1,134 @@
+package support
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	PODS_RESOURCE = iota
+	JOBS_RESOURCE
+	SERVICES_RESOURCE
+	RAYJOBS_RESOURCE
+)
+
+type ResourceLoggerFunc = func(sb *strings.Builder)
+
+func WithRayJobResourceLogger(t Test) types.GomegaTestingT {
+	resources := []int{PODS_RESOURCE, JOBS_RESOURCE, SERVICES_RESOURCE, RAYJOBS_RESOURCE}
+	return &RayResourceLogger{t: t, resources: resources}
+}
+
+type RayResourceLogger struct {
+	t         Test
+	resources []int
+}
+
+func (l *RayResourceLogger) Helper() {
+	l.t.T().Helper()
+}
+
+func (l *RayResourceLogger) Fatalf(format string, args ...interface{}) {
+	l.Helper()
+	loggers := l.GetLoggers()
+	var sb strings.Builder
+	// Log the original failure message
+	fmt.Fprintf(&sb, format, args...)
+	for _, logger := range loggers {
+		logger(&sb)
+	}
+	l.t.T().Fatal(sb.String())
+}
+
+func (l *RayResourceLogger) FprintfPods(sb *strings.Builder) {
+	if pods, err := l.t.Client().Core().CoreV1().Pods("").List(l.t.Ctx(), metav1.ListOptions{}); err == nil {
+		fmt.Fprintf(sb, "\n=== Pods across all namespaces ===\n")
+		for _, pod := range pods.Items {
+			podJSON, err := json.MarshalIndent(pod, "", "    ")
+			if err != nil {
+				fmt.Fprintf(sb, "Error marshaling pod %s/%s: %v\n", pod.Namespace, pod.Name, err)
+				continue
+			}
+			fmt.Fprintf(sb, "---\n# Pod: %s/%s\n%s\n", pod.Namespace, pod.Name, string(podJSON))
+		}
+	} else {
+		fmt.Fprintf(sb, "Failed to get pods: %v\n", err)
+	}
+}
+
+func (l *RayResourceLogger) FprintfJobs(sb *strings.Builder) {
+	if jobs, err := l.t.Client().Core().BatchV1().Jobs("").List(l.t.Ctx(), metav1.ListOptions{}); err == nil {
+		fmt.Fprintf(sb, "\n=== Jobs across all namespaces ===\n")
+		for _, job := range jobs.Items {
+			jobJSON, err := json.MarshalIndent(job, "", "    ")
+			if err != nil {
+				fmt.Fprintf(sb, "Error marshaling job %s/%s: %v\n", job.Namespace, job.Name, err)
+				continue
+			}
+			fmt.Fprintf(sb, "---\n# Job: %s/%s\n%s\n", job.Namespace, job.Name, string(jobJSON))
+		}
+	} else {
+		fmt.Fprintf(sb, "Failed to get jobs: %v\n", err)
+	}
+}
+
+func (l *RayResourceLogger) FprintServices(sb *strings.Builder) {
+	if services, err := l.t.Client().Core().CoreV1().Services("").List(l.t.Ctx(), metav1.ListOptions{}); err == nil {
+		fmt.Fprintf(sb, "\n=== Services across all namespaces ===\n")
+		for _, svc := range services.Items {
+			serviceJSON, err := json.MarshalIndent(svc, "", "    ")
+			if err != nil {
+				fmt.Fprintf(sb, "Error marshaling service %s/%s: %v\n", svc.Namespace, svc.Name, err)
+				continue
+			}
+			fmt.Fprintf(sb, "---\n# Service: %s/%s\n%s\n", svc.Namespace, svc.Name, string(serviceJSON))
+		}
+	} else {
+		fmt.Fprintf(sb, "Failed to get services: %v\n", err)
+	}
+}
+
+func (l *RayResourceLogger) FprintRayJobs(sb *strings.Builder) {
+	if rayJobs, err := l.t.Client().Ray().RayV1().RayJobs("").List(l.t.Ctx(), metav1.ListOptions{}); err == nil {
+		fmt.Fprintf(sb, "\n=== RayJobs across all namespaces ===\n")
+		for _, rayJob := range rayJobs.Items {
+			rayJobJSON, err := json.MarshalIndent(rayJob, "", "    ")
+			if err != nil {
+				fmt.Fprintf(sb, "Error marshaling rayjob %s/%s: %v\n", rayJob.Namespace, rayJob.Name, err)
+				continue
+			}
+			fmt.Fprintf(sb, "---\n# RayJob: %s/%s\n%s\n", rayJob.Namespace, rayJob.Name, string(rayJobJSON))
+		}
+	} else {
+		fmt.Fprintf(sb, "Failed to get rayjobs: %v\n", err)
+	}
+}
+
+func (l *RayResourceLogger) MakeFprintUnsupportedResource(resource int) func(sb *strings.Builder) {
+	return func(sb *strings.Builder) {
+		fmt.Fprintf(sb, "Error: Unsupported resource: %d for RayResourceLogger\n", resource)
+	}
+}
+
+func (l *RayResourceLogger) GetLoggers() []ResourceLoggerFunc {
+	loggers := []ResourceLoggerFunc{}
+	for _, resource := range l.resources {
+		switch resource {
+		case PODS_RESOURCE:
+			loggers = append(loggers, l.FprintfPods)
+		case JOBS_RESOURCE:
+			loggers = append(loggers, l.FprintfJobs)
+		case SERVICES_RESOURCE:
+			loggers = append(loggers, l.FprintServices)
+		case RAYJOBS_RESOURCE:
+			loggers = append(loggers, l.FprintRayJobs)
+		default:
+			loggers = append(loggers, l.MakeFprintUnsupportedResource(resource))
+		}
+	}
+	return loggers
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
Make resource logger composable.
## Why are these changes needed?
Ready to apply to other tests.
<!-- Please give a short summary of the change and the problem this solves. -->
## Screen shots
### error logs(the same to https://github.com/ray-project/kuberay/pull/3025)
![CleanShot 2025-02-18 at 17 05 05@2x](https://github.com/user-attachments/assets/18e0d565-52f4-43ba-9eaa-093ca77a1828)

### unsupported resource error
![CleanShot 2025-02-18 at 17 04 39@2x](https://github.com/user-attachments/assets/78fe9f34-3d6b-407c-a55a-249244d69bb5)

## Related issue number

<!-- For example: "Closes #1234" -->
#3069

## Checks
This PR depends on the PR https://github.com/ray-project/kuberay/pull/3025 , please review the latest commit [14c452f](https://github.com/ray-project/kuberay/pull/3070/commits/14c452f24d3ea1ab6970825320149ef47d7820a5).
- [X] I've made sure the tests are passing.
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
