### PR TITLE
[Feat][kubectl-plugin] Add dynamic shell completion for kubectl ray get node & workergroup

### DIFF
--- a/kubectl-plugin/pkg/cmd/get/get_nodes.go
+++ b/kubectl-plugin/pkg/cmd/get/get_nodes.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/completion"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -99,6 +100,11 @@ func NewGetNodesCommand(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd.Flags().StringVarP(&options.cluster, "ray-cluster", "c", "", "Ray cluster")
 	cmd.Flags().BoolVarP(&options.allNamespaces, "all-namespaces", "A", false, "If present, list nodes across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+
+	err := cmd.RegisterFlagCompletionFunc("ray-cluster", completion.RayClusterCompletionFunc(cmdFactory))
+	if err != nil {
+		fmt.Fprintf(streams.ErrOut, "Error registering completion function for --ray-cluster: %v\n", err)
+	}
 
 	options.configFlags.AddFlags(cmd.Flags())
 	return cmd

--- a/kubectl-plugin/pkg/cmd/get/get_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/get/get_workergroup.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/completion"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -104,6 +105,11 @@ func NewGetWorkerGroupCommand(streams genericclioptions.IOStreams) *cobra.Comman
 
 	cmd.Flags().StringVarP(&options.cluster, "ray-cluster", "c", "", "Ray cluster")
 	cmd.Flags().BoolVarP(&options.allNamespaces, "all-namespaces", "A", false, "If present, list nodes across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+
+	err := cmd.RegisterFlagCompletionFunc("ray-cluster", completion.RayClusterCompletionFunc(cmdFactory))
+	if err != nil {
+		fmt.Fprintf(streams.ErrOut, "Error registering completion function for --ray-cluster: %v\n", err)
+	}
 
 	options.configFlags.AddFlags(cmd.Flags())
 	return cmd


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add dynamic shell completion for `kubectl ray get node` and `kubectl ray get workergroup`.
This feature is only limited to the `--ray-cluster` flag.

https://github.com/user-attachments/assets/7d27e24f-0896-444a-9463-32cdd86bd351


<!-- Please give a short summary of the change and the problem this solves. -->


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
