### PR TITLE
[CI] apply resource logger to ray cluster test

### DIFF
--- a/ray-operator/test/sampleyaml/raycluster_test.go
+++ b/ray-operator/test/sampleyaml/raycluster_test.go
@@ -70,6 +70,7 @@ func TestRayCluster(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			test := With(t)
 			g := NewWithT(t)
+			g.ConfigureWithT(WithRayClusterResourceLogger(test))
 
 			yamlFilePath := path.Join(GetSampleYAMLDir(test), tt.name)
 			namespace := test.NewTestNamespace()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Print related resources when a cluster test failed.
<!-- Please give a short summary of the change and the problem this solves. -->
Easier to debug.

## Related issue number

<!-- For example: "Closes #1234" -->
## Related PR
This PR depends on
https://github.com/ray-project/kuberay/pull/3070
Please review based on the last commit [[CI] apply resource logger to ray cluster test](https://github.com/ray-project/kuberay/pull/3075/commits/6260d3764df25ccf300063792b73a1ae43a1b91e).
## Screen shots
![CleanShot 2025-02-19 at 11 43 25@2x](https://github.com/user-attachments/assets/bdf2f036-f431-445c-8627-b5b1bd1c08ed)

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
