### PR TITLE
fix operator: show resource limit values in RayCluster.Status

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
@@ -41,9 +41,9 @@ func TestCreatePodGroup(t *testing.T) {
 				Name: "ray-worker",
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
-						corev1.ResourceMemory: resource.MustParse("512Mi"),
-						"nvidia.com/gpu":      resource.MustParse("1"),
+						corev1.ResourceCPU:          resource.MustParse("500m"),
+						corev1.ResourceMemory:       resource.MustParse("512Mi"),
+						utils.NvidiaGPUResourceName: resource.MustParse("1"),
 					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("256m"),
@@ -87,12 +87,12 @@ func TestCreatePodGroup(t *testing.T) {
 	// 1 head + 2 workers (desired, not min replicas)
 	a.Equal(int32(3), pg.Spec.MinMember)
 
-	// 256m * 3 (requests, not limits)
-	a.Equal("768m", pg.Spec.MinResources.Cpu().String())
+	// 500m * 3 (limits, not requests)
+	a.Equal("1500m", pg.Spec.MinResources.Cpu().String())
 
-	// 256Mi * 3 (requests, not limits)
-	a.Equal("768Mi", pg.Spec.MinResources.Memory().String())
+	// 512Mi * 3 (limits, not requests)
+	a.Equal("1536Mi", pg.Spec.MinResources.Memory().String())
 
 	// 2 GPUs total
-	a.Equal("2", pg.Spec.MinResources.Name("nvidia.com/gpu", resource.BinarySI).String())
+	a.Equal("2", pg.Spec.MinResources.Name(utils.NvidiaGPUResourceName, resource.BinarySI).String())
 }

--- a/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_scheduler_test.go
@@ -144,9 +144,9 @@ func TestPopulateGangSchedulingAnnotations(t *testing.T) {
 	//   nvidia.com/gpu: 1
 	addWorkerPodSpec(rayClusterWithGangScheduling,
 		"worker-group-1", 1, 1, 2, v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("2"),
-			v1.ResourceMemory: resource.MustParse("10Gi"),
-			"nvidia.com/gpu":  resource.MustParse("1"),
+			v1.ResourceCPU:              resource.MustParse("2"),
+			v1.ResourceMemory:           resource.MustParse("10Gi"),
+			utils.NvidiaGPUResourceName: resource.MustParse("1"),
 		})
 
 	// gang-scheduling enabled case, the plugin should populate the taskGroup annotation to the app
@@ -177,7 +177,7 @@ func TestPopulateGangSchedulingAnnotations(t *testing.T) {
 	assert.Equal(t, int32(1), workerGroup.MinMember)
 	assert.Equal(t, resource.MustParse("2"), workerGroup.MinResource[v1.ResourceCPU.String()])
 	assert.Equal(t, resource.MustParse("10Gi"), workerGroup.MinResource[v1.ResourceMemory.String()])
-	assert.Equal(t, resource.MustParse("1"), workerGroup.MinResource["nvidia.com/gpu"])
+	assert.Equal(t, resource.MustParse("1"), workerGroup.MinResource[utils.NvidiaGPUResourceName.String()])
 }
 
 func createRayClusterWithLabels(name string, namespace string, labels map[string]string) *rayv1.RayCluster {

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -36,13 +36,12 @@ const (
 	EnableInitContainerInjectionEnvKey = "ENABLE_INIT_CONTAINER_INJECTION"
 	NeuronCoreContainerResourceName    = "aws.amazon.com/neuroncore"
 	NeuronCoreRayResourceName          = "neuron_cores"
-	TPUContainerResourceName           = "google.com/tpu"
 	TPURayResourceName                 = "TPU"
 )
 
 var customAcceleratorToRayResourceMap = map[string]string{
-	NeuronCoreContainerResourceName: NeuronCoreRayResourceName,
-	TPUContainerResourceName:        TPURayResourceName,
+	NeuronCoreContainerResourceName:      NeuronCoreRayResourceName,
+	utils.GoogleTPUResourceName.String(): TPURayResourceName,
 }
 
 // Get the port required to connect to the Ray cluster by worker nodes and drivers

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -84,9 +84,9 @@ var instance = rayv1.RayCluster{
 								Image: "repo/image:custom",
 								Resources: corev1.ResourceRequirements{
 									Limits: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("1"),
-										corev1.ResourceMemory: testMemoryLimit,
-										"nvidia.com/gpu":      resource.MustParse("3"),
+										corev1.ResourceCPU:          resource.MustParse("1"),
+										corev1.ResourceMemory:       testMemoryLimit,
+										utils.NvidiaGPUResourceName: resource.MustParse("3"),
 									},
 								},
 								Env: []corev1.EnvVar{
@@ -718,9 +718,9 @@ func TestBuildPod(t *testing.T) {
 	rayContainer = pod.Spec.Containers[utils.RayContainerIndex]
 	expectedResources := corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("1"),
-			corev1.ResourceMemory: testMemoryLimit,
-			"nvidia.com/gpu":      resource.MustParse("3"),
+			corev1.ResourceCPU:          resource.MustParse("1"),
+			corev1.ResourceMemory:       testMemoryLimit,
+			utils.NvidiaGPUResourceName: resource.MustParse("3"),
 		},
 	}
 	assert.Equal(t, expectedResources.Limits, rayContainer.Resources.Limits, "Resource limits do not match")
@@ -767,8 +767,8 @@ func TestBuildPod_WithNoCPULimits(t *testing.T) {
 		},
 
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: testMemoryLimit,
-			"nvidia.com/gpu":      resource.MustParse("3"),
+			corev1.ResourceMemory:       testMemoryLimit,
+			utils.NvidiaGPUResourceName: resource.MustParse("3"),
 		},
 	}
 
