### PR TITLE
[test][apiserver] Add unittests for pkg/interceptor

### DIFF
--- a/apiserver/pkg/interceptor/interceptor_test.go
+++ b/apiserver/pkg/interceptor/interceptor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
@@ -68,7 +69,7 @@ func TestAPIServerInterceptor(t *testing.T) {
 
 			// Verify error
 			if tt.expectedError == nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
 				assert.Error(t, err)
 				assert.Equal(t, tt.expectedError.Error(), err.Error())

--- a/apiserver/pkg/interceptor/interceptor_test.go
+++ b/apiserver/pkg/interceptor/interceptor_test.go
@@ -71,8 +71,7 @@ func TestAPIServerInterceptor(t *testing.T) {
 			if tt.expectedError == nil {
 				require.NoError(t, err)
 			} else {
-				assert.Error(t, err)
-				assert.Equal(t, tt.expectedError.Error(), err.Error())
+				require.EqualError(t, err, tt.expectedError.Error(), "A matching error is expected")
 			}
 		})
 	}
@@ -97,6 +96,9 @@ func TestAPIServerInterceptorContextPassing(t *testing.T) {
 }
 
 // TestAPIServerInterceptorLogging verifies logging behavior
+// TODO: Improve logging verification by capturing klog output
+// Currently only verifies code execution without panics
+// See the discussion in https://github.com/ray-project/kuberay/pull/3346 for more details
 func TestAPIServerInterceptorLogging(t *testing.T) {
 	// This test mainly ensures the code paths with logging are executed
 	// Since klog is a global logger, we can't easily verify the output
@@ -114,6 +116,5 @@ func TestAPIServerInterceptorLogging(t *testing.T) {
 		},
 	)
 
-	assert.Error(t, err)
-	assert.Equal(t, "test error", err.Error())
+	require.EqualError(t, err, "test error", "A matching error is expected")
 }

