### PR TITLE
[Prometheus] Add `ray_services_ready_duration_seconds` metric

### DIFF
--- a/ray-operator/controllers/ray/common/metric_test.go
+++ b/ray-operator/controllers/ray/common/metric_test.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestObserveRayServicesReadyDuration(t *testing.T) {
+	ObserveRayServicesReadyDuration("default", 2*time.Minute)
+
+	metric := `
+	# HELP ray_services_ready_duration_seconds The time between RayServices created to ready
+	# TYPE ray_services_ready_duration_seconds histogram
+	ray_services_ready_duration_seconds_bucket{namespace="default",le="30"} 0
+	ray_services_ready_duration_seconds_bucket{namespace="default",le="60"} 0
+	ray_services_ready_duration_seconds_bucket{namespace="default",le="120"} 1
+	ray_services_ready_duration_seconds_bucket{namespace="default",le="180"} 1
+	ray_services_ready_duration_seconds_bucket{namespace="default",le="240"} 1
+	ray_services_ready_duration_seconds_bucket{namespace="default",le="300"} 1
+	ray_services_ready_duration_seconds_bucket{namespace="default",le="600"} 1
+	ray_services_ready_duration_seconds_bucket{namespace="default",le="900"} 1
+	ray_services_ready_duration_seconds_bucket{namespace="default",le="1800"} 1
+	ray_services_ready_duration_seconds_bucket{namespace="default",le="3600"} 1
+	ray_services_ready_duration_seconds_count{namespace="default"} 1
+	ray_services_ready_duration_seconds_sum{namespace="default"} 120
+	`
+
+	if err := testutil.CollectAndCompare(rayServicesReadyHistogram, strings.NewReader(metric)); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -734,12 +734,9 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	} else if len(headPods.Items) == 0 {
 		// Create head Pod if it does not exist.
 		logger.Info("reconcilePods: Found 0 head Pods; creating a head Pod for the RayCluster.")
-		common.CreatedClustersCounterInc(instance.Namespace)
 		if err := r.createHeadPod(ctx, *instance); err != nil {
-			common.FailedClustersCounterInc(instance.Namespace)
 			return errstd.Join(utils.ErrFailedCreateHeadPod, err)
 		}
-		common.SuccessfulClustersCounterInc(instance.Namespace)
 	} else if len(headPods.Items) > 1 { // This should never happen. This protects against the case that users manually create headpod.
 		correctHeadPodName := instance.Name + "-head"
 		headPodNames := make([]string, len(headPods.Items))

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add `ray_services_ready_duration_seconds` metric to track The time between RayServices created to ready (created to [RayServiceReady](https://github.com/ray-project/kuberay/blob/33ee6724ca2a429c77cb7ff5821ba9a3d63f7c34/ray-operator/apis/ray/v1/rayservice_types.go#L135))

### Manual test
```
$ k apply -f config/samples/ray-service.sample.yaml

$ echo $(( $(date -d "$(kubectl get rayservice rayservice-sample -o jsonpath='{.status.conditions[?(@.type=="Ready")].lastTransitionTime}')" +%s) - $(date -d "$(kubectl get rayservice rayservice-sample -o jsonpath='{.metadata.creationTimestamp}')" +%s) )) seconds
62 seconds

$ k apply -f config/samples/ray-service.sample.yaml -n test

$ echo $(( $(date -d "$(kubectl get rayservice rayservice-sample -n test -o jsonpath='{.status.conditions[?(@.type=="Ready")].lastTransitionTime}')" +%s) - $(date -d "$(kubectl get rayservice rayservice-sample -n test -o jsonpath='{.metadata.creationTimestamp}')" +%s) )) seconds
32 seconds

$ k apply -f config/samples/ray-service.sample-2.yaml

$ echo $(( $(date -d "$(kubectl get rayservice rayservice-sample-2 -o jsonpath='{.status.conditions[?(@.type=="Ready")].lastTransitionTime}')" +%s) - $(date -d "$(kubectl get rayservice rayservice-sample-2 -o jsonpath='{.metadata.creationTimestamp}')" +%s) )) seconds
32 seconds
```
![image](https://github.com/user-attachments/assets/24ab9465-faa1-4b5e-8338-addc335696c8)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #3177

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
