### PR TITLE
[1/N] [apiserver] Fix half of linter issues for apiserver

### DIFF
--- a/apiserver/cmd/main.go
+++ b/apiserver/cmd/main.go
@@ -151,7 +151,7 @@ func startHttpProxy() {
 	klog.Info("Http Proxy started")
 }
 
-func serveHealth(w http.ResponseWriter, r *http.Request) {
+func serveHealth(w http.ResponseWriter, _ *http.Request) {
 	if atomic.LoadInt32(&healthy) == 1 {
 		w.WriteHeader(http.StatusOK)
 	} else {

--- a/apiserver/cmd/main.go
+++ b/apiserver/cmd/main.go
@@ -54,7 +54,7 @@ func main() {
 	resourceManager := manager.NewResourceManager(&clientManager)
 
 	atomic.StoreInt32(&healthy, 1)
-	go startRpcServer(resourceManager)
+	go startRPCServer(resourceManager)
 	startHttpProxy()
 	// See also https://gist.github.com/enricofoltran/10b4a980cd07cb02836f70a4ab3e72d7
 	quit := make(chan os.Signal, 1)
@@ -70,7 +70,7 @@ func main() {
 
 type RegisterHttpHandlerFromEndpoint func(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error
 
-func startRpcServer(resourceManager *manager.ResourceManager) {
+func startRPCServer(resourceManager *manager.ResourceManager) {
 	klog.Info("Starting gRPC server")
 
 	listener, err := net.Listen("tcp", *rpcPortFlag)
@@ -86,7 +86,7 @@ func startRpcServer(resourceManager *manager.ResourceManager) {
 
 	s := grpc.NewServer(
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
-		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(grpc_prometheus.UnaryServerInterceptor, interceptor.ApiServerInterceptor)),
+		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(grpc_prometheus.UnaryServerInterceptor, interceptor.APIServerInterceptor)),
 		grpc.MaxRecvMsgSize(math.MaxInt32))
 	api.RegisterClusterServiceServer(s, clusterServer)
 	api.RegisterComputeTemplateServiceServer(s, templateServer)

--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -84,7 +84,7 @@ func (krc *KuberayAPIServerClient) CreateComputeTemplate(request *api.CreateComp
 	}
 	computeTemplate := &api.ComputeTemplate{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, computeTemplate); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 
 	return computeTemplate, nil, nil
@@ -112,7 +112,7 @@ func (krc *KuberayAPIServerClient) GetComputeTemplate(request *api.GetComputeTem
 	}
 	computeTemplate := &api.ComputeTemplate{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, computeTemplate); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return computeTemplate, nil, nil
 }
@@ -133,7 +133,7 @@ func (krc *KuberayAPIServerClient) GetAllComputeTemplates() (*api.ListAllCompute
 	}
 	response := &api.ListAllComputeTemplatesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return response, nil, nil
 }
@@ -154,7 +154,7 @@ func (krc *KuberayAPIServerClient) GetAllComputeTemplatesInNamespace(request *ap
 	}
 	response := &api.ListComputeTemplatesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return response, nil, nil
 }
@@ -182,7 +182,7 @@ func (krc *KuberayAPIServerClient) CreateCluster(request *api.CreateClusterReque
 	}
 	cluster := &api.Cluster{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, cluster); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return cluster, nil, nil
 }
@@ -209,7 +209,7 @@ func (krc *KuberayAPIServerClient) GetCluster(request *api.GetClusterRequest) (*
 	}
 	cluster := &api.Cluster{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, cluster); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return cluster, nil, nil
 }
@@ -235,7 +235,7 @@ func (krc *KuberayAPIServerClient) ListClusters(request *api.ListClustersRequest
 	}
 	response := &api.ListClustersResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return response, nil, nil
 }
@@ -261,7 +261,7 @@ func (krc *KuberayAPIServerClient) ListAllClusters(request *api.ListAllClustersR
 	}
 	response := &api.ListAllClustersResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return response, nil, nil
 }
@@ -288,7 +288,7 @@ func (krc *KuberayAPIServerClient) CreateRayJob(request *api.CreateRayJobRequest
 	}
 	rayJob := &api.RayJob{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayJob); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return rayJob, nil, nil
 }
@@ -309,7 +309,7 @@ func (krc *KuberayAPIServerClient) GetRayJob(request *api.GetRayJobRequest) (*ap
 	}
 	rayJob := &api.RayJob{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayJob); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return rayJob, nil, nil
 }
@@ -330,7 +330,7 @@ func (krc *KuberayAPIServerClient) ListRayJobs(request *api.ListRayJobsRequest) 
 	}
 	response := &api.ListRayJobsResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return response, nil, nil
 }
@@ -351,7 +351,7 @@ func (krc *KuberayAPIServerClient) ListAllRayJobs() (*api.ListAllRayJobsResponse
 	}
 	response := &api.ListAllRayJobsResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return response, nil, nil
 }
@@ -384,7 +384,7 @@ func (krc *KuberayAPIServerClient) CreateRayService(request *api.CreateRayServic
 	}
 	rayService := &api.RayService{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayService); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return rayService, nil, nil
 }
@@ -411,7 +411,7 @@ func (krc *KuberayAPIServerClient) UpdateRayService(request *api.UpdateRayServic
 	}
 	rayService := &api.RayService{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayService); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return rayService, nil, nil
 }
@@ -432,7 +432,7 @@ func (krc *KuberayAPIServerClient) GetRayService(request *api.GetRayServiceReque
 	}
 	response := &api.RayService{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return response, nil, nil
 }
@@ -453,7 +453,7 @@ func (krc *KuberayAPIServerClient) ListRayServices(request *api.ListRayServicesR
 	}
 	response := &api.ListRayServicesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return response, nil, nil
 }
@@ -474,7 +474,7 @@ func (krc *KuberayAPIServerClient) ListAllRayServices() (*api.ListAllRayServices
 	}
 	response := &api.ListAllRayServicesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return response, nil, nil
 }
@@ -507,7 +507,7 @@ func (krc *KuberayAPIServerClient) SubmitRayJob(request *api.SubmitRayJobRequest
 	}
 	submission := &api.SubmitRayJobReply{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, submission); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return submission, nil, nil
 }
@@ -528,7 +528,7 @@ func (krc *KuberayAPIServerClient) GetRayJobDetails(request *api.GetJobDetailsRe
 	}
 	response := &api.JobSubmissionInfo{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return response, nil, nil
 }
@@ -549,7 +549,7 @@ func (krc *KuberayAPIServerClient) GetRayJobLog(request *api.GetJobLogRequest) (
 	}
 	response := &api.GetJobLogReply{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return response, nil, nil
 }
@@ -570,7 +570,7 @@ func (krc *KuberayAPIServerClient) ListRayJobsCluster(request *api.ListJobDetail
 	}
 	response := &api.ListJobSubmissionInfo{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
+		return nil, status, nil
 	}
 	return response, nil, nil
 }

--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -84,7 +84,7 @@ func (krc *KuberayAPIServerClient) CreateComputeTemplate(request *api.CreateComp
 	}
 	computeTemplate := &api.ComputeTemplate{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, computeTemplate); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 
 	return computeTemplate, nil, nil
@@ -112,7 +112,7 @@ func (krc *KuberayAPIServerClient) GetComputeTemplate(request *api.GetComputeTem
 	}
 	computeTemplate := &api.ComputeTemplate{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, computeTemplate); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return computeTemplate, nil, nil
 }
@@ -133,7 +133,7 @@ func (krc *KuberayAPIServerClient) GetAllComputeTemplates() (*api.ListAllCompute
 	}
 	response := &api.ListAllComputeTemplatesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -154,7 +154,7 @@ func (krc *KuberayAPIServerClient) GetAllComputeTemplatesInNamespace(request *ap
 	}
 	response := &api.ListComputeTemplatesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -182,7 +182,7 @@ func (krc *KuberayAPIServerClient) CreateCluster(request *api.CreateClusterReque
 	}
 	cluster := &api.Cluster{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, cluster); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return cluster, nil, nil
 }
@@ -209,7 +209,7 @@ func (krc *KuberayAPIServerClient) GetCluster(request *api.GetClusterRequest) (*
 	}
 	cluster := &api.Cluster{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, cluster); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return cluster, nil, nil
 }
@@ -235,7 +235,7 @@ func (krc *KuberayAPIServerClient) ListClusters(request *api.ListClustersRequest
 	}
 	response := &api.ListClustersResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -261,7 +261,7 @@ func (krc *KuberayAPIServerClient) ListAllClusters(request *api.ListAllClustersR
 	}
 	response := &api.ListAllClustersResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -288,7 +288,7 @@ func (krc *KuberayAPIServerClient) CreateRayJob(request *api.CreateRayJobRequest
 	}
 	rayJob := &api.RayJob{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayJob); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return rayJob, nil, nil
 }
