### PR TITLE
[refactor][operator]: make `RayStartParams` optional

### DIFF
--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -337,7 +337,6 @@ func TestCreateClusterEndpoint(t *testing.T) {
 							ComputeTemplate: tCtx.GetComputeTemplateName(),
 							Image:           tCtx.GetRayImage(),
 							ServiceType:     "NodePort",
-							RayStartParams:  map[string]string{},
 						},
 						WorkerGroupSpec: []*api.WorkerGroupSpec{},
 					},

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -4301,7 +4301,6 @@ spec:
                         type: object
                     type: object
                 required:
-                - rayStartParams
                 - template
                 type: object
               headServiceAnnotations:
@@ -8029,7 +8028,6 @@ spec:
                   - groupName
                   - maxReplicas
                   - minReplicas
-                  - rayStartParams
                   - template
                   type: object
                 type: array

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -4327,7 +4327,6 @@ spec:
                             type: object
                         type: object
                     required:
-                    - rayStartParams
                     - template
                     type: object
                   headServiceAnnotations:
@@ -8055,7 +8054,6 @@ spec:
                       - groupName
                       - maxReplicas
                       - minReplicas
-                      - rayStartParams
                       - template
                       type: object
                     type: array

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -4281,7 +4281,6 @@ spec:
                             type: object
                         type: object
                     required:
-                    - rayStartParams
                     - template
                     type: object
                   headServiceAnnotations:
@@ -8009,7 +8008,6 @@ spec:
                       - groupName
                       - maxReplicas
                       - minReplicas
