### PR TITLE
[Prometheus] Add `ray_services_created_total` metric

### DIFF
--- a/ray-operator/controllers/ray/common/metrics.go
+++ b/ray-operator/controllers/ray/common/metrics.go
@@ -8,31 +8,10 @@ import (
 
 // Define all the prometheus counters for all clusters
 var (
-	clustersCreatedCount = promauto.NewCounterVec(
+	rayServicesCreatedCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "ray_operator_clusters_created_total",
-			Help: "Counts number of clusters created",
-		},
-		[]string{"namespace"},
-	)
-	clustersDeletedCount = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "ray_operator_clusters_deleted_total",
-			Help: "Counts number of clusters deleted",
-		},
-		[]string{"namespace"},
-	)
-	clustersSuccessfulCount = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "ray_operator_clusters_successful_total",
-			Help: "Counts number of clusters successful",
-		},
-		[]string{"namespace"},
-	)
-	clustersFailedCount = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "ray_operator_clusters_failed_total",
-			Help: "Counts number of clusters failed",
+			Name: "ray_services_created_total",
+			Help: "The total number of RayServices created",
 		},
 		[]string{"namespace"},
 	)
@@ -40,25 +19,9 @@ var (
 
 func init() {
 	// Register custom metrics with the global prometheus registry
-	metrics.Registry.MustRegister(clustersCreatedCount,
-		clustersDeletedCount,
-		clustersSuccessfulCount,
-		clustersFailedCount)
+	metrics.Registry.MustRegister(rayServicesCreatedCounter)
 }
 
-func CreatedClustersCounterInc(namespace string) {
-	clustersCreatedCount.WithLabelValues(namespace).Inc()
-}
-
-// TODO: We don't handle the delete events in new reconciler mode, how to emit deletion metrics?
-func DeletedClustersCounterInc(namespace string) {
-	clustersDeletedCount.WithLabelValues(namespace).Inc()
-}
-
-func SuccessfulClustersCounterInc(namespace string) {
-	clustersSuccessfulCount.WithLabelValues(namespace).Inc()
-}
-
-func FailedClustersCounterInc(namespace string) {
-	clustersFailedCount.WithLabelValues(namespace).Inc()
+func CreatedRayServicesCounterInc(namespace string) {
+	rayServicesCreatedCounter.WithLabelValues(namespace).Inc()
 }

--- a/ray-operator/controllers/ray/common/metrics_test.go
+++ b/ray-operator/controllers/ray/common/metrics_test.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestCreatedRayServicesCounterInc(t *testing.T) {
+	CreatedRayServicesCounterInc("default")
+	CreatedRayServicesCounterInc("default")
+	CreatedRayServicesCounterInc("test")
+	CreatedRayServicesCounterInc("test")
+
+	expected := `
+	# HELP ray_services_created_total The total number of RayServices created
+	# TYPE ray_services_created_total counter
+	ray_services_created_total{namespace="default"} 2
+	ray_services_created_total{namespace="test"} 2
+	`
+	if err := testutil.CollectAndCompare(rayServicesCreatedCounter, strings.NewReader(expected)); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -734,12 +734,9 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	} else if len(headPods.Items) == 0 {
 		// Create head Pod if it does not exist.
 		logger.Info("reconcilePods: Found 0 head Pods; creating a head Pod for the RayCluster.")
-		common.CreatedClustersCounterInc(instance.Namespace)
 		if err := r.createHeadPod(ctx, *instance); err != nil {
-			common.FailedClustersCounterInc(instance.Namespace)
 			return errstd.Join(utils.ErrFailedCreateHeadPod, err)
 		}
-		common.SuccessfulClustersCounterInc(instance.Namespace)
 	} else if len(headPods.Items) > 1 { // This should never happen. This protects against the case that users manually create headpod.
 		correctHeadPodName := instance.Name + "-head"
 		headPodNames := make([]string, len(headPods.Items))

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -317,6 +317,8 @@ func calculateConditions(rayServiceInstance *rayv1.RayService) {
 		message := "RayService is initializing"
 		setCondition(rayServiceInstance, rayv1.RayServiceReady, metav1.ConditionFalse, rayv1.RayServiceInitializing, message)
 		setCondition(rayServiceInstance, rayv1.UpgradeInProgress, metav1.ConditionFalse, rayv1.RayServiceInitializing, message)
+		// Increase the counter for the ray_services_created_total metric.
+		common.CreatedRayServicesCounterInc(rayServiceInstance.Namespace)
 	}
 	if rayServiceInstance.Status.NumServeEndpoints > 0 {
 		setCondition(rayServiceInstance, rayv1.RayServiceReady, metav1.ConditionTrue, rayv1.NonZeroServeEndpoints, "Number of serve endpoints is greater than 0")

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add `ray_services_created_total` metric to track the total number of RayServices created

## Manual test
```
$ k apply -f config/samples/ray-service.sample.yaml
$ k apply -f config/samples/ray-service.sample.yaml -n test
$ k apply -f config/samples/ray-service.mobilenet.yaml
```

![image](https://github.com/user-attachments/assets/46b43e51-ceb8-4888-b43a-a89bcc3f0809)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #3176

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
