### PR TITLE
[Fix] RayCluster fails to transit Status.State to Ready when numOfHosts > 1

### DIFF
--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -221,19 +221,27 @@ type RayClusterStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// ReadyWorkerReplicas indicates how many worker replicas are ready in the cluster
+	// ReadyWorkerReplicas indicates the number of worker pods currently in the Ready state in the cluster.
+	// It actually reflects the number of Ready pods, although it is named "replicas" to maintain backward compatibility.
 	// +optional
 	ReadyWorkerReplicas int32 `json:"readyWorkerReplicas,omitempty"`
-	// AvailableWorkerReplicas indicates how many replicas are available in the cluster
+	// AvailableWorkerReplicas indicates how many worker pods are currently available (i.e., running).
+	// It is named "replicas" to maintain backward compatibility.
 	// +optional
 	AvailableWorkerReplicas int32 `json:"availableWorkerReplicas,omitempty"`
-	// DesiredWorkerReplicas indicates overall desired replicas claimed by the user at the cluster level.
+	// DesiredWorkerReplicas indicates the desired total number of worker Pods at the cluster level,
+	// calculated as the sum of `replicas * numOfHosts` for each worker group.
+	// It is named "replicas" to maintain backward compatibility.
 	// +optional
 	DesiredWorkerReplicas int32 `json:"desiredWorkerReplicas,omitempty"`
-	// MinWorkerReplicas indicates sum of minimum replicas of each node group.
+	// MinWorkerReplicas indicates the minimum number of worker pods across all worker groups,
+	// calculated as the sum of `minReplicas * numOfHosts` for each worker group.
+	// It is named "replicas" to maintain backward compatibility.
 	// +optional
 	MinWorkerReplicas int32 `json:"minWorkerReplicas,omitempty"`
-	// MaxWorkerReplicas indicates sum of maximum replicas of each node group.
+	// MaxWorkerReplicas indicates the maximum number of worker pods across all worker groups,
+	// calculated as the sum of `maxReplicas * numOfHosts` for each worker group.
+	// It is named "replicas" to maintain backward compatibility.
 	// +optional
 	MaxWorkerReplicas int32 `json:"maxWorkerReplicas,omitempty"`
 	// observedGeneration is the most recent generation observed for this RayCluster. It corresponds to the

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -708,8 +708,8 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 			continue
 		}
 		// workerReplicas will store the target number of pods for this worker group.