@@ -1632,7 +1632,7 @@ func TestGenerateRayStartCommand(t *testing.T) {
 			rayStartParams: map[string]string{},
 			resource: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					"nvidia.com/gpu": resource.MustParse("1"),
+					utils.NvidiaGPUResourceName: resource.MustParse("1"),
 				},
 			},
 			expected: "ray start  --num-gpus=1 ",
@@ -1643,7 +1643,7 @@ func TestGenerateRayStartCommand(t *testing.T) {
 			rayStartParams: map[string]string{},
 			resource: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					"google.com/tpu": resource.MustParse("4"),
+					utils.GoogleTPUResourceName: resource.MustParse("4"),
 				},
 			},
 			expected: `ray start  --resources='{"TPU":4}' `,
@@ -1666,7 +1666,7 @@ func TestGenerateRayStartCommand(t *testing.T) {
 			resource: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					"aws.amazon.com/neuroncore": resource.MustParse("4"),
-					"nvidia.com/gpu":            resource.MustParse("1"),
+					utils.NvidiaGPUResourceName: resource.MustParse("1"),
 				},
 			},
 			expected: `ray start --head  --num-gpus=1  --resources='{"neuron_cores":4}' `,
@@ -1677,9 +1677,9 @@ func TestGenerateRayStartCommand(t *testing.T) {
 			rayStartParams: map[string]string{},
 			resource: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					"google.com/tpu":            resource.MustParse("8"),
+					utils.GoogleTPUResourceName: resource.MustParse("8"),
 					"aws.amazon.com/neuroncore": resource.MustParse("4"),
-					"nvidia.com/gpu":            resource.MustParse("1"),
+					utils.NvidiaGPUResourceName: resource.MustParse("1"),
 				},
 			},
 			expected: `ray start --head  --num-gpus=1  --resources='{"neuron_cores":4}' `,
@@ -1718,7 +1718,7 @@ func TestGenerateRayStartCommand(t *testing.T) {
 			},
 			resource: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					"google.com/tpu": resource.MustParse("8"),
+					utils.GoogleTPUResourceName: resource.MustParse("8"),
 				},
 			},
 			expected: `ray start --head  --resources='{"custom_resource":2,"TPU":4}' `,

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1292,7 +1292,7 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	newInstance.Status.DesiredCPU = totalResources[corev1.ResourceCPU]
 	newInstance.Status.DesiredMemory = totalResources[corev1.ResourceMemory]
 	newInstance.Status.DesiredGPU = sumGPUs(totalResources)
