### PR TITLE
[feat][plugin] support creating RayCluster with config file

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -45,9 +45,9 @@ type CreateClusterOptions struct {
 	workerEphemeralStorage string
 	workerGPU              string
 	workerTPU              string
+	configFile             string
 	timeout                time.Duration
 	numOfHosts             int32
-	configFile             string
 	workerReplicas         int32
 	dryRun                 bool
 	wait                   bool
@@ -206,13 +206,11 @@ func (options *CreateClusterOptions) Validate(cmd *cobra.Command) error {
 			}
 		}
 	}
-	// we must assign gke-tpu-accelerator and gke-tpu-topology in nodeSelector
-	// if worker-tpu is not 0
-	if options.workerTPU != "" && options.workerTPU != "0" {
-		if err := util.ValidateTPUNodeSelector(options.numOfHosts, options.workerNodeSelectors); err != nil {
-			return fmt.Errorf("%w", err)
-		}
+
+	if err := util.ValidateTPU(&options.workerTPU, &options.numOfHosts, options.workerNodeSelectors); err != nil {
+		return fmt.Errorf("%w", err)
 	}
+
 	return nil
 }
 

--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -5,17 +5,20 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/utils/ptr"
+
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/generation"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/utils/ptr"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
+	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
 	rayclient "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned"
 )
 
