### PR TITLE
[feat][kubectl-plugin] support K8s labels and annotations

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -44,6 +44,9 @@ var (
 
 		# Create a Ray cluster from flags input
 		kubectl ray create cluster sample-cluster --ray-version %s --image %s --head-cpu 1 --head-memory 5Gi --worker-replicas 3 --worker-cpu 1 --worker-memory 5Gi
+
+		# Create a Ray cluster with K8s labels and annotations
+		kubectl ray create cluster sample-cluster --labels app=ray,env=dev --annotations ttl-hours=24,owner=chthulu
 	`, util.RayVersion, util.RayImage))
 )
 

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -29,6 +29,8 @@ type RayClusterSpecObject struct {
 type RayClusterYamlObject struct {
 	ClusterName string
 	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
 	RayClusterSpecObject
 }
 
@@ -41,6 +43,8 @@ type RayJobYamlObject struct {
 
 func (rayClusterObject *RayClusterYamlObject) GenerateRayClusterApplyConfig() *rayv1ac.RayClusterApplyConfiguration {
 	rayClusterApplyConfig := rayv1ac.RayCluster(rayClusterObject.ClusterName, rayClusterObject.Namespace).
+		WithLabels(rayClusterObject.Labels).
+		WithAnnotations(rayClusterObject.Annotations).
 		WithSpec(rayClusterObject.generateRayClusterSpec())
 
 	return rayClusterApplyConfig

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -15,10 +15,21 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
-func TestGenerateRayCluterApplyConfig(t *testing.T) {
+func TestGenerateRayClusterApplyConfig(t *testing.T) {
+	labels := map[string]string{
+		"blue":    "jay",
+		"eastern": "bluebird",
+	}
+	annotations := map[string]string{
+		"mourning":  "dove",
+		"baltimore": "oriole",
+	}
+
 	testRayClusterYamlObject := RayClusterYamlObject{
 		ClusterName: "test-ray-cluster",
 		Namespace:   "default",
+		Labels:      labels,
+		Annotations: annotations,
 		RayClusterSpecObject: RayClusterSpecObject{
 			RayVersion:     util.RayVersion,
 			Image:          util.RayImage,
@@ -36,6 +47,8 @@ func TestGenerateRayCluterApplyConfig(t *testing.T) {
 
 	assert.Equal(t, testRayClusterYamlObject.ClusterName, *result.Name)
 	assert.Equal(t, testRayClusterYamlObject.Namespace, *result.Namespace)
+	assert.Equal(t, testRayClusterYamlObject.Labels, labels)
+	assert.Equal(t, testRayClusterYamlObject.Annotations, annotations)
 	assert.Equal(t, testRayClusterYamlObject.RayVersion, *result.Spec.RayVersion)
 	assert.Equal(t, testRayClusterYamlObject.Image, *result.Spec.HeadGroupSpec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, resource.MustParse(testRayClusterYamlObject.HeadCPU), *result.Spec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests.Cpu())
@@ -86,6 +99,14 @@ func TestConvertRayClusterApplyConfigToYaml(t *testing.T) {
 	testRayClusterYamlObject := RayClusterYamlObject{
 		ClusterName: "test-ray-cluster",
 		Namespace:   "default",
+		Labels: map[string]string{
+			"purple":     "finch",
+			"red-tailed": "hawk",
+		},
+		Annotations: map[string]string{
+			"american": "goldfinch",
+			"piping":   "plover",
+		},
 		RayClusterSpecObject: RayClusterSpecObject{
 			RayVersion:     util.RayVersion,
 			Image:          util.RayImage,
@@ -106,6 +127,12 @@ func TestConvertRayClusterApplyConfigToYaml(t *testing.T) {
 	expectedResultYaml := fmt.Sprintf(`apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
+  annotations:
+    american: goldfinch
+    piping: plover
+  labels:
+    purple: finch
+    red-tailed: hawk
   name: test-ray-cluster
   namespace: default
 spec:


### PR DESCRIPTION
in cluster creation with `kubectl ray create cluster --labels` and
`--annotations`.

Signed-off-by: David Xia <david@davidxia.com>

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
