### PR TITLE
[bug] use passed context instead of TODO context

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/interface/interface.go
+++ b/ray-operator/controllers/ray/batchscheduler/interface/interface.go
@@ -30,7 +30,7 @@ type BatchScheduler interface {
 // necessary callbacks with the operator, and the creation of the BatchScheduler itself.
 type BatchSchedulerFactory interface {
 	// New creates a new BatchScheduler for the scheduler plugin.
-	New(config *rest.Config) (BatchScheduler, error)
+	New(ctx context.Context, config *rest.Config) (BatchScheduler, error)
 
 	// AddToScheme adds the types in this scheduler to the given scheme (runs during init).
 	AddToScheme(scheme *runtime.Scheme)
@@ -59,7 +59,7 @@ func (d *DefaultBatchScheduler) DoBatchSchedulingOnSubmission(_ context.Context,
 func (d *DefaultBatchScheduler) AddMetadataToPod(_ context.Context, _ *rayv1.RayCluster, _ string, _ *corev1.Pod) {
 }
 
-func (df *DefaultBatchSchedulerFactory) New(_ *rest.Config) (BatchScheduler, error) {
+func (df *DefaultBatchSchedulerFactory) New(_ context.Context, _ *rest.Config) (BatchScheduler, error) {
 	return &DefaultBatchScheduler{}, nil
 }
 

--- a/ray-operator/controllers/ray/batchscheduler/schedulermanager.go
+++ b/ray-operator/controllers/ray/batchscheduler/schedulermanager.go
@@ -1,6 +1,7 @@
 package batchscheduler
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -25,14 +26,14 @@ type SchedulerManager struct {
 }
 
 // NewSchedulerManager maintains a specific scheduler plugin based on config
-func NewSchedulerManager(rayConfigs configapi.Configuration, config *rest.Config) (*SchedulerManager, error) {
+func NewSchedulerManager(ctx context.Context, rayConfigs configapi.Configuration, config *rest.Config) (*SchedulerManager, error) {
 	// init the scheduler factory from config
 	factory, err := getSchedulerFactory(rayConfigs)
 	if err != nil {
 		return nil, err
 	}
 
-	scheduler, err := factory.New(config)
+	scheduler, err := factory.New(ctx, config)
 	if err != nil {
 		return nil, err
 	}

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -59,23 +59,23 @@ func (v *VolcanoBatchScheduler) DoBatchSchedulingOnSubmission(ctx context.Contex
 		totalResource = utils.CalculateMinResources(app)
 	}
 
-	return v.syncPodGroup(app, minMember, totalResource)
+	return v.syncPodGroup(ctx, app, minMember, totalResource)
 }
 
 func getAppPodGroupName(app *rayv1.RayCluster) string {
 	return fmt.Sprintf("ray-%s-pg", app.Name)
 }
 
-func (v *VolcanoBatchScheduler) syncPodGroup(app *rayv1.RayCluster, size int32, totalResource corev1.ResourceList) error {
+func (v *VolcanoBatchScheduler) syncPodGroup(ctx context.Context, app *rayv1.RayCluster, size int32, totalResource corev1.ResourceList) error {
 	podGroupName := getAppPodGroupName(app)
-	if pg, err := v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Get(context.TODO(), podGroupName, metav1.GetOptions{}); err != nil {
+	if pg, err := v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Get(ctx, podGroupName, metav1.GetOptions{}); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
 
 		podGroup := createPodGroup(app, podGroupName, size, totalResource)
 		if _, err := v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Create(
-			context.TODO(), &podGroup, metav1.CreateOptions{},
+			ctx, &podGroup, metav1.CreateOptions{},
 		); err != nil {
 			if errors.IsAlreadyExists(err) {
 				v.log.Info("pod group already exists, no need to create")
@@ -90,7 +90,7 @@ func (v *VolcanoBatchScheduler) syncPodGroup(app *rayv1.RayCluster, size int32, 
 			pg.Spec.MinMember = size
 			pg.Spec.MinResources = &totalResource
 			if _, err := v.volcanoClient.SchedulingV1beta1().PodGroups(app.Namespace).Update(
-				context.TODO(), pg, metav1.UpdateOptions{},
+				ctx, pg, metav1.UpdateOptions{},
 			); err != nil {
 				v.log.Error(err, "Pod group UPDATE error!", "podGroup", podGroupName)
 				return err
@@ -146,7 +146,7 @@ func (v *VolcanoBatchScheduler) AddMetadataToPod(_ context.Context, app *rayv1.R
 	pod.Spec.SchedulerName = v.Name()
 }
 
-func (vf *VolcanoBatchSchedulerFactory) New(config *rest.Config) (schedulerinterface.BatchScheduler, error) {
+func (vf *VolcanoBatchSchedulerFactory) New(ctx context.Context, config *rest.Config) (schedulerinterface.BatchScheduler, error) {
 	vkClient, err := volcanoclient.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize volcano client with error %w", err)
@@ -158,12 +158,12 @@ func (vf *VolcanoBatchSchedulerFactory) New(config *rest.Config) (schedulerinter
 	}
 
 	if _, err := extClient.ApiextensionsV1().CustomResourceDefinitions().Get(
-		context.TODO(),
+		ctx,
 		PodGroupName,
 		metav1.GetOptions{},
 	); err != nil {
 		if _, err := extClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(
-			context.TODO(),
+			ctx,
 			PodGroupName,
 			metav1.GetOptions{},
 		); err != nil {

--- a/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_scheduler.go
@@ -105,7 +105,7 @@ func (y *YuniKornScheduler) populateTaskGroupsAnnotationToPod(ctx context.Contex
 	logger.Info("Gang Scheduling enabled for RayCluster")
 }
 
-func (yf *YuniKornSchedulerFactory) New(_ *rest.Config) (schedulerinterface.BatchScheduler, error) {
+func (yf *YuniKornSchedulerFactory) New(_ context.Context, _ *rest.Config) (schedulerinterface.BatchScheduler, error) {
 	return &YuniKornScheduler{}, nil
 }
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -107,7 +107,7 @@ func NewReconciler(ctx context.Context, mgr manager.Manager, options RayClusterR
 	}
 	isOpenShift := getClusterType(ctx)
 	// init the batch scheduler manager
-	schedulerMgr, err := batchscheduler.NewSchedulerManager(rayConfigs, mgr.GetConfig())
+	schedulerMgr, err := batchscheduler.NewSchedulerManager(ctx, rayConfigs, mgr.GetConfig())
 	if err != nil {
 		// fail fast if the scheduler plugin fails to init
 		// prevent running the controller in an undefined state


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently Volcano scheduler is using context.TODO(). We should avoid that and use the passed context instead.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
