### PR TITLE
[Refactor][Helm] Define name templates for kuberay-operator resources

### DIFF
--- a/helm-chart/kuberay-operator/templates/_helpers.tpl
+++ b/helm-chart/kuberay-operator/templates/_helpers.tpl
@@ -51,17 +51,10 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "kuberay-operator.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "kuberay-operator.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+{{- /* Create the name of the deployment to use. */ -}}
+{{- define "kuberay-operator.deployment.name" -}}
+{{- include "kuberay-operator.fullname" . }}
 {{- end -}}
-{{- end -}}
-
 
 {{/*
 FeatureGates
@@ -77,6 +70,49 @@ FeatureGates
 {{- end }}
 {{- end }}
 
+{{- /* Create the name of the service to use. */ -}}
+{{- define "kuberay-operator.service.name" -}}
+{{- include "kuberay-operator.fullname" . }}
+{{- end -}}
+
+{{- /* Create the name of the service account to use. */ -}}
+{{- define "kuberay-operator.serviceAccount.name" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "kuberay-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{- /* Create the name of the cluster role to use. */ -}}
+{{- define "kuberay-operator.clusterRole.name" -}}
+{{- include "kuberay-operator.fullname" . -}}
+{{- end -}}
+
+{{- /* Create the name of the cluster role binding to use. */ -}}
+{{- define "kuberay-operator.clusterRoleBinding.name" -}}
+{{- include "kuberay-operator.fullname" . -}}
+{{- end -}}
+
+{{- /* Create the name of the role to use. */ -}}
+{{- define "kuberay-operator.role.name" -}}
+{{- include "kuberay-operator.fullname" . -}}
+{{- end -}}
+
+{{- /* Create the name of the role binding to use. */ -}}
+{{- define "kuberay-operator.roleBinding.name" -}}
+{{- include "kuberay-operator.fullname" . -}}
+{{- end -}}
+
+{{- /* Create the name of the leader election role to use. */ -}}
+{{- define "kuberay-operator.leaderElectionRole.name" -}}
+{{- include "kuberay-operator.fullname" . -}}-leader-election
+{{- end -}}
+
+{{- /* Create the name of the leader election role binding to use. */ -}}
+{{- define "kuberay-operator.leaderElectionRoleBinding.name" -}}
+{{- include "kuberay-operator.fullname" . -}}-leader-election
+{{- end -}}
 
 {{/*
 Create a template to ensure consistency for Role and ClusterRole.

--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kuberay-operator.fullname" . }}
+  name: {{ include "kuberay-operator.deployment.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kuberay-operator.labels" . | nindent 4 }}

--- a/helm-chart/kuberay-operator/templates/leader_election_role.yaml
+++ b/helm-chart/kuberay-operator/templates/leader_election_role.yaml
@@ -2,8 +2,10 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
-  name: {{ include "kuberay-operator.fullname" . }}-leader-election
+  name: {{ include "kuberay-operator.leaderElectionRole.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/helm-chart/kuberay-operator/templates/leader_election_role_binding.yaml
+++ b/helm-chart/kuberay-operator/templates/leader_election_role_binding.yaml
@@ -1,15 +1,17 @@
-{{- if .Values.rbacEnable }}
+{{- if .Values.rbacEnable -}}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
-  name: {{ include "kuberay-operator.fullname" . }}-leader-election
+  name: {{ include "kuberay-operator.leaderElectionRoleBinding.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "kuberay-operator.leaderElectionRole.name" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount.name  }}
+  name: {{ include "kuberay-operator.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: Role
-  name: {{ include "kuberay-operator.fullname" . }}-leader-election
-  apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
@@ -1,15 +1,13 @@
-# Install Role for namespaces listed in watchNamespace.
-# This should be consistent with `role.yaml`, except for the `kind` field.
 {{- if and .Values.rbacEnable .Values.singleNamespaceInstall .Values.crNamespacedRbacEnable }}
 {{- $watchNamespaces := default (list .Release.Namespace) .Values.watchNamespace }}
 {{- range $namespace := $watchNamespaces }}
 ---
-kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
-  labels: {{ include "kuberay-operator.labels" $ | nindent 4 }}
   name: {{ include "kuberay-operator.fullname" $ }}
   namespace: {{ $namespace }}
+  labels: {{ include "kuberay-operator.labels" $ | nindent 4 }}
 {{ include "role.consistentRules" (dict "batchSchedulerEnabled" $.Values.batchScheduler.enabled) }}
 {{- end }}
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
@@ -1,5 +1,3 @@
-# Install RoleBinding for namespaces listed in watchNamespace.
-# This should be consistent with `rolebinding.yaml`, except for the `kind` field.
 {{- if and .Values.rbacEnable .Values.singleNamespaceInstall .Values.crNamespacedRbacEnable }}
 {{- $watchNamespaces := default (list .Release.Namespace) .Values.watchNamespace }}
 {{- range $namespace := $watchNamespaces }}
@@ -7,16 +5,16 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels: {{ include "kuberay-operator.labels" $ | nindent 4 }}
   name: {{ include "kuberay-operator.fullname" $ }}
   namespace: {{ $namespace }}
-subjects:
-- kind: ServiceAccount
-  name: {{ $.Values.serviceAccount.name  }}
-  namespace: {{ $.Release.Namespace }}
+  labels: {{ include "kuberay-operator.labels" $ | nindent 4 }}
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "kuberay-operator.fullname" $ }}
-  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kuberay-operator.serviceAccount.name" $ }}
+  namespace: {{ $.Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/ray_rayjob_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayjob_editor_role.yaml
@@ -1,11 +1,11 @@
-# permissions for end users to edit rayjobs.
+{{- /* ClusterRole for end users to view and edit RayJob. */ -}}
 {{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
-
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
   name: rayjob-editor-role
+  labels:
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ray.io

--- a/helm-chart/kuberay-operator/templates/ray_rayjob_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayjob_viewer_role.yaml
@@ -1,11 +1,11 @@
-# permissions for end users to view rayjobs.
+{{- /* ClusterRole for end users to view RayJob. */ -}}
 {{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
-
-kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
   name: rayjob-viewer-role
+  labels:
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ray.io

--- a/helm-chart/kuberay-operator/templates/ray_rayservice_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayservice_editor_role.yaml
@@ -1,9 +1,11 @@
-# permissions for end users to edit rayservices.
+{{- /* ClusterRole for end users to view and edit RayService. */ -}}
 {{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: rayservice-editor-role
+  labels:
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ray.io

--- a/helm-chart/kuberay-operator/templates/ray_rayservice_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayservice_viewer_role.yaml
@@ -1,9 +1,11 @@
-# permissions for end users to view rayservices.
+{{- /* ClusterRole for end users to view RayService. */ -}}
 {{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: rayservice-viewer-role
+  labels:
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ray.io

--- a/helm-chart/kuberay-operator/templates/role.yaml
+++ b/helm-chart/kuberay-operator/templates/role.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "kuberay-operator.fullname" . }}
+  name: {{ include "kuberay-operator.clusterRole.name" . }}
   labels:
     {{- include "kuberay-operator.labels" . | nindent 4 }}
 {{ include "role.consistentRules" (dict "batchSchedulerEnabled" .Values.batchScheduler.enabled "batchSchedulerName" .Values.batchScheduler.name) }}

--- a/helm-chart/kuberay-operator/templates/rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/rolebinding.yaml
@@ -2,15 +2,15 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "kuberay-operator.fullname" . }}
+  name: {{ include "kuberay-operator.clusterRoleBinding.name" . }}
   labels:
     {{- include "kuberay-operator.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount.name  }}
+  name: {{ include "kuberay-operator.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kuberay-operator.fullname" . }}
+  name: {{ include "kuberay-operator.clusterRole.name" . }}
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/service.yaml
+++ b/helm-chart/kuberay-operator/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kuberay-operator.fullname" . }}
+  name: {{ include "kuberay-operator.service.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kuberay-operator.labels" . | nindent 4 }}

--- a/helm-chart/kuberay-operator/templates/serviceaccount.yaml
+++ b/helm-chart/kuberay-operator/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "kuberay-operator.serviceAccountName" . }}
+  name: {{ template "kuberay-operator.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kuberay-operator.labels" . | nindent 4 }}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Define name template helpers for all resources. For example, we will define an helper template for the service account:

```gotmpl
{{- /* Create the name of the service account to use. */ -}}
{{- define "kuberay-operator.serviceAccount.name" -}}
{{- if .Values.serviceAccount.create -}}
{{- default (include "kuberay-operator.fullname" .) .Values.serviceAccount.name }}
{{- else }}
{{- default "default" .Values.serviceAccount.name }}
{{- end -}}
{{- end -}}
```

Then we will reuse this helper template multiple times in all RoleBinding/ClusterRoleBinding resources to avoid potential name inconsistency.

```gotmpl
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
...
subjects:
- kind: ServiceAccount
  name: {{ include "kuberay-operator.serviceAccount.name" . }}
  namespace: {{ .Release.Namespace }}
...
```

## Related issue number

<!-- For example: "Closes #1234" -->

Close #3382 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
