### PR TITLE
[Chore][CI] Limit the release-image-build github workflow to only take tag as input

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -71,8 +71,8 @@ jobs:
       run: |
         docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
         docker push quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ env.tag }};
-        docker push quay.io/kuberay/apiserver:${{ env.tag }}
+        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:"${tag}";
+        docker push quay.io/kuberay/apiserver:"${tag}"
 
   release_operator_image:
     env:
@@ -173,7 +173,7 @@ jobs:
         provenance: false
         tags: |
           quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ steps.vars.outputs.sha_short }}
-          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ env.tag }}
+          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:"${tag}"
 
     - name: Create tag
       uses: actions/github-script@v6
@@ -182,6 +182,6 @@ jobs:
           await github.rest.git.createRef({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            ref: 'refs/tags/ray-operator/${{ env.tag }}',
+            ref: 'refs/tags/ray-operator/${tag}',
             sha: '${{ github.sha }}'
           })

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -175,5 +175,5 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             ref: 'refs/tags/ray-operator/${{ github.ref_name }}',
-            sha: '${{ github.sha }}'
+            sha: context.sha,
           })

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -173,7 +173,7 @@ jobs:
         provenance: false
         tags: |
           quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ steps.vars.outputs.sha_short }}
-          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:"${tag}"
+          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:"${{ env.tag }}"
 
     - name: Create tag
       uses: actions/github-script@v6
@@ -182,6 +182,6 @@ jobs:
           await github.rest.git.createRef({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            ref: 'refs/tags/ray-operator/${tag}',
+            ref: 'refs/tags/ray-operator/${{ env.tag }}',
             sha: '${{ github.sha }}'
           })

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Extract tag
       id: tag
-      run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
     - name: Install kubebuilder
       run: |
@@ -99,7 +99,7 @@ jobs:
 
     - name: Extract tag
       id: tag
-      run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
     - name: Install kubebuilder
       run: |

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -71,8 +71,8 @@ jobs:
       run: |
         docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
         docker push quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ tag }};
-        docker push quay.io/kuberay/apiserver:${{ tag }}
+        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ env.tag }};
+        docker push quay.io/kuberay/apiserver:${{ env.tag }}
 
   release_operator_image:
     env:
@@ -173,7 +173,7 @@ jobs:
         provenance: false
         tags: |
           quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ steps.vars.outputs.sha_short }}
-          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ tag }}
+          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ env.tag }}
 
     - name: Create tag
       uses: actions/github-script@v6
@@ -182,6 +182,6 @@ jobs:
           await github.rest.git.createRef({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            ref: 'refs/tags/ray-operator/${{ tag }}',
+            ref: 'refs/tags/ray-operator/${{ env.tag }}',
             sha: '${{ github.sha }}'
           })

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -27,7 +27,7 @@ jobs:
       with:
         script: core.setFailed('This action can only be run on tags')
 
-    - name: install kubebuilder
+    - name: Install kubebuilder
       run: |
         wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.0.0/kubebuilder_$(go env GOOS)_$(go env GOARCH)
         sudo mv kubebuilder_$(go env GOOS)_$(go env GOARCH) /usr/local/bin/kubebuilder
@@ -93,7 +93,7 @@ jobs:
       with:
         script: core.setFailed('This action can only be run on tags')
 
-    - name: install kubebuilder
+    - name: Install kubebuilder
       run: |
         wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.0.0/kubebuilder_$(go env GOOS)_$(go env GOARCH)
         sudo mv kubebuilder_$(go env GOOS)_$(go env GOARCH) /usr/local/bin/kubebuilder

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -16,7 +16,7 @@ jobs:
       if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
       with:
         script: core.setFailed('This action can only be run on tags')
-    
+
     - name: Set up Go
       uses: actions/setup-go@v3
       with:

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -11,6 +11,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
 
+    - name: Error if not a tag
+      uses: actions/github-script@v7
+      if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
+      with:
+        script: core.setFailed('This action can only be run on tags')
+    
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
@@ -21,11 +27,9 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Error if not a tag
-      uses: actions/github-script@v7
-      if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
-      with:
-        script: core.setFailed('This action can only be run on tags')
+    - name: Extract tag
+      id: tag
+      run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
     - name: Install kubebuilder
       run: |
@@ -67,8 +71,8 @@ jobs:
       run: |
         docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
         docker push quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ github.ref_name }};
-        docker push quay.io/kuberay/apiserver:${{ github.ref_name }}
+        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ steps.tag.outputs.tag }};
+        docker push quay.io/kuberay/apiserver:${{ steps.tag.outputs.tag }}
 
   release_operator_image:
     env:
@@ -76,6 +80,12 @@ jobs:
     name: Release Operator Docker Images
     runs-on: ubuntu-22.04
     steps:
+
+    - name: Error if not a tag
+      uses: actions/github-script@v7
+      if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
+      with:
+        script: core.setFailed('This action can only be run on tags')
 
     - name: Set up Go
       uses: actions/setup-go@v3
@@ -87,11 +97,9 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Error if not a tag
-      uses: actions/github-script@v7
-      if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
-      with:
-        script: core.setFailed('This action can only be run on tags')
+    - name: Extract tag
+      id: tag
+      run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
     - name: Install kubebuilder
       run: |
@@ -165,7 +173,7 @@ jobs:
         provenance: false
         tags: |
           quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ steps.vars.outputs.sha_short }}
