### PR TITLE
Add Helm chart unittests for ray-cluster

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -1,322 +1,406 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  labels:
-{{ include "ray-cluster.labels" . | indent 4 }}
   name: {{ include "ray-cluster.fullname" . }}
-  {{ if .Values.annotations }}
-  annotations: {{ toYaml .Values.annotations | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ray-cluster.labels" . | nindent 4 }}
+  {{ with .Values.annotations }}
+  annotations: 
+    {{- toYaml . | nindent 4 }}
   {{ end }}
 spec:
-  {{- if .Values.head.rayVersion }}
-  rayVersion: {{ .Values.head.rayVersion }}
+  {{- with .Values.head.rayVersion }}
+  rayVersion: {{ . }}
   {{- end }}
-  {{- if .Values.head.enableInTreeAutoscaling }}
-  enableInTreeAutoscaling: {{ .Values.head.enableInTreeAutoscaling }}
+  {{- with .Values.head.enableInTreeAutoscaling }}
+  enableInTreeAutoscaling: {{ . }}
   {{- end }}
-  {{- if .Values.head.autoscalerOptions }}
-  autoscalerOptions: {{- toYaml .Values.head.autoscalerOptions | nindent 4 }}
+  {{- with .Values.head.autoscalerOptions }}
+  autoscalerOptions: 
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   headGroupSpec:
-    {{- if .Values.head.headService }}
-    headService: {{- toYaml .Values.head.headService | nindent 6 }}
+    {{- with .Values.head.headService }}
+    headService:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
-    serviceType: {{ .Values.service.type }}
+    {{- with .Values.service.type }}
+    serviceType: {{ . }}
+    {{- end }}
+    {{- if or .Values.head.rayStartParams .Values.head.initArgs }}
     rayStartParams:
-    {{- if and (not .Values.head.rayStartParams) (not .Values.head.initArgs) }}
-      {}
-    {{- else }}
       {{- range $key, $val := .Values.head.rayStartParams }}
         {{ $key }}: {{ $val | quote }}
       {{- end }}
-      {{- /*
-      initArgs is a deprecated alias for rayStartParams.
-      */}}
+      {{- /* initArgs is a deprecated alias for rayStartParams. */}}
       {{- range $key, $val := .Values.head.initArgs }}
         {{ $key }}: {{ $val | quote }}
       {{- end }}
+    {{- else }}
+    rayStartParams: {}
     {{- end }}
     template:
+      metadata:
+        labels:
+          {{- include "ray-cluster.labels" . | nindent 10 }}
+        {{- with .Values.head.labels }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.head.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
-        {{- if .Values.head.dnsConfig }}
-        dnsConfig: {{- toYaml .Values.head.dnsConfig | nindent 10 }}
-        {{- end }}
-        imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
-        {{- if .Values.head.serviceAccountName }}
-        serviceAccountName: {{ .Values.head.serviceAccountName }}
-        {{- end }}
-        {{- if .Values.head.restartPolicy }}
-        restartPolicy: {{ .Values.head.restartPolicy }}
-        {{- end }}
-        {{- if .Values.head.initContainers }}
-        initContainers: {{- toYaml .Values.head.initContainers | nindent 10 }}
+        {{- with .Values.head.initContainers }}
+        initContainers:
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         containers:
-          - {{ if .Values.head.volumeMounts }}
-            volumeMounts: {{- toYaml .Values.head.volumeMounts | nindent 12 }}
-            {{- end }}
-            name: ray-head
-            {{- if .Values.head.image }}
-            image: {{ .Values.head.image.repository }}:{{ .Values.head.image.tag }}
-            imagePullPolicy: {{ .Values.head.image.pullPolicy }}
-            {{- else }}
-            image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-            imagePullPolicy: {{ .Values.image.pullPolicy }}
-            {{- end }}
-            resources: {{- toYaml .Values.head.resources | nindent 14 }}
-            securityContext:
-            {{- toYaml .Values.head.securityContext | nindent 14 }}
-            {{- with concat .Values.common.containerEnv .Values.head.containerEnv }}
-            env:
-            {{- toYaml . | nindent 14 }}
-            {{- end }}
-            {{- with .Values.head.envFrom }}
-            envFrom: {{- toYaml . | nindent 14}}
-            {{- end }}
-            {{- if .Values.head.ports }}
-            ports: {{- toYaml .Values.head.ports | nindent 14}}
-            {{- end }}
-            {{- if .Values.head.lifecycle }}
-            lifecycle:
-            {{- toYaml .Values.head.lifecycle | nindent 14 }}
-            {{- end }}
-            {{- if .Values.head.command }}
-            command: {{- toYaml .Values.head.command | nindent 14}}
-            {{- end }}
-            {{- if .Values.head.args }}
-            args: {{- toYaml .Values.head.args | nindent 14}}
-            {{- end }}
-          {{- if .Values.head.sidecarContainers }}
-          {{- toYaml .Values.head.sidecarContainers | nindent 10 }}
+        - name: ray-head
+          {{- if .Values.head.image }}
+          image: {{ .Values.head.image.repository }}:{{ .Values.head.image.tag }}
+          imagePullPolicy: {{ .Values.head.image.pullPolicy }}
+          {{- else }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- end }}
-        {{ if .Values.head.volumes }}
-        volumes: {{- toYaml .Values.head.volumes | nindent 10 }}
+          {{- with .Values.head.command }}
+          command:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.head.args }}
+          args:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with concat .Values.common.containerEnv .Values.head.containerEnv }}
+          env:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.head.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{ with .Values.head.volumeMounts }}
+          volumeMounts:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.head.ports }}
+          ports:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.head.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.head.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.head.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- with .Values.head.sidecarContainers }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.head.topologySpreadConstraints.enabled }}
-        topologySpreadConstraints: {{- toYaml .Values.head.topologySpreadConstraints | nindent 10 }}
+        {{- with .Values.imagePullSecrets }}
+        imagePullSecrets:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
-        affinity: {{- toYaml .Values.head.affinity | nindent 10 }}
-        {{ if .Values.head.priorityClassName }}
-        priorityClassName: {{- toYaml .Values.head.priorityClassName | nindent 10 }}
+        {{- with .Values.head.volumes }}
+        volumes:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{ if .Values.head.priority }}
-        priority: {{- toYaml .Values.head.priority | nindent 10 }}
+        {{- with .Values.head.dnsConfig }}
+        dnsConfig:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
-        tolerations: {{- toYaml .Values.head.tolerations | nindent 10 }}
-        nodeSelector: {{- toYaml .Values.head.nodeSelector | nindent 10 }}
+        {{- with .Values.head.nodeSelector }}
+        nodeSelector:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.head.affinity }}
+        affinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.head.tolerations }}
+        tolerations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.head.priorityClassName }}
+        priorityClassName: {{ . }}
+        {{- end }}
+        {{- with .Values.head.priority }}
+        priority: {{ . }}
+        {{- end }}
+        {{- with .Values.head.topologySpreadConstraints }}
+        topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.head.restartPolicy }}
+        restartPolicy: {{ . }}
+        {{- end }}
+        {{- with .Values.head.serviceAccountName }}
+        serviceAccountName: {{ . }}
+        {{- end }}
         {{- with .Values.head.podSecurityContext }}
         securityContext:
