### PR TITLE
[WIP] [apiserver] Enable golangci-linter in apiserver and fix all linting errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,35 @@ default_language_version:
   golang: 1.23.2
 
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+        exclude: ^helm-chart/|^mkdocs\.yml$|^benchmark/perf-tests/|^\.krew\.yaml$
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-vcs-permalinks
+      - id: check-json
+      - id: pretty-format-json
+        args: [--autofix, --no-sort-keys, --no-ensure-ascii]
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: detect-private-key
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.2
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+
   - repo: local
     hooks:
       - id: golangci-lint
@@ -17,4 +46,31 @@ repos:
         always_run: true
         pass_filenames: false
         additional_dependencies:
-          - github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+          - github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
+      - id: generate-crd-schema
+        name: generate CRD schemas for use of kubeconform
+        entry: ./scripts/generate-crd-schema.sh
+        language: python
+        require_serial: true
+        always_run: true
+        pass_filenames: false
+        additional_dependencies:
+          - PyYAML==6.0.1
+      - id: validate-helm-charts
+        name: validate helm charts with kubeconform
+        entry: bash scripts/validate-helm.sh
+        language: golang
+        require_serial: true
+        always_run: true
+        pass_filenames: false
+        additional_dependencies:
+          - github.com/yannh/kubeconform/cmd/kubeconform@v0.6.7
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.44.0
+    hooks:
+      - id: markdownlint-fix
+        name: Markdown linting
+        args:
+          - --ignore=.github/pull_request_template.md
+          - --disable=MD033

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         always_run: true
         pass_filenames: false
         additional_dependencies:
-          - github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
+          - github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
       - id: generate-crd-schema
         name: generate CRD schemas for use of kubeconform
         entry: ./scripts/generate-crd-schema.sh
@@ -71,7 +71,6 @@ repos:
     hooks:
       - id: markdownlint-fix
         name: Markdown linting
-        language: system
         args:
           - --ignore=.github/pull_request_template.md
           - --disable=MD033

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,7 @@ repos:
     hooks:
       - id: markdownlint-fix
         name: Markdown linting
+        language: system
         args:
           - --ignore=.github/pull_request_template.md
           - --disable=MD033

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,35 +6,6 @@ default_language_version:
   golang: 1.23.2
 
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
-    hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-        args: [--allow-multiple-documents]
-        exclude: ^helm-chart/|^mkdocs\.yml$|^benchmark/perf-tests/|^\.krew\.yaml$
-      - id: check-added-large-files
-      - id: check-merge-conflict
-      - id: check-case-conflict
-      - id: check-vcs-permalinks
-      - id: check-json
-      - id: pretty-format-json
-        args: [--autofix, --no-sort-keys, --no-ensure-ascii]
-      - id: mixed-line-ending
-        args: [--fix=lf]
-      - id: detect-private-key
-
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.2
-    hooks:
-      - id: gitleaks
-
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
-    hooks:
-      - id: shellcheck
-
   - repo: local
     hooks:
       - id: golangci-lint
@@ -46,31 +17,4 @@ repos:
         always_run: true
         pass_filenames: false
         additional_dependencies:
-          - github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
-      - id: generate-crd-schema
-        name: generate CRD schemas for use of kubeconform
-        entry: ./scripts/generate-crd-schema.sh
-        language: python
-        require_serial: true
-        always_run: true
-        pass_filenames: false
-        additional_dependencies:
-          - PyYAML==6.0.1
-      - id: validate-helm-charts
-        name: validate helm charts with kubeconform
-        entry: bash scripts/validate-helm.sh
-        language: golang
-        require_serial: true
-        always_run: true
-        pass_filenames: false
-        additional_dependencies:
-          - github.com/yannh/kubeconform/cmd/kubeconform@v0.6.7
-
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
-    hooks:
-      - id: markdownlint-fix
-        name: Markdown linting
-        args:
-          - --ignore=.github/pull_request_template.md
-          - --disable=MD033
+          - github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -73,9 +73,7 @@ imports: goimports ## Run goimports against code.
 	$(GOIMPORTS) -l -w .
 
 .PHONY: lint
-lint: golangci-lint fmt vet fumpt imports ## Run the linter.
-	# exclude the SA1019 check which checks the usage of deprecated fields.
-	test -s $(GOLANGCI_LINT) || ($(GOLANGCI_LINT) run --timeout=3m --exclude='SA1019' --no-config --allow-parallel-runners)
+lint: fmt vet fumpt imports ## Run the linter.
 
 build: fmt vet fumpt imports ## Build api server binary.
 	go build  -o ${REPO_ROOT_BIN}/kuberay-apiserver cmd/main.go
@@ -204,7 +202,6 @@ $(REPO_ROOT_BIN):
 KUSTOMIZE ?= $(REPO_ROOT_BIN)/kustomize
 GOIMPORTS ?= $(REPO_ROOT_BIN)/goimports
 GOFUMPT ?= $(REPO_ROOT_BIN)/gofumpt
-GOLANGCI_LINT ?= $(REPO_ROOT_BIN)/golangci-lint
 KIND ?= $(REPO_ROOT_BIN)/kind
 GOBINDATA ?= $(REPO_ROOT_BIN)/go-bindata
 
@@ -233,11 +230,6 @@ gofumpt: $(GOFUMPT) ## Download gofumpt locally if necessary.
 $(GOFUMPT): $(REPO_ROOT_BIN)
 	test -s $(GOFUMPT) || GOBIN=$(REPO_ROOT_BIN) go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
 
-.PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT) ## Download golangci_lint locally if necessary.
-$(GOLANGCI_LINT): $(REPO_ROOT_BIN)
-	test -s $(GOLANGCI_LINT) || (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(REPO_ROOT_BIN)/ $(GOLANGCI_LINT_VERSION))
-
 .PHONY: kind
 kind: $(KIND) ## Download kind locally if necessary.
 $(KIND): $(REPO_ROOT_BIN)
@@ -249,11 +241,10 @@ $(GOBINDATA): $(REPO_ROOT_BIN)
 	test -s $(GOBINDATA) || GOBIN=$(REPO_ROOT_BIN) go install github.com/kevinburke/go-bindata/v4/...@$(GOBINDATA_VERSION)
 
 .PHONY: dev-tools
-dev-tools: kind golangci-lint gofumpt kustomize goimports go-bindata ## Install all development tools
+dev-tools: kind gofumpt kustomize goimports go-bindata ## Install all development tools
 
 .PHONY: clean-dev-tools
 clean-dev-tools: ## Remove all development tools
-	rm -f $(REPO_ROOT_BIN)/golangci-lint
 	rm -f $(REPO_ROOT_BIN)/gofumpt
 	rm -f $(REPO_ROOT_BIN)/kustomize
 	rm -f $(REPO_ROOT_BIN)/goimports

