### PR TITLE
[chore][docs] enable Markdown lint rule MD013

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,6 @@
 default: true
 
-MD013: false
+MD013:
+  line_length: 120
+  code_blocks: false
+  tables: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD024 MD052 -->
+<!-- markdownlint-disable MD013 MD024 MD052 -->
 # Change Log
 
 All notable changes to this project will be documented in this file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Contributing
 
 Thank you for investing your time in contributing to KubeRay project!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # KubeRay
 
 [![Build Status](https://github.com/ray-project/kuberay/workflows/Go-build-and-test/badge.svg)](https://github.com/ray-project/kuberay/actions)

--- a/apiserver/Autoscaling.md
+++ b/apiserver/Autoscaling.md
@@ -1,6 +1,7 @@
 # Creating Autoscaling clusters using API server
 
-One of the fundamental features of Ray is autoscaling. This [document](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html) describes how to set up autoscaling using Ray operator. Here we will describe how to set it up using API server.
+One of the fundamental features of Ray is autoscaling. This [document] describes how to set up
+autoscaling using Ray operator. Here we will describe how to set it up using API server.
 
 ## Deploy KubeRay operator and API server
 
@@ -10,13 +11,14 @@ Refer to [readme](README.md) for setting up KubRay operator and API server.
 make operator-image cluster load-operator-image deploy-operator
 ```
 
-Alternatively, you could build and deploy the Operator and API server from local repo for development purpose.
+Alternatively, you could build and deploy the Operator and API server from local repo for
+development purpose.
 
 ```shell
 make operator-image cluster load-operator-image deploy-operator docker-image load-image deploy
 ```
 
-Additionally install this [configmap](test/cluster/cluster/detachedactor.yaml) containing code that we will use for testing.
+Additionally install this [ConfigMap] containing code that we will use for testing.
 
 ## Deploy Ray cluster
 
@@ -174,3 +176,6 @@ And you should see only head node (worker node is deleted)
 ```shell
 test-cluster-head-pr25j             2/2     Running   0          27m
 ```
+
+[document]: https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html
+[ConfigMap]: test/cluster/cluster/detachedactor.yaml

--- a/apiserver/CreatingServe.md
+++ b/apiserver/CreatingServe.md
@@ -1,6 +1,9 @@
 # Creating a cluster with RayServe support
 
-Up until rescently the only way to create a Ray cluster supporting RayServe was by using `Create ray service` APIs. Although it does work, quite often you want to create cluster supporting Ray serve so that you can experiment with serve APIs directly. Now it is possible by adding the following annotation to the cluster:
+Up until rescently the only way to create a Ray cluster supporting RayServe was by using `Create ray
+service` APIs. Although it does work, quite often you want to create cluster supporting Ray serve so
+that you can experiment with serve APIs directly. Now it is possible by adding the following
+annotation to the cluster:
 
 ```json
 "annotations" : {
@@ -12,71 +15,72 @@ the complete curl command to creation such cluster is as follows:
 
 ```shell
 curl -X POST 'localhost:31888/apis/v1/namespaces/default/clusters' \
---header 'Content-Type: application/json' \
---data '{
-  "name": "test-cluster",
-  "namespace": "default",
-  "user": "boris",
-  "annotations" : {
-    "ray.io/enable-serve-service": "true"
-  },
-  "clusterSpec": {
-    "headGroupSpec": {
-      "computeTemplate": "default-template",
-      "image": "rayproject/ray:2.9.0-py310",
-      "serviceType": "ClusterIP",
-      "rayStartParams": {
-         "dashboard-host": "0.0.0.0",
-         "metrics-export-port": "8080",
-         "dashboard-agent-listen-port": "52365"
-       },
-       "volumes": [
-         {
-           "name": "code-sample",
-           "mountPath": "/home/ray/samples",
-           "volumeType": "CONFIGMAP",
-           "source": "ray-job-code-sample",
-           "items": {"sample_code.py" : "sample_code.py"}
-         }
-       ]
+  --header 'Content-Type: application/json' \
+  --data '{
+    "name": "test-cluster",
+    "namespace": "default",
+    "user": "boris",
+    "annotations" : {
+      "ray.io/enable-serve-service": "true"
     },
-    "workerGroupSpec": [
-      {
-        "groupName": "small-wg",
+    "clusterSpec": {
+      "headGroupSpec": {
         "computeTemplate": "default-template",
         "image": "rayproject/ray:2.9.0-py310",
-        "replicas": 1,
-        "minReplicas": 0,
-        "maxReplicas": 5,
+        "serviceType": "ClusterIP",
         "rayStartParams": {
-           "node-ip-address": "$MY_POD_IP"
+           "dashboard-host": "0.0.0.0",
+           "metrics-export-port": "8080",
+           "dashboard-agent-listen-port": "52365"
          },
-        "volumes": [
-          {
-            "name": "code-sample",
-            "mountPath": "/home/ray/samples",
-            "volumeType": "CONFIGMAP",
-            "source": "ray-job-code-sample",
-            "items": {"sample_code.py" : "sample_code.py"}
-          }
-        ]
-      }
-    ]
-  }
-}'
+         "volumes": [
+           {
+             "name": "code-sample",
+             "mountPath": "/home/ray/samples",
+             "volumeType": "CONFIGMAP",
+             "source": "ray-job-code-sample",
+             "items": {"sample_code.py" : "sample_code.py"}
+           }
+         ]
+      },
+      "workerGroupSpec": [
+        {
+          "groupName": "small-wg",
+          "computeTemplate": "default-template",
+          "image": "rayproject/ray:2.9.0-py310",
+          "replicas": 1,
+          "minReplicas": 0,
+          "maxReplicas": 5,
+          "rayStartParams": {
+             "node-ip-address": "$MY_POD_IP"
+           },
+          "volumes": [
+            {
+              "name": "code-sample",
+              "mountPath": "/home/ray/samples",
+              "volumeType": "CONFIGMAP",
+              "source": "ray-job-code-sample",
+              "items": {"sample_code.py" : "sample_code.py"}
+            }
+          ]
+        }
+      ]
+    }
+  }'
 ```
 
-Note, that before creating a cluster you need to install this [configmap](test/job/code.yaml) and create default template using the following command:
+Note, that before creating a cluster you need to install this [configmap] and
+create default template using the following command:
 
 ```shell
 curl -X POST 'localhost:31888/apis/v1/namespaces/default/compute_templates' \
---header 'Content-Type: application/json' \
---data '{
-  "name": "default-template",
-  "namespace": "default",
-  "cpu": 2,
-  "memory": 4
-}'
+  --header 'Content-Type: application/json' \
+  --data '{
+    "name": "default-template",
+    "namespace": "default",
+    "cpu": 2,
+    "memory": 4
+  }'
 ```
 
 To confirm that the cluster is created correctly, check created services using that following command:
@@ -92,6 +96,9 @@ test-cluster-head-svc    ClusterIP   10.96.19.185    <none>        8265/TCP,5236
 test-cluster-serve-svc   ClusterIP   10.96.144.162   <none>        8000/TCP
 ```
 
-As you can see, in this case two services are created - one for the head node to be able to see the dashboard and configure the cluster and one for submission of the serve requests.
+As you can see, in this case two services are created - one for the head node to be able to see the
+dashboard and configure the cluster and one for submission of the serve requests.
 
 For the head node service note that the additional port - 52365 is created for serve configuration.
+
+[configmap]: test/job/code.yaml

--- a/apiserver/DEVELOPMENT.md
+++ b/apiserver/DEVELOPMENT.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Kuberay API Server User Guide
 
 This guide covers the purpose, requirements, and deployment of the Kuberay API Server.

--- a/apiserver/HACluster.md
+++ b/apiserver/HACluster.md
@@ -151,7 +151,8 @@ password.
 "num-cpu": "0"
 ```
 
-Where the value of `REDIS_PASSWORD` comes from environment variable (below). Additionally `num-cpus: 0` ensures that no application code runs on a head node.
+Where the value of `REDIS_PASSWORD` comes from environment variable (below). Additionally `num-cpus:
+0` ensures that no application code runs on a head node.
 
 The following environment variable have to be added here:
 

--- a/apiserver/JobSubmission.md
+++ b/apiserver/JobSubmission.md
@@ -1,10 +1,18 @@
 # Job Submission using API server
 
-Ray provides very convinient and powerful [Job Submission APIs](https://docs.ray.io/en/latest/cluster/running-applications/job-submission/rest.html). The issue is that it needs to access cluster's dashboard Ingress, which currently does not have any security implementations. Alternatively you can use Ray cluster head service for this, but in this case your Ray job management code has to run in the same kubernetes cluster as Ray. Job submission implementation in the API server leverages already exposed URL of the API server to locate cluster and use its head service to implement Job management functionality. Because you can access API server running on the remote kubernetes cluster you can use these APIs for managing remote Ray clusters without exposing them via Ingress.
+Ray provides very convinient and powerful [Job Submission APIs]. The issue is that it needs to
+access cluster's dashboard Ingress, which currently does not have any security implementations.
+Alternatively you can use Ray cluster head service for this, but in this case your Ray job
+management code has to run in the same kubernetes cluster as Ray. Job submission implementation in
+the API server leverages already exposed URL of the API server to locate cluster and use its head
+service to implement Job management functionality. Because you can access API server running on the
+remote kubernetes cluster you can use these APIs for managing remote Ray clusters without exposing
+them via Ingress.
 
 ## Using Job Submission APIs
 
-Note that job submission APIs will only work if you are running API server within kubernetes cluster. Local Development option of the API server will not work.
+Note that job submission APIs will only work if you are running API server within kubernetes
+cluster. Local Development option of the API server will not work.
 
 The first step is to deploy KubeRay operator and API server.
 
@@ -24,49 +32,29 @@ Execute the following commands:
 
 ```shell
 curl -X POST 'localhost:31888/apis/v1/namespaces/default/compute_templates' \
---header 'Content-Type: application/json' \
---data '{
-  "name": "default-template",
-  "namespace": "default",
-  "cpu": 2,
-  "memory": 4
-}'
+  --header 'Content-Type: application/json' \
+  --data '{
+    "name": "default-template",
+    "namespace": "default",
+    "cpu": 2,
+    "memory": 4
+  }'
+
 curl -X POST 'localhost:31888/apis/v1/namespaces/default/clusters' \
---header 'Content-Type: application/json' \
---data '{
-  "name": "test-cluster",
-  "namespace": "default",
-  "user": "boris",
-  "clusterSpec": {
-    "headGroupSpec": {
-      "computeTemplate": "default-template",
-      "image": "rayproject/ray:2.9.0-py310",
-      "serviceType": "NodePort",
-      "rayStartParams": {
-         "dashboard-host": "0.0.0.0",
-         "metrics-export-port": "8080"
-       },
-       "volumes": [
-         {
-           "name": "code-sample",
-           "mountPath": "/home/ray/samples",
-           "volumeType": "CONFIGMAP",
-           "source": "ray-job-code-sample",
-           "items": {"sample_code.py" : "sample_code.py"}
-         }
-       ]
-    },
-    "workerGroupSpec": [
-      {
-        "groupName": "small-wg",
+  --header 'Content-Type: application/json' \
+  --data '{
+    "name": "test-cluster",
+    "namespace": "default",
+    "user": "boris",
+    "clusterSpec": {
+      "headGroupSpec": {
         "computeTemplate": "default-template",
         "image": "rayproject/ray:2.9.0-py310",
-        "replicas": 1,
-        "minReplicas": 1,
-        "maxReplicas": 1,
+        "serviceType": "NodePort",
         "rayStartParams": {
-           "node-ip-address": "$MY_POD_IP"
-         },
+          "dashboard-host": "0.0.0.0",
+          "metrics-export-port": "8080"
+        },
         "volumes": [
           {
             "name": "code-sample",
@@ -76,13 +64,35 @@ curl -X POST 'localhost:31888/apis/v1/namespaces/default/clusters' \
             "items": {"sample_code.py" : "sample_code.py"}
           }
         ]
-      }
-    ]
-  }
-}'
+      },
+      "workerGroupSpec": [
+        {
+          "groupName": "small-wg",
+          "computeTemplate": "default-template",
+          "image": "rayproject/ray:2.9.0-py310",
+          "replicas": 1,
+          "minReplicas": 1,
+          "maxReplicas": 1,
+          "rayStartParams": {
+            "node-ip-address": "$MY_POD_IP"
+          },
+          "volumes": [
+            {
+              "name": "code-sample",
+              "mountPath": "/home/ray/samples",
+              "volumeType": "CONFIGMAP",
+              "source": "ray-job-code-sample",
+              "items": {"sample_code.py" : "sample_code.py"}
+            }
+          ]
+        }
+      ]
+    }
+  }'
 ```
 
-Note that this cluster is mounting a volume from a configmap. This config map should be created prior to cluster creation using this [yaml](/test/job/code.yaml).
+Note that this cluster is mounting a volume from a configmap. This config map should be created
+prior to cluster creation using [this YAML].
 
 ### Submit Ray Job
 
@@ -90,12 +100,12 @@ Once the cluster is up and running, you can submit a job to the cluster using th
 
 ```shell
 curl -X POST 'localhost:31888/apis/v1/namespaces/default/jobsubmissions/test-cluster' \
---header 'Content-Type: application/json' \
---data '{
-  "entrypoint": "python /home/ray/samples/sample_code.py",
-  "runtimeEnv": "pip:\n  - requests==2.26.0\n  - pendulum==2.1.2\nenv_vars:\n  counter_name: test_counter\n",
-  "numCpus": ".5"
-}'
+  --header 'Content-Type: application/json' \
+  --data '{
+    "entrypoint": "python /home/ray/samples/sample_code.py",
+    "runtimeEnv": "pip:\n  - requests==2.26.0\n  - pendulum==2.1.2\nenv_vars:\n  counter_name: test_counter\n",
+    "numCpus": ".5"
+  }'
 ```
 
 This should return the following:
@@ -110,11 +120,12 @@ Note that the `submissionId` value that you will get is different
 
 ### Get job details
 
-Once the job is submitted, the following command can be used to get job's details (Note that submission id returned during job creation should be used here):
+Once the job is submitted, the following command can be used to get job's details. Note that
+submission ID returned during job creation should be used here.
 
 ```shell
 curl -X GET 'localhost:31888/apis/v1/namespaces/default/jobsubmissions/test-cluster/raysubmit_KWZLwme56esG3Wcr' \
---header 'Content-Type: application/json'
+  --header 'Content-Type: application/json'
 ```
 
 This should return JSON similar to the one below
@@ -137,11 +148,12 @@ This should return JSON similar to the one below
 
 ### Get Job log
 
-You can also get job execution log using the following command (Note that submission id returned during job creation should be used here):
+You can also get job execution log using the following command. Note that submission ID returned
+during job creation should be used here.
 
 ```shell
 curl -X GET 'localhost:31888/apis/v1/namespaces/default/jobsubmissions/test-cluster/log/raysubmit_KWZLwme56esG3Wcr' \
---header 'Content-Type: application/json'
+  --header 'Content-Type: application/json'
 ```
 
 This will return execution log, that will look something like the following
@@ -149,7 +161,7 @@ This will return execution log, that will look something like the following
 ```text
 2023-11-08 03:24:31,904\tINFO worker.py:1329 -- Using address 10.244.2.2:6379 set in the environment variable RAY_ADDRESS
 2023-11-08 03:24:31,905\tINFO worker.py:1458 -- Connecting to existing Ray cluster at address: 10.244.2.2:6379...
-2023-11-08 03:24:31,921\tINFO worker.py:1633 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32m10.244.2.2:8265 \u001b[39m\u001b[22m
+2023-11-08 03:24:31,921\tINFO worker.py:1633 -- Connected to Ray cluster. View the dashboard at 10.244.2.2:8265
 test_counter got 1
 test_counter got 2
 test_counter got 3
@@ -157,7 +169,8 @@ test_counter got 4
 test_counter got 5
 ```
 
-Note that this command always returns execution log from the begining (no streaming support) till the current moment
+Note that this command always returns execution log from the begining (no streaming support) till
+the current moment.
 
 ### List jobs
 
@@ -165,7 +178,7 @@ You can also list all the jobs (in any state) in the Ray cluster using the follo
 
 ```shell
 curl -X GET 'localhost:31888/apis/v1/namespaces/default/jobsubmissions/test-cluster' \
---header 'Content-Type: application/json'
+  --header 'Content-Type: application/json'
 ```
 
 This should return the list of the submissions, that looks as follows:
@@ -192,20 +205,25 @@ This should return the list of the submissions, that looks as follows:
 
 ### Stop Job
 
-Execution of the job can be stoped using the following command (Note that submission id returned during job creation should be used here):
+Execution of the job can be stoped using the following command. Note that submission ID returned
+during job creation should be used here.
 
 ```shell
 curl -X POST 'localhost:31888/apis/v1/namespaces/default/jobsubmissions/test-cluster/raysubmit_KWZLwme56esG3Wcr' \
---header 'Content-Type: application/json'
+  --header 'Content-Type: application/json'
 ```
 
 ### Delete Job
 
-Finally, you can delete job using the following command (Note that submission id returned during job creation should be used here):
+Finally, you can delete job using the following command. Note that submission ID returned during job
+creation should be used here.
 
 ```shell
 curl -X DELETE 'localhost:31888/apis/v1/namespaces/default/jobsubmissions/test-cluster/raysubmit_KWZLwme56esG3Wcr' \
---header 'Content-Type: application/json'
+  --header 'Content-Type: application/json'
 ```
 
 You can validate job deletion by looking at the Ray dashboard (jobs pane) and ensuring that it was removed
+
+[Job Submission APIs]: https://docs.ray.io/en/latest/cluster/running-applications/job-submission/rest.html
+[this YAML]: /test/job/code.yaml

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # KubeRay APIServer
 
 The KubeRay APIServer provides gRPC and HTTP APIs to manage KubeRay resources.

--- a/apiserver/SecuringImplementation.md
+++ b/apiserver/SecuringImplementation.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Securing API server
 
 Currently the KubeRay API server deployed on a publicly accessible cluster is directly exposed to the internet with no authentication/authorization. To protect its endpoint we need to introduce security.

--- a/apiserver/Volumes.md
+++ b/apiserver/Volumes.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Volumes support for Ray cluster by the API server
 
 API server allows to specify multiple types of volumes mounted to the Ray pods (nodes). These include:

--- a/benchmark/memory_benchmark/memory_benchmark.md
+++ b/benchmark/memory_benchmark/memory_benchmark.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # KubeRay memory benchmark
 
 ## Running benchmark experiments on a Google GKE Cluster
@@ -13,7 +14,8 @@ This architecture is not a good practice, but it can fulfill the current require
 We will create a GKE cluster with autoscaling enabled.
 The following command creates a Kubernetes cluster named `kuberay-benchmark-cluster` on Google GKE.
 The cluster can scale up to 16 nodes, and each node of type `e2-highcpu-16` has 16 CPUs and 16 GB of memory.
-The following experiments may create up to ~150 Pods in the Kubernetes cluster, and each Ray Pod requires 1 CPU and 1 GB of memory.
+The following experiments may create up to ~150 Pods in the Kubernetes cluster, and each Ray Pod
+requires 1 CPU and 1 GB of memory.
 
 ```sh
 gcloud container clusters create kuberay-benchmark-cluster \

--- a/benchmark/perf-tests/README.md
+++ b/benchmark/perf-tests/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # KubeRay Performance Tests
 
 This directory contains a collection of large scale KubeRay tests using [clusterloader2](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2).

--- a/clients/python-apiserver-client/README.md
+++ b/clients/python-apiserver-client/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Python client for KubeRay API server
 
 This Python client is currently only supporting Ray cluster management through usage of the `API server` Ray API. It implements all of the current functionality of the API server (and the operator) and provide pythonic APIs to the capabilities.

--- a/clients/python-client/README.md
+++ b/clients/python-client/README.md
@@ -4,17 +4,19 @@ This python client library provide APIs to handle `raycluster` from your python 
 
 ## Prerequisites
 
-It is assumed that your `k8s cluster in already setup`. Your kubectl configuration is expected to be in  `~/.kube/config` if you are running the code directly from you terminal.
+It is assumed that your `k8s cluster in already setup`. Your kubectl configuration is expected to be
+in  `~/.kube/config` if you are running the code directly from you terminal.
 
-It is also expected that the `kuberay operator` is installed. [Installation instructions are here.](https://github.com/ray-project/kuberay#quick-start)
+It is also expected that the `kuberay operator` is installed.
+[Installation instructions are here][quick-start]
 
 ## Usage
 
-There are multiple levels of using the api with increasing levels of complexity.
+There are multiple levels of using the API with increasing levels of complexity.
 
 ### director
 
-This is the easiest form of using the api to create rayclusters with predefined cluster sizes
+This is the easiest form of using the API to create rayclusters with predefined cluster sizes
 
 ```python
 my_kuberay_api = kuberay_cluster_api.RayClusterApi()
@@ -27,11 +29,12 @@ if cluster0:
     my_kuberay_api.create_ray_cluster(body=cluster0)
 ```
 
-the director create the custer definition, and the custer_api acts as the http client sending the create (post) request to the k8s api-server
+the director create the cluster definition, and the `cluster_api` acts as the HTTP client sending
+the create (post) request to the k8s api-server
 
 ### cluster_builder
 
-The builder allows you to build the cluster piece by piece, you are can customize more the values of the cluster definition
+The builder allows you to build the cluster piece by piece. You can customize the cluster more.
 
 ```python
 cluster1 = (
@@ -49,24 +52,27 @@ my_kuberay_api.create_ray_cluster(body=cluster1)
 
 ### cluster_utils
 
-the cluster_utils gives you even more options to modify your cluster definition, add/remove worker groups, change replicas in a worker group, duplicate a worker group, etc.
+`cluster_utils` gives you even more options to modify your cluster definition, add/remove worker
+groups, change replicas in a worker group, duplicate a worker group, etc.
 
 ```python
 my_Cluster_utils = kuberay_cluster_utils.ClusterUtils()
 
 cluster_to_patch, succeeded = my_Cluster_utils.update_worker_group_replicas(
-        cluster2, group_name="workers", max_replicas=4, min_replicas=1, replicas=2
-    )
+    cluster2, group_name="workers", max_replicas=4, min_replicas=1, replicas=2
+)
 
 if succeeded:
-        my_kuberay_api.patch_ray_cluster(
-            name=cluster_to_patch["metadata"]["name"], ray_patch=cluster_to_patch
-        )
+    my_kuberay_api.patch_ray_cluster(
+        name=cluster_to_patch["metadata"]["name"], ray_patch=cluster_to_patch
+    )
 ```
 
 ### cluster_api
 
-Finally, the cluster_api is the one you always use to implement your cluster change in k8s. You can use it with raw `JSON` if you wish. The director/cluster_builder/cluster_utils are just tools to shield the user from using raw `JSON`.
+Finally, the `cluster_api` is the one you always use to implement your cluster change in k8s. You can
+use it with raw `JSON` if you wish. The `director/cluster_builder/cluster_utils` are just tools to
+shield the user from using raw `JSON`.
 
 ## Code Organization
 
@@ -118,3 +124,5 @@ from the directory `path/to/kuberay/clients/python-client`
 ### For testing run
 
  `python -m unittest discover 'path/to/kuberay/clients/python-client/python_client_test/'`
+
+[quick-start]: https://github.com/ray-project/kuberay#quick-start

--- a/docs/best-practice/worker-head-reconnection.md
+++ b/docs/best-practice/worker-head-reconnection.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Explanation and Best Practice for workers-head Reconnection
 
 ## Problem

--- a/docs/deploy/images.md
+++ b/docs/deploy/images.md
@@ -5,7 +5,9 @@ Images for the various KubeRay components are published at the following locatio
 1. [Quay.io](https://quay.io/organization/kuberay)
 2. [DockerHub](https://hub.docker.com/u/kuberay)
 
-We recommend using Quay.io as the primary source for images as there are image-pull restrictions on DockerHub. DockerHub allows you to pull only 100 images per 6 hour window. Refer to [DockerHub rate limiting](https://docs.docker.com/docker-hub/download-rate-limit/) for more details.
+We recommend using Quay.io as the primary source for images as there are image-pull restrictions on
+DockerHub. DockerHub allows you to pull only 100 images per 6 hour window. Refer to [DockerHub rate
+limiting] for more details.
 
 ## Stable versions
 
@@ -19,3 +21,5 @@ The first seven characters of the git SHA specify images built from specific com
 ## Nightly images
 
 The nightly tag specifies images built from the most recent master (e.g. `quay.io/kuberay/operator:nightly`).
+
+[DockerHub rate limiting]: https://docs.docker.com/docker-hub/download-rate-limit/

--- a/docs/design/protobuf-grpc-service.md
+++ b/docs/design/protobuf-grpc-service.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Support proto Core API and RESTful backend services
 
 ## Motivation

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -1,7 +1,8 @@
 # KubeRay Development Guide
 
-This guide provides an overview of the different components in the KubeRay project and instructions for developing and testing each component.
-Most developers will be concerned with the KubeRay Operator; the other components are optional.
+This guide provides an overview of the different components in the KubeRay project and instructions
+for developing and testing each component. Most developers will be concerned with the KubeRay
+Operator; the other components are optional.
 
 ## Pre-commit Hooks
 
@@ -13,21 +14,26 @@ We use [pre-commit] to lint and format code before each commit.
 ## KubeRay Operator
 
 The KubeRay Operator is responsible for managing Ray clusters on Kubernetes.
-To learn more about developing and testing the KubeRay Operator, please refer to the [Operator Development Guide](https://github.com/ray-project/kuberay/blob/master/ray-operator/DEVELOPMENT.md).
+To learn more about developing and testing the KubeRay Operator, please refer to the
+[Operator Development Guide].
 
 ## KubeRay APIServer
 
 The KubeRay APIServer is a central component that exposes the KubeRay API for managing Ray clusters.
-For more information about developing and testing the KubeRay APIServer, please refer to the [APIServer Development Guide](https://github.com/ray-project/kuberay/blob/master/apiserver/DEVELOPMENT.md).
+For more information about developing and testing the KubeRay APIServer, please refer to the
+[APIServer Development Guide].
 
 ## KubeRay Python client
 
-The KubeRay Python client library provides APIs to handle RayCluster from your Python application. For more information about developing and testing the KubeRay Python client, please refer to the [Python Client](https://github.com/ray-project/kuberay/blob/master/components/pythonclient.md), [Python API Client](https://github.com/ray-project/kuberay/blob/master/components/pythonapiclient.md).
+The KubeRay Python client library provides APIs to handle RayCluster from your Python application.
+For more information about developing and testing the KubeRay Python client, please refer to the
+[Python Client] and [Python API Client].
 
 ## Proto and OpenAPI
 
-KubeRay uses Protocol Buffers (protobuf) and OpenAPI specifications to define the API and data structures.
-For more information about developing and testing proto files and OpenAPI specifications, please refer to the [Proto and OpenAPI Development Guide](https://github.com/ray-project/kuberay/blob/master/proto/README.md).
+KubeRay uses Protocol Buffers (protobuf) and OpenAPI specifications to define the API and data
+structures. For more information about developing and testing proto files and OpenAPI
+specifications, please refer to the [Proto and OpenAPI Development Guide].
 
 ## KubeRay Kubectl Plugin (beta)
 
@@ -50,8 +56,14 @@ docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
 
 - Open your web browser and navigate to <http://127.0.0.1:8000/kuberay/> to view the documentation.
 
-If you make any changes to the documentation files, the local preview will automatically update to reflect those changes.
+If you make any changes to the documentation files, the local preview will automatically update to
+reflect those changes.
 
 [pre-commit]: https://pre-commit.com/
 [kubectl plugin]: https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/
 [Kubectl Plugin Development Guide]: ../../kubectl-plugin/DEVELOPMENT.md
+[Python Client]: https://github.com/ray-project/kuberay/blob/master/components/pythonclient.md
+[Python API Client]: https://github.com/ray-project/kuberay/blob/master/components/pythonapiclient.md
+[APIServer Development Guide]: https://github.com/ray-project/kuberay/blob/master/apiserver/DEVELOPMENT.md
+[Proto and OpenAPI Development Guide]: https://github.com/ray-project/kuberay/blob/master/proto/README.md
+[Operator Development Guide]: https://github.com/ray-project/kuberay/blob/master/ray-operator/DEVELOPMENT.md

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # KubeRay Release Process
 
 ## Prerequisite

--- a/docs/guidance/aws-eks-iam.md
+++ b/docs/guidance/aws-eks-iam.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # IAM roles for service account on AWS EKS
 
 Applications in a pod's containers can use an AWS SDK or the AWS CLI to make API requests to AWS services using AWS Identity and Access Management (IAM) permissions. Applications must sign their AWS API requests with AWS credentials. IAM roles for service accounts provide the ability to manage credentials for your applications. To achieve this, you can read the following articles:

--- a/docs/guidance/kuberay-with-MCAD.md
+++ b/docs/guidance/kuberay-with-MCAD.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # KubeRay integration with MCAD (Multi-Cluster-App-Dispatcher)
 
 The multi-cluster-app-dispatcher is a Kubernetes controller providing mechanisms for applications to manage batch jobs in a single or multi-cluster environment. For more details please refer [here](https://github.com/project-codeflare/multi-cluster-app-dispatcher).

--- a/docs/guidance/observability.md
+++ b/docs/guidance/observability.md
@@ -30,7 +30,8 @@ curl --request GET '<baseUrl>/apis/v1alpha2/namespaces/<namespace>/clusters/<ray
 
 ### Endpoint
 
-If you use the nodeport as service to expose the raycluster endpoint, like dashboard or redis, there are `endpoints` field in the status to record the service endpoints.
+If you use the nodeport as service to expose the raycluster endpoint, like dashboard or redis, there
+are `endpoints` field in the status to record the service endpoints.
 
 you can directly use the ports in the `endpoints` to connect to the related service.
 

--- a/docs/guidance/rayStartParams.md
+++ b/docs/guidance/rayStartParams.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Default Ray Start Parameters for KubeRay
 
 This document outlines the default settings for `rayStartParams` in KubeRay.

--- a/docs/guidance/rayclient-nginx-ingress.md
+++ b/docs/guidance/rayclient-nginx-ingress.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Connect to Ray client with NGINX Ingress
 >
 > Warning: Ray client has some known [limitations](https://docs.ray.io/en/latest/cluster/running-applications/job-submission/ray-client.html#things-to-know) and is not actively maintained.

--- a/docs/guidance/rayservice-high-availability.md
+++ b/docs/guidance/rayservice-high-availability.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # RayService high availability
 
 RayService provides high availability (HA) to ensure services continue serving requests without failure during scaling up, scaling down, and upgrading the RayService configuration (zero-downtime upgrade).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD033 -->
+<!-- markdownlint-disable MD013 MD033 -->
 # Welcome
 
 <p align="center">

--- a/docs/release/changelog.md
+++ b/docs/release/changelog.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Generate the changelog for a release
 
 ## Prerequisite

--- a/docs/release/helm-chart.md
+++ b/docs/release/helm-chart.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Helm charts release
 
 We host all Helm charts on [kuberay-helm](https://github.com/ray-project/kuberay-helm).

--- a/helm-chart/kuberay-apiserver/README.md
+++ b/helm-chart/kuberay-apiserver/README.md
@@ -4,7 +4,8 @@ This document provides instructions to install the KubeRay API Server with a Hel
 
 ## Helm
 
-Make sure the version of Helm is v3+. Currently, [existing CI tests](https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm-lint.yaml) are based on Helm v3.4.1 and v3.9.4.
+Make sure the version of Helm is v3+. Currently, [existing CI tests] are based on Helm v3.4.1 and
+v3.9.4.
 
 ```sh
 helm version
@@ -57,3 +58,5 @@ helm uninstall kuberay-apiserver
 kubectl get pods
 # No resources found in default namespace.
 ```
+
+[existing CI tests]: https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm-lint.yaml

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -1,10 +1,11 @@
 # KubeRay Operator
 
-This document provides instructions to install both CRDs (RayCluster, RayJob, RayService) and KubeRay operator with a Helm chart.
+This document provides instructions to install both CRDs (RayCluster, RayJob, RayService) and
+KubeRay operator with a Helm chart.
 
 ## Helm
 
-Make sure the version of Helm is v3+. Currently, [existing CI tests](https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm-lint.yaml) are based on Helm v3.4.1 and v3.9.4.
+Make sure the version of Helm is v3+. Currently, [existing CI tests] are based on Helm v3.4.1 and v3.9.4.
 
 ```sh
 helm version
@@ -38,8 +39,11 @@ helm version
   ```
 
 * Install KubeRay operator without installing CRDs
-  * In some cases, the installation of the CRDs and the installation of the operator may require different levels of admin permissions, so these two installations could be handled as different steps by different roles.
-  * Use Helm's built-in `--skip-crds` flag to install the operator only. See [this document](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) for more details.
+  * In some cases, the installation of the CRDs and the installation of the operator may require
+    different levels of admin permissions, so these two installations could be handled as different
+    steps by different roles.
+  * Use Helm's built-in `--skip-crds` flag to install the operator only.
+    See [this document] for more details.
 
   ```sh
   # Step 1: Install CRDs only (for cluster admin)
@@ -72,8 +76,9 @@ kubectl get pods
 
 ## Working with Argo CD
 
-If you are using [Argo CD](https://argoproj.github.io) to manage the operator, you will encounter the issue which complains the CRDs too long. Same with [this issue](https://github.com/prometheus-operator/prometheus-operator/issues/4439).
-The recommended solution is to split the operator into two Argo apps, such as:
+If you are using [Argo CD] to manage the operator, you will encounter the issue which complains the
+CRDs too long. Same with [this issue]. The recommended solution is to split the operator into two
+Argo apps, such as:
 
 * The first app just for installing the CRDs with `Replace=true` directly, snippet:
 
@@ -118,3 +123,8 @@ spec:
     - CreateNamespace=true
 ...
 ```
+
+[existing CI tests]: https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm-lint.yaml
+[Argo CD]: https://argoproj.github.io
+[this issue]: https://github.com/prometheus-operator/prometheus-operator/issues/4439
+[this document]: https://helm.sh/docs/chart_best_practices/custom_resource_definitions/

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -1,13 +1,16 @@
 # RayCluster
 
-RayCluster is a custom resource definition (CRD). **KubeRay operator** will listen to the resource events about RayCluster and create related Kubernetes resources (e.g. Pod & Service). Hence, **KubeRay operator** installation and **CRD** registration are required for this guide.
+RayCluster is a custom resource definition (CRD). **KubeRay operator** will listen to the resource
+events about RayCluster and create related Kubernetes resources (e.g. Pod & Service). Hence,
+**KubeRay operator** installation and **CRD** registration are required for this guide.
 
 ## Prerequisites
 
-See [kuberay-operator/README.md](https://github.com/ray-project/kuberay/blob/master/helm-chart/kuberay-operator/README.md) for more details.
+See [kuberay-operator/README.md] for more details.
 
 * Helm
-* Install custom resource definition and KubeRay operator (covered by the following end-to-end example.)
+* Install custom resource definition and KubeRay operator (covered by the following end-to-end
+  example.)
 
 ## End-to-end example
 
@@ -53,3 +56,5 @@ helm uninstall raycluster
 # NAME                                READY   STATUS    RESTARTS   AGE
 # kuberay-operator-6fcbb94f64-gkpc9   1/1     Running   0          9m57s
 ```
+
+[kuberay-operator/README.md]: https://github.com/ray-project/kuberay/blob/master/helm-chart/kuberay-operator/README.md

--- a/proto/README.md
+++ b/proto/README.md
@@ -31,11 +31,13 @@ We postpone the client generation until there is a need for external service com
 
 ### API Reference Documentation
 
-Use the tools [bootprint-openapi](https://github.com/bootprint/bootprint-monorepo/tree/master/packages/bootprint-openapi) and [html-inline](https://github.com/substack/html-inline) to generate API reference documentation from the Swagger files. For more information on the API and architecture, refer to the [design document](../docs/design/protobuf-grpc-service.md).
+Use the tools [bootprint-openapi] and [html-inline] to generate API reference documentation from the
+Swagger files. For more information on the API and architecture, refer to the [design document].
 
 ### Third-Party Protos
 
-Third-party proto dependencies are synchronized back to `proto/third_party` for easier development (IDE friendly). Ideally, the directory for searching imports should be specified instead.
+Third-party proto dependencies are synchronized back to `proto/third_party` for easier development
+(IDE friendly). Ideally, the directory for searching imports should be specified instead.
 
 ```bash
 protoc -I.
@@ -48,3 +50,7 @@ Sources:
 
 - [googleapis](https://github.com/googleapis/googleapis/tree/master/google/api)
 - [protoc-gen-openapiv2](https://github.com/grpc-ecosystem/grpc-gateway/tree/master/protoc-gen-openapiv2/options)
+
+[bootprint-openapi]: https://github.com/bootprint/bootprint-monorepo/tree/master/packages/bootprint-openapi
+[html-inline]: https://github.com/substack/html-inline
+[design document]: ../docs/design/protobuf-grpc-service.md

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Development
 
 This section walks through how to build and test the operator in a running Kubernetes cluster.


### PR DESCRIPTION
* MD013: Line length

* Set max line length to 120 characters
* Ignore most files that violate the rule
* Fix some that only have a few violations
* Fix misspellings and formatting in `clients/python-client/README.md`

https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md

Signed-off-by: David Xia <david@davidxia.com>
