### PR TITLE
[CI] apply resource logger to ray service test

### DIFF
--- a/ray-operator/test/sampleyaml/rayservice_test.go
+++ b/ray-operator/test/sampleyaml/rayservice_test.go
@@ -32,6 +32,7 @@ func TestRayService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			test := With(t)
 			g := NewWithT(t)
+			g.ConfigureWithT(WithRayServiceResourceLogger(test))
 
 			yamlFilePath := path.Join(GetSampleYAMLDir(test), tt.name)
 			namespace := test.NewTestNamespace()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Print related resources when a ray service test failed.
<!-- Please give a short summary of the change and the problem this solves. -->
Easier to debug.

## Related issue number
#3069
<!-- For example: "Closes #1234" -->
## Related PR
This PR depends on
https://github.com/ray-project/kuberay/pull/3075
because need to print raycluster when rayservice failed.
Please review the last commit.
## Screen shots

![CleanShot 2025-02-20 at 15 21 11@2x](https://github.com/user-attachments/assets/27f77bc8-12b7-4266-86da-2bf76a299e3a)

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] This PR is not tested :(
