### PR TITLE
[SLI metric] add ray_jobs_created_total metric

### DIFF
--- a/ray-operator/controllers/ray/metrics/ray_job_metrics.go
+++ b/ray-operator/controllers/ray/metrics/ray_job_metrics.go
@@ -1,3 +1,25 @@
 package metrics
 
-func registerRayJobMetrics() {}
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Define all the prometheus metrics for RayJob
+var (
+	rayJobsCreatedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ray_jobs_created_total",
+			Help: "The total number of RayJob CRs created",
+		},
+		[]string{"namespace"},
+	)
+)
+
+func RayJobsCreatedTotalInc(namespace string) {
+	rayJobsCreatedTotal.WithLabelValues(namespace).Inc()
+}
+
+func registerRayJobMetrics() {
+	metrics.Registry.MustRegister(rayJobsCreatedTotal)
+}


### PR DESCRIPTION
## Changes
Added metric `ray_jobs_created_total`, which capture the total number of RayJob CRs created.

## Why are these changes needed?
Proposed in 1.4.0 https://docs.google.com/document/d/1zNiE7lVZYjhrxlTbh1UXOVpR6hh1GIeSfCfE9Lt5v6Y/edit?tab=t.0

## Related issue number
#3178

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