-        {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
-      metadata:
-        annotations: {{- toYaml .Values.head.annotations | nindent 10 }}
-        {{- if .Values.head.labels }}
-        labels: {{- toYaml .Values.head.labels | nindent 10 }}
-{{ include "ray-cluster.labels" . | indent 10 }}
-        {{ else }}
-        labels: {{ include "ray-cluster.labels" . | nindent 10 }}
-        {{- end }}
-
   workerGroupSpecs:
-  {{- range $groupName, $values := .Values.additionalWorkerGroups }}
-  {{- if ne $values.disabled true }}
-  - rayStartParams:
-    {{- if and (not $values.rayStartParams) (not $values.initArgs) }}
-      {}
-    {{- else }}
-      {{- range $key, $val := $values.rayStartParams }}
-        {{ $key }}: {{ $val | quote }}
-      {{- end }}
-      {{- /*
-      initArgs is a deprecated alias for rayStartParams.
-      */}}
-      {{- range $key, $val := $values.initArgs }}
-        {{ $key }}: {{ $val | quote }}
-      {{- end }}
-    {{- end }}
-    replicas: {{ $values.replicas }}
-    minReplicas: {{ $values.minReplicas | default 0 }}
-    maxReplicas: {{ $values.maxReplicas | default 2147483647 }}
-    numOfHosts: {{ $values.numOfHosts | default 1 }}
-    groupName: {{ $groupName }}
-    template:
-      spec:
-        {{- if $values.dnsConfig }}
-        dnsConfig: {{- toYaml $values.dnsConfig | nindent 10 }}
-        {{- end }}
-        imagePullSecrets: {{- toYaml $.Values.imagePullSecrets | nindent 10 }}
-        {{- if $values.serviceAccountName }}
-        serviceAccountName: {{ $values.serviceAccountName }}
-        {{- end }}
-        {{- if $values.restartPolicy }}
-        restartPolicy: {{ $values.restartPolicy }}
-        {{- end }}
-        {{- if $values.initContainers }}
-        initContainers: {{- toYaml $values.initContainers | nindent 10 }}
-        {{- end }}
-        containers:
-          - {{ if $values.volumeMounts }}
-            volumeMounts: {{- toYaml $values.volumeMounts | nindent 12 }}
-            {{- end }}
-            name: ray-worker
-            {{- if $values.image }}
-            image: {{ $values.image.repository }}:{{ $values.image.tag }}
-            imagePullPolicy: {{ $values.image.pullPolicy }}
-            {{- else }}
-            image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
-            imagePullPolicy: {{ $.Values.image.pullPolicy }}
-            {{- end }}
-            resources: {{- toYaml $values.resources | nindent 14 }}
-            securityContext:
-            {{- toYaml $values.securityContext | nindent 14 }}
-            {{- with concat $.Values.common.containerEnv ($values.containerEnv | default list) }}
-            env:
-            {{- toYaml . | nindent 14 }}
-            {{- end }}
-            {{- if $values.envFrom }}
-            envFrom: {{- toYaml $values.envFrom | nindent 14 }}
-            {{- end }}
-            {{- if $values.ports }}
-            ports: {{- toYaml $values.ports | nindent 14}}
-            {{- end }}
-            {{- if $values.lifecycle }}
-            lifecycle:
-            {{- toYaml $values.lifecycle | nindent 14 }}
-            {{- end }}
-            {{- if $values.command }}
-            command: {{- toYaml $values.command | nindent 14}}
-            {{- end }}
-            {{- if $values.args }}
-            args: {{- toYaml $values.args | nindent 14}}
-            {{- end }}
-          {{- if $values.sidecarContainers }}
-          {{- toYaml $values.sidecarContainers | nindent 10 }}
-          {{- end }}
-        {{ if $values.volumes }}
-        volumes: {{- toYaml $values.volumes | nindent 10 }}
-        {{- end }}
-        {{- if $values.topologySpreadConstraints }}
-        topologySpreadConstraints: {{- toYaml $values.topologySpreadConstraints | nindent 10 }}
-        {{- end }}
-        affinity: {{- toYaml $values.affinity | nindent 10 }}
-        {{ if $values.priorityClassName }}
-        priorityClassName: {{- toYaml $values.priorityClassName | nindent 10 }}
-        {{- end }}
-        {{ if $values.priority }}
-        priority: {{- toYaml $values.priority | nindent 10 }}
-        {{- end }}
-        tolerations: {{- toYaml $values.tolerations | nindent 10 }}
-        nodeSelector: {{- toYaml $values.nodeSelector | nindent 10 }}
-        {{- with $values.podSecurityContext }}
-        securityContext:
-        {{- toYaml . | nindent 10 }}
-        {{- end }}
-      metadata:
-        annotations: {{- toYaml $values.annotations | nindent 10 }}
-        {{- if $values.labels }}
-        labels: {{- toYaml $values.labels | nindent 10 }}
-{{ include "ray-cluster.labels" $ | indent 10 }}
-        {{ else }}
-        labels: {{ include "ray-cluster.labels" $ | nindent 10 }}
-        {{- end }}
-
-  {{- end }}
-  {{- end }}
-  {{- if ne (.Values.worker.disabled | default false) true }}
-  - rayStartParams:
-    {{- if and (not .Values.worker.rayStartParams) (not .Values.worker.initArgs) }}
-      {}
-    {{- else }}
-      {{- range $key, $val := .Values.worker.rayStartParams }}
-        {{ $key }}: {{ $val | quote }}
-      {{- end }}
-      {{- /*
-      initArgs is a deprecated alias for rayStartParams.
-      */}}
-      {{- range $key, $val := .Values.worker.initArgs }}
-        {{ $key }}: {{ $val | quote }}
-      {{- end }}
-    {{- end }}
+  {{- if not .Values.worker.disabled }}
+  - groupName: {{ .Values.worker.groupName }}
     replicas: {{ .Values.worker.replicas }}
     minReplicas: {{ .Values.worker.minReplicas | default 0 }}
     maxReplicas: {{ .Values.worker.maxReplicas | default 2147483647 }}
     numOfHosts: {{ .Values.worker.numOfHosts | default 1 }}
-    groupName: {{ .Values.worker.groupName }}
+    {{- if or .Values.worker.rayStartParams .Values.worker.initArgs }}
+    rayStartParams:
+      {{- range $key, $val := .Values.worker.rayStartParams }}
+      {{ $key }}: {{ $val | quote }}
+      {{- end }}
+      {{- /* initArgs is a deprecated alias for rayStartParams. */}}
+      {{- range $key, $val := .Values.worker.initArgs }}
+      {{ $key }}: {{ $val | quote }}
+      {{- end }}
+    {{- else }}
+    rayStartParams: {}
+    {{- end }}
     template:
+      metadata:
+        labels:
+          {{- include "ray-cluster.labels" . | nindent 10 }}
+        {{- with .Values.worker.labels }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.worker.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
-        {{- if .Values.worker.dnsConfig }}
-        dnsConfig: {{- toYaml .Values.worker.dnsConfig | nindent 10 }}
-        {{- end }}
-        imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 10 }}
-        {{- if .Values.worker.serviceAccountName }}
-        serviceAccountName: {{ .Values.worker.serviceAccountName }}
-        {{- end }}
-        {{- if .Values.worker.restartPolicy }}
-        restartPolicy: {{ .Values.worker.restartPolicy }}
-        {{- end }}
-        {{- if .Values.worker.initContainers }}
-        initContainers: {{- toYaml .Values.worker.initContainers | nindent 10 }}
+        {{- with .Values.worker.initContainers }}
+        initContainers:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         containers:
-          - {{ if .Values.worker.volumeMounts }}
-            volumeMounts: {{- toYaml .Values.worker.volumeMounts | nindent 12 }}
-            {{- end }}
-            name: ray-worker
-            {{- if .Values.worker.image }}
-            image: {{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}
-            imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
-            {{- else }}
-            image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-            imagePullPolicy: {{ .Values.image.pullPolicy }}
-            {{- end }}
-            resources: {{- toYaml .Values.worker.resources | nindent 14 }}
-            securityContext:
-            {{- toYaml .Values.worker.securityContext | nindent 14 }}
-            {{- with concat .Values.common.containerEnv .Values.worker.containerEnv }}
-            env:
-            {{- toYaml . | nindent 14 }}
-            {{- end }}
-            {{- with .Values.worker.envFrom }}
-            envFrom: {{- toYaml . | nindent 14}}
-            {{- end }}
-            {{- if .Values.worker.ports }}
-            ports: {{- toYaml .Values.worker.ports | nindent 14}}
-            {{- end }}
-            {{- if .Values.worker.lifecycle }}
-            lifecycle:
-            {{- toYaml .Values.worker.lifecycle | nindent 14 }}
-            {{- end }}
-            {{- if .Values.worker.command }}
-            command: {{- toYaml .Values.worker.command | nindent 14}}
-            {{- end }}
-            {{- if .Values.worker.args }}
-            args: {{- toYaml .Values.worker.args | nindent 14}}
-            {{- end }}
-          {{- if .Values.worker.sidecarContainers }}
-          {{- toYaml .Values.worker.sidecarContainers | nindent 10 }}
+        - name: ray-worker
+          {{- if .Values.worker.image }}
+          image: {{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          {{- else }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- end }}
-        {{ if .Values.worker.volumes }}
-        volumes: {{- toYaml .Values.worker.volumes | nindent 10 }}
+          {{- with .Values.worker.command }}
+          command:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.worker.args }}
+          args:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with concat .Values.common.containerEnv .Values.worker.containerEnv }}
+          env:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.worker.envFrom }}
+          envFrom: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.worker.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with .Values.worker.ports }}
+          ports:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with .Values.worker.resources }}
+          resources:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with .Values.worker.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with .Values.worker.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+        {{- with .Values.worker.sidecarContainers }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
-        affinity: {{- toYaml .Values.worker.affinity | nindent 10 }}
-        {{ if .Values.worker.priorityClassName }}
-        priorityClassName: {{- toYaml .Values.worker.priorityClassName | nindent 10 }}
+        {{- with .Values.imagePullSecrets }}
+        imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{ if .Values.worker.priority }}
-        priority: {{- toYaml .Values.worker.priority | nindent 10 }}
+        {{- with .Values.worker.volumes }}
+        volumes:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
-        tolerations: {{- toYaml .Values.worker.tolerations | nindent 10 }}
-        nodeSelector: {{- toYaml .Values.worker.nodeSelector | nindent 10 }}
-        {{- with .Values.worker.podSecurityContext}}
+        {{- with .Values.worker.dnsConfig }}
+        dnsConfig:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.worker.nodeSelector }}
+        nodeSelector:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.worker.affinity }}
+        affinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.worker.tolerations }}
+        tolerations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.worker.priorityClassName }}
+        priorityClassName: {{ . }}
+        {{- end }}
+        {{- with .Values.worker.priority }}
+        priority: {{ . }}
+        {{- end }}
+        {{- with .Values.worker.topologySpreadConstraints }}
+        topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.worker.restartPolicy }}
+        restartPolicy: {{ . }}
+        {{- end }}
+        {{- with .Values.worker.serviceAccountName }}
+        serviceAccountName: {{ . }}
+        {{- end }}
+        {{- with .Values.worker.podSecurityContext }}
         securityContext:
