### PR TITLE
[Refactor] use constant variable for port name and value

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1345,11 +1345,11 @@ func TestUpdateEndpoints(t *testing.T) {
 	}
 
 	expected := map[string]string{
-		"client":     "10001",
-		"dashboard":  "8265",
-		"metrics":    "8080",
-		"gcs-server": "6379",
-		"serve":      "8000",
+		utils.ClientPortName:    strconv.Itoa(utils.DefaultClientPort),
+		utils.DashboardPortName: strconv.Itoa(utils.DefaultDashboardPort),
+		utils.MetricsPortName:   strconv.Itoa(utils.DefaultMetricsPort),
+		utils.GcsServerPortName: strconv.Itoa(utils.DefaultGcsServerPort),
+		utils.ServingPortName:   strconv.Itoa(utils.DefaultServingPort),
 	}
 	assert.Equal(t, expected, testRayCluster.Status.Endpoints, "RayCluster status endpoints not updated")
 }
@@ -1642,10 +1642,10 @@ func TestInconsistentRayClusterStatus(t *testing.T) {
 		MaxWorkerReplicas:       10,
 		LastUpdateTime:          &timeNow,
 		Endpoints: map[string]string{
-			"client":     "10001",
-			"dashboard":  "8265",
-			"gcs-server": "6379",
-			"metrics":    "8080",
+			utils.ClientPortName:    strconv.Itoa(utils.DefaultClientPort),
+			utils.DashboardPortName: strconv.Itoa(utils.DefaultDashboardPort),
+			utils.GcsServerPortName: strconv.Itoa(utils.DefaultGcsServerPort),
+			utils.MetricsPortName:   strconv.Itoa(utils.DefaultMetricsPort),
 		},
 		Head: rayv1.HeadInfo{
 			PodIP:     "10.244.0.6",

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -77,16 +77,16 @@ func rayJobTemplate(name string, namespace string) *rayv1.RayJob {
 									},
 									Ports: []corev1.ContainerPort{
 										{
-											Name:          "gcs-server",
-											ContainerPort: 6379,
+											Name:          utils.GcsServerPortName,
+											ContainerPort: utils.DefaultGcsServerPort,
 										},
 										{
-											Name:          "dashboard",
-											ContainerPort: 8265,
+											Name:          utils.DashboardPortName,
+											ContainerPort: utils.DefaultDashboardPort,
 										},
 										{
-											Name:          "client",
-											ContainerPort: 10001,
+											Name:          utils.ClientPortName,
+											ContainerPort: utils.DefaultClientPort,
 										},
 									},
 								},

--- a/ray-operator/test/e2e/support.go
+++ b/ray-operator/test/e2e/support.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
@@ -125,10 +126,10 @@ func headPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfigura
 				WithName("ray-head").
 				WithImage(GetRayImage()).
 				WithPorts(
-					corev1ac.ContainerPort().WithName("gcs-server").WithContainerPort(6379),
-					corev1ac.ContainerPort().WithName("serve").WithContainerPort(8000),
-					corev1ac.ContainerPort().WithName("dashboard").WithContainerPort(8265),
-					corev1ac.ContainerPort().WithName("client").WithContainerPort(10001),
+					corev1ac.ContainerPort().WithName(utils.GcsServerPortName).WithContainerPort(utils.DefaultGcsServerPort),
+					corev1ac.ContainerPort().WithName(utils.ServingPortName).WithContainerPort(utils.DefaultServingPort),
+					corev1ac.ContainerPort().WithName(utils.DashboardPortName).WithContainerPort(utils.DefaultDashboardPort),
+					corev1ac.ContainerPort().WithName(utils.ClientPortName).WithContainerPort(utils.DefaultClientPort),
 				).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{

--- a/ray-operator/test/e2eautoscaler/support.go
+++ b/ray-operator/test/e2eautoscaler/support.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
@@ -98,10 +99,10 @@ func headPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfigura
 				WithName("ray-head").
 				WithImage(GetRayImage()).
 				WithPorts(
-					corev1ac.ContainerPort().WithName("gcs-server").WithContainerPort(6379),
-					corev1ac.ContainerPort().WithName("serve").WithContainerPort(8000),
-					corev1ac.ContainerPort().WithName("dashboard").WithContainerPort(8265),
-					corev1ac.ContainerPort().WithName("client").WithContainerPort(10001),
+					corev1ac.ContainerPort().WithName(utils.GcsServerPortName).WithContainerPort(utils.DefaultGcsServerPort),
+					corev1ac.ContainerPort().WithName(utils.ServingPortName).WithContainerPort(utils.DefaultServingPort),
+					corev1ac.ContainerPort().WithName(utils.DashboardPortName).WithContainerPort(utils.DefaultDashboardPort),
+					corev1ac.ContainerPort().WithName(utils.ClientPortName).WithContainerPort(utils.DefaultClientPort),
 				).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{
@@ -122,10 +123,10 @@ func headPodTemplateApplyConfigurationV2() *corev1ac.PodTemplateSpecApplyConfigu
 				WithName("ray-head").
 				WithImage(GetRayImage()).
 				WithPorts(
-					corev1ac.ContainerPort().WithName("gcs-server").WithContainerPort(6379),
-					corev1ac.ContainerPort().WithName("serve").WithContainerPort(8000),
-					corev1ac.ContainerPort().WithName("dashboard").WithContainerPort(8265),
-					corev1ac.ContainerPort().WithName("client").WithContainerPort(10001),
+					corev1ac.ContainerPort().WithName(utils.GcsServerPortName).WithContainerPort(utils.DefaultGcsServerPort),
+					corev1ac.ContainerPort().WithName(utils.ServingPortName).WithContainerPort(utils.DefaultServingPort),
+					corev1ac.ContainerPort().WithName(utils.DashboardPortName).WithContainerPort(utils.DefaultDashboardPort),
+					corev1ac.ContainerPort().WithName(utils.ClientPortName).WithContainerPort(utils.DefaultClientPort),
 				).
 				WithEnv(corev1ac.EnvVar().WithName("RAY_enable_autoscaler_v2").WithValue("1")).
 				WithResources(corev1ac.ResourceRequirements().

--- a/ray-operator/test/e2erayservice/support.go
+++ b/ray-operator/test/e2erayservice/support.go
@@ -12,6 +12,7 @@ import (
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
@@ -146,10 +147,10 @@ func RayServiceSampleYamlApplyConfiguration() *rayv1ac.RayServiceSpecApplyConfig
 							WithName("ray-head").
 							WithImage(GetRayImage()).
 							WithPorts(
-								corev1ac.ContainerPort().WithName("gcs-server").WithContainerPort(6379),
-								corev1ac.ContainerPort().WithName("serve").WithContainerPort(8000),
-								corev1ac.ContainerPort().WithName("dashboard").WithContainerPort(8265),
-								corev1ac.ContainerPort().WithName("client").WithContainerPort(10001),
+								corev1ac.ContainerPort().WithName(utils.GcsServerPortName).WithContainerPort(utils.DefaultGcsServerPort),
+								corev1ac.ContainerPort().WithName(utils.ServingPortName).WithContainerPort(utils.DefaultServingPort),
+								corev1ac.ContainerPort().WithName(utils.DashboardPortName).WithContainerPort(utils.DefaultDashboardPort),
+								corev1ac.ContainerPort().WithName(utils.ClientPortName).WithContainerPort(utils.DefaultClientPort),
 							).
 							WithResources(corev1ac.ResourceRequirements().
 								WithRequests(corev1.ResourceList{


### PR DESCRIPTION
- Convert hard-coded port names and values into constant variables defined in `ray-operator/controllers/ray/utils/constant.go`

https://github.com/ray-project/kuberay/blob/732a6754ff4d1c1e606bd22c14642b33c982e1d4/ray-operator/controllers/ray/utils/constant.go#L66-L77

## Why are these changes needed?

Follow up on https://github.com/ray-project/kuberay/pull/3262#discussion_r2035836143

Some codes include hard-coded port name and value, which may cause some typo. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
