### PR TITLE
Use helm-docs to generate README for chart kuberay-operator automatically 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       - id: golangci-lint
         name: golangci-lint
         entry: ./scripts/lint.sh
-        types: [ go ]
+        types: [go]
         language: golang
         require_serial: true
         always_run: true
@@ -74,3 +74,14 @@ repos:
         args:
           - --ignore=.github/pull_request_template.md
           - --disable=MD033
+
+  - repo: https://github.com/norwoodj/helm-docs
+    rev: v1.14.2
+    hooks:
+      - id: helm-docs-built
+        args:
+          # Make the tool search for charts only under the `helm-chart` directory
+          - --chart-search-root=helm-chart
+          - --chart-to-generate=helm-chart/kuberay-operator
+          - --template-files=README.md.gotmpl
+          - --sort-values-order=file

--- a/helm-chart/Makefile
+++ b/helm-chart/Makefile
@@ -1,0 +1,101 @@
+.SILENT:
+
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
+# Setting SHELL to bash allows bash commands to be executed by recipes.
+# Options are set to exit when a recipe line exits non-zero or a piped command fails.
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
+
+# Absolute path to Makefile (trim trailing slash).
+WORKDIR ?= $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+
+# Absolute paths to Helm charts.
+KUBERAY_OPERATOR_CHART_PATH ?= $(WORKDIR)/kuberay-operator
+KUBERAY_APISERVER_CHART_PATH ?= $(WORKDIR)/kuberay-apiserver
+RAY_CLUSTER_CHART_PATH ?= $(WORKDIR)/ray-cluster
+
+# Tool versions.
+HELM_VERSION ?= v3.17.3
+HELM_UNITTEST_VERSION ?= 0.8.1
+HELM_DOCS_VERSION ?= v1.14.2
+
+# Tool binaries.
+LOCALBIN ?= $(WORKDIR)/bin
+HELM ?= $(LOCALBIN)/helm-$(HELM_VERSION)
+HELM_DOCS ?= $(LOCALBIN)/helm-docs-$(HELM_DOCS_VERSION)
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk command is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Helm
+
+.PHONY: helm-unittest
+helm-unittest: helm-unittest-plugin ## Run Helm chart unittests.
+	$(HELM) unittest $(KUBERAY_OPERATOR_CHART_PATH) --file "tests/**/*_test.yaml" --strict --debug
+	$(HELM) unittest $(KUBERAY_APISERVER_CHART_PATH) --file "tests/**/*_test.yaml" --strict --debug
+	$(HELM) unittest $(RAY_CLUSTER_CHART_PATH) --file "tests/**/*_test.yaml" --strict --debug
+
+.PHONY: helm-lint
+helm-lint: ## Run Helm chart lint test.
+	docker run --rm --workdir /workspace --volume $(WORKDIR):/workspace quay.io/helmpack/chart-testing:v3.12.0 \
+	ct lint --chart-dirs=. --charts=kuberay-operator,kuberay-apiserver,ray-cluster --target-branch=master --validate-maintainers=false
+
+.PHONY: helm-docs
+helm-docs: helm-docs-plugin ## Generates markdown documentation for Helm charts from requirements and values files.
+	$(HELM_DOCS) --chart-search-root=$(WORKDIR) --chart-to-generate=$(KUBERAY_OPERATOR_CHART_PATH) --sort-values-order=file
+
+##@ Dependencies
+
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+.PHONY: helm
+helm: $(HELM) ## Download helm locally if necessary.
+$(HELM): $(LOCALBIN)
+	$(call go-install-tool,$(HELM),helm.sh/helm/v3/cmd/helm,$(HELM_VERSION))
+
+.PHONY: helm-unittest-plugin
+helm-unittest-plugin: helm ## Download helm unittest plugin locally if necessary.
+	if [ -z "$(shell $(HELM) plugin list | grep unittest)" ]; then \
+		echo "Installing helm unittest plugin"; \
+		$(HELM) plugin install https://github.com/helm-unittest/helm-unittest.git --version $(HELM_UNITTEST_VERSION); \
+	fi
+
+.PHONY: helm-docs-plugin
+helm-docs-plugin: $(HELM_DOCS) ## Download helm-docs plugin locally if necessary.
+$(HELM_DOCS): $(LOCALBIN)
+	$(call go-install-tool,$(HELM_DOCS),github.com/norwoodj/helm-docs/cmd/helm-docs,$(HELM_DOCS_VERSION))
+
+# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary (ideally with version)
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
+@[ -f $(1) ] || { \
+set -e; \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+GOBIN=$(LOCALBIN) go install $${package} ;\
+mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
+}
+endef

