### PR TITLE
[apiserver] Add make command to start apiserver

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -54,6 +54,14 @@ all: build
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+##@ Deployment
+
+.PHONY: start-local-apiserver ## Build and start apiserver from scratch. 
+start-local-apiserver: operator-image cluster load-operator-image deploy-operator install run
+
+.PHONY: clean-local-apiserver ## Clear local apiserver.
+clear-local-apiserver: clean-cluster
+
 ##@ Development
 
 .PHONY:

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -56,7 +56,7 @@ help: ## Display this help.
 
 ##@ Deployment
 
-.PHONY: start-local-apiserver ## Build and start apiserver from scratch. 
+.PHONY: start-local-apiserver ## Build and start apiserver from scratch.
 start-local-apiserver: operator-image cluster load-operator-image deploy-operator install run
 
 .PHONY: clean-local-apiserver ## Clear local apiserver.

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -3,9 +3,8 @@
 
 The KubeRay APIServer provides gRPC and HTTP APIs to manage KubeRay resources.
 
-## Note
+## Introduction
 
-```text
 The KubeRay APIServer is an optional component. It provides a layer of simplified configuration for KubeRay resources. The KubeRay API server is used internally by some organizations to back user interfaces for KubeRay resource management.
 
 The KubeRay APIServer is community-managed and is not officially endorsed by the Ray maintainers. At this time, the only officially supported methods for
@@ -16,9 +15,35 @@ managing KubeRay resources are:
 
 KubeRay APIServer maintainer contacts (GitHub handles):
 @Jeffwan @scarlet25151
-```
 
 ## Installation
+
+### Start a local apiserver
+
+You could build and start apiserver from scratch on local environment in one simple command.
+```sh
+make start-local-apiserver
+```
+
+apiserver supports HTTP request, so you could easily check whether it's started successfully by by issuing two simple curl requests.
+```sh
+# Create complete template.
+curl --silent -X 'POST' \
+    'http://localhost:31888/apis/v1/namespaces/ray-system/compute_templates' \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "name": "default-template",
+        "namespace": "ray-system",
+        "cpu": 2,
+        "memory": 4
+      }'
+
+# Check whether compute template is created successfully.
+curl --silent -X 'GET' \
+    'http://localhost:31888/apis/v1/namespaces/ray-system/compute_templates' \
+    -H 'accept: application/json'
+```
 
 ### Helm
 

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -21,11 +21,13 @@ KubeRay APIServer maintainer contacts (GitHub handles):
 ### Start a local apiserver
 
 You could build and start apiserver from scratch on local environment in one simple command.
+
 ```sh
 make start-local-apiserver
 ```
 
 apiserver supports HTTP request, so you could easily check whether it's started successfully by by issuing two simple curl requests.
+
 ```sh
 # Create complete template.
 curl --silent -X 'POST' \
@@ -55,7 +57,7 @@ helm version
 
 ### Install KubeRay Operator
 
-* Install a stable version via Helm repository (only supports KubeRay v0.4.0+)
+- Install a stable version via Helm repository (only supports KubeRay v0.4.0+)
 
   ```sh
     # Install the KubeRay helm repo
@@ -77,7 +79,7 @@ Please note that examples show here will only work with the nightly builds of th
 to the api server that would allow Kuberay Serve endpoints to work properly
 ```
 
-* Install a stable version via Helm repository (only supports KubeRay v0.4.0+)
+- Install a stable version via Helm repository (only supports KubeRay v0.4.0+)
 
   ```sh
   # Install the KubeRay helm repo
@@ -93,7 +95,7 @@ to the api server that would allow Kuberay Serve endpoints to work properly
   # kuberay-operator-7456c6b69b-t6pt7                1/1     Running   0          172m
   ```
 
-* Install the nightly version
+- Install the nightly version
 
   ```sh
   # Step1: Clone KubeRay repository
@@ -105,7 +107,7 @@ to the api server that would allow Kuberay Serve endpoints to work properly
   helm install kuberay-apiserver .
   ```
 
-* Install the current (working branch) version
+- Install the current (working branch) version
 
   ```sh
   # Step1: Clone KubeRay repository
@@ -143,9 +145,9 @@ kubectl get pods
 
 After the deployment we may use the `{{baseUrl}}` to access the service. See [swagger support section](https://ray-project.github.io/kuberay/components/apiserver/#swagger-support) to get the complete definitions of APIs.
 
-* (default) for nodeport access, use port `31888` for connection
+- (default) for nodeport access, use port `31888` for connection
 
-* for ingress access, you will need to create your own ingress
+- for ingress access, you will need to create your own ingress
 
 The requests parameters detail can be seen in [KubeRay swagger](https://github.com/ray-project/kuberay/tree/master/proto/swagger), this document only presents basic examples.
 
@@ -217,9 +219,9 @@ The following steps allow you to validate that the KubeRay API Server components
 
 Kuberay API server has support for Swagger UI. The swagger page can be reached at:
 
-* [localhost:31888/swagger-ui](localhost:31888/swagger-ui) for local kind deployments
-* [localhost:8888/swagger-ui](localhost:8888/swagger-ui) for instances started with `make run` (development machine builds)
-* `<host name>:31888/swagger-ui` for nodeport deployments
+- [localhost:31888/swagger-ui](localhost:31888/swagger-ui) for local kind deployments
+- [localhost:8888/swagger-ui](localhost:8888/swagger-ui) for instances started with `make run` (development machine builds)
+- `<host name>:31888/swagger-ui` for nodeport deployments
 
 ## HTTP definition endpoints
 

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -20,7 +20,7 @@ KubeRay APIServer maintainer contacts (GitHub handles):
 
 ### Start a local apiserver
 
-You could build and start apiserver from scratch on local environment in one simple command.
+You could build and start apiserver from scratch on your local environment in one simple command. It will deploy all the necessities to a local kind cluster.
 
 ```sh
 make start-local-apiserver

--- a/apiserver/cmd/main.go
+++ b/apiserver/cmd/main.go
@@ -71,7 +71,7 @@ func main() {
 type RegisterHttpHandlerFromEndpoint func(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error
 
 func startRPCServer(resourceManager *manager.ResourceManager) {
-	klog.Info("Starting gRPC server")
+	klog.Infof("Starting gRPC server at port %s", *rpcPortFlag)
 
 	listener, err := net.Listen("tcp", *rpcPortFlag)
 	if err != nil {
@@ -109,7 +109,7 @@ func startRPCServer(resourceManager *manager.ResourceManager) {
 }
 
 func startHttpProxy() {
-	klog.Info("Starting Http Proxy")
+	klog.Infof("Starting Http Proxy at port %s", *httpPortFlag)
 
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
## Why are these changes needed?

Part of https://github.com/ray-project/kuberay/issues/3327.

I personally think current readme is not clear as an entrypoint, something I expect:
- An introduction on apiserver, what's the feature set, how does it correlate to other components, etc
- A simple command to launch and play with apiserver
  + There're too many commands apiserver development page
- Hyperlink to other useful resources, for example, HTTP endpoint spec

This PR tries to improve (2).

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
