### PR TITLE
[Bug] Re-enable flaky kubectl plugin e2e test in kubectl_ray_job_submit_test.go

### DIFF
--- a/.buildkite/setup-env.sh
+++ b/.buildkite/setup-env.sh
@@ -32,7 +32,7 @@ apt-get update
 apt-get install -y python3.11 python3-pip
 
 # Install requirements
-pip install --break-system-packages ray==2.41.0 ray\[default\]==2.41.0
+pip install --break-system-packages ray[default]==2.41.0
 
 # Bypass Git's ownership check due to unconventional user IDs in Docker containers
 git config --global --add safe.directory /workdir

--- a/.buildkite/setup-env.sh
+++ b/.buildkite/setup-env.sh
@@ -29,17 +29,10 @@ helm repo update
 
 # Install python 3.11 and pip
 apt-get update
-apt-get install -y python3.11 python3.11-venv
-python3 -m venv .venv
-
-# Activate the virtual environment and then execute the subsequent commands
-
-# shellcheck disable=SC1091  # Ignore: activate script is created by venv
-source .venv/bin/activate
+apt-get install -y python3.11
 
 # Install requirements
-pip install -r tests/framework/config/requirements.txt
-
+pip install ray==2.41.0 ray\[default\]==2.41.0
 
 # Bypass Git's ownership check due to unconventional user IDs in Docker containers
 git config --global --add safe.directory /workdir

--- a/.buildkite/setup-env.sh
+++ b/.buildkite/setup-env.sh
@@ -27,5 +27,19 @@ mv linux-amd64/helm /usr/local/bin/helm
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 
+# Install python 3.11 and pip
+apt-get update
+apt-get install -y python3.11 python3.11-venv
+python3 -m venv .venv
+
+# Activate the virtual environment and then execute the subsequent commands
+
+# shellcheck disable=SC1091  # Ignore: activate script is created by venv
+source .venv/bin/activate
+
+# Install requirements
+pip install -r tests/framework/config/requirements.txt
+
+
 # Bypass Git's ownership check due to unconventional user IDs in Docker containers
 git config --global --add safe.directory /workdir

--- a/.buildkite/setup-env.sh
+++ b/.buildkite/setup-env.sh
@@ -29,7 +29,7 @@ helm repo update
 
 # Install python 3.11 and pip
 apt-get update
-apt-get install -y python3.11
+apt-get install -y python3.11 python3-pip
 
 # Install requirements
 pip install ray==2.41.0 ray\[default\]==2.41.0

--- a/.buildkite/setup-env.sh
+++ b/.buildkite/setup-env.sh
@@ -32,7 +32,7 @@ apt-get update
 apt-get install -y python3.11 python3-pip
 
 # Install requirements
-pip install ray==2.41.0 ray\[default\]==2.41.0
+pip install --break-system-packages ray==2.41.0 ray\[default\]==2.41.0
 
 # Bypass Git's ownership check due to unconventional user IDs in Docker containers
 git config --global --add safe.directory /workdir

--- a/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go
@@ -31,6 +31,8 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 	})
 
 	It("succeed in submitting RayJob", func() {
+		killKubectlCmd := exec.Command("pkill", "-9", "kubectl")
+		_ = killKubectlCmd.Run()
 		cmd := exec.Command("kubectl", "ray", "job", "submit", "--namespace", namespace, "-f", rayJobFilePath, "--working-dir", kubectlRayJobWorkingDir, "--", "python", entrypointSampleFileName)
 		output, err := cmd.CombinedOutput()
 
@@ -66,6 +68,8 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 	})
 
 	It("succeed in submitting RayJob with runtime environment set with working dir", func() {
+		killKubectlCmd := exec.Command("pkill", "-9", "kubectl")
+		_ = killKubectlCmd.Run()
 		runtimeEnvFilePath := path.Join(kubectlRayJobWorkingDir, runtimeEnvSampleFileName)
 		cmd := exec.Command("kubectl", "ray", "job", "submit", "--namespace", namespace, "-f", rayJobNoEnvFilePath, "--runtime-env", runtimeEnvFilePath, "--", "python", entrypointSampleFileName)
 		output, err := cmd.CombinedOutput()

--- a/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"fmt"
 	"os/exec"
 	"path"
 	"regexp"
@@ -34,7 +33,6 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 	It("succeed in submitting RayJob", func() {
 		cmd := exec.Command("kubectl", "ray", "job", "submit", "--namespace", namespace, "-f", rayJobFilePath, "--working-dir", kubectlRayJobWorkingDir, "--", "python", entrypointSampleFileName)
 		output, err := cmd.CombinedOutput()
-		fmt.Printf("output: %s\n", string(output))
 
 		Expect(err).NotTo(HaveOccurred())
 		// Retrieve the Job ID from the output
@@ -71,7 +69,6 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 		runtimeEnvFilePath := path.Join(kubectlRayJobWorkingDir, runtimeEnvSampleFileName)
 		cmd := exec.Command("kubectl", "ray", "job", "submit", "--namespace", namespace, "-f", rayJobNoEnvFilePath, "--runtime-env", runtimeEnvFilePath, "--", "python", entrypointSampleFileName)
 		output, err := cmd.CombinedOutput()
-		fmt.Printf("output: %s\n", string(output))
 
 		Expect(err).NotTo(HaveOccurred())
 		// Retrieve the Job ID from the output

--- a/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	"os/exec"
 	"path"
 	"regexp"
@@ -31,9 +32,9 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 	})
 
 	It("succeed in submitting RayJob", func() {
-		Skip("Skip this test as it is failing on CI")
 		cmd := exec.Command("kubectl", "ray", "job", "submit", "--namespace", namespace, "-f", rayJobFilePath, "--working-dir", kubectlRayJobWorkingDir, "--", "python", entrypointSampleFileName)
 		output, err := cmd.CombinedOutput()
+		fmt.Printf("output: %s\n", string(output))
 
 		Expect(err).NotTo(HaveOccurred())
 		// Retrieve the Job ID from the output
@@ -67,10 +68,10 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 	})
 
 	It("succeed in submitting RayJob with runtime environment set with working dir", func() {
-		Skip("Skip this test as it is failing on CI")
 		runtimeEnvFilePath := path.Join(kubectlRayJobWorkingDir, runtimeEnvSampleFileName)
 		cmd := exec.Command("kubectl", "ray", "job", "submit", "--namespace", namespace, "-f", rayJobNoEnvFilePath, "--runtime-env", runtimeEnvFilePath, "--", "python", entrypointSampleFileName)
 		output, err := cmd.CombinedOutput()
+		fmt.Printf("output: %s\n", string(output))
 
 		Expect(err).NotTo(HaveOccurred())
 		// Retrieve the Job ID from the output

--- a/tests/framework/config/requirements.txt
+++ b/tests/framework/config/requirements.txt
@@ -1,0 +1,7 @@
+docker
+GitPython
+kubernetes
+jsonpatch
+pytest
+ray
+ray[default]

--- a/tests/framework/config/requirements.txt
+++ b/tests/framework/config/requirements.txt
@@ -1,7 +1,0 @@
-docker
-GitPython
-kubernetes
-jsonpatch
-pytest
-ray
-ray[default]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are 2 reason make the test fail.
- There are some kubectl process occupied the 8265 port that is required by the kubectl job submit. But for the independence of tests, we should not expect the test cause this problem to kill the process properly every time, so added the pkill kubectl before running kubectl job submit test.
- The ray is not installed on build kite env, so modified the setup-env.sh to install. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #2801 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
