### PR TITLE
Fix apiserver linter

### DIFF
--- a/apiserver/DEVELOPMENT.md
+++ b/apiserver/DEVELOPMENT.md
@@ -22,7 +22,7 @@ Typing `make dev-tools` will download and install all of them. The `make clean-d
 | Software      | Version  |                                                                    Link |
 | :-------      | :------: | -----------------------------------------------------------------------:|
 | kind          | v0.19.0  | [Install](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) |
-| golangci-lint | v1.54.1  | [Install](https://golangci-lint.run/usage/install/)                     |
+| golangci-lint | v1.64.8  | [Install](https://golangci-lint.run/usage/install/)                     |
 | kustomize     | v3.8.7   | [install](https://kubectl.docs.kubernetes.io/installation/kustomize/)   |
 | gofumpt       | v0.3.1   | To install `go install mvdan.cc/gofumpt@v0.3.1`                         |
 | goimports     | latest   | To install `go install golang.org/x/tools/cmd/goimports@latest`         |

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -75,7 +75,8 @@ imports: goimports ## Run goimports against code.
 .PHONY: lint
 lint: golangci-lint fmt vet fumpt imports ## Run the linter.
 	# exclude the SA1019 check which checks the usage of deprecated fields.
-	$(GOLANGCI_LINT) run  --timeout=3m --exclude='SA1019' --no-config
+	# exclude the S1009 for false positive.
+	test -s $(GOLANGCI_LINT) || ($(GOLANGCI_LINT) run --timeout=3m --exclude='SA1019,S1009' --no-config --allow-parallel-runners)
 
 build: fmt vet fumpt imports ## Build api server binary.
 	go build  -o ${REPO_ROOT_BIN}/kuberay-apiserver cmd/main.go
@@ -213,7 +214,7 @@ GOBINDATA ?= $(REPO_ROOT_BIN)/go-bindata
 KUSTOMIZE_VERSION ?= v5.4.3
 GOFUMPT_VERSION ?= v0.3.1
 GOIMPORTS_VERSION ?= v0.14.0
-GOLANGCI_LINT_VERSION ?= v1.54.1
+GOLANGCI_LINT_VERSION ?= v1.64.8
 KIND_VERSION ?= v0.19.0
 GOBINDATA_VERSION ?= v4.0.2
 
@@ -236,7 +237,7 @@ $(GOFUMPT): $(REPO_ROOT_BIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci_lint locally if necessary.
 $(GOLANGCI_LINT): $(REPO_ROOT_BIN)
-	test -s $(GOLANGCI_LINT) || (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(REPO_ROOT_BIN)/ $(GOLANGCI_LINT_VERSION))
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(REPO_ROOT_BIN)/ $(GOLANGCI_LINT_VERSION)
 
 .PHONY: kind
 kind: $(KIND) ## Download kind locally if necessary.

--- a/apiserver/pkg/manager/resource_manager.go
+++ b/apiserver/pkg/manager/resource_manager.go
@@ -569,7 +569,7 @@ func getRayClusterEventsByName(ctx context.Context, name string, client clientv1
 		return nil, util.Wrap(err, "Get Ray Cluster Events failed")
 	}
 	if len(events.Items) == 0 {
-		return nil, fmt.Errorf("No Event with RayCluster name %s", name)
+		return nil, fmt.Errorf("no Event with RayCluster name %s", name)
 	}
 
 	return events.Items, nil


### PR DESCRIPTION
## Why are these changes needed?

This PR resolves the currently broken apiserver linter by upgrade to a later version.
Also fix a few linting issues.

Two things worth noticing: 
- a feature we require for linter is to exclude certain rules (i.e. ignore deprecated fields), but I don't find it in release newer than v2.0.0; v1.64.8 is the latest version I found workable
  + Worth another TODO to keep upgrade, this PR is to fix the broken linter
- Ignore a new rule `gosimple`, which I consider it false positive, error message see below
```sh
pkg/util/cluster.go:332:5: S1009: should omit nil check; len() for nil maps is defined as zero (gosimple)
        if envs.Values != nil && len(envs.Values) > 0 {
           ^
pkg/util/cluster.go:340:5: S1009: should omit nil check; len() for nil maps is defined as zero (gosimple)
        if envs.ValuesFrom != nil && len(envs.ValuesFrom) > 0 {
           ^
pkg/util/cluster.go:861:5: S1009: should omit nil check; len() for nil slices is defined as zero (gosimple)
        if runtime.Tolerations != nil && len(runtime.Tolerations) > 0 {
           ^
pkg/util/cluster.go:948:5: S1009: should omit nil check; len() for nil slices is defined as zero (gosimple)
        if autoscalerOptions.Volumes != nil && len(autoscalerOptions.Volumes) > 0 {
           ^
``` 

## Related issue number

Closes #3295 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