-                      - rayStartParams
                       - template
                       type: object
                     type: array

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -122,7 +122,7 @@ func TestGenerateRayClusterApplyConfig(t *testing.T) {
 					GroupName:      ptr.To("default-group"),
 					Replicas:       ptr.To(int32(3)),
 					NumOfHosts:     ptr.To(int32(2)),
-					RayStartParams: map[string]string{"metrics-export-port": "8080", "dagon": "azathoth", "shoggoth": "cthulhu"},
+					RayStartParams: map[string]string{"dagon": "azathoth", "shoggoth": "cthulhu"},
 					Template: &corev1ac.PodTemplateSpecApplyConfiguration{
 						Spec: &corev1ac.PodSpecApplyConfiguration{
 							Containers: []corev1ac.ContainerApplyConfiguration{
@@ -176,6 +176,10 @@ func TestGenerateRayJobApplyConfig(t *testing.T) {
 					Memory:     ptr.To("10Gi"),
 					GPU:        ptr.To("0"),
 					TPU:        ptr.To("0"),
+					RayStartParams: map[string]string{
+						"dagon":    "azathoth",
+						"shoggoth": "cthulhu",
+					},
 				},
 			},
 		},
@@ -198,7 +202,6 @@ func TestGenerateRayJobApplyConfig(t *testing.T) {
 			RayClusterSpec: &rayv1ac.RayClusterSpecApplyConfiguration{
 				RayVersion: ptr.To(util.RayVersion),
 				HeadGroupSpec: &rayv1ac.HeadGroupSpecApplyConfiguration{
-					RayStartParams: map[string]string{"dashboard-host": "0.0.0.0"},
 					Template: &corev1ac.PodTemplateSpecApplyConfiguration{
 						Spec: &corev1ac.PodSpecApplyConfiguration{
 							Containers: []corev1ac.ContainerApplyConfiguration{
@@ -240,7 +243,7 @@ func TestGenerateRayJobApplyConfig(t *testing.T) {
 						GroupName:      ptr.To("default-group"),
 						Replicas:       ptr.To(int32(3)),
 						NumOfHosts:     ptr.To(int32(2)),
-						RayStartParams: map[string]string{"metrics-export-port": "8080"},
+						RayStartParams: map[string]string{"dagon": "azathoth", "shoggoth": "cthulhu"},
 						Template: &corev1ac.PodTemplateSpecApplyConfiguration{
 							Spec: &corev1ac.PodSpecApplyConfiguration{
 								Containers: []corev1ac.ContainerApplyConfiguration{
@@ -287,6 +290,9 @@ func TestConvertRayClusterApplyConfigToYaml(t *testing.T) {
 			CPU:    ptr.To("1"),
 			Memory: ptr.To("5Gi"),
 			GPU:    ptr.To("1"),
+			RayStartParams: map[string]string{
+				"num-cpus": "0",
+			},
 		},
 		WorkerGroups: []WorkerGroup{
 			{
@@ -318,7 +324,7 @@ metadata:
 spec:
   headGroupSpec:
     rayStartParams:
-      dashboard-host: 0.0.0.0
+      num-cpus: "0"
     template:
       spec:
         containers:
@@ -342,8 +348,6 @@ spec:
   rayVersion: %s
   workerGroupSpecs:
   - groupName: default-group
-    rayStartParams:
-      metrics-export-port: "8080"
     replicas: 3
     numOfHosts: 2
     template:
@@ -459,7 +463,8 @@ func TestGenerateRayClusterSpec(t *testing.T) {
 				GPU:        ptr.To("0"),
 				TPU:        ptr.To("0"),
 				RayStartParams: map[string]string{
-					"metrics-export-port": "8080",
+					"dagon":    "azathoth",
+					"shoggoth": "cthulhu",
 				},
 				NodeSelectors: map[string]string{
 					"worker-selector1": "baz",
@@ -476,7 +481,7 @@ func TestGenerateRayClusterSpec(t *testing.T) {
 	expected := &rayv1ac.RayClusterSpecApplyConfiguration{
 		RayVersion: ptr.To("1.2.3"),
 		HeadGroupSpec: &rayv1ac.HeadGroupSpecApplyConfiguration{
-			RayStartParams: map[string]string{"dashboard-host": "0.0.0.0", "softmax": "GELU"},
+			RayStartParams: map[string]string{"softmax": "GELU"},
 			Template: &corev1ac.PodTemplateSpecApplyConfiguration{
 				Spec: &corev1ac.PodSpecApplyConfiguration{
 					ServiceAccountName: ptr.To("my-service-account"),
@@ -522,10 +527,13 @@ func TestGenerateRayClusterSpec(t *testing.T) {
 		},
 		WorkerGroupSpecs: []rayv1ac.WorkerGroupSpecApplyConfiguration{
 			{
-				GroupName:      ptr.To("default-group"),
-				NumOfHosts:     ptr.To(int32(1)),
-				Replicas:       ptr.To(int32(3)),
-				RayStartParams: map[string]string{"metrics-export-port": "8080"},
+				GroupName:  ptr.To("default-group"),
+				NumOfHosts: ptr.To(int32(1)),
+				Replicas:   ptr.To(int32(3)),
+				RayStartParams: map[string]string{
+					"dagon":    "azathoth",
+					"shoggoth": "cthulhu",
+				},
 				Template: &corev1ac.PodTemplateSpecApplyConfiguration{
 					Spec: &corev1ac.PodSpecApplyConfiguration{
 						ServiceAccountName: ptr.To("my-service-account"),
@@ -554,9 +562,6 @@ func TestGenerateRayClusterSpec(t *testing.T) {
 			{
 				GroupName: ptr.To("worker-group-2"),
 				Replicas:  ptr.To(int32(0)),
-				RayStartParams: map[string]string{
-					"metrics-export-port": "8080",
-				},
 				Template: &corev1ac.PodTemplateSpecApplyConfiguration{
 					Spec: &corev1ac.PodSpecApplyConfiguration{
 						ServiceAccountName: ptr.To("my-service-account"),

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -77,7 +77,7 @@ type HeadGroupSpec struct {
 	EnableIngress *bool `json:"enableIngress,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	// +optional
-	RayStartParams map[string]string `json:"rayStartParams,omitempty"`
+	RayStartParams map[string]string `json:"rayStartParams"`
 	// ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
@@ -108,7 +108,7 @@ type WorkerGroupSpec struct {
 	IdleTimeoutSeconds *int32 `json:"idleTimeoutSeconds,omitempty"`
 	// RayStartParams are the params of the start command: address, object-store-memory, ...
 	// +optional
-	RayStartParams map[string]string `json:"rayStartParams,omitempty"`
+	RayStartParams map[string]string `json:"rayStartParams"`
 	// Template is a pod template for the worker
 	Template corev1.PodTemplateSpec `json:"template"`
 	// ScaleStrategy defines which pods to remove

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -76,7 +76,8 @@ type HeadGroupSpec struct {
 	// +optional
 	EnableIngress *bool `json:"enableIngress,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
-	RayStartParams map[string]string `json:"rayStartParams"`
+	// +optional
+	RayStartParams map[string]string `json:"rayStartParams,omitempty"`
 	// ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
@@ -106,7 +107,8 @@ type WorkerGroupSpec struct {
 	// +optional
 	IdleTimeoutSeconds *int32 `json:"idleTimeoutSeconds,omitempty"`
 	// RayStartParams are the params of the start command: address, object-store-memory, ...
-	RayStartParams map[string]string `json:"rayStartParams"`
+	// +optional
+	RayStartParams map[string]string `json:"rayStartParams,omitempty"`
 	// Template is a pod template for the worker
 	Template corev1.PodTemplateSpec `json:"template"`
 	// ScaleStrategy defines which pods to remove

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -4301,7 +4301,6 @@ spec:
                         type: object
                     type: object
                 required:
-                - rayStartParams
                 - template
                 type: object
               headServiceAnnotations:
@@ -8029,7 +8028,6 @@ spec:
                   - groupName
                   - maxReplicas
                   - minReplicas
-                  - rayStartParams
                   - template
                   type: object
                 type: array

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -4327,7 +4327,6 @@ spec:
                             type: object
                         type: object
                     required:
-                    - rayStartParams
                     - template
                     type: object
                   headServiceAnnotations:
@@ -8055,7 +8054,6 @@ spec:
                       - groupName
                       - maxReplicas
                       - minReplicas
-                      - rayStartParams
                       - template
                       type: object
                     type: array

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -4281,7 +4281,6 @@ spec:
                             type: object
                         type: object
                     required:
-                    - rayStartParams
                     - template
                     type: object
                   headServiceAnnotations:
@@ -8009,7 +8008,6 @@ spec:
                       - groupName
                       - maxReplicas
                       - minReplicas
-                      - rayStartParams
                       - template
                       type: object
                     type: array

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -54,7 +54,6 @@ func rayClusterTemplate(name string, namespace string) *rayv1.RayCluster {
 		},
 		Spec: rayv1.RayClusterSpec{
 			HeadGroupSpec: rayv1.HeadGroupSpec{
-				RayStartParams: map[string]string{},
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -68,11 +67,10 @@ func rayClusterTemplate(name string, namespace string) *rayv1.RayCluster {
 			},
 			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 				{
-					Replicas:       ptr.To(replicas),
-					MinReplicas:    ptr.To(minReplicas),
-					MaxReplicas:    ptr.To(maxReplicas),
-					GroupName:      "small-group",
-					RayStartParams: map[string]string{},
+					Replicas:    ptr.To(replicas),
+					MinReplicas: ptr.To(minReplicas),
+					MaxReplicas: ptr.To(maxReplicas),
+					GroupName:   "small-group",
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3672,3 +3672,17 @@ func TestEmitRayClusterProvisionedDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestSetDefaults(t *testing.T) {
+	setupTest(t)
+	cluster := testRayCluster.DeepCopy()
+	cluster.Spec.HeadGroupSpec.RayStartParams = nil
+	cluster.Spec.WorkerGroupSpecs[0].RayStartParams = nil
+
+	setDefaults(cluster)
+
+	assert.Equal(t, map[string]string{}, cluster.Spec.HeadGroupSpec.RayStartParams)
+	for i := range cluster.Spec.WorkerGroupSpecs {
+		assert.Equal(t, map[string]string{}, cluster.Spec.WorkerGroupSpecs[i].RayStartParams)
+	}
+}

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -54,7 +54,6 @@ func rayJobTemplate(name string, namespace string) *rayv1.RayJob {
 			RayClusterSpec: &rayv1.RayClusterSpec{
 				RayVersion: support.GetRayVersion(),
 				HeadGroupSpec: rayv1.HeadGroupSpec{
-					RayStartParams: map[string]string{},
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
@@ -92,11 +91,10 @@ func rayJobTemplate(name string, namespace string) *rayv1.RayJob {
 				},
 				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
-						Replicas:       ptr.To[int32](3),
-						MinReplicas:    ptr.To[int32](0),
-						MaxReplicas:    ptr.To[int32](10000),
-						GroupName:      "small-group",
-						RayStartParams: map[string]string{},
+						Replicas:    ptr.To[int32](3),
+						MinReplicas: ptr.To[int32](0),
+						MaxReplicas: ptr.To[int32](10000),
+						GroupName:   "small-group",
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -84,7 +84,6 @@ func rayServiceTemplate(name string, namespace string, serveAppName string) *ray
 			RayClusterSpec: rayv1.RayClusterSpec{
 				RayVersion: support.GetRayVersion(),
 				HeadGroupSpec: rayv1.HeadGroupSpec{
-					RayStartParams: map[string]string{},
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
@@ -98,11 +97,10 @@ func rayServiceTemplate(name string, namespace string, serveAppName string) *ray
 				},
 				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
-						Replicas:       ptr.To[int32](3),
-						MinReplicas:    ptr.To[int32](0),
-						MaxReplicas:    ptr.To[int32](10000),
-						GroupName:      "small-group",
-						RayStartParams: map[string]string{},
+						Replicas:    ptr.To[int32](3),
+						MinReplicas: ptr.To[int32](0),
+						MaxReplicas: ptr.To[int32](10000),
+						GroupName:   "small-group",
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{

--- a/ray-operator/pkg/webhooks/v1/webhook_suite_test.go
+++ b/ray-operator/pkg/webhooks/v1/webhook_suite_test.go
@@ -133,7 +133,6 @@ var _ = Describe("RayCluster validating webhook", func() {
 				},
 				Spec: rayv1.RayClusterSpec{
 					HeadGroupSpec: rayv1.HeadGroupSpec{
-						RayStartParams: map[string]string{"DEADBEEF": "DEADBEEF"},
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{},
@@ -168,7 +167,6 @@ var _ = Describe("RayCluster validating webhook", func() {
 				},
 				Spec: rayv1.RayClusterSpec{
 					HeadGroupSpec: rayv1.HeadGroupSpec{
-						RayStartParams: map[string]string{"DEADBEEF": "DEADBEEF"},
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{},
@@ -177,8 +175,7 @@ var _ = Describe("RayCluster validating webhook", func() {
 					},
 					WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 						{
-							GroupName:      "group1",
-							RayStartParams: map[string]string{"DEADBEEF": "DEADBEEF"},
+							GroupName: "group1",
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{},
@@ -186,8 +183,7 @@ var _ = Describe("RayCluster validating webhook", func() {
 							},
 						},
 						{
-							GroupName:      "group1",
-							RayStartParams: map[string]string{"DEADBEEF": "DEADBEEF"},
+							GroupName: "group1",
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									Containers: []corev1.Container{},


### PR DESCRIPTION
in `RayCluster` CRD by marking it with `// +optional`.
Make it not serialized when empty with `omitempty`.

This change is backwards compatible on K8s clusters with existing
RayCluster CRD and RayCluster CRs.

* RayClusters with non-empty RayStartParams will serialize the same as
  before this change.
* RayClusters with empty RayStartParams will serialize the same as
  before this change: as an empty map, `{}` in YAML.
* New behavior: we can `kubectl create|apply` RayClusters that lack
  RayStartParams in both head and worker groups. Previously the K8s API
  would return validation errors requiring this field to be present.
  When we get these RayClusters back with `kubectl get raycluster -o
  yaml`, there's no `rayStartParams` field present.

See [Optional vs. Required][1] in K8s API Conventions doc.

> Optional fields have the following properties:

> * They have the `+optional` comment tag in Go.
> * They are a pointer type in the Go definition (e.g. AwesomeFlag *SomeFlag)
>   or have a built-in nil value (e.g. maps and slices).
> * The API server should allow POSTing and PUTing a resource with this field
>   unset.

The required changes to the RayCluster CRD YAML can be achieved with only
`omitempty`, but we also add `// +optional` as recommended by the doc above.

[1]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#optional-vs-required

Signed-off-by: David Xia <david@davidxia.com>