### PR TITLE
[apiserver] Enable test coverage for e2e test

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -95,7 +95,7 @@ test: fmt vet fumpt imports ## Run all unit tests.
 
 .PHONY: e2e-test
 e2e-test: ## Run end to end tests using a pre-exiting cluster.
-	go test ./test/e2e/... $(GO_TEST_FLAGS) -timeout 60m  -race -count=1 -parallel 4
+	go test ./test/e2e/... $(GO_TEST_FLAGS) -timeout 60m  -race -coverprofile ray-kube-api-server-e2e-coverage.out -count=1 -parallel 4
 
 .PHONY: local-e2e-test ## Run end to end tests on newly created cluster.
 local-e2e-test: operator-image cluster load-operator-image deploy-operator install load-ray-test-image e2e-test clean-cluster ## Run end to end tests, create a fresh kind cluster will all components deployed.

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -552,6 +552,7 @@ func isMatchingCluster(tCtx *End2EndTestingContext, cluster *api.Cluster) bool {
 
 // TestGetAllClusters tests gets all Ray clusters from k8s cluster
 func TestGetAllClusters(t *testing.T) {
+	t.Skip()
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
@@ -580,6 +581,7 @@ func TestGetAllClusters(t *testing.T) {
 
 // TestGetAllClustersByPagination tests gets all Ray clusters from k8s cluster with pagination
 func TestGetAllClustersByPagination(t *testing.T) {
+	t.Skip()
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
@@ -620,6 +622,7 @@ func TestGetAllClustersByPagination(t *testing.T) {
 
 // TestGetAllClustersByPaginationWithAllResults tests gets all Ray clusters from k8s cluster with pagination returning all results
 func TestGetAllClustersByPaginationWithAllResults(t *testing.T) {
+	t.Skip()
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
@@ -687,6 +690,7 @@ func TestGetClustersInNamespace(t *testing.T) {
 }
 
 func TestGetClustersByPaginationInNamespace(t *testing.T) {
+	t.Skip()
 	tCtx, err := NewEnd2EndTestingContext(t)
 	require.NoError(t, err, "No error expected when creating testing context")
 

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -552,7 +552,6 @@ func isMatchingCluster(tCtx *End2EndTestingContext, cluster *api.Cluster) bool {
 
 // TestGetAllClusters tests gets all Ray clusters from k8s cluster
 func TestGetAllClusters(t *testing.T) {
-	t.Skip()
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
@@ -581,7 +580,6 @@ func TestGetAllClusters(t *testing.T) {
 
 // TestGetAllClustersByPagination tests gets all Ray clusters from k8s cluster with pagination
 func TestGetAllClustersByPagination(t *testing.T) {
-	t.Skip()
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
@@ -622,7 +620,6 @@ func TestGetAllClustersByPagination(t *testing.T) {
 
 // TestGetAllClustersByPaginationWithAllResults tests gets all Ray clusters from k8s cluster with pagination returning all results
 func TestGetAllClustersByPaginationWithAllResults(t *testing.T) {
-	t.Skip()
 	numberOfNamespaces := 3
 	tCtxs := createOneClusterInEachNamespaces(t, numberOfNamespaces)
 	tCtx := tCtxs[0]
@@ -690,7 +687,6 @@ func TestGetClustersInNamespace(t *testing.T) {
 }
 
 func TestGetClustersByPaginationInNamespace(t *testing.T) {
-	t.Skip()
 	tCtx, err := NewEnd2EndTestingContext(t)
 	require.NoError(t, err, "No error expected when creating testing context")
 


### PR DESCRIPTION
## Why are these changes needed?

Before official release, we need to understand the test coverage for integration test; especially for apiserver which is hard to unit test and heavily rely on integration test. 

Result:
```sh
[~/kuberay/apiserver] (master) 
ubuntu@hjiang-devbox-pg$ make e2e-test
go test ./test/e2e/...  -timeout 60m  -race -cover -count=1 -parallel 4
ok      github.com/ray-project/kuberay/apiserver/test/e2e       960.111s        coverage: 78.6% of statements
```

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/3329

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [X] Manual tests
  - [ ] This PR is not tested :(