-		var workerReplicas int32 = utils.GetWorkerGroupDesiredReplicas(ctx, worker)
-		logger.Info("reconcilePods", "desired workerReplicas (always adhering to minReplicas/maxReplica)", workerReplicas, "worker group", worker.GroupName, "maxReplicas", worker.MaxReplicas, "minReplicas", worker.MinReplicas, "replicas", worker.Replicas)
+		numExpectedWorkerPods := int(utils.GetWorkerGroupDesiredReplicas(ctx, worker))
+		logger.Info("reconcilePods", "desired workerReplicas (always adhering to minReplicas/maxReplica)", numExpectedWorkerPods, "worker group", worker.GroupName, "maxReplicas", worker.MaxReplicas, "minReplicas", worker.MinReplicas, "replicas", worker.Replicas)
 
 		workerPods := corev1.PodList{}
 		if err := r.List(ctx, &workerPods, common.RayClusterGroupPodsAssociationOptions(instance, worker.GroupName).ToListOptions()...); err != nil {
@@ -791,10 +791,9 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		if worker.NumOfHosts <= 0 {
 			worker.NumOfHosts = 1
 		}
-		numExpectedPods := int(workerReplicas * worker.NumOfHosts)
-		diff := numExpectedPods - len(runningPods.Items)
+		diff := numExpectedWorkerPods - len(runningPods.Items)
 
-		logger.Info("reconcilePods", "workerReplicas", workerReplicas, "NumOfHosts", worker.NumOfHosts, "runningPods", len(runningPods.Items), "diff", diff)
+		logger.Info("reconcilePods", "workerReplicas", numExpectedWorkerPods, "NumOfHosts", worker.NumOfHosts, "runningPods", len(runningPods.Items), "diff", diff)
 
 		if diff > 0 {
 			// pods need to be added

--- a/ray-operator/test/sampleyaml/rayjob_test.go
+++ b/ray-operator/test/sampleyaml/rayjob_test.go
@@ -58,14 +58,14 @@ func TestRayJob(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			// Check if the RayCluster created correct number of pods
-			var desiredWorkerReplicas int32
+			var desiredWorkerPods int32
 			if rayCluster.Spec.WorkerGroupSpecs != nil {
 				for _, workerGroupSpec := range rayCluster.Spec.WorkerGroupSpecs {
-					desiredWorkerReplicas += *workerGroupSpec.Replicas
+					desiredWorkerPods += (*workerGroupSpec.Replicas * workerGroupSpec.NumOfHosts)
 				}
 			}
-			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutShort).Should(HaveLen(int(desiredWorkerReplicas)))
-			g.Expect(GetRayCluster(test, namespace.Name, rayCluster.Name)).To(WithTransform(RayClusterDesiredWorkerReplicas, Equal(desiredWorkerReplicas)))
+			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutShort).Should(HaveLen(int(desiredWorkerPods)))
+			g.Expect(GetRayCluster(test, namespace.Name, rayCluster.Name)).To(WithTransform(RayClusterDesiredWorkerReplicas, Equal(desiredWorkerPods)))
 
 			// Check if the head pod is ready
 			g.Eventually(HeadPod(test, rayCluster), TestTimeoutShort).Should(WithTransform(IsPodRunningAndReady, BeTrue()))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When I set workerGroupSpecs.numOfHosts greater than 1, such as 2, the raycluster fails to transit Status.State to Ready, which would block RayJob from submitting as a side effect.
<!-- Please give a short summary of the change and the problem this solves. -->
- In the `GetWorkerGroupDesiredReplicas`, `CalculateMinReplicas`, `CalculateMaxReplicas` function, I modified the way the count is calculated.
- Any other places that use `GetWorkerGroupDesiredReplicas` have also been updated.
- Refactored the `TestGetWorkerGroupDesiredReplicas`, `TestCalculateMinReplicas`, `TestCalculateMaxReplicas` test

### Manual Testing
Apply the following yaml file
- [Multi-Host ray cluster yaml](https://gist.github.com/CheyuWu/911a4868c10bfadbb86c872175ab00d3)
 

After applying the configuration, the result is shown below:
![image](https://github.com/user-attachments/assets/fae33218-f6f3-4c86-968d-502e4953cdb7)

- [multi-host.ray-cluster.volcano-scheduler-queue.yaml](https://gist.github.com/CheyuWu/4a8cb7efe81ad4e284e4e6ec41a305ef)
```yaml
status:
  availableWorkerReplicas: 4
  conditions:
  - lastTransitionTime: "2025-04-20T18:04:14Z"
    message: ""
    reason: HeadPodRunningAndReady
    status: "True"
    type: HeadPodReady
  - lastTransitionTime: "2025-04-20T18:04:29Z"
    message: All Ray Pods are ready for the first time
    reason: AllPodRunningAndReadyFirstTime
    status: "True"
    type: RayClusterProvisioned
  - lastTransitionTime: "2025-04-20T18:04:04Z"
    message: ""
    reason: RayClusterSuspended
    status: "False"
    type: RayClusterSuspended
  - lastTransitionTime: "2025-04-20T18:04:04Z"
    message: ""
    reason: RayClusterSuspending
    status: "False"
    type: RayClusterSuspending
  desiredCPU: "5"
  desiredGPU: "0"
  desiredMemory: 6Gi
  desiredTPU: "0"
  desiredWorkerReplicas: 4
  endpoints:
    client: "10001"
    dashboard: "8265"
    gcs-server: "6379"
    metrics: "8080"
    serve: "8000"
  head:
    podIP: 10.244.0.59
    podName: test-cluster-0-head
    serviceIP: 10.244.0.59
    serviceName: test-cluster-0-head-svc
  lastUpdateTime: "2025-04-20T18:04:29Z"
  maxWorkerReplicas: 12
  minWorkerReplicas: 2
  observedGeneration: 1
  readyWorkerReplicas: 4
  state: ready
  stateTransitionTimes:
    ready: "2025-04-20T18:04:29Z"
```
- [multi-host-tpu-v6e-slice.yaml](https://gist.github.com/CheyuWu/ce7929c5f2d9accf83b3b583fedca420)
This is the resource that I have allocated, single host tpu * 2

![image](https://github.com/user-attachments/assets/c96c2717-b94f-48e3-906d-b0a2867e47f9)

```yaml
status:
  availableWorkerReplicas: 3
  conditions:
  - lastTransitionTime: "2025-04-18T17:00:22Z"
    message: ""
    reason: HeadPodRunningAndReady
    status: "True"
    type: HeadPodReady
  - lastTransitionTime: "2025-04-18T17:00:27Z"
    message: All Ray Pods are ready for the first time
    reason: AllPodRunningAndReadyFirstTime
    status: "True"
    type: RayClusterProvisioned
  - lastTransitionTime: "2025-04-18T17:00:06Z"
    message: ""
    reason: RayClusterSuspended
    status: "False"
    type: RayClusterSuspended
  - lastTransitionTime: "2025-04-18T17:00:06Z"
    message: ""
    reason: RayClusterSuspending
    status: "False"
    type: RayClusterSuspending
  desiredCPU: "16"
  desiredGPU: "0"
  desiredMemory: 16G
  desiredTPU: "3"
  desiredWorkerReplicas: 3
  endpoints:
    client: "10001"
    dashboard: "8265"
    gcs: "6379"
    metrics: "8080"
    serve: "8000"
  head:
    podIP: 10.120.0.19
    podName: raycluster-tpu-v6e-singlehost-head
    serviceIP: 10.120.0.19
    serviceName: raycluster-tpu-v6e-singlehost-head-svc
  lastUpdateTime: "2025-04-18T17:00:27Z"
  maxWorkerReplicas: 12
  minWorkerReplicas: 3
  observedGeneration: 1
  readyWorkerReplicas: 3
  state: ready
  stateTransitionTimes:
```

## Related issue number
Closes #3274 
<!-- For example: "Closes #1234" -->
## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
