### PR TITLE
[Doc] Add a YAML to explain why some worker pod are not ready in RayService

### DIFF
--- a/ray-operator/config/samples/ray-serve/single_deployment_dag.py
+++ b/ray-operator/config/samples/ray-serve/single_deployment_dag.py
@@ -1,0 +1,12 @@
+from ray import serve
+
+@serve.deployment(
+    ray_actor_options={
+        "num_cpus": 0.1,
+    }
+)
+class BaseService:
+    async def __call__(self):
+        return "hello world"
+
+DagNode = BaseService.bind()

--- a/ray-operator/config/samples/ray-serve/single_deployment_dag.py
+++ b/ray-operator/config/samples/ray-serve/single_deployment_dag.py
@@ -1,10 +1,6 @@
 from ray import serve
 
-@serve.deployment(
-    ray_actor_options={
-        "num_cpus": 0.1,
-    }
-)
+@serve.deployment()
 class BaseService:
     async def __call__(self):
         return "hello world"

--- a/ray-operator/config/samples/ray-service.no-ray-serve-replica.yaml
+++ b/ray-operator/config/samples/ray-service.no-ray-serve-replica.yaml
@@ -1,13 +1,8 @@
-# Make sure to increase resource requests and limits before using this example in production.
-# For examples with more realistic resource configuration, see
-# ray-cluster.complete.large.yaml and
-# ray-cluster.autoscaler.large.yaml.
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
   name: rayservice-no-ray-serve-replica
 spec:
-  # serveConfigV2 takes a yaml multi-line scalar, which should be a Ray Serve multi-application config. See https://docs.ray.io/en/latest/serve/multi-app.html.
   serveConfigV2: |
     applications:
       - name: simple_app
@@ -22,16 +17,10 @@ spec:
             ray_actor_options:
               num_cpus: 0.1
   rayClusterConfig:
-    rayVersion: '2.41.0' # should match the Ray version in the image of the containers
-    ######################headGroupSpecs#################################
-    # Ray head pod template.
+    rayVersion: '2.41.0'
     headGroupSpec:
-      # The `rayStartParams` are used to configure the `ray start` command.
-      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
-      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
       rayStartParams:
         num-cpus: "0"
-      #pod template
       template:
         spec:
           containers:
@@ -47,24 +36,18 @@ spec:
               ports:
                 - containerPort: 6379
                   name: gcs-server
-                - containerPort: 8265 # Ray dashboard
+                - containerPort: 8265
                   name: dashboard
                 - containerPort: 10001
                   name: client
                 - containerPort: 8000
                   name: serve
     workerGroupSpecs:
-      # the pod replicas in this group typed worker
       - replicas: 2
         minReplicas: 1
         maxReplicas: 5
-        # logical group name, for this called small-group, also can be functional
         groupName: small-group
-        # The `rayStartParams` are used to configure the `ray start` command.
-        # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
-        # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
         rayStartParams: {}
-        #pod template
         template:
           spec:
             containers:

--- a/ray-operator/config/samples/ray-service.no-ray-serve-replica.yaml
+++ b/ray-operator/config/samples/ray-service.no-ray-serve-replica.yaml
@@ -10,7 +10,7 @@ spec:
   # serveConfigV2 takes a yaml multi-line scalar, which should be a Ray Serve multi-application config. See https://docs.ray.io/en/latest/serve/multi-app.html.
   serveConfigV2: |
     applications:
-      - name: app
+      - name: simple_app
         import_path: ray-operator.config.samples.ray-serve.single_deployment_dag:DagNode
         route_prefix: /basic
         runtime_env:

--- a/ray-operator/config/samples/ray-service.no-ray-serve-replica.yaml
+++ b/ray-operator/config/samples/ray-service.no-ray-serve-replica.yaml
@@ -5,7 +5,7 @@
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
-  name: rayservice-worker-no-serve
+  name: rayservice-no-ray-serve-replica
 spec:
   # serveConfigV2 takes a yaml multi-line scalar, which should be a Ray Serve multi-application config. See https://docs.ray.io/en/latest/serve/multi-app.html.
   serveConfigV2: |