--- a/apiserver/pkg/interceptor/interceptor_test.go
+++ b/apiserver/pkg/interceptor/interceptor_test.go
@@ -139,8 +139,8 @@ func TestAPIServerInterceptorLogging(t *testing.T) {
 
 			// Restore stderr after the test
 			defer func() {
-				os.Stderr = originalStderr
 				klog.Flush()
+				os.Stderr = originalStderr
 			}()
 
 			ctx := context.Background()
@@ -165,7 +165,7 @@ func TestAPIServerInterceptorLogging(t *testing.T) {
 			// Close the write end of the pipe and read the captured output
 			w.Close()
 			var buf bytes.Buffer
-			_, _ = io.Copy(&buf, r)
+			io.Copy(&buf, r)
 			logOutput := buf.String()
 
 			for _, expectedLog := range tt.expectedLogs {

--- a/apiserver/pkg/interceptor/interceptor_test.go
+++ b/apiserver/pkg/interceptor/interceptor_test.go
@@ -94,27 +94,3 @@ func TestAPIServerInterceptorContextPassing(t *testing.T) {
 		},
 	)
 }
-
-// TestAPIServerInterceptorLogging verifies logging behavior
-// TODO: Improve logging verification by capturing klog output
-// Currently only verifies code execution without panics
-// See the discussion in https://github.com/ray-project/kuberay/pull/3346 for more details
-func TestAPIServerInterceptorLogging(t *testing.T) {
-	// This test mainly ensures the code paths with logging are executed
-	// Since klog is a global logger, we can't easily verify the output
-	// but we can ensure the code executes without panics
-	ctx := context.Background()
-	handler := &mockHandler{returnErr: errors.New("test error")}
-	info := &grpc.UnaryServerInfo{FullMethod: "TestMethod"}
-
-	_, err := APIServerInterceptor(
-		ctx,
-		"test_request",
-		info,
-		func(ctx context.Context, req interface{}) (interface{}, error) {
-			return handler.Handle(ctx, req)
-		},
-	)
-
-	require.EqualError(t, err, "test error", "A matching error is expected")
-}

--- a/apiserver/pkg/interceptor/interceptor_test.go
+++ b/apiserver/pkg/interceptor/interceptor_test.go
@@ -1,0 +1,118 @@
+package interceptor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+// mockHandler simulates a gRPC handler for testing
+type mockHandler struct {
+	called    bool
+	returnErr error
+}
+
+func (h *mockHandler) Handle(ctx context.Context, req interface{}) (interface{}, error) {
+	h.called = true
+	return "test_response", h.returnErr
+}
+
+func TestAPIServerInterceptor(t *testing.T) {
+	tests := []struct {
+		name          string
+		handler       *mockHandler
+		expectedResp  interface{}
+		expectedError error
+	}{
+		{
+			name:          "successful handler execution",
+			handler:       &mockHandler{returnErr: nil},
+			expectedResp:  "test_response",
+			expectedError: nil,
+		},
+		{
+			name:          "handler returns error",
+			handler:       &mockHandler{returnErr: errors.New("handler error")},
+			expectedResp:  "test_response",
+			expectedError: errors.New("handler error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test context and request
+			ctx := context.Background()
+			req := "test_request"
+			info := &grpc.UnaryServerInfo{
+				FullMethod: "TestMethod",
+			}
+
+			// Call the interceptor
+			resp, err := APIServerInterceptor(
+				ctx,
+				req,
+				info,
+				func(ctx context.Context, req interface{}) (interface{}, error) {
+					return tt.handler.Handle(ctx, req)
+				},
+			)
+
+			// Verify handler was called
+			assert.True(t, tt.handler.called, "handler should have been called")
+
+			// Verify response
+			assert.Equal(t, tt.expectedResp, resp, "response should match expected")
+
+			// Verify error
+			if tt.expectedError == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+			}
+		})
+	}
+}
+
+// TestAPIServerInterceptorContextPassing ensures context is properly passed through
+func TestAPIServerInterceptorContextPassing(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "test_key", "test_value")
+	handler := &mockHandler{}
+	info := &grpc.UnaryServerInfo{FullMethod: "TestMethod"}
+
+	_, _ = APIServerInterceptor(
+		ctx,
+		"test_request",
+		info,
+		func(receivedCtx context.Context, req interface{}) (interface{}, error) {
+			// Verify context value is passed through
+			assert.Equal(t, "test_value", receivedCtx.Value("test_key"))
+			return handler.Handle(receivedCtx, req)
+		},
+	)
+}
+
+// TestAPIServerInterceptorLogging verifies logging behavior
+func TestAPIServerInterceptorLogging(t *testing.T) {
+	// This test mainly ensures the code paths with logging are executed
+	// Since klog is a global logger, we can't easily verify the output
+	// but we can ensure the code executes without panics
+	ctx := context.Background()
+	handler := &mockHandler{returnErr: errors.New("test error")}
+	info := &grpc.UnaryServerInfo{FullMethod: "TestMethod"}
+
+	_, err := APIServerInterceptor(
+		ctx,
+		"test_request",
+		info,
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			return handler.Handle(ctx, req)
+		},
+	)
+
+	assert.Error(t, err)
+	assert.Equal(t, "test error", err.Error())
+}

--- a/apiserver/pkg/interceptor/interceptor_test.go
+++ b/apiserver/pkg/interceptor/interceptor_test.go
@@ -94,3 +94,8 @@ func TestAPIServerInterceptorContextPassing(t *testing.T) {
 		},
 	)
 }
+
+// TODO: Add proper logging verification tests using one of these approaches:
+// 1. Hijack logging output via klog.SetOutput
+// 2. Redirect stdout/stderr content
+// See https://github.com/ray-project/kuberay/pull/3346#discussion_r2041099261 for details


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The pkg/interceptor package had 0% test coverage, which could lead to potential reliability issues as it's a critical component handling all gRPC API requests. This PR adds tests to verify its functionality, achieving 100% coverage:

```bash
$ make test
go test ./pkg/...  -race -coverprofile ray-kube-api-server-coverage.out  -parallel 4
ok      github.com/ray-project/kuberay/apiserver/pkg/interceptor        1.036s  coverage: 100.0% of statements
```

## Related issue number

Closes #3312

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(