### PR TITLE
[apiserver] No lint at test

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -77,7 +77,7 @@ lint: golangci-lint fmt vet fumpt imports ## Run the linter.
 	# exclude the SA1019 check which checks the usage of deprecated fields.
 	$(GOLANGCI_LINT) run  --timeout=3m --exclude='SA1019' --no-config
 
-build: fmt vet fumpt imports lint ## Build api server binary.
+build: fmt vet fumpt imports ## Build api server binary.
 	go build  -o ${REPO_ROOT_BIN}/kuberay-apiserver cmd/main.go
 
 run: fmt vet fumpt imports lint ## Run the api server from your host.
@@ -90,7 +90,7 @@ build-swagger: go-bindata
 ##@ Testing
 
 .PHONY: test
-test: fmt vet fumpt imports lint  ## Run all unit tests.
+test: fmt vet fumpt imports ## Run all unit tests.
 	go test ./pkg/... ./cmd/... $(GO_TEST_FLAGS) -race -coverprofile ray-kube-api-server-coverage.out  -parallel 4
 
 .PHONY: e2e-test


### PR DESCRIPTION
I would like to remove lint out of test section, there're two reasons:
First, the `golangci-lint` version documented on the [doc](https://github.com/ray-project/kuberay/blob/master/apiserver/DEVELOPMENT.md#optional-development-tools) doesn't work for existing code, which fails test, see [discussion thread](https://ray.slack.com/archives/C01CKH05XBN/p1744155976705229) at slack channel;
Second reason, linter has nothing to do with testing, which should better live in precommit hook and CI.

Error message:
```sh
/home/ubuntu/kuberay/bin/golangci-lint run  --timeout=3m --exclude='SA1019' --no-config
pkg/client/cluster.go:28:3: undefined: klog (typecheck)
                klog.Fatalf("Failed to create RayCluster client. Error: %v", err)
                ^
```

There's a related issue: https://github.com/ray-project/kuberay/issues/3061