### PR TITLE
kubectl ray job submit: provide empty entrypoint

### DIFF
--- a/kubectl-plugin/go.mod
+++ b/kubectl-plugin/go.mod
@@ -79,6 +79,7 @@ require (
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.6.0 // indirect
 	golang.org/x/tools v0.25.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/kubectl-plugin/go.sum
+++ b/kubectl-plugin/go.sum
@@ -180,6 +180,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
+gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -3,6 +3,7 @@ package job
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/kubectl/pkg/cmd/portforward"
@@ -27,6 +29,7 @@ import (
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/generation"
 	"github.com/spf13/cobra"
+	"gomodules.xyz/jsonpatch/v2"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayscheme "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme"
@@ -282,6 +285,10 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 			RayJobName:     options.rayjobName,
 			Namespace:      *options.configFlags.Namespace,
 			SubmissionMode: "InteractiveMode",
+			// The entry point is required, despite the RayJob being interactive
+			// mode (meaning we will submit a ray job with a real entry point
+			// later). See https://github.com/ray-project/kuberay/issues/3126.
+			Entrypoint: "",
 			RayClusterSpecObject: generation.RayClusterSpecObject{
 				RayVersion:     options.rayVersion,
 				Image:          options.image,
@@ -489,15 +496,14 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	if rayJobID == "" {
 		rayJobID = <-rayJobIDChan
 	}
-	// Add annotation to RayJob with the correct Ray job ID and update the CR
-	options.RayJob, err = k8sClients.RayClient().RayV1().RayJobs(*options.configFlags.Namespace).Get(ctx, options.RayJob.GetName(), v1.GetOptions{})
+
+	// Patch the ray job with the correct Ray job ID.
+	patch := []jsonpatch.Operation{jsonpatch.NewOperation("add", "/spec/jobId", rayJobID)}
+	raw, err := json.Marshal(patch)
 	if err != nil {
-		return fmt.Errorf("Failed to get latest version of Ray job")
+		return fmt.Errorf("Generate Ray Job ID patch: %w", err)
 	}
-
-	options.RayJob.Spec.JobId = rayJobID
-
-	_, err = k8sClients.RayClient().RayV1().RayJobs(*options.configFlags.Namespace).Update(ctx, options.RayJob, v1.UpdateOptions{})
+	_, err = k8sClients.RayClient().RayV1().RayJobs(*options.configFlags.Namespace).Patch(ctx, options.RayJob.Name, types.JSONPatchType, raw, v1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("Error occurred when trying to add job ID to RayJob: %w", err)
 	}

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -42,6 +42,7 @@ type RayJobYamlObject struct {
 	RayJobName     string
 	Namespace      string
 	SubmissionMode string
+	Entrypoint     string
 	RayClusterSpecObject
 }
 
@@ -58,6 +59,7 @@ func (rayJobObject *RayJobYamlObject) GenerateRayJobApplyConfig() *rayv1ac.RayJo
 	rayJobApplyConfig := rayv1ac.RayJob(rayJobObject.RayJobName, rayJobObject.Namespace).
 		WithSpec(rayv1ac.RayJobSpec().
 			WithSubmissionMode(rayv1.JobSubmissionMode(rayJobObject.SubmissionMode)).
+			WithEntrypoint(rayJobObject.Entrypoint).
 			WithRayClusterSpec(rayJobObject.generateRayClusterSpec()))
 
 	return rayJobApplyConfig


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The entrypoint is required even for interactive mode jobs (see issue
 #3126). This patch provides an empty endpoint to satisfy the
validation, while the true entrypoint is sent later with `ray job submit`.

The read/modify/update after job completion is also switched a patch request here, since the empty entrypoint gets omitted when roundtripped.

The jsonpatch library added is also pulled in by ray-operator, so not a major new dependency.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Workaround for #3126

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
