### PR TITLE
[RayCluster]Upgrade volcano to 1.11.0

### DIFF
--- a/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
+++ b/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
@@ -1,3 +1,13 @@
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: kuberay-test-queue
+spec:
+  weight: 1
+  capability:
+    cpu: 4
+    memory: 6Gi
+---
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:

--- a/ray-operator/config/samples/ray-cluster.volcano-scheduler-test-queue.yaml
+++ b/ray-operator/config/samples/ray-cluster.volcano-scheduler-test-queue.yaml
@@ -1,9 +1,0 @@
-apiVersion: scheduling.volcano.sh/v1beta1
-kind: Queue
-metadata:
-  name: kuberay-test-queue
-spec:
-  weight: 1
-  capability:
-    cpu: 4
-    memory: 6Gi

--- a/ray-operator/config/samples/ray-cluster.volcano-scheduler-test-queue.yaml
+++ b/ray-operator/config/samples/ray-cluster.volcano-scheduler-test-queue.yaml
@@ -1,0 +1,9 @@
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: kuberay-test-queue
+spec:
+  weight: 1
+  capability:
+    cpu: 4
+    memory: 6Gi

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -32,7 +32,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0
 	sigs.k8s.io/yaml v1.4.0
-	volcano.sh/apis v1.9.0
+	volcano.sh/apis v1.11.0
 )
 
 replace go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.35.1 => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0

--- a/ray-operator/go.sum
+++ b/ray-operator/go.sum
@@ -223,5 +223,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.5.0 h1:nbCitCK2hfnhyiKo6uf2HxUPTCodY6Qaf
 sigs.k8s.io/structured-merge-diff/v4 v4.5.0/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
-volcano.sh/apis v1.9.0 h1:e+9yEbQOi6HvgaayAxYULT6n+59mkYvmqjKhp9Z06sY=
-volcano.sh/apis v1.9.0/go.mod h1:yXNfsZRzAOq6EUyPJYFrlMorh1XsYQGonGWyr4IiznM=
+volcano.sh/apis v1.11.0 h1:Z5ZXxxgUNfXv1OhfVXXfGPN7StoSsozQM+8CAPoNWY8=
+volcano.sh/apis v1.11.0/go.mod h1:FOdmG++9+8lgENJ9XXDh+O3Jcb9YVRnlMSpgIh3NSVI=


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

### Testing Gang Scheduling
1. Create a queue with `cpu: 4`&`memory: 6Gi` and deploy a ray cluster of 1 head pod and 2 worker pods. (They should be scheduled with total resources 3CPUs & memory 4Gi as specified in `ray-cluster.volcano-scheduler-queue.yaml`). And the PodGroup Status should be running.
```console
❯ kubectl apply -f config/samples/ray-cluster.volcano-scheduler-test-queue.yaml
queue.scheduling.volcano.sh/kuberay-test-queue created
❯ kubectl apply -f config/samples/ray-cluster.volcano-scheduler-queue.yaml
raycluster.ray.io/test-cluster-0 created
❯ kubectl get podgroup ray-test-cluster-0-pg -o yaml
apiVersion: scheduling.volcano.sh/v1beta1
kind: PodGroup
metadata:
  creationTimestamp: "2025-03-09T07:38:21Z"
  generation: 4
  name: ray-test-cluster-0-pg
spec:
  minMember: 3
  minResources:
    cpu: "3"
    memory: 4Gi
  queue: kuberay-test-queue
status:
  conditions:
  - lastTransitionTime: "2025-03-09T07:38:42Z"
    reason: tasks in gang are ready to be scheduled
    status: "True"
    transitionID: 3e53ba32-255b-4fe1-ab4a-e1ee416bdd04
    type: Scheduled
  phase: Running
  running: 3
```
![image](https://github.com/user-attachments/assets/291a2ff0-9e73-4fe5-9cf6-ed732f323e5e)

2. Create another rayCluster and  all the pods of this rayCluster should be pending since it will exceed the queue capacity.

```console
❯ sed 's/test-cluster-0/test-cluster-1/' config/samples/ray-cluster.volcano-scheduler-queue.yaml | kubectl apply -f-
raycluster.ray.io/test-cluster-1 created
❯ vcctl queue get -n kuberay-test-queue
Name                     Weight  State   Inqueue Pending Running Unknown Completed
kuberay-test-queue       1       Open    0       1       1       0       0     
```
![image](https://github.com/user-attachments/assets/a8d3ba76-5755-49ed-a169-70db87534918)

3. Delete the first cluster and the second cluster should now be running.
```console
❯ kubectl delete -f config/samples/ray-cluster.volcano-scheduler-queue.yaml
raycluster.ray.io "test-cluster-0" deleted
❯ vcctl queue get -n kuberay-test-queue
Name                     Weight  State   Inqueue Pending Running Unknown Completed
kuberay-test-queue       1       Open    0       0       1       0       0   
```
![image](https://github.com/user-attachments/assets/9d768477-2ba1-4c15-bec2-97c30bdedb08)

---

BTW volcano doesn't print the PodGroup state in queue now (due to some performance issue), so I will also update https://docs.ray.io/en/latest/cluster/kubernetes/k8s-ecosystem/volcano.html#gang-scheduling
after this is merged.
```
❯ kubectl get queue kuberay-test-queue -o yaml
apiVersion: scheduling.volcano.sh/v1beta1
kind: Queue
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"scheduling.volcano.sh/v1beta1","kind":"Queue","metadata":{"annotations":{},"name":"kuberay-test-queue"},"spec":{"capability":{"cpu":4,"memory":"6Gi"},"weight":1}}
  creationTimestamp: "2025-03-09T07:38:09Z"
  generation: 2
  name: kuberay-test-queue
  resourceVersion: "308054"
  uid: 7c91755e-74c6-4167-b3a8-742e82c9263d
spec:
  capability:
    cpu: 4
    memory: 6Gi
  parent: root
  reclaimable: true
  weight: 1
status:
  allocated:
    cpu: "3"
    memory: 4Gi
    pods: "3"
  reservation: {}
  state: Open
```