### PR TITLE
[apiserver] Remove unused code in apiserver error utils

### DIFF
--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -89,20 +89,84 @@ func NewUserErrorWithSingleMessage(err error, message string) *UserError {
 	return NewUserError(err, message, message)
 }
 
+// Util function to convert HTTP status code to gRPC status code.
+func convertHttpStatusToUserError(httpStatusCode int) codes.Code {
+	switch httpStatusCode {
+	// Success and redirect responses
+	case 200, // OK
+		201, // Created
+		204, // No Content
+		206, // Partial Content
+		302, // Found
+		307, // Temporary Redirect
+		308: // Permanent Redirect
+		return codes.OK
+
+	// OUT_OF_RANGE indicates requested range is out of scope.
+	case 416: // Requested Range Not Satisfiable
+		return codes.OutOfRange
+
+	// INVALID_ARGUMENT indicates a problem with how the request is constructed.
+	case 400, // Bad Request
+		411, // Length Required
+		413: // Payload Too Large
+		return codes.InvalidArgument
+
+	// UNAUTHENTICATED indicates an authentication issue.
+	case 401: // Unauthorized
+		return codes.Unauthenticated
+
+	// PERMISSION_DENIED indicates an authorization issue.
+	case 403: // Forbidden
+		return codes.PermissionDenied
+
+	// NOT_FOUND indicates that the requested resource does not exist.
+	case 404, // Not Found
+		410: // Gone
+		return codes.NotFound
+
+	// FAILED_PRECONDITION indicates that the request failed because some
+	// of the underlying assumptions were not satisfied. The request
+	// shouldn't be retried unless the external context has changed.
+	case 303, // See Other
+		304, // Not Modified
+		409, // Conflict
+		412: // Precondition Failed
+		return codes.FailedPrecondition
+
+	// UNAVAILABLE indicates a problem that can go away if the request
+	// is just retried without any modification. 308 return codes are intended
+	// for write requests that can be retried. See the documentation and the
+	// official library:
+	// https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload
+	// https://github.com/google/apitools/blob/master/apitools/base/py/transfer.py
+	case 429, // Too Many Requests
+		503, // Service Unavailable
+		504: // Gateway Timeout
+		return codes.Unavailable
+
+	// INTERNAL indicates server encountered an unexpected condition that
+	// prevented it from fulfilling the request.
+	case 500: // Internal Server Error
+		return codes.Internal
+
+	// Unknown or all other errors
+	case 502: // Bad Gateway
+	default:
+		return codes.Unknown
+	}
+
+	return codes.Unknown
+}
+
 func NewUserError(err error, internalMessage string, externalMessage string) *UserError {
 	// Note apiError.Response is of type github.com/go-openapi/runtime/client
 	var apiError *runtime.APIError
 	if errors.As(err, &apiError) {
-		if apiError.Code == API_CODE_NOT_FOUND {
-			return newUserError(
-				errors.Wrapf(err, internalMessage),
-				fmt.Sprintf("%v: %v", externalMessage, "Resource not found"),
-				codes.Code(apiError.Code))
-		}
 		return newUserError(
 			errors.Wrapf(err, internalMessage),
-			fmt.Sprintf("%v. Raw error from the service: %v", externalMessage, err.Error()),
-			codes.Code(apiError.Code))
+			fmt.Sprintf("%v: %v", externalMessage, "Resource not found"),
+			convertHttpStatusToUserError(apiError.Code))
 	}
 
 	return newUserError(

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -5,7 +5,6 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	"github.com/go-openapi/runtime"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -83,96 +82,6 @@ func newUserError(internalError error, externalMessage string,
 		externalMessage:    externalMessage,
 		externalStatusCode: externalStatusCode,
 	}
-}
-
-func NewUserErrorWithSingleMessage(err error, message string) *UserError {
-	return NewUserError(err, message, message)
-}
-
-// Util function to convert HTTP status code to gRPC status code.
-func convertHttpStatusToUserError(httpStatusCode int) codes.Code {
-	switch httpStatusCode {
-	// Success and redirect responses
-	case 200, // OK
-		201, // Created
-		204, // No Content
-		206, // Partial Content
-		302, // Found
-		307, // Temporary Redirect
-		308: // Permanent Redirect
-		return codes.OK
-
-	// OUT_OF_RANGE indicates requested range is out of scope.
-	case 416: // Requested Range Not Satisfiable
-		return codes.OutOfRange
-
-	// INVALID_ARGUMENT indicates a problem with how the request is constructed.
-	case 400, // Bad Request
-		411, // Length Required
-		413: // Payload Too Large
-		return codes.InvalidArgument
-
-	// UNAUTHENTICATED indicates an authentication issue.
-	case 401: // Unauthorized
-		return codes.Unauthenticated
-
-	// PERMISSION_DENIED indicates an authorization issue.
-	case 403: // Forbidden
-		return codes.PermissionDenied
-
-	// NOT_FOUND indicates that the requested resource does not exist.
-	case 404, // Not Found
-		410: // Gone
-		return codes.NotFound
-
-	// FAILED_PRECONDITION indicates that the request failed because some
-	// of the underlying assumptions were not satisfied. The request
-	// shouldn't be retried unless the external context has changed.
-	case 303, // See Other
-		304, // Not Modified
-		409, // Conflict
-		412: // Precondition Failed
-		return codes.FailedPrecondition
-
-	// UNAVAILABLE indicates a problem that can go away if the request
-	// is just retried without any modification. 308 return codes are intended
-	// for write requests that can be retried. See the documentation and the
-	// official library:
-	// https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload
-	// https://github.com/google/apitools/blob/master/apitools/base/py/transfer.py
-	case 429, // Too Many Requests
-		503, // Service Unavailable
-		504: // Gateway Timeout
-		return codes.Unavailable
-
-	// INTERNAL indicates server encountered an unexpected condition that
-	// prevented it from fulfilling the request.
-	case 500: // Internal Server Error
-		return codes.Internal
-
-	// Unknown or all other errors
-	case 502: // Bad Gateway
-	default:
-		return codes.Unknown
-	}
-
-	return codes.Unknown
-}
-
-func NewUserError(err error, internalMessage string, externalMessage string) *UserError {
-	// Note apiError.Response is of type github.com/go-openapi/runtime/client
-	var apiError *runtime.APIError
-	if errors.As(err, &apiError) {
-		return newUserError(
-			errors.Wrapf(err, internalMessage),
-			fmt.Sprintf("%v: %v", externalMessage, "Resource not found"),
-			convertHttpStatusToUserError(apiError.Code))
-	}
-
-	return newUserError(
-		errors.Wrapf(err, internalMessage),
-		fmt.Sprintf("%v. Raw error from the service: %v", externalMessage, err.Error()),
-		codes.Internal)
 }
 
 func ExtractErrorForCLI(err error, isDebugMode bool) error {

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -14,19 +14,6 @@ import (
 
 type CustomCode uint32
 
-const (
-	CUSTOM_CODE_TRANSIENT CustomCode = 0
-	CUSTOM_CODE_PERMANENT CustomCode = 1
-	CUSTOM_CODE_NOT_FOUND CustomCode = 2
-	CUSTOM_CODE_GENERIC   CustomCode = 3
-)
-
-type APICode int
-
-const (
-	API_CODE_NOT_FOUND = 404
-)
-
 type CustomError struct {
 	error error
 	code  CustomCode

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -12,46 +12,6 @@ import (
 	k8metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type CustomCode uint32
-
-type CustomError struct {
-	error error
-	code  CustomCode
-}
-
-func NewCustomError(err error, code CustomCode, format string, a ...interface{}) *CustomError {
-	message := fmt.Sprintf(format, a...)
-	return &CustomError{
-		error: errors.Wrapf(err, "CustomError (code: %v): %v", code, message),
-		code:  code,
-	}
-}
-
-func NewCustomErrorf(code CustomCode, format string, a ...interface{}) *CustomError {
-	message := fmt.Sprintf(format, a...)
-	return &CustomError{
-		error: errors.Errorf("CustomError (code: %v): %v", code, message),
-		code:  code,
-	}
-}
-
-func (e *CustomError) Error() string {
-	return e.error.Error()
-}
-
-func HasCustomCode(err error, code CustomCode) bool {
-	if err == nil {
-		return false
-	}
-
-	var customErr *CustomError
-	if errors.As(err, &customErr) {
-		return customErr.code == code
-	}
-
-	return false
-}
-
 type UserError struct {
 	// Error for internal debugging.
 	internalError error


### PR DESCRIPTION
## Why are these changes needed?

**Update:**
Suggested by https://github.com/ray-project/kuberay/pull/3352#discussion_r2041273493, I remove unused code in the file.
I didn't do anything to `UserError` because all util functions seem intentionally implemented that way.

This is the linter complaint.
```sh
pkg/util/error.go:103:15: G115: integer overflow conversion int -> uint32 (gosec)
                                codes.Code(apiError.Code))
                                          ^
```
Linter complains because grpc code takes a uint32, while apiError.Code is a signed integer value;

A deeper look into both source code, openapi package is made for HTTP request, and API status code coming from:
https://github.com/go-openapi/runtime/blob/2bd21c899d267cc8aa9d49cefc5ad0e77de56da5/client_response.go#L77-L99
with code value representing http status code.

Here we're using grpc code, **so it's actually a bug**!
We need a function to map from http status code to grpc code.
The status translation from tensorflow gcs filesystem: https://github.com/tensorflow/tensorflow/blob/6f5ef47b4316ef0cb10d711d8de8903b3d6a28cd/third_party/xla/xla/tsl/platform/cloud/curl_http_request.cc#L469-L539.

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
