### PR TITLE
[apiserver] Remove unnecessary test image

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -154,8 +154,6 @@ endif
 load-ray-test-image: ## Load the ray test images
 	$(ENGINE) pull $(E2E_API_SERVER_RAY_IMAGE)
 	$(KIND) load docker-image $(E2E_API_SERVER_RAY_IMAGE) -n $(KIND_CLUSTER_NAME)
-	$(ENGINE) pull rayproject/ray:latest
-	$(KIND) load docker-image rayproject/ray:latest -n $(KIND_CLUSTER_NAME)
 
 ##@ Docker Build
 docker-image: test ## Build image for the api server.


### PR DESCRIPTION
## Why are these changes needed?

As of now we load two ray images into kind cluster for testing:
https://github.com/ray-project/kuberay/blob/732a6754ff4d1c1e606bd22c14642b33c982e1d4/apiserver/Makefile#L153-L158

There're two relates PRs:
- The code was written that way from the beginning (no explanation): https://github.com/ray-project/kuberay/commit/ff459239fde9a6a0998d38f0fd5e3eb5e365610e
- We used to revert PR (which tries to upgrade ray test image): https://github.com/ray-project/kuberay/commit/d8ffec4070e4517d3e144053be27f91fa0fbb0b4

Reading through the above change, my understand is we pin ray image as 2.9.0, and don't think latest image is necessary (otherwise why do we revert the upgrade PR).

I tested with local e2e test, apart from the known flaky test https://github.com/ray-project/kuberay/issues/3293 (which always fail on my devbox), all other tests pass.

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/3339

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [X] Manual tests
  - [ ] This PR is not tested :(