@@ -28,6 +31,7 @@ type CreateClusterOptions struct {
 	headRayStartParams     map[string]string
 	headNodeSelectors      map[string]string
 	workerNodeSelectors    map[string]string
+	rayClusterConfig       *generation.RayClusterConfig
 	namespace              string
 	clusterName            string
 	rayVersion             string
@@ -43,6 +47,7 @@ type CreateClusterOptions struct {
 	workerTPU              string
 	timeout                time.Duration
 	numOfHosts             int32
+	configFile             string
 	workerReplicas         int32
 	dryRun                 bool
 	wait                   bool
@@ -70,6 +75,9 @@ var (
 
 		# For more details on TPU-related node selectors like %s and %s, refer to:
 		# https://cloud.google.com/kubernetes-engine/docs/concepts/plan-tpus#availability
+
+		# Create a Ray cluster from a YAML configuration file
+		kubectl ray create cluster sample-cluster --file ray-cluster-config.yaml
 	`, util.RayVersion, util.RayImage, util.NodeSelectorGKETPUAccelerator, util.NodeSelectorGKETPUTopology, util.NodeSelectorGKETPUAccelerator, util.NodeSelectorGKETPUTopology))
 )
 
@@ -93,7 +101,7 @@ func NewCreateClusterCommand(cmdFactory cmdutil.Factory, streams genericclioptio
 			if err := options.Complete(cmd, args); err != nil {
 				return err
 			}
-			if err := options.Validate(); err != nil {
+			if err := options.Validate(cmd); err != nil {
 				return err
 			}
 
@@ -106,34 +114,35 @@ func NewCreateClusterCommand(cmdFactory cmdutil.Factory, streams genericclioptio
 		},
 	}
 
+	cmd.Flags().StringToStringVar(&options.labels, "labels", nil, "K8s labels (e.g. --labels app=ray,env=dev)")
+	cmd.Flags().StringToStringVar(&options.annotations, "annotations", nil, "K8s annotations (e.g. --annotations ttl-hours=24,owner=chthulu)")
 	cmd.Flags().StringVar(&options.rayVersion, "ray-version", util.RayVersion, "Ray version to use")
 	cmd.Flags().StringVar(&options.image, "image", fmt.Sprintf("rayproject/ray:%s", options.rayVersion), "container image to use")
-	cmd.Flags().StringVar(&options.headCPU, "head-cpu", "2", "number of CPUs in the Ray head")
-	cmd.Flags().StringVar(&options.headMemory, "head-memory", "4Gi", "amount of memory in the Ray head")
-	cmd.Flags().StringVar(&options.headGPU, "head-gpu", "0", "number of GPUs in the Ray head")
-	cmd.Flags().StringVar(&options.headEphemeralStorage, "head-ephemeral-storage", "", "amount of ephemeral storage in the Ray head")
+	cmd.Flags().StringVar(&options.headCPU, "head-cpu", util.DefaultHeadCPU, "number of CPUs in the Ray head")
+	cmd.Flags().StringVar(&options.headMemory, "head-memory", util.DefaultHeadMemory, "amount of memory in the Ray head")
+	cmd.Flags().StringVar(&options.headGPU, "head-gpu", util.DefaultHeadGPU, "number of GPUs in the Ray head")
+	cmd.Flags().StringVar(&options.headEphemeralStorage, "head-ephemeral-storage", util.DefaultHeadEphemeralStorage, "amount of ephemeral storage in the Ray head")
 	cmd.Flags().StringToStringVar(&options.headRayStartParams, "head-ray-start-params", options.headRayStartParams, "a map of arguments to the Ray head's 'ray start' entrypoint, e.g. '--head-ray-start-params dashboard-host=0.0.0.0,num-cpus=2'")
-	cmd.Flags().Int32Var(&options.workerReplicas, "worker-replicas", 1, "desired worker group replicas")
-	cmd.Flags().Int32Var(&options.numOfHosts, "num-of-hosts", 1, "number of hosts in default worker group per replica")
-	cmd.Flags().StringVar(&options.workerCPU, "worker-cpu", "2", "number of CPUs in each worker group replica")
-	cmd.Flags().StringVar(&options.workerMemory, "worker-memory", "4Gi", "amount of memory in each worker group replica")
-	cmd.Flags().StringVar(&options.workerGPU, "worker-gpu", "0", "number of GPUs in each worker group replica")
-	cmd.Flags().StringVar(&options.workerTPU, "worker-tpu", "0",
+	cmd.Flags().StringToStringVar(&options.headNodeSelectors, "head-node-selectors", nil, "Node selectors to apply to all head pods in the cluster (e.g. --head-node-selector=cloud.google.com/gke-accelerator=nvidia-l4,cloud.google.com/gke-nodepool=my-node-pool)")
+	cmd.Flags().Int32Var(&options.workerReplicas, "worker-replicas", util.DefaultWorkerReplicas, "desired worker group replicas")
+	cmd.Flags().StringVar(&options.workerCPU, "worker-cpu", util.DefaultWorkerCPU, "number of CPUs in each worker group replica")
+	cmd.Flags().StringVar(&options.workerMemory, "worker-memory", util.DefaultWorkerMemory, "amount of memory in each worker group replica")
+	cmd.Flags().StringVar(&options.workerGPU, "worker-gpu", util.DefaultWorkerGPU, "number of GPUs in each worker group replica")
+	cmd.Flags().StringVar(&options.workerEphemeralStorage, "worker-ephemeral-storage", util.DefaultWorkerEphemeralStorage, "amount of ephemeral storage in each worker group replica")
+	cmd.Flags().StringVar(&options.workerTPU, "worker-tpu", util.DefaultWorkerTPU,
 		fmt.Sprintf(
 			"number of TPUs in each worker group replica. If greater than 0, you must also set %s and %s in --worker-node-selectors.",
 			util.NodeSelectorGKETPUAccelerator,
 			util.NodeSelectorGKETPUTopology,
 		),
 	)
-	cmd.Flags().StringVar(&options.workerEphemeralStorage, "worker-ephemeral-storage", "", "amount of ephemeral storage in each worker group replica")
 	cmd.Flags().StringToStringVar(&options.workerRayStartParams, "worker-ray-start-params", options.workerRayStartParams, "a map of arguments to the Ray workers' 'ray start' entrypoint, e.g. '--worker-ray-start-params metrics-export-port=8080,num-cpus=2'")
+	cmd.Flags().StringToStringVar(&options.workerNodeSelectors, "worker-node-selectors", nil, "Node selectors to apply to all worker pods in the cluster (e.g. --worker-node-selector=cloud.google.com/gke-accelerator=nvidia-l4,cloud.google.com/gke-nodepool=my-node-pool)")
+	cmd.Flags().Int32Var(&options.numOfHosts, "num-of-hosts", util.DefaultNumOfHosts, "number of hosts in default worker group per replica")
+	cmd.Flags().StringVar(&options.configFile, "file", "", "path to a YAML file containing Ray cluster configuration")
 	cmd.Flags().BoolVar(&options.dryRun, "dry-run", false, "print the generated YAML instead of creating the cluster")
 	cmd.Flags().BoolVar(&options.wait, "wait", false, "wait for the cluster to be provisioned before returning. Returns an error if the cluster is not provisioned by the timeout specified")
 	cmd.Flags().DurationVar(&options.timeout, "timeout", defaultProvisionedTimeout, "the timeout for --wait")
-	cmd.Flags().StringToStringVar(&options.headNodeSelectors, "head-node-selectors", nil, "Node selectors to apply to all head pods in the cluster (e.g. --head-node-selectors cloud.google.com/gke-accelerator=nvidia-l4,cloud.google.com/gke-nodepool=my-node-pool)")
-	cmd.Flags().StringToStringVar(&options.workerNodeSelectors, "worker-node-selectors", nil, "Node selectors to apply to all worker pods in the cluster (e.g. --worker-node-selectors cloud.google.com/gke-accelerator=nvidia-l4,cloud.google.com/gke-nodepool=my-node-pool)")
-	cmd.Flags().StringToStringVar(&options.labels, "labels", nil, "K8s labels (e.g. --labels app=ray,env=dev)")
-	cmd.Flags().StringToStringVar(&options.annotations, "annotations", nil, "K8s annotations (e.g. --annotations ttl-hours=24,owner=chthulu)")
 
 	return cmd
 }
@@ -144,10 +153,6 @@ func (options *CreateClusterOptions) Complete(cmd *cobra.Command, args []string)
 		return fmt.Errorf("failed to get namespace: %w", err)
 	}
 	options.namespace = namespace
-
-	if options.namespace == "" {
-		options.namespace = "default"
-	}
 
 	if len(args) != 1 {
 		return cmdutil.UsageErrorf(cmd, "%s", cmd.Use)
@@ -161,30 +166,49 @@ func (options *CreateClusterOptions) Complete(cmd *cobra.Command, args []string)
 	return nil
 }
 
-func (options *CreateClusterOptions) Validate() error {
-	resourceFields := map[string]string{
-		"head-cpu":                 options.headCPU,
-		"head-gpu":                 options.headGPU,
-		"head-memory":              options.headMemory,
-		"head-ephemeral-storage":   options.headEphemeralStorage,
-		"worker-cpu":               options.workerCPU,
-		"worker-gpu":               options.workerGPU,
-		"worker-tpu":               options.workerTPU,
-		"worker-memory":            options.workerMemory,
-		"worker-ephemeral-storage": options.workerEphemeralStorage,
-	}
-
-	for name, value := range resourceFields {
-		if (name == "head-ephemeral-storage" || name == "worker-ephemeral-storage") && value == "" {
-			continue
+func (options *CreateClusterOptions) Validate(cmd *cobra.Command) error {
+	if options.configFile != "" {
+		if err := flagsIncompatibleWithConfigFilePresent(cmd); err != nil {
+			return err
 		}
-		if err := util.ValidateResourceQuantity(value, name); err != nil {
-			return fmt.Errorf("%w", err)
+
+		// If a cluster config file is provided, check it can be parsed into a RayClusterConfig object
+		rayClusterConfig, err := generation.ParseConfigFile(options.configFile)
+		if err != nil {
+			return fmt.Errorf("failed to parse config file: %w", err)
+		}
+
+		if err := generation.ValidateConfig(rayClusterConfig); err != nil {
+			return fmt.Errorf("failed to validate config file: %w", err)
+		}
+
+		// store the returned RayClusterConfig object for use in Run()
+		options.rayClusterConfig = rayClusterConfig
+	} else {
+		resourceFields := map[string]string{
+			"head-cpu":                 options.headCPU,
+			"head-gpu":                 options.headGPU,
+			"head-memory":              options.headMemory,
+			"head-ephemeral-storage":   options.headEphemeralStorage,
+			"worker-cpu":               options.workerCPU,
+			"worker-gpu":               options.workerGPU,
+			"worker-tpu":               options.workerTPU,
+			"worker-memory":            options.workerMemory,
+			"worker-ephemeral-storage": options.workerEphemeralStorage,
+		}
+
+		for name, value := range resourceFields {
+			if (name == "head-ephemeral-storage" || name == "worker-ephemeral-storage") && value == "" {
+				continue
+			}
+			if err := util.ValidateResourceQuantity(value, name); err != nil {
+				return fmt.Errorf("%w", err)
+			}
 		}
 	}
 	// we must assign gke-tpu-accelerator and gke-tpu-topology in nodeSelector
 	// if worker-tpu is not 0
-	if options.workerTPU != "0" {
+	if options.workerTPU != "" && options.workerTPU != "0" {
 		if err := util.ValidateTPUNodeSelector(options.numOfHosts, options.workerNodeSelectors); err != nil {
 			return fmt.Errorf("%w", err)
 		}
@@ -192,41 +216,97 @@ func (options *CreateClusterOptions) Validate() error {
 	return nil
 }
 
+// resolveClusterName resolves the cluster name from the CLI flag and the config file
+func (options *CreateClusterOptions) resolveClusterName() (string, error) {
+	var name string
+
+	if options.rayClusterConfig.Name != nil && *options.rayClusterConfig.Name != "" && options.clusterName != "" && options.clusterName != *options.rayClusterConfig.Name {
+		return "", fmt.Errorf("the cluster name in the config file %q does not match the cluster name %q. You must use the same name to perform this operation", *options.rayClusterConfig.Name, options.clusterName)
+	}
+
+	if options.clusterName != "" {
+		name = options.clusterName
+	} else if options.rayClusterConfig.Name != nil && *options.rayClusterConfig.Name != "" {
+		name = *options.rayClusterConfig.Name
+	} else {
+		return "", fmt.Errorf("the cluster name is required")
+	}
+
+	return name, nil
+}
+
+// resolveNamespace resolves the namespace from the CLI flag and the config file
+func (options *CreateClusterOptions) resolveNamespace() (string, error) {
+	namespace := "default"
+
+	if options.rayClusterConfig.Namespace != nil && *options.rayClusterConfig.Namespace != "" && options.namespace != "" && options.namespace != *options.rayClusterConfig.Namespace {
+		return "", fmt.Errorf("the namespace in the config file %q does not match the namespace %q. You must pass --namespace=%s to perform this operation", *options.rayClusterConfig.Namespace, options.namespace, *options.rayClusterConfig.Namespace)
+	}
+
+	if options.namespace != "" {
+		namespace = options.namespace
+	} else if options.rayClusterConfig.Namespace != nil && *options.rayClusterConfig.Namespace != "" {
+		namespace = *options.rayClusterConfig.Namespace
+	}
+
+	return namespace, nil
+}
+
 func (options *CreateClusterOptions) Run(ctx context.Context, k8sClient client.Client) error {
-	if clusterExists(k8sClient.RayClient(), options.namespace, options.clusterName) {
-		return fmt.Errorf("the Ray cluster %s in namespace %s already exists", options.clusterName, options.namespace)
-	}
+	var rayClusterac *rayv1ac.RayClusterApplyConfiguration
+	var err error
 
-	rayClusterSpecObject := generation.RayClusterSpecObject{
-		Namespace:            &options.namespace,
-		Name:                 &options.clusterName,
-		Labels:               options.labels,
-		Annotations:          options.annotations,
-		RayVersion:           &options.rayVersion,
-		Image:                &options.image,
-		HeadCPU:              &options.headCPU,
-		HeadMemory:           &options.headMemory,
-		HeadEphemeralStorage: &options.headEphemeralStorage,
-		HeadGPU:              &options.headGPU,
-		HeadRayStartParams:   options.headRayStartParams,
-		HeadNodeSelectors:    options.headNodeSelectors,
-		WorkerGroups: []generation.WorkerGroupConfig{
-			{
-				Name:                   ptr.To("default-group"),
-				WorkerReplicas:         &options.workerReplicas,
-				NumOfHosts:             &options.numOfHosts,
-				WorkerCPU:              &options.workerCPU,
-				WorkerMemory:           &options.workerMemory,
-				WorkerEphemeralStorage: &options.workerEphemeralStorage,
-				WorkerGPU:              &options.workerGPU,
-				WorkerTPU:              &options.workerTPU,
-				WorkerRayStartParams:   options.workerRayStartParams,
-				WorkerNodeSelectors:    options.workerNodeSelectors,
+	// If options.rayClusterConfig is set, use it exclusively because it means the user provided a config file
+	if options.rayClusterConfig != nil {
+		name, err := options.resolveClusterName()
+		if err != nil {
+			return err
+		}
+		options.rayClusterConfig.Name = &name
+
+		namespace, err := options.resolveNamespace()
+		if err != nil {
+			return err
+		}
+		options.rayClusterConfig.Namespace = &namespace
+	} else {
+		if options.namespace == "" {
+			options.namespace = "default"
+		}
+
+		options.rayClusterConfig = &generation.RayClusterConfig{
+			Namespace:   &options.namespace,
+			Name:        &options.clusterName,
+			Labels:      options.labels,
+			Annotations: options.annotations,
+			RayVersion:  &options.rayVersion,
+			Image:       &options.image,
+			Head: &generation.Head{
+				CPU:              &options.headCPU,
+				Memory:           &options.headMemory,
+				EphemeralStorage: &options.headEphemeralStorage,
+				GPU:              &options.headGPU,
+				RayStartParams:   options.headRayStartParams,
+				NodeSelectors:    options.headNodeSelectors,
 			},
-		},
+			WorkerGroups: []generation.WorkerGroup{
+				{
+					Name:             ptr.To("default-group"),
+					Replicas:         options.workerReplicas,
+					NumOfHosts:       &options.numOfHosts,
+					CPU:              &options.workerCPU,
+					Memory:           &options.workerMemory,
+					EphemeralStorage: &options.workerEphemeralStorage,
+					GPU:              &options.workerGPU,
+					TPU:              &options.workerTPU,
+					RayStartParams:   options.workerRayStartParams,
+					NodeSelectors:    options.workerNodeSelectors,
+				},
+			},
+		}
 	}
 
-	rayClusterac := rayClusterSpecObject.GenerateRayClusterApplyConfig()
+	rayClusterac = options.rayClusterConfig.GenerateRayClusterApplyConfig()
 
 	// If dry run is enabled, it will call the YAML converter and print out the YAML
 	if options.dryRun {
@@ -238,16 +318,18 @@ func (options *CreateClusterOptions) Run(ctx context.Context, k8sClient client.C
 		return nil
 	}
 
-	// TODO: Decide whether to save YAML to file or not.
+	if clusterExists(k8sClient.RayClient(), *options.rayClusterConfig.Namespace, *options.rayClusterConfig.Name) {
+		return fmt.Errorf("the Ray cluster %s in namespace %s already exists", *options.rayClusterConfig.Name, *options.rayClusterConfig.Namespace)
+	}
 
-	result, err := k8sClient.RayClient().RayV1().RayClusters(options.namespace).Apply(ctx, rayClusterac, metav1.ApplyOptions{FieldManager: util.FieldManager})
+	result, err := k8sClient.RayClient().RayV1().RayClusters(*options.rayClusterConfig.Namespace).Apply(ctx, rayClusterac, metav1.ApplyOptions{FieldManager: util.FieldManager})
 	if err != nil {
 		return fmt.Errorf("failed to create Ray cluster: %w", err)
 	}
 	fmt.Printf("Created Ray cluster: %s\n", result.GetName())
 
 	if options.wait {
-		err = k8sClient.WaitRayClusterProvisioned(ctx, options.namespace, result.GetName(), options.timeout)
+		err = k8sClient.WaitRayClusterProvisioned(ctx, *options.rayClusterConfig.Namespace, result.GetName(), options.timeout)
 		if err != nil {
 			return err
 		}
@@ -263,4 +345,33 @@ func clusterExists(client rayclient.Interface, namespace, name string) bool {
 		return true
 	}
 	return false
+}
+
+// flagsIncompatibleWithConfigFilePresent returns an error if there are command-line flags that are incompatible with a config file
+func flagsIncompatibleWithConfigFilePresent(cmd *cobra.Command) error {
+	incompatibleFlagsUsed := []string{}
+
+	// Define which flags are allowed to be used with --file.
+	// These are typically flags that modify the command's behavior but not the cluster configuration.
+	allowedWithFile := map[string]bool{
+		"file":      true,
+		"context":   true,
+		"namespace": true,
+		"dry-run":   true,
+		"wait":      true,
+		"timeout":   true,
+	}
+
+	// Check all flags to see if any incompatible flags are set
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		if !allowedWithFile[f.Name] {
+			incompatibleFlagsUsed = append(incompatibleFlagsUsed, f.Name)
+		}
+	})
+
+	if len(incompatibleFlagsUsed) > 0 {
+		return fmt.Errorf("the following flags are incompatible with --file: %v", incompatibleFlagsUsed)
+	}
+
+	return nil
 }

--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -3,17 +3,20 @@ package create
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/generation"
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/utils/ptr"
 
 	kubefake "k8s.io/client-go/kubernetes/fake"
 
@@ -23,28 +26,67 @@ import (
 
 func TestRayCreateClusterComplete(t *testing.T) {
 	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
-	fakeCreateClusterOptions := NewCreateClusterOptions(cmdFactory, testStreams)
-	fakeArgs := []string{"testRayClusterName"}
-	cmd := &cobra.Command{Use: "cluster"}
-	cmd.Flags().StringVarP(&fakeCreateClusterOptions.namespace, "namespace", "n", "", "")
 
-	err := fakeCreateClusterOptions.Complete(cmd, fakeArgs)
-	require.NoError(t, err)
-	assert.Equal(t, "default", fakeCreateClusterOptions.namespace)
-	assert.Equal(t, "testRayClusterName", fakeCreateClusterOptions.clusterName)
+	tests := map[string]struct {
+		image         string
+		rayVersion    string
+		expectedError string
+		expectedImage string
+		args          []string
+	}{
+		"should error when there are no args": {
+			args:          []string{},
+			expectedError: "See 'cluster -h' for help and examples",
+		},
+		"should error when too many args": {
+			args:          []string{"testRayClusterName", "extra-arg"},
+			expectedError: "See 'cluster -h' for help and examples",
+		},
+		"should succeed with default image when no image is specified": {
+			args:          []string{"testRayClusterName"},
+			rayVersion:    util.RayVersion,
+			expectedImage: fmt.Sprintf("rayproject/ray:%s", util.RayVersion),
+		},
+		"should succeed with provided image when provided": {
+			args:          []string{"testRayClusterName"},
+			image:         "DEADBEEF",
+			expectedImage: "DEADBEEF",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+			fakeCreateClusterOptions := NewCreateClusterOptions(cmdFactory, testStreams)
+			cmd := &cobra.Command{Use: "cluster"}
+			cmd.Flags().StringVarP(&fakeCreateClusterOptions.namespace, "namespace", "n", "", "")
+			fakeCreateClusterOptions.rayVersion = tc.rayVersion
+
+			if tc.image != "" {
+				fakeCreateClusterOptions.image = tc.image
+			}
+
+			err := fakeCreateClusterOptions.Complete(cmd, tc.args)
+
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedImage, fakeCreateClusterOptions.image)
+			}
+		})
+	}
 }
 
 func TestRayCreateClusterValidate(t *testing.T) {
 	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
 
-	tests := []struct {
-		name        string
-		opts        *CreateClusterOptions
-		expectError string
+	tests := map[string]struct {
+		opts               *CreateClusterOptions
+		configFileContents string
+		expectError        string
 	}{
-		{
-			name: "should error when a resource quantity is invalid",
+		"should error when a resource quantity is invalid": {
 			opts: &CreateClusterOptions{
 				cmdFactory: cmdFactory,
 				headCPU:    "1",
@@ -52,11 +94,96 @@ func TestRayCreateClusterValidate(t *testing.T) {
 			},
 			expectError: "head-memory is not a valid resource quantity: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'",
 		},
+		"should error when an invalid cluster config file is used": {
+			opts: &CreateClusterOptions{
+				cmdFactory: cmdFactory,
+			},
+			configFileContents: `foo: bar`,
+			expectError:        "field foo not found",
+		},
+		"should not error when a valid config file is used": {
+			opts: &CreateClusterOptions{
+				cmdFactory: cmdFactory,
+			},
+			configFileContents: `image: foo`,
+		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.opts.Validate()
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.configFileContents != "" {
+				tmpFile, err := os.CreateTemp("", "config.yaml")
+				require.NoError(t, err)
+				_, err = tmpFile.WriteString(tc.configFileContents)
+				require.NoError(t, err)
+				tc.opts.configFile = tmpFile.Name()
+				defer os.Remove(tc.opts.configFile)
+			}
+
+			err := tc.opts.Validate(&cobra.Command{})
+
+			if tc.expectError != "" {
+				require.Contains(t, err.Error(), tc.expectError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSwitchesIncompatibleWithConfigFilePresent(t *testing.T) {
+	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+	cmd := NewCreateClusterCommand(cmdFactory, testStreams)
+
+	tests := map[string]struct {
+		expectError string
+		args        []string
+	}{
+		"should not error when no incompatible flags are used": {
+			args: []string{
+				"sample-cluster",
+				"--file", "config.yaml",
+				"--dry-run",
+				"--wait",
+				"--timeout", "10s",
+			},
+		},
+		"should error when incompatible flags are used": {
+			args: []string{
+				"sample-cluster",
+				"--ray-version", "2.44.0",
+				"--image", "rayproject/ray:2.44.0",
+				"--head-cpu", "1",
+				"--head-memory", "5Gi",
+				"--head-gpu", "1",
+				"--head-ephemeral-storage", "10Gi",
+				"--head-ray-start-params", "metrics-export-port=8080,num-cpus=2",
+				"--worker-replicas", "3",
+				"--worker-cpu", "1",
+				"--worker-memory", "5Gi",
+				"--worker-gpu", "1",
+				"--worker-ephemeral-storage", "10Gi",
+				"--worker-ray-start-params", "metrics-export-port=8081,num-cpus=2",
+				// TODO (dxia): Add labels and annotations back in once https://github.com/ray-project/kuberay/pull/3237 is merged
+				// "--labels", "app=ray,env=dev",
+				// "--annotations", "ttl-hours=24,owner=chthulu",
+				"--dry-run",
+				"--wait",
+				"--timeout", "10s",
+			},
+			expectError: "the following flags are incompatible with --file: [head-cpu head-ephemeral-storage head-gpu head-memory head-ray-start-params image ray-version worker-cpu worker-ephemeral-storage worker-gpu worker-memory worker-ray-start-params worker-replicas]",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd.SetArgs(tc.args)
+			// Parse the flags before checking for incompatible flags
+			if err := cmd.Flags().Parse(tc.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+			err := flagsIncompatibleWithConfigFilePresent(cmd)
 			if tc.expectError != "" {
 				require.EqualError(t, err, tc.expectError)
 			} else {
@@ -106,39 +233,185 @@ func TestRayClusterCreateClusterRun(t *testing.T) {
 
 func TestNewCreateClusterCommand(t *testing.T) {
 	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-	cmd := NewCreateClusterCommand(cmdutil.NewFactory(genericclioptions.NewConfigFlags(true)), testStreams)
-	cmd.Flags().StringP("namespace", "n", "", "")
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "config.yaml")
+	file, err := os.Create(filePath)
+	require.NoError(t, err)
+	defer file.Close()
 
-	workerNodeSelectors := fmt.Sprintf(
-		"app=ray,env=dev,%s=tpu-v5,%s=2x4",
-		util.NodeSelectorGKETPUAccelerator,
-		util.NodeSelectorGKETPUTopology,
-	)
+	tests := map[string]struct {
+		expectError string
+		args        []string
+	}{
+		"should succeed when all flags are provided": {
+			args: []string{
+				"sample-cluster",
+				"--ray-version", "2.44.0",
+				"--image", "rayproject/ray:2.44.0",
+				"--head-cpu", "1",
+				"--head-memory", "5Gi",
+				"--head-gpu", "1",
+				"--head-ephemeral-storage", "10Gi",
+				"--head-ray-start-params", "metrics-export-port=8080,num-cpus=2",
+				"--head-node-selectors", "app=ray,env=dev",
+				"--worker-replicas", "3",
+				"--num-of-hosts", "2",
+				"--worker-cpu", "1",
+				"--worker-memory", "5Gi",
+				"--worker-gpu", "1",
+				"--worker-ephemeral-storage", "10Gi",
+				"--worker-ray-start-params", "metrics-export-port=8081,num-cpus=2",
+				"--worker-node-selectors", fmt.Sprintf("app=ray,env=dev,%s=tpu-v5,%s=2x4", util.NodeSelectorGKETPUAccelerator, util.NodeSelectorGKETPUTopology),
+				"--labels", "app=ray,env=dev",
+				"--annotations", "ttl-hours=24,owner=chthulu",
+				"--dry-run",
+				"--wait",
+				"--timeout", "10s",
+			},
+		},
+		"should succeed when --file is provided": {
+			args: []string{
+				"sample-cluster",
+				"--file", filePath,
+				"--dry-run",
+			},
+		},
+		"should error when --file is provided with incompatible flags": {
+			args: []string{
+				"sample-cluster",
+				"--file", "config.yaml",
+				"--ray-version", "2.44.0",
+				"--dry-run",
+			},
+			expectError: "the following flags are incompatible with --file: [ray-version]",
+		},
+	}
 
-	cmd.SetArgs([]string{
-		"sample-cluster",
-		"--ray-version", "2.44.0",
-		"--image", "rayproject/ray:2.44.0",
-		"--head-cpu", "1",
-		"--head-memory", "5Gi",
-		"--head-gpu", "1",
-		"--head-ephemeral-storage", "10Gi",
-		"--head-ray-start-params", "metrics-export-port=8080,num-cpus=2",
-		"--head-node-selectors", "app=ray,env=dev",
-		"--worker-replicas", "3",
-		"--num-of-hosts", "2",
-		"--worker-cpu", "1",
-		"--worker-memory", "5Gi",
-		"--worker-gpu", "1",
-		"--worker-tpu", "1",
-		"--worker-ephemeral-storage", "10Gi",
-		"--worker-ray-start-params", "metrics-export-port=8081,num-cpus=2",
-		"--worker-node-selectors", workerNodeSelectors,
-		"--labels", "app=ray,env=dev",
-		"--annotations", "ttl-hours=24,owner=chthulu",
-		"--dry-run",
-		"--wait",
-		"--timeout", "10s",
-	})
-	require.NoError(t, cmd.Execute())
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := NewCreateClusterCommand(cmdutil.NewFactory(genericclioptions.NewConfigFlags(true)), testStreams)
+			cmd.Flags().StringP("namespace", "n", "", "")
+			cmd.SetArgs(tc.args)
+
+			if tc.expectError != "" {
+				require.EqualError(t, cmd.Execute(), tc.expectError)
+			} else {
+				require.NoError(t, cmd.Execute())
+			}
+		})
+	}
+}
+
+func TestResolveNamespace(t *testing.T) {
+	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+
+	tests := map[string]struct {
+		cliNamespace      string  // namespace from the CLI flag
+		configNamespace   *string // namespace from the config file
+		expectedNamespace string  // expected namespace to be used
+		expectedError     string
+	}{
+		"should use 'default' namespace when no namespace is provided": {
+			cliNamespace:      "",
+			configNamespace:   nil,
+			expectedNamespace: "default",
+		},
+		"should use the config namespace when no CLI namespace is provided": {
+			cliNamespace:      "",
+			configNamespace:   ptr.To("config-namespace"),
+			expectedNamespace: "config-namespace",
+		},
+		"should use the CLI namespace when no config namespace is provided": {
+			cliNamespace:      "cli-namespace",
+			configNamespace:   nil,
+			expectedNamespace: "cli-namespace",
+		},
+		"should error when the config namespace doesn't match the CLI namespace": {
+			cliNamespace:    "cli-namespace",
+			configNamespace: ptr.To("config-namespace"),
+			expectedError:   "the namespace in the config file \"config-namespace\" does not match the namespace \"cli-namespace\". You must pass --namespace=config-namespace to perform this operation",
+		},
+		"should use the specified namespace when it's provided in both the CLI and the config file and is the same": {
+			cliNamespace:      "my-namespace",
+			configNamespace:   ptr.To("my-namespace"),
+			expectedNamespace: "my-namespace",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			options := NewCreateClusterOptions(cmdFactory, testStreams)
+			options.namespace = tc.cliNamespace
+			options.rayClusterConfig = &generation.RayClusterConfig{
+				Namespace: tc.configNamespace,
+			}
+
+			namespace, err := options.resolveNamespace()
+
+			if tc.expectedError != "" {
+				require.EqualError(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedNamespace, namespace)
+			}
+		})
+	}
+}
+
+func TestResolveClusterName(t *testing.T) {
+	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+
+	tests := map[string]struct {
+		cliClusterName      string  // cluster name from the CLI flag
+		configClusterName   *string // cluster name from the config file
+		expectedClusterName string  // expected cluster name to be used
+		expectedError       string
+	}{
+		"should error when no cluster name is provided": {
+			cliClusterName:    "",
+			configClusterName: nil,
+			expectedError:     "the cluster name is required",
+		},
+		"should use the config cluster name when no CLI cluster name is provided": {
+			cliClusterName:      "",
+			configClusterName:   ptr.To("config-cluster-name"),
+			expectedClusterName: "config-cluster-name",
+		},
+		"should use the CLI cluster name when no config cluster name is provided": {
+			cliClusterName:      "cli-cluster-name",
+			configClusterName:   nil,
+			expectedClusterName: "cli-cluster-name",
+		},
+		"should error when the config cluster name doesn't match the CLI cluster name": {
+			cliClusterName:    "cli-cluster-name",
+			configClusterName: ptr.To("config-cluster-name"),
+			expectedError:     "the cluster name in the config file \"config-cluster-name\" does not match the cluster name \"cli-cluster-name\". You must use the same name to perform this operation",
+		},
+		"should use the specified cluster name when it's provided in both the CLI and the config file and is the same": {
+			cliClusterName:      "my-cluster-name",
+			configClusterName:   ptr.To("my-cluster-name"),
+			expectedClusterName: "my-cluster-name",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			options := NewCreateClusterOptions(cmdFactory, testStreams)
+			options.clusterName = tc.cliClusterName
+			options.rayClusterConfig = &generation.RayClusterConfig{
+				Name: tc.configClusterName,
+			}
+
+			name, err := options.resolveClusterName()
+
+			if tc.expectedError != "" {
+				require.EqualError(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedClusterName, name)
+			}
+		})
+	}
 }

--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -165,14 +165,13 @@ func TestSwitchesIncompatibleWithConfigFilePresent(t *testing.T) {
 				"--worker-gpu", "1",
 				"--worker-ephemeral-storage", "10Gi",
 				"--worker-ray-start-params", "metrics-export-port=8081,num-cpus=2",
-				// TODO (dxia): Add labels and annotations back in once https://github.com/ray-project/kuberay/pull/3237 is merged
-				// "--labels", "app=ray,env=dev",
-				// "--annotations", "ttl-hours=24,owner=chthulu",
+				"--labels", "app=ray,env=dev",
+				"--annotations", "ttl-hours=24,owner=chthulu",
 				"--dry-run",
 				"--wait",
 				"--timeout", "10s",
 			},
-			expectError: "the following flags are incompatible with --file: [head-cpu head-ephemeral-storage head-gpu head-memory head-ray-start-params image ray-version worker-cpu worker-ephemeral-storage worker-gpu worker-memory worker-ray-start-params worker-replicas]",
+			expectError: "the following flags are incompatible with --file: [annotations head-cpu head-ephemeral-storage head-gpu head-memory head-ray-start-params image labels ray-version worker-cpu worker-ephemeral-storage worker-gpu worker-memory worker-ray-start-params worker-replicas]",
 		},
 	}
 

--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -137,12 +137,8 @@ func (options *CreateWorkerGroupOptions) Complete(cmd *cobra.Command, args []str
 }
 
 func (options *CreateWorkerGroupOptions) Validate() error {
-	// we must assign gke-tpu-accelerator and gke-tpu-topology in nodeSelector
-	// if worker-tpu is not 0
-	if options.workerTPU != "0" {
-		if err := util.ValidateTPUNodeSelector(options.numOfHosts, options.workerNodeSelectors); err != nil {
-			return fmt.Errorf("%w", err)
-		}
+	if err := util.ValidateTPU(&options.workerTPU, &options.numOfHosts, options.workerNodeSelectors); err != nil {
+		return fmt.Errorf("%w", err)
 	}
 	return nil
 }

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -280,18 +280,20 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 			// here, even though it will be ignored.
 			// See https://github.com/ray-project/kuberay/issues/3126.
 			Entrypoint: options.entryPoint,
-			RayClusterSpecObject: generation.RayClusterSpecObject{
+			RayClusterConfig: generation.RayClusterConfig{
 				RayVersion: &options.rayVersion,
 				Image:      &options.image,
-				HeadCPU:    &options.headCPU,
-				HeadMemory: &options.headMemory,
-				HeadGPU:    &options.headGPU,
-				WorkerGroups: []generation.WorkerGroupConfig{
+				Head: &generation.Head{
+					CPU:    &options.headCPU,
+					Memory: &options.headMemory,
+					GPU:    &options.headGPU,
+				},
+				WorkerGroups: []generation.WorkerGroup{
 					{
-						WorkerCPU:      &options.workerCPU,
-						WorkerMemory:   &options.workerMemory,
-						WorkerGPU:      &options.workerGPU,
-						WorkerReplicas: &options.workerReplicas,
+						CPU:      &options.workerCPU,
+						Memory:   &options.workerMemory,
+						GPU:      &options.workerGPU,
+						Replicas: options.workerReplicas,
 					},
 				},
 			},

--- a/kubectl-plugin/pkg/util/constant.go
+++ b/kubectl-plugin/pkg/util/constant.go
@@ -17,4 +17,16 @@ const (
 	// NodeSelector
 	NodeSelectorGKETPUAccelerator = "cloud.google.com/gke-tpu-accelerator"
 	NodeSelectorGKETPUTopology    = "cloud.google.com/gke-tpu-topology"
+
+	DefaultHeadCPU                = "2"
+	DefaultHeadMemory             = "4Gi"
+	DefaultHeadGPU                = "0"
+	DefaultHeadEphemeralStorage   = ""
+	DefaultWorkerReplicas         = int32(1)
+	DefaultWorkerCPU              = "2"
+	DefaultWorkerMemory           = "4Gi"
+	DefaultWorkerGPU              = "0"
+	DefaultWorkerTPU              = "0"
+	DefaultWorkerEphemeralStorage = ""
+	DefaultNumOfHosts             = 1
 )

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -1,11 +1,17 @@
 package generation
 
 import (
+	"fmt"
 	"maps"
+	"os"
+	"strconv"
+
+	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/utils/ptr"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,8 +22,12 @@ import (
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
 )
 
-type RayClusterSpecObject struct {
-	Context     *string           `yaml:"context,omitempty"`
+const (
+	volumeName       = "cluster-storage"
+	gcsFuseCSIDriver = "gcsfuse.csi.storage.gke.io"
+)
+
+type RayClusterConfig struct {
 	Namespace   *string           `yaml:"namespace,omitempty"`
 	Name        *string           `yaml:"name,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
@@ -26,27 +36,54 @@ type RayClusterSpecObject struct {
 	RayVersion *string `yaml:"ray-version,omitempty"`
 	Image      *string `yaml:"image,omitempty"`
 
-	HeadCPU              *string           `yaml:"head-cpu,omitempty"`
-	HeadGPU              *string           `yaml:"head-gpu,omitempty"`
-	HeadMemory           *string           `yaml:"head-memory,omitempty"`
-	HeadEphemeralStorage *string           `yaml:"head-ephemeral-storage,omitempty"`
-	HeadRayStartParams   map[string]string `yaml:"head-ray-start-params,omitempty"`
-	HeadNodeSelectors    map[string]string `yaml:"head-node-selectors,omitempty"`
+	Head *Head `yaml:"head,omitempty"`
 
-	WorkerGroups []WorkerGroupConfig `yaml:"worker-groups,omitempty"`
+	GKE *GKE `yaml:"gke,omitempty"`
+
+	WorkerGroups []WorkerGroup `yaml:"worker-groups,omitempty"`
 }
 
-type WorkerGroupConfig struct {
-	Name                   *string           `yaml:"name,omitempty"`
-	WorkerCPU              *string           `yaml:"worker-cpu,omitempty"`
-	WorkerGPU              *string           `yaml:"worker-gpu,omitempty"`
-	WorkerTPU              *string           `yaml:"worker-tpu,omitempty"`
-	NumOfHosts             *int32            `yaml:"num-of-hosts,omitempty"`
-	WorkerMemory           *string           `yaml:"worker-memory,omitempty"`
-	WorkerEphemeralStorage *string           `yaml:"worker-ephemeral-storage,omitempty"`
-	WorkerReplicas         *int32            `yaml:"worker-replicas,omitempty"`
-	WorkerRayStartParams   map[string]string `yaml:"worker-ray-start-params,omitempty"`
-	WorkerNodeSelectors    map[string]string `yaml:"worker-node-selectors,omitempty"`
+type Head struct {
+	CPU              *string           `yaml:"cpu,omitempty"`
+	GPU              *string           `yaml:"gpu,omitempty"`
+	Memory           *string           `yaml:"memory,omitempty"`
+	EphemeralStorage *string           `yaml:"ephemeral-storage,omitempty"`
+	RayStartParams   map[string]string `yaml:"ray-start-params,omitempty"`
+	NodeSelectors    map[string]string `yaml:"node-selectors,omitempty"`
+}
+
+type WorkerGroup struct {
+	Name             *string           `yaml:"name,omitempty"`
+	CPU              *string           `yaml:"cpu,omitempty"`
+	GPU              *string           `yaml:"gpu,omitempty"`
+	TPU              *string           `yaml:"tpu,omitempty"`
+	NumOfHosts       *int32            `yaml:"num-of-hosts,omitempty"`
+	Memory           *string           `yaml:"memory,omitempty"`
+	EphemeralStorage *string           `yaml:"ephemeral-storage,omitempty"`
+	RayStartParams   map[string]string `yaml:"ray-start-params,omitempty"`
+	NodeSelectors    map[string]string `yaml:"node-selectors,omitempty"`
+	Replicas         int32             `yaml:"replicas"`
+}
+
+// GKE is a struct that contains the GKE specific configuration
+type GKE struct {
+	GCSFuse *GCSFuse `yaml:"gcsfuse,omitempty"`
+}
+
+type GCSFuse struct {
+	MountOptions                   *string           `yaml:"mount-options,omitempty"`
+	DisableMetrics                 *bool             `yaml:"disable-metrics,omitempty"`
+	GCSFuseMetadataPrefetchOnMount *bool             `yaml:"gcsfuse-metadata-prefetch-on-mount,omitempty"`
+	SkipCSIBucketAccessCheck       *bool             `yaml:"skip-csi-bucket-access-check,omitempty"`
+	Resources                      *GCSFuseResources `yaml:"resources,omitempty"`
+	BucketName                     string            `yaml:"bucket-name"`
+	MountPath                      string            `yaml:"mount-path"`
+}
+
+type GCSFuseResources struct {
+	CPU              *string `yaml:"cpu,omitempty"`
+	Memory           *string `yaml:"memory,omitempty"`
+	EphemeralStorage *string `yaml:"ephemeral-storage,omitempty"`
 }
 
 type RayJobYamlObject struct {
@@ -54,14 +91,14 @@ type RayJobYamlObject struct {
 	Namespace      string
 	SubmissionMode string
 	Entrypoint     string
-	RayClusterSpecObject
+	RayClusterConfig
 }
 
-func (rayClusterSpecObject *RayClusterSpecObject) GenerateRayClusterApplyConfig() *rayv1ac.RayClusterApplyConfiguration {
-	rayClusterApplyConfig := rayv1ac.RayCluster(*rayClusterSpecObject.Name, *rayClusterSpecObject.Namespace).
-		WithLabels(rayClusterSpecObject.Labels).
-		WithAnnotations(rayClusterSpecObject.Annotations).
-		WithSpec(rayClusterSpecObject.generateRayClusterSpec())
+func (rayClusterConfig *RayClusterConfig) GenerateRayClusterApplyConfig() *rayv1ac.RayClusterApplyConfiguration {
+	rayClusterApplyConfig := rayv1ac.RayCluster(*rayClusterConfig.Name, *rayClusterConfig.Namespace).
+		WithLabels(rayClusterConfig.Labels).
+		WithAnnotations(rayClusterConfig.Annotations).
+		WithSpec(rayClusterConfig.generateRayClusterSpec())
 
 	return rayClusterApplyConfig
 }
@@ -153,85 +190,163 @@ func generateLimitResources(memory, ephemeralStorage, gpu, tpu *string) corev1.R
 	return resources
 }
 
-func (rayClusterSpecObject *RayClusterSpecObject) generateRayClusterSpec() *rayv1ac.RayClusterSpecApplyConfiguration {
+func (rayClusterConfig *RayClusterConfig) generateRayClusterSpec() *rayv1ac.RayClusterSpecApplyConfiguration {
 	// TODO: Look for better workaround/fixes for RayStartParams. Currently using `WithRayStartParams()` requires
 	// a non-empty map with valid key value pairs and will not populate the field with empty/nil values. This
 	// isn't ideal as it forces the generated RayCluster yamls to use those parameters.
 	headRayStartParams := map[string]string{
 		"dashboard-host": "0.0.0.0",
 	}
-	workerRayStartParams := map[string]string{
-		"metrics-export-port": "8080",
-	}
-	maps.Copy(headRayStartParams, rayClusterSpecObject.HeadRayStartParams)
-	maps.Copy(workerRayStartParams, rayClusterSpecObject.WorkerGroups[0].WorkerRayStartParams)
+	maps.Copy(headRayStartParams, rayClusterConfig.Head.RayStartParams)
 
-	headRequestResources := generateRequestResources(
-		rayClusterSpecObject.HeadCPU,
-		rayClusterSpecObject.HeadMemory,
-		rayClusterSpecObject.HeadEphemeralStorage,
-		rayClusterSpecObject.HeadGPU,
+	headRequestResources := generateRequestResources(rayClusterConfig.Head.CPU, rayClusterConfig.Head.Memory, rayClusterConfig.Head.EphemeralStorage, rayClusterConfig.Head.GPU,
 		// TPU is not used for head request resources
-		nil,
-	)
-	headLimitResources := generateLimitResources(
-		rayClusterSpecObject.HeadMemory,
-		rayClusterSpecObject.HeadEphemeralStorage,
-		rayClusterSpecObject.HeadGPU,
+		nil)
+	headLimitResources := generateLimitResources(rayClusterConfig.Head.Memory, rayClusterConfig.Head.EphemeralStorage, rayClusterConfig.Head.GPU,
 		// TPU is not used for head limit resources
-		nil,
-	)
-	workerRequestResources := generateRequestResources(
-		rayClusterSpecObject.WorkerGroups[0].WorkerCPU,
-		rayClusterSpecObject.WorkerGroups[0].WorkerMemory,
-		rayClusterSpecObject.WorkerGroups[0].WorkerEphemeralStorage,
-		rayClusterSpecObject.WorkerGroups[0].WorkerGPU,
-		rayClusterSpecObject.WorkerGroups[0].WorkerTPU,
-	)
-	workerLimitResources := generateLimitResources(
-		rayClusterSpecObject.WorkerGroups[0].WorkerMemory,
-		rayClusterSpecObject.WorkerGroups[0].WorkerEphemeralStorage,
-		rayClusterSpecObject.WorkerGroups[0].WorkerGPU,
-		rayClusterSpecObject.WorkerGroups[0].WorkerTPU,
-	)
+		nil)
 
-	workerGroupName := "default-group"
-	if rayClusterSpecObject.WorkerGroups[0].Name != nil {
-		workerGroupName = *rayClusterSpecObject.WorkerGroups[0].Name
+	workerGroupSpecs := make([]*rayv1ac.WorkerGroupSpecApplyConfiguration, len(rayClusterConfig.WorkerGroups))
+	for i, workerGroup := range rayClusterConfig.WorkerGroups {
+		if workerGroup.Name == nil || *workerGroup.Name == "" {
+			name := "default-group"
+			// For backwards compatibility, if no name is specified, use "default-group"
+			if i != 0 {
+				name = fmt.Sprintf("default-group-%d", i)
+			}
+			workerGroup.Name = ptr.To(name)
+		}
+
+		workerRayStartParams := map[string]string{
+			"metrics-export-port": "8080",
+		}
+		maps.Copy(workerRayStartParams, workerGroup.RayStartParams)
+
+		workerRequestResources := generateRequestResources(workerGroup.CPU, workerGroup.Memory, workerGroup.EphemeralStorage, workerGroup.GPU, workerGroup.TPU)
+		workerLimitResources := generateLimitResources(workerGroup.Memory, workerGroup.EphemeralStorage, workerGroup.GPU, workerGroup.TPU)
+
+		workerGroupSpecs[i] = rayv1ac.WorkerGroupSpec().
+			WithRayStartParams(workerRayStartParams).
+			WithGroupName(*workerGroup.Name).
+			WithReplicas(workerGroup.Replicas).
+			WithTemplate(corev1ac.PodTemplateSpec().
+				WithSpec(corev1ac.PodSpec().
+					WithNodeSelector(workerGroup.NodeSelectors).
+					WithContainers(corev1ac.Container().
+						WithName("ray-worker").
+						WithImage(*rayClusterConfig.Image).
+						WithResources(corev1ac.ResourceRequirements().
+							WithRequests(workerRequestResources).
+							WithLimits(workerLimitResources)))))
+
+		if workerGroup.NumOfHosts != nil {
+			workerGroupSpecs[i].WithNumOfHosts(*workerGroup.NumOfHosts)
+		}
 	}
 
 	rayClusterSpec := rayv1ac.RayClusterSpec().
-		WithRayVersion(*rayClusterSpecObject.RayVersion).
+		WithRayVersion(*rayClusterConfig.RayVersion).
 		WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 			WithRayStartParams(headRayStartParams).
 			WithTemplate(corev1ac.PodTemplateSpec().
 				WithSpec(corev1ac.PodSpec().
-					WithNodeSelector(rayClusterSpecObject.HeadNodeSelectors).
+					WithNodeSelector(rayClusterConfig.Head.NodeSelectors).
 					WithContainers(corev1ac.Container().
 						WithName("ray-head").
-						WithImage(*rayClusterSpecObject.Image).
+						WithImage(*rayClusterConfig.Image).
 						WithResources(corev1ac.ResourceRequirements().
 							WithRequests(headRequestResources).
 							WithLimits(headLimitResources)).
 						WithPorts(corev1ac.ContainerPort().WithContainerPort(6379).WithName("gcs-server"),
 							corev1ac.ContainerPort().WithContainerPort(8265).WithName("dashboard"),
 							corev1ac.ContainerPort().WithContainerPort(10001).WithName("client")))))).
-		WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
-			WithRayStartParams(workerRayStartParams).
-			WithGroupName(workerGroupName).
-			WithReplicas(*rayClusterSpecObject.WorkerGroups[0].WorkerReplicas).
-			WithNumOfHosts(*rayClusterSpecObject.WorkerGroups[0].NumOfHosts).
-			WithTemplate(corev1ac.PodTemplateSpec().
-				WithSpec(corev1ac.PodSpec().
-					WithNodeSelector(rayClusterSpecObject.WorkerGroups[0].WorkerNodeSelectors).
-					WithContainers(corev1ac.Container().
-						WithName("ray-worker").
-						WithImage(*rayClusterSpecObject.Image).
-						WithResources(corev1ac.ResourceRequirements().
-							WithRequests(workerRequestResources).
-							WithLimits(workerLimitResources))))))
+		WithWorkerGroupSpecs(workerGroupSpecs...)
+
+	if rayClusterConfig.GKE != nil {
+		setGCSFuseOptions(rayClusterSpec, rayClusterConfig.GKE.GCSFuse)
+	}
 
 	return rayClusterSpec
+}
+
+func setGCSFuseOptions(rayClusterSpec *rayv1ac.RayClusterSpecApplyConfiguration, gcsFuse *GCSFuse) {
+	if gcsFuse == nil {
+		return
+	}
+
+	volumeAttributes := getGCSFuseVolumeAttributes(gcsFuse)
+
+	rayClusterSpec.HeadGroupSpec.Template.Spec.Volumes = append(rayClusterSpec.HeadGroupSpec.Template.Spec.Volumes, *corev1ac.Volume().
+		WithName(volumeName).
+		WithCSI(corev1ac.CSIVolumeSource().
+			WithDriver(gcsFuseCSIDriver).
+			WithVolumeAttributes(volumeAttributes)))
+
+	rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].VolumeMounts = append(rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].VolumeMounts, *corev1ac.VolumeMount().
+		WithName(volumeName).
+		WithMountPath(gcsFuse.MountPath))
+
+	for _, workerGroup := range rayClusterSpec.WorkerGroupSpecs {
+		workerGroup.Template.Spec.Volumes = append(workerGroup.Template.Spec.Volumes, *corev1ac.Volume().
+			WithName(volumeName).
+			WithCSI(corev1ac.CSIVolumeSource().
+				WithDriver(gcsFuseCSIDriver).
+				WithVolumeAttributes(volumeAttributes)))
+
+		workerGroup.Template.Spec.Containers[0].VolumeMounts = append(workerGroup.Template.Spec.Containers[0].VolumeMounts, *corev1ac.VolumeMount().
+			WithName(volumeName).
+			WithMountPath(gcsFuse.MountPath))
+	}
+
+	// If GCSFuse sidecar resources are specified, add as K8s annotations to all Pods
+	extraAnnotations := make(map[string]string, 5)
+	if gcsFuse.Resources != nil {
+		if gcsFuse.Resources.CPU != nil && *gcsFuse.Resources.CPU != "" {
+			extraAnnotations["gke-gcsfuse/cpu-request"] = *gcsFuse.Resources.CPU
+		}
+
+		if gcsFuse.Resources.Memory != nil && *gcsFuse.Resources.Memory != "" {
+			extraAnnotations["gke-gcsfuse/memory-limit"] = *gcsFuse.Resources.Memory
+			extraAnnotations["gke-gcsfuse/memory-request"] = *gcsFuse.Resources.Memory
+		}
+
+		if gcsFuse.Resources.EphemeralStorage != nil && *gcsFuse.Resources.EphemeralStorage != "" {
+			extraAnnotations["gke-gcsfuse/ephemeral-storage-limit"] = *gcsFuse.Resources.EphemeralStorage
+			extraAnnotations["gke-gcsfuse/ephemeral-storage-request"] = *gcsFuse.Resources.EphemeralStorage
+		}
+	}
+
+	if rayClusterSpec.HeadGroupSpec.Template.ObjectMetaApplyConfiguration == nil || rayClusterSpec.HeadGroupSpec.Template.ObjectMetaApplyConfiguration.Annotations == nil {
+		rayClusterSpec.HeadGroupSpec.Template.ObjectMetaApplyConfiguration = &metav1.ObjectMetaApplyConfiguration{
+			Annotations: extraAnnotations,
+		}
+	} else {
+		maps.Copy(rayClusterSpec.HeadGroupSpec.Template.Annotations, extraAnnotations)
+	}
+
+	for _, workerGroup := range rayClusterSpec.WorkerGroupSpecs {
+		if workerGroup.Template.ObjectMetaApplyConfiguration == nil || workerGroup.Template.ObjectMetaApplyConfiguration.Annotations == nil {
+			workerGroup.Template.ObjectMetaApplyConfiguration = &metav1.ObjectMetaApplyConfiguration{
+				Annotations: extraAnnotations,
+			}
+		} else {
+			maps.Copy(workerGroup.Template.Annotations, extraAnnotations)
+		}
+	}
+}
+
+func ConvertRayClusterSpecApplyConfigToYaml(rayClusterSpec *rayv1ac.RayClusterSpecApplyConfiguration) (string, error) {
+	resource, err := runtime.DefaultUnstructuredConverter.ToUnstructured(rayClusterSpec)
+	if err != nil {
+		return "", err
+	}
+
+	podByte, err := yaml.Marshal(resource)
+	if err != nil {
+		return "", err
+	}
+
+	return string(podByte), nil
 }
 
 // Converts RayClusterApplyConfiguration object into a yaml string
@@ -262,4 +377,150 @@ func ConvertRayJobApplyConfigToYaml(rayJobac *rayv1ac.RayJobApplyConfiguration) 
 	}
 
 	return string(podByte), nil
+}
+
+// newRayClusterConfigWithDefaults returns a new RayClusterConfig object with default values
+func newRayClusterConfigWithDefaults() *RayClusterConfig {
+	return &RayClusterConfig{
+		RayVersion: ptr.To(util.RayVersion),
+		Image:      ptr.To(fmt.Sprintf("rayproject/ray:%s", util.RayVersion)),
+		Head: &Head{
+			CPU:    ptr.To(util.DefaultHeadCPU),
+			Memory: ptr.To(util.DefaultHeadMemory),
+		},
+		WorkerGroups: []WorkerGroup{
+			{
+				Name:     ptr.To("default-group"),
+				Replicas: util.DefaultWorkerReplicas,
+				CPU:      ptr.To(util.DefaultWorkerCPU),
+				Memory:   ptr.To(util.DefaultWorkerMemory),
+			},
+		},
+	}
+}
+
+// ParseConfigFile parses the YAML configuration file into a RayClusterConfig object
+
+func ParseConfigFile(filePath string) (*RayClusterConfig, error) {
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("config file %s does not exist", filePath)
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	config := newRayClusterConfigWithDefaults()
+	if err := yaml.UnmarshalStrict(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	return config, nil
+}
+
+// ValidateConfig validates the RayClusterConfig object
+func ValidateConfig(config *RayClusterConfig) error {
+	// Validate head resource quantities
+	resourceFields := map[string]*string{
+		"cpu":               config.Head.CPU,
+		"gpu":               config.Head.GPU,
+		"memory":            config.Head.Memory,
+		"ephemeral-storage": config.Head.EphemeralStorage,
+	}
+
+	for name, value := range resourceFields {
+		if value == nil {
+			continue
+		}
+		if err := util.ValidateResourceQuantity(*value, name); err != nil {
+			return fmt.Errorf("%w", err)
+		}
+	}
+
+	// Validate worker groups
+	for i, workerGroup := range config.WorkerGroups {
+		workerResourceFields := map[string]*string{
+			"cpu":               workerGroup.CPU,
+			"gpu":               workerGroup.GPU,
+			"memory":            workerGroup.Memory,
+			"ephemeral-storage": workerGroup.EphemeralStorage,
+		}
+
+		for name, value := range workerResourceFields {
+			if value == nil {
+				continue
+			}
+			if err := util.ValidateResourceQuantity(*value, fmt.Sprintf("%s (worker group %d)", name, i)); err != nil {
+				return fmt.Errorf("%w", err)
+			}
+		}
+	}
+
+	if config.GKE != nil && config.GKE.GCSFuse != nil {
+		if err := validateGCSFuse(config.GKE.GCSFuse); err != nil {
+			return fmt.Errorf("%w", err)
+		}
+	}
+
+	return nil
+}
+
+func validateGCSFuse(gcsfuse *GCSFuse) error {
+	if gcsfuse == nil {
+		return nil
+	}
+
+	if gcsfuse.BucketName == "" {
+		return fmt.Errorf(".gcsfuse.bucket-name is required")
+	}
+
+	if gcsfuse.MountPath == "" {
+		return fmt.Errorf(".gcsfuse.mount-path is required")
+	}
+
+	if gcsfuse.Resources != nil {
+		resourceFields := map[string]*string{
+			"cpu":               gcsfuse.Resources.CPU,
+			"memory":            gcsfuse.Resources.Memory,
+			"ephemeral-storage": gcsfuse.Resources.EphemeralStorage,
+		}
+
+		for name, value := range resourceFields {
+			if value == nil {
+				continue
+			}
+			if err := util.ValidateResourceQuantity(*value, fmt.Sprintf("gcsfuse.resources.%s", name)); err != nil {
+				return fmt.Errorf("%w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// getGCSFuseVolumeAttributes returns a map of volume attributes for the Cloud Storage FUSE CSI driver
+// See https://cloud.google.com/kubernetes-engine/docs/reference/cloud-storage-fuse-csi-driver/volume-attr
+func getGCSFuseVolumeAttributes(gcsfuse *GCSFuse) map[string]string {
+	volumeAttributes := map[string]string{
+		"bucketName": gcsfuse.BucketName,
+	}
+
+	if gcsfuse.MountOptions != nil && *gcsfuse.MountOptions != "" {
+		volumeAttributes["mountOptions"] = *gcsfuse.MountOptions
+	}
+
+	if gcsfuse.DisableMetrics != nil {
+		volumeAttributes["disableMetrics"] = strconv.FormatBool(*gcsfuse.DisableMetrics)
+	}
+
+	if gcsfuse.GCSFuseMetadataPrefetchOnMount != nil {
+		volumeAttributes["gcsfuseMetadataPrefetchOnMount"] = strconv.FormatBool(*gcsfuse.GCSFuseMetadataPrefetchOnMount)
+	}
+
+	if gcsfuse.SkipCSIBucketAccessCheck != nil {
+		volumeAttributes["skipCSIBucketAccessCheck"] = strconv.FormatBool(*gcsfuse.SkipCSIBucketAccessCheck)
+	}
+
+	return volumeAttributes
 }

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -435,8 +435,9 @@ func TestGenerateResources(t *testing.T) {
 
 func TestGenerateRayClusterSpec(t *testing.T) {
 	testRayClusterConfig := RayClusterConfig{
-		RayVersion: ptr.To("1.2.3"),
-		Image:      ptr.To("rayproject/ray:1.2.3"),
+		RayVersion:     ptr.To("1.2.3"),
+		Image:          ptr.To("rayproject/ray:1.2.3"),
+		ServiceAccount: ptr.To("my-service-account"),
 		Head: &Head{
 			CPU:              ptr.To("1"),
 			Memory:           ptr.To("5Gi"),
@@ -479,6 +480,7 @@ func TestGenerateRayClusterSpec(t *testing.T) {
 			RayStartParams: map[string]string{"dashboard-host": "0.0.0.0", "softmax": "GELU"},
 			Template: &corev1ac.PodTemplateSpecApplyConfiguration{
 				Spec: &corev1ac.PodSpecApplyConfiguration{
+					ServiceAccountName: ptr.To("my-service-account"),
 					Containers: []corev1ac.ContainerApplyConfiguration{
 						{
 							Name:  ptr.To("ray-head"),
@@ -527,6 +529,7 @@ func TestGenerateRayClusterSpec(t *testing.T) {
 				RayStartParams: map[string]string{"metrics-export-port": "8080"},
 				Template: &corev1ac.PodTemplateSpecApplyConfiguration{
 					Spec: &corev1ac.PodSpecApplyConfiguration{
+						ServiceAccountName: ptr.To("my-service-account"),
 						Containers: []corev1ac.ContainerApplyConfiguration{
 							{
 								Name:  ptr.To("ray-worker"),
@@ -557,6 +560,7 @@ func TestGenerateRayClusterSpec(t *testing.T) {
 				},
 				Template: &corev1ac.PodTemplateSpecApplyConfiguration{
 					Spec: &corev1ac.PodSpecApplyConfiguration{
+						ServiceAccountName: ptr.To("my-service-account"),
 						Containers: []corev1ac.ContainerApplyConfiguration{
 							{
 								Name:  ptr.To("ray-worker"),

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -2,6 +2,7 @@ package generation
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,37 +29,43 @@ func TestGenerateRayClusterApplyConfig(t *testing.T) {
 		"baltimore": "oriole",
 	}
 
-	testRayClusterSpecObject := RayClusterSpecObject{
+	testRayClusterConfig := RayClusterConfig{
 		Name:        ptr.To("test-ray-cluster"),
 		Namespace:   ptr.To("default"),
 		Labels:      labels,
 		Annotations: annotations,
 		RayVersion:  ptr.To(util.RayVersion),
 		Image:       ptr.To(util.RayImage),
-		HeadCPU:     ptr.To("1"),
-		HeadMemory:  ptr.To("5Gi"),
-		HeadGPU:     ptr.To("1"),
-		HeadRayStartParams: map[string]string{
-			"dashboard-host": "1.2.3.4",
-			"num-cpus":       "0",
+		Head: &Head{
+			CPU:    ptr.To("1"),
+			Memory: ptr.To("5Gi"),
+			GPU:    ptr.To("1"),
+			RayStartParams: map[string]string{
+				"dashboard-host": "1.2.3.4",
+				"num-cpus":       "0",
+			},
 		},
-		WorkerGroups: []WorkerGroupConfig{
+		WorkerGroups: []WorkerGroup{
 			{
-				WorkerReplicas: ptr.To(int32(3)),
-				NumOfHosts:     ptr.To(int32(2)),
-				WorkerCPU:      ptr.To("2"),
-				WorkerMemory:   ptr.To("10Gi"),
-				WorkerGPU:      ptr.To("1"),
-				WorkerTPU:      ptr.To("1"),
-				WorkerRayStartParams: map[string]string{
+				Replicas:   int32(3),
+				NumOfHosts: ptr.To(int32(2)),
+				CPU:        ptr.To("2"),
+				Memory:     ptr.To("10Gi"),
+				GPU:        ptr.To("1"),
+				TPU:        ptr.To("1"),
+				RayStartParams: map[string]string{
 					"dagon":    "azathoth",
 					"shoggoth": "cthulhu",
+				},
+				NodeSelectors: map[string]string{
+					"app": "ray",
+					"env": "dev",
 				},
 			},
 		},
 	}
 
-	result := testRayClusterSpecObject.GenerateRayClusterApplyConfig()
+	result := testRayClusterConfig.GenerateRayClusterApplyConfig()
 
 	expected := rayv1ac.RayClusterApplyConfiguration{
 		TypeMetaApplyConfiguration: metav1.TypeMetaApplyConfiguration{
@@ -138,6 +145,7 @@ func TestGenerateRayClusterApplyConfig(t *testing.T) {
 									},
 								},
 							},
+							NodeSelector: map[string]string{"app": "ray", "env": "dev"},
 						},
 					},
 				},
@@ -153,20 +161,22 @@ func TestGenerateRayJobApplyConfig(t *testing.T) {
 		RayJobName:     "test-ray-job",
 		Namespace:      "default",
 		SubmissionMode: "InteractiveMode",
-		RayClusterSpecObject: RayClusterSpecObject{
+		RayClusterConfig: RayClusterConfig{
 			RayVersion: ptr.To(util.RayVersion),
 			Image:      ptr.To(util.RayImage),
-			HeadCPU:    ptr.To("1"),
-			HeadGPU:    ptr.To("1"),
-			HeadMemory: ptr.To("5Gi"),
-			WorkerGroups: []WorkerGroupConfig{
+			Head: &Head{
+				CPU:    ptr.To("1"),
+				GPU:    ptr.To("1"),
+				Memory: ptr.To("5Gi"),
+			},
+			WorkerGroups: []WorkerGroup{
 				{
-					WorkerReplicas: ptr.To(int32(3)),
-					NumOfHosts:     ptr.To(int32(2)),
-					WorkerCPU:      ptr.To("2"),
-					WorkerMemory:   ptr.To("10Gi"),
-					WorkerGPU:      ptr.To("0"),
-					WorkerTPU:      ptr.To("0"),
+					Replicas:   int32(3),
+					NumOfHosts: ptr.To(int32(2)),
+					CPU:        ptr.To("2"),
+					Memory:     ptr.To("10Gi"),
+					GPU:        ptr.To("0"),
+					TPU:        ptr.To("0"),
 				},
 			},
 		},
@@ -261,7 +271,7 @@ func TestGenerateRayJobApplyConfig(t *testing.T) {
 }
 
 func TestConvertRayClusterApplyConfigToYaml(t *testing.T) {
-	testRayClusterSpecObject := RayClusterSpecObject{
+	testRayClusterConfig := RayClusterConfig{
 		Name:      ptr.To("test-ray-cluster"),
 		Namespace: ptr.To("default"),
 		Labels: map[string]string{
@@ -274,22 +284,24 @@ func TestConvertRayClusterApplyConfigToYaml(t *testing.T) {
 		},
 		RayVersion: ptr.To(util.RayVersion),
 		Image:      ptr.To(util.RayImage),
-		HeadCPU:    ptr.To("1"),
-		HeadMemory: ptr.To("5Gi"),
-		HeadGPU:    ptr.To("1"),
-		WorkerGroups: []WorkerGroupConfig{
+		Head: &Head{
+			CPU:    ptr.To("1"),
+			Memory: ptr.To("5Gi"),
+			GPU:    ptr.To("1"),
+		},
+		WorkerGroups: []WorkerGroup{
 			{
-				WorkerReplicas: ptr.To(int32(3)),
-				NumOfHosts:     ptr.To(int32(2)),
-				WorkerCPU:      ptr.To("2"),
-				WorkerMemory:   ptr.To("10Gi"),
-				WorkerGPU:      ptr.To("0"),
-				WorkerTPU:      ptr.To("0"),
+				Replicas:   int32(3),
+				NumOfHosts: ptr.To(int32(2)),
+				CPU:        ptr.To("2"),
+				Memory:     ptr.To("10Gi"),
+				GPU:        ptr.To("0"),
+				TPU:        ptr.To("0"),
 			},
 		},
 	}
 
-	result := testRayClusterSpecObject.GenerateRayClusterApplyConfig()
+	result := testRayClusterConfig.GenerateRayClusterApplyConfig()
 
 	resultString, err := ConvertRayClusterApplyConfigToYaml(result)
 	require.NoError(t, err)
@@ -422,35 +434,41 @@ func TestGenerateResources(t *testing.T) {
 }
 
 func TestGenerateRayClusterSpec(t *testing.T) {
-	testRayClusterSpecObject := RayClusterSpecObject{
-		RayVersion:           ptr.To("1.2.3"),
-		Image:                ptr.To("rayproject/ray:1.2.3"),
-		HeadCPU:              ptr.To("1"),
-		HeadMemory:           ptr.To("5Gi"),
-		HeadGPU:              ptr.To("1"),
-		HeadEphemeralStorage: ptr.To("10Gi"),
-		HeadRayStartParams: map[string]string{
-			"softmax": "GELU",
+	testRayClusterConfig := RayClusterConfig{
+		RayVersion: ptr.To("1.2.3"),
+		Image:      ptr.To("rayproject/ray:1.2.3"),
+		Head: &Head{
+			CPU:              ptr.To("1"),
+			Memory:           ptr.To("5Gi"),
+			GPU:              ptr.To("1"),
+			EphemeralStorage: ptr.To("10Gi"),
+			RayStartParams: map[string]string{
+				"softmax": "GELU",
+			},
+			NodeSelectors: map[string]string{
+				"head-selector1": "foo",
+				"head-selector2": "bar",
+			},
 		},
-		HeadNodeSelectors: map[string]string{
-			"head-selector1": "foo",
-			"head-selector2": "bar",
-		},
-		WorkerGroups: []WorkerGroupConfig{
+		WorkerGroups: []WorkerGroup{
 			{
-				WorkerReplicas: ptr.To(int32(3)),
-				NumOfHosts:     ptr.To(int32(1)),
-				WorkerCPU:      ptr.To("2"),
-				WorkerMemory:   ptr.To("10Gi"),
-				WorkerGPU:      ptr.To("0"),
-				WorkerTPU:      ptr.To("0"),
-				WorkerRayStartParams: map[string]string{
+				Replicas:   int32(3),
+				NumOfHosts: ptr.To(int32(1)),
+				CPU:        ptr.To("2"),
+				Memory:     ptr.To("10Gi"),
+				GPU:        ptr.To("0"),
+				TPU:        ptr.To("0"),
+				RayStartParams: map[string]string{
 					"metrics-export-port": "8080",
 				},
-				WorkerNodeSelectors: map[string]string{
+				NodeSelectors: map[string]string{
 					"worker-selector1": "baz",
 					"worker-selector2": "qux",
 				},
+			},
+			{
+				Name: ptr.To("worker-group-2"),
+				GPU:  ptr.To("1"),
 			},
 		},
 	}
@@ -531,10 +549,530 @@ func TestGenerateRayClusterSpec(t *testing.T) {
 					},
 				},
 			},
+			{
+				GroupName: ptr.To("worker-group-2"),
+				Replicas:  ptr.To(int32(0)),
+				RayStartParams: map[string]string{
+					"metrics-export-port": "8080",
+				},
+				Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+					Spec: &corev1ac.PodSpecApplyConfiguration{
+						Containers: []corev1ac.ContainerApplyConfiguration{
+							{
+								Name:  ptr.To("ray-worker"),
+								Image: ptr.To("rayproject/ray:1.2.3"),
+								Resources: &corev1ac.ResourceRequirementsApplyConfiguration{
+									Requests: &corev1.ResourceList{
+										corev1.ResourceName(util.ResourceNvidiaGPU): resource.MustParse("1"),
+									},
+									Limits: &corev1.ResourceList{
+										corev1.ResourceName(util.ResourceNvidiaGPU): resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
-	result := testRayClusterSpecObject.generateRayClusterSpec()
+	result := testRayClusterConfig.generateRayClusterSpec()
 
+	assert.Equal(t, expected, result)
+}
+
+func TestSetGCSFuseOptions(t *testing.T) {
+	gcsFuse := &GCSFuse{
+		BucketName:   "my-bucket",
+		MountPath:    "/mnt/my-data",
+		MountOptions: ptr.To("uid=1234,gid=5678"),
+		Resources: &GCSFuseResources{
+			CPU:              ptr.To("1"),
+			Memory:           ptr.To("5Gi"),
+			EphemeralStorage: ptr.To("10Gi"),
+		},
+		DisableMetrics:                 ptr.To(false),
+		GCSFuseMetadataPrefetchOnMount: ptr.To(true),
+		SkipCSIBucketAccessCheck:       ptr.To(true),
+	}
+
+	expected := &rayv1ac.RayClusterSpecApplyConfiguration{
+		HeadGroupSpec: &rayv1ac.HeadGroupSpecApplyConfiguration{
+			Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+				ObjectMetaApplyConfiguration: &metav1.ObjectMetaApplyConfiguration{
+					Annotations: map[string]string{
+						"gke-gcsfuse/cpu-request":               "1",
+						"gke-gcsfuse/ephemeral-storage-limit":   "10Gi",
+						"gke-gcsfuse/ephemeral-storage-request": "10Gi",
+						"gke-gcsfuse/memory-limit":              "5Gi",
+						"gke-gcsfuse/memory-request":            "5Gi",
+					},
+				},
+				Spec: &corev1ac.PodSpecApplyConfiguration{
+					Containers: []corev1ac.ContainerApplyConfiguration{
+						{
+							Name: ptr.To("ray-head"),
+							VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+								{
+									Name:      ptr.To("cluster-storage"),
+									MountPath: ptr.To("/mnt/my-data"),
+								},
+							},
+						},
+					},
+					Volumes: []corev1ac.VolumeApplyConfiguration{
+						{
+							Name: ptr.To("cluster-storage"),
+							VolumeSourceApplyConfiguration: corev1ac.VolumeSourceApplyConfiguration{
+								CSI: &corev1ac.CSIVolumeSourceApplyConfiguration{
+									Driver: ptr.To(gcsFuseCSIDriver),
+									VolumeAttributes: map[string]string{
+										"bucketName":                     "my-bucket",
+										"mountOptions":                   "uid=1234,gid=5678",
+										"disableMetrics":                 "false",
+										"gcsfuseMetadataPrefetchOnMount": "true",
+										"skipCSIBucketAccessCheck":       "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		WorkerGroupSpecs: []rayv1ac.WorkerGroupSpecApplyConfiguration{
+			{
+				Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+					ObjectMetaApplyConfiguration: &metav1.ObjectMetaApplyConfiguration{
+						Annotations: map[string]string{
+							"gke-gcsfuse/cpu-request":               "1",
+							"gke-gcsfuse/ephemeral-storage-limit":   "10Gi",
+							"gke-gcsfuse/ephemeral-storage-request": "10Gi",
+							"gke-gcsfuse/memory-limit":              "5Gi",
+							"gke-gcsfuse/memory-request":            "5Gi",
+						},
+					},
+					Spec: &corev1ac.PodSpecApplyConfiguration{
+						Containers: []corev1ac.ContainerApplyConfiguration{
+							{
+								Name: ptr.To("ray-worker"),
+								VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+									{
+										Name:      ptr.To("cluster-storage"),
+										MountPath: ptr.To("/mnt/my-data"),
+									},
+								},
+							},
+						},
+						Volumes: []corev1ac.VolumeApplyConfiguration{
+							{
+								Name: ptr.To("cluster-storage"),
+								VolumeSourceApplyConfiguration: corev1ac.VolumeSourceApplyConfiguration{
+									CSI: &corev1ac.CSIVolumeSourceApplyConfiguration{
+										Driver: ptr.To(gcsFuseCSIDriver),
+										VolumeAttributes: map[string]string{
+											"bucketName":                     "my-bucket",
+											"mountOptions":                   "uid=1234,gid=5678",
+											"disableMetrics":                 "false",
+											"gcsfuseMetadataPrefetchOnMount": "true",
+											"skipCSIBucketAccessCheck":       "true",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+					ObjectMetaApplyConfiguration: &metav1.ObjectMetaApplyConfiguration{
+						Annotations: map[string]string{
+							"gke-gcsfuse/cpu-request":               "1",
+							"gke-gcsfuse/ephemeral-storage-limit":   "10Gi",
+							"gke-gcsfuse/ephemeral-storage-request": "10Gi",
+							"gke-gcsfuse/memory-limit":              "5Gi",
+							"gke-gcsfuse/memory-request":            "5Gi",
+						},
+					},
+					Spec: &corev1ac.PodSpecApplyConfiguration{
+						Containers: []corev1ac.ContainerApplyConfiguration{
+							{
+								Name: ptr.To("ray-worker"),
+								VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+									{
+										Name:      ptr.To("cluster-storage"),
+										MountPath: ptr.To("/mnt/my-data"),
+									},
+								},
+							},
+						},
+						Volumes: []corev1ac.VolumeApplyConfiguration{
+							{
+								Name: ptr.To("cluster-storage"),
+								VolumeSourceApplyConfiguration: corev1ac.VolumeSourceApplyConfiguration{
+									CSI: &corev1ac.CSIVolumeSourceApplyConfiguration{
+										Driver: ptr.To(gcsFuseCSIDriver),
+										VolumeAttributes: map[string]string{
+											"bucketName":                     "my-bucket",
+											"mountOptions":                   "uid=1234,gid=5678",
+											"disableMetrics":                 "false",
+											"gcsfuseMetadataPrefetchOnMount": "true",
+											"skipCSIBucketAccessCheck":       "true",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := &rayv1ac.RayClusterSpecApplyConfiguration{
+		HeadGroupSpec: &rayv1ac.HeadGroupSpecApplyConfiguration{
+			Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+				Spec: &corev1ac.PodSpecApplyConfiguration{
+					Containers: []corev1ac.ContainerApplyConfiguration{
+						{
+							Name: ptr.To("ray-head"),
+						},
+					},
+				},
+			},
+		},
+		WorkerGroupSpecs: []rayv1ac.WorkerGroupSpecApplyConfiguration{
+			{
+				Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+					Spec: &corev1ac.PodSpecApplyConfiguration{
+						Containers: []corev1ac.ContainerApplyConfiguration{
+							{
+								Name: ptr.To("ray-worker"),
+							},
+						},
+					},
+				},
+			},
+			{
+				Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+					Spec: &corev1ac.PodSpecApplyConfiguration{
+						Containers: []corev1ac.ContainerApplyConfiguration{
+							{
+								Name: ptr.To("ray-worker"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	setGCSFuseOptions(result, gcsFuse)
+
+	assert.Equal(t, expected, result)
+}
+
+func TestNewRayClusterConfigWithDefaults(t *testing.T) {
+	result := newRayClusterConfigWithDefaults()
+	expected := &RayClusterConfig{
+		Image:      ptr.To(fmt.Sprintf("rayproject/ray:%s", util.RayVersion)),
+		RayVersion: ptr.To(util.RayVersion),
+		Head: &Head{
+			CPU:    ptr.To("2"),
+			Memory: ptr.To("4Gi"),
+		},
+		WorkerGroups: []WorkerGroup{
+			{
+				Name:     ptr.To("default-group"),
+				CPU:      ptr.To("2"),
+				Memory:   ptr.To("4Gi"),
+				Replicas: int32(1),
+			},
+		},
+	}
+
+	assert.Equal(t, expected, result)
+}
+
+func TestParseConfigFile(t *testing.T) {
+	tests := map[string]struct {
+		config      string
+		expected    *RayClusterConfig
+		expectedErr string
+	}{
+		"invalid config": {
+			config: `foo: bar`,
+			expected: &RayClusterConfig{
+				RayVersion: ptr.To(util.RayVersion),
+				Image:      ptr.To(fmt.Sprintf("rayproject/ray:%s", util.RayVersion)),
+			},
+			expectedErr: "field foo not found in type generation.RayClusterConfig",
+		},
+		"empty config": {
+			config: "",
+			expected: &RayClusterConfig{
+				RayVersion: ptr.To(util.RayVersion),
+				Image:      ptr.To(fmt.Sprintf("rayproject/ray:%s", util.RayVersion)),
+				Head: &Head{
+					CPU:    ptr.To("2"),
+					Memory: ptr.To("4Gi"),
+				},
+				WorkerGroups: []WorkerGroup{
+					{
+						Name:     ptr.To("default-group"),
+						Replicas: int32(1),
+						CPU:      ptr.To("2"),
+						Memory:   ptr.To("4Gi"),
+					},
+				},
+			},
+		},
+		"minimal config": {
+			config: `worker-groups:
+- replicas: 1
+  gpu: 1
+`,
+			expected: &RayClusterConfig{
+				RayVersion: ptr.To(util.RayVersion),
+				Image:      ptr.To(fmt.Sprintf("rayproject/ray:%s", util.RayVersion)),
+				Head: &Head{
+					CPU:    ptr.To("2"),
+					Memory: ptr.To("4Gi"),
+				},
+				WorkerGroups: []WorkerGroup{
+					{
+						Replicas: int32(1),
+						GPU:      ptr.To("1"),
+					},
+				},
+			},
+		},
+		"full config": {
+			config: `namespace: hyperkube
+name: dxia-test
+
+labels:
+  foo: bar
+annotations:
+  dead: beef
+
+ray-version: 2.44.0
+image: rayproject/ray:2.44.0
+
+head:
+  cpu: 3
+  memory: 5Gi
+  gpu: 0
+  ephemeral-storage: 8Gi
+  ray-start-params:
+    metrics-export-port: 8082
+
+worker-groups:
+- name: cpu-workers
+  replicas: 1
+  cpu: 2
+  memory: 4Gi
+  gpu: 0
+  ephemeral-storage: 12Gi
+  ray-start-params:
+    metrics-export-port: 8081
+- name: gpu-workers
+  replicas: 1
+  cpu: 3
+  memory: 6Gi
+  gpu: 1
+  ephemeral-storage: 13Gi
+  ray-start-params:
+    metrics-export-port: 8081
+
+gke:
+  # Cloud Storage FUSE options
+  gcsfuse:
+    bucket-name: my-bucket
+    mount-path: /mnt/cluster_storage
+    mount-options: "implicit-dirs,uid=1000,gid=100"
+    resources:
+      cpu: 250m
+      memory: 256Mi
+      ephemeral-storage: 5Gi
+    disable-metrics: true
+    gcsfuse-metadata-prefetch-on-mount: false
+    skip-csi-bucket-access-check: false
+`,
+			expected: &RayClusterConfig{
+				Namespace:   ptr.To("hyperkube"),
+				Name:        ptr.To("dxia-test"),
+				Labels:      map[string]string{"foo": "bar"},
+				Annotations: map[string]string{"dead": "beef"},
+				RayVersion:  ptr.To("2.44.0"),
+				Image:       ptr.To("rayproject/ray:2.44.0"),
+				Head: &Head{
+					CPU:              ptr.To("3"),
+					Memory:           ptr.To("5Gi"),
+					GPU:              ptr.To("0"),
+					RayStartParams:   map[string]string{"metrics-export-port": "8082"},
+					EphemeralStorage: ptr.To("8Gi"),
+				},
+				WorkerGroups: []WorkerGroup{
+					{
+						Name:             ptr.To("cpu-workers"),
+						Replicas:         int32(1),
+						CPU:              ptr.To("2"),
+						Memory:           ptr.To("4Gi"),
+						GPU:              ptr.To("0"),
+						EphemeralStorage: ptr.To("12Gi"),
+						RayStartParams:   map[string]string{"metrics-export-port": "8081"},
+					},
+					{
+						Name:             ptr.To("gpu-workers"),
+						Replicas:         int32(1),
+						CPU:              ptr.To("3"),
+						Memory:           ptr.To("6Gi"),
+						GPU:              ptr.To("1"),
+						EphemeralStorage: ptr.To("13Gi"),
+						RayStartParams:   map[string]string{"metrics-export-port": "8081"},
+					},
+				},
+				GKE: &GKE{
+					GCSFuse: &GCSFuse{
+						BucketName:   "my-bucket",
+						MountPath:    "/mnt/cluster_storage",
+						MountOptions: ptr.To("implicit-dirs,uid=1000,gid=100"),
+						Resources: &GCSFuseResources{
+							CPU:              ptr.To("250m"),
+							Memory:           ptr.To("256Mi"),
+							EphemeralStorage: ptr.To("5Gi"),
+						},
+						DisableMetrics:                 ptr.To(true),
+						GCSFuseMetadataPrefetchOnMount: ptr.To(false),
+						SkipCSIBucketAccessCheck:       ptr.To(false),
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tmpFile, err := os.CreateTemp("", "test-config.yaml")
+			require.NoError(t, err)
+			defer os.Remove(tmpFile.Name())
+
+			_, err = tmpFile.WriteString(test.config)
+			require.NoError(t, err)
+
+			result, err := ParseConfigFile(tmpFile.Name())
+			if test.expectedErr != "" {
+				assert.Contains(t, err.Error(), test.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	tests := map[string]struct {
+		config      *RayClusterConfig
+		expectedErr string
+	}{
+		"invalid config": {
+			config: &RayClusterConfig{
+				Head: &Head{
+					CPU: ptr.To("invalid"),
+				},
+			},
+			expectedErr: "cpu is not a valid resource quantity",
+		},
+		"valid config": {
+			config: &RayClusterConfig{
+				Head: &Head{
+					CPU:              ptr.To("2"),
+					Memory:           ptr.To("4Gi"),
+					GPU:              ptr.To("0"),
+					EphemeralStorage: ptr.To("8Gi"),
+				},
+				WorkerGroups: []WorkerGroup{
+					{
+						CPU:              ptr.To("2"),
+						Memory:           ptr.To("4Gi"),
+						GPU:              ptr.To("0"),
+						EphemeralStorage: ptr.To("8Gi"),
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateConfig(test.config)
+			if test.expectedErr != "" {
+				assert.Contains(t, err.Error(), test.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateGCSFuse(t *testing.T) {
+	tests := map[string]struct {
+		config      *GCSFuse
+		expectedErr string
+	}{
+		"bucket name is required": {
+			config:      &GCSFuse{},
+			expectedErr: ".gcsfuse.bucket-name is required",
+		},
+		"mount path is required": {
+			config: &GCSFuse{
+				BucketName: "my-bucket",
+			},
+			expectedErr: ".gcsfuse.mount-path is required",
+		},
+		"valid config": {
+			config: &GCSFuse{
+				BucketName: "my-bucket",
+				MountPath:  "/mnt/cluster_storage",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateGCSFuse(test.config)
+			if test.expectedErr != "" {
+				assert.Contains(t, err.Error(), test.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetGCSFuseVolumeAttributes(t *testing.T) {
+	config := &GCSFuse{
+		BucketName:                     "my-bucket",
+		MountPath:                      "/mnt/cluster_storage",
+		MountOptions:                   ptr.To("implicit-dirs,uid=1000,gid=100"),
+		DisableMetrics:                 ptr.To(true),
+		GCSFuseMetadataPrefetchOnMount: ptr.To(false),
+		SkipCSIBucketAccessCheck:       ptr.To(false),
+	}
+
+	expected := map[string]string{
+		"bucketName":                     "my-bucket",
+		"mountOptions":                   "implicit-dirs,uid=1000,gid=100",
+		"disableMetrics":                 "true",
+		"gcsfuseMetadataPrefetchOnMount": "false",
+		"skipCSIBucketAccessCheck":       "false",
+	}
+
+	result := getGCSFuseVolumeAttributes(config)
 	assert.Equal(t, expected, result)
 }

--- a/kubectl-plugin/pkg/util/validation.go
+++ b/kubectl-plugin/pkg/util/validation.go
@@ -6,6 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+const tpuDocURL = "https://cloud.google.com/kubernetes-engine/docs/concepts/plan-tpus#availability"
+
 func ValidateResourceQuantity(value string, name string) error {
 	if value == "" {
 		return nil
@@ -21,22 +23,24 @@ func ValidateResourceQuantity(value string, name string) error {
 	return nil
 }
 
-func ValidateTPUNodeSelector(numOfHosts int32, nodeSelector map[string]string) error {
+func ValidateTPU(tpu *string, numOfHosts *int32, nodeSelector map[string]string) error {
+	if tpu == nil || *tpu == "" || *tpu == "0" {
+		return nil
+	}
+
 	// @TODO:
 	// In the future we could validate that the accelerator and topology nodeSelectors are supported values,
 	// and also validate the value for numOfHosts since it is deterministic based on the previous two values.
 	// https://github.com/ray-project/kuberay/pull/3258#discussion_r2027973436
 
-	const docURL = "https://cloud.google.com/kubernetes-engine/docs/concepts/plan-tpus#availability"
-
-	if numOfHosts == 0 {
+	if numOfHosts != nil && *numOfHosts == 0 {
 		return fmt.Errorf("numOfHosts cannot be 0 when using TPU")
 	}
 	if _, ok := nodeSelector[NodeSelectorGKETPUAccelerator]; !ok {
-		return fmt.Errorf("%s is not set in --worker-node-selectors. See %s for supported values", NodeSelectorGKETPUAccelerator, docURL)
+		return fmt.Errorf("%s is not set in --worker-node-selectors. See %s for supported values", NodeSelectorGKETPUAccelerator, tpuDocURL)
 	}
 	if _, ok := nodeSelector[NodeSelectorGKETPUTopology]; !ok {
-		return fmt.Errorf("%s is not set in --worker-node-selectors. See %s for supported values", NodeSelectorGKETPUTopology, docURL)
+		return fmt.Errorf("%s is not set in --worker-node-selectors. See %s for supported values", NodeSelectorGKETPUTopology, tpuDocURL)
 	}
 	return nil
 }


### PR DESCRIPTION
as described in the [Ray Kubectl Plugin 1.4.0 Wishlist][1].

Here are the resulting RayCluster YAMLs after running `kubectl ray create cluster dxia-test --file /path/to/file.yaml --dry-run` on various config files.

<details>
<summary>RayCluster from a minimal config file</summary>

```yaml
worker-groups:
- replicas: 1
  gpu: 1
```

```yaml
apiVersion: ray.io/v1
kind: RayCluster
metadata:
  name: dxia-test
  namespace: default
spec:
  headGroupSpec:
    rayStartParams:
      dashboard-host: 0.0.0.0
    template:
      spec:
        containers:
        - image: rayproject/ray:2.41.0
          name: ray-head
          ports:
          - containerPort: 6379
            name: gcs-server
          - containerPort: 8265
            name: dashboard
          - containerPort: 10001
            name: client
          resources:
            limits:
              memory: 4Gi
            requests:
              cpu: "2"
              memory: 4Gi
  rayVersion: 2.41.0
  workerGroupSpecs:
  - groupName: default-group
    rayStartParams:
      metrics-export-port: "8080"
    replicas: 1
    template:
      spec:
        containers:
        - image: rayproject/ray:2.41.0
          name: ray-worker
          resources:
            limits:
              nvidia.com/gpu: "1"
            requests:
              nvidia.com/gpu: "1"
```
</details>


<details>
<summary>RayCluster from a full config file</summary>

```yaml
namespace: hyperkube
name: dxia-test

labels:
  foo: bar
annotations:
  dead: beef

ray-version: 2.44.0
image: rayproject/ray:2.44.0

head:
  cpu: 3
  memory: 5Gi
  gpu: 0
  ephemeral-storage: 8Gi
  ray-start-params:
    metrics-export-port: 8082
  node-selectors:
    foo: bar
    baz: qux

worker-groups:
- name: cpu-workers
  replicas: 1
  cpu: 2
  memory: 4Gi
  gpu: 0
  ephemeral-storage: 12Gi
  ray-start-params:
    metrics-export-port: 8081
  node-selectors:
    hi: there
- name: gpu-workers
  replicas: 1
  cpu: 3
  memory: 6Gi
  gpu: 1
  ephemeral-storage: 13Gi
  ray-start-params:
    metrics-export-port: 8081

gke:
  # Cloud Storage FUSE options
  gcsfuse:
    # Required bucket name
    bucket-name: my-bucket
    # Required mount path where bucket will be mounted in both head and worker nodes
    mount-path: /mnt/cluster_storage
    # See the Cloud Storage FUSE CLI file docs for all supported mount options.
    # https://cloud.google.com/storage/docs/cloud-storage-fuse/cli-options#options
    mount-options: "implicit-dirs,uid=1000,gid=100"
    # Optional resource configs for Cloud Storage FUSE CSI driver sidecar container
    resources:
      cpu: 250m
      memory: 256Mi
      ephemeral-storage: 5Gi
    # Optional volume attributes for Cloud Storage FUSE CSI driver
    # from the following page excluding the ones that Google recommends you set as mount options.
    # https://cloud.google.com/kubernetes-engine/docs/reference/cloud-storage-fuse-csi-driver/volume-attr
    disable-metrics: true
    gcsfuse-metadata-prefetch-on-mount: false
    skip-csi-bucket-access-check: false
```

```yaml
apiVersion: ray.io/v1
kind: RayCluster
metadata:
  annotations:
    dead: beef
  labels:
    foo: bar
  name: dxia-test
  namespace: hyperkube
spec:
  headGroupSpec:
    rayStartParams:
      dashboard-host: 0.0.0.0
      metrics-export-port: "8082"
    template:
      metadata:
        annotations:
          gke-gcsfuse/cpu-request: 250m
          gke-gcsfuse/ephemeral-storage-limit: 5Gi
          gke-gcsfuse/ephemeral-storage-request: 5Gi
          gke-gcsfuse/memory-limit: 256Mi
          gke-gcsfuse/memory-request: 256Mi
      spec:
        containers:
        - image: rayproject/ray:2.44.0
          name: ray-head
          ports:
          - containerPort: 6379
            name: gcs-server
          - containerPort: 8265
            name: dashboard
          - containerPort: 10001
            name: client
          resources:
            limits:
              ephemeral-storage: 8Gi
              memory: 5Gi
            requests:
              cpu: "3"
              ephemeral-storage: 8Gi
              memory: 5Gi
          volumeMounts:
          - mountPath: /mnt/cluster_storage
            name: cluster-storage
        nodeSelector:
          baz: qux
          foo: bar
        volumes:
        - csi:
            driver: gcsfuse.csi.storage.gke.io
            volumeAttributes:
              bucketName: my-bucket
              disableMetrics: "true"
              gcsfuseMetadataPrefetchOnMount: "false"
              mountOptions: implicit-dirs,uid=1000,gid=100
              skipCSIBucketAccessCheck: "false"
          name: cluster-storage
  rayVersion: 2.44.0
  workerGroupSpecs:
  - groupName: cpu-workers
    rayStartParams:
      metrics-export-port: "8081"
    replicas: 1
    template:
      metadata:
        annotations:
          gke-gcsfuse/cpu-request: 250m
          gke-gcsfuse/ephemeral-storage-limit: 5Gi
          gke-gcsfuse/ephemeral-storage-request: 5Gi
          gke-gcsfuse/memory-limit: 256Mi
          gke-gcsfuse/memory-request: 256Mi
      spec:
        containers:
        - image: rayproject/ray:2.44.0
          name: ray-worker
          resources:
            limits:
              ephemeral-storage: 12Gi
              memory: 4Gi
            requests:
              cpu: "2"
              ephemeral-storage: 12Gi
              memory: 4Gi
          volumeMounts:
          - mountPath: /mnt/cluster_storage
            name: cluster-storage
        nodeSelector:
          hi: there
        volumes:
        - csi:
            driver: gcsfuse.csi.storage.gke.io
            volumeAttributes:
              bucketName: my-bucket
              disableMetrics: "true"
              gcsfuseMetadataPrefetchOnMount: "false"
              mountOptions: implicit-dirs,uid=1000,gid=100
              skipCSIBucketAccessCheck: "false"
          name: cluster-storage
  - groupName: gpu-workers
    rayStartParams:
      metrics-export-port: "8081"
    replicas: 1
    template:
      metadata:
        annotations:
          gke-gcsfuse/cpu-request: 250m
          gke-gcsfuse/ephemeral-storage-limit: 5Gi
          gke-gcsfuse/ephemeral-storage-request: 5Gi
          gke-gcsfuse/memory-limit: 256Mi
          gke-gcsfuse/memory-request: 256Mi
      spec:
        containers:
        - image: rayproject/ray:2.44.0
          name: ray-worker
          resources:
            limits:
              ephemeral-storage: 13Gi
              memory: 6Gi
              nvidia.com/gpu: "1"
            requests:
              cpu: "3"
              ephemeral-storage: 13Gi
              memory: 6Gi
              nvidia.com/gpu: "1"
          volumeMounts:
          - mountPath: /mnt/cluster_storage
            name: cluster-storage
        volumes:
        - csi:
            driver: gcsfuse.csi.storage.gke.io
            volumeAttributes:
              bucketName: my-bucket
              disableMetrics: "true"
              gcsfuseMetadataPrefetchOnMount: "false"
              mountOptions: implicit-dirs,uid=1000,gid=100
              skipCSIBucketAccessCheck: "false"
          name: cluster-storage
```
</details>

[1]: https://docs.google.com/document/d/18V5_7SGUzS0LGlaJB7xus04omyr3drKkK4vV6Kz14jY/edit?tab=t.0#heading=h.tuqyq1b6b2x7

depends on https://github.com/ray-project/kuberay/pull/3238
closes #3142

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
