### PR TITLE
kubectl ray job submit: provide entrypoint

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -282,6 +282,11 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 			RayJobName:     options.rayjobName,
 			Namespace:      *options.configFlags.Namespace,
 			SubmissionMode: "InteractiveMode",
+			// Prior to kuberay 1.2.2, the entry point is required. To maintain
+			// backwards compatability with 1.2.x, we submit the entry point
+			// here, even though it will be ignored.
+			// See https://github.com/ray-project/kuberay/issues/3126.
+			Entrypoint: options.entryPoint,
 			RayClusterSpecObject: generation.RayClusterSpecObject{
 				RayVersion:     options.rayVersion,
 				Image:          options.image,

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -283,7 +283,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 			Namespace:      *options.configFlags.Namespace,
 			SubmissionMode: "InteractiveMode",
 			// Prior to kuberay 1.2.2, the entry point is required. To maintain
-			// backwards compatability with 1.2.x, we submit the entry point
+			// backwards compatibility with 1.2.x, we submit the entry point
 			// here, even though it will be ignored.
 			// See https://github.com/ray-project/kuberay/issues/3126.
 			Entrypoint: options.entryPoint,

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -44,6 +44,7 @@ type RayJobYamlObject struct {
 	RayJobName     string
 	Namespace      string
 	SubmissionMode string
+	Entrypoint     string
 	RayClusterSpecObject
 }
 
@@ -60,6 +61,7 @@ func (rayJobObject *RayJobYamlObject) GenerateRayJobApplyConfig() *rayv1ac.RayJo
 	rayJobApplyConfig := rayv1ac.RayJob(rayJobObject.RayJobName, rayJobObject.Namespace).
 		WithSpec(rayv1ac.RayJobSpec().
 			WithSubmissionMode(rayv1.JobSubmissionMode(rayJobObject.SubmissionMode)).
+			WithEntrypoint(rayJobObject.Entrypoint).
 			WithRayClusterSpec(rayJobObject.generateRayClusterSpec()))
 
 	return rayJobApplyConfig


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The entrypoint is required on kuberay versions prior to 1.2.2. To provide backwards compatability, this patch mirrors the entrypoint that will be used with `ray job submit` to the RayJob object.

The behavior when using 1.2.1 without this patch is confusing -- the user sees an "entry point required" message from kube-apiserver that doesn't make sense since they're providing an entry point to the plugin.  But we can work around that easily and make it "just work" with all 1.2.x versions.

## Related issue number

<!-- For example: "Closes #1234" -->
See #3126, discussion at #3127

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
