### PR TITLE
[readme] Make collapsible section for apiserver readme

### DIFF
--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -400,7 +400,8 @@ Examples: (please make sure that template `default-template` is created before r
   }'
   ```
 
-* Response
+<details>
+  <summary>* Response</summary>
 
   ```json
   {
@@ -473,6 +474,7 @@ Examples: (please make sure that template `default-template` is created before r
     ]
   }
   ```
+</details>
 
 #### List all clusters in a given namespace
 
@@ -490,7 +492,8 @@ Examples:
     -H 'accept: application/json'
   ```
 
-* Response
+<details>
+  <summary>* Response</summary>
 
   ```json
   {
@@ -607,6 +610,7 @@ Examples:
     ]
   }
   ```
+</details>
 
 #### List all clusters in all namespaces
 
@@ -624,7 +628,8 @@ Examples:
     -H 'accept: application/json'
   ```
 
-* Response
+<details>
+  <summary>* Response</summary>
 
   ```json
   {
@@ -741,6 +746,7 @@ Examples:
     ]
   }
   ```
+</details>
 
 #### Get cluster by its name and namespace
 
@@ -758,7 +764,8 @@ Examples:
     -H 'accept: application/json'
   ```
 
-* Response
+<details>
+  <summary>* Response</summary>
 
   ```json
   {
@@ -875,6 +882,7 @@ Examples:
     ]
   }
   ```
+</details>
 
 #### Delete cluster by its name and namespace
 
@@ -947,7 +955,8 @@ Examples:
     }'
   ```
 
-* Response
+<details>
+  <summary>* Response</summary>
 
   ```json
   {
@@ -981,6 +990,7 @@ Examples:
     "createdAt": "2023-09-25T11:36:02Z"
   }
   ```
+</details>
 
 The above example creates a new Ray cluster, executes a job on it and optionally deletes a cluster. As an alternative, the same command allows creating a new job on the existing cluster by referencing it in the payload.
 
@@ -1044,7 +1054,8 @@ curl -X POST 'localhost:31888/apis/v1/namespaces/default/clusters' \
 }'
 ```
 
-* Response
+<details>
+  <summary>* Response</summary>
 
 ```json
 {
@@ -1110,6 +1121,7 @@ curl -X POST 'localhost:31888/apis/v1/namespaces/default/clusters' \
    "createdAt":"2023-10-18T08:47:48Z"
 }
 ```
+</details>
 
 Once the cluster is created, we can create a job to run on it.
 
@@ -1258,7 +1270,8 @@ Examples:
   -H 'accept: application/json'
   ```
 
-* Response
+<details>
+  <summary>* Response</summary>
 
   ```json
   {
@@ -1300,6 +1313,7 @@ Examples:
     ]
   }
   ```
+</details>
 
 #### List all jobs in all namespaces
 
@@ -1317,7 +1331,8 @@ Examples:
   -H 'accept: application/json'
   ```
 
-* Response
+<details>
+  <summary>* Response</summary>
 
   ```json
   {
@@ -1359,6 +1374,7 @@ Examples:
     ]
   }
   ```
+</details>
 
 #### Get job by its name and namespace
 
@@ -1376,7 +1392,8 @@ Examples:
   -H 'accept: application/json'
   ```
 
-* Response:
+<details>
+  <summary>* Response</summary>
 
   ```json
   {
@@ -1414,6 +1431,7 @@ Examples:
     "message": "Job finished successfully."
   }
   ```
+</details>
 
 #### Delete job by its name and namespace
 
@@ -1488,7 +1506,8 @@ Examples:
   }'
 ```
 
-* Response
+<details>
+  <summary>* Response</summary>
 
 ```json
 {
@@ -1633,6 +1652,7 @@ Examples:
    "deleteAt":"1969-12-31T23:59:59Z"
 }
 ```
+</details>
 
 #### List all services in a given namespace
 
@@ -1650,7 +1670,8 @@ Examples
   -H 'accept: application/json'
   ```
 
-* Response:
+<details>
+  <summary>* Response</summary>
 
 ```json
   {
@@ -1908,6 +1929,7 @@ Examples
    ]
 }
 ```
+</details>
 
 #### List all services in all namespaces
 
@@ -1925,7 +1947,8 @@ Examples:
   -H 'accept: application/json'
   ```
 
-* Response:
+<details>
+  <summary>* Response</summary>
 
 ```json
 {
@@ -2183,6 +2206,7 @@ Examples:
    ]
 }
 ```
+</details>
 
 #### Get service by its name and namespace
 
@@ -2200,7 +2224,8 @@ Examples:
     -H 'accept: application/json'
   ```
 
-* Response:
+<details>
+  <summary>* Response</summary>
 
 ```json
 {
@@ -2454,6 +2479,7 @@ Examples:
    "deleteAt":"1969-12-31T23:59:59Z"
 }
 ```
+</details>
 
 #### Delete service by its name and namespace
 


### PR DESCRIPTION
When reading the API server readme, I found most of the lines are responses;
As I newcomer (me personally) care more about request spec, because that's what submit to API server.

I make large responses (i.e. >15 lines) collapsible, so it doesn't account for most of the reading space.