### PR TITLE
[chore][docs] enable Markdown lint rules MD050 MD052

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -2,5 +2,3 @@ default: true
 
 MD013: false
 MD024: false
-MD050: false
-MD052: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD052 -->
 # Change Log
 
 All notable changes to this project will be documented in this file.


### PR DESCRIPTION
* MD050: Strong style
* MD052: Reference links and images should use a label that is defined

https://github.com/DavidAnson/markdownlint/tree/main/doc