### PR TITLE
[Chore] Set default go version in pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,9 @@
 # See https://pre-commit.com/hooks.html for more hooks
 exclude: _generated.go$|\.svg$|^third_party/|^proto/swagger/|^apiserver/pkg/swagger/datafile.go$|^docs/reference/api.md$|^config/grafana/
 
+default_language_version:
+  golang: 1.22.9
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When I first run the pre-commit, I got a bunch of errors. I found the error came from it using different version of golang. It would be better to set the golang version so that people won't run into similar issue.
For the golang version, I tried 1.22.0, but it's not compatible with golangci-lint@v1.60.3. If I downgrade golangci-lint there will be other format error. I also tried 1.22.4, but pre-commit failed with code 137 (OOM). I am not sure if it's bug or a platform issue. I think 1.22.9 is fine since this is only for pre-commit. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
