### PR TITLE
Add basic Helm chart unittests for kuberay-operator

### DIFF
--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -4,9 +4,9 @@ metadata:
   name: {{ include "kuberay-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "kuberay-operator.labels" . | nindent 4 }}
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
     {{- with .Values.labels }}
-    {{-  toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   replicas: 1
@@ -45,8 +45,10 @@ spec:
           emptyDir: {}
           {{- end }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}
@@ -54,7 +56,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- with .Values.imagePullPolicy }}
+          {{- with .Values.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
           {{- if and (.Values.logging.baseDir) (.Values.logging.fileName) }}
@@ -109,7 +111,7 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          {{ with .Values.env }}
+          {{- with .Values.env }}
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -2,11 +2,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kuberay-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
-{{- if .Values.labels }}
-{{- toYaml .Values.labels | nindent 4 }}
-{{- end }}
+    {{ include "kuberay-operator.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{-  toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: 1
   strategy:
@@ -21,12 +22,12 @@ spec:
         app.kubernetes.io/name: {{ include "kuberay-operator.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: {{ include "kuberay-operator.component" . }}
-        {{- if .Values.labels }}
-        {{- toYaml .Values.labels | nindent 8 }}
+        {{- with .Values.labels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if .Values.annotations }}
+      {{- with .Values.annotations }}
       annotations:
-        {{- toYaml .Values.annotations | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
@@ -48,10 +49,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.imagePullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           {{- if and (.Values.logging.baseDir) (.Values.logging.fileName) }}
           volumeMounts:
             - name: kuberay-logs
@@ -104,8 +109,10 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{ with .Values.env }}
           env:
-          {{- toYaml .Values.env | nindent 12}}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /metrics
@@ -120,17 +127,19 @@ spec:
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}

--- a/helm-chart/kuberay-operator/templates/role.yaml
+++ b/helm-chart/kuberay-operator/templates/role.yaml
@@ -1,10 +1,9 @@
 {{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
-
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
   name: {{ include "kuberay-operator.fullname" . }}
+  labels:
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
 {{ include "role.consistentRules" (dict "batchSchedulerEnabled" .Values.batchScheduler.enabled "batchSchedulerName" .Values.batchScheduler.name) }}
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/rolebinding.yaml
@@ -2,15 +2,15 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
   name: {{ include "kuberay-operator.fullname" . }}
+  labels:
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name  }}
   namespace: {{ .Release.Namespace }}
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ include "kuberay-operator.fullname" . }}
-  apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/service.yaml
+++ b/helm-chart/kuberay-operator/templates/service.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kuberay-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm-chart/kuberay-operator/templates/serviceaccount.yaml
+++ b/helm-chart/kuberay-operator/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kuberay-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
 {{- end -}}

--- a/helm-chart/kuberay-operator/tests/deployment_test.yaml
+++ b/helm-chart/kuberay-operator/tests/deployment_test.yaml
@@ -98,20 +98,27 @@ tests:
 
   - it: Should use the specified container security context if `securityContext` is set
     set:
-      podSecurityContext:
-        runAsUser: 1000
-        runAsGroup: 2000
-        fsGroup: 3000
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
     asserts:
       - equal:
-          path: spec.template.spec.securityContext.runAsUser
-          value: 1000
-      - equal:
-          path: spec.template.spec.securityContext.runAsGroup
-          value: 2000
-      - equal:
-          path: spec.template.spec.securityContext.fsGroup
-          value: 3000
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].securityContext
+          value:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
 
   - it: Should add environment variables if `env` is set
     set:

--- a/helm-chart/kuberay-operator/tests/deployment_test.yaml
+++ b/helm-chart/kuberay-operator/tests/deployment_test.yaml
@@ -1,0 +1,253 @@
+suite: Test Deployment
+
+templates:
+  - deployment.yaml
+
+release:
+  name: kuberay-operator
+  namespace: kuberay-system
+
+tests:
+  - it: Should create deployment
+    asserts:
+      - containsDocument:
+          apiVersion: apps/v1
+          kind: Deployment
+          name: kuberay-operator
+          namespace: kuberay-system
+
+  - it: Should add deployment labels if `labels` is set
+    set:
+      labels:
+        key1: value1
+        key2: value2
+    asserts:
+      - equal:
+          path: metadata.labels.key1
+          value: value1
+      - equal:
+          path: metadata.labels.key2
+          value: value2
+
+  - it: Should add pod template labels if `labels` is set
+    set:
+      labels:
+        key1: value1
+        key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.labels.key2
+          value: value2
+
+  - it: Should add pod template annotations if `annotations` is set
+    set:
+      annotations:
+        key1: value1
+        key2: value2
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.key1
+          value: value1
+      - equal:
+          path: spec.template.metadata.annotations.key2
+          value: value2
+
+  - it: Should use the specified image pull secrets if `imagePullsecrets` is set
+    set:
+      imagePullSecrets:
+        - name: test-secret1
+        - name: test-secret2
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: test-secret1
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: test-secret2
+
+  - it: Should use the specified service account name if `serviceAccount.name` is set
+    set:
+      serviceAccount:
+        name: test-service-account
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: test-service-account
+
+  - it: Should use the specified pod security context if `podSecurityContext` is set
+    set:
+      podSecurityContext:
+        runAsUser: 1000
+        runAsGroup: 2000
+        fsGroup: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 3000
+
+  - it: Should use the specified container security context if `securityContext` is set
+    set:
+      podSecurityContext:
+        runAsUser: 1000
+        runAsGroup: 2000
+        fsGroup: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 3000
+
+  - it: Should add environment variables if `env` is set
+    set:
+      env:
+        - name: KEY1
+          value: VALUE1
+        - name: KEY2
+          valueFrom:
+            configMapKeyRef:
+              name: test-configmap
+              key: TEST_KEY2
+              optional: false
+        - name: KEY3
+          valueFrom:
+            secretRef:
+              name: test-secret
+              key: TEST_KEY3
+              optional: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].env
+          content:
+            name: KEY1
+            value: VALUE1
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].env
+          content:
+            name: KEY2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: TEST_KEY2
+                optional: false
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].env
+          content:
+            name: KEY3
+            valueFrom:
+              secretRef:
+                name: test-secret
+                key: TEST_KEY3
+                optional: false
+
+  - it: Should add resources if `resources` is set
+    set:
+      resources:
+        requests:
+          memory: 64Mi
+          cpu: 250m
+        limits:
+          memory: 128Mi
+          cpu: 500m
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].resources
+          value:
+            requests:
+              memory: 64Mi
+              cpu: 250m
+            limits:
+              memory: 128Mi
+              cpu: 500m
+
+  - it: Should add nodeSelector if `nodeSelector` is set
+    set:
+      nodeSelector:
+        key1: value1
+        key2: value2
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.key1
+          value: value1
+      - equal:
+          path: spec.template.spec.nodeSelector.key2
+          value: value2
+
+  - it: Should add affinity if `affinity` is set
+    set:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - antarctica-east1
+                      - antarctica-west1
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: another-node-label-key
+                    operator: In
+                    values:
+                      - another-node-label-value
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity
+          value:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: topology.kubernetes.io/zone
+                        operator: In
+                        values:
+                          - antarctica-east1
+                          - antarctica-west1
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: another-node-label-key
+                        operator: In
+                        values:
+                          - another-node-label-value
+
+  - it: Should add tolerations if `tolerations` is set
+    set:
+      tolerations:
+        - key: key1
+          operator: Equal
+          value: value1
+          effect: NoSchedule
+        - key: key2
+          operator: Exists
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule

--- a/helm-chart/kuberay-operator/tests/deployment_test.yaml
+++ b/helm-chart/kuberay-operator/tests/deployment_test.yaml
@@ -55,6 +55,15 @@ tests:
           path: spec.template.metadata.annotations.key2
           value: value2
 
+  - it: Should use the specified image pull policy if `image.pullPolicy` is set
+    set:
+      image:
+        pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[*].imagePullPolicy
+          value: Always
+
   - it: Should use the specified image pull secrets if `imagePullsecrets` is set
     set:
       imagePullSecrets:
@@ -103,7 +112,7 @@ tests:
         readOnlyRootFilesystem: true
         capabilities:
           drop:
-          - ALL
+            - ALL
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -115,7 +124,7 @@ tests:
             readOnlyRootFilesystem: true
             capabilities:
               drop:
-              - ALL
+                - ALL
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault

--- a/helm-chart/kuberay-operator/tests/role_test.yaml
+++ b/helm-chart/kuberay-operator/tests/role_test.yaml
@@ -1,0 +1,33 @@
+suite: Test ClusterRole
+
+templates:
+  - role.yaml
+
+release:
+  name: kuberay-operator
+  namespace: kuberay-system
+
+tests:
+  - it: Should not create ClusterRole if `rbacEnable` is `false`
+    set:
+      rbacEnable: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not create ClusterRole if `singleNamespaceInstall` is `true`
+    set:
+      singleNamespaceInstall: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create ClusterRole if `rbacEnable` is `true` and `singleNamespaceInstall` is `false`
+    set:
+      rbacEnable: true
+      singleNamespaceInstall: false
+    asserts:
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          name: kuberay-operator

--- a/helm-chart/kuberay-operator/tests/rolebinding_test.yaml
+++ b/helm-chart/kuberay-operator/tests/rolebinding_test.yaml
@@ -1,0 +1,51 @@
+suite: Test ClusterRoleBinding
+
+templates:
+  - rolebinding.yaml
+
+release:
+  name: kuberay-operator
+  namespace: kuberay-system
+
+tests:
+  - it: Should not create ClusterRoleBinding if `rbacEnable` is `false`
+    set:
+      rbacEnable: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not create ClusterRoleBinding if `singleNamespaceInstall` is `true`
+    set:
+      singleNamespaceInstall: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create ClusterRoleBinding if `rbacEnable` is `true` and `singleNamespaceInstall` is `false`
+    set:
+      rbacEnable: true
+      singleNamespaceInstall: false
+    asserts:
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          name: kuberay-operator
+
+  - it: Should bind ClusterRole to ServiceAccount
+    set:
+      rbacEnable: true
+      singleNamespaceInstall: false
+    asserts:
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: kuberay-operator
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: kuberay-operator
+            namespace: kuberay-system

--- a/helm-chart/kuberay-operator/tests/service_test.yaml
+++ b/helm-chart/kuberay-operator/tests/service_test.yaml
@@ -1,0 +1,35 @@
+suite: Test Service
+
+templates:
+  - service.yaml
+
+release:
+  name: kuberay-operator
+  namespace: kuberay-system
+
+tests:
+  - it: Should create Service
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Service
+          name: kuberay-operator
+          namespace: kuberay-system
+
+  - it: Should use the specified service type if `service.type` is set
+    set:
+      service:
+        type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+
+  - it: Should use the specified service port if `service.port` is set
+    set:
+      service:
+        port: 18080
+    asserts:
+      - equal:
+          path: spec.ports[?(@.name=="http")].port
+          value: 18080

--- a/helm-chart/kuberay-operator/tests/serviceaccount_test.yaml
+++ b/helm-chart/kuberay-operator/tests/serviceaccount_test.yaml
@@ -1,0 +1,28 @@
+suite: Test ServiceAccount
+
+templates:
+  - serviceaccount.yaml
+
+release:
+  name: kuberay-operator
+  namespace: kuberay-system
+
+tests:
+  - it: Should create ServiceAccount if `serviceAccount.create` is `true`
+    set:
+      serviceAccount:
+        create: true
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: ServiceAccount
+          name: kuberay-operator
+          namespace: kuberay-system
+
+  - it: Should not create ServiceAccount if `serviceAccount.create` is `false`
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -11,6 +11,12 @@ nameOverride: "kuberay-operator"
 fullnameOverride: "kuberay-operator"
 componentOverride: "kuberay-operator"
 
+# -- Extra labels.
+labels: {}
+
+# -- Extra annotations.
+annotations: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Make sure kuberay-operator Helm chart can work as expected with various configurations by adding unit tests.

One can run Helm chart unit tests by:

```bash
$ helm plugin install https://github.com/helm-unittest/helm-unittest.git

$ helm unittest helm-chart/kuberay-operator --strict --debug
### Chart [ kuberay-operator ] helm-chart/kuberay-operator

 PASS  Test Deployment  helm-chart/kuberay-operator/tests/deployment_test.yaml
 PASS  Test ClusterRole helm-chart/kuberay-operator/tests/role_test.yaml
 PASS  Test ClusterRoleBinding  helm-chart/kuberay-operator/tests/rolebinding_test.yaml
 PASS  Test Service     helm-chart/kuberay-operator/tests/service_test.yaml
 PASS  Test ServiceAccount      helm-chart/kuberay-operator/tests/serviceaccount_test.yaml

Charts:      1 passed, 1 total
Test Suites: 5 passed, 5 total
Tests:       25 passed, 25 total
Snapshot:    0 passed, 0 total
Time:        118.062459ms
```

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #3244

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(