### PR TITLE
[CI] fix locust versions

### DIFF
--- a/ray-operator/test/e2erayservice/rayservice_ha_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_ha_test.go
@@ -56,7 +56,7 @@ func TestStaticRayService(t *testing.T) {
 	LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
 
 	// Install Locust in the head Pod
-	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust"})
+	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10"})
 
 	// Run Locust test
 	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
@@ -116,7 +116,7 @@ func TestAutoscalingRayService(t *testing.T) {
 	LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
 
 	// Install Locust in the head Pod
-	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust"})
+	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10"})
 
 	// Run Locust test
 	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
@@ -173,7 +173,7 @@ func TestRayServiceZeroDowntimeUpgrade(t *testing.T) {
 	LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
 
 	// Install Locust in the head Pod
-	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust"})
+	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10"})
 
 	// Start a goroutine to perform zero-downtime upgrade
 	var wg sync.WaitGroup
@@ -268,7 +268,7 @@ func TestRayServiceGCSFaultTolerance(t *testing.T) {
 	LogWithTimestamp(test.T(), "Found head pod %s/%s", locustHeadPod.Namespace, locustHeadPod.Name)
 
 	// Install Locust in the Locust head Pod
-	ExecPodCmd(test, locustHeadPod, common.RayHeadContainer, []string{"pip", "install", "locust"})
+	ExecPodCmd(test, locustHeadPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10"})
 
 	// Get current head pod
 	oldHeadPod, err := GetHeadPod(test, rayServiceUnderlyingRayCluster)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current tests use `pip install locust` to install the latest version of locust, but the latest version is incompatible with our tests. This PR pins the version to `2.32.10`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
