### PR TITLE
[feat][kubectl-plugin] `delete` accepts multiple resources

### DIFF
--- a/kubectl-plugin/pkg/cmd/delete/delete.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete.go
@@ -23,9 +23,9 @@ type DeleteOptions struct {
 	configFlags   *genericclioptions.ConfigFlags
 	ioStreams     *genericiooptions.IOStreams
 	kubeContexter util.KubeContexter
-	ResourceType  util.ResourceType
-	ResourceName  string
-	Namespace     string
+	resources     map[util.ResourceType][]string
+	namespace     string
+	yes           bool
 }
 
 var deleteExample = templates.Examples(`
@@ -48,6 +48,7 @@ func NewDeleteOptions(streams genericiooptions.IOStreams) *DeleteOptions {
 		ioStreams:     &streams,
 		configFlags:   configFlags,
 		kubeContexter: &util.DefaultKubeContexter{},
+		resources:     map[util.ResourceType][]string{},
 	}
 }
 
@@ -56,10 +57,16 @@ func NewDeleteCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	factory := cmdutil.NewFactory(options.configFlags)
 
 	cmd := &cobra.Command{
-		Use:               "delete (RAYCLUSTER | TYPE/NAME)",
-		Short:             "Delete Ray resource",
-		Example:           deleteExample,
-		Long:              `Deletes Ray custom resources such as RayCluster, RayService, or RayJob`,
+		Use:     "delete (RAYCLUSTER | TYPE/NAME)",
+		Short:   "Delete Ray resources",
+		Example: deleteExample,
+		Long:    `Deletes Ray custom resources such as RayCluster, RayService, or RayJob`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return cmdutil.UsageErrorf(cmd, "accepts a minimum of 1 arg, received %d\n%s", len(args), cmd.Use)
+			}
+			return nil
+		},
 		ValidArgsFunction: completion.RayClusterResourceNameCompletionFunc(factory),
 		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -73,42 +80,54 @@ func NewDeleteCommand(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVarP(&options.yes, "yes", "y", false, "answer 'yes' to all prompts and run non-interactively")
 	options.configFlags.AddFlags(cmd.Flags())
 	return cmd
 }
 
 func (options *DeleteOptions) Complete(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return cmdutil.UsageErrorf(cmd, "%s", cmd.Use)
-	}
-
 	if *options.configFlags.Namespace == "" {
-		options.Namespace = "default"
+		options.namespace = "default"
 	} else {
-		options.Namespace = *options.configFlags.Namespace
+		options.namespace = *options.configFlags.Namespace
 	}
 
-	typeAndName := strings.Split(args[0], "/")
-	if len(typeAndName) == 1 {
-		options.ResourceType = util.RayCluster
-		options.ResourceName = typeAndName[0]
-	} else {
-		if len(typeAndName) != 2 || typeAndName[1] == "" {
-			return cmdutil.UsageErrorf(cmd, "invalid resource type/name: %s", args[0])
-		}
+	if options.resources == nil {
+		options.resources = map[util.ResourceType][]string{}
+	}
 
-		switch strings.ToLower(typeAndName[0]) {
-		case string(util.RayCluster):
-			options.ResourceType = util.RayCluster
-		case string(util.RayJob):
-			options.ResourceType = util.RayJob
-		case string(util.RayService):
-			options.ResourceType = util.RayService
-		default:
-			return cmdutil.UsageErrorf(cmd, "unsupported resource type: %s", args[0])
-		}
+	for _, arg := range args {
+		typeAndName := strings.Split(arg, "/")
+		if len(typeAndName) == 1 {
+			if _, ok := options.resources[util.RayCluster]; !ok {
+				options.resources[util.RayCluster] = []string{}
+			}
+			options.resources[util.RayCluster] = append(options.resources[util.RayCluster], typeAndName[0])
+		} else {
+			if len(typeAndName) != 2 || typeAndName[1] == "" {
+				return cmdutil.UsageErrorf(cmd, "invalid resource type/name: %s", arg)
+			}
 
-		options.ResourceName = typeAndName[1]
+			switch strings.ToLower(typeAndName[0]) {
+			case string(util.RayCluster):
+				if _, ok := options.resources[util.RayCluster]; !ok {
+					options.resources[util.RayCluster] = []string{}
+				}
+				options.resources[util.RayCluster] = append(options.resources[util.RayCluster], typeAndName[1])
+			case string(util.RayJob):
+				if _, ok := options.resources[util.RayJob]; !ok {
+					options.resources[util.RayJob] = []string{}
+				}
+				options.resources[util.RayJob] = append(options.resources[util.RayJob], typeAndName[1])
+			case string(util.RayService):
+				if _, ok := options.resources[util.RayService]; !ok {
+					options.resources[util.RayService] = []string{}
+				}
+				options.resources[util.RayService] = append(options.resources[util.RayService], typeAndName[1])
+			default:
+				return cmdutil.UsageErrorf(cmd, "unsupported resource type: %s", arg)
+			}
+		}
 	}
 
 	return nil
@@ -132,40 +151,63 @@ func (options *DeleteOptions) Run(ctx context.Context, factory cmdutil.Factory) 
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	// Ask user for confirmation
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Printf("Are you sure you want to delete %s %s? (y/yes/n/no) ", options.ResourceType, options.ResourceName)
-	confirmation, err := reader.ReadString('\n')
-	if err != nil {
-		return fmt.Errorf("Failed to read user input: %w", err)
+	resources := ""
+	for resourceType, resourceNames := range options.resources {
+		for _, resourceName := range resourceNames {
+			resources += fmt.Sprintf("\n- %s/%s", resourceType, resourceName)
+		}
 	}
 
-	switch strings.ToLower(strings.TrimSpace(confirmation)) {
-	case "y", "yes":
-	case "n", "no":
-		fmt.Printf("Canceled deletion.\n")
-		return nil
-	default:
-		fmt.Printf("Unknown input %s\n", confirmation)
-		return nil
+	if !options.yes {
+		// Ask user for confirmation
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Printf("Are you sure you want to delete the following resources?%s\n(y/yes/n/no)", resources)
+		confirmation, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("Failed to read user input: %w", err)
+		}
+
+		switch strings.ToLower(strings.TrimSpace(confirmation)) {
+		case "y", "yes":
+		case "n", "no":
+			fmt.Printf("Canceled deletion.\n")
+			return nil
+		default:
+			fmt.Printf("Unknown input %s\n", confirmation)
+			return nil
+		}
 	}
 
-	// Delete the Ray Resources
-	switch options.ResourceType {
+	// Delete the Ray resources
+	for resourceType, resourceNames := range options.resources {
+		for _, resourceName := range resourceNames {
+			if err := deleteResource(ctx, k8sClient, options.namespace, resourceType, resourceName); err != nil {
+				return fmt.Errorf("failed to delete %s/%s: %w", resourceType, resourceName, err)
+			}
+			fmt.Printf("Deleted %s %s\n", resourceType, resourceName)
+		}
+	}
+
+	return nil
+}
+
+func deleteResource(ctx context.Context, k8sClient client.Client, namespace string, resourceType util.ResourceType, resourceName string) error {
+	var err error
+
+	switch resourceType {
 	case util.RayCluster:
-		err = k8sClient.RayClient().RayV1().RayClusters(options.Namespace).Delete(ctx, options.ResourceName, metav1.DeleteOptions{})
+		err = k8sClient.RayClient().RayV1().RayClusters(namespace).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	case util.RayJob:
-		err = k8sClient.RayClient().RayV1().RayJobs(options.Namespace).Delete(ctx, options.ResourceName, metav1.DeleteOptions{})
+		err = k8sClient.RayClient().RayV1().RayJobs(namespace).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	case util.RayService:
-		err = k8sClient.RayClient().RayV1().RayServices(options.Namespace).Delete(ctx, options.ResourceName, metav1.DeleteOptions{})
+		err = k8sClient.RayClient().RayV1().RayServices(namespace).Delete(ctx, resourceName, metav1.DeleteOptions{})
 	default:
-		err = fmt.Errorf("unknown/unsupported resource type: %s", options.ResourceType)
+		err = fmt.Errorf("unknown/unsupported resource type: %s", resourceType)
 	}
 
 	if err != nil {
-		return fmt.Errorf("Failed to delete %s/%s: %w", options.ResourceType, options.ResourceName, err)
+		return err
 	}
 
-	fmt.Printf("Delete %s %s\n", options.ResourceType, options.ResourceName)
 	return nil
 }

--- a/kubectl-plugin/pkg/cmd/delete/delete_test.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete_test.go
@@ -16,6 +16,7 @@ func TestComplete(t *testing.T) {
 	tests := []struct {
 		name                 string
 		namespace            string
+		expectedResources    map[util.ResourceType][]string
 		expectedResourceType util.ResourceType
 		expectedNamespace    string
 		expectedName         string
@@ -23,35 +24,33 @@ func TestComplete(t *testing.T) {
 		hasErr               bool
 	}{
 		{
-			name:                 "valid raycluster without explicit resource and without namespace",
-			namespace:            "",
-			expectedResourceType: util.RayCluster,
-			expectedNamespace:    "default",
-			expectedName:         "test-raycluster",
-			args:                 []string{"test-raycluster"},
-			hasErr:               false,
+			name:              "valid raycluster without explicit resource and without namespace",
+			namespace:         "",
+			expectedResources: map[util.ResourceType][]string{util.RayCluster: {"test-raycluster"}},
+			expectedNamespace: "default",
+			args:              []string{"test-raycluster"},
+			hasErr:            false,
 		},
 		{
-			name:                 "valid raycluster with explicit resource and with namespace",
-			namespace:            "test-namespace",
-			expectedResourceType: util.RayCluster,
-			expectedNamespace:    "test-namespace",
-			expectedName:         "test-raycluster",
-			args:                 []string{"raycluster/test-raycluster"},
-			hasErr:               false,
+			name:              "valid raycluster with explicit resource and with namespace",
+			namespace:         "test-namespace",
+			expectedResources: map[util.ResourceType][]string{util.RayCluster: {"test-raycluster"}},
+			expectedNamespace: "test-namespace",
+			args:              []string{"raycluster/test-raycluster"},
+			hasErr:            false,
 		},
 		{
-			name:                 "valid raycluster without explicit resource and with namespace",
-			namespace:            "test-namespace",
-			expectedResourceType: util.RayCluster,
-			expectedNamespace:    "test-namespace",
-			expectedName:         "test-raycluster",
-			args:                 []string{"test-raycluster"},
-			hasErr:               false,
+			name:              "valid raycluster without explicit resource and with namespace",
+			namespace:         "test-namespace",
+			expectedResources: map[util.ResourceType][]string{util.RayCluster: {"test-raycluster"}},
+			expectedNamespace: "test-namespace",
+			args:              []string{"test-raycluster"},
+			hasErr:            false,
 		},
 		{
 			name:                 "valid RayJob with namespace",
 			namespace:            "test-namespace",
+			expectedResources:    map[util.ResourceType][]string{util.RayJob: {"test-rayjob"}},
 			expectedResourceType: util.RayJob,
 			expectedNamespace:    "test-namespace",
 			expectedName:         "test-rayjob",
@@ -59,13 +58,12 @@ func TestComplete(t *testing.T) {
 			hasErr:               false,
 		},
 		{
-			name:                 "valid rayservice with namespace",
-			namespace:            "test-namespace",
-			expectedResourceType: util.RayService,
-			expectedNamespace:    "test-namespace",
-			expectedName:         "test-rayservice",
-			args:                 []string{"rayservice/test-rayservice"},
-			hasErr:               false,
+			name:              "valid rayservice with namespace",
+			namespace:         "test-namespace",
+			expectedResources: map[util.ResourceType][]string{util.RayService: {"test-rayservice"}},
+			expectedNamespace: "test-namespace",
+			args:              []string{"rayservice/test-rayservice"},
+			hasErr:            false,
 		},
 		{
 			name:      "invalid service type",
@@ -74,22 +72,27 @@ func TestComplete(t *testing.T) {
 			hasErr:    true,
 		},
 		{
-			name:                 "valid raycluster with namespace but weird ray type casing",
-			namespace:            "test-namespace",
-			expectedResourceType: util.RayCluster,
-			expectedNamespace:    "test-namespace",
-			expectedName:         "test-raycluster",
-			args:                 []string{"rayCluStER/test-raycluster"},
-			hasErr:               false,
+			name:              "valid raycluster with namespace but weird ray type casing",
+			namespace:         "test-namespace",
+			expectedResources: map[util.ResourceType][]string{util.RayCluster: {"test-raycluster"}},
+			expectedNamespace: "test-namespace",
+			args:              []string{"rayCluStER/test-raycluster"},
+			hasErr:            false,
 		},
 		{
-			name:   "invalid args, too many args",
-			args:   []string{"test", "raytype", "raytypename"},
-			hasErr: true,
+			name: "valid args with multiple resources",
+			args: []string{"raycluster/test", "rayjob/my-job", "rayservice/barista", "other-cluster"},
+			expectedResources: map[util.ResourceType][]string{
+				util.RayCluster: {"test", "other-cluster"},
+				util.RayJob:     {"my-job"},
+				util.RayService: {"barista"},
+			},
+			expectedNamespace: "default",
+			hasErr:            false,
 		},
 		{
 			name:   "invalid args, non valid resource type",
-			args:   []string{"test/test"},
+			args:   []string{"raycluster/test-raycluster", "test/test"},
 			hasErr: true,
 		},
 	}
@@ -104,9 +107,8 @@ func TestComplete(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tc.expectedName, fakeDeleteOptions.ResourceName)
-				assert.Equal(t, tc.expectedNamespace, fakeDeleteOptions.Namespace)
-				assert.Equal(t, tc.expectedResourceType, fakeDeleteOptions.ResourceType)
+				assert.Equal(t, tc.expectedResources, fakeDeleteOptions.resources)
+				assert.Equal(t, tc.expectedNamespace, fakeDeleteOptions.namespace)
 			}
 		})
 	}


### PR DESCRIPTION
and user can skip interactive confirmation prompt with `-y/--yes`.

## Before

```console
$ kubectl ray delete raycluster/dxia-test1 raycluster/dxia-test2 rayjob/rayjob-sample
Error: delete (RAYCLUSTER | TYPE/NAME)
See 'ray delete -h' for help and examples
```

## After

### Without `--yes`

```console
$ kubectl ray delete raycluster/dxia-test1 raycluster/dxia-test2 rayjob/rayjob-sample
Are you sure you want to delete the following resources?
- raycluster/dxia-test1
- raycluster/dxia-test2
- rayjob/rayjob-sample
(y/yes/n/no)y
Deleted raycluster dxia-test1
Deleted raycluster dxia-test2
Deleted rayjob rayjob-sample
```

### With `--yes`

```console
$ kubectl ray delete raycluster/dxia-test1 raycluster/dxia-test2 rayjob/rayjob-sample --yes
Deleted raycluster dxia-test1
Deleted raycluster dxia-test2
Deleted rayjob rayjob-sample
```

Signed-off-by: David Xia <david@davidxia.com>

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
