### PR TITLE
Api server refactor/allow multiple job statuses in servicee2e

### DIFF
--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -659,7 +659,7 @@ func TestCreateJobWithClusterSelector(t *testing.T) {
 }
 
 func createTestJob(t *testing.T, tCtx *End2EndTestingContext, expectedJobStatues []rayv1api.JobStatus) *api.CreateRayJobRequest {
-	// expectedJobStatuses is a slice of job statuses that we expect the job to be in
+	// `expectedJobStatues` is a slice of job statuses that we expect the job to be in
 	// create config map and register a cleanup hook upon success
 	configMapName := tCtx.CreateConfigMap(t, map[string]string{
 		"counter_sample.py": ReadFileAsString(t, "resources/counter_sample.py"),
@@ -731,8 +731,8 @@ func createTestJob(t *testing.T, tCtx *End2EndTestingContext, expectedJobStatues
 }
 
 func waitForRayJob(t *testing.T, tCtx *End2EndTestingContext, rayJobName string, expectedJobStatuses []rayv1api.JobStatus) {
-	// expectedJobStatuses is a slice of job statuses that we expect the job to be in
-	// wait for the job to be in any of the expectedJobStatuses state for 3 minutes
+	// `expectedJobStatuses` is a slice of job statuses that we expect the job to be in
+	// wait for the job to be in any of the `expectedJobStatuses` state for 3 minutes
 	// if is not in that state, return an error
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
 		rayJob, err := tCtx.GetRayJobByName(rayJobName)

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -367,7 +367,16 @@ func createTestServiceV2(t *testing.T, tCtx *End2EndTestingContext) *api.CreateR
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualService, "A service is expected")
 
+	// Check if the service was created successfully
+	checkRayServiceCreatedSuccessfully(t, tCtx, actualService.Name)
+
 	return testServiceRequest
+}
+
+func checkRayServiceCreatedSuccessfully(t *testing.T, tCtx *End2EndTestingContext, serviceName string) {
+	rayService, err := tCtx.GetRayServiceByName(serviceName)
+	require.NoError(t, err, "No error expected")
+	require.NotNil(t, rayService, "A service is expected")
 }
 
 func waitForDeletedService(t *testing.T, tCtx *End2EndTestingContext, serviceName string) {

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -384,8 +385,9 @@ func waitForRayService(t *testing.T, tCtx *End2EndTestingContext, serviceName st
 		if err != nil {
 			return true, err
 		}
-		t.Logf("Found status of '%s' for ray service '%s'", rayService.Status.Conditions[0].Status, serviceName)
-		return slices.Contains(expectedServiceConditionStatus, rayService.Status.Conditions[0].Status), nil
+		condition := meta.FindStatusCondition(rayService.Status.Conditions, "Ready")
+		t.Logf("Found status of '%s' for ray service '%s'", condition.Status, serviceName)
+		return slices.Contains(expectedServiceConditionStatus, condition.Status), nil
 	})
 	require.NoErrorf(t, err, "No error expected when getting ray service: '%s', err %v", serviceName, err)
 }

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -367,7 +367,6 @@ func createTestServiceV2(t *testing.T, tCtx *End2EndTestingContext) *api.CreateR
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualService, "A service is expected")
 
-	// Check if the service was created successfully
 	checkRayServiceCreatedSuccessfully(t, tCtx, actualService.Name)
 
 	return testServiceRequest
