### PR TITLE
[Bug] Re-enable flaky kubectl plugin e2e test "should reconnect after pod connection is lost"

### DIFF
--- a/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
@@ -64,7 +64,6 @@ var _ = Describe("Calling ray plugin `session` command", func() {
 	})
 
 	It("should reconnect after pod connection is lost", func() {
-		Skip("Skip this because it is flaky now")
 		sessionCmd := exec.Command("kubectl", "ray", "session", "--namespace", namespace, "raycluster-kuberay")
 
 		err := sessionCmd.Start()
@@ -103,7 +102,7 @@ var _ = Describe("Calling ray plugin `session` command", func() {
 		}, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 		// Wait for the new pod to be ready
-		cmd = exec.Command("kubectl", "wait", "--namespace", namespace, "pod", newPodName, "--for=condition=Ready", "--timeout=60s")
+		cmd = exec.Command("kubectl", "wait", "--namespace", namespace, "pod", newPodName, "--for=condition=Ready", "--timeout=120s")
 		err = cmd.Run()
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #2752
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
