### PR TITLE
RayService event can't set redis password in both GCSFaultTolerance and rayStartParam 

### DIFF
--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -181,7 +181,7 @@ func ValidateRayServiceMetadata(metadata metav1.ObjectMeta) error {
 }
 
 func ValidateRayServiceSpec(rayService *rayv1.RayService) error {
-	if !reflect.DeepEqual(rayService.Spec.RayClusterSpec, rayv1.RayClusterSpec{}) {
+	if !reflect.ValueOf(rayService.Spec.RayClusterSpec).IsZero() {
 		if err := ValidateRayClusterSpec(&rayService.Spec.RayClusterSpec, rayService.Annotations); err != nil {
 			return err
 		}

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -3,6 +3,7 @@ package utils
 import (
 	errstd "errors"
 	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -180,6 +181,12 @@ func ValidateRayServiceMetadata(metadata metav1.ObjectMeta) error {
 }
 
 func ValidateRayServiceSpec(rayService *rayv1.RayService) error {
+	if !reflect.DeepEqual(rayService.Spec.RayClusterSpec, rayv1.RayClusterSpec{}) {
+		if err := ValidateRayClusterSpec(&rayService.Spec.RayClusterSpec, rayService.Annotations); err != nil {
+			return err
+		}
+	}
+
 	if headSvc := rayService.Spec.RayClusterSpec.HeadGroupSpec.HeadService; headSvc != nil && headSvc.Name != "" {
 		return fmt.Errorf("spec.rayClusterConfig.headGroupSpec.headService.metadata.name should not be set")
 	}

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -3,7 +3,6 @@ package utils
 import (
 	errstd "errors"
 	"fmt"
-	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -181,10 +180,8 @@ func ValidateRayServiceMetadata(metadata metav1.ObjectMeta) error {
 }
 
 func ValidateRayServiceSpec(rayService *rayv1.RayService) error {
-	if !reflect.ValueOf(rayService.Spec.RayClusterSpec).IsZero() {
-		if err := ValidateRayClusterSpec(&rayService.Spec.RayClusterSpec, rayService.Annotations); err != nil {
-			return err
-		}
+	if err := ValidateRayClusterSpec(&rayService.Spec.RayClusterSpec, rayService.Annotations); err != nil {
+		return err
 	}
 
 	if headSvc := rayService.Spec.RayClusterSpec.HeadGroupSpec.HeadService; headSvc != nil && headSvc.Name != "" {

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -753,7 +753,6 @@ func TestValidateRayJobMetadata(t *testing.T) {
 
 func TestValidateRayServiceSpec(t *testing.T) {
 	upgradeStrat := rayv1.RayServiceUpgradeType("invalidStrategy")
-	newClusterStrat := rayv1.NewCluster
 
 	tests := []struct {
 		name              string
@@ -777,8 +776,10 @@ func TestValidateRayServiceSpec(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:        "The RayService spec is valid.",
-			spec:        rayv1.RayServiceSpec{},
+			name: "The RayService spec is valid.",
+			spec: rayv1.RayServiceSpec{
+				RayClusterSpec: *createBasicRayClusterSpec(),
+			},
 			expectError: false,
 		},
 		{
@@ -787,6 +788,7 @@ func TestValidateRayServiceSpec(t *testing.T) {
 				UpgradeStrategy: &rayv1.RayServiceUpgradeStrategy{
 					Type: &upgradeStrat,
 				},
+				RayClusterSpec: *createBasicRayClusterSpec(),
 			},
 			expectError: true,
 		},
@@ -801,16 +803,6 @@ func TestValidateRayServiceSpec(t *testing.T) {
 				},
 			},
 			expectError: true,
-		},
-		{
-			name: "It is okay that RayClusterSpec is empty.",
-			spec: rayv1.RayServiceSpec{
-				UpgradeStrategy: &rayv1.RayServiceUpgradeStrategy{
-					Type: &newClusterStrat,
-				},
-				RayClusterSpec: rayv1.RayClusterSpec{},
-			},
-			expectError: false,
 		},
 	}
 

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -784,6 +784,18 @@ func TestValidateRayServiceSpec(t *testing.T) {
 		},
 	})
 	require.Error(t, err, "spec.UpgradeSpec.Type is invalid")
+
+	err = ValidateRayServiceSpec(&rayv1.RayService{
+		Spec: rayv1.RayServiceSpec{
+			RayClusterSpec: rayv1.RayClusterSpec{
+				HeadServiceAnnotations: map[string]string{
+					"foo": "bar",
+				},
+				HeadGroupSpec: rayv1.HeadGroupSpec{},
+			},
+		},
+	})
+	require.Error(t, err, "headGroupSpec should have at least one container")
 }
 
 func TestValidateRayServiceMetadata(t *testing.T) {

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -793,15 +793,8 @@ func TestValidateRayServiceSpec(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "headGroupSpec should have at least one container",
-			spec: rayv1.RayServiceSpec{
-				RayClusterSpec: rayv1.RayClusterSpec{
-					HeadServiceAnnotations: map[string]string{
-						"foo": "bar",
-					},
-					HeadGroupSpec: rayv1.HeadGroupSpec{},
-				},
-			},
+			name:        "headGroupSpec should have at least one container",
+			spec:        rayv1.RayServiceSpec{},
 			expectError: true,
 		},
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
If an user sets redis password in both GCSFaultTolerance and rayStartParam, it will prompt CR event in RayCluster.
However, it's not show in RayService. Thus, the user need to find the CR event in RayCluster to know the cause.

Here is result of screenshot.
<img width="1439" alt="fail" src="https://github.com/user-attachments/assets/23de1013-64a6-4708-be4e-d69558a27cd9" />


## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/kuberay/issues/2986

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
