### PR TITLE
Allow app.kubernetes.io/component to be overriden in kuberay-operator helm chart

### DIFF
--- a/helm-chart/kuberay-operator/templates/_helpers.tpl
+++ b/helm-chart/kuberay-operator/templates/_helpers.tpl
@@ -7,6 +7,13 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Allow the component label to be overridden, otherwise provide a default value.
+*/}}
+{{- define "kuberay-operator.component" -}}
+{{- default .Chart.Name .Values.componentOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "kuberay-operator.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/component: kuberay-operator
+        app.kubernetes.io/component: {{ include "kuberay-operator.component" . }}
         {{- if .Values.labels }}
         {{- toYaml .Values.labels | nindent 8 }}
         {{- end }}

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -9,6 +9,7 @@ image:
 
 nameOverride: "kuberay-operator"
 fullnameOverride: "kuberay-operator"
+componentOverride: "kuberay-operator"
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
## Why are these changes needed?

We need to be able to override `app.kubernetes.io/component`, in the same way that the helm chart allows us to override `app.kubernetes.io/name`.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
