### PR TITLE
Rename rayCluster variable from app to rayCluster

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/interface/interface.go
+++ b/ray-operator/controllers/ray/batchscheduler/interface/interface.go
@@ -19,11 +19,11 @@ type BatchScheduler interface {
 
 	// DoBatchSchedulingOnSubmission handles submitting the RayCluster to the batch scheduler on creation / update
 	// For most batch schedulers, this results in the creation of a PodGroup.
-	DoBatchSchedulingOnSubmission(ctx context.Context, app *rayv1.RayCluster) error
+	DoBatchSchedulingOnSubmission(ctx context.Context, rayCluster *rayv1.RayCluster) error
 
 	// AddMetadataToPod enriches Pod specs with metadata necessary to tie them to the scheduler.
 	// For example, setting labels for queues / priority, and setting schedulerName.
-	AddMetadataToPod(ctx context.Context, app *rayv1.RayCluster, groupName string, pod *corev1.Pod)
+	AddMetadataToPod(ctx context.Context, rayCluster *rayv1.RayCluster, groupName string, pod *corev1.Pod)
 }
 
 // BatchSchedulerFactory handles initial setup of the scheduler plugin by registering the

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
@@ -80,7 +80,7 @@ func TestCreatePodGroup(t *testing.T) {
 
 	minMember := utils.CalculateDesiredReplicas(context.Background(), &cluster) + 1
 	totalResource := utils.CalculateDesiredResources(&cluster)
-	pg := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource)
+	pg := createPodGroup(&cluster, getRayClusterPodGroupName(&cluster), minMember, totalResource)
 
 	a.Equal(cluster.Namespace, pg.Namespace)
 

--- a/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_scheduler_test.go
@@ -149,7 +149,7 @@ func TestPopulateGangSchedulingAnnotations(t *testing.T) {
 			"nvidia.com/gpu":  resource.MustParse("1"),
 		})
 
-	// gang-scheduling enabled case, the plugin should populate the taskGroup annotation to the app
+	// gang-scheduling enabled case, the plugin should populate the taskGroup annotation to the pod
 	rayPod := createPod("ray-pod", "default")
 	yk.populateTaskGroupsAnnotationToPod(ctx, rayClusterWithGangScheduling, rayPod)
 
@@ -192,8 +192,8 @@ func createRayClusterWithLabels(name string, namespace string, labels map[string
 	return rayCluster
 }
 
-func addHeadPodSpec(app *rayv1.RayCluster, resource v1.ResourceList) {
-	// app.Spec.HeadGroupSpec.Template.Spec.Containers
+func addHeadPodSpec(rayCluster *rayv1.RayCluster, resource v1.ResourceList) {
+	// rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers
 	headContainers := []v1.Container{
 		{
 			Name:  "head-pod",
@@ -205,10 +205,10 @@ func addHeadPodSpec(app *rayv1.RayCluster, resource v1.ResourceList) {
 		},
 	}
 
-	app.Spec.HeadGroupSpec.Template.Spec.Containers = headContainers
+	rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers = headContainers
 }
 
-func addWorkerPodSpec(app *rayv1.RayCluster, workerGroupName string,
+func addWorkerPodSpec(rayCluster *rayv1.RayCluster, workerGroupName string,
 	replicas int32, minReplicas int32, maxReplicas int32, resources v1.ResourceList,
 ) {
 	workerContainers := []v1.Container{
@@ -222,7 +222,7 @@ func addWorkerPodSpec(app *rayv1.RayCluster, workerGroupName string,
 		},
 	}
 
-	app.Spec.WorkerGroupSpecs = append(app.Spec.WorkerGroupSpecs, rayv1.WorkerGroupSpec{
+	rayCluster.Spec.WorkerGroupSpecs = append(rayCluster.Spec.WorkerGroupSpecs, rayv1.WorkerGroupSpec{
 		GroupName:   workerGroupName,
 		Replicas:    &replicas,
 		MinReplicas: &minReplicas,

--- a/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_task_groups.go
+++ b/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_task_groups.go
@@ -33,11 +33,11 @@ func newTaskGroups() *TaskGroups {
 	}
 }
 
-func newTaskGroupsFromApp(app *v1.RayCluster) *TaskGroups {
+func newTaskGroupsFromRayCluster(rayCluster *v1.RayCluster) *TaskGroups {
 	taskGroups := newTaskGroups()
 
 	// head group
-	headGroupSpec := app.Spec.HeadGroupSpec
+	headGroupSpec := rayCluster.Spec.HeadGroupSpec
 	headPodMinResource := utils.CalculatePodResource(headGroupSpec.Template.Spec)
 	taskGroups.addTaskGroup(
 		TaskGroup{
@@ -50,7 +50,7 @@ func newTaskGroupsFromApp(app *v1.RayCluster) *TaskGroups {
 		})
 
 	// worker groups
-	for _, workerGroupSpec := range app.Spec.WorkerGroupSpecs {
+	for _, workerGroupSpec := range rayCluster.Spec.WorkerGroupSpecs {
 		workerMinResource := utils.CalculatePodResource(workerGroupSpec.Template.Spec)
 		minWorkers := workerGroupSpec.MinReplicas
 		taskGroups.addTaskGroup(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We are going to integrate batch scheduler with rayJob, the variable name `app` will be confusing if there are other CRs.

So renaming from `app` to `rayCluster` solve this problem while also maintaining naming consistency with other files in the codebase that use `rayCluster` as the variable name

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