--- a/apiserver/cmd/main.go
+++ b/apiserver/cmd/main.go
@@ -54,7 +54,7 @@ func main() {
 	resourceManager := manager.NewResourceManager(&clientManager)
 
 	atomic.StoreInt32(&healthy, 1)
-	go startRpcServer(resourceManager)
+	go startRPCServer(resourceManager)
 	startHttpProxy()
 	// See also https://gist.github.com/enricofoltran/10b4a980cd07cb02836f70a4ab3e72d7
 	quit := make(chan os.Signal, 1)
@@ -70,7 +70,7 @@ func main() {
 
 type RegisterHttpHandlerFromEndpoint func(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error
 
-func startRpcServer(resourceManager *manager.ResourceManager) {
+func startRPCServer(resourceManager *manager.ResourceManager) {
 	klog.Info("Starting gRPC server")
 
 	listener, err := net.Listen("tcp", *rpcPortFlag)
@@ -86,7 +86,7 @@ func startRpcServer(resourceManager *manager.ResourceManager) {
 
 	s := grpc.NewServer(
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
-		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(grpc_prometheus.UnaryServerInterceptor, interceptor.ApiServerInterceptor)),
+		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(grpc_prometheus.UnaryServerInterceptor, interceptor.APIServerInterceptor)),
 		grpc.MaxRecvMsgSize(math.MaxInt32))
 	api.RegisterClusterServiceServer(s, clusterServer)
 	api.RegisterComputeTemplateServiceServer(s, templateServer)

--- a/apiserver/cmd/main.go
+++ b/apiserver/cmd/main.go
@@ -129,11 +129,11 @@ func startHttpProxy() {
 		runtime.WithErrorHandler(runtime.DefaultHTTPErrorHandler),
 	)
 	// Register endpoints
-	registerHttpHandlerFromEndpoint(api.RegisterClusterServiceHandlerFromEndpoint, "ClusterService", ctx, runtimeMux)
-	registerHttpHandlerFromEndpoint(api.RegisterComputeTemplateServiceHandlerFromEndpoint, "ComputeTemplateService", ctx, runtimeMux)
-	registerHttpHandlerFromEndpoint(api.RegisterRayJobServiceHandlerFromEndpoint, "JobService", ctx, runtimeMux)
-	registerHttpHandlerFromEndpoint(api.RegisterRayServeServiceHandlerFromEndpoint, "ServeService", ctx, runtimeMux)
-	registerHttpHandlerFromEndpoint(api.RegisterRayJobSubmissionServiceHandlerFromEndpoint, "RayJobSubmissionService", ctx, runtimeMux)
+	registerHttpHandlerFromEndpoint(ctx, api.RegisterClusterServiceHandlerFromEndpoint, "ClusterService", runtimeMux)
+	registerHttpHandlerFromEndpoint(ctx, api.RegisterComputeTemplateServiceHandlerFromEndpoint, "ComputeTemplateService", runtimeMux)
+	registerHttpHandlerFromEndpoint(ctx, api.RegisterRayJobServiceHandlerFromEndpoint, "JobService", runtimeMux)
+	registerHttpHandlerFromEndpoint(ctx, api.RegisterRayServeServiceHandlerFromEndpoint, "ServeService", runtimeMux)
+	registerHttpHandlerFromEndpoint(ctx, api.RegisterRayJobSubmissionServiceHandlerFromEndpoint, "RayJobSubmissionService", runtimeMux)
 
 	// Create a top level mux to include both Http gRPC servers and other endpoints like metrics
 	topMux := http.NewServeMux()
@@ -151,7 +151,7 @@ func startHttpProxy() {
 	klog.Info("Http Proxy started")
 }
 
-func serveHealth(w http.ResponseWriter, r *http.Request) {
+func serveHealth(w http.ResponseWriter, _ *http.Request) {
 	if atomic.LoadInt32(&healthy) == 1 {
 		w.WriteHeader(http.StatusOK)
 	} else {
@@ -194,7 +194,7 @@ func serveSwaggerUI(mux *http.ServeMux) {
 	mux.Handle(prefix, http.StripPrefix(prefix, fileServer))
 }
 
-func registerHttpHandlerFromEndpoint(handler RegisterHttpHandlerFromEndpoint, serviceName string, ctx context.Context, mux *runtime.ServeMux) {
+func registerHttpHandlerFromEndpoint(ctx context.Context, handler RegisterHttpHandlerFromEndpoint, serviceName string, mux *runtime.ServeMux) {
 	endpoint := "localhost" + *rpcPortFlag
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32))}
 

--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -646,7 +647,8 @@ func (krc *KuberayAPIServerClient) extractStatus(bodyBytes []byte) (*rpcStatus.S
 }
 
 func (krc *KuberayAPIServerClient) createHttpRequest(method string, endPoint string, body io.Reader) (*http.Request, error) {
-	req, err := http.NewRequest(method, endPoint, body)
+	// TODO(hjiang): Figure out how to pass in context from callers.
+	req, err := http.NewRequestWithContext(context.TODO(), method, endPoint, body)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -235,7 +235,7 @@ func (krc *KuberayAPIServerClient) ListClusters(request *api.ListClustersRequest
 	}
 	response := &api.ListClustersResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, err
 	}
 	return response, nil, nil
 }
@@ -261,7 +261,7 @@ func (krc *KuberayAPIServerClient) ListAllClusters(request *api.ListAllClustersR
 	}
 	response := &api.ListAllClustersResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, err
 	}
 	return response, nil, nil
 }

--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -71,7 +71,7 @@ func (krc *KuberayAPIServerClient) CreateComputeTemplate(request *api.CreateComp
 		return nil, nil, fmt.Errorf("failed to marshal api.ComputeTemplate to JSON: %w", err)
 	}
 
-	httpRequest, err := krc.createHttpRequest("POST", createURL, bytes.NewReader(bytez))
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "POST", createURL, bytes.NewReader(bytez))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", createURL, err)
 	}
@@ -100,7 +100,7 @@ func (krc *KuberayAPIServerClient) DeleteComputeTemplate(request *api.DeleteComp
 // Finds a specific compute template by its name and namespace.
 func (krc *KuberayAPIServerClient) GetComputeTemplate(request *api.GetComputeTemplateRequest) (*api.ComputeTemplate, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/compute_templates/" + request.Name
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -121,7 +121,7 @@ func (krc *KuberayAPIServerClient) GetComputeTemplate(request *api.GetComputeTem
 // GetAllComputeTemplates finds all compute templates in all namespaces.
 func (krc *KuberayAPIServerClient) GetAllComputeTemplates() (*api.ListAllComputeTemplatesResponse, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/compute_templates"
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -142,7 +142,7 @@ func (krc *KuberayAPIServerClient) GetAllComputeTemplates() (*api.ListAllCompute
 // GetAllComputeTemplatesInNamespace Finds all compute templates in a given namespace.
 func (krc *KuberayAPIServerClient) GetAllComputeTemplatesInNamespace(request *api.ListComputeTemplatesRequest) (*api.ListComputeTemplatesResponse, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/compute_templates"
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -169,7 +169,7 @@ func (krc *KuberayAPIServerClient) CreateCluster(request *api.CreateClusterReque
 		return nil, nil, fmt.Errorf("failed to marshal api.Cluster to JSON: %w", err)
 	}
 
-	httpRequest, err := krc.createHttpRequest("POST", createURL, bytes.NewReader(bytez))
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "POST", createURL, bytes.NewReader(bytez))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", createURL, err)
 	}
@@ -197,7 +197,7 @@ func (krc *KuberayAPIServerClient) DeleteCluster(request *api.DeleteClusterReque
 // GetCluster finds a specific Cluster by ID.
 func (krc *KuberayAPIServerClient) GetCluster(request *api.GetClusterRequest) (*api.Cluster, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/clusters/" + request.Name
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -218,7 +218,7 @@ func (krc *KuberayAPIServerClient) GetCluster(request *api.GetClusterRequest) (*
 // ListCluster finds all clusters in a given namespace.
 func (krc *KuberayAPIServerClient) ListClusters(request *api.ListClustersRequest) (*api.ListClustersResponse, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/clusters"
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -244,7 +244,7 @@ func (krc *KuberayAPIServerClient) ListClusters(request *api.ListClustersRequest
 // ListAllClusters finds all Clusters in all namespaces. Supports pagination, and sorting on certain fields.
 func (krc *KuberayAPIServerClient) ListAllClusters(request *api.ListAllClustersRequest) (*api.ListAllClustersResponse, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/clusters"
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -275,7 +275,7 @@ func (krc *KuberayAPIServerClient) CreateRayJob(request *api.CreateRayJobRequest
 		return nil, nil, fmt.Errorf("failed to marshal api.Cluster to JSON: %w", err)
 	}
 
-	httpRequest, err := krc.createHttpRequest("POST", createURL, bytes.NewReader(bytez))
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "POST", createURL, bytes.NewReader(bytez))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", createURL, err)
 	}
@@ -297,7 +297,7 @@ func (krc *KuberayAPIServerClient) CreateRayJob(request *api.CreateRayJobRequest
 // GetRayJob finds a specific job by its name and namespace.
 func (krc *KuberayAPIServerClient) GetRayJob(request *api.GetRayJobRequest) (*api.RayJob, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/jobs/" + request.Name
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -318,7 +318,7 @@ func (krc *KuberayAPIServerClient) GetRayJob(request *api.GetRayJobRequest) (*ap
 // Finds all job in a given namespace.
 func (krc *KuberayAPIServerClient) ListRayJobs(request *api.ListRayJobsRequest) (*api.ListRayJobsResponse, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/jobs"
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -339,7 +339,7 @@ func (krc *KuberayAPIServerClient) ListRayJobs(request *api.ListRayJobsRequest) 
 // ListAllRayJobs Finds all job in all namespaces.
 func (krc *KuberayAPIServerClient) ListAllRayJobs() (*api.ListAllRayJobsResponse, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/jobs"
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -371,7 +371,7 @@ func (krc *KuberayAPIServerClient) CreateRayService(request *api.CreateRayServic
 		return nil, nil, fmt.Errorf("failed to marshal api.Cluster to JSON: %w", err)
 	}
 
-	httpRequest, err := krc.createHttpRequest("POST", createURL, bytes.NewReader(bytez))
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "POST", createURL, bytes.NewReader(bytez))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", createURL, err)
 	}
@@ -398,7 +398,7 @@ func (krc *KuberayAPIServerClient) UpdateRayService(request *api.UpdateRayServic
 		return nil, nil, fmt.Errorf("failed to marshal api.Cluster to JSON: %w", err)
 	}
 
-	httpRequest, err := krc.createHttpRequest("PUT", updateURL, bytes.NewReader(bytez))
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "PUT", updateURL, bytes.NewReader(bytez))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", updateURL, err)
 	}
@@ -420,7 +420,7 @@ func (krc *KuberayAPIServerClient) UpdateRayService(request *api.UpdateRayServic
 // Find a specific ray serve by name and namespace.
 func (krc *KuberayAPIServerClient) GetRayService(request *api.GetRayServiceRequest) (*api.RayService, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/services/" + request.Name
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -441,7 +441,7 @@ func (krc *KuberayAPIServerClient) GetRayService(request *api.GetRayServiceReque
 // Finds all ray services in a given namespace. Supports pagination, and sorting on certain fields.
 func (krc *KuberayAPIServerClient) ListRayServices(request *api.ListRayServicesRequest) (*api.ListRayServicesResponse, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/services"
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -462,7 +462,7 @@ func (krc *KuberayAPIServerClient) ListRayServices(request *api.ListRayServicesR
 // Finds all ray services in a given namespace. Supports pagination, and sorting on certain fields.
 func (krc *KuberayAPIServerClient) ListAllRayServices() (*api.ListAllRayServicesResponse, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/services"
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -494,7 +494,7 @@ func (krc *KuberayAPIServerClient) SubmitRayJob(request *api.SubmitRayJobRequest
 		return nil, nil, fmt.Errorf("failed to marshal api.Cluster to JSON: %w", err)
 	}
 
-	httpRequest, err := krc.createHttpRequest("POST", createURL, bytes.NewReader(bytez))
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "POST", createURL, bytes.NewReader(bytez))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", createURL, err)
 	}
@@ -516,7 +516,7 @@ func (krc *KuberayAPIServerClient) SubmitRayJob(request *api.SubmitRayJobRequest
 // GetRayJobDetails. Get details about specific job on a given cluster.
 func (krc *KuberayAPIServerClient) GetRayJobDetails(request *api.GetJobDetailsRequest) (*api.JobSubmissionInfo, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/jobsubmissions/" + request.Clustername + "/" + request.Submissionid
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -537,7 +537,7 @@ func (krc *KuberayAPIServerClient) GetRayJobDetails(request *api.GetJobDetailsRe
 // GetRayJobLog. Get log for a specific job on a given cluster.
 func (krc *KuberayAPIServerClient) GetRayJobLog(request *api.GetJobLogRequest) (*api.GetJobLogReply, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/jobsubmissions/" + request.Clustername + "/log/" + request.Submissionid
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -558,7 +558,7 @@ func (krc *KuberayAPIServerClient) GetRayJobLog(request *api.GetJobLogRequest) (
 // ListRayJobsCluster. List Ray jobs on a given cluster.
 func (krc *KuberayAPIServerClient) ListRayJobsCluster(request *api.ListJobDetailsRequest) (*api.ListJobSubmissionInfo, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/jobsubmissions/" + request.Clustername
-	httpRequest, err := krc.createHttpRequest("GET", getURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
@@ -580,7 +580,7 @@ func (krc *KuberayAPIServerClient) ListRayJobsCluster(request *api.ListJobDetail
 func (krc *KuberayAPIServerClient) StopRayJob(request *api.StopRayJobSubmissionRequest) (*rpcStatus.Status, error) {
 	createURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/jobsubmissions/" + request.Clustername + "/" + request.Submissionid
 
-	httpRequest, err := krc.createHttpRequest("POST", createURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "POST", createURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create http request for url '%s': %w", createURL, err)
 	}
@@ -602,7 +602,7 @@ func (krc *KuberayAPIServerClient) DeleteRayJobCluster(request *api.DeleteRayJob
 }
 
 func (krc *KuberayAPIServerClient) doDelete(deleteURL string) (*rpcStatus.Status, error) {
-	httpRequest, err := krc.createHttpRequest("DELETE", deleteURL, nil)
+	httpRequest, err := krc.createHttpRequest(context.TODO(), "DELETE", deleteURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create http request for url '%s': %w", deleteURL, err)
 	}
@@ -646,9 +646,8 @@ func (krc *KuberayAPIServerClient) extractStatus(bodyBytes []byte) (*rpcStatus.S
 	return status, nil
 }
 
-func (krc *KuberayAPIServerClient) createHttpRequest(method string, endPoint string, body io.Reader) (*http.Request, error) {
-	// TODO(hjiang): Figure out how to pass in context from callers.
-	req, err := http.NewRequestWithContext(context.TODO(), method, endPoint, body)
+func (krc *KuberayAPIServerClient) createHttpRequest(ctx context.Context, method string, endPoint string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, endPoint, body)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -17,9 +17,9 @@ import (
 
 type KuberayAPIServerClient struct {
 	httpClient  *http.Client
-	baseURL     string
 	marshaler   *protojson.MarshalOptions
 	unmarshaler *protojson.UnmarshalOptions
+	baseURL     string
 }
 
 type KuberayAPIServerClientError struct {
@@ -84,7 +84,7 @@ func (krc *KuberayAPIServerClient) CreateComputeTemplate(request *api.CreateComp
 	}
 	computeTemplate := &api.ComputeTemplate{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, computeTemplate); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 
 	return computeTemplate, nil, nil
@@ -112,7 +112,7 @@ func (krc *KuberayAPIServerClient) GetComputeTemplate(request *api.GetComputeTem
 	}
 	computeTemplate := &api.ComputeTemplate{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, computeTemplate); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return computeTemplate, nil, nil
 }
@@ -133,7 +133,7 @@ func (krc *KuberayAPIServerClient) GetAllComputeTemplates() (*api.ListAllCompute
 	}
 	response := &api.ListAllComputeTemplatesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -154,7 +154,7 @@ func (krc *KuberayAPIServerClient) GetAllComputeTemplatesInNamespace(request *ap
 	}
 	response := &api.ListComputeTemplatesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -182,7 +182,7 @@ func (krc *KuberayAPIServerClient) CreateCluster(request *api.CreateClusterReque
 	}
 	cluster := &api.Cluster{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, cluster); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return cluster, nil, nil
 }
@@ -209,7 +209,7 @@ func (krc *KuberayAPIServerClient) GetCluster(request *api.GetClusterRequest) (*
 	}
 	cluster := &api.Cluster{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, cluster); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return cluster, nil, nil
 }
@@ -288,7 +288,7 @@ func (krc *KuberayAPIServerClient) CreateRayJob(request *api.CreateRayJobRequest
 	}
 	rayJob := &api.RayJob{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayJob); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return rayJob, nil, nil
 }
@@ -309,7 +309,7 @@ func (krc *KuberayAPIServerClient) GetRayJob(request *api.GetRayJobRequest) (*ap
 	}
 	rayJob := &api.RayJob{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayJob); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return rayJob, nil, nil
 }
@@ -330,7 +330,7 @@ func (krc *KuberayAPIServerClient) ListRayJobs(request *api.ListRayJobsRequest) 
 	}
 	response := &api.ListRayJobsResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -351,7 +351,7 @@ func (krc *KuberayAPIServerClient) ListAllRayJobs() (*api.ListAllRayJobsResponse
 	}
 	response := &api.ListAllRayJobsResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -384,7 +384,7 @@ func (krc *KuberayAPIServerClient) CreateRayService(request *api.CreateRayServic
 	}
 	rayService := &api.RayService{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayService); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return rayService, nil, nil
 }
@@ -411,7 +411,7 @@ func (krc *KuberayAPIServerClient) UpdateRayService(request *api.UpdateRayServic
 	}
 	rayService := &api.RayService{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayService); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return rayService, nil, nil
 }
@@ -432,7 +432,7 @@ func (krc *KuberayAPIServerClient) GetRayService(request *api.GetRayServiceReque
 	}
 	response := &api.RayService{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -453,7 +453,7 @@ func (krc *KuberayAPIServerClient) ListRayServices(request *api.ListRayServicesR
 	}
 	response := &api.ListRayServicesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -474,7 +474,7 @@ func (krc *KuberayAPIServerClient) ListAllRayServices() (*api.ListAllRayServices
 	}
 	response := &api.ListAllRayServicesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -507,7 +507,7 @@ func (krc *KuberayAPIServerClient) SubmitRayJob(request *api.SubmitRayJobRequest
 	}
 	submission := &api.SubmitRayJobReply{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, submission); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return submission, nil, nil
 }
@@ -528,7 +528,7 @@ func (krc *KuberayAPIServerClient) GetRayJobDetails(request *api.GetJobDetailsRe
 	}
 	response := &api.JobSubmissionInfo{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -549,7 +549,7 @@ func (krc *KuberayAPIServerClient) GetRayJobLog(request *api.GetJobLogRequest) (
 	}
 	response := &api.GetJobLogReply{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -570,7 +570,7 @@ func (krc *KuberayAPIServerClient) ListRayJobsCluster(request *api.ListJobDetail
 	}
 	response := &api.ListJobSubmissionInfo{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal http response: %+w", err)
 	}
 	return response, nil, nil
 }

--- a/apiserver/pkg/interceptor/interceptor.go
+++ b/apiserver/pkg/interceptor/interceptor.go
@@ -7,10 +7,10 @@ import (
 	klog "k8s.io/klog/v2"
 )
 
-// ApiServerInterceptor implements UnaryServerInterceptor that provides the common wrapping logic
+// APIServerInterceptor implements UnaryServerInterceptor that provides the common wrapping logic
 // to be executed before and after all API handler calls, e.g. Logging, error handling.
 // For more details, see https://github.com/grpc/grpc-go/blob/master/interceptor.go
-func ApiServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+func APIServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 	klog.Infof("%v handler starting", info.FullMethod)
 	resp, err = handler(ctx, req)
 	if err != nil {

--- a/apiserver/pkg/manager/resource_manager.go
+++ b/apiserver/pkg/manager/resource_manager.go
@@ -91,11 +91,9 @@ func (r *ResourceManager) CreateCluster(ctx context.Context, apiCluster *api.Clu
 	}
 
 	// convert *api.Cluster to rayv1api.RayCluster
-	rayCluster, err := util.
-		NewRayCluster(apiCluster, computeTemplateDict)
+	rayCluster, err := util.NewRayCluster(apiCluster, computeTemplateDict)
 	if err != nil {
-		return nil, util.
-			NewInvalidInputErrorWithDetails(err, "Failed to create a Ray cluster")
+		return nil, util.NewInvalidInputErrorWithDetails(err, "Failed to create a Ray cluster")
 	}
 
 	// set our own fields.
@@ -104,8 +102,7 @@ func (r *ResourceManager) CreateCluster(ctx context.Context, apiCluster *api.Clu
 
 	newRayCluster, err := r.getRayClusterClient(apiCluster.Namespace).Create(ctx, rayCluster.Get(), metav1.CreateOptions{})
 	if err != nil {
-		return nil, util.
-			NewInternalServerError(err, "Failed to create a cluster for (%s/%s)", rayCluster.Namespace, rayCluster.Name)
+		return nil, util.NewInternalServerError(err, "Failed to create a cluster for (%s/%s)", rayCluster.Namespace, rayCluster.Name)
 	}
 
 	return newRayCluster, nil

--- a/apiserver/pkg/manager/resource_manager.go
+++ b/apiserver/pkg/manager/resource_manager.go
@@ -94,7 +94,9 @@ func (r *ResourceManager) CreateCluster(ctx context.Context, apiCluster *api.Clu
 	rayCluster, err := util.
 							NewRayCluster(apiCluster, computeTemplateDict)
 	if err != nil {
-		return nil, util.NewInvalidInputErrorWithDetails(err, "Failed to create a Ray cluster")
+		return nil, util.
+
+			NewInvalidInputErrorWithDetails(err, "Failed to create a Ray cluster")
 	}
 
 	// set our own fields.
@@ -103,7 +105,8 @@ func (r *ResourceManager) CreateCluster(ctx context.Context, apiCluster *api.Clu
 
 	newRayCluster, err := r.getRayClusterClient(apiCluster.Namespace).Create(ctx, rayCluster.Get(), metav1.CreateOptions{})
 	if err != nil {
-		return nil, util.NewInternalServerError(err, "Failed to create a cluster for (%s/%s)", rayCluster.Namespace, rayCluster.Name)
+		return nil, util.
+			NewInternalServerError(err, "Failed to create a cluster for (%s/%s)", rayCluster.Namespace, rayCluster.Name)
 	}
 
 	return newRayCluster, nil

--- a/apiserver/pkg/manager/resource_manager.go
+++ b/apiserver/pkg/manager/resource_manager.go
@@ -92,10 +92,9 @@ func (r *ResourceManager) CreateCluster(ctx context.Context, apiCluster *api.Clu
 
 	// convert *api.Cluster to rayv1api.RayCluster
 	rayCluster, err := util.
-							NewRayCluster(apiCluster, computeTemplateDict)
+		NewRayCluster(apiCluster, computeTemplateDict)
 	if err != nil {
 		return nil, util.
-
 			NewInvalidInputErrorWithDetails(err, "Failed to create a Ray cluster")
 	}
 

--- a/apiserver/pkg/manager/resource_manager.go
+++ b/apiserver/pkg/manager/resource_manager.go
@@ -91,7 +91,8 @@ func (r *ResourceManager) CreateCluster(ctx context.Context, apiCluster *api.Clu
 	}
 
 	// convert *api.Cluster to rayv1api.RayCluster
-	rayCluster, err := util.NewRayCluster(apiCluster, computeTemplateDict)
+	rayCluster, err := util.
+							NewRayCluster(apiCluster, computeTemplateDict)
 	if err != nil {
 		return nil, util.NewInvalidInputErrorWithDetails(err, "Failed to create a Ray cluster")
 	}

--- a/apiserver/pkg/model/converter.go
+++ b/apiserver/pkg/model/converter.go
@@ -410,9 +410,9 @@ func FromKubeToAPIComputeTemplate(configMap *corev1.ConfigMap) *api.ComputeTempl
 	runtime := &api.ComputeTemplate{}
 	runtime.Name = configMap.Name
 	runtime.Namespace = configMap.Namespace
-	runtime.Cpu = uint32(cpu)
-	runtime.Memory = uint32(memory)
-	runtime.Gpu = uint32(gpu)
+	runtime.Cpu = uint32(cpu) //nolint:gosec // value is a valid uint32
+	runtime.Memory = uint32(memory) //nolint:gosec // value is a valid uint32
+	runtime.Gpu = uint32(gpu) //nolint:gosec // value is a valid uint32
 	runtime.GpuAccelerator = configMap.Data["gpu_accelerator"]
 
 	val, ok := configMap.Data["extended_resources"]

--- a/apiserver/pkg/model/converter.go
+++ b/apiserver/pkg/model/converter.go
@@ -410,9 +410,9 @@ func FromKubeToAPIComputeTemplate(configMap *corev1.ConfigMap) *api.ComputeTempl
 	runtime := &api.ComputeTemplate{}
 	runtime.Name = configMap.Name
 	runtime.Namespace = configMap.Namespace
-	runtime.Cpu = uint32(cpu)       //nolint:gosec // value is a valid uint32
-	runtime.Memory = uint32(memory) //nolint:gosec // value is a valid uint32
-	runtime.Gpu = uint32(gpu)       //nolint:gosec // value is a valid uint32
+	runtime.Cpu = uint32(cpu)
+	runtime.Memory = uint32(memory)
+	runtime.Gpu = uint32(gpu)
 	runtime.GpuAccelerator = configMap.Data["gpu_accelerator"]
 
 	val, ok := configMap.Data["extended_resources"]

--- a/apiserver/pkg/model/converter.go
+++ b/apiserver/pkg/model/converter.go
@@ -88,15 +88,15 @@ func contains(s []string, str string) bool {
 	return false
 }
 
-func FromCrdToApiClusters(clusters []*rayv1api.RayCluster, clusterEventsMap map[string][]corev1.Event) []*api.Cluster {
+func FromCrdToAPIClusters(clusters []*rayv1api.RayCluster, clusterEventsMap map[string][]corev1.Event) []*api.Cluster {
 	apiClusters := make([]*api.Cluster, 0)
 	for _, cluster := range clusters {
-		apiClusters = append(apiClusters, FromCrdToApiCluster(cluster, clusterEventsMap[cluster.Name]))
+		apiClusters = append(apiClusters, FromCrdToAPICluster(cluster, clusterEventsMap[cluster.Name]))
 	}
 	return apiClusters
 }
 
-func FromCrdToApiCluster(cluster *rayv1api.RayCluster, events []corev1.Event) *api.Cluster {
+func FromCrdToAPICluster(cluster *rayv1api.RayCluster, events []corev1.Event) *api.Cluster {
 	pbCluster := &api.Cluster{
 		Name:      cluster.Name,
 		Namespace: cluster.Namespace,
@@ -443,15 +443,15 @@ func FromKubeToAPIComputeTemplates(configMaps []*corev1.ConfigMap) []*api.Comput
 	return apiComputeTemplates
 }
 
-func FromCrdToApiJobs(jobs []*rayv1api.RayJob) []*api.RayJob {
+func FromCrdToAPIJobs(jobs []*rayv1api.RayJob) []*api.RayJob {
 	apiJobs := make([]*api.RayJob, 0)
 	for _, job := range jobs {
-		apiJobs = append(apiJobs, FromCrdToApiJob(job))
+		apiJobs = append(apiJobs, FromCrdToAPIJob(job))
 	}
 	return apiJobs
 }
 
-func FromCrdToApiJob(job *rayv1api.RayJob) (pbJob *api.RayJob) {
+func FromCrdToAPIJob(job *rayv1api.RayJob) (pbJob *api.RayJob) {
 	defer func() {
 		err := recover()
 		if err != nil {
@@ -523,18 +523,18 @@ func FromCrdToApiJob(job *rayv1api.RayJob) (pbJob *api.RayJob) {
 	return pbJob
 }
 
-func FromCrdToApiServices(
+func FromCrdToAPIServices(
 	services []*rayv1api.RayService,
 	serviceEventsMap map[string][]corev1.Event,
 ) []*api.RayService {
 	apiServices := make([]*api.RayService, 0)
 	for _, service := range services {
-		apiServices = append(apiServices, FromCrdToApiService(service, serviceEventsMap[service.Name]))
+		apiServices = append(apiServices, FromCrdToAPIService(service, serviceEventsMap[service.Name]))
 	}
 	return apiServices
 }
 
-func FromCrdToApiService(service *rayv1api.RayService, events []corev1.Event) *api.RayService {
+func FromCrdToAPIService(service *rayv1api.RayService, events []corev1.Event) *api.RayService {
 	defer func() {
 		err := recover()
 		if err != nil {

--- a/apiserver/pkg/model/converter.go
+++ b/apiserver/pkg/model/converter.go
@@ -410,9 +410,9 @@ func FromKubeToAPIComputeTemplate(configMap *corev1.ConfigMap) *api.ComputeTempl
 	runtime := &api.ComputeTemplate{}
 	runtime.Name = configMap.Name
 	runtime.Namespace = configMap.Namespace
-	runtime.Cpu = uint32(cpu) //nolint:gosec // value is a valid uint32
+	runtime.Cpu = uint32(cpu)       //nolint:gosec // value is a valid uint32
 	runtime.Memory = uint32(memory) //nolint:gosec // value is a valid uint32
-	runtime.Gpu = uint32(gpu) //nolint:gosec // value is a valid uint32
+	runtime.Gpu = uint32(gpu)       //nolint:gosec // value is a valid uint32
 	runtime.GpuAccelerator = configMap.Data["gpu_accelerator"]
 
 	val, ok := configMap.Data["extended_resources"]

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -8,7 +8,7 @@ import (
 
 	util "github.com/ray-project/kuberay/apiserver/pkg/util"
 	api "github.com/ray-project/kuberay/proto/go_client"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -557,15 +557,15 @@ func TestPopulateWorkerNodeSpec(t *testing.T) {
 
 func TestAutoscalerOptions(t *testing.T) {
 	options := convertAutoscalingOptions(autoscalerOptions)
-	assert.Equal(t, int32(60), options.IdleTimeoutSeconds)
-	assert.Equal(t, "Default", options.UpscalingMode)
-	assert.Equal(t, "Some Image", options.Image)
-	assert.Equal(t, "Always", options.ImagePullPolicy)
-	assert.Equal(t, "500m", options.Cpu)
-	assert.Equal(t, "512Mi", options.Memory)
-	assert.Len(t, options.Envs.Values, 1)
-	assert.Len(t, options.Envs.ValuesFrom, 2)
-	assert.Len(t, options.Volumes, 2)
+	require.Equal(t, int32(60), options.IdleTimeoutSeconds)
+	require.Equal(t, "Default", options.UpscalingMode)
+	require.Equal(t, "Some Image", options.Image)
+	require.Equal(t, "Always", options.ImagePullPolicy)
+	require.Equal(t, "500m", options.Cpu)
+	require.Equal(t, "512Mi", options.Memory)
+	require.Len(t, options.Envs.Values, 1)
+	require.Len(t, options.Envs.ValuesFrom, 2)
+	require.Len(t, options.Volumes, 2)
 }
 
 func TestPopulateRayClusterSpec(t *testing.T) {
@@ -573,39 +573,39 @@ func TestPopulateRayClusterSpec(t *testing.T) {
 	if len(cluster.Annotations) != 1 {
 		t.Errorf("failed to convert cluster's annotations")
 	}
-	assert.False(t, cluster.ClusterSpec.EnableInTreeAutoscaling)
+	require.False(t, cluster.ClusterSpec.EnableInTreeAutoscaling)
 	if cluster.ClusterSpec.AutoscalerOptions != nil {
 		t.Errorf("unexpected autoscaler annotations")
 	}
 	cluster = FromCrdToAPICluster(&ClusterSpecAutoscalerTest, []corev1.Event{})
-	assert.True(t, cluster.ClusterSpec.EnableInTreeAutoscaling)
+	require.True(t, cluster.ClusterSpec.EnableInTreeAutoscaling)
 	if cluster.ClusterSpec.AutoscalerOptions == nil {
 		t.Errorf("autoscaler annotations not found")
 	}
-	assert.Equal(t, int32(60), cluster.ClusterSpec.AutoscalerOptions.IdleTimeoutSeconds)
-	assert.Equal(t, "Default", cluster.ClusterSpec.AutoscalerOptions.UpscalingMode)
-	assert.Equal(t, "Always", cluster.ClusterSpec.AutoscalerOptions.ImagePullPolicy)
-	assert.Equal(t, "500m", cluster.ClusterSpec.AutoscalerOptions.Cpu)
-	assert.Equal(t, "512Mi", cluster.ClusterSpec.AutoscalerOptions.Memory)
-	assert.Len(t, cluster.ClusterSpec.HeadGroupSpec.Environment.ValuesFrom, 4)
+	require.Equal(t, int32(60), cluster.ClusterSpec.AutoscalerOptions.IdleTimeoutSeconds)
+	require.Equal(t, "Default", cluster.ClusterSpec.AutoscalerOptions.UpscalingMode)
+	require.Equal(t, "Always", cluster.ClusterSpec.AutoscalerOptions.ImagePullPolicy)
+	require.Equal(t, "500m", cluster.ClusterSpec.AutoscalerOptions.Cpu)
+	require.Equal(t, "512Mi", cluster.ClusterSpec.AutoscalerOptions.Memory)
+	require.Len(t, cluster.ClusterSpec.HeadGroupSpec.Environment.ValuesFrom, 4)
 	for name, value := range cluster.ClusterSpec.HeadGroupSpec.Environment.ValuesFrom {
 		switch name {
 		case "REDIS_PASSWORD":
-			assert.Equal(t, "SECRET", value.Source.String())
-			assert.Equal(t, "redis-password-secret", value.Name)
-			assert.Equal(t, "password", value.Key)
+			require.Equal(t, "SECRET", value.Source.String())
+			require.Equal(t, "redis-password-secret", value.Name)
+			require.Equal(t, "password", value.Key)
 		case "CONFIGMAP":
-			assert.Equal(t, "CONFIGMAP", value.Source.String())
-			assert.Equal(t, "special-config", value.Name)
-			assert.Equal(t, "special.how", value.Key)
+			require.Equal(t, "CONFIGMAP", value.Source.String())
+			require.Equal(t, "special-config", value.Name)
+			require.Equal(t, "special.how", value.Key)
 		case "ResourceFieldRef":
-			assert.Equal(t, "RESOURCEFIELD", value.Source.String())
-			assert.Equal(t, "my-container", value.Name)
-			assert.Equal(t, "resource", value.Key)
+			require.Equal(t, "RESOURCEFIELD", value.Source.String())
+			require.Equal(t, "my-container", value.Name)
+			require.Equal(t, "resource", value.Key)
 		default:
-			assert.Equal(t, "FIELD", value.Source.String())
-			assert.Equal(t, "", value.Name)
-			assert.Equal(t, "path", value.Key)
+			require.Equal(t, "FIELD", value.Source.String())
+			require.Equal(t, "", value.Name)
+			require.Equal(t, "path", value.Key)
 		}
 	}
 }
@@ -627,10 +627,10 @@ func TestPopulateTemplate(t *testing.T) {
 			tolerationToString(&expectedTolerations))
 	}
 
-	assert.Equal(t, uint32(4), template.Cpu, "CPU mismatch")
-	assert.Equal(t, uint32(8), template.Memory, "Memory mismatch")
-	assert.Equal(t, uint32(0), template.Gpu, "GPU mismatch")
-	assert.Equal(
+	require.Equal(t, uint32(4), template.Cpu, "CPU mismatch")
+	require.Equal(t, uint32(8), template.Memory, "Memory mismatch")
+	require.Equal(t, uint32(0), template.Gpu, "GPU mismatch")
+	require.Equal(
 		t,
 		map[string]uint32{"vpc.amazonaws.com/efa": 32},
 		template.ExtendedResources,
@@ -645,39 +645,39 @@ func tolerationToString(toleration *api.PodToleration) string {
 func TestPopulateJob(t *testing.T) {
 	job := FromCrdToAPIJob(&JobNewClusterTest)
 	fmt.Printf("jobWithCluster = %#v\n", job)
-	assert.Equal(t, "test", job.Name)
-	assert.Equal(t, "test", job.Namespace)
-	assert.Equal(t, "user", job.User)
-	assert.Greater(t, len(job.RuntimeEnv), 1)
-	assert.Nil(t, job.ClusterSelector)
-	assert.NotNil(t, job.ClusterSpec)
+	require.Equal(t, "test", job.Name)
+	require.Equal(t, "test", job.Namespace)
+	require.Equal(t, "user", job.User)
+	require.Greater(t, len(job.RuntimeEnv), 1)
+	require.Nil(t, job.ClusterSelector)
+	require.NotNil(t, job.ClusterSpec)
 
 	job = FromCrdToAPIJob(&JobExistingClusterTest)
 	fmt.Printf("jobReferenceCluster = %#v\n", job)
-	assert.Equal(t, "test", job.Name)
-	assert.Equal(t, "test", job.Namespace)
-	assert.Equal(t, "user", job.User)
-	assert.Greater(t, len(job.RuntimeEnv), 1)
-	assert.NotNil(t, job.ClusterSelector)
-	assert.Nil(t, job.ClusterSpec)
+	require.Equal(t, "test", job.Name)
+	require.Equal(t, "test", job.Namespace)
+	require.Equal(t, "user", job.User)
+	require.Greater(t, len(job.RuntimeEnv), 1)
+	require.NotNil(t, job.ClusterSelector)
+	require.Nil(t, job.ClusterSpec)
 
 	job = FromCrdToAPIJob(&JobExistingClusterSubmitterTest)
 	fmt.Printf("jobReferenceCluster = %#v\n", job)
-	assert.Equal(t, "test", job.Name)
-	assert.Equal(t, "test", job.Namespace)
-	assert.Equal(t, "user", job.User)
-	assert.Greater(t, len(job.RuntimeEnv), 1)
-	assert.NotNil(t, job.ClusterSelector)
-	assert.Nil(t, job.ClusterSpec)
-	assert.Equal(t, "image", job.JobSubmitter.Image)
-	assert.Equal(t, "2", job.JobSubmitter.Cpu)
+	require.Equal(t, "test", job.Name)
+	require.Equal(t, "test", job.Namespace)
+	require.Equal(t, "user", job.User)
+	require.Greater(t, len(job.RuntimeEnv), 1)
+	require.NotNil(t, job.ClusterSelector)
+	require.Nil(t, job.ClusterSpec)
+	require.Equal(t, "image", job.JobSubmitter.Image)
+	require.Equal(t, "2", job.JobSubmitter.Cpu)
 
 	job = FromCrdToAPIJob(&JobWithOutputTest)
 	fmt.Printf("jobWithOutput = %#v\n", job)
-	assert.Equal(t, time.Date(2024, 0o7, 25, 0, 0, 0, 0, time.UTC), job.StartTime.AsTime())
-	assert.Nil(t, job.EndTime)
-	assert.Equal(t, "RUNNING", job.JobStatus)
-	assert.Equal(t, "Initializing", job.JobDeploymentStatus)
-	assert.Equal(t, "Job is currently running", job.Message)
-	assert.Equal(t, "raycluster-sample-xxxxx", job.RayClusterName)
+	require.Equal(t, time.Date(2024, 0o7, 25, 0, 0, 0, 0, time.UTC), job.StartTime.AsTime())
+	require.Nil(t, job.EndTime)
+	require.Equal(t, "RUNNING", job.JobStatus)
+	require.Equal(t, "Initializing", job.JobDeploymentStatus)
+	require.Equal(t, "Job is currently running", job.Message)
+	require.Equal(t, "raycluster-sample-xxxxx", job.RayClusterName)
 }

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -569,7 +569,7 @@ func TestAutoscalerOptions(t *testing.T) {
 }
 
 func TestPopulateRayClusterSpec(t *testing.T) {
-	cluster := FromCrdToApiCluster(&ClusterSpecTest, []corev1.Event{})
+	cluster := FromCrdToAPICluster(&ClusterSpecTest, []corev1.Event{})
 	if len(cluster.Annotations) != 1 {
 		t.Errorf("failed to convert cluster's annotations")
 	}
@@ -577,7 +577,7 @@ func TestPopulateRayClusterSpec(t *testing.T) {
 	if cluster.ClusterSpec.AutoscalerOptions != nil {
 		t.Errorf("unexpected autoscaler annotations")
 	}
-	cluster = FromCrdToApiCluster(&ClusterSpecAutoscalerTest, []corev1.Event{})
+	cluster = FromCrdToAPICluster(&ClusterSpecAutoscalerTest, []corev1.Event{})
 	assert.True(t, cluster.ClusterSpec.EnableInTreeAutoscaling)
 	if cluster.ClusterSpec.AutoscalerOptions == nil {
 		t.Errorf("autoscaler annotations not found")
@@ -643,7 +643,7 @@ func tolerationToString(toleration *api.PodToleration) string {
 }
 
 func TestPopulateJob(t *testing.T) {
-	job := FromCrdToApiJob(&JobNewClusterTest)
+	job := FromCrdToAPIJob(&JobNewClusterTest)
 	fmt.Printf("jobWithCluster = %#v\n", job)
 	assert.Equal(t, "test", job.Name)
 	assert.Equal(t, "test", job.Namespace)
@@ -652,7 +652,7 @@ func TestPopulateJob(t *testing.T) {
 	assert.Nil(t, job.ClusterSelector)
 	assert.NotNil(t, job.ClusterSpec)
 
-	job = FromCrdToApiJob(&JobExistingClusterTest)
+	job = FromCrdToAPIJob(&JobExistingClusterTest)
 	fmt.Printf("jobReferenceCluster = %#v\n", job)
 	assert.Equal(t, "test", job.Name)
 	assert.Equal(t, "test", job.Namespace)
@@ -661,7 +661,7 @@ func TestPopulateJob(t *testing.T) {
 	assert.NotNil(t, job.ClusterSelector)
 	assert.Nil(t, job.ClusterSpec)
 
-	job = FromCrdToApiJob(&JobExistingClusterSubmitterTest)
+	job = FromCrdToAPIJob(&JobExistingClusterSubmitterTest)
 	fmt.Printf("jobReferenceCluster = %#v\n", job)
 	assert.Equal(t, "test", job.Name)
 	assert.Equal(t, "test", job.Namespace)
@@ -672,7 +672,7 @@ func TestPopulateJob(t *testing.T) {
 	assert.Equal(t, "image", job.JobSubmitter.Image)
 	assert.Equal(t, "2", job.JobSubmitter.Cpu)
 
-	job = FromCrdToApiJob(&JobWithOutputTest)
+	job = FromCrdToAPIJob(&JobWithOutputTest)
 	fmt.Printf("jobWithOutput = %#v\n", job)
 	assert.Equal(t, time.Date(2024, 0o7, 25, 0, 0, 0, 0, time.UTC), job.StartTime.AsTime())
 	assert.Nil(t, job.EndTime)

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -557,15 +557,15 @@ func TestPopulateWorkerNodeSpec(t *testing.T) {
 
 func TestAutoscalerOptions(t *testing.T) {
 	options := convertAutoscalingOptions(autoscalerOptions)
-	assert.Equal(t, options.IdleTimeoutSeconds, int32(60))
-	assert.Equal(t, options.UpscalingMode, "Default")
-	assert.Equal(t, options.Image, "Some Image")
-	assert.Equal(t, options.ImagePullPolicy, "Always")
-	assert.Equal(t, options.Cpu, "500m")
-	assert.Equal(t, options.Memory, "512Mi")
-	assert.Equal(t, len(options.Envs.Values), 1)
-	assert.Equal(t, len(options.Envs.ValuesFrom), 2)
-	assert.Equal(t, len(options.Volumes), 2)
+	assert.Equal(t, int32(60), options.IdleTimeoutSeconds)
+	assert.Equal(t, "Default", options.UpscalingMode)
+	assert.Equal(t, "Some Image", options.Image)
+	assert.Equal(t, "Always", options.ImagePullPolicy)
+	assert.Equal(t, "500m", options.Cpu)
+	assert.Equal(t, "512Mi", options.Memory)
+	assert.Len(t, options.Envs.Values, 1)
+	assert.Len(t, options.Envs.ValuesFrom, 2)
+	assert.Len(t, options.Volumes, 2)
 }
 
 func TestPopulateRayClusterSpec(t *testing.T) {
@@ -573,39 +573,39 @@ func TestPopulateRayClusterSpec(t *testing.T) {
 	if len(cluster.Annotations) != 1 {
 		t.Errorf("failed to convert cluster's annotations")
 	}
-	assert.Equal(t, cluster.ClusterSpec.EnableInTreeAutoscaling, false)
+	assert.False(t, cluster.ClusterSpec.EnableInTreeAutoscaling)
 	if cluster.ClusterSpec.AutoscalerOptions != nil {
 		t.Errorf("unexpected autoscaler annotations")
 	}
 	cluster = FromCrdToApiCluster(&ClusterSpecAutoscalerTest, []corev1.Event{})
-	assert.Equal(t, cluster.ClusterSpec.EnableInTreeAutoscaling, true)
+	assert.True(t, cluster.ClusterSpec.EnableInTreeAutoscaling)
 	if cluster.ClusterSpec.AutoscalerOptions == nil {
 		t.Errorf("autoscaler annotations not found")
 	}
-	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.IdleTimeoutSeconds, int32(60))
-	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.UpscalingMode, "Default")
-	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.ImagePullPolicy, "Always")
-	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.Cpu, "500m")
-	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.Memory, "512Mi")
-	assert.Equal(t, len(cluster.ClusterSpec.HeadGroupSpec.Environment.ValuesFrom), 4)
+	assert.Equal(t, int32(60), cluster.ClusterSpec.AutoscalerOptions.IdleTimeoutSeconds)
+	assert.Equal(t, "Default", cluster.ClusterSpec.AutoscalerOptions.UpscalingMode)
+	assert.Equal(t, "Always", cluster.ClusterSpec.AutoscalerOptions.ImagePullPolicy)
+	assert.Equal(t, "500m", cluster.ClusterSpec.AutoscalerOptions.Cpu)
+	assert.Equal(t, "512Mi", cluster.ClusterSpec.AutoscalerOptions.Memory)
+	assert.Len(t, cluster.ClusterSpec.HeadGroupSpec.Environment.ValuesFrom, 4)
 	for name, value := range cluster.ClusterSpec.HeadGroupSpec.Environment.ValuesFrom {
 		switch name {
 		case "REDIS_PASSWORD":
-			assert.Equal(t, value.Source.String(), "SECRET")
-			assert.Equal(t, value.Name, "redis-password-secret")
-			assert.Equal(t, value.Key, "password")
+			assert.Equal(t, "SECRET", value.Source.String())
+			assert.Equal(t, "redis-password-secret", value.Name)
+			assert.Equal(t, "password", value.Key)
 		case "CONFIGMAP":
-			assert.Equal(t, value.Source.String(), "CONFIGMAP")
-			assert.Equal(t, value.Name, "special-config")
-			assert.Equal(t, value.Key, "special.how")
+			assert.Equal(t, "CONFIGMAP", value.Source.String())
+			assert.Equal(t, "special-config", value.Name)
+			assert.Equal(t, "special.how", value.Key)
 		case "ResourceFieldRef":
-			assert.Equal(t, value.Source.String(), "RESOURCEFIELD")
-			assert.Equal(t, value.Name, "my-container")
-			assert.Equal(t, value.Key, "resource")
+			assert.Equal(t, "RESOURCEFIELD", value.Source.String())
+			assert.Equal(t, "my-container", value.Name)
+			assert.Equal(t, "resource", value.Key)
 		default:
-			assert.Equal(t, value.Source.String(), "FIELD")
-			assert.Equal(t, value.Name, "")
-			assert.Equal(t, value.Key, "path")
+			assert.Equal(t, "FIELD", value.Source.String())
+			assert.Equal(t, "", value.Name)
+			assert.Equal(t, "path", value.Key)
 		}
 	}
 }
@@ -639,11 +639,7 @@ func TestPopulateTemplate(t *testing.T) {
 }
 
 func tolerationToString(toleration *api.PodToleration) string {
-	return "Key: " + toleration.Key + " Operator: " + string(
-		toleration.Operator,
-	) + " Effect: " + string(
-		toleration.Effect,
-	)
+	return "Key: " + toleration.Key + " Operator: " + toleration.Operator + " Effect: " + toleration.Effect
 }
 
 func TestPopulateJob(t *testing.T) {

--- a/apiserver/pkg/server/cluster_server.go
+++ b/apiserver/pkg/server/cluster_server.go
@@ -19,9 +19,9 @@ type ClusterServerOptions struct {
 // implements `type ClusterServiceServer interface` in cluster_grpc.pb.go
 // ClusterServer is the server API for ClusterService service.
 type ClusterServer struct {
+	api.UnimplementedClusterServiceServer
 	resourceManager *manager.ResourceManager
 	options         *ClusterServerOptions
-	api.UnimplementedClusterServiceServer
 }
 
 // Creates a new Cluster.

--- a/apiserver/pkg/server/cluster_server.go
+++ b/apiserver/pkg/server/cluster_server.go
@@ -98,7 +98,7 @@ func (s *ClusterServer) ListCluster(ctx context.Context, request *api.ListCluste
 // TODO: Supports pagination and sorting on certain fields when we have DB support. request needs to be extended.
 func (s *ClusterServer) ListAllClusters(ctx context.Context, request *api.ListAllClustersRequest) (*api.ListAllClustersResponse, error) {
 	// Leave the namespace empty to list all clusters in all namespaces.
-	clusters, continueToken, err := s.resourceManager.ListClusters(ctx, /*namespace=*/ "", request.Continue, request.Limit)
+	clusters, continueToken, err := s.resourceManager.ListClusters(ctx /*namespace=*/, "", request.Continue, request.Limit)
 	if err != nil {
 		return nil, util.Wrap(err, "List clusters from all namespaces failed.")
 	}

--- a/apiserver/pkg/server/cluster_server.go
+++ b/apiserver/pkg/server/cluster_server.go
@@ -155,11 +155,7 @@ func ValidateCreateClusterRequest(request *api.CreateClusterRequest) error {
 		return util.NewInvalidInputError("User who create the cluster is empty. Please specify a valid value.")
 	}
 
-	if err := ValidateClusterSpec(request.Cluster.ClusterSpec); err != nil {
-		return err
-	}
-
-	return nil
+	return ValidateClusterSpec(request.Cluster.ClusterSpec)
 }
 
 func NewClusterServer(resourceManager *manager.ResourceManager, options *ClusterServerOptions) *ClusterServer {

--- a/apiserver/pkg/server/cluster_server.go
+++ b/apiserver/pkg/server/cluster_server.go
@@ -98,7 +98,7 @@ func (s *ClusterServer) ListCluster(ctx context.Context, request *api.ListCluste
 // TODO: Supports pagination and sorting on certain fields when we have DB support. request needs to be extended.
 func (s *ClusterServer) ListAllClusters(ctx context.Context, request *api.ListAllClustersRequest) (*api.ListAllClustersResponse, error) {
 	// Leave the namespace empty to list all clusters in all namespaces.
-	clusters, continueToken, err := s.resourceManager.ListClusters(ctx /*namespace=*/, "", request.Continue, request.Limit)
+	clusters, continueToken, err := s.resourceManager.ListClusters(ctx, "" /*namespace=*/, request.Continue, request.Limit)
 	if err != nil {
 		return nil, util.Wrap(err, "List clusters from all namespaces failed.")
 	}

--- a/apiserver/pkg/server/cluster_server.go
+++ b/apiserver/pkg/server/cluster_server.go
@@ -42,7 +42,7 @@ func (s *ClusterServer) CreateCluster(ctx context.Context, request *api.CreateCl
 		klog.Warningf("Failed to get cluster's event, cluster: %s/%s, err: %v", cluster.Namespace, cluster.Name, err)
 	}
 
-	return model.FromCrdToApiCluster(cluster, events), nil
+	return model.FromCrdToAPICluster(cluster, events), nil
 }
 
 // Finds a specific Cluster by cluster name.
@@ -64,7 +64,7 @@ func (s *ClusterServer) GetCluster(ctx context.Context, request *api.GetClusterR
 		klog.Warningf("Failed to get cluster's event, cluster: %s/%s, err: %v", cluster.Namespace, cluster.Name, err)
 	}
 
-	return model.FromCrdToApiCluster(cluster, events), nil
+	return model.FromCrdToAPICluster(cluster, events), nil
 }
 
 // Finds all Clusters in a given namespace.
@@ -89,7 +89,7 @@ func (s *ClusterServer) ListCluster(ctx context.Context, request *api.ListCluste
 	}
 
 	return &api.ListClustersResponse{
-		Clusters: model.FromCrdToApiClusters(clusters, clusterEventMap),
+		Clusters: model.FromCrdToAPIClusters(clusters, clusterEventMap),
 		Continue: continueToken,
 	}, nil
 }
@@ -113,7 +113,7 @@ func (s *ClusterServer) ListAllClusters(ctx context.Context, request *api.ListAl
 	}
 
 	return &api.ListAllClustersResponse{
-		Clusters: model.FromCrdToApiClusters(clusters, clusterEventMap),
+		Clusters: model.FromCrdToAPIClusters(clusters, clusterEventMap),
 		Continue: continueToken,
 	}, nil
 }

--- a/apiserver/pkg/server/compute_template_server.go
+++ b/apiserver/pkg/server/compute_template_server.go
@@ -18,9 +18,9 @@ type ComputeTemplateServerOptions struct {
 // implements `type ComputeTemplateServiceServer interface` in runtime_grpc.pb.go
 // ComputeTemplateServer is the server API for ClusterRuntimeService.
 type ComputeTemplateServer struct {
+	api.UnimplementedComputeTemplateServiceServer
 	resourceManager *manager.ResourceManager
 	options         *ComputeTemplateServerOptions
-	api.UnimplementedComputeTemplateServiceServer
 }
 
 func (s *ComputeTemplateServer) CreateComputeTemplate(ctx context.Context, request *api.CreateComputeTemplateRequest) (*api.ComputeTemplate, error) {
@@ -71,7 +71,7 @@ func (s *ComputeTemplateServer) ListComputeTemplates(ctx context.Context, reques
 	}, nil
 }
 
-func (s *ComputeTemplateServer) ListAllComputeTemplates(ctx context.Context, request *api.ListAllComputeTemplatesRequest) (*api.ListAllComputeTemplatesResponse, error) {
+func (s *ComputeTemplateServer) ListAllComputeTemplates(ctx context.Context, _ *api.ListAllComputeTemplatesRequest) (*api.ListAllComputeTemplatesResponse, error) {
 	runtimes, err := s.resourceManager.ListAllComputeTemplates(ctx)
 	if err != nil {
 		return nil, util.Wrap(err, "List all compute templates from all namespaces failed.")

--- a/apiserver/pkg/server/job_server.go
+++ b/apiserver/pkg/server/job_server.go
@@ -79,7 +79,7 @@ func (s *RayJobServer) ListRayJobs(ctx context.Context, request *api.ListRayJobs
 }
 
 // Finds all Jobs in all namespaces.
-func (s *RayJobServer) ListAllRayJobs(ctx context.Context, request *api.ListAllRayJobsRequest) (*api.ListAllRayJobsResponse, error) {
+func (s *RayJobServer) ListAllRayJobs(ctx context.Context, _ *api.ListAllRayJobsRequest) (*api.ListAllRayJobsResponse, error) {
 	jobs, err := s.resourceManager.ListAllJobs(ctx)
 	if err != nil {
 		return nil, util.Wrap(err, "List jobs failed.")

--- a/apiserver/pkg/server/job_server.go
+++ b/apiserver/pkg/server/job_server.go
@@ -22,9 +22,9 @@ func NewRayJobServer(resourceManager *manager.ResourceManager, options *JobServe
 }
 
 type RayJobServer struct {
+	api.UnimplementedRayJobServiceServer
 	resourceManager *manager.ResourceManager
 	options         *JobServerOptions
-	api.UnimplementedRayJobServiceServer
 }
 
 // Creates a new Ray Job.
@@ -128,9 +128,5 @@ func ValidateCreateJobRequest(request *api.CreateRayJobRequest) error {
 		return nil
 	}
 
-	if err := ValidateClusterSpec(request.Job.ClusterSpec); err != nil {
-		return err
-	}
-
-	return nil
+	return ValidateClusterSpec(request.Job.ClusterSpec)
 }

--- a/apiserver/pkg/server/job_server.go
+++ b/apiserver/pkg/server/job_server.go
@@ -41,7 +41,7 @@ func (s *RayJobServer) CreateRayJob(ctx context.Context, request *api.CreateRayJ
 		return nil, util.Wrap(err, "Create Job failed.")
 	}
 
-	return model.FromCrdToApiJob(job), nil
+	return model.FromCrdToAPIJob(job), nil
 }
 
 // Finds a specific Job by job name.
@@ -59,7 +59,7 @@ func (s *RayJobServer) GetRayJob(ctx context.Context, request *api.GetRayJobRequ
 		return nil, util.Wrap(err, "Get cluster failed.")
 	}
 
-	return model.FromCrdToApiJob(job), nil
+	return model.FromCrdToAPIJob(job), nil
 }
 
 // Finds all Jobs in a given namespace.
@@ -74,7 +74,7 @@ func (s *RayJobServer) ListRayJobs(ctx context.Context, request *api.ListRayJobs
 	}
 
 	return &api.ListRayJobsResponse{
-		Jobs: model.FromCrdToApiJobs(jobs),
+		Jobs: model.FromCrdToAPIJobs(jobs),
 	}, nil
 }
 
@@ -86,7 +86,7 @@ func (s *RayJobServer) ListAllRayJobs(ctx context.Context, _ *api.ListAllRayJobs
 	}
 
 	return &api.ListAllRayJobsResponse{
-		Jobs: model.FromCrdToApiJobs(jobs),
+		Jobs: model.FromCrdToAPIJobs(jobs),
 	}, nil
 }
 

--- a/apiserver/pkg/server/ray_job_submission_service_server.go
+++ b/apiserver/pkg/server/ray_job_submission_service_server.go
@@ -28,12 +28,11 @@ type RayJobSubmissionServiceServerOptions struct {
 // implements `type ClusterServiceServer interface` in cluster_grpc.pb.go
 // ClusterServer is the server API for ClusterService service.
 type RayJobSubmissionServiceServer struct {
-	options       *RayJobSubmissionServiceServerOptions
-	clusterServer *ClusterServer
-	log           logr.Logger
 	api.UnimplementedRayJobSubmissionServiceServer
-
+	options             *RayJobSubmissionServiceServerOptions
+	clusterServer       *ClusterServer
 	dashboardClientFunc func() utils.RayDashboardClientInterface
+	log                 logr.Logger
 }
 
 // Create RayJobSubmissionServiceServer

--- a/apiserver/pkg/server/serve_server.go
+++ b/apiserver/pkg/server/serve_server.go
@@ -44,7 +44,7 @@ func (s *RayServiceServer) CreateRayService(ctx context.Context, request *api.Cr
 	if err != nil {
 		klog.Warningf("failed to get rayService's event, service: %s/%s, err: %v", rayService.Namespace, rayService.Name, err)
 	}
-	return model.FromCrdToApiService(rayService, events), nil
+	return model.FromCrdToAPIService(rayService, events), nil
 }
 
 func (s *RayServiceServer) UpdateRayService(ctx context.Context, request *api.UpdateRayServiceRequest) (*api.RayService, error) {
@@ -61,7 +61,7 @@ func (s *RayServiceServer) UpdateRayService(ctx context.Context, request *api.Up
 	if err != nil {
 		klog.Warningf("failed to get rayService's event, service: %s/%s, err: %v", rayService.Namespace, rayService.Name, err)
 	}
-	return model.FromCrdToApiService(rayService, events), nil
+	return model.FromCrdToAPIService(rayService, events), nil
 }
 
 func (s *RayServiceServer) GetRayService(ctx context.Context, request *api.GetRayServiceRequest) (*api.RayService, error) {
@@ -80,7 +80,7 @@ func (s *RayServiceServer) GetRayService(ctx context.Context, request *api.GetRa
 	if err != nil {
 		klog.Warningf("failed to get rayService's event, service: %s/%s, err: %v", service.Namespace, service.Name, err)
 	}
-	return model.FromCrdToApiService(service, events), nil
+	return model.FromCrdToAPIService(service, events), nil
 }
 
 func (s *RayServiceServer) ListRayServices(ctx context.Context, request *api.ListRayServicesRequest) (*api.ListRayServicesResponse, error) {
@@ -101,7 +101,7 @@ func (s *RayServiceServer) ListRayServices(ctx context.Context, request *api.Lis
 		serviceEventMap[service.Name] = serviceEvents
 	}
 	return &api.ListRayServicesResponse{
-		Services: model.FromCrdToApiServices(services, serviceEventMap),
+		Services: model.FromCrdToAPIServices(services, serviceEventMap),
 	}, nil
 }
 
@@ -120,7 +120,7 @@ func (s *RayServiceServer) ListAllRayServices(ctx context.Context, _ *api.ListAl
 		serviceEventMap[service.Name] = serviceEvents
 	}
 	return &api.ListAllRayServicesResponse{
-		Services: model.FromCrdToApiServices(services, serviceEventMap),
+		Services: model.FromCrdToAPIServices(services, serviceEventMap),
 	}, nil
 }
 

--- a/apiserver/pkg/server/serve_server.go
+++ b/apiserver/pkg/server/serve_server.go
@@ -105,7 +105,7 @@ func (s *RayServiceServer) ListRayServices(ctx context.Context, request *api.Lis
 	}, nil
 }
 
-func (s *RayServiceServer) ListAllRayServices(ctx context.Context, request *api.ListAllRayServicesRequest) (*api.ListAllRayServicesResponse, error) {
+func (s *RayServiceServer) ListAllRayServices(ctx context.Context, _ *api.ListAllRayServicesRequest) (*api.ListAllRayServicesResponse, error) {
 	services, err := s.resourceManager.ListAllServices(ctx)
 	if err != nil {
 		return nil, util.Wrap(err, "list all services failed.")
@@ -163,11 +163,7 @@ func ValidateCreateServiceRequest(request *api.CreateRayServiceRequest) error {
 		return util.NewInvalidInputError("User who create the Service is empty. Please specify a valid value.")
 	}
 
-	if err := ValidateClusterSpec(request.Service.ClusterSpec); err != nil {
-		return err
-	}
-
-	return nil
+	return ValidateClusterSpec(request.Service.ClusterSpec)
 }
 
 func ValidateUpdateServiceRequest(request *api.UpdateRayServiceRequest) error {
@@ -194,9 +190,5 @@ func ValidateUpdateServiceRequest(request *api.UpdateRayServiceRequest) error {
 		return util.NewInvalidInputError("User who create the Service is empty. Please specify a valid value.")
 	}
 
-	if err := ValidateClusterSpec(request.Service.ClusterSpec); err != nil {
-		return err
-	}
-
-	return nil
+	return ValidateClusterSpec(request.Service.ClusterSpec)
 }

--- a/apiserver/pkg/server/serve_server.go
+++ b/apiserver/pkg/server/serve_server.go
@@ -19,9 +19,9 @@ type ServiceServerOptions struct {
 // implements `type RayServeServiceServer interface` in serve_grpc.pb.go
 // RayServiceServer is the server API for RayServeService service.
 type RayServiceServer struct {
+	api.UnimplementedRayServeServiceServer
 	resourceManager *manager.ResourceManager
 	options         *ServiceServerOptions
-	api.UnimplementedRayServeServiceServer
 }
 
 func NewRayServiceServer(resourceManager *manager.ResourceManager, options *ServiceServerOptions) *RayServiceServer {

--- a/apiserver/pkg/server/validations_test.go
+++ b/apiserver/pkg/server/validations_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestValidateClusterSpec(t *testing.T) {
 	tests := []struct {
-		name          string
-		clusterSpec   *api.ClusterSpec
 		expectedError error
+		clusterSpec   *api.ClusterSpec
+		name          string
 	}{
 		{
 			name: "A valid cluster spec",
@@ -221,9 +221,9 @@ func TestValidateClusterSpec(t *testing.T) {
 
 func TestValidateCreateServiceRequest(t *testing.T) {
 	tests := []struct {
-		name          string
-		request       *api.CreateRayServiceRequest
 		expectedError error
+		request       *api.CreateRayServiceRequest
+		name          string
 	}{
 		{
 			name: "A valid create service request V2",

--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -836,7 +836,7 @@ func (c *RayCluster) Get() *rayv1api.RayCluster {
 }
 
 // SetAnnotations sets annotations on all templates in a RayCluster
-func (c *RayCluster) SetAnnotationsToAllTemplates(key string, value string) {
+func (c *RayCluster) SetAnnotationsToAllTemplates(_ string, _ string) {
 	// TODO: reserved for common parameters.
 }
 
@@ -844,7 +844,7 @@ func (c *RayCluster) SetAnnotationsToAllTemplates(key string, value string) {
 func NewComputeTemplate(runtime *api.ComputeTemplate) (*corev1.ConfigMap, error) {
 	extendedResourcesJSON, err := json.Marshal(runtime.ExtendedResources)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal extended resources: %v", err)
+		return nil, fmt.Errorf("failed to marshal extended resources: %w", err)
 	}
 
 	// Create data map
@@ -930,10 +930,10 @@ func buildAutoscalerOptions(autoscalerOptions *api.AutoscalerOptions) (*rayv1api
 	if autoscalerOptions.Envs != nil {
 		if len(autoscalerOptions.Envs.Values) > 0 {
 			options.Env = make([]corev1.EnvVar, len(autoscalerOptions.Envs.Values))
-			ev_count := 0
+			evCount := 0
 			for key, value := range autoscalerOptions.Envs.Values {
-				options.Env[ev_count] = corev1.EnvVar{Name: key, Value: value}
-				ev_count += 1
+				options.Env[evCount] = corev1.EnvVar{Name: key, Value: value}
+				evCount += 1
 			}
 		}
 		if len(autoscalerOptions.Envs.ValuesFrom) > 0 {

--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -933,7 +933,7 @@ func buildAutoscalerOptions(autoscalerOptions *api.AutoscalerOptions) (*rayv1api
 			evCount := 0
 			for key, value := range autoscalerOptions.Envs.Values {
 				options.Env[evCount] = corev1.EnvVar{Name: key, Value: value}
-				evCount += 1
+				evCount++
 			}
 		}
 		if len(autoscalerOptions.Envs.ValuesFrom) > 0 {

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -97,13 +97,13 @@ func NewUserError(err error, internalMessage string, externalMessage string) *Us
 			return newUserError(
 				errors.Wrapf(err, internalMessage),
 				fmt.Sprintf("%v: %v", externalMessage, "Resource not found"),
-				codes.Code(uint32(apiError.Code)),
+				codes.Code(uint32(apiError.Code)), //nolint:gosec // apiError.Code is validated upstream
 			)
 		}
 		return newUserError(
 			errors.Wrapf(err, internalMessage),
 			fmt.Sprintf("%v. Raw error from the service: %v", externalMessage, err.Error()),
-			codes.Code(uint32(apiError.Code)),
+			codes.Code(uint32(apiError.Code)), //nolint:gosec // apiError.Code is validated upstream
 		)
 	}
 

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -258,12 +258,12 @@ func Wrapf(err error, format string, args ...interface{}) error {
 		return nil
 	}
 
-	switch e := err.(type) {
-	case *UserError:
-		return e.wrapf(format, args...)
-	default:
-		return errors.Wrapf(err, format, args...)
+	var userError *UserError
+	if errors.As(err, &userError) {
+		return userError.wrapf(format, args...)
 	}
+
+	return errors.Wrapf(err, format, args...)
 }
 
 func Wrap(err error, message string) error {
@@ -280,11 +280,13 @@ func Wrap(err error, message string) error {
 }
 
 func LogError(err error) {
-	switch e := err.(type) {
-	case *UserError:
-		e.Log()
-	default:
-		// We log all the details.
+	// Check if the error is of type *UserError, even if it's wrapped
+	var userError *UserError
+	if errors.As(err, &userError) {
+		// If it's a *UserError, log it using the Log method
+		userError.Log()
+	} else {
+		// For all other errors, log all the details
 		klog.Errorf("InternalError: %+v", err)
 	}
 }

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -95,20 +95,20 @@ func NewUserError(err error, internalMessage string, externalMessage string) *Us
 	if errors.As(err, &apiError) {
 		if apiError.Code == API_CODE_NOT_FOUND {
 			return newUserError(
-				errors.Wrapf(err, internalMessage),
+				errors.Wrapf(err, "%s", internalMessage),
 				fmt.Sprintf("%v: %v", externalMessage, "Resource not found"),
 				codes.Code(uint32(apiError.Code)), //nolint:gosec // apiError.Code is validated upstream
 			)
 		}
 		return newUserError(
-			errors.Wrapf(err, internalMessage),
+			errors.Wrapf(err, "%s", internalMessage),
 			fmt.Sprintf("%v. Raw error from the service: %v", externalMessage, err.Error()),
 			codes.Code(uint32(apiError.Code)), //nolint:gosec // apiError.Code is validated upstream
 		)
 	}
 
 	return newUserError(
-		errors.Wrapf(err, internalMessage),
+		errors.Wrapf(err, "%s", internalMessage),
 		fmt.Sprintf("%v. Raw error from the service: %v", externalMessage, err.Error()),
 		codes.Internal)
 }
@@ -276,7 +276,7 @@ func Wrap(err error, message string) error {
 		return userErr.wrap(message)
 	}
 
-	return errors.Wrapf(err, message)
+	return errors.Wrapf(err, "%s", message)
 }
 
 func LogError(err error) {

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -57,12 +57,13 @@ func HasCustomCode(err error, code CustomCode) bool {
 	if err == nil {
 		return false
 	}
-	switch e := err.(type) {
-	case *CustomError:
-		return e.code == code
-	default:
-		return false
+
+	var customErr *CustomError
+	if errors.As(err, &customErr) {
+		return customErr.code == code
 	}
+
+	return false
 }
 
 type UserError struct {

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -36,7 +36,7 @@ type CustomError struct {
 func NewCustomError(err error, code CustomCode, format string, a ...interface{}) *CustomError {
 	message := fmt.Sprintf(format, a...)
 	return &CustomError{
-		error: errors.Wrapf(err, fmt.Sprintf("CustomError (code: %v): %v", code, message)),
+		error: errors.Wrapf(err, "CustomError (code: %v): %v", code, message),
 		code:  code,
 	}
 }
@@ -130,7 +130,7 @@ func NewInternalServerError(err error, internalMessageFormat string,
 ) *UserError {
 	internalMessage := fmt.Sprintf(internalMessageFormat, a...)
 	return newUserError(
-		errors.Wrapf(err, fmt.Sprintf("InternalServerError: %v", internalMessage)),
+		errors.Wrapf(err, "InternalServerError: %v", internalMessage),
 		"Internal Server Error",
 		codes.Internal)
 }
@@ -140,7 +140,7 @@ func NewNotFoundError(err error, externalMessageFormat string,
 ) *UserError {
 	externalMessage := fmt.Sprintf(externalMessageFormat, a...)
 	return newUserError(
-		errors.Wrapf(err, fmt.Sprintf("NotFoundError: %v", externalMessage)),
+		errors.Wrapf(err, "NotFoundError: %v", externalMessage),
 		externalMessage,
 		codes.NotFound)
 }
@@ -168,7 +168,7 @@ func NewInvalidInputError(messageFormat string, a ...interface{}) *UserError {
 
 func NewInvalidInputErrorWithDetails(err error, externalMessage string) *UserError {
 	return newUserError(
-		errors.Wrapf(err, fmt.Sprintf("InvalidInputError: %v", externalMessage)),
+		errors.Wrapf(err, "InvalidInputError: %v", externalMessage),
 		externalMessage,
 		codes.InvalidArgument)
 }
@@ -181,7 +181,7 @@ func NewAlreadyExistError(messageFormat string, a ...interface{}) *UserError {
 func NewBadRequestError(err error, externalFormat string, a ...interface{}) *UserError {
 	externalMessage := fmt.Sprintf(externalFormat, a...)
 	return newUserError(
-		errors.Wrapf(err, fmt.Sprintf("BadRequestError: %v", externalMessage)),
+		errors.Wrapf(err, "BadRequestError: %v", externalMessage),
 		externalMessage,
 		codes.Aborted)
 }
@@ -189,7 +189,7 @@ func NewBadRequestError(err error, externalFormat string, a ...interface{}) *Use
 func NewUnauthenticatedError(err error, externalFormat string, a ...interface{}) *UserError {
 	externalMessage := fmt.Sprintf(externalFormat, a...)
 	return newUserError(
-		errors.Wrapf(err, fmt.Sprintf("Unauthenticated: %v", externalMessage)),
+		errors.Wrapf(err, "Unauthenticated: %v", externalMessage),
 		externalMessage,
 		codes.Unauthenticated)
 }
@@ -197,7 +197,7 @@ func NewUnauthenticatedError(err error, externalFormat string, a ...interface{})
 func NewPermissionDeniedError(err error, externalFormat string, a ...interface{}) *UserError {
 	externalMessage := fmt.Sprintf(externalFormat, a...)
 	return newUserError(
-		errors.Wrapf(err, fmt.Sprintf("PermissionDenied: %v", externalMessage)),
+		errors.Wrapf(err, "PermissionDenied: %v", externalMessage),
 		externalMessage,
 		codes.PermissionDenied)
 }

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -91,17 +91,20 @@ func NewUserErrorWithSingleMessage(err error, message string) *UserError {
 
 func NewUserError(err error, internalMessage string, externalMessage string) *UserError {
 	// Note apiError.Response is of type github.com/go-openapi/runtime/client
-	if apiError, ok := err.(*runtime.APIError); ok {
+	var apiError *runtime.APIError
+	if errors.As(err, &apiError) {
 		if apiError.Code == API_CODE_NOT_FOUND {
 			return newUserError(
 				errors.Wrapf(err, internalMessage),
 				fmt.Sprintf("%v: %v", externalMessage, "Resource not found"),
-				codes.Code(uint32(apiError.Code)))
+				codes.Code(uint32(apiError.Code)),
+			)
 		}
 		return newUserError(
 			errors.Wrapf(err, internalMessage),
 			fmt.Sprintf("%v. Raw error from the service: %v", externalMessage, err.Error()),
-			codes.Code(uint32(apiError.Code)))
+			codes.Code(uint32(apiError.Code)),
+		)
 	}
 
 	return newUserError(
@@ -111,7 +114,9 @@ func NewUserError(err error, internalMessage string, externalMessage string) *Us
 }
 
 func ExtractErrorForCLI(err error, isDebugMode bool) error {
-	if userError, ok := err.(*UserError); ok {
+	// Check if the error is of type *UserError, even if it's wrapped
+	var userError *UserError
+	if errors.As(err, &userError) {
 		if isDebugMode {
 			return fmt.Errorf("%+w", userError.internalError)
 		}
@@ -266,12 +271,12 @@ func Wrap(err error, message string) error {
 		return nil
 	}
 
-	switch e := err.(type) {
-	case *UserError:
-		return e.wrap(message)
-	default:
-		return errors.Wrapf(err, message)
+	var userErr *UserError
+	if errors.As(err, &userErr) {
+		return userErr.wrap(message)
 	}
+
+	return errors.Wrapf(err, message)
 }
 
 func LogError(err error) {
@@ -298,17 +303,24 @@ func IsNotFound(err error) bool {
 
 // IsUserErrorCodeMatch returns whether the error is a user error with specified code.
 func IsUserErrorCodeMatch(err error, code codes.Code) bool {
-	userError, ok := err.(*UserError)
-	return ok && userError.externalStatusCode == code
+	var userError *UserError
+	if errors.As(err, &userError) {
+		return userError.externalStatusCode == code
+	}
+	return false
 }
 
 // ReasonForError returns the HTTP status for a particular error.
 func reasonForError(err error) k8metav1.StatusReason {
-	switch t := err.(type) {
-	case *k8errors.StatusError:
-		return t.Status().Reason
-	case k8errors.APIStatus:
-		return t.Status().Reason
+	var statusErr *k8errors.StatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.Status().Reason
 	}
+
+	var apiStatus k8errors.APIStatus
+	if errors.As(err, &apiStatus) {
+		return apiStatus.Status().Reason
+	}
+
 	return k8metav1.StatusReasonUnknown
 }

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -95,12 +95,12 @@ func NewUserError(err error, internalMessage string, externalMessage string) *Us
 			return newUserError(
 				errors.Wrapf(err, internalMessage),
 				fmt.Sprintf("%v: %v", externalMessage, "Resource not found"),
-				codes.Code(apiError.Code))
+				codes.Code(uint32(apiError.Code)))
 		}
 		return newUserError(
 			errors.Wrapf(err, internalMessage),
 			fmt.Sprintf("%v. Raw error from the service: %v", externalMessage, err.Error()),
-			codes.Code(apiError.Code))
+			codes.Code(uint32(apiError.Code)))
 	}
 
 	return newUserError(
@@ -115,9 +115,8 @@ func ExtractErrorForCLI(err error, isDebugMode bool) error {
 			return fmt.Errorf("%+w", userError.internalError)
 		}
 		return fmt.Errorf("%v", userError.externalMessage)
-	} else {
-		return err
-	}
+	} 
+	return err
 }
 
 func NewInternalServerError(err error, internalMessageFormat string,

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -96,12 +96,11 @@ func NewUserError(err error, internalMessage string, externalMessage string) *Us
 				errors.Wrapf(err, internalMessage),
 				fmt.Sprintf("%v: %v", externalMessage, "Resource not found"),
 				codes.Code(apiError.Code))
-		} else {
-			return newUserError(
-				errors.Wrapf(err, internalMessage),
-				fmt.Sprintf("%v. Raw error from the service: %v", externalMessage, err.Error()),
-				codes.Code(apiError.Code))
 		}
+		return newUserError(
+			errors.Wrapf(err, internalMessage),
+			fmt.Sprintf("%v. Raw error from the service: %v", externalMessage, err.Error()),
+			codes.Code(apiError.Code))
 	}
 
 	return newUserError(
@@ -113,10 +112,9 @@ func NewUserError(err error, internalMessage string, externalMessage string) *Us
 func ExtractErrorForCLI(err error, isDebugMode bool) error {
 	if userError, ok := err.(*UserError); ok {
 		if isDebugMode {
-			return fmt.Errorf("%+v", userError.internalError)
-		} else {
-			return fmt.Errorf("%v", userError.externalMessage)
+			return fmt.Errorf("%+w", userError.internalError)
 		}
+		return fmt.Errorf("%v", userError.externalMessage)
 	} else {
 		return err
 	}
@@ -153,7 +151,7 @@ func NewResourceNotFoundError(resourceType string, resourceName string) *UserErr
 func NewResourcesNotFoundError(resourceTypesFormat string, resourceNames ...interface{}) *UserError {
 	externalMessage := fmt.Sprintf("%s not found.", fmt.Sprintf(resourceTypesFormat, resourceNames...))
 	return newUserError(
-		errors.New(fmt.Sprintf("ResourceNotFoundError: %v", externalMessage)),
+		fmt.Errorf("ResourceNotFoundError: %v", externalMessage),
 		externalMessage,
 		codes.NotFound)
 }

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -115,7 +115,7 @@ func ExtractErrorForCLI(err error, isDebugMode bool) error {
 			return fmt.Errorf("%+w", userError.internalError)
 		}
 		return fmt.Errorf("%v", userError.externalMessage)
-	} 
+	}
 	return err
 }
 
@@ -142,7 +142,7 @@ func NewNotFoundError(err error, externalMessageFormat string,
 func NewResourceNotFoundError(resourceType string, resourceName string) *UserError {
 	externalMessage := fmt.Sprintf("%s %s not found.", resourceType, resourceName)
 	return newUserError(
-		errors.New(fmt.Sprintf("ResourceNotFoundError: %v", externalMessage)),
+		fmt.Errorf("ResourceNotFoundError: %v", externalMessage),
 		externalMessage,
 		codes.NotFound)
 }

--- a/apiserver/pkg/util/job_test.go
+++ b/apiserver/pkg/util/job_test.go
@@ -110,7 +110,7 @@ func TestBuildRayJob(t *testing.T) {
 	require.Greater(t, len(job.Spec.RuntimeEnvYAML), 1)
 	require.NotNil(t, job.Spec.ClusterSelector)
 	require.Nil(t, job.Spec.RayClusterSpec)
-	require.InEpsilon(t, float32(2), job.Spec.EntrypointNumCpus)
+	require.InEpsilon(t, float32(2), job.Spec.EntrypointNumCpus, 1e-9 /*epsilon*/)
 	require.NotNil(t, job.Spec.SubmitterPodTemplate)
 	require.Equal(t, "ray-job-submitter", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Name)
 	require.Equal(t, "image", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Image)

--- a/apiserver/pkg/util/job_test.go
+++ b/apiserver/pkg/util/job_test.go
@@ -4,7 +4,8 @@ import (
 	"testing"
 
 	api "github.com/ray-project/kuberay/proto/go_client"
-	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
 )
 
 var apiJobNewCluster = &api.RayJob{
@@ -76,49 +77,49 @@ var apiJobExistingClusterSubmitterBadParams = &api.RayJob{
 func TestBuildRayJob(t *testing.T) {
 	// Test request with cluster creation
 	job, err := NewRayJob(apiJobNewCluster, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.Nil(t, err)
-	assert.Equal(t, "test", job.ObjectMeta.Name)
-	assert.Equal(t, "test", job.ObjectMeta.Namespace)
-	assert.Equal(t, 4, len(job.ObjectMeta.Labels))
-	assert.Equal(t, "test", job.ObjectMeta.Labels[RayClusterUserLabelKey])
-	assert.Equal(t, 1, len(job.ObjectMeta.Annotations))
-	assert.Greater(t, len(job.Spec.RuntimeEnvYAML), 1)
-	assert.Equal(t, 1, len(job.Spec.Metadata))
-	assert.Nil(t, job.Spec.ClusterSelector)
-	assert.NotNil(t, job.Spec.RayClusterSpec)
+	require.NoError(t, err)
+	require.Equal(t, "test", job.ObjectMeta.Name)
+	require.Equal(t, "test", job.ObjectMeta.Namespace)
+	require.Len(t, job.ObjectMeta.Labels, 4)
+	require.Equal(t, "test", job.ObjectMeta.Labels[RayClusterUserLabelKey])
+	require.Len(t, job.ObjectMeta.Annotations, 1)
+	require.Greater(t, len(job.Spec.RuntimeEnvYAML), 1)
+	require.Len(t, job.Spec.Metadata, 1)
+	require.Nil(t, job.Spec.ClusterSelector)
+	require.NotNil(t, job.Spec.RayClusterSpec)
 
 	// Test request without cluster creation
 	job, err = NewRayJob(apiJobExistingCluster, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.Nil(t, err)
-	assert.Equal(t, "test", job.ObjectMeta.Name)
-	assert.Equal(t, "test", job.ObjectMeta.Namespace)
-	assert.Equal(t, 4, len(job.ObjectMeta.Labels))
-	assert.Equal(t, "test", job.ObjectMeta.Labels[RayClusterUserLabelKey])
-	assert.Greater(t, len(job.Spec.RuntimeEnvYAML), 1)
-	assert.NotNil(t, job.Spec.ClusterSelector)
-	assert.Nil(t, job.Spec.RayClusterSpec)
-	assert.Nil(t, job.Spec.SubmitterPodTemplate)
+	require.NoError(t, err)
+	require.Equal(t, "test", job.ObjectMeta.Name)
+	require.Equal(t, "test", job.ObjectMeta.Namespace)
+	require.Len(t, job.ObjectMeta.Labels, 4)
+	require.Equal(t, "test", job.ObjectMeta.Labels[RayClusterUserLabelKey])
+	require.Greater(t, len(job.Spec.RuntimeEnvYAML), 1)
+	require.NotNil(t, job.Spec.ClusterSelector)
+	require.Nil(t, job.Spec.RayClusterSpec)
+	require.Nil(t, job.Spec.SubmitterPodTemplate)
 
 	// Test request without cluster creation with submitter
 	job, err = NewRayJob(apiJobExistingClusterSubmitter, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.Nil(t, err)
-	assert.Equal(t, "test", job.ObjectMeta.Name)
-	assert.Equal(t, "test", job.ObjectMeta.Namespace)
-	assert.Equal(t, 4, len(job.ObjectMeta.Labels))
-	assert.Equal(t, "test", job.ObjectMeta.Labels[RayClusterUserLabelKey])
-	assert.Greater(t, len(job.Spec.RuntimeEnvYAML), 1)
-	assert.NotNil(t, job.Spec.ClusterSelector)
-	assert.Nil(t, job.Spec.RayClusterSpec)
-	assert.Equal(t, float32(2), job.Spec.EntrypointNumCpus)
-	assert.NotNil(t, job.Spec.SubmitterPodTemplate)
-	assert.Equal(t, "ray-job-submitter", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Name)
-	assert.Equal(t, "image", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Image)
-	assert.Equal(t, "400m", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Resources.Limits.Cpu().String())
-	assert.Equal(t, "150Mi", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Resources.Limits.Memory().String())
-	assert.Equal(t, "400m", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Resources.Requests.Cpu().String())
-	assert.Equal(t, "150Mi", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Resources.Requests.Memory().String())
+	require.NoError(t, err)
+	require.Equal(t, "test", job.ObjectMeta.Name)
+	require.Equal(t, "test", job.ObjectMeta.Namespace)
+	require.Len(t, job.ObjectMeta.Labels, 4)
+	require.Equal(t, "test", job.ObjectMeta.Labels[RayClusterUserLabelKey])
+	require.Greater(t, len(job.Spec.RuntimeEnvYAML), 1)
+	require.NotNil(t, job.Spec.ClusterSelector)
+	require.Nil(t, job.Spec.RayClusterSpec)
+	require.Equal(t, float32(2), job.Spec.EntrypointNumCpus)
+	require.NotNil(t, job.Spec.SubmitterPodTemplate)
+	require.Equal(t, "ray-job-submitter", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Name)
+	require.Equal(t, "image", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Image)
+	require.Equal(t, "400m", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Resources.Limits.Cpu().String())
+	require.Equal(t, "150Mi", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Resources.Limits.Memory().String())
+	require.Equal(t, "400m", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Resources.Requests.Cpu().String())
+	require.Equal(t, "150Mi", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Resources.Requests.Memory().String())
 
 	// Test request without cluster creation with submitter bad parameters
 	_, err = NewRayJob(apiJobExistingClusterSubmitterBadParams, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.NotNil(t, err)
+	require.Error(t, err)
 }

--- a/apiserver/pkg/util/job_test.go
+++ b/apiserver/pkg/util/job_test.go
@@ -110,7 +110,7 @@ func TestBuildRayJob(t *testing.T) {
 	require.Greater(t, len(job.Spec.RuntimeEnvYAML), 1)
 	require.NotNil(t, job.Spec.ClusterSelector)
 	require.Nil(t, job.Spec.RayClusterSpec)
-	require.Equal(t, float32(2), job.Spec.EntrypointNumCpus)
+	require.InEpsilon(t, float32(2), job.Spec.EntrypointNumCpus)
 	require.NotNil(t, job.Spec.SubmitterPodTemplate)
 	require.Equal(t, "ray-job-submitter", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Name)
 	require.Equal(t, "image", job.Spec.SubmitterPodTemplate.Spec.Containers[0].Image)

--- a/apiserver/pkg/util/service.go
+++ b/apiserver/pkg/util/service.go
@@ -44,7 +44,7 @@ func buildRayServiceLabels(apiService *api.RayService) map[string]string {
 	return labels
 }
 
-func buildRayServiceAnnotations(apiService *api.RayService) map[string]string {
+func buildRayServiceAnnotations(_ *api.RayService) map[string]string {
 	annotations := map[string]string{}
 	// TODO: Add optional annotations
 	return annotations

--- a/apiserver/pkg/util/service_test.go
+++ b/apiserver/pkg/util/service_test.go
@@ -5,7 +5,7 @@ import (
 
 	api "github.com/ray-project/kuberay/proto/go_client"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var apiServiceNoServe = &api.RayService{
@@ -26,15 +26,15 @@ var apiServiceV2 = &api.RayService{
 
 func TestBuildService(t *testing.T) {
 	_, err := NewRayService(apiServiceNoServe, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	if err.Error() != "serve configuration is not defined" {
 		t.Errorf("wrong error returned")
 	}
 	got, err := NewRayService(apiServiceV2, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	if got.RayService.Spec.ServeConfigV2 == "" {
 		t.Errorf("Got empty V2")
 	}
-	assert.NotNil(t, got.Spec.ServiceUnhealthySecondThreshold)
-	assert.Nil(t, got.Spec.DeploymentUnhealthySecondThreshold)
+	require.NotNil(t, got.Spec.ServiceUnhealthySecondThreshold)
+	require.Nil(t, got.Spec.DeploymentUnhealthySecondThreshold)
 }

--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -89,9 +89,9 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 	}
 
 	// Create cluster
-	actualCluster, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateCluster(&clusterReq)
+	actualCluster, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateCluster(&clusterReq)
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualCluster, "A cluster is expected")
 	waitForRunningCluster(t, tCtx, actualCluster.Name)
 
@@ -114,9 +114,9 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 		},
 	}
 
-	actualJob, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(&createActorRequest)
+	actualJob, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayJob(&createActorRequest)
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
 	waitForRayJob(t, tCtx, createActorRequest.Job.Name, rayv1api.JobStatusSucceeded)
 
@@ -141,9 +141,9 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 			},
 		},
 	}
-	actualJob, actualRpcStatus, err = tCtx.GetRayApiServerClient().CreateRayJob(&deleteActorRequest)
+	actualJob, actualRPCStatus, err = tCtx.GetRayAPIServerClient().CreateRayJob(&deleteActorRequest)
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
 	waitForRayJob(t, tCtx, createActorRequest.Job.Name, rayv1api.JobStatusSucceeded)
 

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -433,7 +433,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateCluster(tc.Input)
+			actualCluster, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateCluster(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
@@ -504,7 +504,7 @@ func TestDeleteCluster(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRPCStatus, err := tCtx.GetRayApiServerClient().DeleteCluster(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayAPIServerClient().DeleteCluster(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
@@ -555,7 +555,7 @@ func TestGetAllClusters(t *testing.T) {
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
-	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{})
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllClusters(&api.ListAllClustersRequest{})
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
@@ -587,7 +587,7 @@ func TestGetAllClustersByPagination(t *testing.T) {
 	continueToken := ""
 	for i := 0; i < numberOfNamespaces; i++ {
 		limit := 1
-		response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{
+		response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllClusters(&api.ListAllClustersRequest{
 			Limit:    int64(limit),
 			Continue: continueToken,
 		})
@@ -623,7 +623,7 @@ func TestGetAllClustersByPaginationWithAllResults(t *testing.T) {
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
-	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllClusters(&api.ListAllClustersRequest{
 		Limit: 10,
 	})
 	require.NoError(t, err, "No error expected")
@@ -666,7 +666,7 @@ func TestGetClustersInNamespace(t *testing.T) {
 		tCtx.DeleteConfigMap(t, configMapName)
 	})
 
-	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListClusters(
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListClusters(
 		&api.ListClustersRequest{
 			Namespace: tCtx.GetNamespaceName(),
 		})
@@ -711,7 +711,7 @@ func TestGetClustersByPaginationInNamespace(t *testing.T) {
 
 	continueToken := ""
 	for i := 1; i <= 2; i++ {
-		response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListClusters(
+		response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListClusters(
 			&api.ListClustersRequest{
 				Namespace: tCtx.GetNamespaceName(),
 				Limit:     1,
@@ -788,7 +788,7 @@ func TestGetClustersByNameInNamespace(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetCluster(tc.Input)
+			actualCluster, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetCluster(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -433,16 +433,16 @@ func TestCreateClusterEndpoint(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualCluster, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateCluster(tc.Input)
+			actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateCluster(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.NotNil(t, actualCluster, "A cluster is expected")
 				waitForRunningCluster(t, tCtx, actualCluster.Name)
 				tCtx.DeleteRayCluster(t, actualCluster.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -504,14 +504,14 @@ func TestDeleteCluster(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRpcStatus, err := tCtx.GetRayApiServerClient().DeleteCluster(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayApiServerClient().DeleteCluster(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				waitForDeletedCluster(t, tCtx, tc.Input.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -555,9 +555,9 @@ func TestGetAllClusters(t *testing.T) {
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{})
+	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{})
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.Empty(t, response.Continue, "No continue token is expected")
 	require.NotEmpty(t, response.Clusters, "A list of clusters is required")
@@ -587,12 +587,12 @@ func TestGetAllClustersByPagination(t *testing.T) {
 	continueToken := ""
 	for i := 0; i < numberOfNamespaces; i++ {
 		limit := 1
-		response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{
+		response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{
 			Limit:    int64(limit),
 			Continue: continueToken,
 		})
 		require.NoError(t, err, "No error expected")
-		require.Nil(t, actualRpcStatus, "No RPC status expected")
+		require.Nil(t, actualRPCStatus, "No RPC status expected")
 		require.NotNil(t, response, "A response is expected")
 		if i != numberOfNamespaces-1 {
 			require.NotEmpty(t, response.Continue, "A continue token is expected")
@@ -623,11 +623,11 @@ func TestGetAllClustersByPaginationWithAllResults(t *testing.T) {
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{
+	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{
 		Limit: 10,
 	})
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.Empty(t, response.Continue, "No continue token is expected")
 	require.NotEmpty(t, response.Clusters, "A list of clusters is required")
@@ -666,12 +666,12 @@ func TestGetClustersInNamespace(t *testing.T) {
 		tCtx.DeleteConfigMap(t, configMapName)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListClusters(
+	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListClusters(
 		&api.ListClustersRequest{
 			Namespace: tCtx.GetNamespaceName(),
 		})
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.Clusters, "A list of compute templates is required")
 	gotCluster := false
@@ -711,14 +711,14 @@ func TestGetClustersByPaginationInNamespace(t *testing.T) {
 
 	continueToken := ""
 	for i := 1; i <= 2; i++ {
-		response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListClusters(
+		response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListClusters(
 			&api.ListClustersRequest{
 				Namespace: tCtx.GetNamespaceName(),
 				Limit:     1,
 				Continue:  continueToken,
 			})
 		require.NoError(t, err, "No error expected")
-		require.Nil(t, actualRpcStatus, "No RPC status expected")
+		require.Nil(t, actualRPCStatus, "No RPC status expected")
 		require.NotNil(t, response, "A response is expected")
 		require.Len(t, response.Clusters, 1)
 		require.Equal(t, response.Clusters[0].Name, fmt.Sprintf("cluster%d", i))
@@ -788,15 +788,15 @@ func TestGetClustersByNameInNamespace(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualCluster, actualRpcStatus, err := tCtx.GetRayApiServerClient().GetCluster(tc.Input)
+			actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetCluster(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.Equal(t, tCtx.GetRayClusterName(), actualCluster.Name)
 				require.Equal(t, tCtx.GetNamespaceName(), actualCluster.Namespace)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -10,7 +10,6 @@ import (
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -520,7 +519,7 @@ func createOneClusterInEachNamespaces(t *testing.T, numberOfNamespaces int) []*E
 	tCtxs := make([]*End2EndTestingContext, numberOfNamespaces)
 	for i := 0; i < numberOfNamespaces; i++ {
 		tCtx, err := NewEnd2EndTestingContext(t)
-		assert.NoError(t, err, "No error expected when creating testing context")
+		require.NoError(t, err, "No error expected when creating testing context")
 
 		tCtx.CreateComputeTemplate(t)
 		t.Cleanup(func() {
@@ -815,7 +814,7 @@ func waitForDeletedCluster(t *testing.T, tCtx *End2EndTestingContext, clusterNam
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
 		rayCluster, err00 := tCtx.GetRayClusterByName(clusterName)
 		if err00 != nil &&
-			assert.EqualError(t, err00, "rayclusters.ray.io \""+tCtx.GetRayClusterName()+"\" not found") {
+			require.EqualError(t, err00, "rayclusters.ray.io \""+tCtx.GetRayClusterName()+"\" not found") {
 			return true, nil
 		}
 		t.Logf("Found status of '%s' for ray cluster '%s'", rayCluster.Status.State, clusterName)

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -813,8 +814,7 @@ func waitForDeletedCluster(t *testing.T, tCtx *End2EndTestingContext, clusterNam
 	// if is not in that state, return an error
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
 		rayCluster, err00 := tCtx.GetRayClusterByName(clusterName)
-		if err00 != nil &&
-			require.EqualError(t, err00, "rayclusters.ray.io \""+tCtx.GetRayClusterName()+"\" not found") {
+		if err00 != nil && strings.Contains(err00.Error(), "rayclusters.ray.io \""+tCtx.GetRayClusterName()+"\" not found") {
 			return true, nil
 		}
 		t.Logf("Found status of '%s' for ray cluster '%s'", rayCluster.Status.State, clusterName)

--- a/apiserver/test/e2e/config_server_e2e_test.go
+++ b/apiserver/test/e2e/config_server_e2e_test.go
@@ -116,13 +116,13 @@ func TestCreateTemplate(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualTemplate, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateComputeTemplate(tc.Input)
+			actualTemplate, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateComputeTemplate(tc.Input)
 			if tc.ExpectedError != nil {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			} else {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.Truef(t, reflect.DeepEqual(tc.Input.ComputeTemplate, actualTemplate), "Equal templates expected")
 			}
 		})
@@ -179,13 +179,13 @@ func TestDeleteTemplate(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRpcStatus, err := tCtx.GetRayApiServerClient().DeleteComputeTemplate(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayAPIServerClient().DeleteComputeTemplate(tc.Input)
 			if tc.ExpectedError != nil {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			} else {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 			}
 		})
 	}
@@ -202,9 +202,9 @@ func TestGetAllComputeTemplates(t *testing.T) {
 		tCtx.DeleteComputeTemplate(t)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().GetAllComputeTemplates()
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetAllComputeTemplates()
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.ComputeTemplates, "A list of compute templates is required")
 	foundName := false
@@ -228,12 +228,12 @@ func TestGetTemplatesInNamespace(t *testing.T) {
 		tCtx.DeleteComputeTemplate(t)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().GetAllComputeTemplatesInNamespace(
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetAllComputeTemplatesInNamespace(
 		&api.ListComputeTemplatesRequest{
 			Namespace: tCtx.GetNamespaceName(),
 		})
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.ComputeTemplates, "A list of compute templates is required")
 	foundName := false
@@ -296,13 +296,13 @@ func TestGetTemplateByNameInNamespace(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualTemplate, actualRpcStatus, err := tCtx.GetRayApiServerClient().GetComputeTemplate(tc.Input)
+			actualTemplate, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetComputeTemplate(tc.Input)
 			if tc.ExpectedError != nil {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			} else {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.Equal(t, tCtx.GetComputeTemplateName(), actualTemplate.Name)
 				require.Equal(t, tCtx.GetNamespaceName(), actualTemplate.Namespace)
 			}

--- a/apiserver/test/e2e/config_server_e2e_test.go
+++ b/apiserver/test/e2e/config_server_e2e_test.go
@@ -214,7 +214,7 @@ func TestGetAllComputeTemplates(t *testing.T) {
 			break
 		}
 	}
-	require.Equal(t, foundName, true)
+	require.True(t, foundName)
 }
 
 // TestGetTemplatesInNamespace get all compute templates in namespace endpoint
@@ -243,7 +243,7 @@ func TestGetTemplatesInNamespace(t *testing.T) {
 			break
 		}
 	}
-	require.Equal(t, foundName, true)
+	require.True(t, foundName)
 }
 
 // TestDeleteTemplate sequentially iterates over the delete compute template endpoint

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -214,16 +214,16 @@ func TestCreateJobWithDisposableClusters(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualJob, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(tc.Input)
+			actualJob, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayJob(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.NotNil(t, actualJob, "A job is expected")
 				waitForRayJob(t, tCtx, tc.Input.Job.Name, tc.ExpectedJobStatus)
 				tCtx.DeleteRayJobByName(t, actualJob.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -273,14 +273,14 @@ func TestDeleteJob(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRpcStatus, err := tCtx.GetRayApiServerClient().DeleteRayJob(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayAPIServerClient().DeleteRayJob(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				waitForDeletedRayJob(t, tCtx, testJobRequest.Job.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -299,9 +299,9 @@ func TestGetAllJobs(t *testing.T) {
 		tCtx.DeleteRayJobByName(t, testJobRequest.Job.Name)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListAllRayJobs()
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllRayJobs()
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.Jobs, "A list of jobs is required")
 	foundName := false
@@ -327,11 +327,11 @@ func TestGetJobsInNamespace(t *testing.T) {
 		tCtx.DeleteRayJobByName(t, testJobRequest.Job.Name)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListRayJobs(&api.ListRayJobsRequest{
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListRayJobs(&api.ListRayJobsRequest{
 		Namespace: tCtx.GetNamespaceName(),
 	})
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.Jobs, "A list of jobs is required")
 	foundName := false
@@ -398,15 +398,15 @@ func TestGetJob(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualJob, actualRpcStatus, err := tCtx.GetRayApiServerClient().GetRayJob(tc.Input)
+			actualJob, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetRayJob(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.Equal(t, tc.Input.Name, actualJob.Name)
 				require.Equal(t, tCtx.GetNamespaceName(), actualJob.Namespace)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -485,16 +485,16 @@ func TestCreateJobWithClusterSelector(t *testing.T) {
 	// Execute tests sequentially
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			actualJob, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(tc.Input)
+			actualJob, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayJob(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.NotNil(t, actualJob, "A job is expected")
 				waitForRayJob(t, tCtx, tc.Input.Job.Name, tc.ExpectedJobStatus)
 				tCtx.DeleteRayJobByName(t, actualJob.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -563,9 +563,9 @@ func createTestJob(t *testing.T, tCtx *End2EndTestingContext) *api.CreateRayJobR
 		Namespace: tCtx.GetNamespaceName(),
 	}
 
-	actualJob, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(testJobRequest)
+	actualJob, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayJob(testJobRequest)
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
 	waitForRayJob(t, tCtx, testJobRequest.Job.Name, rayv1api.JobStatusSucceeded)
 	return testJobRequest

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -311,7 +311,7 @@ func TestGetAllJobs(t *testing.T) {
 			break
 		}
 	}
-	require.Equal(t, foundName, true)
+	require.True(t, foundName)
 }
 
 func TestGetJobsInNamespace(t *testing.T) {
@@ -341,7 +341,7 @@ func TestGetJobsInNamespace(t *testing.T) {
 			break
 		}
 	}
-	require.Equal(t, foundName, true)
+	require.True(t, foundName)
 }
 
 func TestGetJob(t *testing.T) {

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -3,10 +3,10 @@ package e2e
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -590,8 +590,7 @@ func waitForDeletedRayJob(t *testing.T, tCtx *End2EndTestingContext, jobName str
 	// if is not in that state, return an error
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
 		rayJob, err00 := tCtx.GetRayJobByName(jobName)
-		if err00 != nil &&
-			assert.EqualError(t, err00, "rayjobs.ray.io \""+jobName+"\" not found") {
+		if err00 != nil && strings.Contains(err00.Error(), "rayjobs.ray.io \""+jobName+"\" not found") {
 			return true, nil
 		}
 		t.Logf("Found status of '%s' for ray cluster '%s'", rayJob.Status.JobStatus, jobName)

--- a/apiserver/test/e2e/job_submission_e2e_test.go
+++ b/apiserver/test/e2e/job_submission_e2e_test.go
@@ -73,9 +73,9 @@ func TestCreateJobSubmission(t *testing.T) {
 	}
 
 	// Create cluster
-	actualCluster, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateCluster(&clusterReq)
+	actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateCluster(&clusterReq)
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualCluster, "A cluster is expected")
 	waitForRunningCluster(t, tCtx, actualCluster.Name)
 

--- a/apiserver/test/e2e/job_submission_e2e_test.go
+++ b/apiserver/test/e2e/job_submission_e2e_test.go
@@ -73,7 +73,7 @@ func TestCreateJobSubmission(t *testing.T) {
 	}
 
 	// Create cluster
-	actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateCluster(&clusterReq)
+	actualCluster, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateCluster(&clusterReq)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualCluster, "A cluster is expected")
@@ -90,13 +90,13 @@ func TestCreateJobSubmission(t *testing.T) {
 		},
 	}
 	// Request for the wrong namespace, should fail
-	_, jobSubmissionStatus, err := tCtx.GetRayApiServerClient().SubmitRayJob(&submitJobRequest)
+	_, jobSubmissionStatus, err := tCtx.GetRayAPIServerClient().SubmitRayJob(&submitJobRequest)
 	require.Error(t, err, "An error is expected")
 	require.NotNil(t, jobSubmissionStatus, "A not nill RPC status is required")
 
 	// Fix request and resubmit
 	submitJobRequest.Namespace = tCtx.GetNamespaceName()
-	jobSubmission, jobSubmissionStatus, err := tCtx.GetRayApiServerClient().SubmitRayJob(&submitJobRequest)
+	jobSubmission, jobSubmissionStatus, err := tCtx.GetRayAPIServerClient().SubmitRayJob(&submitJobRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobSubmissionStatus, "No RPC status expected")
 	require.NotNil(t, jobSubmission, "A job  submission is expected")
@@ -108,13 +108,13 @@ func TestCreateJobSubmission(t *testing.T) {
 		Submissionid: "1234567", // Not valid submission ID
 	}
 	// Request with the wrong submission ID should fail
-	_, jobDetailsStatus, err := tCtx.GetRayApiServerClient().GetRayJobDetails(&jobDetailsRequest)
+	_, jobDetailsStatus, err := tCtx.GetRayAPIServerClient().GetRayJobDetails(&jobDetailsRequest)
 	require.Error(t, err, "An error is expected")
 	require.NotNil(t, jobDetailsStatus, "A not nill RPC status is required")
 
 	// Set the correct submission ID and resubmit
 	jobDetailsRequest.Submissionid = jobSubmission.SubmissionId
-	jobDetails, jobDetailsStatus, err := tCtx.GetRayApiServerClient().GetRayJobDetails(&jobDetailsRequest)
+	jobDetails, jobDetailsStatus, err := tCtx.GetRayAPIServerClient().GetRayJobDetails(&jobDetailsRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobDetailsStatus, "No RPC status expected")
 	require.NotNil(t, jobDetails, "Job  details are expected")
@@ -124,7 +124,7 @@ func TestCreateJobSubmission(t *testing.T) {
 		Namespace:   tCtx.GetNamespaceName(),
 		Clustername: actualCluster.Name,
 	}
-	jobList, jobListStatus, err := tCtx.GetRayApiServerClient().ListRayJobsCluster(&listJobRequest)
+	jobList, jobListStatus, err := tCtx.GetRayAPIServerClient().ListRayJobsCluster(&listJobRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobListStatus, "No RPC status expected")
 	require.NotNil(t, jobList, "List of Job details is expected")
@@ -135,13 +135,13 @@ func TestCreateJobSubmission(t *testing.T) {
 		Clustername:  actualCluster.Name,
 		Submissionid: "1234567", // Not valid submission ID
 	}
-	_, jobLogStatus, err := tCtx.GetRayApiServerClient().GetRayJobLog(&logJobRequest)
+	_, jobLogStatus, err := tCtx.GetRayAPIServerClient().GetRayJobLog(&logJobRequest)
 	require.Error(t, err, "An error is expected")
 	require.NotNil(t, jobLogStatus, "A not nill RPC status is required")
 
 	// Set the correct submission ID and resubmit
 	logJobRequest.Submissionid = jobSubmission.SubmissionId
-	jobLog, jobLogStatus, err := tCtx.GetRayApiServerClient().GetRayJobLog(&logJobRequest)
+	jobLog, jobLogStatus, err := tCtx.GetRayAPIServerClient().GetRayJobLog(&logJobRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobLogStatus, "No RPC status expected")
 	require.NotNil(t, jobLog, "Job log is expected")
@@ -152,12 +152,12 @@ func TestCreateJobSubmission(t *testing.T) {
 		Clustername:  actualCluster.Name,
 		Submissionid: "1234567", // Not valid submission ID
 	}
-	jobStopStatus, err := tCtx.GetRayApiServerClient().StopRayJob(&stopJobRequest)
+	jobStopStatus, err := tCtx.GetRayAPIServerClient().StopRayJob(&stopJobRequest)
 	require.Error(t, err, "An error is expected")
 	require.NotNil(t, jobStopStatus, "A not nill RPC status is required")
 	// Set the correct submission ID and resubmit
 	stopJobRequest.Submissionid = jobSubmission.SubmissionId
-	jobStopStatus, err = tCtx.GetRayApiServerClient().StopRayJob(&stopJobRequest)
+	jobStopStatus, err = tCtx.GetRayAPIServerClient().StopRayJob(&stopJobRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobStopStatus, "No RPC status expected")
 
@@ -167,7 +167,7 @@ func TestCreateJobSubmission(t *testing.T) {
 		Clustername:  actualCluster.Name,
 		Submissionid: jobSubmission.SubmissionId,
 	}
-	jobDeleteStatus, err := tCtx.GetRayApiServerClient().DeleteRayJobCluster(&deleteJobRequest)
+	jobDeleteStatus, err := tCtx.GetRayAPIServerClient().DeleteRayJobCluster(&deleteJobRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobDeleteStatus, "No RPC status expected")
 }

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -137,16 +137,16 @@ func TestCreateServiceV2(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualService, actualRpcStatus, err := tCtx.GetRayAPIServerClient().CreateRayService(tc.Input)
+			actualService, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayService(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.NotNil(t, actualService, "A service is expected")
 				waitForRunningService(t, tCtx, actualService.Name)
 				tCtx.DeleteRayService(t, actualService.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -196,14 +196,14 @@ func TestDeleteService(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRpcStatus, err := tCtx.GetRayAPIServerClient().DeleteRayService(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayAPIServerClient().DeleteRayService(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				waitForDeletedService(t, tCtx, testServiceRequest.Service.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -222,9 +222,9 @@ func TestGetAllServices(t *testing.T) {
 		tCtx.DeleteRayService(t, testServiceRequest.Service.Name)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayAPIServerClient().ListAllRayServices()
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllRayServices()
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.Services, "A list of services is required")
 	require.Equal(t, testServiceRequest.Service.Name, response.Services[0].Name)
@@ -244,11 +244,11 @@ func TestGetServicesInNamespace(t *testing.T) {
 		tCtx.DeleteRayService(t, testServiceRequest.Service.Name)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayAPIServerClient().ListRayServices(&api.ListRayServicesRequest{
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListRayServices(&api.ListRayServicesRequest{
 		Namespace: tCtx.GetNamespaceName(),
 	})
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.Services, "A list of compute templates is required")
 	require.Equal(t, testServiceRequest.Service.Name, response.Services[0].Name)
@@ -309,15 +309,15 @@ func TestGetService(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualService, actualRpcStatus, err := tCtx.GetRayAPIServerClient().GetRayService(tc.Input)
+			actualService, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetRayService(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.Equal(t, tc.Input.Name, actualService.Name)
 				require.Equal(t, tCtx.GetNamespaceName(), actualService.Namespace)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -364,9 +364,9 @@ func createTestServiceV2(t *testing.T, tCtx *End2EndTestingContext) *api.CreateR
 		},
 		Namespace: tCtx.GetNamespaceName(),
 	}
-	actualService, actualRpcStatus, err := tCtx.GetRayAPIServerClient().CreateRayService(testServiceRequest)
+	actualService, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayService(testServiceRequest)
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualService, "A service is expected")
 	waitForRunningService(t, tCtx, actualService.Name)
 

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -3,12 +3,12 @@ package e2e
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -392,8 +392,7 @@ func waitForDeletedService(t *testing.T, tCtx *End2EndTestingContext, serviceNam
 	// if is not in that state, return an error
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
 		rayService, err00 := tCtx.GetRayServiceByName(serviceName)
-		if err00 != nil &&
-			assert.EqualError(t, err00, "rayservices.ray.io \""+serviceName+"\" not found") {
+		if err00 != nil && strings.Contains(err00.Error(), "rayservices.ray.io \""+serviceName+"\" not found") {
 			return true, nil
 		}
 		t.Logf("Found status of '%s' for ray service '%s'", rayService.Status.ServiceStatus, serviceName)

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -137,7 +137,7 @@ func TestCreateServiceV2(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualService, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateRayService(tc.Input)
+			actualService, actualRpcStatus, err := tCtx.GetRayAPIServerClient().CreateRayService(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRpcStatus, "No RPC status expected")
@@ -196,7 +196,7 @@ func TestDeleteService(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRpcStatus, err := tCtx.GetRayApiServerClient().DeleteRayService(tc.Input)
+			actualRpcStatus, err := tCtx.GetRayAPIServerClient().DeleteRayService(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRpcStatus, "No RPC status expected")
@@ -222,7 +222,7 @@ func TestGetAllServices(t *testing.T) {
 		tCtx.DeleteRayService(t, testServiceRequest.Service.Name)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListAllRayServices()
+	response, actualRpcStatus, err := tCtx.GetRayAPIServerClient().ListAllRayServices()
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRpcStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
@@ -244,7 +244,7 @@ func TestGetServicesInNamespace(t *testing.T) {
 		tCtx.DeleteRayService(t, testServiceRequest.Service.Name)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListRayServices(&api.ListRayServicesRequest{
+	response, actualRpcStatus, err := tCtx.GetRayAPIServerClient().ListRayServices(&api.ListRayServicesRequest{
 		Namespace: tCtx.GetNamespaceName(),
 	})
 	require.NoError(t, err, "No error expected")
@@ -309,7 +309,7 @@ func TestGetService(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualService, actualRpcStatus, err := tCtx.GetRayApiServerClient().GetRayService(tc.Input)
+			actualService, actualRpcStatus, err := tCtx.GetRayAPIServerClient().GetRayService(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRpcStatus, "No RPC status expected")
@@ -364,7 +364,7 @@ func createTestServiceV2(t *testing.T, tCtx *End2EndTestingContext) *api.CreateR
 		},
 		Namespace: tCtx.GetNamespaceName(),
 	}
-	actualService, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateRayService(testServiceRequest)
+	actualService, actualRpcStatus, err := tCtx.GetRayAPIServerClient().CreateRayService(testServiceRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRpcStatus, "No RPC status expected")
 	require.NotNil(t, actualService, "A service is expected")

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -12,7 +12,6 @@ import (
 	petnames "github.com/dustinkirkland/golang-petname"
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	batchv1 "k8s.io/api/batch/v1"
@@ -171,7 +170,7 @@ func withNamespace() contextOption {
 		// register an automatic deletion of the namespace at test's end
 		t.Cleanup(func() {
 			err := tCtx.k8client.CoreV1().Namespaces().Delete(tCtx.ctx, tCtx.namespaceName, metav1.DeleteOptions{})
-			assert.NoErrorf(t, err, "No error expected when deleting namespace '%s'", tCtx.namespaceName)
+			require.NoErrorf(t, err, "No error expected when deleting namespace '%s'", tCtx.namespaceName)
 		})
 		return nil
 	}
@@ -427,6 +426,6 @@ func (e2etc *End2EndTestingContext) CreateConfigMap(t *testing.T, values map[str
 func (e2etc *End2EndTestingContext) DeleteConfigMap(t *testing.T, configMapName string) {
 	err := e2etc.k8client.CoreV1().ConfigMaps(e2etc.namespaceName).Delete(e2etc.ctx, configMapName, metav1.DeleteOptions{})
 	if err != nil {
-		assert.Truef(t, k8sApiErrors.IsNotFound(err), "Only IsNotFoundException allowed, received %v", err)
+		require.Truef(t, k8sApiErrors.IsNotFound(err), "Only IsNotFoundException allowed, received %v", err)
 	}
 }

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -29,9 +29,9 @@ import (
 
 // GenericEnd2EndTest struct allows for reuse in setting up and running tests
 type GenericEnd2EndTest[I proto.Message] struct {
-	Name          string
 	Input         I
 	ExpectedError error
+	Name          string
 }
 
 // End2EndTestingContext provides a common set of values and methods that
@@ -251,10 +251,8 @@ func (e2etc *End2EndTestingContext) CreateComputeTemplate(t *testing.T) {
 		Namespace: e2etc.namespaceName,
 	}
 
-	_, status, err := e2etc.kuberayAPIServerClient.CreateComputeTemplate(computeTemplateRequest)
-	if !assert.NoErrorf(t, err, "No error expected while creating a compute template (%s, %s)", e2etc.namespaceName, e2etc.computeTemplateName) {
-		t.Fatalf("Received status of %v when attempting to create compute template", status)
-	}
+	_, _, err := e2etc.kuberayAPIServerClient.CreateComputeTemplate(computeTemplateRequest)
+	require.NoErrorf(t, err, "No error expected while creating a compute template (%s, %s)", e2etc.namespaceName, e2etc.computeTemplateName)
 }
 
 func (e2etc *End2EndTestingContext) DeleteComputeTemplate(t *testing.T) {
@@ -262,10 +260,8 @@ func (e2etc *End2EndTestingContext) DeleteComputeTemplate(t *testing.T) {
 		Name:      e2etc.computeTemplateName,
 		Namespace: e2etc.namespaceName,
 	}
-	status, err := e2etc.kuberayAPIServerClient.DeleteComputeTemplate((*api.DeleteComputeTemplateRequest)(deleteComputeTemplateRequest))
-	if !assert.NoErrorf(t, err, "No error expected while deleting a compute template (%s, %s)", e2etc.computeTemplateName, e2etc.namespaceName) {
-		t.Fatalf("Received status of %v when attempting to create compute template", status)
-	}
+	_, err := e2etc.kuberayAPIServerClient.DeleteComputeTemplate((*api.DeleteComputeTemplateRequest)(deleteComputeTemplateRequest))
+	require.NoErrorf(t, err, "No error expected while deleting a compute template (%s, %s)", e2etc.computeTemplateName, e2etc.namespaceName)
 }
 
 func (e2etc *End2EndTestingContext) CreateRayClusterWithConfigMaps(t *testing.T, configMapValues map[string]string, name ...string) (*api.Cluster, string) {
@@ -281,7 +277,7 @@ func (e2etc *End2EndTestingContext) CreateRayClusterWithConfigMaps(t *testing.T,
 	if len(name) > 0 {
 		clusterName = name[0]
 	}
-	actualCluster, status, err := e2etc.kuberayAPIServerClient.CreateCluster(&api.CreateClusterRequest{
+	actualCluster, _, err := e2etc.kuberayAPIServerClient.CreateCluster(&api.CreateClusterRequest{
 		Cluster: &api.Cluster{
 			Name:        clusterName,
 			Namespace:   e2etc.namespaceName,
@@ -334,9 +330,8 @@ func (e2etc *End2EndTestingContext) CreateRayClusterWithConfigMaps(t *testing.T,
 		},
 		Namespace: e2etc.namespaceName,
 	})
-	if !assert.NoErrorf(t, err, "No error expected while creating cluster (%s/%s)", e2etc.namespaceName, clusterName) {
-		t.Fatalf("Received status of %v when attempting to create a cluster", status)
-	}
+	require.NoErrorf(t, err, "No error expected while creating cluster (%s/%s)", e2etc.namespaceName, clusterName)
+
 	// wait for the cluster to be in a running state for 3 minutes
 	// if is not in that state, return an error
 	err = wait.PollUntilContextTimeout(e2etc.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -227,7 +227,7 @@ func (e2etc *End2EndTestingContext) GetRayVersion() string {
 	return e2etc.rayVersion
 }
 
-func (e2etc *End2EndTestingContext) GetRayApiServerClient() *kuberayHTTP.KuberayAPIServerClient {
+func (e2etc *End2EndTestingContext) GetRayAPIServerClient() *kuberayHTTP.KuberayAPIServerClient {
 	return e2etc.kuberayAPIServerClient
 }
 

--- a/apiserver/test/e2e/utils.go
+++ b/apiserver/test/e2e/utils.go
@@ -43,8 +43,7 @@ func PrettyPrintResponseBody(body io.ReadCloser) (string, error) {
 		return "", err
 	}
 	var prettyJSON bytes.Buffer
-	error := json.Indent(&prettyJSON, inputBytez, "", "\t")
-	if error != nil {
+	if err := json.Indent(&prettyJSON, inputBytez, "", "\t"); err != nil {
 		return "", err
 	}
 	return prettyJSON.String(), nil

--- a/apiserver/test/e2e/utils.go
+++ b/apiserver/test/e2e/utils.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"bytes"
+	"context"
 	"embed"
 	"encoding/json"
 	"io"
@@ -18,7 +19,7 @@ var files embed.FS
 // CreateHttpRequest instantiates a http request for the  specified endpoint and host
 func CreateHttpRequest(method string, host string, endPoint string, body io.Reader) (*http.Request, error) {
 	url := host + endPoint
-	req, err := http.NewRequest(method, url, body)
+	req, err := http.NewRequestWithContext(context.TODO(), method, url, body)
 	if err != nil {
 		return nil, err
 	}

--- a/kubectl-plugin/pkg/cmd/get/get_cluster.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster.go
@@ -163,7 +163,7 @@ func printClusters(rayclusterList *rayv1.RayClusterList, output io.Writer) error
 				raycluster.Status.DesiredTPU.String(),
 				raycluster.Status.DesiredMemory.String(),
 				relevantConditionType,
-				raycluster.Status.State, //nolint:staticcheck // Display State for now until it's removed from the CRD
+				raycluster.Status.State,
 				age,
 			},
 		})

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -605,5 +605,5 @@ func runtimeEnvHasWorkingDir(runtimePath string) (string, error) {
 }
 
 func isRayClusterReady(rayCluster *rayv1.RayCluster) bool {
-	return meta.IsStatusConditionTrue(rayCluster.Status.Conditions, "Ready") || rayCluster.Status.State == rayv1.Ready //nolint:staticcheck // Still need to check State even though it is deprecated
+	return meta.IsStatusConditionTrue(rayCluster.Status.Conditions, "Ready") || rayCluster.Status.State == rayv1.Ready
 }

--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -413,7 +413,7 @@ func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec 
 				fmt.Fprintf(options.ioStreams.Out, "file mode out side of accceptable value %d skipping file", header.Mode)
 			}
 			// Create file and write contents
-			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //nolint:gosec // header mode is guaranteed not to overflow
 			if err != nil {
 				return fmt.Errorf("Error creating file: %w", err)
 			}

--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -413,7 +413,7 @@ func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec 
 				fmt.Fprintf(options.ioStreams.Out, "file mode out side of accceptable value %d skipping file", header.Mode)
 			}
 			// Create file and write contents
-			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //nolint:gosec // header mode is guaranteed not to overflow
+			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 			if err != nil {
 				return fmt.Errorf("Error creating file: %w", err)
 			}

--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -413,7 +413,7 @@ func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec 
 				fmt.Fprintf(options.ioStreams.Out, "file mode out side of accceptable value %d skipping file", header.Mode)
 			}
 			// Create file and write contents
-			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //nolint:gosec // lint failing due to file mode conversion from uint64 to int32, checked above
+			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 			if err != nil {
 				return fmt.Errorf("Error creating file: %w", err)
 			}

--- a/kubectl-plugin/pkg/util/client/client.go
+++ b/kubectl-plugin/pkg/util/client/client.go
@@ -145,7 +145,7 @@ func (c *k8sClient) WaitRayClusterProvisioned(ctx context.Context, namespace, na
 				return fmt.Errorf("unexpected type %T", event.Object)
 			}
 
-			if meta.IsStatusConditionTrue(cluster.Status.Conditions, string(rayv1.RayClusterProvisioned)) || cluster.Status.State == rayv1.Ready { //nolint:staticcheck // Check .Status.State in case RayClusterStatusConditions feature gate isn't enabled
+			if meta.IsStatusConditionTrue(cluster.Status.Conditions, string(rayv1.RayClusterProvisioned)) || cluster.Status.State == rayv1.Ready {
 				return nil
 			}
 		}

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -37,7 +37,7 @@ func TestGetRuntimeEnvJsonFromBase64(t *testing.T) {
 	expected := `{"test":"test"}`
 	jsonOutput, err := getRuntimeEnvJson(testRayJob)
 	require.NoError(t, err)
-	assert.Equal(t, expected, jsonOutput)
+	assert.JSONEq(t, expected, jsonOutput)
 }
 
 func TestGetRuntimeEnvJsonFromYAML(t *testing.T) {
@@ -68,7 +68,7 @@ func TestGetMetadataJson(t *testing.T) {
 	expected := `{"testKey":"testValue"}`
 	metadataJson, err := GetMetadataJson(testRayJob.Spec.Metadata, testRayJob.Spec.RayClusterSpec.RayVersion)
 	require.NoError(t, err)
-	assert.Equal(t, expected, metadataJson)
+	assert.JSONEq(t, expected, metadataJson)
 }
 
 func TestGetK8sJobCommand(t *testing.T) {

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -668,7 +668,7 @@ func TestBuildPod(t *testing.T) {
 	checkContainerEnv(t, rayContainer, utils.RAY_NODE_TYPE_NAME, fmt.Sprintf("metadata.labels['%s']", utils.RayNodeGroupLabelKey))
 	checkContainerEnv(t, rayContainer, utils.RAY_USAGE_STATS_EXTRA_TAGS, fmt.Sprintf("kuberay_version=%s;kuberay_crd=%s", utils.KUBERAY_VERSION, utils.RayClusterCRD))
 	headRayStartCommandEnv := getEnvVar(rayContainer, utils.KUBERAY_GEN_RAY_START_CMD)
-	assert.True(t, strings.Contains(headRayStartCommandEnv.Value, "ray start"))
+	assert.Contains(t, headRayStartCommandEnv.Value, "ray start")
 
 	// In head, init container needs FQ_RAY_IP to create a self-signed certificate for its TLS authenticate.
 	for _, initContainer := range pod.Spec.InitContainers {
@@ -734,7 +734,7 @@ func TestBuildPod(t *testing.T) {
 	checkContainerEnv(t, rayContainer, utils.RAY_DASHBOARD_ENABLE_K8S_DISK_USAGE, "1")
 	checkContainerEnv(t, rayContainer, utils.RAY_NODE_TYPE_NAME, fmt.Sprintf("metadata.labels['%s']", utils.RayNodeGroupLabelKey))
 	workerRayStartCommandEnv := getEnvVar(rayContainer, utils.KUBERAY_GEN_RAY_START_CMD)
-	assert.True(t, strings.Contains(workerRayStartCommandEnv.Value, "ray start"))
+	assert.Contains(t, workerRayStartCommandEnv.Value, "ray start")
 
 	expectedCommandArg := splitAndSort("ulimit -n 65536; ray start --block --dashboard-agent-listen-port=52365 --memory=1073741824 --num-cpus=1 --num-gpus=3 --address=raycluster-sample-head-svc.default.svc.cluster.local:6379 --port=6379 --metrics-export-port=8080")
 	actualCommandArg := splitAndSort(pod.Spec.Containers[0].Args[0])
@@ -1598,8 +1598,8 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayServiceCRD)
 	assert.NotNil(t, rayContainer.LivenessProbe.Exec)
 	assert.NotNil(t, rayContainer.ReadinessProbe.Exec)
-	assert.False(t, strings.Contains(strings.Join(rayContainer.LivenessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath))
-	assert.True(t, strings.Contains(strings.Join(rayContainer.ReadinessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath))
+	assert.NotContains(t, strings.Join(rayContainer.LivenessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath)
+	assert.Contains(t, strings.Join(rayContainer.ReadinessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath)
 	assert.Equal(t, int32(2), rayContainer.LivenessProbe.TimeoutSeconds)
 	assert.Equal(t, int32(2), rayContainer.ReadinessProbe.TimeoutSeconds)
 
@@ -1612,8 +1612,8 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 	assert.NotNil(t, rayContainer.LivenessProbe.Exec)
 	assert.NotNil(t, rayContainer.ReadinessProbe.Exec)
 	// head pod should not have Ray Serve proxy health probes
-	assert.False(t, strings.Contains(strings.Join(rayContainer.LivenessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath))
-	assert.False(t, strings.Contains(strings.Join(rayContainer.ReadinessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath))
+	assert.NotContains(t, strings.Join(rayContainer.LivenessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath)
+	assert.NotContains(t, strings.Join(rayContainer.ReadinessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath)
 	assert.Equal(t, int32(5), rayContainer.LivenessProbe.TimeoutSeconds)
 	assert.Equal(t, int32(5), rayContainer.ReadinessProbe.TimeoutSeconds)
 }

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -418,11 +418,11 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 func (r *RayClusterReconciler) inconsistentRayClusterStatus(ctx context.Context, oldStatus rayv1.RayClusterStatus, newStatus rayv1.RayClusterStatus) bool {
 	logger := ctrl.LoggerFrom(ctx)
 
-	if oldStatus.State != newStatus.State || oldStatus.Reason != newStatus.Reason { //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	if oldStatus.State != newStatus.State || oldStatus.Reason != newStatus.Reason {
 		logger.Info(
 			"inconsistentRayClusterStatus",
-			"oldState", oldStatus.State, //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
-			"newState", newStatus.State, //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+			"oldState", oldStatus.State,
+			"newState", newStatus.State,
 			"oldReason", oldStatus.Reason,
 			"newReason", newStatus.Reason,
 		)
@@ -1296,7 +1296,7 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 
 	if reconcileErr == nil && len(runtimePods.Items) == int(newInstance.Status.DesiredWorkerReplicas)+1 { // workers + 1 head
 		if utils.CheckAllPodsRunning(ctx, runtimePods) {
-			newInstance.Status.State = rayv1.Ready //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+			newInstance.Status.State = rayv1.Ready
 			newInstance.Status.Reason = ""
 		}
 	}
@@ -1391,7 +1391,7 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	}
 
 	if newInstance.Spec.Suspend != nil && *newInstance.Spec.Suspend && len(runtimePods.Items) == 0 {
-		newInstance.Status.State = rayv1.Suspended //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+		newInstance.Status.State = rayv1.Suspended
 	}
 
 	if err := r.updateEndpoints(ctx, newInstance); err != nil {
@@ -1405,11 +1405,11 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	timeNow := metav1.Now()
 	newInstance.Status.LastUpdateTime = &timeNow
 
-	if instance.Status.State != newInstance.Status.State { //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	if instance.Status.State != newInstance.Status.State {
 		if newInstance.Status.StateTransitionTimes == nil {
 			newInstance.Status.StateTransitionTimes = make(map[rayv1.ClusterState]*metav1.Time)
 		}
-		newInstance.Status.StateTransitionTimes[newInstance.Status.State] = &timeNow //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+		newInstance.Status.StateTransitionTimes[newInstance.Status.State] = &timeNow
 	}
 
 	return newInstance, nil

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -117,7 +117,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 		})
 
 		It("Check head service", func() {
@@ -129,7 +129,7 @@ var _ = Context("Inside the default namespace", func() {
 
 			Eventually(
 				getResourceFunc(ctx, namespacedName, svc),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Head service: %v", svc)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Head service: %v", svc)
 		})
 
 		It("Check the number of worker Pods", func() {
@@ -210,7 +210,7 @@ var _ = Context("Inside the default namespace", func() {
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "rayCluster: %v", rayCluster)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "rayCluster: %v", rayCluster)
 				rayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](5)
 
 				// Operator may update revision after we get cluster earlier. Update may result in 409 conflict error.
@@ -256,7 +256,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 		})
 
 		It("Check the number of head Pods", func() {
@@ -350,7 +350,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 		})
 
 		It("Check the number of head Pods", func() {
@@ -442,7 +442,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 		})
 
 		It("Check RoleBinding / Role / ServiceAccount", func() {
@@ -450,19 +450,19 @@ var _ = Context("Inside the default namespace", func() {
 			namespacedName := common.RayClusterAutoscalerRoleBindingNamespacedName(rayCluster)
 			Eventually(
 				getResourceFunc(ctx, namespacedName, rb),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Autoscaler RoleBinding: %v", namespacedName)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Autoscaler RoleBinding: %v", namespacedName)
 
 			role := &rbacv1.Role{}
 			namespacedName = common.RayClusterAutoscalerRoleNamespacedName(rayCluster)
 			Eventually(
 				getResourceFunc(ctx, namespacedName, role),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Autoscaler Role: %v", namespacedName)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Autoscaler Role: %v", namespacedName)
 
 			sa := &corev1.ServiceAccount{}
 			namespacedName = common.RayClusterAutoscalerServiceAccountNamespacedName(rayCluster)
 			Eventually(
 				getResourceFunc(ctx, namespacedName, sa),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Autoscaler ServiceAccount: %v", namespacedName)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Autoscaler ServiceAccount: %v", namespacedName)
 		})
 
 		It("Check the number of worker Pods", func() {
@@ -476,7 +476,7 @@ var _ = Context("Inside the default namespace", func() {
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
+					time.Second*3, time.Millisecond*500).Should(Succeed())
 				podToDelete := workerPods.Items[0]
 				rayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](2)
 				rayCluster.Spec.WorkerGroupSpecs[0].ScaleStrategy.WorkersToDelete = []string{podToDelete.Name}
@@ -498,7 +498,7 @@ var _ = Context("Inside the default namespace", func() {
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
+					time.Second*3, time.Millisecond*500).Should(Succeed())
 				rayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](4)
 				return k8sClient.Update(ctx, rayCluster)
 			})
@@ -515,7 +515,7 @@ var _ = Context("Inside the default namespace", func() {
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: rayCluster.Namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "rayCluster = %v", rayCluster)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "rayCluster = %v", rayCluster)
 			rayCluster.Spec.Suspend = &suspend
 			return k8sClient.Update(ctx, rayCluster)
 		})
@@ -525,7 +525,7 @@ var _ = Context("Inside the default namespace", func() {
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: rayCluster.Namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "rayCluster = %v", rayCluster)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "rayCluster = %v", rayCluster)
 			rayCluster.Spec.WorkerGroupSpecs[0].Suspend = &suspend
 			return k8sClient.Update(ctx, rayCluster)
 		})
@@ -578,7 +578,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 		})
 
 		By("Check the number of worker Pods", func() {
@@ -733,7 +733,7 @@ var _ = Context("Inside the default namespace", func() {
 				err := k8sClient.Create(ctx, rayCluster)
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 				Eventually(getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 			})
 
 			By("Check the number of Pods and add finalizers", func() {
@@ -830,7 +830,7 @@ var _ = Context("Inside the default namespace", func() {
 				err := k8sClient.Create(ctx, rayCluster)
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 				Eventually(getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 			})
 
 			By("Check the number of Pods and add finalizers", func() {
@@ -875,7 +875,7 @@ var _ = Context("Inside the default namespace", func() {
 				err := k8sClient.Create(ctx, rayCluster)
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 				Eventually(getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 			})
 
 			By("Check the number of Pods", func() {
@@ -930,7 +930,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 		})
 
 		It("Check the number of worker Pods", func() {
@@ -944,7 +944,7 @@ var _ = Context("Inside the default namespace", func() {
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
+					time.Second*3, time.Millisecond*500).Should(Succeed())
 				rayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](2)
 				rayCluster.Spec.WorkerGroupSpecs[0].ScaleStrategy.WorkersToDelete = []string{
 					workerPods.Items[0].Name, workerPods.Items[1].Name, workerPods.Items[2].Name, workerPods.Items[3].Name,
@@ -967,7 +967,7 @@ var _ = Context("Inside the default namespace", func() {
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
+					time.Second*3, time.Millisecond*500).Should(Succeed())
 				rayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](4)
 				return k8sClient.Update(ctx, rayCluster)
 			})
@@ -1013,7 +1013,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 		})
 
 		It("Check workers are in the same namespace as RayCluster", func() {
@@ -1065,7 +1065,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 		})
 
 		It("Check the number of worker Pods", func() {
@@ -1108,7 +1108,7 @@ var _ = Context("Inside the default namespace", func() {
 		It("Check DesiredMemory and DesiredCPU", func() {
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 			desiredMemory := resource.MustParse("4Gi")
 			desiredCPU := resource.MustParse("4")
 			Expect(rayCluster.Status.DesiredMemory).To(Equal(desiredMemory))
@@ -1144,7 +1144,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 		})
 
 		It("Check the number of worker Pods", func() {
@@ -1184,7 +1184,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 
 			By("Check the number of worker Pods")
 			Eventually(
@@ -1318,7 +1318,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 
 			By("Check RayCluster RayClusterReplicaFailure condition is true")
 			Eventually(
@@ -1348,7 +1348,7 @@ var _ = Context("Inside the default namespace", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayCluster: %v", rayCluster.Name)
 		})
 
 		It("Check the number of worker Pods", func() {
@@ -1362,13 +1362,13 @@ var _ = Context("Inside the default namespace", func() {
 			var svc corev1.Service
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name + "-head-svc", Namespace: namespace}, &svc),
-				time.Second*3, time.Millisecond*500).Should(BeNil())
+				time.Second*3, time.Millisecond*500).Should(Succeed())
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name + "-serve-svc", Namespace: namespace}, &svc),
-				time.Second*3, time.Millisecond*500).Should(BeNil())
+				time.Second*3, time.Millisecond*500).Should(Succeed())
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name + "-headless", Namespace: namespace}, &svc),
-				time.Second*3, time.Millisecond*500).Should(BeNil())
+				time.Second*3, time.Millisecond*500).Should(Succeed())
 		})
 	})
 })

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1600,7 +1600,7 @@ func TestReconcile_UpdateClusterState(t *testing.T) {
 	cluster := rayv1.RayCluster{}
 	err := fakeClient.Get(ctx, namespacedName, &cluster)
 	require.NoError(t, err, "Fail to get RayCluster")
-	assert.Empty(t, cluster.Status.State, "Cluster state should be empty") //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Empty(t, cluster.Status.State, "Cluster state should be empty")
 
 	testRayClusterReconciler := &RayClusterReconciler{
 		Client:                     fakeClient,
@@ -1611,14 +1611,14 @@ func TestReconcile_UpdateClusterState(t *testing.T) {
 
 	state := rayv1.Ready
 	newTestRayCluster := testRayCluster.DeepCopy()
-	newTestRayCluster.Status.State = state //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	newTestRayCluster.Status.State = state
 	inconsistent, err := testRayClusterReconciler.updateRayClusterStatus(ctx, testRayCluster, newTestRayCluster)
 	require.NoError(t, err, "Fail to update cluster state")
 	assert.True(t, inconsistent)
 
 	err = fakeClient.Get(ctx, namespacedName, &cluster)
 	require.NoError(t, err, "Fail to get RayCluster after updating state")
-	assert.Equal(t, cluster.Status.State, state, "Cluster state should be updated") //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Equal(t, cluster.Status.State, state, "Cluster state should be updated")
 }
 
 func TestInconsistentRayClusterStatus(t *testing.T) {
@@ -1668,7 +1668,7 @@ func TestInconsistentRayClusterStatus(t *testing.T) {
 		{
 			name: "State is updated, expect result to be true",
 			modifyStatus: func(newStatus *rayv1.RayClusterStatus) {
-				newStatus.State = rayv1.Suspended //nolint:staticcheck // Still need to check State even though it is deprecated, delete this no lint after this field is removed.
+				newStatus.State = rayv1.Suspended
 			},
 			expectResult: true,
 		},
@@ -1927,7 +1927,7 @@ func TestCalculateStatusWithoutDesiredReplicas(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, newInstance.Status.DesiredWorkerReplicas)
 	assert.NotEqual(t, newInstance.Status.DesiredWorkerReplicas, newInstance.Status.ReadyWorkerReplicas)
-	assert.Equal(t, newInstance.Status.State, rayv1.ClusterState("")) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Equal(t, newInstance.Status.State, rayv1.ClusterState(""))
 	assert.Empty(t, newInstance.Status.Reason)
 	assert.Nil(t, newInstance.Status.StateTransitionTimes)
 }
@@ -1995,7 +1995,7 @@ func TestCalculateStatusWithSuspendedWorkerGroups(t *testing.T) {
 	assert.Zero(t, newInstance.Status.MaxWorkerReplicas)
 	assert.Zero(t, newInstance.Status.DesiredCPU)
 	assert.Zero(t, newInstance.Status.DesiredMemory)
-	assert.Equal(t, rayv1.Ready, newInstance.Status.State) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Equal(t, rayv1.Ready, newInstance.Status.State)
 	assert.NotNil(t, newInstance.Status.StateTransitionTimes)
 }
 
@@ -2069,7 +2069,7 @@ func TestCalculateStatusWithReconcileErrorBackAndForth(t *testing.T) {
 	assert.NotZero(t, newInstance.Status.DesiredWorkerReplicas)
 	// Note that even if there are DesiredWorkerReplicas ready, we don't mark CR to be Ready state due to the reconcile error.
 	assert.Equal(t, newInstance.Status.DesiredWorkerReplicas, newInstance.Status.ReadyWorkerReplicas)
-	assert.Equal(t, rayv1.ClusterState(""), newInstance.Status.State) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Equal(t, rayv1.ClusterState(""), newInstance.Status.State)
 	assert.Empty(t, newInstance.Status.Reason)
 	assert.Nil(t, newInstance.Status.StateTransitionTimes)
 
@@ -2078,7 +2078,7 @@ func TestCalculateStatusWithReconcileErrorBackAndForth(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotZero(t, newInstance.Status.DesiredWorkerReplicas)
 	assert.Equal(t, newInstance.Status.DesiredWorkerReplicas, newInstance.Status.ReadyWorkerReplicas)
-	assert.Equal(t, rayv1.Ready, newInstance.Status.State) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Equal(t, rayv1.Ready, newInstance.Status.State)
 	assert.Empty(t, newInstance.Status.Reason)
 	assert.NotNil(t, newInstance.Status.StateTransitionTimes)
 	assert.NotNil(t, newInstance.Status.StateTransitionTimes[rayv1.Ready])
@@ -2089,7 +2089,7 @@ func TestCalculateStatusWithReconcileErrorBackAndForth(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotZero(t, newInstance.Status.DesiredWorkerReplicas)
 	assert.Equal(t, newInstance.Status.DesiredWorkerReplicas, newInstance.Status.ReadyWorkerReplicas)
-	assert.Equal(t, rayv1.Ready, newInstance.Status.State) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Equal(t, rayv1.Ready, newInstance.Status.State)
 	assert.Empty(t, newInstance.Status.Reason)
 	assert.NotNil(t, newInstance.Status.StateTransitionTimes)
 	assert.NotNil(t, newInstance.Status.StateTransitionTimes[rayv1.Ready])
@@ -2236,7 +2236,7 @@ func TestStateTransitionTimes_NoStateChange(t *testing.T) {
 	}
 
 	preUpdateTime := metav1.Now()
-	testRayCluster.Status.State = rayv1.Ready //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	testRayCluster.Status.State = rayv1.Ready
 	testRayCluster.Status.StateTransitionTimes = map[rayv1.ClusterState]*metav1.Time{rayv1.Ready: &preUpdateTime}
 	newInstance, err := r.calculateStatus(ctx, testRayCluster, nil)
 	require.NoError(t, err)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -190,8 +190,8 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 
 		// Check the current status of RayCluster before submitting.
 		if clientURL := rayJobInstance.Status.DashboardURL; clientURL == "" {
-			if rayClusterInstance.Status.State != rayv1.Ready { //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
-				logger.Info("Wait for the RayCluster.Status.State to be ready before submitting the job.", "RayCluster", rayClusterInstance.Name, "State", rayClusterInstance.Status.State) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+			if rayClusterInstance.Status.State != rayv1.Ready {
+				logger.Info("Wait for the RayCluster.Status.State to be ready before submitting the job.", "RayCluster", rayClusterInstance.Name, "State", rayClusterInstance.Status.State)
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 			}
 

--- a/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_suspended_test.go
@@ -66,9 +66,9 @@ var _ = Context("RayJob with suspend operation", func() {
 				time.Second*15, time.Millisecond*500).Should(Not(BeEmpty()))
 			// The actual cluster instance and underlying resources SHOULD be created when suspend == false
 			Eventually(
-				// k8sClient client does not throw error if cluster IS found
+
 				getResourceFunc(ctx, common.RayJobRayClusterNamespacedName(rayJob), rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil())
+				time.Second*3, time.Millisecond*500).Should(Succeed())
 		})
 
 		It("should NOT create the underlying K8s job yet because the cluster is not ready", func() {
@@ -98,7 +98,7 @@ var _ = Context("RayJob with suspend operation", func() {
 			// The underlying Kubernetes Job should be created when the RayJob is created
 			Eventually(
 				getResourceFunc(ctx, common.RayJobK8sJobNamespacedName(rayJob), underlyingK8sJob),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Expected Kubernetes job to be present")
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Expected Kubernetes job to be present")
 		})
 	})
 

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -145,7 +145,7 @@ var _ = Context("RayJob with different submission modes", func() {
 					Expect(err).NotTo(HaveOccurred(), "Failed to create RayJob: %v", rayJob.Name)
 					Eventually(
 						getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-						time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayJob: %v", rayJob.Name)
+						time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayJob: %v", rayJob.Name)
 				}
 			})
 
@@ -162,7 +162,7 @@ var _ = Context("RayJob with different submission modes", func() {
 					rayCluster := &rayv1.RayCluster{}
 					Eventually(
 						getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-						time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+						time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 
 					// Make RayCluster.Status.State to be rayv1.Ready.
 					updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -216,7 +216,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayJob")
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayJob: %v", rayJob.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayJob: %v", rayJob.Name)
 			})
 
 			It("RayJobs's JobDeploymentStatus transitions from New to Initializing.", func() {
@@ -233,7 +233,7 @@ var _ = Context("RayJob with different submission modes", func() {
 			It("In Initializing state, the RayCluster should eventually be created.", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 
 				// Check whether RayCluster is consistent with RayJob's RayClusterSpec.
 				Expect(rayCluster.Spec.WorkerGroupSpecs[0].Replicas).To(Equal(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas))
@@ -248,7 +248,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			It("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -316,7 +316,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				job := &batchv1.Job{}
 				Consistently(
 					getResourceFunc(ctx, namespacedName, job),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
+					time.Second*3, time.Millisecond*500).Should(Succeed())
 			})
 		})
 
@@ -331,7 +331,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayJob")
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayJob: %v", rayJob.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayJob: %v", rayJob.Name)
 			})
 
 			It("RayJobs's JobDeploymentStatus transitions from New to Initializing.", func() {
@@ -349,11 +349,11 @@ var _ = Context("RayJob with different submission modes", func() {
 				var svc corev1.Service
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 				// Also check its service name.
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName + "-head-svc", Namespace: namespace}, &svc),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
+					time.Second*3, time.Millisecond*500).Should(Succeed())
 			})
 		})
 
@@ -375,7 +375,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayJob")
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayJob: %v", rayJob.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayJob: %v", rayJob.Name)
 			})
 
 			It("RayJobs's JobDeploymentStatus transitions from New to Initializing.", func() {
@@ -387,12 +387,12 @@ var _ = Context("RayJob with different submission modes", func() {
 			It("In Initializing state, the RayCluster should eventually be created.", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 			})
 
 			It("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -441,7 +441,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayJob")
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayJob: %v", rayJob.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayJob: %v", rayJob.Name)
 			})
 
 			It("RayJobs's JobDeploymentStatus transitions from New to Initializing.", func() {
@@ -458,7 +458,7 @@ var _ = Context("RayJob with different submission modes", func() {
 			It("In Initializing state, the RayCluster should eventually be created.", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 
 				// Check whether RayCluster is consistent with RayJob's RayClusterSpec.
 				Expect(rayCluster.Spec.WorkerGroupSpecs[0].Replicas).To(Equal(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas))
@@ -473,7 +473,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			It("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -561,7 +561,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayJob")
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayJob: %v", rayJob.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayJob: %v", rayJob.Name)
 			})
 
 			It("RayJobs's JobDeploymentStatus transitions from New to Initializing.", func() {
@@ -605,7 +605,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayJob")
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayJob: %v", rayJob.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayJob: %v", rayJob.Name)
 			})
 
 			It("RayJobs's JobDeploymentStatus transitions from New to Initializing.", func() {
@@ -622,7 +622,7 @@ var _ = Context("RayJob with different submission modes", func() {
 			It("In Initializing state, the RayCluster should eventually be created.", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 
 				// Check whether RayCluster is consistent with RayJob's RayClusterSpec.
 				Expect(rayCluster.Spec.WorkerGroupSpecs[0].Replicas).To(Equal(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas))
@@ -637,7 +637,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			It("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -717,7 +717,7 @@ var _ = Context("RayJob with different submission modes", func() {
 			It("In Initializing state, the RayCluster should eventually be created (attempt 2)", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 
 				// Check whether RayCluster is consistent with RayJob's RayClusterSpec.
 				Expect(rayCluster.Spec.WorkerGroupSpecs[0].Replicas).To(Equal(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas))
@@ -732,7 +732,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			It("Make RayCluster.Status.State to be rayv1.Ready (attempt 2)", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -823,7 +823,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayJob")
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayJob: %v", rayJob.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayJob: %v", rayJob.Name)
 			})
 
 			It("RayJobs's JobDeploymentStatus transitions from New to Initializing.", func() {
@@ -839,7 +839,7 @@ var _ = Context("RayJob with different submission modes", func() {
 			It("In Initializing state, the RayCluster should eventually be created.", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 
 				// Check whether RayCluster is consistent with RayJob's RayClusterSpec.
 				Expect(rayCluster.Spec.WorkerGroupSpecs[0].Replicas).To(Equal(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas))
@@ -854,7 +854,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			It("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -911,7 +911,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayJob")
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayJob: %v", rayJob.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayJob: %v", rayJob.Name)
 			})
 
 			By("RayJobs's JobDeploymentStatus transitions from New to Initializing.", func() {
@@ -928,7 +928,7 @@ var _ = Context("RayJob with different submission modes", func() {
 			By("In Initializing state, the RayCluster should eventually be created.", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 
 				// Check whether RayCluster is consistent with RayJob's RayClusterSpec.
 				Expect(rayCluster.Spec.WorkerGroupSpecs[0].Replicas).To(Equal(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas))
@@ -943,7 +943,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			By("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -1011,7 +1011,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				job := &batchv1.Job{}
 				Consistently(
 					getResourceFunc(ctx, namespacedName, job),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
+					time.Second*3, time.Millisecond*500).Should(Succeed())
 			})
 		})
 
@@ -1033,7 +1033,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayJob")
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayJob: %v", rayJob.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayJob: %v", rayJob.Name)
 			})
 
 			By("RayJobs's JobDeploymentStatus transitions from New to Initializing.", func() {
@@ -1050,7 +1050,7 @@ var _ = Context("RayJob with different submission modes", func() {
 			By("In Initializing state, the RayCluster should eventually be created.", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 
 				// Check whether RayCluster is consistent with RayJob's RayClusterSpec.
 				Expect(rayCluster.Spec.WorkerGroupSpecs[0].Replicas).To(Equal(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas))
@@ -1065,7 +1065,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			By("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -1127,7 +1127,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				// RayCluster exists
 				Consistently(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 
 				// Check worker group is suspended
 				Expect(*rayCluster.Spec.WorkerGroupSpecs[0].Suspend).To(BeTrue())
@@ -1150,7 +1150,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				job := &batchv1.Job{}
 				Consistently(
 					getResourceFunc(ctx, namespacedName, job),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
+					time.Second*3, time.Millisecond*500).Should(Succeed())
 			})
 		})
 
@@ -1168,7 +1168,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayJob")
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayJob: %v", rayJob.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayJob: %v", rayJob.Name)
 			})
 
 			By("RayJobs's JobDeploymentStatus transitions from New to Initializing.", func() {
@@ -1185,7 +1185,7 @@ var _ = Context("RayJob with different submission modes", func() {
 			By("In Initializing state, the RayCluster should eventually be created.", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 
 				// Check whether RayCluster is consistent with RayJob's RayClusterSpec.
 				Expect(rayCluster.Spec.WorkerGroupSpecs[0].Replicas).To(Equal(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas))
@@ -1200,7 +1200,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			By("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -1278,7 +1278,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(err).NotTo(HaveOccurred(), "Failed to create RayJob")
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Should be able to see RayJob: %v", rayJob.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Should be able to see RayJob: %v", rayJob.Name)
 			})
 
 			By("RayJobs's JobDeploymentStatus transitions from New to Initializing.", func() {
@@ -1295,7 +1295,7 @@ var _ = Context("RayJob with different submission modes", func() {
 			By("In Initializing state, the RayCluster should eventually be created.", func() {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 
 				// Check whether RayCluster is consistent with RayJob's RayClusterSpec.
 				Expect(rayCluster.Spec.WorkerGroupSpecs[0].Replicas).To(Equal(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas))
@@ -1310,7 +1310,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			By("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -1372,12 +1372,12 @@ var _ = Context("RayJob with different submission modes", func() {
 				// RayJob exists
 				Consistently(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayJob %v not found", rayJob)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayJob %v not found", rayJob)
 
 				// RayCluster exists
 				Consistently(
 					getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Status.RayClusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster %v not found", rayJob.Status.RayClusterName)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster %v not found", rayJob.Status.RayClusterName)
 
 				// Worker replicas set to 3
 				Expect(*rayCluster.Spec.WorkerGroupSpecs[0].Replicas).To(Equal(int32(3)))
@@ -1400,7 +1400,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				job := &batchv1.Job{}
 				Consistently(
 					getResourceFunc(ctx, namespacedName, job),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
+					time.Second*3, time.Millisecond*500).Should(Succeed())
 			})
 		})
 	})

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -302,9 +302,9 @@ func (r *RayServiceReconciler) calculateStatus(ctx context.Context, rayServiceIn
 	calculateConditions(rayServiceInstance)
 
 	// The definition of `ServiceStatus` is equivalent to the `RayServiceReady` condition
-	rayServiceInstance.Status.ServiceStatus = rayv1.NotRunning //nolint:staticcheck // `ServiceStatus` is deprecated
+	rayServiceInstance.Status.ServiceStatus = rayv1.NotRunning
 	if meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.RayServiceReady)) {
-		rayServiceInstance.Status.ServiceStatus = rayv1.Running //nolint:staticcheck // `ServiceStatus` is deprecated
+		rayServiceInstance.Status.ServiceStatus = rayv1.Running
 	}
 	return nil
 }
@@ -405,8 +405,8 @@ func inconsistentRayServiceStatus(ctx context.Context, oldStatus rayv1.RayServic
 // Determine whether to update the status of the RayService instance.
 func inconsistentRayServiceStatuses(ctx context.Context, oldStatus rayv1.RayServiceStatuses, newStatus rayv1.RayServiceStatuses) bool {
 	logger := ctrl.LoggerFrom(ctx)
-	if oldStatus.ServiceStatus != newStatus.ServiceStatus { //nolint:staticcheck // `ServiceStatus` is deprecated
-		logger.Info("inconsistentRayServiceStatus RayService ServiceStatus changed", "oldServiceStatus", oldStatus.ServiceStatus, "newServiceStatus", newStatus.ServiceStatus) //nolint:staticcheck // `ServiceStatus` is deprecated
+	if oldStatus.ServiceStatus != newStatus.ServiceStatus {
+		logger.Info("inconsistentRayServiceStatus RayService ServiceStatus changed", "oldServiceStatus", oldStatus.ServiceStatus, "newServiceStatus", newStatus.ServiceStatus)
 		return true
 	}
 

--- a/ray-operator/controllers/ray/rayservice_controller_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_test.go
@@ -161,7 +161,7 @@ var _ = Context("RayService env tests", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create RayService resource")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayService.Name, Namespace: namespace}, rayService),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "RayService: %v", rayService.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "RayService: %v", rayService.Name)
 		})
 
 		It("Should create a pending RayCluster", func() {
@@ -184,17 +184,17 @@ var _ = Context("RayService env tests", func() {
 			// Initialize RayCluster for the following tests.
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayService.Status.ActiveServiceStatus.RayClusterName, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster: %v", rayCluster.Name)
 		})
 
 		It("Check RayService service names", func() {
 			var svc corev1.Service
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayService.Name + "-head-svc", Namespace: namespace}, &svc),
-				time.Second*3, time.Millisecond*500).Should(BeNil())
+				time.Second*3, time.Millisecond*500).Should(Succeed())
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayService.Name + "-serve-svc", Namespace: namespace}, &svc),
-				time.Second*3, time.Millisecond*500).Should(BeNil())
+				time.Second*3, time.Millisecond*500).Should(Succeed())
 		})
 	})
 
@@ -211,7 +211,7 @@ var _ = Context("RayService env tests", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create RayService resource")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayService.Name, Namespace: namespace}, rayService),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "RayService: %v", rayService.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "RayService: %v", rayService.Name)
 		})
 
 		It("Should create a pending RayCluster", func() {
@@ -227,7 +227,7 @@ var _ = Context("RayService env tests", func() {
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: clusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Pending RayCluster: %v", rayCluster.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Pending RayCluster: %v", rayCluster.Name)
 				*rayCluster.Spec.WorkerGroupSpecs[0].Replicas++
 				return k8sClient.Update(ctx, rayCluster)
 			})
@@ -253,7 +253,7 @@ var _ = Context("RayService env tests", func() {
 			// Initialize RayCluster for the following tests.
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayService.Status.ActiveServiceStatus.RayClusterName, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster: %v", rayCluster.Name)
 		})
 
 		It("Autoscaler updates the active RayCluster and should not switch to a new RayCluster", func() {
@@ -263,7 +263,7 @@ var _ = Context("RayService env tests", func() {
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: clusterName, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil(), "Active RayCluster: %v", rayCluster.Name)
+					time.Second*3, time.Millisecond*500).Should(Succeed(), "Active RayCluster: %v", rayCluster.Name)
 				*rayCluster.Spec.WorkerGroupSpecs[0].Replicas++
 				return k8sClient.Update(ctx, rayCluster)
 			})
@@ -299,7 +299,7 @@ var _ = Context("RayService env tests", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create RayService resource")
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayService.Name, Namespace: namespace}, rayService),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "RayService: %v", rayService.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "RayService: %v", rayService.Name)
 
 			By("Conditions should be initialized correctly")
 			Eventually(
@@ -332,7 +332,7 @@ var _ = Context("RayService env tests", func() {
 			// Initialize RayCluster for the following tests.
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: rayService.Status.ActiveServiceStatus.RayClusterName, Namespace: namespace}, rayCluster),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "RayCluster: %v", rayCluster.Name)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "RayCluster: %v", rayCluster.Name)
 
 			// Make sure the annotations are populated to the RayCluster.
 			Expect(rayCluster.Annotations).Should(Satisfy(func(annotations map[string]string) bool {
@@ -357,14 +357,14 @@ var _ = Context("RayService env tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: headSvcName, Namespace: namespace}, svc),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Head service: %v", svc)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Head service: %v", svc)
 			// TODO: Verify the head service by checking labels and annotations.
 
 			By("Should create a new serve service resource")
 			svc = &corev1.Service{}
 			Eventually(
 				getResourceFunc(ctx, client.ObjectKey{Name: utils.GenerateServeServiceName(rayService.Name), Namespace: namespace}, svc),
-				time.Second*3, time.Millisecond*500).Should(BeNil(), "Serve service: %v", svc)
+				time.Second*3, time.Millisecond*500).Should(Succeed(), "Serve service: %v", svc)
 			// TODO: Verify the serve service by checking labels and annotations.
 
 			By("The RayServiceReady condition should be true when the number of endpoints is greater than 0")
@@ -402,7 +402,7 @@ var _ = Context("RayService env tests", func() {
 				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					Eventually(
 						getResourceFunc(ctx, client.ObjectKey{Name: rayService.Name, Namespace: namespace}, rayService),
-						time.Second*3, time.Millisecond*500).Should(BeNil(), "RayService: %v", rayService.Name)
+						time.Second*3, time.Millisecond*500).Should(Succeed(), "RayService: %v", rayService.Name)
 					rayService.Spec.ServeConfigV2 = newConfigV2
 					return k8sClient.Update(ctx, rayService)
 				})
@@ -458,7 +458,7 @@ var _ = Context("RayService env tests", func() {
 				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					Eventually(
 						getResourceFunc(ctx, client.ObjectKey{Name: rayService.Name, Namespace: namespace}, rayService),
-						time.Second*3, time.Millisecond*500).Should(BeNil(), "RayService: %v", rayService.Name)
+						time.Second*3, time.Millisecond*500).Should(Succeed(), "RayService: %v", rayService.Name)
 					rayService.Spec.RayClusterSpec.WorkerGroupSpecs = workerGroupSpecs
 					return k8sClient.Update(ctx, rayService)
 				})
@@ -491,7 +491,7 @@ var _ = Context("RayService env tests", func() {
 				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					Eventually(
 						getResourceFunc(ctx, client.ObjectKey{Name: rayService.Name, Namespace: namespace}, rayService),
-						time.Second*3, time.Millisecond*500).Should(BeNil(), "RayService: %v", rayService.Name)
+						time.Second*3, time.Millisecond*500).Should(Succeed(), "RayService: %v", rayService.Name)
 					Expect(rayService.Spec.RayClusterSpec.RayVersion).NotTo(Equal(mockRayVersion))
 					rayService.Spec.RayClusterSpec.RayVersion = mockRayVersion
 					return k8sClient.Update(ctx, rayService)
@@ -509,7 +509,7 @@ var _ = Context("RayService env tests", func() {
 				pendingCluster := &rayv1.RayCluster{}
 				Eventually(
 					getResourceFunc(ctx, client.ObjectKey{Name: pendingClusterName, Namespace: namespace}, pendingCluster),
-					time.Second*15, time.Millisecond*500).Should(BeNil(), "Pending RayCluster: %v", pendingCluster.Name)
+					time.Second*15, time.Millisecond*500).Should(Succeed(), "Pending RayCluster: %v", pendingCluster.Name)
 			})
 
 			When("Promote the pending RayCluster to the active RayCluster", Ordered, func() {
@@ -527,7 +527,7 @@ var _ = Context("RayService env tests", func() {
 					err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 						Eventually(
 							getResourceFunc(ctx, client.ObjectKey{Name: rayService.Name, Namespace: namespace}, rayService),
-							time.Second*3, time.Millisecond*500).Should(BeNil(), "RayService: %v", rayService.Name)
+							time.Second*3, time.Millisecond*500).Should(Succeed(), "RayService: %v", rayService.Name)
 						Expect(rayService.Spec.RayClusterSpec.RayVersion).NotTo(Equal(mockRayVersion))
 						rayService.Spec.RayClusterSpec.RayVersion = mockRayVersion
 						return k8sClient.Update(ctx, rayService)
@@ -552,7 +552,7 @@ var _ = Context("RayService env tests", func() {
 					err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 						Eventually(
 							getResourceFunc(ctx, client.ObjectKey{Name: rayService.Name, Namespace: namespace}, rayService),
-							time.Second*3, time.Millisecond*500).Should(BeNil(), "RayService: %v", rayService.Name)
+							time.Second*3, time.Millisecond*500).Should(Succeed(), "RayService: %v", rayService.Name)
 						rayService.Spec.RayClusterSpec.WorkerGroupSpecs = workerGroupSpecs
 						return k8sClient.Update(ctx, rayService)
 					})

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -100,7 +100,7 @@ func TestInconsistentRayServiceStatuses(t *testing.T) {
 
 	// Test 1: Update ServiceStatus only.
 	newStatus := oldStatus.DeepCopy()
-	newStatus.ServiceStatus = rayv1.Running //nolint:staticcheck // `ServiceStatus` is deprecated
+	newStatus.ServiceStatus = rayv1.Running
 	assert.True(t, inconsistentRayServiceStatuses(ctx, oldStatus, *newStatus))
 
 	// Test 2: Test RayServiceStatus

--- a/ray-operator/controllers/ray/suite_helpers_test.go
+++ b/ray-operator/controllers/ray/suite_helpers_test.go
@@ -47,7 +47,7 @@ func getClusterState(ctx context.Context, namespace string, clusterName string) 
 		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: clusterName}, &cluster); err != nil {
 			log.Fatal(err)
 		}
-		return cluster.Status.State //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+		return cluster.Status.State
 	}
 }
 
@@ -78,7 +78,7 @@ func cleanUpWorkersToDelete(ctx context.Context, rayCluster *rayv1.RayCluster) {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		gomega.Eventually(
 			getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: "default"}, rayCluster),
-			time.Second*9, time.Millisecond*500).Should(gomega.BeNil(), "raycluster = %v", rayCluster)
+			time.Second*9, time.Millisecond*500).Should(gomega.Succeed(), "raycluster = %v", rayCluster)
 		rayCluster.Spec.WorkerGroupSpecs[0].ScaleStrategy.WorkersToDelete = []string{}
 		return k8sClient.Update(ctx, rayCluster)
 	})
@@ -252,7 +252,7 @@ func updateHeadPodToRunningAndReady(ctx context.Context, rayClusterName string, 
 	var instance rayv1.RayCluster
 	gomega.Eventually(
 		getResourceFunc(ctx, client.ObjectKey{Name: rayClusterName, Namespace: namespace}, &instance),
-		time.Second*3, time.Millisecond*500).Should(gomega.BeNil(), "RayCluster %v not found", rayClusterName)
+		time.Second*3, time.Millisecond*500).Should(gomega.Succeed(), "RayCluster %v not found", rayClusterName)
 
 	headPods := corev1.PodList{}
 	headLabels := common.RayClusterHeadPodsAssociationOptions(&instance).ToListOptions()
@@ -282,7 +282,7 @@ func updateWorkerPodsToRunningAndReady(ctx context.Context, rayClusterName strin
 	rayCluster := &rayv1.RayCluster{}
 	gomega.Eventually(
 		getResourceFunc(ctx, client.ObjectKey{Name: rayClusterName, Namespace: namespace}, rayCluster),
-		time.Second*3, time.Millisecond*500).Should(gomega.BeNil(), "RayCluster %v not found", rayClusterName)
+		time.Second*3, time.Millisecond*500).Should(gomega.Succeed(), "RayCluster %v not found", rayClusterName)
 
 	workerPods := corev1.PodList{}
 	workerLabels := common.RayClusterWorkerPodsAssociationOptions(rayCluster).ToListOptions()

--- a/ray-operator/test/e2erayservice/rayservice_ha_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_ha_test.go
@@ -290,7 +290,7 @@ func TestRayServiceGCSFaultTolerance(t *testing.T) {
 	})
 	// Because this test shares the Locust RayCluster YAML file with other tests,
 	// we need to ensure the YAML file is not accidentally updated.
-	g.Expect(time.Since(startTime) > 2*time.Minute).To(BeTrue())
+	g.Expect(time.Since(startTime)).To(BeNumerically(">", 2*time.Minute))
 
 	newHeadPod, err := GetHeadPod(test, rayServiceUnderlyingRayCluster)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -71,7 +71,7 @@ func GetRayCluster(t Test, namespace, name string) (*rayv1.RayCluster, error) {
 }
 
 func RayClusterState(cluster *rayv1.RayCluster) rayv1.ClusterState {
-	return cluster.Status.State //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	return cluster.Status.State
 }
 
 func StatusCondition(condType rayv1.RayClusterConditionType) func(*rayv1.RayCluster) metav1.Condition {
@@ -201,7 +201,7 @@ func RayService(t Test, namespace, name string) func() (*rayv1.RayService, error
 }
 
 func RayServiceStatus(service *rayv1.RayService) rayv1.ServiceStatus {
-	return service.Status.ServiceStatus //nolint:staticcheck // `ServiceStatus` is deprecated
+	return service.Status.ServiceStatus
 }
 
 func IsRayServiceReady(service *rayv1.RayService) bool {

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -6,7 +6,6 @@ dirs_to_lint="ray-operator kubectl-plugin apiserver"
 
 for dir in $dirs_to_lint; do
   pushd "$dir"
-  golangci-lint --version
   # exclude the SA1019 check which checks the usage of deprecated fields.
   golangci-lint run --fix --exclude='SA1019' --exclude-files _generated.go --timeout 10m0s --allow-parallel-runners
   popd

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,6 +7,7 @@ dirs_to_lint="ray-operator kubectl-plugin apiserver"
 for dir in $dirs_to_lint; do
   pushd "$dir"
   golangci-lint --version
+  # exclude the SA1019 check which checks the usage of deprecated fields.
   golangci-lint run --fix --exclude='SA1019' --exclude-files _generated.go --timeout 10m0s --allow-parallel-runners
   popd
 done

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,10 +2,11 @@
 
 set -euo pipefail
 
-dirs_to_lint="ray-operator kubectl-plugin"
+dirs_to_lint="ray-operator kubectl-plugin apiserver"
 
 for dir in $dirs_to_lint; do
   pushd "$dir"
-  golangci-lint run --fix --exclude-files _generated.go --timeout 10m0s
+  golangci-lint --version
+  golangci-lint run --fix --exclude='SA1019' --exclude-files _generated.go --timeout 10m0s --allow-parallel-runners
   popd
 done


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

This PR does a few things:
- Enable golang linter for apiserver in precommit hook, and upgrade `golangci-linter` to v1.64.8
  + Remove ci linter from apiserver, so we have a single source of linter for all directories
- All of the code changes in the PR are either auto-fixed or fixed via linter error message, let me know if you have any questions for any of the code change

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/3302

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [X] Manual tests
  - [ ] This PR is not tested :(
