### PR TITLE
[apiserver] Delete resource manager interface

### DIFF
--- a/apiserver/pkg/manager/resource_manager.go
+++ b/apiserver/pkg/manager/resource_manager.go
@@ -19,33 +19,6 @@ import (
 
 const DefaultNamespace = "ray-system"
 
-// ResourceManagerInterface can be used by services to operate resources
-// kubernetes objects and potential db objects underneath operations should be encapsulated at this layer
-type ResourceManagerInterface interface {
-	CreateCluster(ctx context.Context, apiCluster *api.Cluster) (*rayv1api.RayCluster, error)
-	GetCluster(ctx context.Context, clusterName string, namespace string) (*rayv1api.RayCluster, error)
-	ListClusters(ctx context.Context, namespace string) ([]*rayv1api.RayCluster, error)
-	ListAllClusters(ctx context.Context) ([]*rayv1api.RayCluster, error)
-	DeleteCluster(ctx context.Context, clusterName string, namespace string) error
-	CreateComputeTemplate(ctx context.Context, runtime *api.ComputeTemplate) (*corev1.ConfigMap, error)
-	GetComputeTemplate(ctx context.Context, name string, namespace string) (*corev1.ConfigMap, error)
-	ListComputeTemplates(ctx context.Context, namespace string) ([]*corev1.ConfigMap, error)
-	DeleteComputeTemplate(ctx context.Context, name string, namespace string) error
-	CreateJob(ctx context.Context, apiJob *api.RayJob) (*rayv1api.RayJob, error)
-	GetJob(ctx context.Context, jobName string, namespace string) (*rayv1api.RayJob, error)
-	ListJobs(ctx context.Context, namespace string) ([]*rayv1api.RayJob, error)
-	ListAllJobs(ctx context.Context) ([]*rayv1api.RayJob, error)
-	DeleteJob(ctx context.Context, jobName string, namespace string) error
-	CreateService(ctx context.Context, apiService *api.RayService) (*rayv1api.RayService, error)
-	UpdateRayService(ctx context.Context, request *api.UpdateRayServiceRequest) (*rayv1api.RayService, error)
-	GetService(ctx context.Context, serviceName, namespace string) error
-	ListServices(ctx context.Context, namespace string) ([]*rayv1api.RayService, error)
-	ListAllServices(ctx context.Context) ([]*rayv1api.RayService, error)
-	DeleteService(ctx context.Context, serviceName, namespace string) error
-	GetClusterEvents(ctx context.Context, clusterName string, namespace string) ([]corev1.Event, error)
-	GetServiceEvents(ctx context.Context, service rayv1api.RayService) ([]corev1.Event, error)
-}
-
 type ResourceManager struct {
 	clientManager ClientManagerInterface
 }


### PR DESCRIPTION
## Why are these changes needed?

I found resource manager interface is out of sync with its implementation; for example, we recently add pagination to a bunch of list operations, but they're not reflected in interface, nor it breaks CI and local test => the interface is not used anywhere.

Usually these interfaces are used as a way to do dependency injection, but I checked where the resource manager is used, the logic looks simple so I don't think it's really worthwhile.

There're two ways proposed here to fix the inconsistency and prevent later breakage:
- We use `ResourceManagerInterface` everywhere as data member type;
- We delete the interface declaration.

I took the second path in the PR because:
(1) (major) As I mentioned above, I don't think unit test is a must-have here, considering we already have integration test coverage;
(2) (minor) Interface, compared with concrete type, hurts performance.

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/3369

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
