### PR TITLE
[Prometheus] Add serviceMonitor for KubeRay Operator

### DIFF
--- a/config/prometheus/serviceMonitor.yaml
+++ b/config/prometheus/serviceMonitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    # `release: $HELM_RELEASE`: Prometheus can only detect ServiceMonitor with this label.
+    release: prometheus
+  name: kuberay-operator-monitor
+  namespace: prometheus-system
+spec:
+  jobLabel: kuberay-operator
+  # Only select Kubernetes Services in the "default" namespace.
+  namespaceSelector:
+    matchNames:
+      - default
+  # Only select Kubernetes Services with "matchLabels".
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kuberay-operator
+  endpoints:
+    - port: http
+      path: /metrics


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
adds `serviceMonitor`  to scrape metrics from KubeRay Operator, this is helpful for the team in establishing SLA.

![image](https://github.com/user-attachments/assets/7b220270-2811-4ce0-96e2-d7ca6b62fa2c)

Currently, the KubeRay Operator only provides the following metrics:

- ray_operator_clusters_created_total
- ray_operator_clusters_deleted_total
- ray_operator_clusters_successful_total
- ray_operator_clusters_failed_total -> ToDo

I plan to start working on adding relevant metrics for RayCluster, RayService, and RayJob next. referencing [Ray Infrastructure at Pinterest](https://medium.com/pinterest-engineering/ray-infrastructure-at-pinterest-0248efe4fd52).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->


## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
