### PR TITLE
[ci] remove the test for modin because its certificate is broken

### DIFF
--- a/ray-operator/test/sampleyaml/rayjob_test.go
+++ b/ray-operator/test/sampleyaml/rayjob_test.go
@@ -18,9 +18,6 @@ func TestRayJob(t *testing.T) {
 			name: "ray-job.custom-head-svc.yaml",
 		},
 		{
-			name: "ray-job.modin.yaml",
-		},
-		{
 			name: "ray-job.resources.yaml",
 		},
 		{


### PR DESCRIPTION
## Why are these changes needed?

Closes https://github.com/ray-project/kuberay/issues/3134.

The certificate of `modin-datasets.intel.com` is broken. Therefore, remove the test until https://github.com/modin-project/modin/issues/7451 is resolved.

Screenshot:
<img width="1309" alt="image" src="https://github.com/user-attachments/assets/76b0379f-5973-496d-9955-9300d41705c1" />
![image](https://github.com/user-attachments/assets/f4497ab2-b520-4aa5-a3cf-ab77f0722081)
![image](https://github.com/user-attachments/assets/9c3b08f9-4830-4470-add4-d754549697f1)



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/3134.


## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
