### PR TITLE
[Fix] Adjust crd path to verify changed files

### DIFF
--- a/.github/workflows/consistency-check.yaml
+++ b/.github/workflows/consistency-check.yaml
@@ -86,7 +86,7 @@ jobs:
         uses: tj-actions/verify-changed-files@v17
         with:
           files: |
-            ./config/bases/*.yaml
+            ./config/crd/bases/*.yaml
             ./config/rbac/*.yaml
 
       - name: Check changed files


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It appears that consistency check `ray-operator-verify-crd-rbac` in step `Verify Changed files` has wrong path to base CRDs.
The path `config/bases` does not exist, while `config/crd/bases` does exist, thus an obvious fix.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #3068 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
