### PR TITLE
[easy] Remove cmd folder from test command

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -91,7 +91,7 @@ build-swagger: go-bindata
 
 .PHONY: test
 test: fmt vet fumpt imports ## Run all unit tests.
-	go test ./pkg/... ./cmd/... $(GO_TEST_FLAGS) -race -coverprofile ray-kube-api-server-coverage.out  -parallel 4
+	go test ./pkg/... $(GO_TEST_FLAGS) -race -coverprofile ray-kube-api-server-coverage.out  -parallel 4
 
 .PHONY: e2e-test
 e2e-test: ## Run end to end tests using a pre-exiting cluster.


### PR DESCRIPTION
## Why are these changes needed?

`cmd` folder is used to place executables and don't have any tests in it: https://github.com/ray-project/kuberay/tree/master/apiserver/cmd

My understanding for unit test, they target for a class or function, not an executable; which should in turn checked in integration test (our e2e test suite).

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [X] Manual tests
  - [ ] This PR is not tested :(
