### PR TITLE
kubectl plugin: version shows commit for dev

### DIFF
--- a/kubectl-plugin/pkg/cmd/version/version.go
+++ b/kubectl-plugin/pkg/cmd/version/version.go
@@ -104,5 +104,8 @@ func buildInfo() (commit, buildtime string, err error) {
 			buildtime = setting.Value
 		}
 	}
+	if commit == "" || buildtime == "" {
+		return "", "", fmt.Errorf("missing revision or build time from build info")
+	}
 	return
 }

--- a/kubectl-plugin/pkg/cmd/version/version_test.go
+++ b/kubectl-plugin/pkg/cmd/version/version_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime/debug"
 	"testing"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
@@ -49,6 +50,25 @@ func TestRayVersionCheckContext(t *testing.T) {
 	}
 }
 
+func createBuildInfo(revision, time string) *debug.BuildInfo {
+	return &debug.BuildInfo{
+		Main: debug.Module{
+			Path:    "github.com/ray-project/kuberay/kubectl-plugin",
+			Version: "(devel)",
+		},
+		Settings: []debug.BuildSetting{
+			{
+				Key:   "vcs.revision",
+				Value: revision,
+			},
+			{
+				Key:   "vcs.time",
+				Value: time,
+			},
+		},
+	}
+}
+
 // Tests the Run() step of the command and checks the output.
 func TestRayVersionRun(t *testing.T) {
 	fakeVersionOptions := &VersionOptions{
@@ -60,6 +80,9 @@ func TestRayVersionRun(t *testing.T) {
 		name                           string
 		kuberayImageVersion            string
 		getKubeRayOperatorVersionError error
+		pluginCommit                   string
+		pluginBuildTime                string
+		buildInfoErr                   bool
 		expected                       string
 	}{
 		{
@@ -77,14 +100,37 @@ func TestRayVersionRun(t *testing.T) {
 				"warning: KubeRay operator installation cannot be found: something went wrong. "+
 				"Did you install it with the name \"kuberay-operator\"?\n", Version),
 		},
+		{
+			name:                "Test when build info is included",
+			kuberayImageVersion: "v0.0.1",
+			pluginCommit:        "abcdefg",
+			pluginBuildTime:     "2023-10-27T12:00:00Z",
+			buildInfoErr:        false,
+			expected: fmt.Sprintf("kubectl ray plugin version: development (%s, built %s)\n"+
+				"KubeRay operator version: %s\n", "abcdefg", "2023-10-27T12:00:00Z", "v0.0.1"),
+		},
+		{
+			name:                "Test when build info fails",
+			kuberayImageVersion: "v0.0.1",
+			buildInfoErr:        true,
+			expected: fmt.Sprintf("kubectl ray plugin version: %s\n"+
+				"KubeRay operator version: %s\n", Version, "v0.0.1"),
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			testVersion := Version                   // Store the global Version value
+			defer func() { Version = testVersion }() // Restore after the test
+
 			client := clientfake.NewFakeClient().WithKubeRayImageVersion(tc.kuberayImageVersion).WithKubeRayOperatorVersionError(tc.getKubeRayOperatorVersionError)
 
+			fakeBuildInfo := func() (*debug.BuildInfo, bool) {
+				return createBuildInfo(tc.pluginCommit, tc.pluginBuildTime), !tc.buildInfoErr
+			}
+
 			var buf bytes.Buffer
-			err := fakeVersionOptions.Run(context.Background(), client, &buf)
+			err := fakeVersionOptions.Run(context.Background(), client, fakeBuildInfo, &buf)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expected, buf.String())

--- a/kubectl-plugin/pkg/cmd/version/version_test.go
+++ b/kubectl-plugin/pkg/cmd/version/version_test.go
@@ -82,8 +82,8 @@ func TestRayVersionRun(t *testing.T) {
 		getKubeRayOperatorVersionError error
 		pluginCommit                   string
 		pluginBuildTime                string
-		buildInfoErr                   bool
 		expected                       string
+		buildInfoErr                   bool
 	}{
 		{
 			name:                           "Test when we can successfully get the KubeRay operator image version",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I think it would be helpful for `kubectl ray version` to print the git commit it was built with for dev versions.

Example output:

```
 $ kubectl ray version
kubectl ray plugin version: development (0056fbf, built 2025-03-10T05:43:22Z)
...
```

## Related issue number

n/a

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
