### PR TITLE
[kubectl-plugin] TestSwitchesIncompatibleWithConfigFilePresent is flaky

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -134,7 +134,6 @@ func TestRayCreateClusterValidate(t *testing.T) {
 func TestSwitchesIncompatibleWithConfigFilePresent(t *testing.T) {
 	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
 	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
-	cmd := NewCreateClusterCommand(cmdFactory, testStreams)
 
 	tests := map[string]struct {
 		expectError string
@@ -177,6 +176,7 @@ func TestSwitchesIncompatibleWithConfigFilePresent(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			cmd := NewCreateClusterCommand(cmdFactory, testStreams)
 			cmd.SetArgs(tc.args)
 			// Parse the flags before checking for incompatible flags
 			if err := cmd.Flags().Parse(tc.args); err != nil {


### PR DESCRIPTION
## Why are these changes needed?

`TestSwitchesIncompatibleWithConfigFilePresent` is flaky because the test reused the same `cmd` object across subtests, causing `SetArgs` in one iteration to affect the next due to shared flag state. This led to flakiness depending on map iteration order.  
This PR ensures a new command is created per subtest to ensure isolation between each subtest.
## Related issue number

Closes #3325 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

To ensure the test is not flaky with this PR, I've run 100 times of the `TestSwitchesIncompatibleWithConfigFile` with the following script and passed all of them. In comparison, the original test failed roughly every 10 times.
```
#!/bin/bash

for i in {1..100}; do
  echo "Run #$i"
  go test ./pkg/cmd/create -run ^TestSwitchesIncompatibleWithConfigFilePresent$ -count=1 -v -race || break
done
```