### PR TITLE
[kubectl-plugin] fix rayStartParams error when creating workgroup

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -143,6 +143,10 @@ func (options *CreateWorkerGroupOptions) Run(ctx context.Context, factory cmduti
 }
 
 func createWorkerGroupSpec(options *CreateWorkerGroupOptions) rayv1.WorkerGroupSpec {
+	if options.rayStartParams == nil {
+		options.rayStartParams = map[string]string{}
+	}
+
 	podTemplate := corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/kubectl-plugin/pkg/cmd/create/create_workergroup_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup_test.go
@@ -14,54 +14,115 @@ import (
 )
 
 func TestCreateWorkerGroupSpec(t *testing.T) {
-	rayStartParams := map[string]string{"dashboard-host": "0.0.0.0", "num-cpus": "2"}
-	options := &CreateWorkerGroupOptions{
-		groupName:         "example-group",
-		image:             "DEADBEEF",
-		workerReplicas:    3,
-		workerMinReplicas: 1,
-		workerMaxReplicas: 5,
-		workerCPU:         "2",
-		workerMemory:      "5Gi",
-		workerGPU:         "1",
-		rayStartParams:    rayStartParams,
-		workerNodeSelectors: map[string]string{
-			"worker-node-selector": "worker-node-selector-value",
-		},
-	}
-
-	expected := rayv1.WorkerGroupSpec{
-		RayStartParams: rayStartParams,
-		GroupName:      "example-group",
-		Template: corev1.PodTemplateSpec{
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "ray-worker",
-						Image: "DEADBEEF",
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:     resource.MustParse("2"),
-								corev1.ResourceMemory:  resource.MustParse("5Gi"),
-								util.ResourceNvidiaGPU: resource.MustParse("1"),
-							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:     resource.MustParse("2"),
-								corev1.ResourceMemory:  resource.MustParse("5Gi"),
-								util.ResourceNvidiaGPU: resource.MustParse("1"),
-							},
-						},
-					},
-				},
-				NodeSelector: map[string]string{
+	tests := []struct {
+		name     string
+		options  *CreateWorkerGroupOptions
+		expected rayv1.WorkerGroupSpec
+	}{
+		{
+			name: "default worker group spec",
+			options: &CreateWorkerGroupOptions{
+				groupName:         "example-group",
+				image:             "DEADBEEF",
+				workerReplicas:    3,
+				workerMinReplicas: 1,
+				workerMaxReplicas: 5,
+				workerCPU:         "2",
+				workerMemory:      "5Gi",
+				workerGPU:         "1",
+				rayStartParams:    map[string]string{"dashboard-host": "0.0.0.0", "num-cpus": "2"},
+				workerNodeSelectors: map[string]string{
 					"worker-node-selector": "worker-node-selector-value",
 				},
 			},
+			expected: rayv1.WorkerGroupSpec{
+				RayStartParams: map[string]string{"dashboard-host": "0.0.0.0", "num-cpus": "2"},
+				GroupName:      "example-group",
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "ray-worker",
+								Image: "DEADBEEF",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:     resource.MustParse("2"),
+										corev1.ResourceMemory:  resource.MustParse("5Gi"),
+										util.ResourceNvidiaGPU: resource.MustParse("1"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:     resource.MustParse("2"),
+										corev1.ResourceMemory:  resource.MustParse("5Gi"),
+										util.ResourceNvidiaGPU: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+						NodeSelector: map[string]string{
+							"worker-node-selector": "worker-node-selector-value",
+						},
+					},
+				},
+				Replicas:    ptr.To[int32](3),
+				MinReplicas: ptr.To[int32](1),
+				MaxReplicas: ptr.To[int32](5),
+			},
 		},
-		Replicas:    ptr.To[int32](3),
-		MinReplicas: ptr.To[int32](1),
-		MaxReplicas: ptr.To[int32](5),
+		{
+			name: "worker group spec with nil ray start params",
+			options: &CreateWorkerGroupOptions{
+				groupName:         "example-group",
+				image:             "DEADBEEF",
+				workerReplicas:    3,
+				workerMinReplicas: 1,
+				workerMaxReplicas: 5,
+				workerCPU:         "2",
+				workerMemory:      "5Gi",
+				workerGPU:         "1",
+				rayStartParams:    nil,
+				workerNodeSelectors: map[string]string{
+					"worker-node-selector": "worker-node-selector-value",
+				},
+			},
+			expected: rayv1.WorkerGroupSpec{
+				RayStartParams: map[string]string{},
+				GroupName:      "example-group",
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "ray-worker",
+								Image: "DEADBEEF",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:     resource.MustParse("2"),
+										corev1.ResourceMemory:  resource.MustParse("5Gi"),
+										util.ResourceNvidiaGPU: resource.MustParse("1"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:     resource.MustParse("2"),
+										corev1.ResourceMemory:  resource.MustParse("5Gi"),
+										util.ResourceNvidiaGPU: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+						NodeSelector: map[string]string{
+							"worker-node-selector": "worker-node-selector-value",
+						},
+					},
+				},
+				Replicas:    ptr.To[int32](3),
+				MinReplicas: ptr.To[int32](1),
+				MaxReplicas: ptr.To[int32](5),
+			},
+		},
 	}
 
-	assert.Equal(t, expected, createWorkerGroupSpec(options))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, createWorkerGroupSpec(tt.options))
+		})
+	}
+
 }

--- a/kubectl-plugin/pkg/cmd/create/create_workergroup_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup_test.go
@@ -124,5 +124,4 @@ func TestCreateWorkerGroupSpec(t *testing.T) {
 			assert.Equal(t, tt.expected, createWorkerGroupSpec(tt.options))
 		})
 	}
-
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
> While following the instruction from [document  ](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/kubectl-plugin.html) with master branch's kubectl-plugin, it raise error

```shell=
$ kubectl ray create cluster raycluster-sample
$ kubectl ray create workergroup example-group --ray-cluster raycluster-sample --worker-memory 5Gi
```
> It will raise error
```
Error: error updating Ray cluster with new worker group: RayCluster.ray.io "raycluster-sample" is invalid: spec.workerGroupSpecs[1].rayStartParams: Required value
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #3250 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
