### PR TITLE
[lint] Apply golangci-lint autofix on `apiserver` directory

### DIFF
--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -17,9 +17,9 @@ import (
 
 type KuberayAPIServerClient struct {
 	httpClient  *http.Client
-	baseURL     string
 	marshaler   *protojson.MarshalOptions
 	unmarshaler *protojson.UnmarshalOptions
+	baseURL     string
 }
 
 type KuberayAPIServerClientError struct {

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -557,15 +557,15 @@ func TestPopulateWorkerNodeSpec(t *testing.T) {
 
 func TestAutoscalerOptions(t *testing.T) {
 	options := convertAutoscalingOptions(autoscalerOptions)
-	assert.Equal(t, options.IdleTimeoutSeconds, int32(60))
-	assert.Equal(t, options.UpscalingMode, "Default")
-	assert.Equal(t, options.Image, "Some Image")
-	assert.Equal(t, options.ImagePullPolicy, "Always")
-	assert.Equal(t, options.Cpu, "500m")
-	assert.Equal(t, options.Memory, "512Mi")
-	assert.Equal(t, len(options.Envs.Values), 1)
-	assert.Equal(t, len(options.Envs.ValuesFrom), 2)
-	assert.Equal(t, len(options.Volumes), 2)
+	assert.Equal(t, int32(60), options.IdleTimeoutSeconds)
+	assert.Equal(t, "Default", options.UpscalingMode)
+	assert.Equal(t, "Some Image", options.Image)
+	assert.Equal(t, "Always", options.ImagePullPolicy)
+	assert.Equal(t, "500m", options.Cpu)
+	assert.Equal(t, "512Mi", options.Memory)
+	assert.Len(t, options.Envs.Values, 1)
+	assert.Len(t, options.Envs.ValuesFrom, 2)
+	assert.Len(t, options.Volumes, 2)
 }
 
 func TestPopulateRayClusterSpec(t *testing.T) {
@@ -573,39 +573,39 @@ func TestPopulateRayClusterSpec(t *testing.T) {
 	if len(cluster.Annotations) != 1 {
 		t.Errorf("failed to convert cluster's annotations")
 	}
-	assert.Equal(t, cluster.ClusterSpec.EnableInTreeAutoscaling, false)
+	assert.False(t, cluster.ClusterSpec.EnableInTreeAutoscaling)
 	if cluster.ClusterSpec.AutoscalerOptions != nil {
 		t.Errorf("unexpected autoscaler annotations")
 	}
 	cluster = FromCrdToApiCluster(&ClusterSpecAutoscalerTest, []corev1.Event{})
-	assert.Equal(t, cluster.ClusterSpec.EnableInTreeAutoscaling, true)
+	assert.True(t, cluster.ClusterSpec.EnableInTreeAutoscaling)
 	if cluster.ClusterSpec.AutoscalerOptions == nil {
 		t.Errorf("autoscaler annotations not found")
 	}
-	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.IdleTimeoutSeconds, int32(60))
-	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.UpscalingMode, "Default")
-	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.ImagePullPolicy, "Always")
-	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.Cpu, "500m")
-	assert.Equal(t, cluster.ClusterSpec.AutoscalerOptions.Memory, "512Mi")
-	assert.Equal(t, len(cluster.ClusterSpec.HeadGroupSpec.Environment.ValuesFrom), 4)
+	assert.Equal(t, int32(60), cluster.ClusterSpec.AutoscalerOptions.IdleTimeoutSeconds)
+	assert.Equal(t, "Default", cluster.ClusterSpec.AutoscalerOptions.UpscalingMode)
+	assert.Equal(t, "Always", cluster.ClusterSpec.AutoscalerOptions.ImagePullPolicy)
+	assert.Equal(t, "500m", cluster.ClusterSpec.AutoscalerOptions.Cpu)
+	assert.Equal(t, "512Mi", cluster.ClusterSpec.AutoscalerOptions.Memory)
+	assert.Len(t, cluster.ClusterSpec.HeadGroupSpec.Environment.ValuesFrom, 4)
 	for name, value := range cluster.ClusterSpec.HeadGroupSpec.Environment.ValuesFrom {
 		switch name {
 		case "REDIS_PASSWORD":
-			assert.Equal(t, value.Source.String(), "SECRET")
-			assert.Equal(t, value.Name, "redis-password-secret")
-			assert.Equal(t, value.Key, "password")
+			assert.Equal(t, "SECRET", value.Source.String())
+			assert.Equal(t, "redis-password-secret", value.Name)
+			assert.Equal(t, "password", value.Key)
 		case "CONFIGMAP":
-			assert.Equal(t, value.Source.String(), "CONFIGMAP")
-			assert.Equal(t, value.Name, "special-config")
-			assert.Equal(t, value.Key, "special.how")
+			assert.Equal(t, "CONFIGMAP", value.Source.String())
+			assert.Equal(t, "special-config", value.Name)
+			assert.Equal(t, "special.how", value.Key)
 		case "ResourceFieldRef":
-			assert.Equal(t, value.Source.String(), "RESOURCEFIELD")
-			assert.Equal(t, value.Name, "my-container")
-			assert.Equal(t, value.Key, "resource")
+			assert.Equal(t, "RESOURCEFIELD", value.Source.String())
+			assert.Equal(t, "my-container", value.Name)
+			assert.Equal(t, "resource", value.Key)
 		default:
-			assert.Equal(t, value.Source.String(), "FIELD")
-			assert.Equal(t, value.Name, "")
-			assert.Equal(t, value.Key, "path")
+			assert.Equal(t, "FIELD", value.Source.String())
+			assert.Equal(t, "", value.Name)
+			assert.Equal(t, "path", value.Key)
 		}
 	}
 }

