### PR TITLE
[refactor] Make options as a direct field in reconciler

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -43,7 +43,7 @@ type RayJobReconciler struct {
 	Recorder record.EventRecorder
 
 	dashboardClientFunc func() utils.RayDashboardClientInterface
-	enableMetrics       bool
+	options             RayJobReconcilerOptions
 }
 
 type RayJobReconcilerOptions struct {
@@ -58,7 +58,7 @@ func NewRayJobReconciler(_ context.Context, mgr manager.Manager, options RayJobR
 		Scheme:              mgr.GetScheme(),
 		Recorder:            mgr.GetEventRecorderFor("rayjob-controller"),
 		dashboardClientFunc: dashboardClientFunc,
-		enableMetrics:       options.EnableMetrics,
+		options:             options,
 	}
 }
 


### PR DESCRIPTION
## Changes
Make options as a direct field in reconciler.

## Why are these changes needed?
As the number of options grows, it can be messy if we make all of them a field of the reconciler.

## Related issue number
N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
