### PR TITLE
[Fix][kubectl-plugin] Fix the flaky test "should reconnect after pod connection is lost"

### DIFF
--- a/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Calling ray plugin `session` command", func() {
+var _ = Describe("Calling ray plugin `session` command", Ordered, func() {
 	var namespace string
 
 	BeforeEach(func() {
@@ -98,7 +98,8 @@ var _ = Describe("Calling ray plugin `session` command", func() {
 			if string(output) == oldPodName {
 				return err
 			}
-			return nil
+			cmd = exec.Command("kubectl", "get", "--namespace", namespace, "pod", newPodName)
+			return cmd.Run()
 		}, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 		// Wait for the new pod to be ready


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fix the flaky test "should reconnect after pod connection is lost"

Run 10 times and no error:
- https://github.com/ray-project/kuberay/pull/3148
- https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/7287#01955d48-b403-4b6f-a9a1-b94c09446169
![image](https://github.com/user-attachments/assets/d5f8c62b-2881-4cf9-91b1-a59dee19b3ea)


## Related issue number

<!-- For example: "Closes #1234" -->
Closes: ray-project/kuberay#3140

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