--- a/apiserver/pkg/server/cluster_server.go
+++ b/apiserver/pkg/server/cluster_server.go
@@ -19,9 +19,9 @@ type ClusterServerOptions struct {
 // implements `type ClusterServiceServer interface` in cluster_grpc.pb.go
 // ClusterServer is the server API for ClusterService service.
 type ClusterServer struct {
+	api.UnimplementedClusterServiceServer
 	resourceManager *manager.ResourceManager
 	options         *ClusterServerOptions
-	api.UnimplementedClusterServiceServer
 }
 
 // Creates a new Cluster.
@@ -98,7 +98,7 @@ func (s *ClusterServer) ListCluster(ctx context.Context, request *api.ListCluste
 // TODO: Supports pagination and sorting on certain fields when we have DB support. request needs to be extended.
 func (s *ClusterServer) ListAllClusters(ctx context.Context, request *api.ListAllClustersRequest) (*api.ListAllClustersResponse, error) {
 	// Leave the namespace empty to list all clusters in all namespaces.
-	clusters, continueToken, err := s.resourceManager.ListClusters(ctx, /*namespace=*/ "", request.Continue, request.Limit)
+	clusters, continueToken, err := s.resourceManager.ListClusters(ctx /*namespace=*/, "", request.Continue, request.Limit)
 	if err != nil {
 		return nil, util.Wrap(err, "List clusters from all namespaces failed.")
 	}

--- a/apiserver/pkg/server/compute_template_server.go
+++ b/apiserver/pkg/server/compute_template_server.go
@@ -18,9 +18,9 @@ type ComputeTemplateServerOptions struct {
 // implements `type ComputeTemplateServiceServer interface` in runtime_grpc.pb.go
 // ComputeTemplateServer is the server API for ClusterRuntimeService.
 type ComputeTemplateServer struct {
+	api.UnimplementedComputeTemplateServiceServer
 	resourceManager *manager.ResourceManager
 	options         *ComputeTemplateServerOptions
-	api.UnimplementedComputeTemplateServiceServer
 }
 
 func (s *ComputeTemplateServer) CreateComputeTemplate(ctx context.Context, request *api.CreateComputeTemplateRequest) (*api.ComputeTemplate, error) {

--- a/apiserver/pkg/server/job_server.go
+++ b/apiserver/pkg/server/job_server.go
@@ -22,9 +22,9 @@ func NewRayJobServer(resourceManager *manager.ResourceManager, options *JobServe
 }
 
 type RayJobServer struct {
+	api.UnimplementedRayJobServiceServer
 	resourceManager *manager.ResourceManager
 	options         *JobServerOptions
-	api.UnimplementedRayJobServiceServer
 }
 
 // Creates a new Ray Job.

--- a/apiserver/pkg/server/ray_job_submission_service_server.go
+++ b/apiserver/pkg/server/ray_job_submission_service_server.go
@@ -28,12 +28,11 @@ type RayJobSubmissionServiceServerOptions struct {
 // implements `type ClusterServiceServer interface` in cluster_grpc.pb.go
 // ClusterServer is the server API for ClusterService service.
 type RayJobSubmissionServiceServer struct {
-	options       *RayJobSubmissionServiceServerOptions
-	clusterServer *ClusterServer
-	log           logr.Logger
 	api.UnimplementedRayJobSubmissionServiceServer
-
+	options             *RayJobSubmissionServiceServerOptions
+	clusterServer       *ClusterServer
 	dashboardClientFunc func() utils.RayDashboardClientInterface
+	log                 logr.Logger
 }
 
 // Create RayJobSubmissionServiceServer

--- a/apiserver/pkg/server/serve_server.go
+++ b/apiserver/pkg/server/serve_server.go
@@ -19,9 +19,9 @@ type ServiceServerOptions struct {
 // implements `type RayServeServiceServer interface` in serve_grpc.pb.go
 // RayServiceServer is the server API for RayServeService service.
 type RayServiceServer struct {
+	api.UnimplementedRayServeServiceServer
 	resourceManager *manager.ResourceManager
 	options         *ServiceServerOptions
-	api.UnimplementedRayServeServiceServer
 }
 
 func NewRayServiceServer(resourceManager *manager.ResourceManager, options *ServiceServerOptions) *RayServiceServer {

--- a/apiserver/pkg/server/validations_test.go
+++ b/apiserver/pkg/server/validations_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestValidateClusterSpec(t *testing.T) {
 	tests := []struct {
-		name          string
-		clusterSpec   *api.ClusterSpec
 		expectedError error
+		clusterSpec   *api.ClusterSpec
+		name          string
 	}{
 		{
 			name: "A valid cluster spec",
@@ -221,9 +221,9 @@ func TestValidateClusterSpec(t *testing.T) {
 
 func TestValidateCreateServiceRequest(t *testing.T) {
 	tests := []struct {
-		name          string
-		request       *api.CreateRayServiceRequest
 		expectedError error
+		request       *api.CreateRayServiceRequest
+		name          string
 	}{
 		{
 			name: "A valid create service request V2",

--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -844,7 +844,7 @@ func (c *RayCluster) SetAnnotationsToAllTemplates(key string, value string) {
 func NewComputeTemplate(runtime *api.ComputeTemplate) (*corev1.ConfigMap, error) {
 	extendedResourcesJSON, err := json.Marshal(runtime.ExtendedResources)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal extended resources: %v", err)
+		return nil, fmt.Errorf("failed to marshal extended resources: %w", err)
 	}
 
 	// Create data map

--- a/apiserver/pkg/util/cluster_test.go
+++ b/apiserver/pkg/util/cluster_test.go
@@ -476,7 +476,7 @@ func TestBuildVolumes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := buildVols(tt.apiVolume)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			if tt.name == "configmap test" {
 				// Sort items for comparison
 				sort.SliceStable(got[0].ConfigMap.Items, func(i, j int) bool {
@@ -545,7 +545,7 @@ func TestBuildVolumeMounts(t *testing.T) {
 
 func TestBuildHeadPodTemplate(t *testing.T) {
 	podSpec, err := buildHeadPodTemplate("2.4", &api.EnvironmentVariables{}, &headGroup, &template, false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	if podSpec.Spec.ServiceAccountName != "account" {
 		t.Errorf("failed to propagate service account")
@@ -593,7 +593,7 @@ func TestBuildHeadPodTemplate(t *testing.T) {
 	}
 
 	podSpec, err = buildHeadPodTemplate("2.4", &api.EnvironmentVariables{}, &headGroup, &template, true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	if len(podSpec.Spec.Containers[0].Ports) != 6 {
 		t.Errorf("failed build ports")
 	}
@@ -601,36 +601,36 @@ func TestBuildHeadPodTemplate(t *testing.T) {
 
 func TestConvertAutoscalerOptions(t *testing.T) {
 	options, err := buildAutoscalerOptions(&testAutoscalerOptions)
-	assert.Nil(t, err)
-	assert.Equal(t, *options.IdleTimeoutSeconds, int32(25))
+	assert.NoError(t, err)
+	assert.Equal(t, int32(25), *options.IdleTimeoutSeconds)
 	assert.Equal(t, (string)(*options.UpscalingMode), "Default")
 	assert.Equal(t, (string)(*options.ImagePullPolicy), "Always")
-	assert.Equal(t, len(options.Env), 1)
-	assert.Equal(t, len(options.EnvFrom), 2)
-	assert.Equal(t, len(options.VolumeMounts), 2)
-	assert.Equal(t, options.Resources.Requests.Cpu().String(), "300m")
-	assert.Equal(t, options.Resources.Requests.Memory().String(), "512Mi")
+	assert.Len(t, options.Env, 1)
+	assert.Len(t, options.EnvFrom, 2)
+	assert.Len(t, options.VolumeMounts, 2)
+	assert.Equal(t, "300m", options.Resources.Requests.Cpu().String())
+	assert.Equal(t, "512Mi", options.Resources.Requests.Memory().String())
 }
 
 func TestBuildRayCluster(t *testing.T) {
 	cluster, err := NewRayCluster(&rayCluster, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	if len(cluster.ObjectMeta.Annotations) != 1 {
 		t.Errorf("failed to propagate annotations")
 	}
 	if !(*cluster.Spec.HeadGroupSpec.EnableIngress) {
 		t.Errorf("failed to propagate create Ingress")
 	}
-	assert.Equal(t, cluster.Spec.EnableInTreeAutoscaling, (*bool)(nil))
+	assert.Equal(t, (*bool)(nil), cluster.Spec.EnableInTreeAutoscaling)
 	cluster, err = NewRayCluster(&rayClusterAutoScaler, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.Nil(t, err)
-	assert.Equal(t, *cluster.Spec.EnableInTreeAutoscaling, true)
-	assert.NotEqual(t, cluster.Spec.AutoscalerOptions, nil)
+	assert.NoError(t, err)
+	assert.True(t, *cluster.Spec.EnableInTreeAutoscaling)
+	assert.NotNil(t, cluster.Spec.AutoscalerOptions)
 }
 
 func TestBuilWorkerPodTemplate(t *testing.T) {
 	podSpec, err := buildWorkerPodTemplate("2.4", &api.EnvironmentVariables{}, &workerGroup, &templateWorker)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "account", podSpec.Spec.ServiceAccountName, "failed to propagate service account")
 	assert.Equal(t, "foo", podSpec.Spec.ImagePullSecrets[0].Name, "failed to propagate image pull secret")

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -113,7 +113,7 @@ func NewUserError(err error, internalMessage string, externalMessage string) *Us
 func ExtractErrorForCLI(err error, isDebugMode bool) error {
 	if userError, ok := err.(*UserError); ok {
 		if isDebugMode {
-			return fmt.Errorf("%+v", userError.internalError)
+			return fmt.Errorf("%+w", userError.internalError)
 		} else {
 			return fmt.Errorf("%v", userError.externalMessage)
 		}

--- a/apiserver/pkg/util/job_test.go
+++ b/apiserver/pkg/util/job_test.go
@@ -76,23 +76,23 @@ var apiJobExistingClusterSubmitterBadParams = &api.RayJob{
 func TestBuildRayJob(t *testing.T) {
 	// Test request with cluster creation
 	job, err := NewRayJob(apiJobNewCluster, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "test", job.ObjectMeta.Name)
 	assert.Equal(t, "test", job.ObjectMeta.Namespace)
-	assert.Equal(t, 4, len(job.ObjectMeta.Labels))
+	assert.Len(t, job.ObjectMeta.Labels, 4)
 	assert.Equal(t, "test", job.ObjectMeta.Labels[RayClusterUserLabelKey])
-	assert.Equal(t, 1, len(job.ObjectMeta.Annotations))
+	assert.Len(t, job.ObjectMeta.Annotations, 1)
 	assert.Greater(t, len(job.Spec.RuntimeEnvYAML), 1)
-	assert.Equal(t, 1, len(job.Spec.Metadata))
+	assert.Len(t, job.Spec.Metadata, 1)
 	assert.Nil(t, job.Spec.ClusterSelector)
 	assert.NotNil(t, job.Spec.RayClusterSpec)
 
 	// Test request without cluster creation
 	job, err = NewRayJob(apiJobExistingCluster, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "test", job.ObjectMeta.Name)
 	assert.Equal(t, "test", job.ObjectMeta.Namespace)
-	assert.Equal(t, 4, len(job.ObjectMeta.Labels))
+	assert.Len(t, job.ObjectMeta.Labels, 4)
 	assert.Equal(t, "test", job.ObjectMeta.Labels[RayClusterUserLabelKey])
 	assert.Greater(t, len(job.Spec.RuntimeEnvYAML), 1)
 	assert.NotNil(t, job.Spec.ClusterSelector)
@@ -101,10 +101,10 @@ func TestBuildRayJob(t *testing.T) {
 
 	// Test request without cluster creation with submitter
 	job, err = NewRayJob(apiJobExistingClusterSubmitter, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "test", job.ObjectMeta.Name)
 	assert.Equal(t, "test", job.ObjectMeta.Namespace)
-	assert.Equal(t, 4, len(job.ObjectMeta.Labels))
+	assert.Len(t, job.ObjectMeta.Labels, 4)
 	assert.Equal(t, "test", job.ObjectMeta.Labels[RayClusterUserLabelKey])
 	assert.Greater(t, len(job.Spec.RuntimeEnvYAML), 1)
 	assert.NotNil(t, job.Spec.ClusterSelector)
@@ -120,5 +120,5 @@ func TestBuildRayJob(t *testing.T) {
 
 	// Test request without cluster creation with submitter bad parameters
 	_, err = NewRayJob(apiJobExistingClusterSubmitterBadParams, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/apiserver/pkg/util/service_test.go
+++ b/apiserver/pkg/util/service_test.go
@@ -26,12 +26,12 @@ var apiServiceV2 = &api.RayService{
 
 func TestBuildService(t *testing.T) {
 	_, err := NewRayService(apiServiceNoServe, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	if err.Error() != "serve configuration is not defined" {
 		t.Errorf("wrong error returned")
 	}
 	got, err := NewRayService(apiServiceV2, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	if got.RayService.Spec.ServeConfigV2 == "" {
 		t.Errorf("Got empty V2")
 	}

--- a/apiserver/test/e2e/config_server_e2e_test.go
+++ b/apiserver/test/e2e/config_server_e2e_test.go
@@ -214,7 +214,7 @@ func TestGetAllComputeTemplates(t *testing.T) {
 			break
 		}
 	}
-	require.Equal(t, foundName, true)
+	require.True(t, foundName)
 }
 
 // TestGetTemplatesInNamespace get all compute templates in namespace endpoint
@@ -243,7 +243,7 @@ func TestGetTemplatesInNamespace(t *testing.T) {
 			break
 		}
 	}
-	require.Equal(t, foundName, true)
+	require.True(t, foundName)
 }
 
 // TestDeleteTemplate sequentially iterates over the delete compute template endpoint

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -311,7 +311,7 @@ func TestGetAllJobs(t *testing.T) {
 			break
 		}
 	}
-	require.Equal(t, foundName, true)
+	require.True(t, foundName)
 }
 
 func TestGetJobsInNamespace(t *testing.T) {
@@ -341,7 +341,7 @@ func TestGetJobsInNamespace(t *testing.T) {
 			break
 		}
 	}
-	require.Equal(t, foundName, true)
+	require.True(t, foundName)
 }
 
 func TestGetJob(t *testing.T) {

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -29,9 +29,9 @@ import (
 
 // GenericEnd2EndTest struct allows for reuse in setting up and running tests
 type GenericEnd2EndTest[I proto.Message] struct {
-	Name          string
 	Input         I
 	ExpectedError error
+	Name          string
 }
 
 // End2EndTestingContext provides a common set of values and methods that

--- a/kubectl-plugin/pkg/cmd/get/get_cluster.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster.go
@@ -163,7 +163,7 @@ func printClusters(rayclusterList *rayv1.RayClusterList, output io.Writer) error
 				raycluster.Status.DesiredTPU.String(),
 				raycluster.Status.DesiredMemory.String(),
 				relevantConditionType,
-				raycluster.Status.State, //nolint:staticcheck // Display State for now until it's removed from the CRD
+				raycluster.Status.State,
 				age,
 			},
 		})

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -607,5 +607,5 @@ func runtimeEnvHasWorkingDir(runtimePath string) (string, error) {
 }
 
 func isRayClusterReady(rayCluster *rayv1.RayCluster) bool {
-	return meta.IsStatusConditionTrue(rayCluster.Status.Conditions, "Ready") || rayCluster.Status.State == rayv1.Ready //nolint:staticcheck // Still need to check State even though it is deprecated
+	return meta.IsStatusConditionTrue(rayCluster.Status.Conditions, "Ready") || rayCluster.Status.State == rayv1.Ready
 }

--- a/kubectl-plugin/pkg/util/client/client.go
+++ b/kubectl-plugin/pkg/util/client/client.go
@@ -145,7 +145,7 @@ func (c *k8sClient) WaitRayClusterProvisioned(ctx context.Context, namespace, na
 				return fmt.Errorf("unexpected type %T", event.Object)
 			}
 
-			if meta.IsStatusConditionTrue(cluster.Status.Conditions, string(rayv1.RayClusterProvisioned)) || cluster.Status.State == rayv1.Ready { //nolint:staticcheck // Check .Status.State in case RayClusterStatusConditions feature gate isn't enabled
+			if meta.IsStatusConditionTrue(cluster.Status.Conditions, string(rayv1.RayClusterProvisioned)) || cluster.Status.State == rayv1.Ready {
 				return nil
 			}
 		}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -418,11 +418,11 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 func (r *RayClusterReconciler) inconsistentRayClusterStatus(ctx context.Context, oldStatus rayv1.RayClusterStatus, newStatus rayv1.RayClusterStatus) bool {
 	logger := ctrl.LoggerFrom(ctx)
 
-	if oldStatus.State != newStatus.State || oldStatus.Reason != newStatus.Reason { //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	if oldStatus.State != newStatus.State || oldStatus.Reason != newStatus.Reason {
 		logger.Info(
 			"inconsistentRayClusterStatus",
-			"oldState", oldStatus.State, //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
-			"newState", newStatus.State, //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+			"oldState", oldStatus.State,
+			"newState", newStatus.State,
 			"oldReason", oldStatus.Reason,
 			"newReason", newStatus.Reason,
 		)
@@ -1296,7 +1296,7 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 
 	if reconcileErr == nil && len(runtimePods.Items) == int(newInstance.Status.DesiredWorkerReplicas)+1 { // workers + 1 head
 		if utils.CheckAllPodsRunning(ctx, runtimePods) {
-			newInstance.Status.State = rayv1.Ready //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+			newInstance.Status.State = rayv1.Ready
 			newInstance.Status.Reason = ""
 		}
 	}
@@ -1391,7 +1391,7 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	}
 
 	if newInstance.Spec.Suspend != nil && *newInstance.Spec.Suspend && len(runtimePods.Items) == 0 {
-		newInstance.Status.State = rayv1.Suspended //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+		newInstance.Status.State = rayv1.Suspended
 	}
 
 	if err := r.updateEndpoints(ctx, newInstance); err != nil {
@@ -1405,11 +1405,11 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	timeNow := metav1.Now()
 	newInstance.Status.LastUpdateTime = &timeNow
 
-	if instance.Status.State != newInstance.Status.State { //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	if instance.Status.State != newInstance.Status.State {
 		if newInstance.Status.StateTransitionTimes == nil {
 			newInstance.Status.StateTransitionTimes = make(map[rayv1.ClusterState]*metav1.Time)
 		}
-		newInstance.Status.StateTransitionTimes[newInstance.Status.State] = &timeNow //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+		newInstance.Status.StateTransitionTimes[newInstance.Status.State] = &timeNow
 	}
 
 	return newInstance, nil

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1600,7 +1600,7 @@ func TestReconcile_UpdateClusterState(t *testing.T) {
 	cluster := rayv1.RayCluster{}
 	err := fakeClient.Get(ctx, namespacedName, &cluster)
 	require.NoError(t, err, "Fail to get RayCluster")
-	assert.Empty(t, cluster.Status.State, "Cluster state should be empty") //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Empty(t, cluster.Status.State, "Cluster state should be empty")
 
 	testRayClusterReconciler := &RayClusterReconciler{
 		Client:                     fakeClient,
@@ -1611,14 +1611,14 @@ func TestReconcile_UpdateClusterState(t *testing.T) {
 
 	state := rayv1.Ready
 	newTestRayCluster := testRayCluster.DeepCopy()
-	newTestRayCluster.Status.State = state //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	newTestRayCluster.Status.State = state
 	inconsistent, err := testRayClusterReconciler.updateRayClusterStatus(ctx, testRayCluster, newTestRayCluster)
 	require.NoError(t, err, "Fail to update cluster state")
 	assert.True(t, inconsistent)
 
 	err = fakeClient.Get(ctx, namespacedName, &cluster)
 	require.NoError(t, err, "Fail to get RayCluster after updating state")
-	assert.Equal(t, cluster.Status.State, state, "Cluster state should be updated") //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Equal(t, cluster.Status.State, state, "Cluster state should be updated")
 }
 
 func TestInconsistentRayClusterStatus(t *testing.T) {
@@ -1668,7 +1668,7 @@ func TestInconsistentRayClusterStatus(t *testing.T) {
 		{
 			name: "State is updated, expect result to be true",
 			modifyStatus: func(newStatus *rayv1.RayClusterStatus) {
-				newStatus.State = rayv1.Suspended //nolint:staticcheck // Still need to check State even though it is deprecated, delete this no lint after this field is removed.
+				newStatus.State = rayv1.Suspended
 			},
 			expectResult: true,
 		},
@@ -1927,7 +1927,7 @@ func TestCalculateStatusWithoutDesiredReplicas(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, newInstance.Status.DesiredWorkerReplicas)
 	assert.NotEqual(t, newInstance.Status.DesiredWorkerReplicas, newInstance.Status.ReadyWorkerReplicas)
-	assert.Equal(t, newInstance.Status.State, rayv1.ClusterState("")) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Equal(t, newInstance.Status.State, rayv1.ClusterState(""))
 	assert.Empty(t, newInstance.Status.Reason)
 	assert.Nil(t, newInstance.Status.StateTransitionTimes)
 }
@@ -1995,7 +1995,7 @@ func TestCalculateStatusWithSuspendedWorkerGroups(t *testing.T) {
 	assert.Zero(t, newInstance.Status.MaxWorkerReplicas)
 	assert.Zero(t, newInstance.Status.DesiredCPU)
 	assert.Zero(t, newInstance.Status.DesiredMemory)
-	assert.Equal(t, rayv1.Ready, newInstance.Status.State) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Equal(t, rayv1.Ready, newInstance.Status.State)
 	assert.NotNil(t, newInstance.Status.StateTransitionTimes)
 }
 
@@ -2069,7 +2069,7 @@ func TestCalculateStatusWithReconcileErrorBackAndForth(t *testing.T) {
 	assert.NotZero(t, newInstance.Status.DesiredWorkerReplicas)
 	// Note that even if there are DesiredWorkerReplicas ready, we don't mark CR to be Ready state due to the reconcile error.
 	assert.Equal(t, newInstance.Status.DesiredWorkerReplicas, newInstance.Status.ReadyWorkerReplicas)
-	assert.Equal(t, rayv1.ClusterState(""), newInstance.Status.State) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Equal(t, rayv1.ClusterState(""), newInstance.Status.State)
 	assert.Empty(t, newInstance.Status.Reason)
 	assert.Nil(t, newInstance.Status.StateTransitionTimes)
 
@@ -2078,7 +2078,7 @@ func TestCalculateStatusWithReconcileErrorBackAndForth(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotZero(t, newInstance.Status.DesiredWorkerReplicas)
 	assert.Equal(t, newInstance.Status.DesiredWorkerReplicas, newInstance.Status.ReadyWorkerReplicas)
-	assert.Equal(t, rayv1.Ready, newInstance.Status.State) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Equal(t, rayv1.Ready, newInstance.Status.State)
 	assert.Empty(t, newInstance.Status.Reason)
 	assert.NotNil(t, newInstance.Status.StateTransitionTimes)
 	assert.NotNil(t, newInstance.Status.StateTransitionTimes[rayv1.Ready])
@@ -2089,7 +2089,7 @@ func TestCalculateStatusWithReconcileErrorBackAndForth(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotZero(t, newInstance.Status.DesiredWorkerReplicas)
 	assert.Equal(t, newInstance.Status.DesiredWorkerReplicas, newInstance.Status.ReadyWorkerReplicas)
-	assert.Equal(t, rayv1.Ready, newInstance.Status.State) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	assert.Equal(t, rayv1.Ready, newInstance.Status.State)
 	assert.Empty(t, newInstance.Status.Reason)
 	assert.NotNil(t, newInstance.Status.StateTransitionTimes)
 	assert.NotNil(t, newInstance.Status.StateTransitionTimes[rayv1.Ready])
@@ -2236,7 +2236,7 @@ func TestStateTransitionTimes_NoStateChange(t *testing.T) {
 	}
 
 	preUpdateTime := metav1.Now()
-	testRayCluster.Status.State = rayv1.Ready //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	testRayCluster.Status.State = rayv1.Ready
 	testRayCluster.Status.StateTransitionTimes = map[rayv1.ClusterState]*metav1.Time{rayv1.Ready: &preUpdateTime}
 	newInstance, err := r.calculateStatus(ctx, testRayCluster, nil)
 	require.NoError(t, err)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -190,8 +190,8 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 
 		// Check the current status of RayCluster before submitting.
 		if clientURL := rayJobInstance.Status.DashboardURL; clientURL == "" {
-			if rayClusterInstance.Status.State != rayv1.Ready { //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
-				logger.Info("Wait for the RayCluster.Status.State to be ready before submitting the job.", "RayCluster", rayClusterInstance.Name, "State", rayClusterInstance.Status.State) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+			if rayClusterInstance.Status.State != rayv1.Ready {
+				logger.Info("Wait for the RayCluster.Status.State to be ready before submitting the job.", "RayCluster", rayClusterInstance.Name, "State", rayClusterInstance.Status.State)
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 			}
 

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -248,7 +248,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			It("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -392,7 +392,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			It("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -473,7 +473,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			It("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -637,7 +637,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			It("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -732,7 +732,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			It("Make RayCluster.Status.State to be rayv1.Ready (attempt 2)", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -854,7 +854,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			It("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -943,7 +943,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			By("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -1065,7 +1065,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			By("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -1200,7 +1200,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			By("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
@@ -1310,7 +1310,7 @@ var _ = Context("RayJob with different submission modes", func() {
 
 			By("Make RayCluster.Status.State to be rayv1.Ready", func() {
 				// The RayCluster is not 'Ready' yet because Pods are not running and ready.
-				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready)) //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+				Expect(rayCluster.Status.State).NotTo(Equal(rayv1.Ready))
 
 				updateHeadPodToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)
 				updateWorkerPodsToRunningAndReady(ctx, rayJob.Status.RayClusterName, namespace)

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -302,9 +302,9 @@ func (r *RayServiceReconciler) calculateStatus(ctx context.Context, rayServiceIn
 	calculateConditions(rayServiceInstance)
 
 	// The definition of `ServiceStatus` is equivalent to the `RayServiceReady` condition
-	rayServiceInstance.Status.ServiceStatus = rayv1.NotRunning //nolint:staticcheck // `ServiceStatus` is deprecated
+	rayServiceInstance.Status.ServiceStatus = rayv1.NotRunning
 	if meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.RayServiceReady)) {
-		rayServiceInstance.Status.ServiceStatus = rayv1.Running //nolint:staticcheck // `ServiceStatus` is deprecated
+		rayServiceInstance.Status.ServiceStatus = rayv1.Running
 	}
 	return nil
 }
@@ -405,8 +405,8 @@ func inconsistentRayServiceStatus(ctx context.Context, oldStatus rayv1.RayServic
 // Determine whether to update the status of the RayService instance.
 func inconsistentRayServiceStatuses(ctx context.Context, oldStatus rayv1.RayServiceStatuses, newStatus rayv1.RayServiceStatuses) bool {
 	logger := ctrl.LoggerFrom(ctx)
-	if oldStatus.ServiceStatus != newStatus.ServiceStatus { //nolint:staticcheck // `ServiceStatus` is deprecated
-		logger.Info("inconsistentRayServiceStatus RayService ServiceStatus changed", "oldServiceStatus", oldStatus.ServiceStatus, "newServiceStatus", newStatus.ServiceStatus) //nolint:staticcheck // `ServiceStatus` is deprecated
+	if oldStatus.ServiceStatus != newStatus.ServiceStatus {
+		logger.Info("inconsistentRayServiceStatus RayService ServiceStatus changed", "oldServiceStatus", oldStatus.ServiceStatus, "newServiceStatus", newStatus.ServiceStatus)
 		return true
 	}
 

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -100,7 +100,7 @@ func TestInconsistentRayServiceStatuses(t *testing.T) {
 
 	// Test 1: Update ServiceStatus only.
 	newStatus := oldStatus.DeepCopy()
-	newStatus.ServiceStatus = rayv1.Running //nolint:staticcheck // `ServiceStatus` is deprecated
+	newStatus.ServiceStatus = rayv1.Running
 	assert.True(t, inconsistentRayServiceStatuses(ctx, oldStatus, *newStatus))
 
 	// Test 2: Test RayServiceStatus

--- a/ray-operator/controllers/ray/suite_helpers_test.go
+++ b/ray-operator/controllers/ray/suite_helpers_test.go
@@ -47,7 +47,7 @@ func getClusterState(ctx context.Context, namespace string, clusterName string) 
 		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: clusterName}, &cluster); err != nil {
 			log.Fatal(err)
 		}
-		return cluster.Status.State //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+		return cluster.Status.State
 	}
 }
 

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -71,7 +71,7 @@ func GetRayCluster(t Test, namespace, name string) (*rayv1.RayCluster, error) {
 }
 
 func RayClusterState(cluster *rayv1.RayCluster) rayv1.ClusterState {
-	return cluster.Status.State //nolint:staticcheck // https://github.com/ray-project/kuberay/pull/2288
+	return cluster.Status.State
 }
 
 func StatusCondition(condType rayv1.RayClusterConditionType) func(*rayv1.RayCluster) metav1.Condition {
@@ -201,7 +201,7 @@ func RayService(t Test, namespace, name string) func() (*rayv1.RayService, error
 }
 
 func RayServiceStatus(service *rayv1.RayService) rayv1.ServiceStatus {
-	return service.Status.ServiceStatus //nolint:staticcheck // `ServiceStatus` is deprecated
+	return service.Status.ServiceStatus
 }
 
 func IsRayServiceReady(service *rayv1.RayService) bool {

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -6,6 +6,6 @@ dirs_to_lint="ray-operator kubectl-plugin"
 
 for dir in $dirs_to_lint; do
   pushd "$dir"
-  golangci-lint run --fix --exclude-files _generated.go --timeout 10m0s
+  golangci-lint run --fix --exclude-files _generated.go --exclude='SA1019' --timeout 10m0s
   popd
 done


### PR DESCRIPTION
## Why are these changes needed?

Based on suggestion https://github.com/ray-project/kuberay/pull/3303#pullrequestreview-2761211609, for easier code review, in this PR, I apply golangci-lint to `apiserver` directory and it only contain auto-fixed changes.

In the followup PR, there'll two things included:
- All left linter issues manually fixed;
- Enable linter in precommit hook for apiserver.

Commands to execute:
```sh
[~/kuberay] (hjiang/golanglint-autofix-apiserver) 
ubuntu@hjiang-devbox-pg$ pre-commit install -t pre-push
pre-commit installed at .git/hooks/pre-push
[~/kuberay] (hjiang/golanglint-autofix-apiserver) 
ubuntu@hjiang-devbox-pg$ pre-commit run golangci-lint --all-files
```

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
