### PR TITLE
[chore][docs] enable Markdown lint rules MD033 MD034

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Numerous fixes to the API server to make RayJob APIs working ([#1447](https://github.com/ray-project/kuberay/pull/1447), @blublinsky)
 * Updated API server documentation ([#1435](https://github.com/ray-project/kuberay/pull/1435), @z103cb)
 * servev2 support for API server ([#1419](https://github.com/ray-project/kuberay/pull/1419), @blublinsky)
-* replacement for https://github.com/ray-project/kuberay/pull/1312 ([#1409](https://github.com/ray-project/kuberay/pull/1409), @blublinsky)
+* replacement for <https://github.com/ray-project/kuberay/pull/1312> ([#1409](https://github.com/ray-project/kuberay/pull/1409), @blublinsky)
 * Updates to the apiserver swagger-ui ([#1410](https://github.com/ray-project/kuberay/pull/1410), @z103cb)
 * implemented liveness/readyness probe for the API server ([#1369](https://github.com/ray-project/kuberay/pull/1369), @blublinsky)
 * Operator support for openShift ([#1371](https://github.com/ray-project/kuberay/pull/1371), @blublinsky)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -116,7 +116,7 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
@@ -124,5 +124,5 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/ci/markdownlint.yaml
+++ b/ci/markdownlint.yaml
@@ -4,8 +4,6 @@ default: true
 
 MD013: false
 MD024: false
-MD033: false
-MD034: false
 MD036: false
 MD041: false
 MD050: false

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -126,8 +126,8 @@ Now, we have the Docker images and Helm charts for v0.5.0.
 #### Step 7. Update KubeRay documentation in Ray repository
 
 * Update KubeRay documentation in Ray repository with v0.5.0. Examples for v0.5.0:
-  * https://github.com/ray-project/ray/pull/33339
-  * https://github.com/ray-project/ray/pull/34178
+  * <https://github.com/ray-project/ray/pull/33339>
+  * <https://github.com/ray-project/ray/pull/34178>
 
 #### Step 8. Generate release
 

--- a/docs/guidance/aws-eks-iam.md
+++ b/docs/guidance/aws-eks-iam.md
@@ -24,7 +24,7 @@ s3.download_file(bucket_name, key, filename)
 ```
 
 The root cause is that the version of `boto3` in the Ray image is too old. To elaborate, `rayproject/ray:2.3.0` provides boto3 version 1.4.8 (Nov. 21, 2017),
-a more recent version (1.26) is currently available as per https://pypi.org/project/boto3/#history. The `boto3` 1.4.8 does not support to initialize the security credentials automatically in some cases (e.g. `AssumeRoleWithWebIdentity`).
+a more recent version (1.26) is currently available as per <https://pypi.org/project/boto3/#history>. The `boto3` 1.4.8 does not support to initialize the security credentials automatically in some cases (e.g. `AssumeRoleWithWebIdentity`).
 
 ```shell
 # image: rayproject/ray:2.5.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD033 -->
 # Welcome
 
 <p align="center">
@@ -54,7 +55,7 @@ by some organizations to back user interfaces for KubeRay resource management.
 
 **Security and isolation must be enforced outside of the Ray Cluster.** Restrict network access with Kubernetes or other external controls. Refer to [**Ray security documentation**](https://docs.ray.io/en/master/ray-security/index.html) for more guidance on what controls to implement.
 
-Please report security issues to security@anyscale.com.
+Please report security issues to <security@anyscale.com>.
 
 ## The Ray docs
 

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -221,7 +221,7 @@ Run tests with docker
 
 Run tests on your local environment
 
-* Step1: Install `ct` (chart-testing) and related dependencies. See https://github.com/helm/chart-testing for more details.
+* Step1: Install `ct` (chart-testing) and related dependencies. See <https://github.com/helm/chart-testing> for more details.
 * Step2: `./helm-chart/script/chart-test.sh local`
 
 ### Generating API Reference


### PR DESCRIPTION
* MD033: Inline HTML
* MD034: Bare URL used

https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
