### PR TITLE
[RayCluster] IsAutoscalingEnabled takes RayClusterSpec

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -51,7 +51,7 @@ func (v *VolcanoBatchScheduler) Name() string {
 func (v *VolcanoBatchScheduler) DoBatchSchedulingOnSubmission(ctx context.Context, app *rayv1.RayCluster) error {
 	var minMember int32
 	var totalResource corev1.ResourceList
-	if !utils.IsAutoscalingEnabled(app) {
+	if !utils.IsAutoscalingEnabled(&app.Spec) {
 		minMember = utils.CalculateDesiredReplicas(ctx, app) + 1
 		totalResource = utils.CalculateDesiredResources(app)
 	} else {

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -179,7 +179,7 @@ func DefaultHeadPodTemplate(ctx context.Context, instance rayv1.RayCluster, head
 	initTemplateAnnotations(instance, &podTemplate)
 
 	// if in-tree autoscaling is enabled, then autoscaler container should be injected into head pod.
-	if utils.IsAutoscalingEnabled(&instance) {
+	if utils.IsAutoscalingEnabled(&instance.Spec) {
 		// The default autoscaler is not compatible with Kubernetes. As a result, we disable
 		// the monitor process by default and inject a KubeRay autoscaler side container into the head pod.
 		headSpec.RayStartParams["no-monitor"] = "true"

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -859,7 +859,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 			// diff < 0 indicates the need to delete some Pods to match the desired number of replicas. However,
 			// randomly deleting Pods is certainly not ideal. So, if autoscaling is enabled for the cluster, we
 			// will disable random Pod deletion, making Autoscaler the sole decision-maker for Pod deletions.
-			enableInTreeAutoscaling := utils.IsAutoscalingEnabled(instance)
+			enableInTreeAutoscaling := utils.IsAutoscalingEnabled(&instance.Spec)
 
 			// TODO (kevin85421): `enableRandomPodDelete` is a feature flag for KubeRay v0.6.0. If users want to use
 			// the old behavior, they can set the environment variable `ENABLE_RANDOM_POD_DELETE` to `true`. When the
@@ -1090,7 +1090,7 @@ func (r *RayClusterReconciler) buildHeadPod(ctx context.Context, instance rayv1.
 	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, instance, instance.Namespace) // Fully Qualified Domain Name
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
-	autoscalingEnabled := utils.IsAutoscalingEnabled(&instance)
+	autoscalingEnabled := utils.IsAutoscalingEnabled(&instance.Spec)
 	podConf := common.DefaultHeadPodTemplate(ctx, instance, instance.Spec.HeadGroupSpec, podName, headPort)
 	if len(r.headSidecarContainers) > 0 {
 		podConf.Spec.Containers = append(podConf.Spec.Containers, r.headSidecarContainers...)
@@ -1118,7 +1118,7 @@ func (r *RayClusterReconciler) buildWorkerPod(ctx context.Context, instance rayv
 
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)
 	headPort := common.GetHeadPort(instance.Spec.HeadGroupSpec.RayStartParams)
-	autoscalingEnabled := utils.IsAutoscalingEnabled(&instance)
+	autoscalingEnabled := utils.IsAutoscalingEnabled(&instance.Spec)
 	podTemplateSpec := common.DefaultWorkerPodTemplate(ctx, instance, worker, podName, fqdnRayIP, headPort)
 	if len(r.workerSidecarContainers) > 0 {
 		podTemplateSpec.Spec.Containers = append(podTemplateSpec.Spec.Containers, r.workerSidecarContainers...)
@@ -1504,7 +1504,7 @@ func (r *RayClusterReconciler) updateHeadInfo(ctx context.Context, instance *ray
 
 func (r *RayClusterReconciler) reconcileAutoscalerServiceAccount(ctx context.Context, instance *rayv1.RayCluster) error {
 	logger := ctrl.LoggerFrom(ctx)
-	if !utils.IsAutoscalingEnabled(instance) {
+	if !utils.IsAutoscalingEnabled(&instance.Spec) {
 		return nil
 	}
 
@@ -1561,7 +1561,7 @@ func (r *RayClusterReconciler) reconcileAutoscalerServiceAccount(ctx context.Con
 
 func (r *RayClusterReconciler) reconcileAutoscalerRole(ctx context.Context, instance *rayv1.RayCluster) error {
 	logger := ctrl.LoggerFrom(ctx)
-	if !utils.IsAutoscalingEnabled(instance) {
+	if !utils.IsAutoscalingEnabled(&instance.Spec) {
 		return nil
 	}
 
@@ -1603,7 +1603,7 @@ func (r *RayClusterReconciler) reconcileAutoscalerRole(ctx context.Context, inst
 
 func (r *RayClusterReconciler) reconcileAutoscalerRoleBinding(ctx context.Context, instance *rayv1.RayCluster) error {
 	logger := ctrl.LoggerFrom(ctx)
-	if !utils.IsAutoscalingEnabled(instance) {
+	if !utils.IsAutoscalingEnabled(&instance.Spec) {
 		return nil
 	}
 

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -629,17 +629,9 @@ func ManagedByExternalController(controllerName *string) *string {
 	return nil
 }
 
-func IsAutoscalingEnabled[T *rayv1.RayCluster | *rayv1.RayJob | *rayv1.RayService](obj T) bool {
-	switch obj := (interface{})(obj).(type) {
-	case *rayv1.RayCluster:
-		return obj.Spec.EnableInTreeAutoscaling != nil && *obj.Spec.EnableInTreeAutoscaling
-	case *rayv1.RayJob:
-		return obj.Spec.RayClusterSpec != nil && obj.Spec.RayClusterSpec.EnableInTreeAutoscaling != nil && *obj.Spec.RayClusterSpec.EnableInTreeAutoscaling
-	case *rayv1.RayService:
-		return obj.Spec.RayClusterSpec.EnableInTreeAutoscaling != nil && *obj.Spec.RayClusterSpec.EnableInTreeAutoscaling
-	default:
-		panic(fmt.Sprintf("unsupported type: %T", obj))
-	}
+func IsAutoscalingEnabled(spec *rayv1.RayClusterSpec) bool {
+	return spec != nil && spec.EnableInTreeAutoscaling != nil &&
+		*spec.EnableInTreeAutoscaling
 }
 
 // Check if the RayCluster has GCS fault tolerance enabled.

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -739,18 +739,18 @@ func TestErrRayClusterReplicaFailureReason(t *testing.T) {
 func TestIsAutoscalingEnabled(t *testing.T) {
 	// Test: RayCluster
 	cluster := &rayv1.RayCluster{}
-	assert.False(t, IsAutoscalingEnabled(cluster))
+	assert.False(t, IsAutoscalingEnabled(&cluster.Spec))
 
 	cluster = &rayv1.RayCluster{
 		Spec: rayv1.RayClusterSpec{
 			EnableInTreeAutoscaling: ptr.To[bool](true),
 		},
 	}
-	assert.True(t, IsAutoscalingEnabled(cluster))
+	assert.True(t, IsAutoscalingEnabled(&cluster.Spec))
 
 	// Test: RayJob
 	job := &rayv1.RayJob{}
-	assert.False(t, IsAutoscalingEnabled(job))
+	assert.False(t, IsAutoscalingEnabled(job.Spec.RayClusterSpec))
 
 	job = &rayv1.RayJob{
 		Spec: rayv1.RayJobSpec{
@@ -759,11 +759,11 @@ func TestIsAutoscalingEnabled(t *testing.T) {
 			},
 		},
 	}
-	assert.True(t, IsAutoscalingEnabled(job))
+	assert.True(t, IsAutoscalingEnabled(job.Spec.RayClusterSpec))
 
 	// Test: RayService
 	service := &rayv1.RayService{}
-	assert.False(t, IsAutoscalingEnabled(service))
+	assert.False(t, IsAutoscalingEnabled(&service.Spec.RayClusterSpec))
 
 	service = &rayv1.RayService{
 		Spec: rayv1.RayServiceSpec{
@@ -772,7 +772,7 @@ func TestIsAutoscalingEnabled(t *testing.T) {
 			},
 		},
 	}
-	assert.True(t, IsAutoscalingEnabled(service))
+	assert.True(t, IsAutoscalingEnabled(&service.Spec.RayClusterSpec))
 }
 
 func TestIsGCSFaultToleranceEnabled(t *testing.T) {

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -79,7 +79,7 @@ func ValidateRayClusterSpec(instance *rayv1.RayCluster) error {
 		}
 	}
 
-	if IsAutoscalingEnabled(instance) {
+	if IsAutoscalingEnabled(&instance.Spec) {
 		for _, workerGroup := range instance.Spec.WorkerGroupSpecs {
 			if workerGroup.Suspend != nil && *workerGroup.Suspend {
 				// TODO (rueian): This can be supported in future Ray. We should check the RayVersion once we know the version.
@@ -138,7 +138,7 @@ func ValidateRayJobSpec(rayJob *rayv1.RayJob) error {
 			}
 		}
 
-		if policy == rayv1.DeleteWorkersDeletionPolicy && IsAutoscalingEnabled(rayJob) {
+		if policy == rayv1.DeleteWorkersDeletionPolicy && IsAutoscalingEnabled(rayJob.Spec.RayClusterSpec) {
 			// TODO (rueian): This can be supported in a future Ray version. We should check the RayVersion once we know it.
 			return fmt.Errorf("DeletionPolicy=DeleteWorkers currently does not support RayCluster with autoscaling enabled")
 		}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This is the support PR for https://github.com/ray-project/kuberay/pull/3093 to make easier to review according to https://github.com/ray-project/kuberay/pull/3093#pullrequestreview-2638641916.

To make `ValidateRayClusterSpec` adapt for RayJob and RayService, `IsAutoscalingEnabled` is subject to change.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