--- a/ray-operator/config/samples/ray-service.no-ray-serve-replica.yaml
+++ b/ray-operator/config/samples/ray-service.no-ray-serve-replica.yaml
@@ -68,7 +68,7 @@ spec:
         template:
           spec:
             containers:
-              - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+              - name: ray-worker
                 image: rayproject/ray:2.41.0
                 resources:
                   limits:

--- a/ray-operator/config/samples/ray-service.no-ray-serve-replica.yaml
+++ b/ray-operator/config/samples/ray-service.no-ray-serve-replica.yaml
@@ -28,10 +28,10 @@ spec:
               image: rayproject/ray:2.41.0
               resources:
                 limits:
-                  cpu: 0
+                  cpu: 1
                   memory: 2Gi
                 requests:
-                  cpu: 0
+                  cpu: 1
                   memory: 2Gi
               ports:
                 - containerPort: 6379

--- a/ray-operator/config/samples/ray-service.worker-no-serve.yaml
+++ b/ray-operator/config/samples/ray-service.worker-no-serve.yaml
@@ -1,0 +1,79 @@
+# Make sure to increase resource requests and limits before using this example in production.
+# For examples with more realistic resource configuration, see
+# ray-cluster.complete.large.yaml and
+# ray-cluster.autoscaler.large.yaml.
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: rayservice-sample
+spec:
+  # serveConfigV2 takes a yaml multi-line scalar, which should be a Ray Serve multi-application config. See https://docs.ray.io/en/latest/serve/multi-app.html.
+  serveConfigV2: |
+    applications:
+      - name: app
+        import_path: ray-operator.config.samples.ray-serve.single_deployment_dag:DagNode
+        route_prefix: /basic
+        runtime_env:
+          working_dir: "https://github.com/ray-project/kuberay/archive/master.zip"
+        deployments:
+          - name: BaseService
+            num_replicas: 1
+            max_replicas_per_node: 1
+            ray_actor_options:
+              num_cpus: 0.1
+  rayClusterConfig:
+    rayVersion: '2.41.0' # should match the Ray version in the image of the containers
+    ######################headGroupSpecs#################################
+    # Ray head pod template.
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        num-cpus: "0"
+      #pod template
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: rayproject/ray:2.41.0
+              resources:
+                limits:
+                  cpu: 0
+                  memory: 2Gi
+                requests:
+                  cpu: 0
+                  memory: 2Gi
+              ports:
+                - containerPort: 6379
+                  name: gcs-server
+                - containerPort: 8265 # Ray dashboard
+                  name: dashboard
+                - containerPort: 10001
+                  name: client
+                - containerPort: 8000
+                  name: serve
+    workerGroupSpecs:
+      # the pod replicas in this group typed worker
+      - replicas: 2
+        minReplicas: 1
+        maxReplicas: 5
+        # logical group name, for this called small-group, also can be functional
+        groupName: small-group
+        # The `rayStartParams` are used to configure the `ray start` command.
+        # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+        # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+        rayStartParams: {}
+        #pod template
+        template:
+          spec:
+            containers:
+              - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+                image: rayproject/ray:2.41.0
+                resources:
+                  limits:
+                    cpu: "1"
+                    memory: "2Gi"
+                  requests:
+                    cpu: "500m"
+                    memory: "2Gi"

--- a/ray-operator/config/samples/ray-service.worker-no-serve.yaml
+++ b/ray-operator/config/samples/ray-service.worker-no-serve.yaml
@@ -5,7 +5,7 @@
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
-  name: rayservice-sample
+  name: rayservice-worker-no-serve
 spec:
   # serveConfigV2 takes a yaml multi-line scalar, which should be a Ray Serve multi-application config. See https://docs.ray.io/en/latest/serve/multi-app.html.
   serveConfigV2: |


### PR DESCRIPTION
## Why are these changes needed?

A worker pod in RayService without a ray serve replica will be set as readiness probe failed.
We add an YAML and example python file here for demonstration.
The document for this example will be a PR send to `ray-project/ray`

## Related issue number

Closes #3048 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