@@ -309,7 +309,7 @@ func (krc *KuberayAPIServerClient) GetRayJob(request *api.GetRayJobRequest) (*ap
 	}
 	rayJob := &api.RayJob{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayJob); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return rayJob, nil, nil
 }
@@ -330,7 +330,7 @@ func (krc *KuberayAPIServerClient) ListRayJobs(request *api.ListRayJobsRequest) 
 	}
 	response := &api.ListRayJobsResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -351,7 +351,7 @@ func (krc *KuberayAPIServerClient) ListAllRayJobs() (*api.ListAllRayJobsResponse
 	}
 	response := &api.ListAllRayJobsResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -384,7 +384,7 @@ func (krc *KuberayAPIServerClient) CreateRayService(request *api.CreateRayServic
 	}
 	rayService := &api.RayService{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayService); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return rayService, nil, nil
 }
@@ -411,7 +411,7 @@ func (krc *KuberayAPIServerClient) UpdateRayService(request *api.UpdateRayServic
 	}
 	rayService := &api.RayService{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayService); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return rayService, nil, nil
 }
@@ -432,7 +432,7 @@ func (krc *KuberayAPIServerClient) GetRayService(request *api.GetRayServiceReque
 	}
 	response := &api.RayService{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -453,7 +453,7 @@ func (krc *KuberayAPIServerClient) ListRayServices(request *api.ListRayServicesR
 	}
 	response := &api.ListRayServicesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -474,7 +474,7 @@ func (krc *KuberayAPIServerClient) ListAllRayServices() (*api.ListAllRayServices
 	}
 	response := &api.ListAllRayServicesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -507,7 +507,7 @@ func (krc *KuberayAPIServerClient) SubmitRayJob(request *api.SubmitRayJobRequest
 	}
 	submission := &api.SubmitRayJobReply{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, submission); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return submission, nil, nil
 }
@@ -528,7 +528,7 @@ func (krc *KuberayAPIServerClient) GetRayJobDetails(request *api.GetJobDetailsRe
 	}
 	response := &api.JobSubmissionInfo{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -549,7 +549,7 @@ func (krc *KuberayAPIServerClient) GetRayJobLog(request *api.GetJobLogRequest) (
 	}
 	response := &api.GetJobLogReply{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return response, nil, nil
 }
@@ -570,7 +570,7 @@ func (krc *KuberayAPIServerClient) ListRayJobsCluster(request *api.ListJobDetail
 	}
 	response := &api.ListJobSubmissionInfo{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
+		return nil, status, fmt.Errorf("failed to unmarshal: %+w", err)
 	}
 	return response, nil, nil
 }

--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -84,7 +84,7 @@ func (krc *KuberayAPIServerClient) CreateComputeTemplate(request *api.CreateComp
 	}
 	computeTemplate := &api.ComputeTemplate{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, computeTemplate); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 
 	return computeTemplate, nil, nil
@@ -112,7 +112,7 @@ func (krc *KuberayAPIServerClient) GetComputeTemplate(request *api.GetComputeTem
 	}
 	computeTemplate := &api.ComputeTemplate{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, computeTemplate); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return computeTemplate, nil, nil
 }
@@ -133,7 +133,7 @@ func (krc *KuberayAPIServerClient) GetAllComputeTemplates() (*api.ListAllCompute
 	}
 	response := &api.ListAllComputeTemplatesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return response, nil, nil
 }
@@ -154,7 +154,7 @@ func (krc *KuberayAPIServerClient) GetAllComputeTemplatesInNamespace(request *ap
 	}
 	response := &api.ListComputeTemplatesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return response, nil, nil
 }
@@ -182,7 +182,7 @@ func (krc *KuberayAPIServerClient) CreateCluster(request *api.CreateClusterReque
 	}
 	cluster := &api.Cluster{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, cluster); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return cluster, nil, nil
 }
@@ -209,7 +209,7 @@ func (krc *KuberayAPIServerClient) GetCluster(request *api.GetClusterRequest) (*
 	}
 	cluster := &api.Cluster{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, cluster); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return cluster, nil, nil
 }
@@ -235,7 +235,7 @@ func (krc *KuberayAPIServerClient) ListClusters(request *api.ListClustersRequest
 	}
 	response := &api.ListClustersResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return response, nil, nil
 }
@@ -261,7 +261,7 @@ func (krc *KuberayAPIServerClient) ListAllClusters(request *api.ListAllClustersR
 	}
 	response := &api.ListAllClustersResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return response, nil, nil
 }
@@ -288,7 +288,7 @@ func (krc *KuberayAPIServerClient) CreateRayJob(request *api.CreateRayJobRequest
 	}
 	rayJob := &api.RayJob{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayJob); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return rayJob, nil, nil
 }
@@ -309,7 +309,7 @@ func (krc *KuberayAPIServerClient) GetRayJob(request *api.GetRayJobRequest) (*ap
 	}
 	rayJob := &api.RayJob{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayJob); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return rayJob, nil, nil
 }
@@ -330,7 +330,7 @@ func (krc *KuberayAPIServerClient) ListRayJobs(request *api.ListRayJobsRequest) 
 	}
 	response := &api.ListRayJobsResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return response, nil, nil
 }
@@ -351,7 +351,7 @@ func (krc *KuberayAPIServerClient) ListAllRayJobs() (*api.ListAllRayJobsResponse
 	}
 	response := &api.ListAllRayJobsResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return response, nil, nil
 }
@@ -384,7 +384,7 @@ func (krc *KuberayAPIServerClient) CreateRayService(request *api.CreateRayServic
 	}
 	rayService := &api.RayService{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayService); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return rayService, nil, nil
 }
@@ -411,7 +411,7 @@ func (krc *KuberayAPIServerClient) UpdateRayService(request *api.UpdateRayServic
 	}
 	rayService := &api.RayService{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, rayService); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return rayService, nil, nil
 }
@@ -432,7 +432,7 @@ func (krc *KuberayAPIServerClient) GetRayService(request *api.GetRayServiceReque
 	}
 	response := &api.RayService{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return response, nil, nil
 }
@@ -453,7 +453,7 @@ func (krc *KuberayAPIServerClient) ListRayServices(request *api.ListRayServicesR
 	}
 	response := &api.ListRayServicesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return response, nil, nil
 }
@@ -474,7 +474,7 @@ func (krc *KuberayAPIServerClient) ListAllRayServices() (*api.ListAllRayServices
 	}
 	response := &api.ListAllRayServicesResponse{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return response, nil, nil
 }
@@ -507,7 +507,7 @@ func (krc *KuberayAPIServerClient) SubmitRayJob(request *api.SubmitRayJobRequest
 	}
 	submission := &api.SubmitRayJobReply{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, submission); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return submission, nil, nil
 }
@@ -528,7 +528,7 @@ func (krc *KuberayAPIServerClient) GetRayJobDetails(request *api.GetJobDetailsRe
 	}
 	response := &api.JobSubmissionInfo{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return response, nil, nil
 }
@@ -549,7 +549,7 @@ func (krc *KuberayAPIServerClient) GetRayJobLog(request *api.GetJobLogRequest) (
 	}
 	response := &api.GetJobLogReply{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return response, nil, nil
 }
@@ -570,7 +570,7 @@ func (krc *KuberayAPIServerClient) ListRayJobsCluster(request *api.ListJobDetail
 	}
 	response := &api.ListJobSubmissionInfo{}
 	if err := krc.unmarshaler.Unmarshal(bodyBytes, response); err != nil {
-		return nil, status, nil
+		return nil, status, fmt.Errorf("failed to unmarshal: %+v", err)
 	}
 	return response, nil, nil
 }

--- a/apiserver/pkg/interceptor/interceptor.go
+++ b/apiserver/pkg/interceptor/interceptor.go
@@ -7,10 +7,10 @@ import (
 	klog "k8s.io/klog/v2"
 )
 
-// ApiServerInterceptor implements UnaryServerInterceptor that provides the common wrapping logic
+// APIServerInterceptor implements UnaryServerInterceptor that provides the common wrapping logic
 // to be executed before and after all API handler calls, e.g. Logging, error handling.
 // For more details, see https://github.com/grpc/grpc-go/blob/master/interceptor.go
