### PR TITLE
[apiserver] Enable golang linter for apiserver

### DIFF
--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -17,9 +17,14 @@ import (
 )
 
 type KuberayAPIServerClient struct {
-	httpClient         *http.Client
-	marshaler          *protojson.MarshalOptions
-	unmarshaler        *protojson.UnmarshalOptions
+	httpClient  *http.Client
+	marshaler   *protojson.MarshalOptions
+	unmarshaler *protojson.UnmarshalOptions
+	// TODO(hjiang): here we use function to allow customized http request handling logic in unit test, worth revisiting if there're better ways;
+	// for example, (1) wrap an interface to process request; (2) inject round-trip logic into http client.
+	// See https://github.com/ray-project/kuberay/pull/3334/files#r2041183495 for details.
+	//
+	// Store http request handling function for unit test purpose.
 	executeHttpRequest func(httpRequest *http.Request, URL string) ([]byte, *rpcStatus.Status, error)
 	baseURL            string
 }

--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -17,17 +17,11 @@ import (
 )
 
 type KuberayAPIServerClient struct {
-	httpClient  *http.Client
-	marshaler   *protojson.MarshalOptions
-	unmarshaler *protojson.UnmarshalOptions
-	baseURL     string
-
-	// TODO(hjiang): here we use function to allow customized http request handling logic in unit test, worth revisiting if there're better ways;
-	// for example, (1) wrap an interface to process request; (2) inject round-trip logic into http client.
-	// See https://github.com/ray-project/kuberay/pull/3334/files#r2041183495 for details.
-	//
-	// Store http request handling function for unit test purpose.
+	httpClient         *http.Client
+	marshaler          *protojson.MarshalOptions
+	unmarshaler        *protojson.UnmarshalOptions
 	executeHttpRequest func(httpRequest *http.Request, URL string) ([]byte, *rpcStatus.Status, error)
+	baseURL            string
 }
 
 type KuberayAPIServerClientError struct {

--- a/apiserver/pkg/http/client_test.go
+++ b/apiserver/pkg/http/client_test.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"net/http"
-	"strings"
 	"testing"
 
 	api "github.com/ray-project/kuberay/proto/go_client"
@@ -12,7 +11,7 @@ import (
 
 func TestUnmarshalHttpResponseOK(t *testing.T) {
 	client := NewKuberayAPIServerClient("baseurl", nil /*httpClient*/)
-	client.executeHttpRequest = func(httpRequest *http.Request, URL string) ([]byte, *rpcStatus.Status, error) {
+	client.executeHttpRequest = func(_ *http.Request, _ string) ([]byte, *rpcStatus.Status, error) {
 		resp := &api.ListClustersResponse{
 			Clusters: []*api.Cluster{
 				{
@@ -32,7 +31,7 @@ func TestUnmarshalHttpResponseOK(t *testing.T) {
 	require.Nil(t, status)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Clusters)
-	require.Equal(t, 1, len(resp.Clusters))
+	require.Len(t, resp.Clusters, 1)
 	require.Equal(t, "test-cluster", resp.Clusters[0].Name)
 	require.Equal(t, "test-namespace", resp.Clusters[0].Namespace)
 }
@@ -40,7 +39,7 @@ func TestUnmarshalHttpResponseOK(t *testing.T) {
 // Unmarshal response fails and check error returned.
 func TestUnmarshalHttpResponseFails(t *testing.T) {
 	client := NewKuberayAPIServerClient("baseurl", nil /*httpClient*/)
-	client.executeHttpRequest = func(httpRequest *http.Request, URL string) ([]byte, *rpcStatus.Status, error) {
+	client.executeHttpRequest = func(_ *http.Request, _ string) ([]byte, *rpcStatus.Status, error) {
 		// Intentionall returning a bad response.
 		return []byte("helloworld"), nil, nil
 	}
@@ -49,7 +48,7 @@ func TestUnmarshalHttpResponseFails(t *testing.T) {
 	resp, status, err := client.ListClusters(req)
 	require.Nil(t, status)
 	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "failed to unmarshal"), err.Error())
+	require.Contains(t, err.Error(), "failed to unmarshal", err.Error())
 	require.Nil(t, resp)
 }
 

--- a/apiserver/pkg/util/cluster_test.go
+++ b/apiserver/pkg/util/cluster_test.go
@@ -637,9 +637,9 @@ func TestGetNodeHostIP(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		addresses   []corev1.NodeAddress
 		expectIP    string
 		expectError string
+		addresses   []corev1.NodeAddress
 	}{
 		{
 			name: "InternalOnly",
@@ -684,7 +684,7 @@ func TestGetNodeHostIP(t *testing.T) {
 			if tc.expectError != "" {
 				assert.EqualError(t, err, tc.expectError)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tc.expectIP, ip.String())
 			}
 		})

--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	api "github.com/ray-project/kuberay/proto/go_client"
+
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	"github.com/stretchr/testify/require"

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -9,6 +9,7 @@ import (
 
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
+
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	"github.com/stretchr/testify/assert"

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -9,6 +9,7 @@ import (
 
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
+
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	"github.com/stretchr/testify/assert"

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -8,6 +8,7 @@ import (
 
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
+
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	"github.com/stretchr/testify/assert"

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -12,12 +12,13 @@ import (
 	petnames "github.com/dustinkirkland/golang-petname"
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
-	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	rayv1 "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-# TODO(hjiang): Enable linter for apiserver after all issues addressed.
 dirs_to_lint="ray-operator kubectl-plugin apiserver"
 
 for dir in $dirs_to_lint; do

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # TODO(hjiang): Enable linter for apiserver after all issues addressed.
-dirs_to_lint="ray-operator kubectl-plugin"
+dirs_to_lint="ray-operator kubectl-plugin apiserver"
 
 for dir in $dirs_to_lint; do
   pushd "$dir"


### PR DESCRIPTION
## Why are these changes needed?

All noticeable linter issues fixed, this PR enables precommit hook for the whole apiserver.

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/3302

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
