### PR TITLE
[kubectl-plugin] Add 'node-selector' Flag

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -23,6 +23,7 @@ type CreateClusterOptions struct {
 	ioStreams              *genericclioptions.IOStreams
 	workerRayStartParams   map[string]string
 	headRayStartParams     map[string]string
+	nodeSelectors          map[string]string
 	kubeContexter          util.KubeContexter
 	clusterName            string
 	rayVersion             string
@@ -106,6 +107,7 @@ func NewCreateClusterCommand(streams genericclioptions.IOStreams) *cobra.Command
 	cmd.Flags().BoolVar(&options.dryRun, "dry-run", false, "print the generated YAML instead of creating the cluster")
 	cmd.Flags().BoolVar(&options.wait, "wait", false, "wait for the cluster to be provisioned before returning. Returns an error if the cluster is not provisioned by the timeout specified")
 	cmd.Flags().DurationVar(&options.timeout, "timeout", defaultProvisionedTimeout, "the timeout for --wait")
+	cmd.Flags().StringToStringVar(&options.nodeSelectors, "node-selector", nil, "Node selectors to apply to all pods in the cluster (e.g. --node-selector=cloud.google.com/gke-accelerator=nvidia-l4,cloud.google.com/gke-nodepool=my-node-pool)")
 
 	options.configFlags.AddFlags(cmd.Flags())
 	return cmd
@@ -182,6 +184,7 @@ func (options *CreateClusterOptions) Run(ctx context.Context, k8sClient client.C
 			WorkerEphemeralStorage: options.workerEphemeralStorage,
 			WorkerGPU:              options.workerGPU,
 			WorkerRayStartParams:   options.workerRayStartParams,
+			NodeSelectors:          options.nodeSelectors,
 		},
 	}
 

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -19,6 +19,7 @@ import (
 type RayClusterSpecObject struct {
 	HeadRayStartParams     map[string]string
 	WorkerRayStartParams   map[string]string
+	NodeSelectors          map[string]string
 	RayVersion             string
 	Image                  string
 	HeadCPU                string
@@ -107,6 +108,7 @@ func (rayClusterSpecObject *RayClusterSpecObject) generateRayClusterSpec() *rayv
 			WithRayStartParams(headRayStartParams).
 			WithTemplate(corev1ac.PodTemplateSpec().
 				WithSpec(corev1ac.PodSpec().
+					WithNodeSelector(rayClusterSpecObject.NodeSelectors).
 					WithContainers(corev1ac.Container().
 						WithName("ray-head").
 						WithImage(rayClusterSpecObject.Image).
@@ -122,6 +124,7 @@ func (rayClusterSpecObject *RayClusterSpecObject) generateRayClusterSpec() *rayv
 			WithReplicas(rayClusterSpecObject.WorkerReplicas).
 			WithTemplate(corev1ac.PodTemplateSpec().
 				WithSpec(corev1ac.PodSpec().
+					WithNodeSelector(rayClusterSpecObject.NodeSelectors).
 					WithContainers(corev1ac.Container().
 						WithName("ray-worker").
 						WithImage(rayClusterSpecObject.Image).


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Changes Made
- Added a new flag `--node-selector` to the `kubectl ray create cluster` command
- Ensured node selectors are properly passed to both head and worker pod specifications

## Why are these changes needed?

This PR adds support for node selectors when creating Ray clusters with the kubectl plugin. Node selectors are very common to set for RayCluster, especially since most providers use node selectors as a way to specify the GPU type or other node characteristics.

The implementation adds a new `--node-selector` flag that accepts comma-separated key-value pairs and applies them to both head and worker pods in the cluster.

## Related issue number

Closes #3143

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

## Testing
I've tested the implementation by first compiling the kubectl-ray plugin in the ./kubectl-plugin/cmd directory, which generated an executable file called "cmd". I then used this executable with the following command:

```bash
./cmd create cluster test-cluster --node-selector=cloud.google.com/gke-accelerator=nvidia-l4,cloud.google.com/gke-nodepool=my-node-pool --dry-run

The output is the following. The dry-run output shows that the node selectors are correctly applied to both the head and worker pod specifications:

apiVersion: ray.io/v1
kind: RayCluster
metadata:
  name: test-cluster
  namespace: default
spec:
  headGroupSpec:
    rayStartParams:
      dashboard-host: 0.0.0.0
    template:
      spec:
        containers:
        - image: rayproject/ray:2.41.0
          name: ray-head
          ports:
          - containerPort: 6379
            name: gcs-server
          - containerPort: 8265
            name: dashboard
          - containerPort: 10001
            name: client
          resources:
            limits:
              cpu: "2"
              memory: 4Gi
            requests:
              cpu: "2"
              memory: 4Gi
        **nodeSelector:
          cloud.google.com/gke-accelerator: nvidia-l4
          cloud.google.com/gke-nodepool: my-node-pool**
  rayVersion: 2.41.0
  workerGroupSpecs:
  - groupName: default-group
    rayStartParams:
      metrics-export-port: "8080"
    replicas: 1
    template:
      spec:
        containers:
        - image: rayproject/ray:2.41.0
          name: ray-worker
          resources:
            limits:
              cpu: "2"
              memory: 4Gi
            requests:
              cpu: "2"
              memory: 4Gi
        **nodeSelector:
          cloud.google.com/gke-accelerator: nvidia-l4
          cloud.google.com/gke-nodepool: my-node-pool**