-func ApiServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+func APIServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 	klog.Infof("%v handler starting", info.FullMethod)
 	resp, err = handler(ctx, req)
 	if err != nil {

--- a/apiserver/pkg/model/converter.go
+++ b/apiserver/pkg/model/converter.go
@@ -88,15 +88,15 @@ func contains(s []string, str string) bool {
 	return false
 }
 
-func FromCrdToApiClusters(clusters []*rayv1api.RayCluster, clusterEventsMap map[string][]corev1.Event) []*api.Cluster {
+func FromCrdToAPIClusters(clusters []*rayv1api.RayCluster, clusterEventsMap map[string][]corev1.Event) []*api.Cluster {
 	apiClusters := make([]*api.Cluster, 0)
 	for _, cluster := range clusters {
-		apiClusters = append(apiClusters, FromCrdToApiCluster(cluster, clusterEventsMap[cluster.Name]))
+		apiClusters = append(apiClusters, FromCrdToAPICluster(cluster, clusterEventsMap[cluster.Name]))
 	}
 	return apiClusters
 }
 
-func FromCrdToApiCluster(cluster *rayv1api.RayCluster, events []corev1.Event) *api.Cluster {
+func FromCrdToAPICluster(cluster *rayv1api.RayCluster, events []corev1.Event) *api.Cluster {
 	pbCluster := &api.Cluster{
 		Name:      cluster.Name,
 		Namespace: cluster.Namespace,

--- a/apiserver/pkg/model/converter.go
+++ b/apiserver/pkg/model/converter.go
@@ -443,7 +443,7 @@ func FromKubeToAPIComputeTemplates(configMaps []*corev1.ConfigMap) []*api.Comput
 	return apiComputeTemplates
 }
 
-func FromCrdToApiJobs(jobs []*rayv1api.RayJob) []*api.RayJob {
+func FromCrdToAPIJobs(jobs []*rayv1api.RayJob) []*api.RayJob {
 	apiJobs := make([]*api.RayJob, 0)
 	for _, job := range jobs {
 		apiJobs = append(apiJobs, FromCrdToApiJob(job))
@@ -523,7 +523,7 @@ func FromCrdToApiJob(job *rayv1api.RayJob) (pbJob *api.RayJob) {
 	return pbJob
 }
 
-func FromCrdToApiServices(
+func FromCrdToAPIServices(
 	services []*rayv1api.RayService,
 	serviceEventsMap map[string][]corev1.Event,
 ) []*api.RayService {

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -569,7 +569,7 @@ func TestAutoscalerOptions(t *testing.T) {
 }
 
 func TestPopulateRayClusterSpec(t *testing.T) {
-	cluster := FromCrdToApiCluster(&ClusterSpecTest, []corev1.Event{})
+	cluster := FromCrdToAPICluster(&ClusterSpecTest, []corev1.Event{})
 	if len(cluster.Annotations) != 1 {
 		t.Errorf("failed to convert cluster's annotations")
 	}
@@ -577,7 +577,7 @@ func TestPopulateRayClusterSpec(t *testing.T) {
 	if cluster.ClusterSpec.AutoscalerOptions != nil {
 		t.Errorf("unexpected autoscaler annotations")
 	}
-	cluster = FromCrdToApiCluster(&ClusterSpecAutoscalerTest, []corev1.Event{})
+	cluster = FromCrdToAPICluster(&ClusterSpecAutoscalerTest, []corev1.Event{})
 	assert.True(t, cluster.ClusterSpec.EnableInTreeAutoscaling)
 	if cluster.ClusterSpec.AutoscalerOptions == nil {
 		t.Errorf("autoscaler annotations not found")

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -639,11 +639,7 @@ func TestPopulateTemplate(t *testing.T) {
 }
 
 func tolerationToString(toleration *api.PodToleration) string {
-	return "Key: " + toleration.Key + " Operator: " + string(
-		toleration.Operator,
-	) + " Effect: " + string(
-		toleration.Effect,
-	)
+	return "Key: " + toleration.Key + " Operator: " + toleration.Operator + " Effect: " + toleration.Effect
 }
 
 func TestPopulateJob(t *testing.T) {

--- a/apiserver/pkg/server/cluster_server.go
+++ b/apiserver/pkg/server/cluster_server.go
@@ -155,11 +155,7 @@ func ValidateCreateClusterRequest(request *api.CreateClusterRequest) error {
 		return util.NewInvalidInputError("User who create the cluster is empty. Please specify a valid value.")
 	}
 
-	if err := ValidateClusterSpec(request.Cluster.ClusterSpec); err != nil {
-		return err
-	}
-
-	return nil
+	return ValidateClusterSpec(request.Cluster.ClusterSpec)
 }
 
 func NewClusterServer(resourceManager *manager.ResourceManager, options *ClusterServerOptions) *ClusterServer {

--- a/apiserver/pkg/server/cluster_server.go
+++ b/apiserver/pkg/server/cluster_server.go
@@ -42,7 +42,7 @@ func (s *ClusterServer) CreateCluster(ctx context.Context, request *api.CreateCl
 		klog.Warningf("Failed to get cluster's event, cluster: %s/%s, err: %v", cluster.Namespace, cluster.Name, err)
 	}
 
-	return model.FromCrdToApiCluster(cluster, events), nil
+	return model.FromCrdToAPICluster(cluster, events), nil
 }
 
 // Finds a specific Cluster by cluster name.
@@ -64,7 +64,7 @@ func (s *ClusterServer) GetCluster(ctx context.Context, request *api.GetClusterR
 		klog.Warningf("Failed to get cluster's event, cluster: %s/%s, err: %v", cluster.Namespace, cluster.Name, err)
 	}
 
-	return model.FromCrdToApiCluster(cluster, events), nil
+	return model.FromCrdToAPICluster(cluster, events), nil
 }
 
 // Finds all Clusters in a given namespace.
@@ -89,7 +89,7 @@ func (s *ClusterServer) ListCluster(ctx context.Context, request *api.ListCluste
 	}
 
 	return &api.ListClustersResponse{
-		Clusters: model.FromCrdToApiClusters(clusters, clusterEventMap),
+		Clusters: model.FromCrdToAPIClusters(clusters, clusterEventMap),
 		Continue: continueToken,
 	}, nil
 }
@@ -113,7 +113,7 @@ func (s *ClusterServer) ListAllClusters(ctx context.Context, request *api.ListAl
 	}
 
 	return &api.ListAllClustersResponse{
-		Clusters: model.FromCrdToApiClusters(clusters, clusterEventMap),
+		Clusters: model.FromCrdToAPIClusters(clusters, clusterEventMap),
 		Continue: continueToken,
 	}, nil
 }

--- a/apiserver/pkg/server/compute_template_server.go
+++ b/apiserver/pkg/server/compute_template_server.go
@@ -71,7 +71,7 @@ func (s *ComputeTemplateServer) ListComputeTemplates(ctx context.Context, reques
 	}, nil
 }
 
-func (s *ComputeTemplateServer) ListAllComputeTemplates(ctx context.Context, request *api.ListAllComputeTemplatesRequest) (*api.ListAllComputeTemplatesResponse, error) {
+func (s *ComputeTemplateServer) ListAllComputeTemplates(ctx context.Context, _ *api.ListAllComputeTemplatesRequest) (*api.ListAllComputeTemplatesResponse, error) {
 	runtimes, err := s.resourceManager.ListAllComputeTemplates(ctx)
 	if err != nil {
 		return nil, util.Wrap(err, "List all compute templates from all namespaces failed.")

--- a/apiserver/pkg/server/job_server.go
+++ b/apiserver/pkg/server/job_server.go
@@ -79,7 +79,7 @@ func (s *RayJobServer) ListRayJobs(ctx context.Context, request *api.ListRayJobs
 }
 
 // Finds all Jobs in all namespaces.
-func (s *RayJobServer) ListAllRayJobs(ctx context.Context, request *api.ListAllRayJobsRequest) (*api.ListAllRayJobsResponse, error) {
+func (s *RayJobServer) ListAllRayJobs(ctx context.Context, _ *api.ListAllRayJobsRequest) (*api.ListAllRayJobsResponse, error) {
 	jobs, err := s.resourceManager.ListAllJobs(ctx)
 	if err != nil {
 		return nil, util.Wrap(err, "List jobs failed.")

--- a/apiserver/pkg/server/job_server.go
+++ b/apiserver/pkg/server/job_server.go
@@ -74,7 +74,7 @@ func (s *RayJobServer) ListRayJobs(ctx context.Context, request *api.ListRayJobs
 	}
 
 	return &api.ListRayJobsResponse{
-		Jobs: model.FromCrdToApiJobs(jobs),
+		Jobs: model.FromCrdToAPIJobs(jobs),
 	}, nil
 }
 
@@ -86,7 +86,7 @@ func (s *RayJobServer) ListAllRayJobs(ctx context.Context, _ *api.ListAllRayJobs
 	}
 
 	return &api.ListAllRayJobsResponse{
-		Jobs: model.FromCrdToApiJobs(jobs),
+		Jobs: model.FromCrdToAPIJobs(jobs),
 	}, nil
 }
 

--- a/apiserver/pkg/server/job_server.go
+++ b/apiserver/pkg/server/job_server.go
@@ -128,9 +128,5 @@ func ValidateCreateJobRequest(request *api.CreateRayJobRequest) error {
 		return nil
 	}
 
-	if err := ValidateClusterSpec(request.Job.ClusterSpec); err != nil {
-		return err
-	}
-
-	return nil
+	return ValidateClusterSpec(request.Job.ClusterSpec)
 }

--- a/apiserver/pkg/server/serve_server.go
+++ b/apiserver/pkg/server/serve_server.go
@@ -163,11 +163,7 @@ func ValidateCreateServiceRequest(request *api.CreateRayServiceRequest) error {
 		return util.NewInvalidInputError("User who create the Service is empty. Please specify a valid value.")
 	}
 
-	if err := ValidateClusterSpec(request.Service.ClusterSpec); err != nil {
-		return err
-	}
-
-	return nil
+	return ValidateClusterSpec(request.Service.ClusterSpec)
 }
 
 func ValidateUpdateServiceRequest(request *api.UpdateRayServiceRequest) error {
@@ -194,9 +190,5 @@ func ValidateUpdateServiceRequest(request *api.UpdateRayServiceRequest) error {
 		return util.NewInvalidInputError("User who create the Service is empty. Please specify a valid value.")
 	}
 
-	if err := ValidateClusterSpec(request.Service.ClusterSpec); err != nil {
-		return err
-	}
-
-	return nil
+	return ValidateClusterSpec(request.Service.ClusterSpec)
 }

--- a/apiserver/pkg/server/serve_server.go
+++ b/apiserver/pkg/server/serve_server.go
@@ -101,7 +101,7 @@ func (s *RayServiceServer) ListRayServices(ctx context.Context, request *api.Lis
 		serviceEventMap[service.Name] = serviceEvents
 	}
 	return &api.ListRayServicesResponse{
-		Services: model.FromCrdToApiServices(services, serviceEventMap),
+		Services: model.FromCrdToAPIServices(services, serviceEventMap),
 	}, nil
 }
 
@@ -120,7 +120,7 @@ func (s *RayServiceServer) ListAllRayServices(ctx context.Context, _ *api.ListAl
 		serviceEventMap[service.Name] = serviceEvents
 	}
 	return &api.ListAllRayServicesResponse{
-		Services: model.FromCrdToApiServices(services, serviceEventMap),
+		Services: model.FromCrdToAPIServices(services, serviceEventMap),
 	}, nil
 }
 

--- a/apiserver/pkg/server/serve_server.go
+++ b/apiserver/pkg/server/serve_server.go
@@ -105,7 +105,7 @@ func (s *RayServiceServer) ListRayServices(ctx context.Context, request *api.Lis
 	}, nil
 }
 
-func (s *RayServiceServer) ListAllRayServices(ctx context.Context, request *api.ListAllRayServicesRequest) (*api.ListAllRayServicesResponse, error) {
+func (s *RayServiceServer) ListAllRayServices(ctx context.Context, _ *api.ListAllRayServicesRequest) (*api.ListAllRayServicesResponse, error) {
 	services, err := s.resourceManager.ListAllServices(ctx)
 	if err != nil {
 		return nil, util.Wrap(err, "list all services failed.")

--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -930,10 +930,10 @@ func buildAutoscalerOptions(autoscalerOptions *api.AutoscalerOptions) (*rayv1api
 	if autoscalerOptions.Envs != nil {
 		if len(autoscalerOptions.Envs.Values) > 0 {
 			options.Env = make([]corev1.EnvVar, len(autoscalerOptions.Envs.Values))
-			ev_count := 0
+			evCount := 0
 			for key, value := range autoscalerOptions.Envs.Values {
-				options.Env[ev_count] = corev1.EnvVar{Name: key, Value: value}
-				ev_count += 1
+				options.Env[evCount] = corev1.EnvVar{Name: key, Value: value}
+				evCount++
 			}
 		}
 		if len(autoscalerOptions.Envs.ValuesFrom) > 0 {

--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -836,7 +836,7 @@ func (c *RayCluster) Get() *rayv1api.RayCluster {
 }
 
 // SetAnnotations sets annotations on all templates in a RayCluster
-func (c *RayCluster) SetAnnotationsToAllTemplates(key string, value string) {
+func (c *RayCluster) SetAnnotationsToAllTemplates(_ string, _ string) {
 	// TODO: reserved for common parameters.
 }
 

--- a/apiserver/pkg/util/cluster_test.go
+++ b/apiserver/pkg/util/cluster_test.go
@@ -7,6 +7,7 @@ import (
 
 	api "github.com/ray-project/kuberay/proto/go_client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -476,7 +477,7 @@ func TestBuildVolumes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := buildVols(tt.apiVolume)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if tt.name == "configmap test" {
 				// Sort items for comparison
 				sort.SliceStable(got[0].ConfigMap.Items, func(i, j int) bool {
@@ -545,7 +546,7 @@ func TestBuildVolumeMounts(t *testing.T) {
 
 func TestBuildHeadPodTemplate(t *testing.T) {
 	podSpec, err := buildHeadPodTemplate("2.4", &api.EnvironmentVariables{}, &headGroup, &template, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	if podSpec.Spec.ServiceAccountName != "account" {
 		t.Errorf("failed to propagate service account")
@@ -593,7 +594,7 @@ func TestBuildHeadPodTemplate(t *testing.T) {
 	}
 
 	podSpec, err = buildHeadPodTemplate("2.4", &api.EnvironmentVariables{}, &headGroup, &template, true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if len(podSpec.Spec.Containers[0].Ports) != 6 {
 		t.Errorf("failed build ports")
 	}
@@ -601,7 +602,7 @@ func TestBuildHeadPodTemplate(t *testing.T) {
 
 func TestConvertAutoscalerOptions(t *testing.T) {
 	options, err := buildAutoscalerOptions(&testAutoscalerOptions)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int32(25), *options.IdleTimeoutSeconds)
 	assert.Equal(t, (string)(*options.UpscalingMode), "Default")
 	assert.Equal(t, (string)(*options.ImagePullPolicy), "Always")
@@ -614,7 +615,7 @@ func TestConvertAutoscalerOptions(t *testing.T) {
 
 func TestBuildRayCluster(t *testing.T) {
 	cluster, err := NewRayCluster(&rayCluster, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if len(cluster.ObjectMeta.Annotations) != 1 {
 		t.Errorf("failed to propagate annotations")
 	}
@@ -623,14 +624,14 @@ func TestBuildRayCluster(t *testing.T) {
 	}
 	assert.Equal(t, (*bool)(nil), cluster.Spec.EnableInTreeAutoscaling)
 	cluster, err = NewRayCluster(&rayClusterAutoScaler, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, *cluster.Spec.EnableInTreeAutoscaling)
 	assert.NotNil(t, cluster.Spec.AutoscalerOptions)
 }
 
 func TestBuilWorkerPodTemplate(t *testing.T) {
 	podSpec, err := buildWorkerPodTemplate("2.4", &api.EnvironmentVariables{}, &workerGroup, &templateWorker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "account", podSpec.Spec.ServiceAccountName, "failed to propagate service account")
 	assert.Equal(t, "foo", podSpec.Spec.ImagePullSecrets[0].Name, "failed to propagate image pull secret")

--- a/apiserver/pkg/util/job_test.go
+++ b/apiserver/pkg/util/job_test.go
@@ -5,6 +5,7 @@ import (
 
 	api "github.com/ray-project/kuberay/proto/go_client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var apiJobNewCluster = &api.RayJob{
@@ -76,7 +77,7 @@ var apiJobExistingClusterSubmitterBadParams = &api.RayJob{
 func TestBuildRayJob(t *testing.T) {
 	// Test request with cluster creation
 	job, err := NewRayJob(apiJobNewCluster, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test", job.ObjectMeta.Name)
 	assert.Equal(t, "test", job.ObjectMeta.Namespace)
 	assert.Len(t, job.ObjectMeta.Labels, 4)
@@ -89,7 +90,7 @@ func TestBuildRayJob(t *testing.T) {
 
 	// Test request without cluster creation
 	job, err = NewRayJob(apiJobExistingCluster, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test", job.ObjectMeta.Name)
 	assert.Equal(t, "test", job.ObjectMeta.Namespace)
 	assert.Len(t, job.ObjectMeta.Labels, 4)
@@ -101,7 +102,7 @@ func TestBuildRayJob(t *testing.T) {
 
 	// Test request without cluster creation with submitter
 	job, err = NewRayJob(apiJobExistingClusterSubmitter, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test", job.ObjectMeta.Name)
 	assert.Equal(t, "test", job.ObjectMeta.Namespace)
 	assert.Len(t, job.ObjectMeta.Labels, 4)

--- a/apiserver/pkg/util/job_test.go
+++ b/apiserver/pkg/util/job_test.go
@@ -121,5 +121,5 @@ func TestBuildRayJob(t *testing.T) {
 
 	// Test request without cluster creation with submitter bad parameters
 	_, err = NewRayJob(apiJobExistingClusterSubmitterBadParams, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/apiserver/pkg/util/service.go
+++ b/apiserver/pkg/util/service.go
@@ -44,7 +44,7 @@ func buildRayServiceLabels(apiService *api.RayService) map[string]string {
 	return labels
 }
 
-func buildRayServiceAnnotations(apiService *api.RayService) map[string]string {
+func buildRayServiceAnnotations(_ *api.RayService) map[string]string {
 	annotations := map[string]string{}
 	// TODO: Add optional annotations
 	return annotations

--- a/apiserver/pkg/util/service_test.go
+++ b/apiserver/pkg/util/service_test.go
@@ -6,6 +6,7 @@ import (
 	api "github.com/ray-project/kuberay/proto/go_client"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var apiServiceNoServe = &api.RayService{
@@ -31,7 +32,7 @@ func TestBuildService(t *testing.T) {
 		t.Errorf("wrong error returned")
 	}
 	got, err := NewRayService(apiServiceV2, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if got.RayService.Spec.ServeConfigV2 == "" {
 		t.Errorf("Got empty V2")
 	}

--- a/apiserver/pkg/util/service_test.go
+++ b/apiserver/pkg/util/service_test.go
@@ -27,7 +27,7 @@ var apiServiceV2 = &api.RayService{
 
 func TestBuildService(t *testing.T) {
 	_, err := NewRayService(apiServiceNoServe, map[string]*api.ComputeTemplate{"foo": &template})
-	assert.Error(t, err)
+	require.Error(t, err)
 	if err.Error() != "serve configuration is not defined" {
 		t.Errorf("wrong error returned")
 	}

--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -89,9 +89,9 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 	}
 
 	// Create cluster
-	actualCluster, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateCluster(&clusterReq)
+	actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateCluster(&clusterReq)
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualCluster, "A cluster is expected")
 	waitForRunningCluster(t, tCtx, actualCluster.Name)
 
@@ -114,9 +114,9 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 		},
 	}
 
-	actualJob, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(&createActorRequest)
+	actualJob, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(&createActorRequest)
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
 	waitForRayJob(t, tCtx, createActorRequest.Job.Name, rayv1api.JobStatusSucceeded)
 
@@ -141,9 +141,9 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 			},
 		},
 	}
-	actualJob, actualRpcStatus, err = tCtx.GetRayApiServerClient().CreateRayJob(&deleteActorRequest)
+	actualJob, actualRPCStatus, err = tCtx.GetRayApiServerClient().CreateRayJob(&deleteActorRequest)
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
 	waitForRayJob(t, tCtx, createActorRequest.Job.Name, rayv1api.JobStatusSucceeded)
 

--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -89,7 +89,7 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 	}
 
 	// Create cluster
-	actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateCluster(&clusterReq)
+	actualCluster, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateCluster(&clusterReq)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualCluster, "A cluster is expected")
@@ -114,7 +114,7 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 		},
 	}
 
-	actualJob, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(&createActorRequest)
+	actualJob, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayJob(&createActorRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
@@ -141,7 +141,7 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 			},
 		},
 	}
-	actualJob, actualRPCStatus, err = tCtx.GetRayApiServerClient().CreateRayJob(&deleteActorRequest)
+	actualJob, actualRPCStatus, err = tCtx.GetRayAPIServerClient().CreateRayJob(&deleteActorRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -525,7 +525,7 @@ func createOneClusterInEachNamespaces(t *testing.T, numberOfNamespaces int) []*E
 		go func(i int) {
 			defer wg.Done()
 			tCtx, err := NewEnd2EndTestingContext(t)
-			assert.NoError(t, err, "No error expected when creating testing context")
+			require.NoError(t, err, "No error expected when creating testing context")
 
 			tCtx.CreateComputeTemplate(t)
 			t.Cleanup(func() {

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -433,7 +433,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateCluster(tc.Input)
+			actualCluster, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateCluster(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
@@ -504,7 +504,7 @@ func TestDeleteCluster(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRPCStatus, err := tCtx.GetRayApiServerClient().DeleteCluster(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayAPIServerClient().DeleteCluster(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
@@ -555,7 +555,7 @@ func TestGetAllClusters(t *testing.T) {
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
-	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{})
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllClusters(&api.ListAllClustersRequest{})
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
@@ -587,7 +587,7 @@ func TestGetAllClustersByPagination(t *testing.T) {
 	continueToken := ""
 	for i := 0; i < numberOfNamespaces; i++ {
 		limit := 1
-		response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{
+		response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllClusters(&api.ListAllClustersRequest{
 			Limit:    int64(limit),
 			Continue: continueToken,
 		})
@@ -623,7 +623,7 @@ func TestGetAllClustersByPaginationWithAllResults(t *testing.T) {
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
-	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllClusters(&api.ListAllClustersRequest{
 		Limit: 10,
 	})
 	require.NoError(t, err, "No error expected")
@@ -666,7 +666,7 @@ func TestGetClustersInNamespace(t *testing.T) {
 		tCtx.DeleteConfigMap(t, configMapName)
 	})
 
-	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListClusters(
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListClusters(
 		&api.ListClustersRequest{
 			Namespace: tCtx.GetNamespaceName(),
 		})
@@ -711,7 +711,7 @@ func TestGetClustersByPaginationInNamespace(t *testing.T) {
 
 	continueToken := ""
 	for i := 1; i <= 2; i++ {
-		response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListClusters(
+		response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListClusters(
 			&api.ListClustersRequest{
 				Namespace: tCtx.GetNamespaceName(),
 				Limit:     1,
@@ -788,7 +788,7 @@ func TestGetClustersByNameInNamespace(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetCluster(tc.Input)
+			actualCluster, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetCluster(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -433,16 +433,16 @@ func TestCreateClusterEndpoint(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualCluster, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateCluster(tc.Input)
+			actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateCluster(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.NotNil(t, actualCluster, "A cluster is expected")
 				waitForRunningCluster(t, tCtx, actualCluster.Name)
 				tCtx.DeleteRayCluster(t, actualCluster.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -504,14 +504,14 @@ func TestDeleteCluster(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRpcStatus, err := tCtx.GetRayApiServerClient().DeleteCluster(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayApiServerClient().DeleteCluster(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				waitForDeletedCluster(t, tCtx, tc.Input.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -555,9 +555,9 @@ func TestGetAllClusters(t *testing.T) {
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{})
+	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{})
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.Empty(t, response.Continue, "No continue token is expected")
 	require.NotEmpty(t, response.Clusters, "A list of clusters is required")
@@ -587,12 +587,12 @@ func TestGetAllClustersByPagination(t *testing.T) {
 	continueToken := ""
 	for i := 0; i < numberOfNamespaces; i++ {
 		limit := 1
-		response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{
+		response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{
 			Limit:    int64(limit),
 			Continue: continueToken,
 		})
 		require.NoError(t, err, "No error expected")
-		require.Nil(t, actualRpcStatus, "No RPC status expected")
+		require.Nil(t, actualRPCStatus, "No RPC status expected")
 		require.NotNil(t, response, "A response is expected")
 		if i != numberOfNamespaces-1 {
 			require.NotEmpty(t, response.Continue, "A continue token is expected")
@@ -623,11 +623,11 @@ func TestGetAllClustersByPaginationWithAllResults(t *testing.T) {
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{
+	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllClusters(&api.ListAllClustersRequest{
 		Limit: 10,
 	})
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.Empty(t, response.Continue, "No continue token is expected")
 	require.NotEmpty(t, response.Clusters, "A list of clusters is required")
@@ -666,12 +666,12 @@ func TestGetClustersInNamespace(t *testing.T) {
 		tCtx.DeleteConfigMap(t, configMapName)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListClusters(
+	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListClusters(
 		&api.ListClustersRequest{
 			Namespace: tCtx.GetNamespaceName(),
 		})
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.Clusters, "A list of compute templates is required")
 	gotCluster := false
@@ -711,14 +711,14 @@ func TestGetClustersByPaginationInNamespace(t *testing.T) {
 
 	continueToken := ""
 	for i := 1; i <= 2; i++ {
-		response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListClusters(
+		response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListClusters(
 			&api.ListClustersRequest{
 				Namespace: tCtx.GetNamespaceName(),
 				Limit:     1,
 				Continue:  continueToken,
 			})
 		require.NoError(t, err, "No error expected")
-		require.Nil(t, actualRpcStatus, "No RPC status expected")
+		require.Nil(t, actualRPCStatus, "No RPC status expected")
 		require.NotNil(t, response, "A response is expected")
 		require.Len(t, response.Clusters, 1)
 		require.Equal(t, response.Clusters[0].Name, fmt.Sprintf("cluster%d", i))
@@ -788,15 +788,15 @@ func TestGetClustersByNameInNamespace(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualCluster, actualRpcStatus, err := tCtx.GetRayApiServerClient().GetCluster(tc.Input)
+			actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetCluster(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.Equal(t, tCtx.GetRayClusterName(), actualCluster.Name)
 				require.Equal(t, tCtx.GetNamespaceName(), actualCluster.Namespace)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}

--- a/apiserver/test/e2e/config_server_e2e_test.go
+++ b/apiserver/test/e2e/config_server_e2e_test.go
@@ -116,13 +116,13 @@ func TestCreateTemplate(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualTemplate, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateComputeTemplate(tc.Input)
+			actualTemplate, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateComputeTemplate(tc.Input)
 			if tc.ExpectedError != nil {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			} else {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.Truef(t, reflect.DeepEqual(tc.Input.ComputeTemplate, actualTemplate), "Equal templates expected")
 			}
 		})
@@ -179,13 +179,13 @@ func TestDeleteTemplate(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRpcStatus, err := tCtx.GetRayApiServerClient().DeleteComputeTemplate(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayApiServerClient().DeleteComputeTemplate(tc.Input)
 			if tc.ExpectedError != nil {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			} else {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 			}
 		})
 	}
@@ -202,9 +202,9 @@ func TestGetAllComputeTemplates(t *testing.T) {
 		tCtx.DeleteComputeTemplate(t)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().GetAllComputeTemplates()
+	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetAllComputeTemplates()
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.ComputeTemplates, "A list of compute templates is required")
 	foundName := false
@@ -228,12 +228,12 @@ func TestGetTemplatesInNamespace(t *testing.T) {
 		tCtx.DeleteComputeTemplate(t)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().GetAllComputeTemplatesInNamespace(
+	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetAllComputeTemplatesInNamespace(
 		&api.ListComputeTemplatesRequest{
 			Namespace: tCtx.GetNamespaceName(),
 		})
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.ComputeTemplates, "A list of compute templates is required")
 	foundName := false
@@ -296,13 +296,13 @@ func TestGetTemplateByNameInNamespace(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualTemplate, actualRpcStatus, err := tCtx.GetRayApiServerClient().GetComputeTemplate(tc.Input)
+			actualTemplate, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetComputeTemplate(tc.Input)
 			if tc.ExpectedError != nil {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			} else {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.Equal(t, tCtx.GetComputeTemplateName(), actualTemplate.Name)
 				require.Equal(t, tCtx.GetNamespaceName(), actualTemplate.Namespace)
 			}

--- a/apiserver/test/e2e/config_server_e2e_test.go
+++ b/apiserver/test/e2e/config_server_e2e_test.go
@@ -116,7 +116,7 @@ func TestCreateTemplate(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualTemplate, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateComputeTemplate(tc.Input)
+			actualTemplate, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateComputeTemplate(tc.Input)
 			if tc.ExpectedError != nil {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
 				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
@@ -179,7 +179,7 @@ func TestDeleteTemplate(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRPCStatus, err := tCtx.GetRayApiServerClient().DeleteComputeTemplate(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayAPIServerClient().DeleteComputeTemplate(tc.Input)
 			if tc.ExpectedError != nil {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
 				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
@@ -202,7 +202,7 @@ func TestGetAllComputeTemplates(t *testing.T) {
 		tCtx.DeleteComputeTemplate(t)
 	})
 
-	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetAllComputeTemplates()
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetAllComputeTemplates()
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
@@ -228,7 +228,7 @@ func TestGetTemplatesInNamespace(t *testing.T) {
 		tCtx.DeleteComputeTemplate(t)
 	})
 
-	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetAllComputeTemplatesInNamespace(
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetAllComputeTemplatesInNamespace(
 		&api.ListComputeTemplatesRequest{
 			Namespace: tCtx.GetNamespaceName(),
 		})
@@ -296,7 +296,7 @@ func TestGetTemplateByNameInNamespace(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualTemplate, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetComputeTemplate(tc.Input)
+			actualTemplate, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetComputeTemplate(tc.Input)
 			if tc.ExpectedError != nil {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
 				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -214,7 +214,7 @@ func TestCreateJobWithDisposableClusters(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualJob, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(tc.Input)
+			actualJob, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayJob(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
@@ -273,7 +273,7 @@ func TestDeleteJob(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRPCStatus, err := tCtx.GetRayApiServerClient().DeleteRayJob(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayAPIServerClient().DeleteRayJob(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
@@ -299,7 +299,7 @@ func TestGetAllJobs(t *testing.T) {
 		tCtx.DeleteRayJobByName(t, testJobRequest.Job.Name)
 	})
 
-	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllRayJobs()
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllRayJobs()
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
@@ -327,7 +327,7 @@ func TestGetJobsInNamespace(t *testing.T) {
 		tCtx.DeleteRayJobByName(t, testJobRequest.Job.Name)
 	})
 
-	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListRayJobs(&api.ListRayJobsRequest{
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListRayJobs(&api.ListRayJobsRequest{
 		Namespace: tCtx.GetNamespaceName(),
 	})
 	require.NoError(t, err, "No error expected")
@@ -398,7 +398,7 @@ func TestGetJob(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualJob, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetRayJob(tc.Input)
+			actualJob, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetRayJob(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
@@ -485,7 +485,7 @@ func TestCreateJobWithClusterSelector(t *testing.T) {
 	// Execute tests sequentially
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			actualJob, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(tc.Input)
+			actualJob, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayJob(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
@@ -563,7 +563,7 @@ func createTestJob(t *testing.T, tCtx *End2EndTestingContext) *api.CreateRayJobR
 		Namespace: tCtx.GetNamespaceName(),
 	}
 
-	actualJob, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(testJobRequest)
+	actualJob, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayJob(testJobRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -214,16 +214,16 @@ func TestCreateJobWithDisposableClusters(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualJob, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(tc.Input)
+			actualJob, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.NotNil(t, actualJob, "A job is expected")
 				waitForRayJob(t, tCtx, tc.Input.Job.Name, tc.ExpectedJobStatus)
 				tCtx.DeleteRayJobByName(t, actualJob.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -273,14 +273,14 @@ func TestDeleteJob(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRpcStatus, err := tCtx.GetRayApiServerClient().DeleteRayJob(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayApiServerClient().DeleteRayJob(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				waitForDeletedRayJob(t, tCtx, testJobRequest.Job.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -299,9 +299,9 @@ func TestGetAllJobs(t *testing.T) {
 		tCtx.DeleteRayJobByName(t, testJobRequest.Job.Name)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListAllRayJobs()
+	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllRayJobs()
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.Jobs, "A list of jobs is required")
 	foundName := false
@@ -327,11 +327,11 @@ func TestGetJobsInNamespace(t *testing.T) {
 		tCtx.DeleteRayJobByName(t, testJobRequest.Job.Name)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListRayJobs(&api.ListRayJobsRequest{
+	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListRayJobs(&api.ListRayJobsRequest{
 		Namespace: tCtx.GetNamespaceName(),
 	})
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.Jobs, "A list of jobs is required")
 	foundName := false
@@ -398,15 +398,15 @@ func TestGetJob(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualJob, actualRpcStatus, err := tCtx.GetRayApiServerClient().GetRayJob(tc.Input)
+			actualJob, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetRayJob(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.Equal(t, tc.Input.Name, actualJob.Name)
 				require.Equal(t, tCtx.GetNamespaceName(), actualJob.Namespace)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -485,16 +485,16 @@ func TestCreateJobWithClusterSelector(t *testing.T) {
 	// Execute tests sequentially
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			actualJob, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(tc.Input)
+			actualJob, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.NotNil(t, actualJob, "A job is expected")
 				waitForRayJob(t, tCtx, tc.Input.Job.Name, tc.ExpectedJobStatus)
 				tCtx.DeleteRayJobByName(t, actualJob.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -563,9 +563,9 @@ func createTestJob(t *testing.T, tCtx *End2EndTestingContext) *api.CreateRayJobR
 		Namespace: tCtx.GetNamespaceName(),
 	}
 
-	actualJob, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(testJobRequest)
+	actualJob, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateRayJob(testJobRequest)
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
 	waitForRayJob(t, tCtx, testJobRequest.Job.Name, rayv1api.JobStatusSucceeded)
 	return testJobRequest

--- a/apiserver/test/e2e/job_submission_e2e_test.go
+++ b/apiserver/test/e2e/job_submission_e2e_test.go
@@ -73,9 +73,9 @@ func TestCreateJobSubmission(t *testing.T) {
 	}
 
 	// Create cluster
-	actualCluster, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateCluster(&clusterReq)
+	actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateCluster(&clusterReq)
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualCluster, "A cluster is expected")
 	waitForRunningCluster(t, tCtx, actualCluster.Name)
 

--- a/apiserver/test/e2e/job_submission_e2e_test.go
+++ b/apiserver/test/e2e/job_submission_e2e_test.go
@@ -73,7 +73,7 @@ func TestCreateJobSubmission(t *testing.T) {
 	}
 
 	// Create cluster
-	actualCluster, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateCluster(&clusterReq)
+	actualCluster, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateCluster(&clusterReq)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualCluster, "A cluster is expected")
@@ -90,13 +90,13 @@ func TestCreateJobSubmission(t *testing.T) {
 		},
 	}
 	// Request for the wrong namespace, should fail
-	_, jobSubmissionStatus, err := tCtx.GetRayApiServerClient().SubmitRayJob(&submitJobRequest)
+	_, jobSubmissionStatus, err := tCtx.GetRayAPIServerClient().SubmitRayJob(&submitJobRequest)
 	require.Error(t, err, "An error is expected")
 	require.NotNil(t, jobSubmissionStatus, "A not nill RPC status is required")
 
 	// Fix request and resubmit
 	submitJobRequest.Namespace = tCtx.GetNamespaceName()
-	jobSubmission, jobSubmissionStatus, err := tCtx.GetRayApiServerClient().SubmitRayJob(&submitJobRequest)
+	jobSubmission, jobSubmissionStatus, err := tCtx.GetRayAPIServerClient().SubmitRayJob(&submitJobRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobSubmissionStatus, "No RPC status expected")
 	require.NotNil(t, jobSubmission, "A job  submission is expected")
@@ -108,13 +108,13 @@ func TestCreateJobSubmission(t *testing.T) {
 		Submissionid: "1234567", // Not valid submission ID
 	}
 	// Request with the wrong submission ID should fail
-	_, jobDetailsStatus, err := tCtx.GetRayApiServerClient().GetRayJobDetails(&jobDetailsRequest)
+	_, jobDetailsStatus, err := tCtx.GetRayAPIServerClient().GetRayJobDetails(&jobDetailsRequest)
 	require.Error(t, err, "An error is expected")
 	require.NotNil(t, jobDetailsStatus, "A not nill RPC status is required")
 
 	// Set the correct submission ID and resubmit
 	jobDetailsRequest.Submissionid = jobSubmission.SubmissionId
-	jobDetails, jobDetailsStatus, err := tCtx.GetRayApiServerClient().GetRayJobDetails(&jobDetailsRequest)
+	jobDetails, jobDetailsStatus, err := tCtx.GetRayAPIServerClient().GetRayJobDetails(&jobDetailsRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobDetailsStatus, "No RPC status expected")
 	require.NotNil(t, jobDetails, "Job  details are expected")
@@ -124,7 +124,7 @@ func TestCreateJobSubmission(t *testing.T) {
 		Namespace:   tCtx.GetNamespaceName(),
 		Clustername: actualCluster.Name,
 	}
-	jobList, jobListStatus, err := tCtx.GetRayApiServerClient().ListRayJobsCluster(&listJobRequest)
+	jobList, jobListStatus, err := tCtx.GetRayAPIServerClient().ListRayJobsCluster(&listJobRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobListStatus, "No RPC status expected")
 	require.NotNil(t, jobList, "List of Job details is expected")
@@ -135,13 +135,13 @@ func TestCreateJobSubmission(t *testing.T) {
 		Clustername:  actualCluster.Name,
 		Submissionid: "1234567", // Not valid submission ID
 	}
-	_, jobLogStatus, err := tCtx.GetRayApiServerClient().GetRayJobLog(&logJobRequest)
+	_, jobLogStatus, err := tCtx.GetRayAPIServerClient().GetRayJobLog(&logJobRequest)
 	require.Error(t, err, "An error is expected")
 	require.NotNil(t, jobLogStatus, "A not nill RPC status is required")
 
 	// Set the correct submission ID and resubmit
 	logJobRequest.Submissionid = jobSubmission.SubmissionId
-	jobLog, jobLogStatus, err := tCtx.GetRayApiServerClient().GetRayJobLog(&logJobRequest)
+	jobLog, jobLogStatus, err := tCtx.GetRayAPIServerClient().GetRayJobLog(&logJobRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobLogStatus, "No RPC status expected")
 	require.NotNil(t, jobLog, "Job log is expected")
@@ -152,12 +152,12 @@ func TestCreateJobSubmission(t *testing.T) {
 		Clustername:  actualCluster.Name,
 		Submissionid: "1234567", // Not valid submission ID
 	}
-	jobStopStatus, err := tCtx.GetRayApiServerClient().StopRayJob(&stopJobRequest)
+	jobStopStatus, err := tCtx.GetRayAPIServerClient().StopRayJob(&stopJobRequest)
 	require.Error(t, err, "An error is expected")
 	require.NotNil(t, jobStopStatus, "A not nill RPC status is required")
 	// Set the correct submission ID and resubmit
 	stopJobRequest.Submissionid = jobSubmission.SubmissionId
-	jobStopStatus, err = tCtx.GetRayApiServerClient().StopRayJob(&stopJobRequest)
+	jobStopStatus, err = tCtx.GetRayAPIServerClient().StopRayJob(&stopJobRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobStopStatus, "No RPC status expected")
 
@@ -167,7 +167,7 @@ func TestCreateJobSubmission(t *testing.T) {
 		Clustername:  actualCluster.Name,
 		Submissionid: jobSubmission.SubmissionId,
 	}
-	jobDeleteStatus, err := tCtx.GetRayApiServerClient().DeleteRayJobCluster(&deleteJobRequest)
+	jobDeleteStatus, err := tCtx.GetRayAPIServerClient().DeleteRayJobCluster(&deleteJobRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobDeleteStatus, "No RPC status expected")
 }

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -137,7 +137,7 @@ func TestCreateServiceV2(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualService, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateRayService(tc.Input)
+			actualService, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayService(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
@@ -196,7 +196,7 @@ func TestDeleteService(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRPCStatus, err := tCtx.GetRayApiServerClient().DeleteRayService(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayAPIServerClient().DeleteRayService(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
@@ -222,7 +222,7 @@ func TestGetAllServices(t *testing.T) {
 		tCtx.DeleteRayService(t, testServiceRequest.Service.Name)
 	})
 
-	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllRayServices()
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllRayServices()
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
@@ -244,7 +244,7 @@ func TestGetServicesInNamespace(t *testing.T) {
 		tCtx.DeleteRayService(t, testServiceRequest.Service.Name)
 	})
 
-	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListRayServices(&api.ListRayServicesRequest{
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListRayServices(&api.ListRayServicesRequest{
 		Namespace: tCtx.GetNamespaceName(),
 	})
 	require.NoError(t, err, "No error expected")
@@ -309,7 +309,7 @@ func TestGetService(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualService, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetRayService(tc.Input)
+			actualService, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetRayService(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
@@ -364,7 +364,7 @@ func createTestServiceV2(t *testing.T, tCtx *End2EndTestingContext) *api.CreateR
 		},
 		Namespace: tCtx.GetNamespaceName(),
 	}
-	actualService, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateRayService(testServiceRequest)
+	actualService, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayService(testServiceRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualService, "A service is expected")

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -137,16 +137,16 @@ func TestCreateServiceV2(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualService, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateRayService(tc.Input)
+			actualService, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateRayService(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.NotNil(t, actualService, "A service is expected")
 				waitForRunningService(t, tCtx, actualService.Name)
 				tCtx.DeleteRayService(t, actualService.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -196,14 +196,14 @@ func TestDeleteService(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualRpcStatus, err := tCtx.GetRayApiServerClient().DeleteRayService(tc.Input)
+			actualRPCStatus, err := tCtx.GetRayApiServerClient().DeleteRayService(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				waitForDeletedService(t, tCtx, testServiceRequest.Service.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -222,9 +222,9 @@ func TestGetAllServices(t *testing.T) {
 		tCtx.DeleteRayService(t, testServiceRequest.Service.Name)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListAllRayServices()
+	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListAllRayServices()
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.Services, "A list of services is required")
 	require.Equal(t, testServiceRequest.Service.Name, response.Services[0].Name)
@@ -244,11 +244,11 @@ func TestGetServicesInNamespace(t *testing.T) {
 		tCtx.DeleteRayService(t, testServiceRequest.Service.Name)
 	})
 
-	response, actualRpcStatus, err := tCtx.GetRayApiServerClient().ListRayServices(&api.ListRayServicesRequest{
+	response, actualRPCStatus, err := tCtx.GetRayApiServerClient().ListRayServices(&api.ListRayServicesRequest{
 		Namespace: tCtx.GetNamespaceName(),
 	})
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")
 	require.NotEmpty(t, response.Services, "A list of compute templates is required")
 	require.Equal(t, testServiceRequest.Service.Name, response.Services[0].Name)
@@ -309,15 +309,15 @@ func TestGetService(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // capture range variable
 		t.Run(tc.Name, func(t *testing.T) {
-			actualService, actualRpcStatus, err := tCtx.GetRayApiServerClient().GetRayService(tc.Input)
+			actualService, actualRPCStatus, err := tCtx.GetRayApiServerClient().GetRayService(tc.Input)
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
-				require.Nil(t, actualRpcStatus, "No RPC status expected")
+				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.Equal(t, tc.Input.Name, actualService.Name)
 				require.Equal(t, tCtx.GetNamespaceName(), actualService.Namespace)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
-				require.NotNil(t, actualRpcStatus, "A not nill RPC status is required")
+				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
 			}
 		})
 	}
@@ -364,9 +364,9 @@ func createTestServiceV2(t *testing.T, tCtx *End2EndTestingContext) *api.CreateR
 		},
 		Namespace: tCtx.GetNamespaceName(),
 	}
-	actualService, actualRpcStatus, err := tCtx.GetRayApiServerClient().CreateRayService(testServiceRequest)
+	actualService, actualRPCStatus, err := tCtx.GetRayApiServerClient().CreateRayService(testServiceRequest)
 	require.NoError(t, err, "No error expected")
-	require.Nil(t, actualRpcStatus, "No RPC status expected")
+	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualService, "A service is expected")
 	waitForRunningService(t, tCtx, actualService.Name)
 

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -171,7 +171,7 @@ func withNamespace() contextOption {
 		// register an automatic deletion of the namespace at test's end
 		t.Cleanup(func() {
 			err := tCtx.k8client.CoreV1().Namespaces().Delete(tCtx.ctx, tCtx.namespaceName, metav1.DeleteOptions{})
-			assert.NoErrorf(t, err, "No error expected when deleting namespace '%s'", tCtx.namespaceName)
+			require.NoErrorf(t, err, "No error expected when deleting namespace '%s'", tCtx.namespaceName)
 		})
 		return nil
 	}
@@ -251,10 +251,8 @@ func (e2etc *End2EndTestingContext) CreateComputeTemplate(t *testing.T) {
 		Namespace: e2etc.namespaceName,
 	}
 
-	_, status, err := e2etc.kuberayAPIServerClient.CreateComputeTemplate(computeTemplateRequest)
-	if !assert.NoErrorf(t, err, "No error expected while creating a compute template (%s, %s)", e2etc.namespaceName, e2etc.computeTemplateName) {
-		t.Fatalf("Received status of %v when attempting to create compute template", status)
-	}
+	_, _, err := e2etc.kuberayAPIServerClient.CreateComputeTemplate(computeTemplateRequest)
+	require.NoErrorf(t, err, "No error expected while creating a compute template (%s, %s)", e2etc.namespaceName, e2etc.computeTemplateName)
 }
 
 func (e2etc *End2EndTestingContext) DeleteComputeTemplate(t *testing.T) {
@@ -262,10 +260,8 @@ func (e2etc *End2EndTestingContext) DeleteComputeTemplate(t *testing.T) {
 		Name:      e2etc.computeTemplateName,
 		Namespace: e2etc.namespaceName,
 	}
-	status, err := e2etc.kuberayAPIServerClient.DeleteComputeTemplate((*api.DeleteComputeTemplateRequest)(deleteComputeTemplateRequest))
-	if !assert.NoErrorf(t, err, "No error expected while deleting a compute template (%s, %s)", e2etc.computeTemplateName, e2etc.namespaceName) {
-		t.Fatalf("Received status of %v when attempting to create compute template", status)
-	}
+	_, err := e2etc.kuberayAPIServerClient.DeleteComputeTemplate((*api.DeleteComputeTemplateRequest)(deleteComputeTemplateRequest))
+	require.NoErrorf(t, err, "No error expected while deleting a compute template (%s, %s)", e2etc.computeTemplateName, e2etc.namespaceName)
 }
 
 func (e2etc *End2EndTestingContext) CreateRayClusterWithConfigMaps(t *testing.T, configMapValues map[string]string, name ...string) (*api.Cluster, string) {
@@ -281,7 +277,7 @@ func (e2etc *End2EndTestingContext) CreateRayClusterWithConfigMaps(t *testing.T,
 	if len(name) > 0 {
 		clusterName = name[0]
 	}
-	actualCluster, status, err := e2etc.kuberayAPIServerClient.CreateCluster(&api.CreateClusterRequest{
+	actualCluster, _, err := e2etc.kuberayAPIServerClient.CreateCluster(&api.CreateClusterRequest{
 		Cluster: &api.Cluster{
 			Name:        clusterName,
 			Namespace:   e2etc.namespaceName,
@@ -334,9 +330,8 @@ func (e2etc *End2EndTestingContext) CreateRayClusterWithConfigMaps(t *testing.T,
 		},
 		Namespace: e2etc.namespaceName,
 	})
-	if !assert.NoErrorf(t, err, "No error expected while creating cluster (%s/%s)", e2etc.namespaceName, clusterName) {
-		t.Fatalf("Received status of %v when attempting to create a cluster", status)
-	}
+	require.NoErrorf(t, err, "No error expected while creating cluster (%s/%s)", e2etc.namespaceName, clusterName)
+
 	// wait for the cluster to be in a running state for 3 minutes
 	// if is not in that state, return an error
 	err = wait.PollUntilContextTimeout(e2etc.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -227,7 +227,7 @@ func (e2etc *End2EndTestingContext) GetRayVersion() string {
 	return e2etc.rayVersion
 }
 
-func (e2etc *End2EndTestingContext) GetRayApiServerClient() *kuberayHTTP.KuberayAPIServerClient {
+func (e2etc *End2EndTestingContext) GetRayAPIServerClient() *kuberayHTTP.KuberayAPIServerClient {
 	return e2etc.kuberayAPIServerClient
 }
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,10 +2,11 @@
 
 set -euo pipefail
 
-dirs_to_lint="ray-operator kubectl-plugin"
+dirs_to_lint="ray-operator kubectl-plugin apiserver"
 
 for dir in $dirs_to_lint; do
   pushd "$dir"
+  # exclude the SA1019 check which checks the usage of deprecated fields.
   golangci-lint run --fix --exclude-files _generated.go --exclude='SA1019' --timeout 10m0s
   popd
 done

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-dirs_to_lint="ray-operator kubectl-plugin apiserver"
+# TODO(hjiang): Enable linter for apiserver after all issues addressed.
+dirs_to_lint="ray-operator kubectl-plugin"
 
 for dir in $dirs_to_lint; do
   pushd "$dir"


### PR DESCRIPTION
## Why are these changes needed?

Followup for suggestion https://github.com/ray-project/kuberay/pull/3303#pullrequestreview-2761211609, this PR **fixes half of the linter issues** for apiserver; I didn't put all fixes in one PR for easier review.

To reviewers: each commit in the PR is a self-contained fix for one particular linter complaint; hopefully it relieves your review burden. :)

Command I used to do suggested string replacements:
```sh
find . -regextype posix-egrep -type f -name "*.go" | xargs -o sed -i "s/ApiServerInterceptor/APIServerInterceptor/g"
find . -regextype posix-egrep -type f -name "*.go" | xargs -o sed -i "s/actualRpcStatus/actualRPCStatus/g"
find . -regextype posix-egrep -type f -name "*.go" | xargs -o sed -i "s/startRpcServer/startRPCServer/g"
find . -regextype posix-egrep -type f -name "*.go" | xargs -o sed -i "s/FromCrdToApiCluster/FromCrdToAPICluster/g"
find . -regextype posix-egrep -type f -name "*.go" | xargs -o sed -i "s/FromCrdToApiJobs/FromCrdToAPIJobs/g"
find . -regextype posix-egrep -type f -name "*.go" | xargs -o sed -i "s/FromCrdToApiServices/FromCrdToAPIServices/g"
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
