### PR TITLE
[feat] enforce DNS1035 validations on RayCluster, RayService, and RayJob names

### DIFF
--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -6,6 +6,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/pkg/features"
@@ -23,6 +24,9 @@ func ValidateRayClusterStatus(instance *rayv1.RayCluster) error {
 func ValidateRayClusterMetadata(metadata metav1.ObjectMeta) error {
 	if len(metadata.Name) > MaxRayClusterNameLength {
 		return fmt.Errorf("RayCluster name should be no more than %d characters", MaxRayClusterNameLength)
+	}
+	if errs := validation.IsDNS1035Label(metadata.Name); len(errs) > 0 {
+		return fmt.Errorf("RayCluster name should be a valid DNS1035 label: %v", errs)
 	}
 	return nil
 }
@@ -109,6 +113,9 @@ func ValidateRayJobMetadata(metadata metav1.ObjectMeta) error {
 	if len(metadata.Name) > MaxRayJobNameLength {
 		return fmt.Errorf("RayJob name should be no more than %d characters", MaxRayJobNameLength)
 	}
+	if errs := validation.IsDNS1035Label(metadata.Name); len(errs) > 0 {
+		return fmt.Errorf("RayJob name should be a valid DNS1035 label: %v", errs)
+	}
 	return nil
 }
 
@@ -175,6 +182,9 @@ func ValidateRayJobSpec(rayJob *rayv1.RayJob) error {
 func ValidateRayServiceMetadata(metadata metav1.ObjectMeta) error {
 	if len(metadata.Name) > MaxRayServiceNameLength {
 		return fmt.Errorf("RayService name should be no more than %d characters", MaxRayServiceNameLength)
+	}
+	if errs := validation.IsDNS1035Label(metadata.Name); len(errs) > 0 {
+		return fmt.Errorf("RayService name should be a valid DNS1035 label: %v", errs)
 	}
 	return nil
 }

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -380,7 +380,7 @@ func TestValidateRayClusterSpecNames(t *testing.T) {
 		{
 			name: "RayCluster name is too long (> MaxRayClusterNameLength characters)",
 			metadata: metav1.ObjectMeta{
-				Name: strings.Repeat("A", MaxRayClusterNameLength+1),
+				Name: strings.Repeat("a", MaxRayClusterNameLength+1),
 			},
 			expectError:  true,
 			errorMessage: fmt.Sprintf("RayCluster name should be no more than %d characters", MaxRayClusterNameLength),
@@ -388,9 +388,17 @@ func TestValidateRayClusterSpecNames(t *testing.T) {
 		{
 			name: "RayCluster name is ok (== MaxRayClusterNameLength)",
 			metadata: metav1.ObjectMeta{
-				Name: strings.Repeat("A", MaxRayClusterNameLength),
+				Name: strings.Repeat("a", MaxRayClusterNameLength),
 			},
 			expectError: false,
+		},
+		{
+			name: "RayCluster name is not a DNS1035 label",
+			metadata: metav1.ObjectMeta{
+				Name: strings.Repeat("1", MaxRayClusterNameLength),
+			},
+			expectError:  true,
+			errorMessage: "RayCluster name should be a valid DNS1035 label: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
 		},
 	}
 	for _, tt := range tests {
@@ -746,6 +754,11 @@ func TestValidateRayJobMetadata(t *testing.T) {
 	require.ErrorContains(t, err, fmt.Sprintf("RayJob name should be no more than %d characters", MaxRayJobNameLength))
 
 	err = ValidateRayJobMetadata(metav1.ObjectMeta{
+		Name: strings.Repeat("1", MaxRayJobNameLength),
+	})
+	require.ErrorContains(t, err, "RayJob name should be a valid DNS1035 label: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]")
+
+	err = ValidateRayJobMetadata(metav1.ObjectMeta{
 		Name: strings.Repeat("j", MaxRayJobNameLength),
 	})
 	require.NoError(t, err)
@@ -818,6 +831,11 @@ func TestValidateRayServiceMetadata(t *testing.T) {
 		Name: strings.Repeat("j", MaxRayServiceNameLength+1),
 	})
 	require.ErrorContains(t, err, fmt.Sprintf("RayService name should be no more than %d characters", MaxRayServiceNameLength))
+
+	err = ValidateRayServiceMetadata(metav1.ObjectMeta{
+		Name: strings.Repeat("1", MaxRayServiceNameLength),
+	})
+	require.ErrorContains(t, err, "RayService name should be a valid DNS1035 label: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]")
 
 	err = ValidateRayServiceMetadata(metav1.ObjectMeta{
 		Name: strings.Repeat("j", MaxRayServiceNameLength),


### PR DESCRIPTION
## Why are these changes needed?

One of the goals of https://github.com/ray-project/kuberay/pull/3083 is to provide more predictable Kubernetes service names generated by the KubeRay controller for RayCluster, RayService, and RayJob. Therefore, we shortened the allowed length for CR names and validated them at the beginning so that we can now only add fixed suffixes to generate their Kubernetes service names without mutating and trimming the prefixes of their names. Mutating and trimming their prefixes make them less predictable.

A case mentioned in https://github.com/ray-project/kuberay/issues/2169 shows why we want https://github.com/ray-project/kuberay/pull/3083 for not mutating and trimming the prefixes of service names: A user tends to fully copy the CR name with the generated suffix, such as `-head-svc`, and uses it elsewhere:

> For example, if the RayCluster name is 82ac5612-3bd9-4ef9-8828-5133dfe1a1fa-raycluster-pfsxh, the head service name becomes r-4ef9-8828-5133dfe1a1fa-raycluster-pfsxh-head-svc
>
> But when we pass the cluster name in the Job Submission service, it raises the following error
>
> ```
> dial tcp: lookup 82ac5612-3bd9-4ef9-8828-5133dfe1a1fa-raycluster-pfsxh-head-svc.default.svc.cluster.local on 10.96.0.10:53: no such host
> ```

But it also shows another case we missed: Kubernetes requires a service name to be a DNS1035 label or we will get this error when creating a service:
```
Failed creating service default/82ac5612-3bd9-4ef9-8828-5133dfe1a1fa-2fnql-head-svc, 
 Service "82ac5612-3bd9-4ef9-8828-5133dfe1a1fa-2fnql-head-svc" is invalid: metadata.name: Invalid value:
  "82ac5612-3bd9-4ef9-8828-5133dfe1a1fa-2fnql-head-svc": a DNS-1035 label must consist of lower case alphanumeric characters or '-', 
  start with an alphabetic character, 
  and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')
```

This PR adds DNS1035 validations on RayCluster, RayService, and RayJob names.
 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
