### PR TITLE
[operator] add `+optional` to CRD fields that are optional

### DIFF
--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -309,12 +309,10 @@ const (
 // +genclient
 type RayCluster struct {
 	// Standard object metadata.
-	metav1.TypeMeta `json:",inline"`
-	// +optional
+	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Specification of the desired behavior of the RayCluster.
-	// +optional
 	Spec RayClusterSpec `json:"spec,omitempty"`
 	// +optional
 	Status RayClusterStatus `json:"status,omitempty"`
@@ -325,7 +323,6 @@ type RayCluster struct {
 // RayClusterList contains a list of RayCluster
 type RayClusterList struct {
 	metav1.TypeMeta `json:",inline"`
-	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []RayCluster `json:"items"`
 }

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -73,6 +73,7 @@ const (
 
 type SubmitterConfig struct {
 	// BackoffLimit of the submitter k8s job.
+	// +optional
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
 }
 
@@ -80,20 +81,26 @@ type SubmitterConfig struct {
 type RayJobSpec struct {
 	// ActiveDeadlineSeconds is the duration in seconds that the RayJob may be active before
 	// KubeRay actively tries to terminate the RayJob; value must be positive integer.
+	// +optional
 	ActiveDeadlineSeconds *int32 `json:"activeDeadlineSeconds,omitempty"`
 	// Specifies the number of retries before marking this job failed.
 	// Each retry creates a new RayCluster.
 	// +kubebuilder:default:=0
+	// +optional
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
 	// RayClusterSpec is the cluster template to run the job
 	RayClusterSpec *RayClusterSpec `json:"rayClusterSpec,omitempty"`
 	// SubmitterPodTemplate is the template for the pod that will run `ray job submit`.
+	// +optional
 	SubmitterPodTemplate *corev1.PodTemplateSpec `json:"submitterPodTemplate,omitempty"`
 	// Metadata is data to store along with this job.
+	// +optional
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// clusterSelector is used to select running rayclusters by labels
+	// +optional
 	ClusterSelector map[string]string `json:"clusterSelector,omitempty"`
 	// Configurations of submitter k8s job.
+	// +optional
 	SubmitterConfig *SubmitterConfig `json:"submitterConfig,omitempty"`
 	// ManagedBy is an optional configuration for the controller or entity that manages a RayJob.
 	// The value must be either 'ray.io/kuberay-operator' or 'kueue.x-k8s.io/multikueue'.
@@ -103,44 +110,56 @@ type RayJobSpec struct {
 	// The field is immutable.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="the managedBy field is immutable"
 	// +kubebuilder:validation:XValidation:rule="self in ['ray.io/kuberay-operator', 'kueue.x-k8s.io/multikueue']",message="the managedBy field value must be either 'ray.io/kuberay-operator' or 'kueue.x-k8s.io/multikueue'"
+	// +optional
 	ManagedBy *string `json:"managedBy,omitempty"`
 	// DeletionPolicy indicates what resources of the RayJob are deleted upon job completion.
 	// Valid values are 'DeleteCluster', 'DeleteWorkers', 'DeleteSelf' or 'DeleteNone'.
 	// If unset, deletion policy is based on 'spec.shutdownAfterJobFinishes'.
 	// This field requires the RayJobDeletionPolicy feature gate to be enabled.
 	// +kubebuilder:validation:XValidation:rule="self in ['DeleteCluster', 'DeleteWorkers', 'DeleteSelf', 'DeleteNone']",message="the deletionPolicy field value must be either 'DeleteCluster', 'DeleteWorkers', 'DeleteSelf', or 'DeleteNone'"
+	// +optional
 	DeletionPolicy *DeletionPolicy `json:"deletionPolicy,omitempty"`
 	// Entrypoint represents the command to start execution.
+	// +optional
 	Entrypoint string `json:"entrypoint,omitempty"`
 	// RuntimeEnvYAML represents the runtime environment configuration
 	// provided as a multi-line YAML string.
+	// +optional
 	RuntimeEnvYAML string `json:"runtimeEnvYAML,omitempty"`
 	// If jobId is not set, a new jobId will be auto-generated.
+	// +optional
 	JobId string `json:"jobId,omitempty"`
 	// SubmissionMode specifies how RayJob submits the Ray job to the RayCluster.
 	// In "K8sJobMode", the KubeRay operator creates a submitter Kubernetes Job to submit the Ray job.
 	// In "HTTPMode", the KubeRay operator sends a request to the RayCluster to create a Ray job.
 	// In "InteractiveMode", the KubeRay operator waits for a user to submit a job to the Ray cluster.
 	// +kubebuilder:default:=K8sJobMode
+	// +optional
 	SubmissionMode JobSubmissionMode `json:"submissionMode,omitempty"`
 	// EntrypointResources specifies the custom resources and quantities to reserve for the
 	// entrypoint command.
+	// +optional
 	EntrypointResources string `json:"entrypointResources,omitempty"`
 	// EntrypointNumCpus specifies the number of cpus to reserve for the entrypoint command.
+	// +optional
 	EntrypointNumCpus float32 `json:"entrypointNumCpus,omitempty"`
 	// EntrypointNumGpus specifies the number of gpus to reserve for the entrypoint command.
+	// +optional
 	EntrypointNumGpus float32 `json:"entrypointNumGpus,omitempty"`
 	// TTLSecondsAfterFinished is the TTL to clean up RayCluster.
 	// It's only working when ShutdownAfterJobFinishes set to true.
 	// +kubebuilder:default:=0
+	// +optional
 	TTLSecondsAfterFinished int32 `json:"ttlSecondsAfterFinished,omitempty"`
 	// ShutdownAfterJobFinishes will determine whether to delete the ray cluster once rayJob succeed or failed.
+	// +optional
 	ShutdownAfterJobFinishes bool `json:"shutdownAfterJobFinishes,omitempty"`
 	// suspend specifies whether the RayJob controller should create a RayCluster instance
 	// If a job is applied with the suspend field set to true,
 	// the RayCluster will not be created and will wait for the transition to false.
 	// If the RayCluster is already created, it will be deleted.
 	// In case of transition to false a new RayCluster will be created.
+	// +optional
 	Suspend bool `json:"suspend,omitempty"`
 }
 
@@ -148,30 +167,43 @@ type RayJobSpec struct {
 type RayJobStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	JobId               string              `json:"jobId,omitempty"`
-	RayClusterName      string              `json:"rayClusterName,omitempty"`
-	DashboardURL        string              `json:"dashboardURL,omitempty"`
-	JobStatus           JobStatus           `json:"jobStatus,omitempty"`
+	// +optional
+	JobId string `json:"jobId,omitempty"`
+	// +optional
+	RayClusterName string `json:"rayClusterName,omitempty"`
+	// +optional
+	DashboardURL string `json:"dashboardURL,omitempty"`
+	// +optional
+	JobStatus JobStatus `json:"jobStatus,omitempty"`
+	// +optional
 	JobDeploymentStatus JobDeploymentStatus `json:"jobDeploymentStatus,omitempty"`
-	Reason              JobFailedReason     `json:"reason,omitempty"`
-	Message             string              `json:"message,omitempty"`
+	// +optional
+	Reason JobFailedReason `json:"reason,omitempty"`
+	// +optional
+	Message string `json:"message,omitempty"`
 	// StartTime is the time when JobDeploymentStatus transitioned from 'New' to 'Initializing'.
+	// +optional
 	StartTime *metav1.Time `json:"startTime,omitempty"`
 	// EndTime is the time when JobDeploymentStatus transitioned to 'Complete' status.
 	// This occurs when the Ray job reaches a terminal state (SUCCEEDED, FAILED, STOPPED)
 	// or the submitter Job has failed.
+	// +optional
 	EndTime *metav1.Time `json:"endTime,omitempty"`
 	// Succeeded is the number of times this job succeeded.
 	// +kubebuilder:default:=0
+	// +optional
 	Succeeded *int32 `json:"succeeded,omitempty"`
 	// Failed is the number of times this job failed.
 	// +kubebuilder:default:=0
+	// +optional
 	Failed *int32 `json:"failed,omitempty"`
 	// RayClusterStatus is the status of the RayCluster running the job.
+	// +optional
 	RayClusterStatus RayClusterStatus `json:"rayClusterStatus,omitempty"`
 
 	// observedGeneration is the most recent generation observed for this RayJob. It corresponds to the
 	// RayJob's generation, which is updated on mutation by the API Server.
+	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
@@ -191,7 +223,8 @@ type RayJob struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   RayJobSpec   `json:"spec,omitempty"`
+	Spec RayJobSpec `json:"spec,omitempty"`
+	// +optional
 	Status RayJobStatus `json:"status,omitempty"`
 }
 

--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -59,25 +59,32 @@ var DeploymentStatusEnum = struct {
 
 type RayServiceUpgradeStrategy struct {
 	// Type represents the strategy used when upgrading the RayService. Currently supports `NewCluster` and `None`.
+	// +optional
 	Type *RayServiceUpgradeType `json:"type,omitempty"`
 }
 
 // RayServiceSpec defines the desired state of RayService
 type RayServiceSpec struct {
 	// Deprecated: This field is not used anymore. ref: https://github.com/ray-project/kuberay/issues/1685
+	// +optional
 	ServiceUnhealthySecondThreshold *int32 `json:"serviceUnhealthySecondThreshold,omitempty"`
 	// Deprecated: This field is not used anymore. ref: https://github.com/ray-project/kuberay/issues/1685
+	// +optional
 	DeploymentUnhealthySecondThreshold *int32 `json:"deploymentUnhealthySecondThreshold,omitempty"`
 	// ServeService is the Kubernetes service for head node and worker nodes who have healthy http proxy to serve traffics.
+	// +optional
 	ServeService *corev1.Service `json:"serveService,omitempty"`
 	// UpgradeStrategy defines the scaling policy used when upgrading the RayService.
+	// +optional
 	UpgradeStrategy *RayServiceUpgradeStrategy `json:"upgradeStrategy,omitempty"`
 	// Important: Run "make" to regenerate code after modifying this file
 	// Defines the applications and deployments to deploy, should be a YAML multi-line scalar string.
+	// +optional
 	ServeConfigV2  string         `json:"serveConfigV2,omitempty"`
 	RayClusterSpec RayClusterSpec `json:"rayClusterConfig"`
 	// If the field is set to true, the value of the label `ray.io/serve` on the head Pod should always be false.
 	// Therefore, the head Pod's endpoint will not be added to the Kubernetes Serve service.
+	// +optional
 	ExcludeHeadPodFromServeSvc bool `json:"excludeHeadPodFromServeSvc,omitempty"`
 }
 
@@ -88,40 +95,55 @@ type RayServiceStatuses struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// LastUpdateTime represents the timestamp when the RayService status was last updated.
+	// +optional
 	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty"`
 	// Deprecated: `ServiceStatus` is deprecated - use `Conditions` instead. `Running` means the RayService is ready to
 	// serve requests. An empty `ServiceStatus` means the RayService is not ready to serve requests. The definition of
 	// `ServiceStatus` is equivalent to the `RayServiceReady` condition.
-	ServiceStatus       ServiceStatus    `json:"serviceStatus,omitempty"`
+	// +optional
+	ServiceStatus ServiceStatus `json:"serviceStatus,omitempty"`
+	// +optional
 	ActiveServiceStatus RayServiceStatus `json:"activeServiceStatus,omitempty"`
 	// Pending Service Status indicates a RayCluster will be created or is being created.
+	// +optional
 	PendingServiceStatus RayServiceStatus `json:"pendingServiceStatus,omitempty"`
 	// NumServeEndpoints indicates the number of Ray Pods that are actively serving or have been selected by the serve service.
 	// Ray Pods without a proxy actor or those that are unhealthy will not be counted.
+	// +optional
 	NumServeEndpoints int32 `json:"numServeEndpoints,omitempty"`
 	// observedGeneration is the most recent generation observed for this RayService. It corresponds to the
 	// RayService's generation, which is updated on mutation by the API Server.
+	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 type RayServiceStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
-	Applications     map[string]AppStatus `json:"applicationStatuses,omitempty"`
-	RayClusterName   string               `json:"rayClusterName,omitempty"`
-	RayClusterStatus RayClusterStatus     `json:"rayClusterStatus,omitempty"`
+	// +optional
+	Applications map[string]AppStatus `json:"applicationStatuses,omitempty"`
+	// +optional
+	RayClusterName string `json:"rayClusterName,omitempty"`
+	// +optional
+	RayClusterStatus RayClusterStatus `json:"rayClusterStatus,omitempty"`
 }
 
 type AppStatus struct {
+	// +optional
 	Deployments map[string]ServeDeploymentStatus `json:"serveDeploymentStatuses,omitempty"`
-	Status      string                           `json:"status,omitempty"`
-	Message     string                           `json:"message,omitempty"`
+	// +optional
+	Status string `json:"status,omitempty"`
+	// +optional
+	Message string `json:"message,omitempty"`
 }
 
 // ServeDeploymentStatus defines the current state of a Serve deployment
 type ServeDeploymentStatus struct {
-	Status  string `json:"status,omitempty"`
+	// +optional
+	Status string `json:"status,omitempty"`
+	// +optional
 	Message string `json:"message,omitempty"`
 }
 
@@ -158,7 +180,8 @@ type RayService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   RayServiceSpec     `json:"spec,omitempty"`
+	Spec RayServiceSpec `json:"spec,omitempty"`
+	// +optional
 	Status RayServiceStatuses `json:"status,omitempty"`
 }
 


### PR DESCRIPTION
for v1 RayJob and RayService CRDs.
https://github.com/ray-project/kuberay/pull/3220 only did this for v1 RayCluster.
We do this for these other two CRDs to be consistent.

Signed-off-by: David Xia <david@davidxia.com>

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
