### PR TITLE
[Refactor] move `rayStartParams` to options.complete

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -106,6 +106,10 @@ func (options *CreateWorkerGroupOptions) Complete(cmd *cobra.Command, args []str
 		options.namespace = "default"
 	}
 
+	if options.rayStartParams == nil {
+		options.rayStartParams = map[string]string{}
+	}
+
 	if len(args) != 1 {
 		return cmdutil.UsageErrorf(cmd, "%s", cmd.Use)
 	}
@@ -143,10 +147,6 @@ func (options *CreateWorkerGroupOptions) Run(ctx context.Context, factory cmduti
 }
 
 func createWorkerGroupSpec(options *CreateWorkerGroupOptions) rayv1.WorkerGroupSpec {
-	if options.rayStartParams == nil {
-		options.rayStartParams = map[string]string{}
-	}
-
 	podTemplate := corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/kubectl-plugin/pkg/cmd/create/create_workergroup_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup_test.go
@@ -3,7 +3,9 @@ package create
 import (
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
@@ -68,60 +70,134 @@ func TestCreateWorkerGroupSpec(t *testing.T) {
 				MaxReplicas: ptr.To[int32](5),
 			},
 		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, createWorkerGroupSpec(tt.options))
+		})
+	}
+}
+
+func TestCreateWorkerGroupCommandComplete(t *testing.T) {
+	tests := []struct {
+		flags         map[string]string
+		expected      *CreateWorkerGroupOptions
+		name          string
+		expectedError string
+		args          []string
+	}{
 		{
-			name: "worker group spec with nil ray start params",
-			options: &CreateWorkerGroupOptions{
-				groupName:         "example-group",
-				image:             "DEADBEEF",
-				workerReplicas:    3,
-				workerMinReplicas: 1,
-				workerMaxReplicas: 5,
-				workerCPU:         "2",
-				workerMemory:      "5Gi",
-				workerGPU:         "1",
-				rayStartParams:    nil,
-				workerNodeSelectors: map[string]string{
-					"worker-node-selector": "worker-node-selector-value",
+			name: "Valid input with namespace",
+			args: []string{"example-group"},
+			flags: map[string]string{
+				"namespace": "test-namespace",
+			},
+			expected: &CreateWorkerGroupOptions{
+				namespace:  "test-namespace",
+				groupName:  "example-group",
+				image:      "rayproject/ray:latest",
+				rayVersion: "latest",
+			},
+		},
+		{
+			name:          "Valid input without namespace flag",
+			args:          []string{"example-group"},
+			flags:         map[string]string{},
+			expectedError: "failed to get namespace: flag accessed but not defined: namespace",
+		},
+		{
+			name: "mMissing group name",
+			args: []string{},
+			flags: map[string]string{
+				"namespace": "",
+			},
+			expectedError: "See ' -h' for help and examples",
+		},
+		{
+			name: "Empty namespace flag",
+			args: []string{"example-group"},
+			flags: map[string]string{
+				"namespace": "",
+			},
+			expected: &CreateWorkerGroupOptions{
+				namespace:  "default",
+				groupName:  "example-group",
+				image:      "rayproject/ray:latest",
+				rayVersion: "latest",
+			},
+		},
+		{
+			name: "Valid input with rayStartParams",
+			args: []string{"example-group"},
+			flags: map[string]string{
+				"namespace":               "test-namespace",
+				"worker-ray-start-params": "dashboard-host=0.0.0.0,num-cpus=2",
+			},
+			expected: &CreateWorkerGroupOptions{
+				namespace:  "test-namespace",
+				groupName:  "example-group",
+				image:      "rayproject/ray:latest",
+				rayVersion: "latest",
+				rayStartParams: map[string]string{
+					"dashboard-host": "0.0.0.0",
+					"num-cpus":       "2",
 				},
 			},
-			expected: rayv1.WorkerGroupSpec{
-				RayStartParams: map[string]string{},
-				GroupName:      "example-group",
-				Template: corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "ray-worker",
-								Image: "DEADBEEF",
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:     resource.MustParse("2"),
-										corev1.ResourceMemory:  resource.MustParse("5Gi"),
-										util.ResourceNvidiaGPU: resource.MustParse("1"),
-									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceCPU:     resource.MustParse("2"),
-										corev1.ResourceMemory:  resource.MustParse("5Gi"),
-										util.ResourceNvidiaGPU: resource.MustParse("1"),
-									},
-								},
-							},
-						},
-						NodeSelector: map[string]string{
-							"worker-node-selector": "worker-node-selector-value",
-						},
-					},
-				},
-				Replicas:    ptr.To[int32](3),
-				MinReplicas: ptr.To[int32](1),
-				MaxReplicas: ptr.To[int32](5),
+		},
+		{
+			name: "Empty rayStartParams",
+			args: []string{"example-group"},
+			flags: map[string]string{
+				"namespace":               "test-namespace",
+				"worker-ray-start-params": "",
+			},
+			expected: &CreateWorkerGroupOptions{
+				namespace:      "test-namespace",
+				groupName:      "example-group",
+				image:          "rayproject/ray:latest",
+				rayVersion:     "latest",
+				rayStartParams: map[string]string{},
+			},
+		},
+		{
+			name: "Not assign rayStartParams",
+			args: []string{"example-group"},
+			flags: map[string]string{
+				"namespace": "test-namespace",
+			},
+			expected: &CreateWorkerGroupOptions{
+				namespace:      "test-namespace",
+				groupName:      "example-group",
+				image:          "rayproject/ray:latest",
+				rayVersion:     "latest",
+				rayStartParams: map[string]string{},
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, createWorkerGroupSpec(tt.options))
+			cmd := &cobra.Command{}
+			for key, value := range tt.flags {
+				cmd.Flags().String(key, value, "")
+			}
+
+			options := &CreateWorkerGroupOptions{
+				rayVersion: "latest",
+			}
+
+			err := options.Complete(cmd, tt.args)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected.namespace, options.namespace)
+				assert.Equal(t, tt.expected.groupName, options.groupName)
+				assert.Equal(t, tt.expected.image, options.image)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
> It's weird to put checking in createWorkerGroupSpec, so rayStartParams will be moved to options.Complete()

### In `kubectl-plugin/pkg/cmd/create/create_workergroup.go`
The `rayStartParams` will be check in `func (options *CreateWorkerGroupOptions) Complete(cmd *cobra.Command, args []string)`

## Related issue number
Closes #3259 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
