### PR TITLE
[chore][docs] enable more Markdown lint rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v1.0.0 (2023-11-06)
 
-### KubeRay is officially in General Availability!
+### KubeRay is officially in General Availability
 
 * Bump the CRD version from v1alpha1 to v1.
 * Relocate almost all documentation to the Ray website.
@@ -282,6 +282,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Highlights
 
 The KubeRay 0.5.2 patch release includes the following improvements.
+
 * Allow specifying the entire headService and serveService YAML spec. Previously, only certain special fields such as `labels` and `annotations` were exposed to the user.
   * Expose entire head pod Service to the user ([#1040](https://github.com/ray-project/kuberay/pull/1040), [@architkulkarni](https://github.com/architkulkarni))
   * Exposing Serve Service ([#1117](https://github.com/ray-project/kuberay/pull/1117), [@kodwanis](https://github.com/kodwanis))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ If you spot a problem with the problem, [search if an issue already exists](http
 
 KubeRay has subproject and each of them may have different development and testing procedure. Please check `DEVELOPMENT.md` in sub folder to get familar with running and testing codes.
 
-### Open a Pull request.
+### Open a Pull request
 
 When you're done making the changes, open a pull request and fill PR template so we can better review your PR. The template helps reviewers understand your changes and the purpose of your pull request.
 

--- a/benchmark/memory_benchmark/memory_benchmark.md
+++ b/benchmark/memory_benchmark/memory_benchmark.md
@@ -1,14 +1,14 @@
 # KubeRay memory benchmark
 
-# Running benchmark experiments on a Google GKE Cluster
+## Running benchmark experiments on a Google GKE Cluster
 
-## Architecture
+### Architecture
 
 ![benchmark architecture](images/benchmark_architecture.png)
 
 This architecture is not a good practice, but it can fulfill the current requirements.
 
-## Step 1: Create a new Kubernetes cluster
+### Step 1: Create a new Kubernetes cluster
 
 We will create a GKE cluster with autoscaling enabled.
 The following command creates a Kubernetes cluster named `kuberay-benchmark-cluster` on Google GKE.
@@ -21,7 +21,7 @@ gcloud container clusters create kuberay-benchmark-cluster \
     --zone=us-west1-b --machine-type e2-highcpu-16
 ```
 
-## Step 2: Install Prometheus and Grafana
+### Step 2: Install Prometheus and Grafana
 
 ```sh
 # Path: kuberay/
@@ -30,19 +30,21 @@ gcloud container clusters create kuberay-benchmark-cluster \
 
 Follow "Step 2: Install Kubernetes Prometheus Stack via Helm chart" in [prometheus-grafana.md](https://github.com/ray-project/kuberay/blob/master/docs/guidance/prometheus-grafana.md#step-2-install-kubernetes-prometheus-stack-via-helm-chart) to install the [kube-prometheus-stack v48.2.1](https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-48.2.1/charts/kube-prometheus-stack) chart and related custom resources.
 
-## Step 3: Install a KubeRay operator
+### Step 3: Install a KubeRay operator
 
 Follow [this document](https://github.com/ray-project/kuberay/blob/master/helm-chart/kuberay-operator/README.md) to install the latest stable KubeRay operator via Helm repository.
 
-## Step 4: Run experiments
+### Step 4: Run experiments
 
 * Step 4.1: Make sure the `kubectl` CLI can connect to your GKE cluster. If not, please run `gcloud auth login`.
 * Step 4.2: Run an experiment
+
   ```sh
   # You can modify `memory_benchmark_utils` to run the experiment you want to run.
   # (path: benchmark/memory_benchmark/scripts)
   python3 memory_benchmark_utils.py | tee benchmark_log
   ```
+
 * Step 4.3: Follow [prometheus-grafana.md](https://github.com/ray-project/kuberay/blob/master/docs/guidance/prometheus-grafana.md#step-2-install-kubernetes-prometheus-stack-via-helm-chart) to access Grafana's dashboard.
   * Sign into the Grafana dashboard.
   * Click on "Dashboards"
@@ -50,12 +52,14 @@ Follow [this document](https://github.com/ray-project/kuberay/blob/master/helm-c
   * You will see the "Memory Usage" panel for the KubeRay operator Pod.
   * Select the time range, then click on "Inspect" followed by "Data" to download the memory usage data of the KubeRay operator Pod.
 * Step 4.4: Delete all RayCluster custom resources.
+
   ```sh
   kubectl delete --all rayclusters.ray.io --namespace=default
   ```
+
 * Step 4.5: Repeat Step 4.2 to Step 4.4 for other experiments.
 
-# Experiments
+## Experiments
 
 We've designed three benchmark experiments:
 
@@ -65,11 +69,12 @@ We've designed three benchmark experiments:
 
 Based on [the survey](https://forms.gle/KtMLzjXcKoeSTj359) for KubeRay users, we decided to set our benchmark target at 150 Ray Pods which can cover most use cases.
 
-## Experiment results (KubeRay v0.6.0)
+### Experiment results (KubeRay v0.6.0)
 
 ![benchmark result](images/benchmark_result.png)
 
 * You can generate the figure by running:
+
   ```sh
   # (path: benchmark/memory_benchmark/scripts)
   python3 experiment_figures.py

--- a/benchmark/perf-tests/README.md
+++ b/benchmark/perf-tests/README.md
@@ -25,6 +25,7 @@ Each directory contains a test scenario and it's clusterloader2 configuraiton. W
 for previously executed runs of the tests.
 
 The current lists of tests are:
+
 * [100 RayCluster test](./100-raycluster/)
 * [100 RayJob test](./100-rayjob/)
 * [1000 RayCluster test](./1000-raycluster/)
@@ -43,16 +44,19 @@ To learn more about the benchmark measurements, see [Cluster Loader 2 Measuremen
 You can test clusterloader2 configs using Kind.
 
 First create a kind cluster:
+
 ```sh
 kind create cluster --image=kindest/node:v1.27.3
 ```
 
 Install KubeRay;
+
 ```sh
 helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0
 ```
 
 Run a clusterloader2 test:
+
 ```sh
 clusterloader2 --provider kind --kubeconfig ~/.kube/config --testconfig ./100-rayjob/config.yaml
 ```

--- a/ci/markdownlint.yaml
+++ b/ci/markdownlint.yaml
@@ -4,10 +4,6 @@ default: true
 
 MD013: false
 MD024: false
-MD025: false
-MD026: false
-MD031: false
-MD032: false
 MD033: false
 MD034: false
 MD036: false

--- a/docs/design/protobuf-grpc-service.md
+++ b/docs/design/protobuf-grpc-service.md
@@ -31,6 +31,7 @@ kuberay-operator-785476b948-fmlm7                         1/1     Running   0   
 In issue [#29](https://github.com/ray-project/kuberay/issues/29), `RayCluster` CRD clientset has been generated and gRPC service can leverage it to operate Custom Resources.
 
 A simple flow would be like this. (Thanks [@akanso](https://github.com/akanso) for providing the flow)
+
 ```
 client --> GRPC Server --> [created Custom Resources] <-- Ray Operator (reads CR and accordingly performs CRUD)
 ```

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -56,13 +56,15 @@ Manual testing can be time-consuming, and to relieve the workload, we plan to ad
 
 * Depending on whether the release is for a major, minor, or patch version, take the following steps.
   * **Major or Minor version** (e.g. `0.5.0` or `1.0.0`). Create a release branch named `release-X.Y`:
+
     ```
     git checkout -b release-0.5
     git push -u upstream release-0.5
     ```
+
   * **Patch version** (e.g. `0.5.1`). You don't need to cut a release branch for a patch version. Instead add commits to the release branch.
 
-#### Step 3. Create a first release candidate (`v0.5.0-rc.0`).
+#### Step 3. Create a first release candidate (`v0.5.0-rc.0`)
 
 * Merge a PR into the release branch updating Helm chart versions, Helm chart image tags, and kustomize manifest image tags. For `v0.5.0-rc0`, we did this in [PR #1001](https://github.com/ray-project/kuberay/pull/1001)
 
@@ -72,12 +74,14 @@ Manual testing can be time-consuming, and to relieve the workload, we plan to ad
 You will be prompted for a commit reference and an image tag. The commit reference should be the SHA of the tip of the release branch. The image tag should be `vX.Y.Z-rc.0`.
 
 * Tag the tip of release branch with `vX.Y.Z-rc.0`.
+
     ```
     git tag v0.5.0-rc.0
     git push upstream v0.5.0-rc.0
     ```
 
 * The [image release CI pipeline](https://github.com/ray-project/kuberay/blob/master/.github/workflows/image-release.yaml) also publishes the `github.com/ray-project/kuberay/ray-operator@vX.Y.Z-rc.0` Go module. KubeRay has supported Go modules since v0.6.0. Follow these instructions to verify the Go module installation.
+
     ```sh
     # Install the module. This step is highly possible to fail because the module is not available in the proxy server.
     go install github.com/ray-project/kuberay/ray-operator@v1.0.0-rc.0
@@ -119,7 +123,7 @@ Now, we have the Docker images and Helm charts for v0.5.0.
 
 * Merge post-release pull requests (example: [#1010](https://github.com/ray-project/kuberay/pull/1010)). See [here](https://github.com/ray-project/kuberay/issues/940) to understand the definition of "post-release" and the compatibility philosophy for KubeRay.
 
-#### Step 7. Update KubeRay documentation in Ray repository.
+#### Step 7. Update KubeRay documentation in Ray repository
 
 * Update KubeRay documentation in Ray repository with v0.5.0. Examples for v0.5.0:
   * https://github.com/ray-project/ray/pull/33339
@@ -130,7 +134,7 @@ Now, we have the Docker images and Helm charts for v0.5.0.
 * Manually trigger the `release-kubectl-plugin` CI job to generate the release.
 * Follow the [instructions](../release/changelog.md) to generate release notes and add notes in the GitHub release.
 
-#### Step 9. Announce the release on the KubeRay slack!
+#### Step 9. Announce the release on the KubeRay slack
 
 * Announce the release on the KubeRay slack ([example](https://ray-distributed.slack.com/archives/C02GFQ82JPM/p1681244150758839))!
 
@@ -138,6 +142,6 @@ Now, we have the Docker images and Helm charts for v0.5.0.
 
 * Send a PR to add the release notes to [CHANGELOG.md](../../CHANGELOG.md).
 
-#### Step 11. Update and improve this release document!
+#### Step 11. Update and improve this release document
 
 * Update this document and optimize the release process!

--- a/docs/guidance/rayclient-nginx-ingress.md
+++ b/docs/guidance/rayclient-nginx-ingress.md
@@ -1,10 +1,10 @@
-# Connect to Rayclient with NGINX Ingress
+# Connect to Ray client with NGINX Ingress
 >
 > Warning: Ray client has some known [limitations](https://docs.ray.io/en/latest/cluster/running-applications/job-submission/ray-client.html#things-to-know) and is not actively maintained.
 
 This document provides an example for connecting Ray client to a Raycluster via [NGINX Ingress](https://kubernetes.github.io/ingress-nginx/) on Kind. Although this is a Kind example, the steps applies to any Kubernetes Cluster that runs the NGINX Ingress Controller.
 
-# Requirements
+## Requirements
 
 * Environment:
   * `Ubuntu`
@@ -17,6 +17,7 @@ This document provides an example for connecting Ray client to a Raycluster via 
 ## Step 1: Create a Kind cluster
 
 The extra arg prepares the Kind cluster for deploying the ingress controller
+
 ```sh
 cat <<EOF | kind create cluster --config=-
 kind: Cluster
@@ -42,6 +43,7 @@ EOF
 ## Step 2: Deploy NGINX Ingress Controller
 
 The [SSL Passthrough feature](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) is required to pass on the encryption to the backend service directly.
+
 ```sh
 # Deploy the NGINX Ingress Controller
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
@@ -60,14 +62,17 @@ Follow this [document](../../helm-chart/kuberay-operator/README.md) to install t
 ## Step 4: Create a Raycluster with TLS enabled
 
 The Ray client server is a GRPC service. The NGINX Ingress Controller supports GRPC backend service which uses http/2 and requires secured connection. The command below creates a Raycluster with TLS enabled:
+
 ```sh
 kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-cluster.tls.yaml
 ```
+
 Refer to the [TLS document](tls.md) for more detail.
 
 ## Step 5: Create an ingress for the Ray client service
 
 With the Raycluster running, create an ingress for the Ray client backend service using the [rayclient-ingress](../../ray-operator/config/samples/ingress-rayclient-tls.yaml) example below:
+
 ```sh
 cat << EOF | kubectl apply -f -
 apiVersion: networking.k8s.io/v1
@@ -92,12 +97,14 @@ spec:
                 number: 10001
 EOF
 ```
+
 The annotation, `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` sets up the appropriate NGINX configuration to route http/2 traffic to a GRPC backend service. The `nginx.ingress.kubernetes.io/ssl-passthrough: "true"` annotation tells the ingress to forward the encrypted traffic to the backend service to be handled inside the Raycluster itself.
 
 ## Step 6: Connecting to Ray client service via the ingress
 
 Since the Raycluster uses TLS, the local Ray client would require a set of certificates to connect to Raycluster.
 > Warning: Ray client has some known [limitations](https://docs.ray.io/en/latest/cluster/running-applications/job-submission/ray-client.html#things-to-know) and is not actively maintained.
+
 ```sh
 # Download the ca key pair and create a cert signing request (CSR)
 kubectl get secret ca-tls -o template='{{index .data "ca.key"}}'|base64 -d > ./ca.key
@@ -126,6 +133,7 @@ ray.init(address="ray://localhost", logging_level="DEBUG")'
 ```
 
 The output should be similar to:
+
 ```
 2023-04-25 16:33:32,452   INFO client_builder.py:253 -- Passing the following kwargs to ray.init() on the server: logging_level
 2023-04-25 16:33:32,460   DEBUG worker.py:378 -- client gRPC channel state change: ChannelConnectivity.IDLE

--- a/docs/release/changelog.md
+++ b/docs/release/changelog.md
@@ -5,6 +5,7 @@
 1. Prepare your [Github Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 
 1. Install the Github python dependencies needed to generate the changelog.
+
     ```
     pip install PyGithub
     ```
@@ -69,10 +70,12 @@ Run the script to generate changelogs.
 
 1. To create the release notes, save the output of the script. Modify the script's output as follows.
     - Remove extraneous data, such as commits with tag information or links to other PRs, e.g.
+
     ```
     - c1cbaed (tag: v0.4.0-rc.0) Update chart versions for 0.4.0-rc.0 (#804) -> c1cbaed Update chart versions for 0.4.0-rc.0 (#804)
     - 86b0af2 Remove ingress.enabled from KubeRay operator chart (#812) (#816) -> 86b0af2 Remove ingress.enabled from KubeRay operator chart (#816)
     ```
+
     - Group commits by category e.g. `KubeRay Operator`, `Documentation`, etc. (The choice of categories is at the release manager's discretion.)
     - Add a section summarizing important changes.
     - Add a section listing individuals who contributed to the release.

--- a/docs/release/helm-chart.md
+++ b/docs/release/helm-chart.md
@@ -29,6 +29,7 @@ You can validate the charts as follows:
 * Check the creation/update time of all releases and `index.yaml` to ensure they are updated.
 
 * Install charts from Helm repository.
+
     ```sh
     helm repo add kuberay https://ray-project.github.io/kuberay-helm/
     helm repo update
@@ -59,6 +60,7 @@ If you really need to do that, please read this section carefully before you do 
     # The following command deletes the tag "ray-cluster-0.4.0".
     git push --delete upstream ray-cluster-0.4.0
     ```
+
 * Remove `index.yaml`
 * Trigger kuberay-helm CI again to create new releases and a new index.yaml.
 * Follow "Step 3: Validate the charts" to test it.

--- a/helm-chart/kuberay-apiserver/README.md
+++ b/helm-chart/kuberay-apiserver/README.md
@@ -13,6 +13,7 @@ helm version
 ## Install KubeRay API Server
 
 * Install a stable version via Helm repository (only supports KubeRay v0.4.0+)
+
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
@@ -26,6 +27,7 @@ helm version
   ```
 
 * Install the nightly version
+
   ```sh
   # Step1: Clone KubeRay repository
 

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -13,6 +13,7 @@ helm version
 ## Install CRDs and KubeRay operator
 
 * Install a stable version via Helm repository (only supports KubeRay v0.4.0+)
+
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
@@ -26,6 +27,7 @@ helm version
   ```
 
 * Install the nightly version
+
   ```sh
   # Step1: Clone KubeRay repository
 
@@ -38,6 +40,7 @@ helm version
 * Install KubeRay operator without installing CRDs
   * In some cases, the installation of the CRDs and the installation of the operator may require different levels of admin permissions, so these two installations could be handled as different steps by different roles.
   * Use Helm's built-in `--skip-crds` flag to install the operator only. See [this document](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) for more details.
+
   ```sh
   # Step 1: Install CRDs only (for cluster admin)
   kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.1.0&timeout=90s"

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -5,6 +5,7 @@ RayCluster is a custom resource definition (CRD). **KubeRay operator** will list
 ## Prerequisites
 
 See [kuberay-operator/README.md](https://github.com/ray-project/kuberay/blob/master/helm-chart/kuberay-operator/README.md) for more details.
+
 * Helm
 * Install custom resource definition and KubeRay operator (covered by the following end-to-end example.)
 

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -190,11 +190,13 @@ Alternatively, You can run the e2e test(s) from your preferred IDE / debugger.
 ### Manually test new image in running cluster
 
 Build and apply the CRD:
+
 ```bash
 make install
 ```
 
 Deploy the manifests and controller
+
 ```bash
 helm uninstall kuberay-operator; helm install kuberay-operator --set image.repository=kuberay/operator --set image.tag=nightly ../helm-chart/kuberay-operator
 ```
@@ -212,10 +214,13 @@ See [main development documentation][main-dev-doc].
 We have [chart lint tests](https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm-lint.yaml) with Helm v3.4.1 and Helm v3.9.4 on GitHub Actions. We also provide a script to execute the lint tests on your laptop. If you cannot reproduce the errors on GitHub Actions, the possible reason is the different version of Helm. Issue [#537](https://github.com/ray-project/kuberay/issues/537) is an example that some errors only happen in old helm versions.
 
 Run tests with docker
+
 ```bash
 ./helm-chart/script/chart-test.sh
 ```
+
 Run tests on your local environment
+
 * Step1: Install `ct` (chart-testing) and related dependencies. See https://github.com/helm/chart-testing for more details.
 * Step2: `./helm-chart/script/chart-test.sh local`
 
@@ -268,14 +273,19 @@ python3 ../scripts/rbac-check.py
 
 Most of image repositories supports multiple architectures container images. When running an image from a device, the docker client automatically pulls the correct the image with a matching architectures. The easiest way to build multi-arch images is to utilize Docker `Buildx` plug-in which allows easily building multi-arch images using Qemu emulation from a single machine. Buildx plugin is readily available when you install the [Docker Desktop](https://docs.docker.com/desktop/) on your machine.
 Verify Buildx installation and make sure it does not return error
+
 ```
 docker buildx version
 ```
+
 Verify the builder instance has a default(with *) DRIVER/ENDPOINT starting with `docker-container` by running:
+
 ```
 docker buildx ls
 ```
+
 You may see something:
+
 ```
 NAME/NODE    DRIVER/ENDPOINT             STATUS  BUILDKIT             PLATFORMS
 sad_brown *  docker-container
@@ -285,15 +295,18 @@ default      docker
 ```
 
 If not, create the instance by running:
+
 ```
 docker buildx create --use --bootstrap
 ```
 
 Run the following `docker buildx build` command to build and push linux/arm64 and linux/amd64 images(manifests) in a single command:
+
 ```
 cd ray-operator
 docker buildx build --tag quay.io/<my org>/operator:latest --tag docker.io/<my org>/operator:latest --platform linux/amd64,linux/arm64 --push --provenance=false .
 ```
+
 * --platform is a comma separated list of targeted platforms to build.
 * --tag is a remote repo_name:tag to push.
 * --push/--load optionally Push to remote registry or Load into local docker.


### PR DESCRIPTION
* MD025: Multiple top level headers in the same document
* MD026: Trailing punctuation in header
* MD031: Fenced code blocks should be surrounded by blank lines
* MD032: Lists should be surrounded by blank lines