-        {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
+  {{- end }}
+  {{- range $groupName, $values := .Values.additionalWorkerGroups }}
+  {{- if not $values.disabled }}
+  - groupName: {{ $groupName }}
+    replicas: {{ $values.replicas }}
+    minReplicas: {{ $values.minReplicas | default 0 }}
+    maxReplicas: {{ $values.maxReplicas | default 2147483647 }}
+    numOfHosts: {{ $values.numOfHosts | default 1 }}
+    {{- if or $values.rayStartParams $values.initArgs }}
+    rayStartParams:
+      {{- range $key, $val := $values.rayStartParams }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
+      {{- /* initArgs is a deprecated alias for rayStartParams. */}}
+      {{- range $key, $val := $values.initArgs }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
+    {{- else }}
+    rayStartParams: {}
+    {{- end }}
+    template:
       metadata:
-        annotations: {{- toYaml .Values.worker.annotations | nindent 10 }}
-        {{- if .Values.worker.labels }}
-        labels: {{- toYaml .Values.worker.labels | nindent 10 }}
-{{ include "ray-cluster.labels" . | indent 10 }}
-        {{ else }}
-        labels: {{ include "ray-cluster.labels" $ | nindent 10 }}
+        labels:
+          {{- include "ray-cluster.labels" $ | nindent 10 }}
+        {{- with $values.labels }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with $values.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        {{- with $values.initContainers }}
+        initContainers:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        containers:
+        - name: ray-worker
+          {{- if $values.image }}
+          image: {{ $values.image.repository }}:{{ $values.image.tag }}
+          imagePullPolicy: {{ $values.image.pullPolicy }}
+          {{- else }}
+          image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          {{- end }}
+          {{- with $values.command }}
+          command:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with $values.args }}
+          args:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with concat $.Values.common.containerEnv ($values.containerEnv | default list) }}
+          env:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with $values.envFrom }}
+          envFrom:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with $values.volumeMounts }}
+          volumeMounts:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with $values.ports }}
+          ports:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with $values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- with $values.sidecarContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.imagePullSecrets }}
+        imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $values.volumes }}
+        volumes:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $values.dnsConfig }}
+        dnsConfig:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $values.nodeSelector }}
+        nodeSelector:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $values.affinity }}
+        affinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $values.tolerations }}
+        tolerations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $values.priorityClassName }}
+        priorityClassName: {{ . }}
+        {{- end }}
+        {{- with $values.priority }}
+        priority: {{ . }}
+        {{- end }}
+        {{- with $values.topologySpreadConstraints }}
+        topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $values.restartPolicy }}
+        restartPolicy: {{ . }}
+        {{- end }}
+        {{- with $values.serviceAccountName }}
+        serviceAccountName: {{ . }}
+        {{- end }}
+        {{- with $values.podSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+  {{- end }}
   {{- end }}

--- a/helm-chart/ray-cluster/tests/raycluster_test.yaml
+++ b/helm-chart/ray-cluster/tests/raycluster_test.yaml
@@ -1,0 +1,2128 @@
+suite: Test RayCluster
+
+templates:
+  - raycluster-cluster.yaml
+
+release:
+  name: test
+  namespace: ray
+
+tests:
+  - it: Should create a RayCluster
+    asserts:
+      - containsDocument:
+          apiVersion: ray.io/v1
+          kind: RayCluster
+          name: test-kuberay
+          namespace: ray
+
+  - it: Should set Ray version when `head.rayVersion` is set
+    set:
+      head:
+        rayVersion: 2.44.1
+    asserts:
+      - equal:
+          path: spec.rayVersion
+          value: 2.44.1
+
+  - it: Should enable in-tree auto scaling when `head.enableInTreeAutoscaling` is `true`
+    set:
+      head:
+        enableInTreeAutoscaling: true
+    asserts:
+      - equal:
+          path: spec.enableInTreeAutoscaling
+          value: true
+
+  - it: Should use the specified auto scaler options when `head.autoScalerOptions` is set
+    set:
+      head:
+        autoscalerOptions:
+          upscalingMode: Default
+          idleTimeoutSeconds: 60
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ENV_KEY
+              value: ENV_VALUE
+          envFrom:
+            - configMapRef:
+                name: test-cm
+            - secretRef:
+                name: test-secret
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+    asserts:
+      - equal:
+          path: spec.autoscalerOptions
+          value:
+            upscalingMode: Default
+            idleTimeoutSeconds: 60
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: ENV_KEY
+                value: ENV_VALUE
+            envFrom:
+              - configMapRef:
+                  name: test-cm
+              - secretRef:
+                  name: test-secret
+            resources:
+              limits:
+                cpu: 500m
+                memory: 512Mi
+              requests:
+                cpu: 500m
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+
+  # ===========================================================================
+  # Test Head Group
+  # ===========================================================================
+
+  - it: Should use the specified head service if `head.headService` is set
+    set:
+      head:
+        headService:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-head-service
+            namespace: ray
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.headService
+          value:
+            apiVersion: v1
+            kind: Service
+            metadata:
+              name: test-head-service
+              namespace: ray
+
+  - it: Should use the specified service type if `service.type` is set
+    set:
+      service:
+        type: LoadBalancer
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.serviceType
+          value: LoadBalancer
+
+  - it: Should add ray start parameters if `head.rayStartParams` is set
+    set:
+      head:
+        rayStartParams:
+          dashboard-host: 0.0.0.0
+          num-cpus: "4"
+          num-gpus: "2"
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.rayStartParams
+          value:
+            dashboard-host: 0.0.0.0
+            num-cpus: "4"
+            num-gpus: "2"
+
+  - it: Should add ray start parameters if `head.initArgs` is set
+    set:
+      head:
+        initArgs:
+          dashboard-host: 0.0.0.0
+          num-cpus: "4"
+          num-gpus: "2"
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.rayStartParams
+          value:
+            dashboard-host: 0.0.0.0
+            num-cpus: "4"
+            num-gpus: "2"
+
+  - it: Should add ray start parameters if both `head.rayStartParams` and `head.initArgs` are set
+    set:
+      head:
+        rayStartParams:
+          dashboard-host: 0.0.0.0
+          port: "6379"
+        initArgs:
+          num-cpus: "4"
+          num-gpus: "2"
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.rayStartParams
+          value:
+            dashboard-host: 0.0.0.0
+            port: "6379"
+            num-cpus: "4"
+            num-gpus: "2"
+
+  - it: Should add the specified labels if `head.labels` is set
+    set:
+      head:
+        labels:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.metadata.labels.key1
+          value: value1
+      - equal:
+          path: spec.headGroupSpec.template.metadata.labels.key2
+          value: value2
+
+  - it: Should add the specified annotations if `head.annotations` is set
+    set:
+      head:
+        annotations:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.metadata.annotations.key1
+          value: value1
+      - equal:
+          path: spec.headGroupSpec.template.metadata.annotations.key2
+          value: value2
+
+  - it: Should add init containers if `head.initContainers` is set
+    set:
+      head:
+        initContainers:
+          - name: test-init-container-1
+            image: test-image-1
+            command:
+              - echo
+              - "Hello, Ray!"
+          - name: test-init-container-2
+            image: test-image-2
+            command:
+              - echo
+              - "Hello, Kuberay!"
+    asserts:
+      - contains:
+          path: spec.headGroupSpec.template.spec.initContainers
+          content:
+            name: test-init-container-1
+            image: test-image-1
+            command:
+              - echo
+              - "Hello, Ray!"
+      - contains:
+          path: spec.headGroupSpec.template.spec.initContainers
+          content:
+            name: test-init-container-2
+            image: test-image-2
+            command:
+              - echo
+              - "Hello, Kuberay!"
+
+  - it: Should first use the image specified by `head.image`
+    set:
+      image:
+        repository: test-repository-1
+        tag: test-tag-1
+        pullPolicy: IfNotPresent
+      head:
+        image:
+          repository: test-repository-2
+          tag: test-tag-2
+          pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name == "ray-head")].image
+          value: test-repository-2:test-tag-2
+      - equal:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name == "ray-head")].imagePullPolicy
+          value: Always
+
+  - it: Should use the image specified by `image` if `head.image` is not set
+    set:
+      image:
+        repository: test-repository
+        tag: test-tag
+        pullPolicy: Always
+      head:
+        image: {}
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name == "ray-head")].image
+          value: test-repository:test-tag
+      - equal:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name == "ray-head")].imagePullPolicy
+          value: Always
+
+  - it: Should add command if `head.command` is set
+    set:
+      head:
+        command:
+          - /bin/bash
+          - -c
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name == "ray-head")].command
+          value:
+            - /bin/bash
+            - -c
+
+  - it: Should add args if `head.args` is set
+    set:
+      head:
+        args:
+          - arg1
+          - arg2
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name == "ray-head")].args
+          value:
+            - arg1
+            - arg2
+
+  - it: Should add env specified by `common.containerEnv` and `head.containerEnv`
+    set:
+      common:
+        containerEnv:
+          - name: KEY1
+            value: VALUE1
+          - name: KEY2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: TEST_KEY2
+                optional: false
+          - name: KEY3
+            valueFrom:
+              secretRef:
+                name: test-secret
+                key: TEST_KEY3
+                optional: false
+      head:
+        containerEnv:
+          - name: KEY4
+            value: VALUE4
+          - name: KEY5
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: TEST_KEY5
+                optional: false
+          - name: KEY6
+            valueFrom:
+              secretRef:
+                name: test-secret
+                key: TEST_KEY6
+                optional: false
+    asserts:
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].env
+          content:
+            name: KEY1
+            value: VALUE1
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].env
+          content:
+            name: KEY2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: TEST_KEY2
+                optional: false
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].env
+          content:
+            name: KEY3
+            valueFrom:
+              secretRef:
+                name: test-secret
+                key: TEST_KEY3
+                optional: false
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].env
+          content:
+            name: KEY4
+            value: VALUE4
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].env
+          content:
+            name: KEY5
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: TEST_KEY5
+                optional: false
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].env
+          content:
+            name: KEY6
+            valueFrom:
+              secretRef:
+                name: test-secret
+                key: TEST_KEY6
+                optional: false
+
+  - it: Should add envFrom if `head.envFrom` is set
+    set:
+      head:
+        envFrom:
+          - configMapRef:
+              name: test-configmap
+          - secretRef:
+              name: test-secret
+    asserts:
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].envFrom
+          content:
+            configMapRef:
+              name: test-configmap
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].envFrom
+          content:
+            secretRef:
+              name: test-secret
+
+  - it: Should add volumeMounts if `head.volumeMounts` is set
+    set:
+      head:
+        volumeMounts:
+          - name: test-volume-1
+            mountPath: /mnt/test-volume-1
+          - name: test-volume-2
+            mountPath: /mnt/test-volume-2
+    asserts:
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].volumeMounts
+          content:
+            name: test-volume-1
+            mountPath: /mnt/test-volume-1
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].volumeMounts
+          content:
+            name: test-volume-2
+            mountPath: /mnt/test-volume-2
+
+  - it: Should add container ports if `head.ports` is set
+    set:
+      head:
+        ports:
+          - name: port1
+            containerPort: 1234
+            protocol: TCP
+          - name: port2
+            containerPort: 5678
+            protocol: UDP
+    asserts:
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].ports
+          content:
+            name: port1
+            containerPort: 1234
+            protocol: TCP
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].ports
+          content:
+            name: port2
+            containerPort: 5678
+            protocol: UDP
+
+  - it: Should add resources if `head.resources` is set
+    set:
+      head:
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 250m
+          limits:
+            memory: 128Mi
+            cpu: 500m
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].resources
+          value:
+            requests:
+              memory: 64Mi
+              cpu: 250m
+            limits:
+              memory: 128Mi
+              cpu: 500m
+
+  - it: Should add lifecycle if `head.lifecycle` is set
+    set:
+      head:
+        lifecycle:
+          postStart:
+            httpGet:
+              port: 80
+              path: /healthz
+          preStop:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  echo "Pre-stop command executed"
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].lifecycle
+          value:
+            postStart:
+              httpGet:
+                port: 80
+                path: /healthz
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    echo "Pre-stop command executed"
+
+  - it: Should add container security context if `head.securityContext` is set
+    set:
+      head:
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].securityContext
+          value:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+
+  - it: Should add sidecar containers if `head.sidecarContainers` is set
+    set:
+      head:
+        sidecarContainers:
+          - name: sidecar-1
+            image: sidecar-image-1
+          - name: sidecar-2
+            image: sidecar-image-2
+    asserts:
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers
+          content:
+            name: sidecar-1
+            image: sidecar-image-1
+      - contains:
+          path: spec.headGroupSpec.template.spec.containers
+          content:
+            name: sidecar-2
+            image: sidecar-image-2
+
+  - it: Should use the specified image pull secrets if `imagePullSecrets` is set
+    set:
+      imagePullSecrets:
+        - name: test-secret-1
+        - name: test-secret-2
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.imagePullSecrets
+          value:
+            - name: test-secret-1
+            - name: test-secret-2
+
+  - it: Should add volumes if `head.volumes` is set
+    set:
+      head:
+        volumes:
+          - name: volume1
+            emptyDir:
+              sizeLimit: 1Gi
+          - name: volume2
+            hostPath:
+              path: /host/path
+    asserts:
+      - contains:
+          path: spec.headGroupSpec.template.spec.volumes
+          content:
+            name: volume1
+            emptyDir:
+              sizeLimit: 1Gi
+      - contains:
+          path: spec.headGroupSpec.template.spec.volumes
+          content:
+            name: volume2
+            hostPath:
+              path: /host/path
+
+  - it: Should use the specified dns config if `head.dnsConfig` is set
+    set:
+      head:
+        dnsConfig:
+          nameservers:
+            - 8.8.8.8
+          searches:
+            - example.local
+          options:
+            - name: ndots
+              value: "2"
+            - name: edns0
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.dnsConfig
+          value:
+            nameservers:
+              - 8.8.8.8
+            searches:
+              - example.local
+            options:
+              - name: ndots
+                value: "2"
+              - name: edns0
+
+  - it: Should add nodeSelector if `head.nodeSelector` is set
+    set:
+      head:
+        nodeSelector:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.nodeSelector.key1
+          value: value1
+      - equal:
+          path: spec.headGroupSpec.template.spec.nodeSelector.key2
+          value: value2
+
+  - it: Should add affinity if `head.affinity` is set
+    set:
+      head:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - antarctica-east1
+                        - antarctica-west1
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: another-node-label-key
+                      operator: In
+                      values:
+                        - another-node-label-value
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.affinity
+          value:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: topology.kubernetes.io/zone
+                        operator: In
+                        values:
+                          - antarctica-east1
+                          - antarctica-west1
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: another-node-label-key
+                        operator: In
+                        values:
+                          - another-node-label-value
+
+  - it: Should add tolerations if `head.tolerations` is set
+    set:
+      head:
+        tolerations:
+          - key: key1
+            operator: Equal
+            value: value1
+            effect: NoSchedule
+          - key: key2
+            operator: Exists
+            effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+
+  - it: Should add priorityClassName if `head.priorityClassName` is set
+    set:
+      head:
+        priorityClassName: test-priority-class
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.priorityClassName
+          value: test-priority-class
+
+  - it: Should add priority if `head.priority` is set
+    set:
+      head:
+        priority: 100
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.priority
+          value: 100
+
+  - it: Should add topology spread constraints if `head.topologySpreadConstraints` is set
+    set:
+      head:
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: zone
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                foo: bar
+          - maxSkew: 1
+            topologyKey: node
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                foo: bar
+    asserts:
+      - contains:
+          path: spec.headGroupSpec.template.spec.topologySpreadConstraints
+          content:
+            maxSkew: 1
+            topologyKey: zone
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                foo: bar
+      - contains:
+          path: spec.headGroupSpec.template.spec.topologySpreadConstraints
+          content:
+            maxSkew: 1
+            topologyKey: node
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                foo: bar
+
+  - it: Should use the specified restart policy if `head.restartPolicy` is set
+    set:
+      head:
+        restartPolicy: Always
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.restartPolicy
+          value: Always
+
+  - it: Should use the specified service account name if `head.serviceAccountName` is set
+    set:
+      head:
+        serviceAccountName: test-sa
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.serviceAccountName
+          value: test-sa
+
+  - it: Should add pod securityContext if `head.podSecurityContext` is set
+    set:
+      head:
+        podSecurityContext:
+          runAsUser: 1000
+          runAsGroup: 2000
+          fsGroup: 3000
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.headGroupSpec.template.spec.securityContext.runAsGroup
+          value: 2000
+      - equal:
+          path: spec.headGroupSpec.template.spec.securityContext.fsGroup
+          value: 3000
+
+  # ===========================================================================
+  # Test Default Worker Group
+  # ===========================================================================
+
+  - it: Should add ray start parameters if `worker.rayStartParams` is set
+    set:
+      worker:
+        rayStartParams:
+          dashboard-host: 0.0.0.0
+          num-cpus: "4"
+          num-gpus: "2"
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].rayStartParams
+          value:
+            dashboard-host: 0.0.0.0
+            num-cpus: "4"
+            num-gpus: "2"
+
+  - it: Should add ray start parameters if `worker.initArgs` is set
+    set:
+      worker:
+        initArgs:
+          dashboard-host: 0.0.0.0
+          num-cpus: "4"
+          num-gpus: "2"
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].rayStartParams
+          value:
+            dashboard-host: 0.0.0.0
+            num-cpus: "4"
+            num-gpus: "2"
+
+  - it: Should add ray start parameters if both `worker.rayStartParams` and `worker.initArgs` are set
+    set:
+      worker:
+        rayStartParams:
+          dashboard-host: 0.0.0.0
+          port: "6379"
+        initArgs:
+          num-cpus: "4"
+          num-gpus: "2"
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].rayStartParams
+          value:
+            dashboard-host: 0.0.0.0
+            port: "6379"
+            num-cpus: "4"
+            num-gpus: "2"
+
+  - it: Should add the specified labels if `worker.labels` is set
+    set:
+      worker:
+        labels:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.metadata.labels.key1
+          value: value1
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.metadata.labels.key2
+          value: value2
+
+  - it: Should add the specified annotations if `worker.annotations` is set
+    set:
+      worker:
+        annotations:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.metadata.annotations.key1
+          value: value1
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.metadata.annotations.key2
+          value: value2
+
+  - it: Should add init containers if `worker.initContainers` is set
+    set:
+      worker:
+        initContainers:
+          - name: test-init-container-1
+            image: test-image-1
+            command:
+              - echo
+              - "Hello, Ray!"
+          - name: test-init-container-2
+            image: test-image-2
+            command:
+              - echo
+              - "Hello, Kuberay!"
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.initContainers
+          content:
+            name: test-init-container-1
+            image: test-image-1
+            command:
+              - echo
+              - "Hello, Ray!"
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.initContainers
+          content:
+            name: test-init-container-2
+            image: test-image-2
+            command:
+              - echo
+              - "Hello, Kuberay!"
+
+  - it: Should first use the image specified by `worker.image`
+    set:
+      image:
+        repository: test-repository-1
+        tag: test-tag-1
+        pullPolicy: IfNotPresent
+      worker:
+        image:
+          repository: test-repository-2
+          tag: test-tag-2
+          pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name == "ray-worker")].image
+          value: test-repository-2:test-tag-2
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name == "ray-worker")].imagePullPolicy
+          value: Always
+
+  - it: Should use the image specified by `image` if `worker.image` is not set
+    set:
+      image:
+        repository: test-repository
+        tag: test-tag
+        pullPolicy: Always
+      worker:
+        image: {}
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name == "ray-worker")].image
+          value: test-repository:test-tag
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name == "ray-worker")].imagePullPolicy
+          value: Always
+
+  - it: Should add command if `worker.command` is set
+    set:
+      worker:
+        command:
+          - /bin/bash
+          - -c
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name == "ray-worker")].command
+          value:
+            - /bin/bash
+            - -c
+
+  - it: Should add args if `worker.args` is set
+    set:
+      worker:
+        args:
+          - arg1
+          - arg2
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name == "ray-worker")].args
+          value:
+            - arg1
+            - arg2
+
+  - it: Should add env specified by `common.containerEnv` and `worker.containerEnv`
+    set:
+      common:
+        containerEnv:
+          - name: KEY1
+            value: VALUE1
+          - name: KEY2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: TEST_KEY2
+                optional: false
+          - name: KEY3
+            valueFrom:
+              secretRef:
+                name: test-secret
+                key: TEST_KEY3
+                optional: false
+      worker:
+        containerEnv:
+          - name: KEY4
+            value: VALUE4
+          - name: KEY5
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: TEST_KEY5
+                optional: false
+          - name: KEY6
+            valueFrom:
+              secretRef:
+                name: test-secret
+                key: TEST_KEY6
+                optional: false
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].env
+          content:
+            name: KEY1
+            value: VALUE1
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].env
+          content:
+            name: KEY2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: TEST_KEY2
+                optional: false
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].env
+          content:
+            name: KEY3
+            valueFrom:
+              secretRef:
+                name: test-secret
+                key: TEST_KEY3
+                optional: false
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].env
+          content:
+            name: KEY4
+            value: VALUE4
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].env
+          content:
+            name: KEY5
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: TEST_KEY5
+                optional: false
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].env
+          content:
+            name: KEY6
+            valueFrom:
+              secretRef:
+                name: test-secret
+                key: TEST_KEY6
+                optional: false
+
+  - it: Should add envFrom if `worker.envFrom` is set
+    set:
+      worker:
+        envFrom:
+          - configMapRef:
+              name: test-configmap
+          - secretRef:
+              name: test-secret
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].envFrom
+          content:
+            configMapRef:
+              name: test-configmap
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].envFrom
+          content:
+            secretRef:
+              name: test-secret
+
+  - it: Should add volumeMounts if `worker.volumeMounts` is set
+    set:
+      worker:
+        volumeMounts:
+          - name: test-volume-1
+            mountPath: /mnt/test-volume-1
+          - name: test-volume-2
+            mountPath: /mnt/test-volume-2
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].volumeMounts
+          content:
+            name: test-volume-1
+            mountPath: /mnt/test-volume-1
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].volumeMounts
+          content:
+            name: test-volume-2
+            mountPath: /mnt/test-volume-2
+
+  - it: Should add container ports if `worker.ports` is set
+    set:
+      worker:
+        ports:
+          - name: port1
+            containerPort: 1234
+            protocol: TCP
+          - name: port2
+            containerPort: 5678
+            protocol: UDP
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].ports
+          content:
+            name: port1
+            containerPort: 1234
+            protocol: TCP
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].ports
+          content:
+            name: port2
+            containerPort: 5678
+            protocol: UDP
+
+  - it: Should add resources if `worker.resources` is set
+    set:
+      worker:
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 250m
+          limits:
+            memory: 128Mi
+            cpu: 500m
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].resources
+          value:
+            requests:
+              memory: 64Mi
+              cpu: 250m
+            limits:
+              memory: 128Mi
+              cpu: 500m
+
+  - it: Should add lifecycle if `worker.lifecycle` is set
+    set:
+      worker:
+        lifecycle:
+          postStart:
+            httpGet:
+              port: 80
+              path: /healthz
+          preStop:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  echo "Pre-stop command executed"
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].lifecycle
+          value:
+            postStart:
+              httpGet:
+                port: 80
+                path: /healthz
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    echo "Pre-stop command executed"
+
+  - it: Should add container security context if `worker.securityContext` is set
+    set:
+      worker:
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].securityContext
+          value:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+
+  - it: Should add sidecar containers if `worker.sidecarContainers` is set
+    set:
+      worker:
+        sidecarContainers:
+          - name: sidecar-1
+            image: sidecar-image-1
+          - name: sidecar-2
+            image: sidecar-image-2
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers
+          content:
+            name: sidecar-1
+            image: sidecar-image-1
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers
+          content:
+            name: sidecar-2
+            image: sidecar-image-2
+
+  - it: Should use the specified image pull secrets if `imagePullSecrets` is set
+    set:
+      imagePullSecrets:
+        - name: test-secret-1
+        - name: test-secret-2
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.imagePullSecrets
+          value:
+            - name: test-secret-1
+            - name: test-secret-2
+
+  - it: Should add volumes if `worker.volumes` is set
+    set:
+      worker:
+        volumes:
+          - name: volume1
+            emptyDir:
+              sizeLimit: 1Gi
+          - name: volume2
+            hostPath:
+              path: /host/path
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.volumes
+          content:
+            name: volume1
+            emptyDir:
+              sizeLimit: 1Gi
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.volumes
+          content:
+            name: volume2
+            hostPath:
+              path: /host/path
+
+  - it: Should use the specified dns config if `worker.dnsConfig` is set
+    set:
+      worker:
+        dnsConfig:
+          nameservers:
+            - 8.8.8.8
+          searches:
+            - example.local
+          options:
+            - name: ndots
+              value: "2"
+            - name: edns0
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.dnsConfig
+          value:
+            nameservers:
+              - 8.8.8.8
+            searches:
+              - example.local
+            options:
+              - name: ndots
+                value: "2"
+              - name: edns0
+
+  - it: Should add nodeSelector if `worker.nodeSelector` is set
+    set:
+      worker:
+        nodeSelector:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.nodeSelector.key1
+          value: value1
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.nodeSelector.key2
+          value: value2
+
+  - it: Should add affinity if `worker.affinity` is set
+    set:
+      worker:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - antarctica-east1
+                        - antarctica-west1
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: another-node-label-key
+                      operator: In
+                      values:
+                        - another-node-label-value
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.affinity
+          value:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: topology.kubernetes.io/zone
+                        operator: In
+                        values:
+                          - antarctica-east1
+                          - antarctica-west1
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: another-node-label-key
+                        operator: In
+                        values:
+                          - another-node-label-value
+
+  - it: Should add tolerations if `worker.tolerations` is set
+    set:
+      worker:
+        tolerations:
+          - key: key1
+            operator: Equal
+            value: value1
+            effect: NoSchedule
+          - key: key2
+            operator: Exists
+            effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+
+  - it: Should add priorityClassName if `worker.priorityClassName` is set
+    set:
+      worker:
+        priorityClassName: test-priority-class
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.priorityClassName
+          value: test-priority-class
+
+  - it: Should add priority if `worker.priority` is set
+    set:
+      worker:
+        priority: 100
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.priority
+          value: 100
+
+  - it: Should add topology spread constraints if `worker.topologySpreadConstraints` is set
+    set:
+      worker:
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: zone
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                foo: bar
+          - maxSkew: 1
+            topologyKey: node
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                foo: bar
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.topologySpreadConstraints
+          content:
+            maxSkew: 1
+            topologyKey: zone
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                foo: bar
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.topologySpreadConstraints
+          content:
+            maxSkew: 1
+            topologyKey: node
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                foo: bar
+
+  - it: Should use the specified restart policy if `worker.restartPolicy` is set
+    set:
+      worker:
+        restartPolicy: Always
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.restartPolicy
+          value: Always
+
+  - it: Should use the specified service account name if `worker.serviceAccountName` is set
+    set:
+      worker:
+        serviceAccountName: test-sa
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.serviceAccountName
+          value: test-sa
+
+  - it: Should add pod securityContext if `worker.podSecurityContext` is set
+    set:
+      worker:
+        podSecurityContext:
+          runAsUser: 1000
+          runAsGroup: 2000
+          fsGroup: 3000
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.securityContext.runAsGroup
+          value: 2000
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.securityContext.fsGroup
+          value: 3000
+
+  # ===========================================================================
+  # Test Additional Worker Groups
+  # ===========================================================================
+
+  - it: Should add ray start parameters if `additionalWorkerGroups.smallGroup.rayStartParams` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          rayStartParams:
+            dashboard-host: 0.0.0.0
+            num-cpus: "4"
+            num-gpus: "2"
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].rayStartParams
+          value:
+            dashboard-host: 0.0.0.0
+            num-cpus: "4"
+            num-gpus: "2"
+
+  - it: Should add ray start parameters if `additionalWorkerGroups.smallGroup.initArgs` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          initArgs:
+            dashboard-host: 0.0.0.0
+            num-cpus: "4"
+            num-gpus: "2"
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].rayStartParams
+          value:
+            dashboard-host: 0.0.0.0
+            num-cpus: "4"
+            num-gpus: "2"
+
+  - it: Should add ray start parameters if both `additionalWorkerGroups.smallGroup.rayStartParams` and `additionalWorkerGroups.smallGroup.initArgs` are set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          rayStartParams:
+            dashboard-host: 0.0.0.0
+            port: "6379"
+          initArgs:
+            num-cpus: "4"
+            num-gpus: "2"
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].rayStartParams
+          value:
+            dashboard-host: 0.0.0.0
+            port: "6379"
+            num-cpus: "4"
+            num-gpus: "2"
+
+  - it: Should add the specified labels if `additionalWorkerGroups.smallGroup.labels` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          labels:
+            key1: value1
+            key2: value2
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.metadata.labels.key1
+          value: value1
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.metadata.labels.key2
+          value: value2
+
+  - it: Should add the specified annotations if `additionalWorkerGroups.smallGroup.annotations` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          annotations:
+            key1: value1
+            key2: value2
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.metadata.annotations.key1
+          value: value1
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.metadata.annotations.key2
+          value: value2
+
+  - it: Should add init containers if `additionalWorkerGroups.smallGroup.initContainers` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          initContainers:
+            - name: test-init-container-1
+              image: test-image-1
+              command:
+                - echo
+                - "Hello, Ray!"
+            - name: test-init-container-2
+              image: test-image-2
+              command:
+                - echo
+                - "Hello, Kuberay!"
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.initContainers
+          content:
+            name: test-init-container-1
+            image: test-image-1
+            command:
+              - echo
+              - "Hello, Ray!"
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.initContainers
+          content:
+            name: test-init-container-2
+            image: test-image-2
+            command:
+              - echo
+              - "Hello, Kuberay!"
+
+  - it: Should first use the image specified by `additionalWorkerGroups.smallGroup.image`
+    set:
+      image:
+        repository: test-repository-1
+        tag: test-tag-1
+        pullPolicy: IfNotPresent
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          image:
+            repository: test-repository-2
+            tag: test-tag-2
+            pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name == "ray-worker")].image
+          value: test-repository-2:test-tag-2
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name == "ray-worker")].imagePullPolicy
+          value: Always
+
+  - it: Should use the image specified by `image` if `additionalWorkerGroups.smallGroup.image` is not set
+    set:
+      image:
+        repository: test-repository
+        tag: test-tag
+        pullPolicy: Always
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          image: {}
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name == "ray-worker")].image
+          value: test-repository:test-tag
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name == "ray-worker")].imagePullPolicy
+          value: Always
+
+  - it: Should add command if `additionalWorkerGroups.smallGroup.command` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          command:
+            - /bin/bash
+            - -c
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name == "ray-worker")].command
+          value:
+            - /bin/bash
+            - -c
+
+  - it: Should add args if `additionalWorkerGroups.smallGroup.args` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          args:
+            - arg1
+            - arg2
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name == "ray-worker")].args
+          value:
+            - arg1
+            - arg2
+
+  - it: Should add env specified by `common.containerEnv` and `additionalWorkerGroups.smallGroup.containerEnv`
+    set:
+      common:
+        containerEnv:
+          - name: KEY1
+            value: VALUE1
+          - name: KEY2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: TEST_KEY2
+                optional: false
+          - name: KEY3
+            valueFrom:
+              secretRef:
+                name: test-secret
+                key: TEST_KEY3
+                optional: false
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          containerEnv:
+            - name: KEY4
+              value: VALUE4
+            - name: KEY5
+              valueFrom:
+                configMapKeyRef:
+                  name: test-configmap
+                  key: TEST_KEY5
+                  optional: false
+            - name: KEY6
+              valueFrom:
+                secretRef:
+                  name: test-secret
+                  key: TEST_KEY6
+                  optional: false
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].env
+          content:
+            name: KEY1
+            value: VALUE1
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].env
+          content:
+            name: KEY2
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: TEST_KEY2
+                optional: false
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].env
+          content:
+            name: KEY3
+            valueFrom:
+              secretRef:
+                name: test-secret
+                key: TEST_KEY3
+                optional: false
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].env
+          content:
+            name: KEY4
+            value: VALUE4
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].env
+          content:
+            name: KEY5
+            valueFrom:
+              configMapKeyRef:
+                name: test-configmap
+                key: TEST_KEY5
+                optional: false
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].env
+          content:
+            name: KEY6
+            valueFrom:
+              secretRef:
+                name: test-secret
+                key: TEST_KEY6
+                optional: false
+
+  - it: Should add envFrom if `additionalWorkerGroups.smallGroup.envFrom` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          envFrom:
+            - configMapRef:
+                name: test-configmap
+            - secretRef:
+                name: test-secret
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].envFrom
+          content:
+            configMapRef:
+              name: test-configmap
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].envFrom
+          content:
+            secretRef:
+              name: test-secret
+
+  - it: Should add volumeMounts if `additionalWorkerGroups.smallGroup.volumeMounts` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          volumeMounts:
+            - name: test-volume-1
+              mountPath: /mnt/test-volume-1
+            - name: test-volume-2
+              mountPath: /mnt/test-volume-2
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].volumeMounts
+          content:
+            name: test-volume-1
+            mountPath: /mnt/test-volume-1
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].volumeMounts
+          content:
+            name: test-volume-2
+            mountPath: /mnt/test-volume-2
+
+  - it: Should add container ports if `additionalWorkerGroups.smallGroup.ports` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          ports:
+            - name: port1
+              containerPort: 1234
+              protocol: TCP
+            - name: port2
+              containerPort: 5678
+              protocol: UDP
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].ports
+          content:
+            name: port1
+            containerPort: 1234
+            protocol: TCP
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].ports
+          content:
+            name: port2
+            containerPort: 5678
+            protocol: UDP
+
+  - it: Should add resources if `additionalWorkerGroups.smallGroup.resources` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 250m
+            limits:
+              memory: 128Mi
+              cpu: 500m
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].resources
+          value:
+            requests:
+              memory: 64Mi
+              cpu: 250m
+            limits:
+              memory: 128Mi
+              cpu: 500m
+
+  - it: Should add lifecycle if `additionalWorkerGroups.smallGroup.lifecycle` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          lifecycle:
+            postStart:
+              httpGet:
+                port: 80
+                path: /healthz
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    echo "Pre-stop command executed"
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].lifecycle
+          value:
+            postStart:
+              httpGet:
+                port: 80
+                path: /healthz
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    echo "Pre-stop command executed"
+
+  - it: Should add container security context if `additionalWorkerGroups.smallGroup.securityContext` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].securityContext
+          value:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+
+  - it: Should add sidecar containers if `additionalWorkerGroups.smallGroup.sidecarContainers` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          sidecarContainers:
+            - name: sidecar-1
+              image: sidecar-image-1
+            - name: sidecar-2
+              image: sidecar-image-2
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers
+          content:
+            name: sidecar-1
+            image: sidecar-image-1
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers
+          content:
+            name: sidecar-2
+            image: sidecar-image-2
+
+  - it: Should use the specified image pull secrets if `imagePullSecrets` is set
+    set:
+      imagePullSecrets:
+        - name: test-secret-1
+        - name: test-secret-2
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.imagePullSecrets
+          value:
+            - name: test-secret-1
+            - name: test-secret-2
+
+  - it: Should add volumes if `additionalWorkerGroups.smallGroup.volumes` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          volumes:
+            - name: volume1
+              emptyDir:
+                sizeLimit: 1Gi
+            - name: volume2
+              hostPath:
+                path: /host/path
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.volumes
+          content:
+            name: volume1
+            emptyDir:
+              sizeLimit: 1Gi
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.volumes
+          content:
+            name: volume2
+            hostPath:
+              path: /host/path
+
+  - it: Should use the specified dns config if `additionalWorkerGroups.smallGroup.dnsConfig` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          dnsConfig:
+            nameservers:
+              - 8.8.8.8
+            searches:
+              - example.local
+            options:
+              - name: ndots
+                value: "2"
+              - name: edns0
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.dnsConfig
+          value:
+            nameservers:
+              - 8.8.8.8
+            searches:
+              - example.local
+            options:
+              - name: ndots
+                value: "2"
+              - name: edns0
+
+  - it: Should add nodeSelector if `additionalWorkerGroups.smallGroup.nodeSelector` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          nodeSelector:
+            key1: value1
+            key2: value2
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.nodeSelector.key1
+          value: value1
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.nodeSelector.key2
+          value: value2
+
+  - it: Should add affinity if `additionalWorkerGroups.smallGroup.affinity` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: topology.kubernetes.io/zone
+                        operator: In
+                        values:
+                          - antarctica-east1
+                          - antarctica-west1
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: another-node-label-key
+                        operator: In
+                        values:
+                          - another-node-label-value
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.affinity
+          value:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: topology.kubernetes.io/zone
+                        operator: In
+                        values:
+                          - antarctica-east1
+                          - antarctica-west1
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: another-node-label-key
+                        operator: In
+                        values:
+                          - another-node-label-value
+
+  - it: Should add tolerations if `additionalWorkerGroups.smallGroup.tolerations` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          tolerations:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.tolerations
+          value:
+            - key: key1
+              operator: Equal
+              value: value1
+              effect: NoSchedule
+            - key: key2
+              operator: Exists
+              effect: NoSchedule
+
+  - it: Should add priorityClassName if `additionalWorkerGroups.smallGroup.priorityClassName` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          priorityClassName: test-priority-class
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.priorityClassName
+          value: test-priority-class
+
+  - it: Should add priority if `additionalWorkerGroups.smallGroup.priority` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          priority: 100
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.priority
+          value: 100
+
+  - it: Should add topology spread constraints if `additionalWorkerGroups.smallGroup.topologySpreadConstraints` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: zone
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  foo: bar
+            - maxSkew: 1
+              topologyKey: node
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  foo: bar
+    asserts:
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.topologySpreadConstraints
+          content:
+            maxSkew: 1
+            topologyKey: zone
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                foo: bar
+      - contains:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.topologySpreadConstraints
+          content:
+            maxSkew: 1
+            topologyKey: node
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                foo: bar
+
+  - it: Should use the specified restart policy if `additionalWorkerGroups.smallGroup.restartPolicy` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          restartPolicy: Always
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.restartPolicy
+          value: Always
+
+  - it: Should use the specified service account name if `additionalWorkerGroups.smallGroup.serviceAccountName` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          serviceAccountName: test-sa
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.serviceAccountName
+          value: test-sa
+
+  - it: Should add pod securityContext if `additionalWorkerGroups.smallGroup.podSecurityContext` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          podSecurityContext:
+            runAsUser: 1000
+            runAsGroup: 2000
+            fsGroup: 3000
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.securityContext.runAsGroup
+          value: 2000
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.securityContext.fsGroup
+          value: 3000

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -52,6 +52,7 @@ head:
     #   requests:
     #     cpu: "500m"
     #     memory: "512Mi"