-          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ github.ref_name }}
+          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ steps.tag.outputs.tag }}
 
     - name: Create tag
       uses: actions/github-script@v6
@@ -174,6 +182,6 @@ jobs:
           await github.rest.git.createRef({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            ref: 'refs/tags/ray-operator/${{ github.ref_name }}',
-            sha: context.sha,
+            ref: 'refs/tags/ray-operator/${{ steps.tag.outputs.tag }}',
+            sha: '${{ github.sha }}'
           })

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -71,8 +71,8 @@ jobs:
       run: |
         docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
         docker push quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ steps.tag.outputs.tag }};
-        docker push quay.io/kuberay/apiserver:${{ steps.tag.outputs.tag }}
+        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ tag }};
+        docker push quay.io/kuberay/apiserver:${{ tag }}
 
   release_operator_image:
     env:
@@ -173,7 +173,7 @@ jobs:
         provenance: false
         tags: |
           quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ steps.vars.outputs.sha_short }}
-          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ steps.tag.outputs.tag }}
+          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ tag }}
 
     - name: Create tag
       uses: actions/github-script@v6
@@ -182,6 +182,6 @@ jobs:
           await github.rest.git.createRef({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            ref: 'refs/tags/ray-operator/${{ steps.tag.outputs.tag }}',
+            ref: 'refs/tags/ray-operator/${{ tag }}',
             sha: '${{ github.sha }}'
           })

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -71,8 +71,8 @@ jobs:
       run: |
         docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
         docker push quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:"${ tag }";
-        docker push quay.io/kuberay/apiserver:"${ tag }"
+        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ env.tag }};
+        docker push quay.io/kuberay/apiserver:${{ env.tag }}
 
   release_operator_image:
     env:
@@ -173,7 +173,7 @@ jobs:
         provenance: false
         tags: |
           quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ steps.vars.outputs.sha_short }}
-          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:"${{ env.tag }}"
+          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ env.tag }}
 
     - name: Create tag
       uses: actions/github-script@v6

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -71,8 +71,8 @@ jobs:
       run: |
         docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
         docker push quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:"${tag}";
-        docker push quay.io/kuberay/apiserver:"${tag}"
+        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:"${ tag }";
+        docker push quay.io/kuberay/apiserver:"${ tag }"
 
   release_operator_image:
     env:

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -19,7 +19,13 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.inputs.commit }}
+        fetch-depth: 0
+
+    - name: Error if not a tag
+      uses: actions/github-script@v7
+      if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
+      with:
+        script: core.setFailed('This action can only be run on tags')
 
     - name: install kubebuilder
       run: |
@@ -61,8 +67,8 @@ jobs:
       run: |
         docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
         docker push quay.io/kuberay/apiserver:${{ steps.vars.outputs.sha_short }};
-        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ github.event.inputs.tag }};
-        docker push quay.io/kuberay/apiserver:${{ github.event.inputs.tag }}
+        docker image tag kuberay/apiserver:${{ steps.vars.outputs.sha_short }} quay.io/kuberay/apiserver:${{ github.ref_name }};
+        docker push quay.io/kuberay/apiserver:${{ github.ref_name }}
 
   release_operator_image:
     env:
@@ -79,7 +85,13 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.inputs.commit }}
+        fetch-depth: 0
+
+    - name: Error if not a tag
+      uses: actions/github-script@v7
+      if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
+      with:
+        script: core.setFailed('This action can only be run on tags')
 
     - name: install kubebuilder
       run: |
@@ -153,7 +165,7 @@ jobs:
         provenance: false
         tags: |
           quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ steps.vars.outputs.sha_short }}
-          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ github.event.inputs.tag }}
+          quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ github.ref_name }}
 
     - name: Create tag
       uses: actions/github-script@v6
@@ -162,6 +174,6 @@ jobs:
           await github.rest.git.createRef({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            ref: 'refs/tags/ray-operator/${{ github.event.inputs.tag }}',
-            sha: '${{ github.event.inputs.commit }}'
+            ref: 'refs/tags/ray-operator/${{ github.ref_name }}',
+            sha: '${{ github.sha }}'
           })

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -2,13 +2,6 @@ name: release-image-build
 
 on:
   workflow_dispatch:
-    inputs:
-      commit:
-        description: 'Commit reference (branch or SHA) from which to build the images.'
-        required: true
-      tag:
-        description: 'Desired release version tag (e.g. v1.1.0-rc.1).'
-        required: true
 
 jobs:
   release_apiserver_image:


### PR DESCRIPTION
## Why are these changes needed?

This Merge Request uses #3015 as a reference to make the `release-image-build` github workflow to take only the tag as input since `krew-release-bot` requires it. 

1. The `workflow-dispatch` step is now empty (i.e., no manual inputs)
<img width="338" alt="Screenshot 2025-03-03 at 3 46 10 PM" src="https://github.com/user-attachments/assets/ebad02fc-b95e-4517-ad43-05f2eaf4f6b5" />

<img width="349" alt="Screenshot 2025-03-03 at 3 46 19 PM" src="https://github.com/user-attachments/assets/564baaad-c197-40aa-af37-47b0334eed1d" />


2. An error checking step enforces the workflow fails if it's not running on a tag. 
3. Extract the tag for other steps to use. 




## Related issue number

Resolve #3016 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
