### PR TITLE
[RayJob][Fix] Use --no-wait for job submission to avoid carrying the error return code to the log tailing

### DIFF
--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -73,17 +73,14 @@ func GetK8sJobCommand(rayJobInstance *rayv1.RayJob) ([]string, error) {
 	// In order to deal with that, we use `ray job status` first to check if the jobId has been submitted.
 	// If the jobId has been submitted, we use `ray job logs` to follow the logs.
 	// Otherwise, we submit the job normally with `ray job submit`. The full shell command looks like this:
-	//   if ray job status --address http://$RAY_ADDRESS $RAY_JOB_SUBMISSION_ID >/dev/null 2>&1 ;
-	//   then ray job logs --address http://RAY_ADDRESS --follow $RAY_JOB_SUBMISSION_ID ;
-	//   else ray job submit --address http://RAY_ADDRESS --submission-id $RAY_JOB_SUBMISSION_ID -- ... ;
-	//   fi
+	//   if ! ray job status --address http://$RAY_ADDRESS $RAY_JOB_SUBMISSION_ID >/dev/null 2>&1 ;
+	//   then ray job submit --address http://$RAY_ADDRESS --submission-id $RAY_JOB_SUBMISSION_ID --no-wait -- ... ;
+	//   fi ; ray job logs --address http://$RAY_ADDRESS --follow $RAY_JOB_SUBMISSION_ID
 	jobStatusCommand := []string{"ray", "job", "status", "--address", address, jobId, ">/dev/null", "2>&1"}
 	jobFollowCommand := []string{"ray", "job", "logs", "--address", address, "--follow", jobId}
-	jobSubmitCommand := []string{"ray", "job", "submit", "--address", address}
-	k8sJobCommand := append([]string{"if"}, jobStatusCommand...)
+	jobSubmitCommand := []string{"ray", "job", "submit", "--address", address, "--no-wait"}
+	k8sJobCommand := append([]string{"if", "!"}, jobStatusCommand...)
 	k8sJobCommand = append(k8sJobCommand, ";", "then")
-	k8sJobCommand = append(k8sJobCommand, jobFollowCommand...)
-	k8sJobCommand = append(k8sJobCommand, ";", "else")
 	k8sJobCommand = append(k8sJobCommand, jobSubmitCommand...)
 
 	runtimeEnvJson, err := getRuntimeEnvJson(rayJobInstance)
@@ -119,7 +116,8 @@ func GetK8sJobCommand(rayJobInstance *rayv1.RayJob) ([]string, error) {
 	}
 
 	// "--" is used to separate the entrypoint from the Ray Job CLI command and its arguments.
-	k8sJobCommand = append(k8sJobCommand, "--", entrypoint, ";", "fi")
+	k8sJobCommand = append(k8sJobCommand, "--", entrypoint, ";", "fi", ";")
+	k8sJobCommand = append(k8sJobCommand, jobFollowCommand...)
 
 	return k8sJobCommand, nil
 }

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -72,7 +72,7 @@ func GetK8sJobCommand(rayJobInstance *rayv1.RayJob) ([]string, error) {
 	// `ray job submit` alone doesn't handle duplicated submission gracefully. See https://github.com/ray-project/kuberay/issues/2154.
 	// In order to deal with that, we use `ray job status` first to check if the jobId has been submitted.
 	// If the jobId has been submitted, we use `ray job logs` to follow the logs.
-	// Otherwise, we submit the job normally with `ray job submit`. The full shell command looks like this:
+	// Otherwise, we submit the job with `ray job submit --no-wait` + `ray job logs`. The full shell command looks like this:
 	//   if ! ray job status --address http://$RAY_ADDRESS $RAY_JOB_SUBMISSION_ID >/dev/null 2>&1 ;
 	//   then ray job submit --address http://$RAY_ADDRESS --submission-id $RAY_JOB_SUBMISSION_ID --no-wait -- ... ;
 	//   fi ; ray job logs --address http://$RAY_ADDRESS --follow $RAY_JOB_SUBMISSION_ID

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -74,11 +74,9 @@ func TestGetMetadataJson(t *testing.T) {
 func TestGetK8sJobCommand(t *testing.T) {
 	expected := []string{
 		"if",
-		"ray", "job", "status", "--address", "http://127.0.0.1:8265", "testJobId", ">/dev/null", "2>&1",
+		"!", "ray", "job", "status", "--address", "http://127.0.0.1:8265", "testJobId", ">/dev/null", "2>&1",
 		";", "then",
-		"ray", "job", "logs", "--address", "http://127.0.0.1:8265", "--follow", "testJobId",
-		";", "else",
-		"ray", "job", "submit", "--address", "http://127.0.0.1:8265",
+		"ray", "job", "submit", "--address", "http://127.0.0.1:8265", "--no-wait",
 		"--runtime-env-json", strconv.Quote(`{"test":"test"}`),
 		"--metadata-json", strconv.Quote(`{"testKey":"testValue"}`),
 		"--submission-id", "testJobId",
@@ -87,7 +85,8 @@ func TestGetK8sJobCommand(t *testing.T) {
 		"--entrypoint-resources", strconv.Quote(`{"Custom_1": 1, "Custom_2": 5.5}`),
 		"--",
 		"echo no quote 'single quote' \"double quote\"",
-		";", "fi",
+		";", "fi", ";",
+		"ray", "job", "logs", "--address", "http://127.0.0.1:8265", "--follow", "testJobId",
 	}
 	command, err := GetK8sJobCommand(testRayJob)
 	require.NoError(t, err)
@@ -116,17 +115,16 @@ pip: ["python-multipart==0.0.6"]
 	}
 	expected := []string{
 		"if",
-		"ray", "job", "status", "--address", "http://127.0.0.1:8265", "testJobId", ">/dev/null", "2>&1",
+		"!", "ray", "job", "status", "--address", "http://127.0.0.1:8265", "testJobId", ">/dev/null", "2>&1",
 		";", "then",
-		"ray", "job", "logs", "--address", "http://127.0.0.1:8265", "--follow", "testJobId",
-		";", "else",
-		"ray", "job", "submit", "--address", "http://127.0.0.1:8265",
+		"ray", "job", "submit", "--address", "http://127.0.0.1:8265", "--no-wait",
 		"--runtime-env-json", strconv.Quote(`{"working_dir":"https://github.com/ray-project/serve_config_examples/archive/b393e77bbd6aba0881e3d94c05f968f05a387b96.zip","pip":["python-multipart==0.0.6"]}`),
 		"--metadata-json", strconv.Quote(`{"testKey":"testValue"}`),
 		"--submission-id", "testJobId",
 		"--",
 		"echo no quote 'single quote' \"double quote\"",
-		";", "fi",
+		";", "fi", ";",
+		"ray", "job", "logs", "--address", "http://127.0.0.1:8265", "--follow", "testJobId",
 	}
 	command, err := GetK8sJobCommand(rayJobWithYAML)
 	require.NoError(t, err)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -511,6 +511,7 @@ func getSubmitterTemplate(ctx context.Context, rayJobInstance *rayv1.RayJob, ray
 			return corev1.PodTemplateSpec{}, err
 		}
 		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/bash"}
+		// Without the -e option, the Bash script will continue executing even if a command returns a non-zero exit code.
 		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args = []string{"-ce", strings.Join(k8sJobCommand, " ")}
 		logger.Info("No command is specified in the user-provided template. Default command is used", "command", k8sJobCommand)
 	} else {

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -511,7 +511,7 @@ func getSubmitterTemplate(ctx context.Context, rayJobInstance *rayv1.RayJob, ray
 			return corev1.PodTemplateSpec{}, err
 		}
 		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/bash"}
-		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args = []string{"-c", strings.Join(k8sJobCommand, " ")}
+		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args = []string{"-ce", strings.Join(k8sJobCommand, " ")}
 		logger.Info("No command is specified in the user-provided template. Default command is used", "command", k8sJobCommand)
 	} else {
 		logger.Info("User-provided command is used", "command", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -166,13 +166,13 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	submitterTemplate, err = getSubmitterTemplate(ctx, rayJobInstanceWithTemplate, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/bin/bash"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	assert.Equal(t, []string{"-c", "if ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job logs --address http://test-url --follow test-job-id ; else ray job submit --address http://test-url --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
+	assert.Equal(t, []string{"-ce", "if ! ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job submit --address http://test-url --no-wait --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 
 	// Test 3: User did not provide template, should use the image of the Ray Head
 	submitterTemplate, err = getSubmitterTemplate(ctx, rayJobInstanceWithoutTemplate, rayClusterInstance)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/bin/bash"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	assert.Equal(t, []string{"-c", "if ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job logs --address http://test-url --follow test-job-id ; else ray job submit --address http://test-url --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
+	assert.Equal(t, []string{"-ce", "if ! ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job submit --address http://test-url --no-wait --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 	assert.Equal(t, "rayproject/ray:custom-version", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Image)
 
 	// Test 4: Check default PYTHONUNBUFFERED setting

--- a/ray-operator/test/e2e/rayjob_retry_test.go
+++ b/ray-operator/test/e2e/rayjob_retry_test.go
@@ -32,7 +32,7 @@ func TestRayJobRetry(t *testing.T) {
 			WithSpec(rayv1ac.RayJobSpec().
 				WithBackoffLimit(2).
 				WithSubmitterConfig(rayv1ac.SubmitterConfig().
-					WithBackoffLimit(1)). // Set SubmitterConfig.BackoffLimit to 1
+					WithBackoffLimit(1)).
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).
 				WithEntrypoint("python /home/ray/jobs/fail.py").
 				WithShutdownAfterJobFinishes(false).
@@ -63,7 +63,7 @@ func TestRayJobRetry(t *testing.T) {
 		job, err := test.Client().Core().BatchV1().Jobs(namespace.Name).Get(test.Ctx(), rayJob.Name, metav1.GetOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(job.Spec.BackoffLimit).To(HaveValue(Equal(int32(1))))
-		g.Expect(job.Status.Failed).To(Equal(int32(0))) // RayJob failures are not counted as Job failures.
+		g.Expect(job.Status.Failed).To(Equal(int32(0))) // Ray job failures (at the application level) are not counted as K8s job submitter failures; K8s job submitter failures only count for issues like network errors.
 		g.Expect(job.Status.Succeeded).To(Equal(int32(1)))
 
 		// Refresh the RayJob status

--- a/ray-operator/test/e2e/rayjob_retry_test.go
+++ b/ray-operator/test/e2e/rayjob_retry_test.go
@@ -32,7 +32,7 @@ func TestRayJobRetry(t *testing.T) {
 			WithSpec(rayv1ac.RayJobSpec().
 				WithBackoffLimit(2).
 				WithSubmitterConfig(rayv1ac.SubmitterConfig().
-					WithBackoffLimit(0)).
+					WithBackoffLimit(1)). // Set SubmitterConfig.BackoffLimit to 1
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).
 				WithEntrypoint("python /home/ray/jobs/fail.py").
 				WithShutdownAfterJobFinishes(false).
@@ -59,6 +59,12 @@ func TestRayJobRetry(t *testing.T) {
 			Should(WithTransform(RayJobFailed, Equal(int32(3))))
 		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobSucceeded, Equal(int32(0))))
+
+		job, err := test.Client().Core().BatchV1().Jobs(namespace.Name).Get(test.Ctx(), rayJob.Name, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(job.Spec.BackoffLimit).To(HaveValue(Equal(int32(1))))
+		g.Expect(job.Status.Failed).To(Equal(int32(0))) // RayJob failures are not counted as Job failures.
+		g.Expect(job.Status.Succeeded).To(Equal(int32(1)))
 
 		// Refresh the RayJob status
 		rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As shown in https://github.com/ray-project/kuberay/issues/3211:


>In v1.3, I observe that the new behavior is:
>
>* Attempt 1: submit job -> tail logs -> error when job fails
>* Attempt 2: ray job status -> ray job logs -> completed
>
>In Attempt 2, the pod successfully completes with exit code 0 because "ray job logs" returns exit 0 even if the job fails. >Here's an example from my cluster:
>
>```
>$ kubectl get po
>NAME                                                        READY   STATUS      RESTARTS   AGE
>pytorch-text-classifier-6q6ff-x59k6                         0/1     Error       0          11m          # first attempt
>pytorch-text-classifier-6q6ff-xqhk7                         0/1     Completed   0          10m.  # second attempt
>```
>
>What I expected was the submitter Job to stop after attempt 1 since that is a terminal state and retrying does not achieve anything.

This PR makes the submitter job stop after attempt 1 by replacing `ray job submit` with `ray job submit --no-wait` + `ray job logs --follow` so that the submitter job will not exit with failures when the ray job fails.

The full script will look like this:

```sh
if ! ray job status --address http://$RAY_ADDRESS $RAY_JOB_SUBMISSION_ID >/dev/null 2>&1 ;
then ray job submit --address http://$RAY_ADDRESS --submission-id $RAY_JOB_SUBMISSION_ID --no-wait -- ... ;
fi ; ray job logs --address http://$RAY_ADDRESS --follow $RAY_JOB_SUBMISSION_ID
```

## Related issue number

https://github.com/ray-project/kuberay/issues/3211

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