@@ -375,8 +374,8 @@ func createTestServiceV2(t *testing.T, tCtx *End2EndTestingContext) *api.CreateR
 
 func checkRayServiceCreatedSuccessfully(t *testing.T, tCtx *End2EndTestingContext, serviceName string) {
 	rayService, err := tCtx.GetRayServiceByName(serviceName)
-	require.NoError(t, err, "No error expected")
-	require.NotNil(t, rayService, "A service is expected")
+	require.NoError(t, err)
+	require.NotNil(t, rayService)
 }
 
 func waitForDeletedService(t *testing.T, tCtx *End2EndTestingContext, serviceName string) {

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -377,8 +377,8 @@ func createTestServiceV2(t *testing.T, tCtx *End2EndTestingContext, expectedServ
 }
 
 func waitForRayService(t *testing.T, tCtx *End2EndTestingContext, serviceName string, expectedServiceStatues []rayv1api.ServiceStatus) {
-	// expectedServiceStatues is a slice of service statuses that we expect the service to be in
-	// wait for the service to be in a running state for 3 minutes
+	// `expectedServiceStatues` is a slice of service statuses that we expect the service to be in
+	// wait for the service to be in any of the `expectedServiceStatues` state for 3 minutes
 	// if is not in that state, return an error
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
 		rayService, err := tCtx.GetRayServiceByName(serviceName)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

For detail please refer to #3354
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Result 

### TL, DR; ~24.19x speedup!

### Before
```log
=== RUN   TestCreateServiceV2
=== RUN   TestCreateServiceV2/Create_a_fruit_stand_ray_service_using_V2_configuration
=== RUN   TestCreateServiceV2/Create_a_service_request_with_no_namespace_value
=== RUN   TestCreateServiceV2/Create_a_service_request_with_mismatching_namespaces
=== RUN   TestCreateServiceV2/Create_a_service_request_with_no_name
=== RUN   TestCreateServiceV2/Create_a_service_request_with_no_user
=== RUN   TestCreateServiceV2/Create_a_service_request_with_no_cluster_spec
--- PASS: TestCreateServiceV2 (43.18s)
    --- PASS: TestCreateServiceV2/Create_a_fruit_stand_ray_service_using_V2_configuration (42.81s)
    --- PASS: TestCreateServiceV2/Create_a_service_request_with_no_namespace_value (0.00s)
    --- PASS: TestCreateServiceV2/Create_a_service_request_with_mismatching_namespaces (0.00s)
    --- PASS: TestCreateServiceV2/Create_a_service_request_with_no_name (0.00s)
    --- PASS: TestCreateServiceV2/Create_a_service_request_with_no_user (0.00s)
    --- PASS: TestCreateServiceV2/Create_a_service_request_with_no_cluster_spec (0.00s)
=== RUN   TestDeleteService
=== RUN   TestDeleteService/Delete_an_existing_service
=== RUN   TestDeleteService/Delete_a_non_existing_service
=== RUN   TestDeleteService/Delete_a_service_without_providing_a_namespace
--- PASS: TestDeleteService (42.83s)
    --- PASS: TestDeleteService/Delete_an_existing_service (0.58s)
    --- PASS: TestDeleteService/Delete_a_non_existing_service (0.01s)
    --- PASS: TestDeleteService/Delete_a_service_without_providing_a_namespace (0.00s)
=== RUN   TestGetAllServices
--- PASS: TestGetAllServices (37.60s)
=== RUN   TestGetServicesInNamespace
--- PASS: TestGetServicesInNamespace (43.55s)
=== RUN   TestGetService
=== RUN   TestGetService/Get_job_by_name_in_a_namespace
=== RUN   TestGetService/Get_non_existing_job
=== RUN   TestGetService/Get_a_job_with_no_Name
=== RUN   TestGetService/Get_a_job_with_no_namespace
--- PASS: TestGetService (42.34s)
    --- PASS: TestGetService/Get_job_by_name_in_a_namespace (0.05s)
    --- PASS: TestGetService/Get_non_existing_job (0.01s)
    --- PASS: TestGetService/Get_a_job_with_no_Name (0.00s)
    --- PASS: TestGetService/Get_a_job_with_no_namespace (0.00s)
PASS
ok  	github.com/ray-project/kuberay/apiserver/test/e2e	210.587s
```

```log
go test -v ./test/e2e/...  -timeout 60m  -race -coverprofile ray-kube-api-server-e2e-coverage.out  -count=1 -parallel 4
=== RUN   TestCreateServiceV2
=== RUN   TestCreateServiceV2/Create_a_fruit_stand_ray_service_using_V2_configuration
    service_server_e2e_test.go:390: Found status of 'False' for ray service 'reptile'
=== RUN   TestCreateServiceV2/Create_a_service_request_with_no_namespace_value
=== RUN   TestCreateServiceV2/Create_a_service_request_with_mismatching_namespaces
=== RUN   TestCreateServiceV2/Create_a_service_request_with_no_name
=== RUN   TestCreateServiceV2/Create_a_service_request_with_no_user
=== RUN   TestCreateServiceV2/Create_a_service_request_with_no_cluster_spec
--- PASS: TestCreateServiceV2 (1.53s)
    --- PASS: TestCreateServiceV2/Create_a_fruit_stand_ray_service_using_V2_configuration (1.14s)
    --- PASS: TestCreateServiceV2/Create_a_service_request_with_no_namespace_value (0.00s)
    --- PASS: TestCreateServiceV2/Create_a_service_request_with_mismatching_namespaces (0.00s)
    --- PASS: TestCreateServiceV2/Create_a_service_request_with_no_name (0.00s)
    --- PASS: TestCreateServiceV2/Create_a_service_request_with_no_user (0.00s)
    --- PASS: TestCreateServiceV2/Create_a_service_request_with_no_cluster_spec (0.00s)
=== RUN   TestDeleteService
    service_server_e2e_test.go:390: Found status of 'False' for ray service 'cockatoo'
=== RUN   TestDeleteService/Delete_an_existing_service
=== RUN   TestDeleteService/Delete_a_non_existing_service
=== RUN   TestDeleteService/Delete_a_service_without_providing_a_namespace
--- PASS: TestDeleteService (1.31s)
    --- PASS: TestDeleteService/Delete_an_existing_service (0.54s)
    --- PASS: TestDeleteService/Delete_a_non_existing_service (0.01s)
    --- PASS: TestDeleteService/Delete_a_service_without_providing_a_namespace (0.00s)
=== RUN   TestGetAllServices
    service_server_e2e_test.go:390: Found status of 'False' for ray service 'stork'
--- PASS: TestGetAllServices (3.01s)
=== RUN   TestGetServicesInNamespace
    service_server_e2e_test.go:390: Found status of 'False' for ray service 'mole'
--- PASS: TestGetServicesInNamespace (1.57s)
=== RUN   TestGetService
    service_server_e2e_test.go:390: Found status of 'False' for ray service 'seahorse'
=== RUN   TestGetService/Get_job_by_name_in_a_namespace
=== RUN   TestGetService/Get_non_existing_job
=== RUN   TestGetService/Get_a_job_with_no_Name
=== RUN   TestGetService/Get_a_job_with_no_namespace
--- PASS: TestGetService (1.37s)
    --- PASS: TestGetService/Get_job_by_name_in_a_namespace (0.03s)
    --- PASS: TestGetService/Get_non_existing_job (0.02s)
    --- PASS: TestGetService/Get_a_job_with_no_Name (0.00s)
    --- PASS: TestGetService/Get_a_job_with_no_namespace (0.00s)
PASS
coverage: 49.7% of statements
ok      github.com/ray-project/kuberay/apiserver/test/e2e       9.885s  coverage: 49.7% of statements
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #3356 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
