### PR TITLE
[Fix][CI] Redirect stderr to stdout in Test Autoscaler E2E (nightly operator)

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -52,5 +52,5 @@
     # Run e2e tests and print KubeRay operator logs if tests fail
     - echo "--- START:Running Autoscaler e2e (nightly operator) tests"
     - set -o pipefail
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2eautoscaler | awk -f ../.buildkite/format.awk || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2eautoscaler 2>&1 | awk -f ../.buildkite/format.awk || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay && exit 1)
     - echo "--- END:Autoscaler e2e (nightly operator) tests finished"


### PR DESCRIPTION
## Why are these changes needed?
This PR follows up on this PR https://github.com/ray-project/kuberay/pull/3021 to address a case where e2e tests failed but displayed success. This fix redirects stderr to stdout to ensure output logs are properly captured and processed by the awk formatter. 

Test with failed `TestRayClusterAutoscaler`:
https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/7025#01951c77-5a62-4cfc-9cc5-5601c688faaf
Failed logs are properly printed and displayed.
<img width="1497" alt="Screenshot 2025-02-18 at 23 54 39" src="https://github.com/user-attachments/assets/75d366ed-c40c-4fb7-98c7-af1a29f0ec52" />
<img width="860" alt="Screenshot 2025-02-18 at 23 55 28" src="https://github.com/user-attachments/assets/2f3aab5e-e6de-4d52-b0e7-26168dadd6ba" />





## Related issue number
N/A


## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
