### PR TITLE
[RayService] make RayClusterSpec required

### DIFF
--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -16573,8 +16573,6 @@ spec:
               serviceUnhealthySecondThreshold:
                 format: int32
                 type: integer
-            required:
-            - rayClusterConfig
             type: object
           status:
             properties:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -8209,6 +8209,8 @@ spec:
                   type:
                     type: string
                 type: object
+            required:
+            - rayClusterConfig
             type: object
           status:
             properties:
@@ -16571,6 +16573,8 @@ spec:
               serviceUnhealthySecondThreshold:
                 format: int32
                 type: integer
+            required:
+            - rayClusterConfig
             type: object
           status:
             properties:

--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -75,7 +75,7 @@ type RayServiceSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	// Defines the applications and deployments to deploy, should be a YAML multi-line scalar string.
 	ServeConfigV2  string         `json:"serveConfigV2,omitempty"`
-	RayClusterSpec RayClusterSpec `json:"rayClusterConfig,omitempty"`
+	RayClusterSpec RayClusterSpec `json:"rayClusterConfig"`
 	// If the field is set to true, the value of the label `ray.io/serve` on the head Pod should always be false.
 	// Therefore, the head Pod's endpoint will not be added to the Kubernetes Serve service.
 	ExcludeHeadPodFromServeSvc bool `json:"excludeHeadPodFromServeSvc,omitempty"`

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -54,7 +54,7 @@ type RayServiceSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	// Defines the applications and deployments to deploy, should be a YAML multi-line scalar string.
 	ServeConfigV2  string         `json:"serveConfigV2,omitempty"`
-	RayClusterSpec RayClusterSpec `json:"rayClusterConfig"`
+	RayClusterSpec RayClusterSpec `json:"rayClusterConfig,omitempty"`
 }
 
 // RayServiceStatuses defines the observed state of RayService

--- a/ray-operator/apis/ray/v1alpha1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1alpha1/rayservice_types.go
@@ -54,7 +54,7 @@ type RayServiceSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	// Defines the applications and deployments to deploy, should be a YAML multi-line scalar string.
 	ServeConfigV2  string         `json:"serveConfigV2,omitempty"`
-	RayClusterSpec RayClusterSpec `json:"rayClusterConfig,omitempty"`
+	RayClusterSpec RayClusterSpec `json:"rayClusterConfig"`
 }
 
 // RayServiceStatuses defines the observed state of RayService

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -16573,8 +16573,6 @@ spec:
               serviceUnhealthySecondThreshold:
                 format: int32
                 type: integer
-            required:
-            - rayClusterConfig
             type: object
           status:
             properties:

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -8209,6 +8209,8 @@ spec:
                   type:
                     type: string
                 type: object
+            required:
+            - rayClusterConfig
             type: object
           status:
             properties:
@@ -16571,6 +16573,8 @@ spec:
               serviceUnhealthySecondThreshold:
                 format: int32
                 type: integer
+            required:
+            - rayClusterConfig
             type: object
           status:
             properties:

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -782,7 +782,19 @@ func TestValidateRayServiceSpec(t *testing.T) {
 	require.Error(t, err, "spec.rayClusterConfig.headGroupSpec.headService.metadata.name should not be set")
 
 	err = ValidateRayServiceSpec(&rayv1.RayService{
-		Spec: rayv1.RayServiceSpec{},
+		Spec: rayv1.RayServiceSpec{
+			RayClusterSpec: rayv1.RayClusterSpec{
+				HeadGroupSpec: rayv1.HeadGroupSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "ray-head"},
+							},
+						},
+					},
+				},
+			},
+		},
 	})
 	require.NoError(t, err, "The RayService spec is valid.")
 
@@ -791,6 +803,17 @@ func TestValidateRayServiceSpec(t *testing.T) {
 		Spec: rayv1.RayServiceSpec{
 			UpgradeStrategy: &rayv1.RayServiceUpgradeStrategy{
 				Type: &upgradeStrat,
+			},
+			RayClusterSpec: rayv1.RayClusterSpec{
+				HeadGroupSpec: rayv1.HeadGroupSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "ray-head"},
+							},
+						},
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

To make `RayClusterSpec` required in RayService.

This is the support PR according to https://github.com/ray-project/kuberay/pull/3153#discussion_r1983802799

Here is the result after applying a RayService with an empty `RayClusterSpec`.
<img width="1235" alt="fail" src="https://github.com/user-attachments/assets/fe7548b9-5cb1-460f-b36a-e48a2c6bdf7d" />


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