+  initContainers: []
   labels: {}
   # Note: From KubeRay v0.6.0, users need to create the ServiceAccount by themselves if they specify the `serviceAccountName`
   # in the headGroupSpec. See https://github.com/ray-project/kuberay/pull/1128 for more details.
@@ -126,7 +127,7 @@ head:
   #     - name: ndots
   #       value: "2"
   #     - name: edns0
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
 
 
 worker:
@@ -141,6 +142,7 @@ worker:
   serviceAccountName: ""
   restartPolicy: ""
   rayStartParams: {}
+  initContainers: []
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
   containerEnv: []
@@ -190,7 +192,7 @@ worker:
   # container command for worker Pod.
   command: []
   args: []
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
 
 
   # Custom pod DNS configuration
@@ -269,7 +271,7 @@ additionalWorkerGroups:
 
     # Topology Spread Constraints for worker pods
     # See: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
-    topologySpreadConstraints: {}
+    topologySpreadConstraints: []
 
     # Custom pod DNS configuration
     # See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Make sure ray-cluster Helm chart can work as expected with various configurations by adding unit tests.

One can run Helm chart unit tests by:

```bash
$ helm plugin install https://github.com/helm-unittest/helm-unittest.git

$ helm unittest helm-chart/ray-cluster --strict --debug
load_plugins.go:110: [info] file (/Users/chenyi/Library/helm/plugins/helm-acr/completion.yaml) not provided by plugin. No plugin auto-completion possible

### Chart [ ray-cluster ] helm-chart/ray-cluster

 PASS  Test RayCluster  helm-chart/ray-cluster/tests/raycluster_test.yaml

Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       96 passed, 96 total
Snapshot:    0 passed, 0 total
Time:        281.1805ms
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
