### PR TITLE
[fix][proto] install missing `unzip` in Dockerfile

### DIFF
--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -14,6 +14,7 @@ ENV GOBIN=/go/bin
 USER root
 RUN wget https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 -O /usr/bin/jq && chmod +x /usr/bin/jq
 RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+RUN apt-get update && apt-get install -y unzip
 RUN unzip -o protoc.zip -d /usr/ bin/protoc
 RUN unzip -o protoc.zip -d /usr/ 'include/*'
 RUN rm -f protoc.zip


### PR DESCRIPTION
Right now running `cd proto && make build-image` errors because the required `unzip` package isn't installed. We install it.

```console
$ make build-image

docker build -t kuberay/proto-generator:7a64c574b9c899871c3b0126d1f33e55e30f7dfb -f Dockerfile .
[+] Building 1.4s (7/16)                                                                                                                               docker:default
 => [internal] load build definition from Dockerfile                                                                                                             0.1s
 => => transferring dockerfile: 1.66kB                                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/golang:1.23.6-bullseye                                                                                        0.4s
 => [internal] load .dockerignore                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                  0.0s
 => [ 1/13] FROM docker.io/library/golang:1.23.6-bullseye@sha256:13ae4c4b1ee4c1d1983c8dcbbbb7db7aea3972b0853bb1d01b37176567448762                                0.0s
 => CACHED [ 2/13] RUN wget https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 -O /usr/bin/jq && chmod +x /usr/bin/jq                              0.0s
 => CACHED [ 3/13] RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protoc-3.17.3-linux-x86_64.zip                0.0s
 => ERROR [ 4/13] RUN unzip -o protoc.zip -d /usr/ bin/protoc                                                                                                    0.6s
------
 > [ 4/13] RUN unzip -o protoc.zip -d /usr/ bin/protoc:
0.501 /bin/sh: 1: unzip: not found
------
Dockerfile:17
--------------------
  15 |     RUN wget https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 -O /usr/bin/jq && chmod +x /usr/bin/jq
  16 |     RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
  17 | >>> RUN unzip -o protoc.zip -d /usr/ bin/protoc
  18 |     RUN unzip -o protoc.zip -d /usr/ 'include/*'
  19 |     RUN rm -f protoc.zip
--------------------
ERROR: failed to solve: process "/bin/sh -c unzip -o protoc.zip -d /usr/ bin/protoc" did not complete successfully: exit code: 127
make: *** [Makefile:19: build-image] Error 1
```

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
