### PR TITLE
Clean up ray kubectl plugin job ID update

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -503,7 +503,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	if err != nil {
 		return fmt.Errorf("Generate Ray Job ID patch: %w", err)
 	}
-	_, err = k8sClients.RayClient().RayV1().RayJobs(*options.configFlags.Namespace).Patch(ctx, options.RayJob.Name, types.JSONPatchType, raw, v1.PatchOptions{})
+	_, err = k8sClients.RayClient().RayV1().RayJobs(*options.configFlags.Namespace).Patch(ctx, options.RayJob.Name, types.JSONPatchType, raw, v1.PatchOptions{FieldManager: "ray-kubectl-plugin"})
 	if err != nil {
 		return fmt.Errorf("Error occurred when trying to add job ID to RayJob: %w", err)
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fast follow to #3127.

1. The field manager should match the create request.
2. Testing the resource version can prevent data races in rare cases.

## Related issue number

n/a, code health

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
