### PR TITLE
[fix][kubectl-plugin] error when creating cluster that already exists

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -1,13 +1,23 @@
 package create
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/utils/ptr"
+
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	rayClientFake "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/fake"
 )
 
 func TestRayCreateClusterComplete(t *testing.T) {
@@ -55,4 +65,35 @@ func TestRayCreateClusterValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRayClusterCreateClusterRun(t *testing.T) {
+	namespace := "namespace-1"
+	clusterName := "cluster-1"
+
+	options := CreateClusterOptions{
+		configFlags: &genericclioptions.ConfigFlags{
+			Namespace: ptr.To(namespace),
+		},
+		kubeContexter: util.NewMockKubeContexter(true),
+		clusterName:   clusterName,
+	}
+
+	t.Run("should error when the Ray cluster already exists", func(t *testing.T) {
+		rayClusters := []runtime.Object{
+			&rayv1.RayCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: namespace,
+					Name:      clusterName,
+				},
+				Spec: rayv1.RayClusterSpec{},
+			},
+		}
+
+		rayClient := rayClientFake.NewSimpleClientset(rayClusters...)
+		k8sClients := client.NewClientForTesting(kubefake.NewClientset(), rayClient)
+
+		err := options.Run(context.Background(), k8sClients)
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
Right now `kubectl ray create cluster NAME` returns 0 if a cluster with the
same name already exists. We want this command to have the same behavior as
`kubectl create` not `kubectl apply`. `kubectl create` exits with an error if
there's an existing resource with the same name.

Note: this change will break the existing behavior of users who run the command
as a way to update an existing cluster. Perhaps this is a desirable breaking
change.

## Before

```console
$ kubectl ray create cluster dxia-test1
Error: the Ray cluster dxia-test1 in namespace hyperkube already exists

$ echo $?
0
```

## After

```console
$ kubectl ray create cluster dxia-test1
Error: the Ray cluster dxia-test1 in namespace hyperkube already exists

$ echo $?
1
```

Signed-off-by: David Xia <david@davidxia.com>

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
