### PR TITLE
[feat] shorten RayClusterSuffix to have more space for RayService and RayJob names

### DIFF
--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -29,7 +29,6 @@ import (
 )
 
 const (
-	RayClusterSuffix    = "-raycluster-"
 	ServeName           = "serve"
 	ClusterDomainEnvKey = "CLUSTER_DOMAIN"
 	DefaultDomainName   = "cluster.local"
@@ -314,7 +313,7 @@ func GenerateRouteName(clusterName string) string {
 
 // GenerateRayClusterName generates a ray cluster name from ray service name
 func GenerateRayClusterName(serviceName string) string {
-	return fmt.Sprintf("%s%s%s", serviceName, RayClusterSuffix, rand.String(5))
+	return fmt.Sprintf("%s-%s", serviceName, rand.String(5))
 }
 
 // GenerateRayJobId generates a ray job id for submission


### PR DESCRIPTION
## Why are these changes needed?

Currently, KubeRay adds different suffixes to make different services for a RayCluster. It will also trim these service names if they are too long to fit the 63-character limitation by k8s. However, the silent cut is not user user-friendly as users can't easily know the resulting service names beforehand. 

As a part of https://github.com/ray-project/kuberay/issues/3076: we are going to add a length validation to RayCluster names in v1.4 to make sure the silent cut does not take place while keeping sufficient room for the names specified by users, this PR shortens the `-raycluster-xxxxx` RayCluster suffix to just `-xxxxx` for RayJob and RayService, saving 11 characters for users to not be hit by the new length validation.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
