### PR TITLE
[Fix][kubectl-plugin] Release bot opens PRs to Krew repo with unexpected whitespace changes

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -6,30 +6,30 @@ spec:
   version: {{ .TagName }}
   homepage: https://github.com/ray-project/kuberay/tree/master/kubectl-plugin
   platforms:
-  - selector:
-      matchLabels:
-        os: darwin
-        arch: amd64
-    {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
-    bin: kubectl-ray
-  - selector:
-      matchLabels:
-        os: darwin
-        arch: arm64
-    {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
-    bin: kubectl-ray
-  - selector:
-      matchLabels:
-        os: linux
-        arch: amd64
-    {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
-    bin: kubectl-ray
-  - selector:
-      matchLabels:
-        os: linux
-        arch: arm64
-    {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
-    bin: kubectl-ray
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
+      bin: kubectl-ray
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
+      bin: kubectl-ray
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+      bin: kubectl-ray
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
+      bin: kubectl-ray
   shortDescription: Ray kubectl plugin
   description: |
     Kubectl plugin/extension for Kuberay CLI that provides the ability to manage ray resources.


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
There are some whitespace changes in https://github.com/kubernetes-sigs/krew-index/pull/4426, preventing the auto-merge of the version bump for kubectl plugin.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