-	newInstance.Status.DesiredTPU = totalResources[corev1.ResourceName("google.com/tpu")]
+	newInstance.Status.DesiredTPU = totalResources[utils.GoogleTPUResourceName]
 
 	if reconcileErr == nil && len(runtimePods.Items) == int(newInstance.Status.DesiredWorkerReplicas)+1 { // workers + 1 head
 		if utils.CheckAllPodsRunning(ctx, runtimePods) {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3287,9 +3287,6 @@ func TestReconcile_NumOfHosts(t *testing.T) {
 }
 
 func TestSumGPUs(t *testing.T) {
-	nvidiaGPUResourceName := corev1.ResourceName("nvidia.com/gpu")
-	googleTPUResourceName := corev1.ResourceName("google.com/tpu")
-
 	tests := []struct {
 		name     string
 		input    map[corev1.ResourceName]resource.Quantity
@@ -3305,9 +3302,9 @@ func TestSumGPUs(t *testing.T) {
 		{
 			name: "one GPU type specified",
 			input: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				nvidiaGPUResourceName: resource.MustParse("1"),
-				googleTPUResourceName: resource.MustParse("1"),
+				corev1.ResourceCPU:          resource.MustParse("1"),
+				utils.NvidiaGPUResourceName: resource.MustParse("1"),
+				utils.GoogleTPUResourceName: resource.MustParse("1"),
 			},
 			expected: resource.MustParse("1"),
 		},
@@ -3315,9 +3312,9 @@ func TestSumGPUs(t *testing.T) {
 			name: "multiple GPUs specified",
 			input: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceCPU:                 resource.MustParse("1"),
-				nvidiaGPUResourceName:              resource.MustParse("3"),
+				utils.NvidiaGPUResourceName:        resource.MustParse("3"),
 				corev1.ResourceName("foo.bar/gpu"): resource.MustParse("2"),
-				googleTPUResourceName:              resource.MustParse("1"),
+				utils.GoogleTPUResourceName:        resource.MustParse("1"),
 			},
 			expected: resource.MustParse("5"),
 		},

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -1,6 +1,10 @@
 package utils
 
-import "errors"
+import (
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 const (
 
@@ -308,4 +312,7 @@ const (
 	// RoleBinding list
 	CreatedRoleBinding        K8sEventType = "CreatedRoleBinding"
 	FailedToCreateRoleBinding K8sEventType = "FailedToCreateRoleBinding"
+
+	NvidiaGPUResourceName = corev1.ResourceName("nvidia.com/gpu")
+	GoogleTPUResourceName = corev1.ResourceName("google.com/tpu")
 )

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -447,15 +447,16 @@ func CalculateMinResources(cluster *rayv1.RayCluster) corev1.ResourceList {
 }
 
 // CalculatePodResource returns the total resources of a pod.
-// Request values take precedence over limit values.
+// Limit values take precedence over request values.
+// See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#resources:~:text=On%20the%20other%20hand%20CPU%2C%20GPU%2C%20and%20memory%20requests%20will%20be%20ignored%20by%20Ray.%20For%20this%20reason%2C%20it%20is%20best%20when%20possible%20to%20set%20resource%20requests%20equal%20to%20resource%20limits.
 func CalculatePodResource(podSpec corev1.PodSpec) corev1.ResourceList {
 	podResource := corev1.ResourceList{}
 	for _, container := range podSpec.Containers {
-		containerResource := container.Resources.Requests
+		containerResource := container.Resources.Limits
 		if containerResource == nil {
 			containerResource = corev1.ResourceList{}
 		}
-		for name, quantity := range container.Resources.Limits {
+		for name, quantity := range container.Resources.Requests {
 			if _, ok := containerResource[name]; !ok {
 				containerResource[name] = quantity
 			}


### PR DESCRIPTION
instead of resource request values to be consistent with [these docs].

> On the other hand CPU, GPU, and memory **requests** will be ignored by Ray. For
> this reason, it is best when possible to **set resource requests equal to
> resource limits**.

Also make `"nvidia.com/gpu"` and `"google.com/tpu"` into shared constants.

[these docs]: https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#resources:~:text=On%20the%20other%20hand%20CPU%2C%20GPU%2C%20and%20memory%20requests%20will%20be%20ignored%20by%20Ray.%20For%20this%20reason%2C%20it%20is%20best%20when%20possible%20to%20set%20resource%20requests%20equal%20to%20resource%20limits.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