--- a/helm-chart/kuberay-operator/Chart.yaml
+++ b/helm-chart/kuberay-operator/Chart.yaml
@@ -1,6 +1,24 @@
 apiVersion: v2
-description: A Helm chart for Kubernetes
+
 name: kuberay-operator
+
+description: A Helm chart for deploying the Kuberay operator on Kubernetes.
+
 version: 1.1.0
-icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png
+
 type: application
+
+keywords:
+- ray
+- ray operator
+- distributed computing
+- data processing
+- machine learning
+- deep learning
+- hyperparameter tuning
+- reinforcement learning
+- model serving
+
+home: https://github.com/ray-project/kuberay
+
+icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -1,19 +1,30 @@
-# KubeRay Operator
+# kuberay-operator
+
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+A Helm chart for deploying the Kuberay operator on Kubernetes.
+
+**Homepage:** <https://github.com/ray-project/kuberay>
+
+## Introduction
 
 This document provides instructions to install both CRDs (RayCluster, RayJob, RayService) and
 KubeRay operator with a Helm chart.
 
-## Helm
+## Prerequisites
+
+- [Kubernetes](https://kubernetes.io)
+- [Helm](https://helm.sh) >= 3
 
 Make sure the version of Helm is v3+. Currently, [existing CI tests] are based on Helm v3.4.1 and v3.9.4.
 
-```sh
+```bash
 helm version
 ```
 
 ## Install CRDs and KubeRay operator
 
-* Install a stable version via Helm repository (only supports KubeRay v0.4.0+)
+- Install a stable version via Helm repository (only supports KubeRay v0.4.0+)
 
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
@@ -27,7 +38,7 @@ helm version
   # kuberay-operator-6fcbb94f64-mbfnr   1/1     Running   0          17s
   ```
 
-* Install the nightly version
+- Install the nightly version
 
   ```sh
   # Step1: Clone KubeRay repository
@@ -38,11 +49,11 @@ helm version
   helm install kuberay-operator .
   ```
 
-* Install KubeRay operator without installing CRDs
-  * In some cases, the installation of the CRDs and the installation of the operator may require
+- Install KubeRay operator without installing CRDs
+  - In some cases, the installation of the CRDs and the installation of the operator may require
     different levels of admin permissions, so these two installations could be handled as different
     steps by different roles.
-  * Use Helm's built-in `--skip-crds` flag to install the operator only.
+  - Use Helm's built-in `--skip-crds` flag to install the operator only.
     See [this document] for more details.
 
   ```sh
@@ -80,7 +91,7 @@ If you are using [Argo CD] to manage the operator, you will encounter the issue 
 CRDs too long. Same with [this issue]. The recommended solution is to split the operator into two
 Argo apps, such as:
 
-* The first app just for installing the CRDs with `Replace=true` directly, snippet:
+- The first app just for installing the CRDs with `Replace=true` directly, snippet:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -101,7 +112,7 @@ spec:
 ...
 ```
 
-* The second app that installs the Helm chart with `skipCrds=true` (new feature in Argo CD 2.3.0), snippet:
+- The second app that installs the Helm chart with `skipCrds=true` (new feature in Argo CD 2.3.0), snippet:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -128,3 +139,46 @@ spec:
 [Argo CD]: https://argoproj.github.io
 [this issue]: https://github.com/prometheus-operator/prometheus-operator/issues/4439
 [this document]: https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| nameOverride | string | `"kuberay-operator"` | String to partially override release name. |
+| fullnameOverride | string | `"kuberay-operator"` | String to fully override release name. |
+| componentOverride | string | `"kuberay-operator"` | String to override component name. |
+| image.repository | string | `"quay.io/kuberay/operator"` | Image repository. |
+| image.tag | string | `"nightly"` | Image tag. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| labels | object | `{}` | Extra labels. |
+| annotations | object | `{}` | Extra annotations. |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
+| serviceAccount.name | string | `"kuberay-operator"` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
+| logging.stdoutEncoder | string | `"json"` | Log encoder to use for stdout (one of `json` or `console`). |
+| logging.fileEncoder | string | `"json"` | Log encoder to use for file logging (one of `json` or `console`). |
+| logging.baseDir | string | `""` | Directory for kuberay-operator log file. |
+| logging.fileName | string | `""` | File name for kuberay-operator log file. |
+| logging.sizeLimit | string | `""` | EmptyDir volume size limit for kuberay-operator log file. |
+| batchScheduler.enabled | bool | `false` |  |
+| batchScheduler.name | string | `""` |  |
+| featureGates[0].name | string | `"RayClusterStatusConditions"` |  |
+| featureGates[0].enabled | bool | `true` |  |
+| featureGates[1].name | string | `"RayJobDeletionPolicy"` |  |
+| featureGates[1].enabled | bool | `false` |  |
+| metrics.enabled | bool | `true` | Whether KubeRay operator should emit control plane metrics. |
+| operatorComand | string | `"/manager"` | Path to the operator binary |
+| leaderElectionEnabled | bool | `true` | If leaderElectionEnabled is set to true, the KubeRay operator will use leader election for high availability. |
+| rbacEnable | bool | `true` | If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on. |
+| crNamespacedRbacEnable | bool | `true` | When crNamespacedRbacEnable is set to true, the KubeRay operator will create a Role for RayCluster preparation (e.g., Pods, Services) and a corresponding RoleBinding for each namespace listed in the "watchNamespace" parameter. Please note that even if crNamespacedRbacEnable is set to false, the Role and RoleBinding for leader election will still be created.  Note: (1) This variable is only effective when rbacEnable and singleNamespaceInstall are both set to true. (2) In most cases, it should be set to true, unless you are using a Kubernetes cluster managed by GitOps tools such as ArgoCD. |
+| singleNamespaceInstall | bool | `false` | When singleNamespaceInstall is true: - Install namespaced RBAC resources such as Role and RoleBinding instead of cluster-scoped ones like ClusterRole and ClusterRoleBinding so that   the chart can be installed by users with permissions restricted to a single namespace.   (Please note that this excludes the CRDs, which can only be installed at the cluster scope.) - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen   to resource events within its own namespace. |
+| env | string | `nil` | Environment variables. |
+| resources | object | `{"limits":{"cpu":"100m","memory":"512Mi"}}` | Resource requests and limits for containers. |
+| livenessProbe.initialDelaySeconds | int | `10` |  |
+| livenessProbe.periodSeconds | int | `5` |  |
+| livenessProbe.failureThreshold | int | `5` |  |
+| readinessProbe.initialDelaySeconds | int | `10` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.failureThreshold | int | `5` |  |
+| podSecurityContext | object | `{}` | Set up `securityContext` to improve Pod security. |
+| service.type | string | `"ClusterIP"` | Service type. |
+| service.port | int | `8080` | Service port. |

--- a/helm-chart/kuberay-operator/README.md.gotmpl
+++ b/helm-chart/kuberay-operator/README.md.gotmpl
@@ -1,0 +1,145 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Introduction
+
+This document provides instructions to install both CRDs (RayCluster, RayJob, RayService) and
+KubeRay operator with a Helm chart.
+
+## Prerequisites
+
+- [Kubernetes](https://kubernetes.io)
+- [Helm](https://helm.sh) >= 3
+
+Make sure the version of Helm is v3+. Currently, [existing CI tests] are based on Helm v3.4.1 and v3.9.4.
+
+```bash
+helm version
+```
+
+## Install CRDs and KubeRay operator
+
+- Install a stable version via Helm repository (only supports KubeRay v0.4.0+)
+
+  ```sh
+  helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+
+  # Install both CRDs and KubeRay operator v1.1.0.
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0
+
+  # Check the KubeRay operator Pod in `default` namespace
+  kubectl get pods
+  # NAME                                READY   STATUS    RESTARTS   AGE
+  # kuberay-operator-6fcbb94f64-mbfnr   1/1     Running   0          17s
+  ```
+
+- Install the nightly version
+
+  ```sh
+  # Step1: Clone KubeRay repository
+
+  # Step2: Move to `helm-chart/kuberay-operator`
+
+  # Step3: Install KubeRay operator
+  helm install kuberay-operator .
+  ```
+
+- Install KubeRay operator without installing CRDs
+  - In some cases, the installation of the CRDs and the installation of the operator may require
+    different levels of admin permissions, so these two installations could be handled as different
+    steps by different roles.
+  - Use Helm's built-in `--skip-crds` flag to install the operator only.
+    See [this document] for more details.
+
+  ```sh
+  # Step 1: Install CRDs only (for cluster admin)
+  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.1.0&timeout=90s"
+
+  # Step 2: Install KubeRay operator only. (for developer)
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0 --skip-crds
+  ```
+
+## List the chart
+
+To list the `my-release` deployment:
+
+```sh
+helm ls
+# NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
+# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.1.0
+```
+
+## Uninstall the Chart
+
+```sh
+# Uninstall the `kuberay-operator` release
+helm uninstall kuberay-operator
+
+# The operator Pod should be removed.
+kubectl get pods
+# No resources found in default namespace.
+```
+
+## Working with Argo CD
+
+If you are using [Argo CD] to manage the operator, you will encounter the issue which complains the
+CRDs too long. Same with [this issue]. The recommended solution is to split the operator into two
+Argo apps, such as:
+
+- The first app just for installing the CRDs with `Replace=true` directly, snippet:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ray-operator-crds
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ray-project/kuberay
+    targetRevision: v1.0.0-rc.0
+    path: helm-chart/kuberay-operator/crds
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    syncOptions:
+    - Replace=true
+...
+```
+
+- The second app that installs the Helm chart with `skipCrds=true` (new feature in Argo CD 2.3.0), snippet:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ray-operator
+spec:
+  source:
+    repoURL: https://github.com/ray-project/kuberay
+    targetRevision: v1.0.0-rc.0
+    path: helm-chart/kuberay-operator
+    helm:
+      skipCrds: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ray-operator
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
+...
+```
+
+[existing CI tests]: https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm-lint.yaml
+[Argo CD]: https://argoproj.github.io
+[this issue]: https://github.com/prometheus-operator/prometheus-operator/issues/4439
+[this document]: https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
+
+{{ template "chart.valuesSection" . }}

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -2,14 +2,24 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image:
-  repository: quay.io/kuberay/operator
-  tag: nightly
-  pullPolicy: IfNotPresent
+# -- String to partially override release name.
+nameOverride: kuberay-operator
 
-nameOverride: "kuberay-operator"
-fullnameOverride: "kuberay-operator"
-componentOverride: "kuberay-operator"
+# -- String to fully override release name.
+fullnameOverride: kuberay-operator
+
+# -- String to override component name.
+componentOverride: kuberay-operator
+
+image:
+  # -- Image repository.
+  repository: quay.io/kuberay/operator
+
+  # -- Image tag.
+  tag: nightly
+
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
 
 # -- Extra labels.
 labels: {}
@@ -18,51 +28,23 @@ labels: {}
 annotations: {}
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created.
   create: true
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: "kuberay-operator"
-
-service:
-  type: ClusterIP
-  port: 8080
-
-resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do whelm to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  limits:
-    cpu: 100m
-    # Anecdotally, managing 500 Ray pods requires roughly 500MB memory.
-    # Monitor memory usage and adjust as needed.
-    memory: 512Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 512Mi
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: kuberay-operator
 
 logging:
-  # Log encoder to use for stdout (one of 'json' or 'console', default is 'json')
-  stdoutEncoder: ""
-  # Log encoder to use for file logging (one of 'json' or 'console', default is 'json')
-  fileEncoder: ""
-  # Directory for kuberay-operator log file
+  # -- Log encoder to use for stdout (one of `json` or `console`).
+  stdoutEncoder: json
+  # -- Log encoder to use for file logging (one of `json` or `console`).
+  fileEncoder: json
+  # -- Directory for kuberay-operator log file.
   baseDir: ""
-  # File name for kuberay-operator log file
+  # -- File name for kuberay-operator log file.
   fileName: ""
-  # EmptyDir volume size limit for kuberay-operator log file
+  # -- EmptyDir volume size limit for kuberay-operator log file.
   sizeLimit: ""
-
-livenessProbe:
-  initialDelaySeconds: 10
-  periodSeconds: 5
-  failureThreshold: 5
-
-readinessProbe:
-  initialDelaySeconds: 10
-  periodSeconds: 5
-  failureThreshold: 5
 
 # Enable customized Kubernetes scheduler integration. If enabled, Ray workloads will be scheduled
 # by the customized scheduler.
@@ -94,45 +76,30 @@ batchScheduler:
   name: ""
 
 featureGates:
-  - name: RayClusterStatusConditions
-    enabled: true
-  - name: RayJobDeletionPolicy
-    enabled: false
+- name: RayClusterStatusConditions
+  enabled: true
+- name: RayJobDeletionPolicy
+  enabled: false
 
 # Configurations for KubeRay operator metrics.
 metrics:
-  #  Whether KubeRay operator should emit control plane metrics.
+  # -- Whether KubeRay operator should emit control plane metrics.
   enabled: true
 
-# Path to the operator binary
+# -- Path to the operator binary
 operatorComand: /manager
-
-# Set up `securityContext` to improve Pod security.
-# See https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md for further guidance.
-podSecurityContext: {}
-
-# Set up `securityContext` to improve container security.
-securityContext:
-  allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: true
-  capabilities:
-    drop:
-    - ALL
-  runAsNonRoot: true
-  seccompProfile:
-    type: RuntimeDefault
 
 # if userKubernetesProxy is set to true, the KubeRay operator will be configured with the --use-kubernetes-proxy flag.
 # Using this option to configure kuberay-operator to comunitcate to Ray head pods by proxying through the Kubernetes API Server.
 # useKubernetesProxy: true
 
-# If leaderElectionEnabled is set to true, the KubeRay operator will use leader election for high availability.
+# -- If leaderElectionEnabled is set to true, the KubeRay operator will use leader election for high availability.
 leaderElectionEnabled: true
 
-# If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on.
+# -- If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on.
 rbacEnable: true
 
-# When crNamespacedRbacEnable is set to true, the KubeRay operator will create a Role for RayCluster preparation (e.g., Pods, Services)
+# -- When crNamespacedRbacEnable is set to true, the KubeRay operator will create a Role for RayCluster preparation (e.g., Pods, Services)
 # and a corresponding RoleBinding for each namespace listed in the "watchNamespace" parameter. Please note that even if crNamespacedRbacEnable
 # is set to false, the Role and RoleBinding for leader election will still be created.
 #
@@ -141,7 +108,7 @@ rbacEnable: true
 # (2) In most cases, it should be set to true, unless you are using a Kubernetes cluster managed by GitOps tools such as ArgoCD.
 crNamespacedRbacEnable: true
 
-# When singleNamespaceInstall is true:
+# -- When singleNamespaceInstall is true:
 # - Install namespaced RBAC resources such as Role and RoleBinding instead of cluster-scoped ones like ClusterRole and ClusterRoleBinding so that
 #   the chart can be installed by users with permissions restricted to a single namespace.
 #   (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
@@ -154,7 +121,8 @@ singleNamespaceInstall: false
 #   - n1
 #   - n2
 
-# Environment variables
+# -- Environment variables.
+
 env:
 # If not set or set to true, kuberay auto injects an init container waiting for ray GCS.
 # If false, you will need to inject your own init container to ensure ray GCS is up before the ray workers start.
@@ -192,3 +160,46 @@ env:
 # If set to true, the RayJob CR itself will be deleted if shutdownAfterJobFinishes is set to true. Note that all resources created by the RayJob CR will be deleted, including the K8s Job. Otherwise, only the RayCluster CR will be deleted. Default is false.
 # - name: DELETE_RAYJOB_CR_AFTER_JOB_FINISHES
 #   value: "false"
+
+# -- Resource requests and limits for containers.
+resources:
+  limits:
+    cpu: 100m
+    # Anecdotally, managing 500 Ray pods requires roughly 500MB memory.
+    # Monitor memory usage and adjust as needed.
+    memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 512Mi
+
+# @Ignore -- Pod liveness probe configuration.
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 5
+
+# @Ignore -- Pod readiness probe configuration.
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 5
+
+# -- Set up `securityContext` to improve Pod security.
+podSecurityContext: {}
+
+# @ignore -- Set up `securityContext` to improve container security.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+    - ALL
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+service:
+  # -- Service type.
+  type: ClusterIP
+  # -- Service port.
+  port: 8080


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Use [helm-docs](https://github.com/norwoodj/helm-docs) to keep the chart README up-to-date. 

I have added a `Makefile` under the helm-chart directory, and it contains some useful targets, all the dependencies will be installed automatically as needed:

```
$ make          

Usage:
  make <target>

General
  help                            Display this help.

Helm
  helm-unittest                   Run Helm chart unittests.
  helm-lint                       Run Helm chart lint test.
  helm-docs                       Generates markdown documentation for Helm charts from requirements and values files.

Dependencies
  helm                            Download helm locally if necessary.
  helm-unittest-plugin            Download helm unittest plugin locally if necessary.
  helm-docs-plugin                Download helm-docs plugin locally if necessary.
```

If one has made some changes to the `values.yaml`, he can update the Helm chart README by

```
# In the helm-chart directory
make helm-docs

# In the project root direcotory
make -f helm-chart/Makefile helm-docs
```

## Related issue number

<!-- For example: "Closes #1234" -->

Close #3330 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
