### PR TITLE
Api server refactor/allow multiple job statuses in jobe2e

### DIFF
--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -5,10 +5,9 @@ import (
 	"time"
 
 	api "github.com/ray-project/kuberay/proto/go_client"
+	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	"github.com/stretchr/testify/require"
-
-	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
 // TestCreateClusterAutoscalerEndpoint sequentially iterates over the create cluster endpoint

--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -118,7 +118,7 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
-	waitForRayJob(t, tCtx, createActorRequest.Job.Name, rayv1api.JobStatusSucceeded)
+	waitForRayJob(t, tCtx, createActorRequest.Job.Name, []rayv1api.JobStatus{rayv1api.JobStatusSucceeded})
 
 	// worker pod should be created as part of job execution
 	time.Sleep(20 * time.Second)
@@ -145,7 +145,7 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
-	waitForRayJob(t, tCtx, createActorRequest.Job.Name, rayv1api.JobStatusSucceeded)
+	waitForRayJob(t, tCtx, createActorRequest.Job.Name, []rayv1api.JobStatus{rayv1api.JobStatusSucceeded})
 
 	// Sleep for a while to ensure that the worker pod is deleted
 	time.Sleep(100 * time.Second)

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -9,12 +9,11 @@ import (
 
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
+	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
 // TestCreateClusterEndpoint sequentially iterates over the create cluster endpoint

--- a/apiserver/test/e2e/config_server_e2e_test.go
+++ b/apiserver/test/e2e/config_server_e2e_test.go
@@ -7,6 +7,7 @@ import (
 
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
 	"golang.org/x/exp/slices"
 
 	"github.com/stretchr/testify/assert"

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -7,16 +7,14 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/exp/slices"
+	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
+	api "github.com/ray-project/kuberay/proto/go_client"
+	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
-	api "github.com/ray-project/kuberay/proto/go_client"
-
-	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
 func TestCreateJobWithDisposableClusters(t *testing.T) {
@@ -572,6 +570,7 @@ func TestCreateJobWithClusterSelector(t *testing.T) {
 }
 
 func createTestJob(t *testing.T, tCtx *End2EndTestingContext, expectedJobStatues []rayv1api.JobStatus) *api.CreateRayJobRequest {
+	// expectedJobStatuses is a slice of job statuses that we expect the job to be in
 	// create config map and register a cleanup hook upon success
 	configMapName := tCtx.CreateConfigMap(t, map[string]string{
 		"counter_sample.py": ReadFileAsString(t, "resources/counter_sample.py"),
@@ -643,7 +642,8 @@ func createTestJob(t *testing.T, tCtx *End2EndTestingContext, expectedJobStatues
 }
 
 func waitForRayJob(t *testing.T, tCtx *End2EndTestingContext, rayJobName string, expectedJobStatuses []rayv1api.JobStatus) {
-	// wait for the job to be in a JobStatusSucceeded state for 3 minutes
+	// expectedJobStatuses is a slice of job statuses that we expect the job to be in
+	// wait for the job to be in any of the expectedJobStatuses state for 3 minutes
 	// if is not in that state, return an error
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
 		rayJob, err00 := tCtx.GetRayJobByName(rayJobName)

--- a/apiserver/test/e2e/job_submission_e2e_test.go
+++ b/apiserver/test/e2e/job_submission_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	api "github.com/ray-project/kuberay/proto/go_client"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -8,11 +8,11 @@ import (
 
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
+	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
 // TestServiceServerV2 sequentially iterates over the endpoints of the service endpoints using

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -12,19 +12,19 @@ import (
 	petnames "github.com/dustinkirkland/golang-petname"
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
+	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-
-	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	rayv1 "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1"
 )
 
 // GenericEnd2EndTest struct allows for reuse in setting up and running tests


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
#3354 

## Test result for `job_server_e2e_test`
**TLDR; ~6.28x Speedup!**
### Before changes
```log
=== RUN   TestCreateJobWithDisposableClusters
=== RUN   TestCreateJobWithDisposableClusters/Create_a_running_sample_job
=== RUN   TestCreateJobWithDisposableClusters/Create_a_failing_sample_job
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_without_providing_a_namespace
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_with_nil_job_spec
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_with_no_namespace_in_the_job_spec
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_with_no_name
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_with_no_user_name
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_with_entrypoint
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_with_nil_cluster_spec
--- PASS: TestCreateJobWithDisposableClusters (141.13s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_running_sample_job (78.12s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_failing_sample_job (62.76s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_without_providing_a_namespace (0.00s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_with_nil_job_spec (0.00s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_with_no_namespace_in_the_job_spec (0.00s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_with_no_name (0.00s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_with_no_user_name (0.00s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_with_entrypoint (0.00s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_with_nil_cluster_spec (0.00s)
=== RUN   TestDeleteJob
=== RUN   TestDeleteJob/Delete_an_existing_job
=== RUN   TestDeleteJob/Delete_a_non_existing_job
=== RUN   TestDeleteJob/Delete_a_job_without_providing_a_namespace
--- PASS: TestDeleteJob (80.89s)
    --- PASS: TestDeleteJob/Delete_an_existing_job (0.58s)
    --- PASS: TestDeleteJob/Delete_a_non_existing_job (0.01s)
    --- PASS: TestDeleteJob/Delete_a_job_without_providing_a_namespace (0.00s)
=== RUN   TestGetAllJobs
=== RUN   TestGetJobByPaginationInNamespace/Test_pagination_return_part_of_the_result_jobs
=== RUN   TestGetJobByPaginationInNamespace/Test_pagination_return_all_jobs
=== RUN   TestGetJobByPaginationInNamespace/Test_no_pagination
=== NAME  TestGetJobByPaginationInNamespace
--- PASS: TestGetJobByPaginationInNamespace (792.07s)
    --- PASS: TestGetJobByPaginationInNamespace/Test_pagination_return_part_of_the_result_jobs (0.36s)
    --- PASS: TestGetJobByPaginationInNamespace/Test_pagination_return_all_jobs (0.11s)
    --- PASS: TestGetJobByPaginationInNamespace/Test_no_pagination (0.09s)
=== RUN   TestGetJob
=== RUN   TestGetJob/Get_job_by_name_in_a_namespace
=== RUN   TestGetJob/Get_non_existing_job
=== RUN   TestGetJob/Get_a_job_with_no_Name
=== RUN   TestGetJob/Get_a_job_with_no_namespace
--- PASS: TestGetJob (72.85s)
    --- PASS: TestGetJob/Get_job_by_name_in_a_namespace (0.02s)
    --- PASS: TestGetJob/Get_non_existing_job (0.01s)
    --- PASS: TestGetJob/Get_a_job_with_no_Name (0.00s)
    --- PASS: TestGetJob/Get_a_job_with_no_namespace (0.00s)
=== RUN   TestCreateJobWithClusterSelector
=== RUN   TestCreateJobWithClusterSelector/Submit_a_correct_job_on_an_already_running_cluster
=== RUN   TestCreateJobWithClusterSelector/Submit_a_failing_job_on_an_already_running_cluster
--- PASS: TestCreateJobWithClusterSelector (105.33s)
    --- PASS: TestCreateJobWithClusterSelector/Submit_a_correct_job_on_an_already_running_cluster (41.64s)
    --- PASS: TestCreateJobWithClusterSelector/Submit_a_failing_job_on_an_already_running_cluster (11.60s)
PASS
ok  	github.com/ray-project/kuberay/apiserver/test/e2e	1357.052s

```
### After changes
```log
=== RUN   TestCreateJobWithDisposableClusters
=== RUN   TestCreateJobWithDisposableClusters/Create_a_running_sample_job
=== RUN   TestCreateJobWithDisposableClusters/Create_a_failing_sample_job
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_without_providing_a_namespace
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_with_nil_job_spec
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_with_no_namespace_in_the_job_spec
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_with_no_name
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_with_no_user_name
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_with_entrypoint
=== RUN   TestCreateJobWithDisposableClusters/Create_a_job_request_with_nil_cluster_spec
--- PASS: TestCreateJobWithDisposableClusters (102.51s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_running_sample_job (58.73s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_failing_sample_job (42.65s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_without_providing_a_namespace (0.00s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_with_nil_job_spec (0.00s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_with_no_namespace_in_the_job_spec (0.00s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_with_no_name (0.00s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_with_no_user_name (0.00s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_with_entrypoint (0.00s)
    --- PASS: TestCreateJobWithDisposableClusters/Create_a_job_request_with_nil_cluster_spec (0.00s)
=== RUN   TestDeleteJob
=== RUN   TestDeleteJob/Delete_an_existing_job
=== RUN   TestDeleteJob/Delete_a_non_existing_job
=== RUN   TestDeleteJob/Delete_a_job_without_providing_a_namespace
--- PASS: TestDeleteJob (1.93s)
    --- PASS: TestDeleteJob/Delete_an_existing_job (0.54s)
    --- PASS: TestDeleteJob/Delete_a_non_existing_job (0.01s)
    --- PASS: TestDeleteJob/Delete_a_job_without_providing_a_namespace (0.00s)
=== RUN   TestGetAllJobs
--- PASS: TestGetAllJobs (1.77s)
=== RUN   TestGetJobsInNamespace
--- PASS: TestGetJobsInNamespace (2.86s)
=== RUN   TestGetJobByPaginationInNamespace
=== RUN   TestGetJobByPaginationInNamespace/Test_pagination_return_part_of_the_result_jobs
=== RUN   TestGetJobByPaginationInNamespace/Test_pagination_return_all_jobs
=== RUN   TestGetJobByPaginationInNamespace/Test_no_pagination
--- PASS: TestGetJobByPaginationInNamespace (15.16s)
    --- PASS: TestGetJobByPaginationInNamespace/Test_pagination_return_part_of_the_result_jobs (0.16s)
    --- PASS: TestGetJobByPaginationInNamespace/Test_pagination_return_all_jobs (0.14s)
    --- PASS: TestGetJobByPaginationInNamespace/Test_no_pagination (0.18s)
=== RUN   TestGetJob
=== RUN   TestGetJob/Get_job_by_name_in_a_namespace
=== RUN   TestGetJob/Get_non_existing_job
=== RUN   TestGetJob/Get_a_job_with_no_Name
=== RUN   TestGetJob/Get_a_job_with_no_namespace
--- PASS: TestGetJob (1.31s)
    --- PASS: TestGetJob/Get_job_by_name_in_a_namespace (0.01s)
    --- PASS: TestGetJob/Get_non_existing_job (0.01s)
    --- PASS: TestGetJob/Get_a_job_with_no_Name (0.00s)
    --- PASS: TestGetJob/Get_a_job_with_no_namespace (0.00s)
=== RUN   TestCreateJobWithClusterSelector
=== RUN   TestCreateJobWithClusterSelector/Submit_a_correct_job_on_an_already_running_cluster
=== RUN   TestCreateJobWithClusterSelector/Submit_a_failing_job_on_an_already_running_cluster
--- PASS: TestCreateJobWithClusterSelector (89.59s)
    --- PASS: TestCreateJobWithClusterSelector/Submit_a_correct_job_on_an_already_running_cluster (30.63s)
    --- PASS: TestCreateJobWithClusterSelector/Submit_a_failing_job_on_an_already_running_cluster (13.11s)
PASS
ok  	github.com/ray-project/kuberay/apiserver/test/e2e	216.238s

```
## Approach 
As written in issue #3354, we observe that the time spend on e2e test is mostly waiting for created rayCRs to be ready. However for most tests in apiserver, we don't actually need to wait for the job to be succeeded. 

In `waitForRayJob` & `createTestJob` we now use `expectedJobStatues []rayv1api.JobStatus` instead of the original ` expectedJobStatus rayv1api.JobStatus` to allow more job status to be seen as accepted when waiting.

e.g. 
```go
createTestJob(t, tCtx, []rayv1api.JobStatus{rayv1api.JobStatusNew, rayv1api.JobStatusPending, rayv1api.JobStatusRunning, rayv1api.JobStatusSucceeded})
```
Means that the this accept JobStatusNew, JobStatusPending, JobStatusRunning, JobStatusSucceeded when creating so they can proceed to next step when RayJob are in any of these statues.

After these changes the test won't have to wait until the job to get ready, this speed up a lot especially in tests that need to create many CRs.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #3354 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
