### PR TITLE
[DOCS] document step to do before running e2e test

### DIFF
--- a/apiserver/DEVELOPMENT.md
+++ b/apiserver/DEVELOPMENT.md
@@ -66,7 +66,7 @@ make test
 
 There are two `make` targets provide execute the end to end test (integration between Kuberay API server and Kuberay Operator):
 
-* `make e2e-test` executes all the tests defined in the [test/e2e package](./test/e2e/). It uses the cluster defined in `~/.kube/config` to submit the workloads.
+* `make e2e-test` executes all the tests defined in the [test/e2e package](./test/e2e/). It uses the cluster defined in `~/.kube/config` to submit the workloads. Make sure the apiserver is running (see [Build](#build)) before running this command, or the tests will fail.
 * `make local-e2e-test` creates a local kind cluster, builds the Kuberay operator and API server images from the current branch and deploys the operator and API server into the kind cluster. It shuts down the kind cluster upon successful execution of the end to end test. If the tests fail the cluster will be left running and will have to manually be shutdown by executing the `make clean-cluster`
 
 The `e2e` test targets use two variables to control what version of Ray images to use in the end to end tests:

--- a/apiserver/DEVELOPMENT.md
+++ b/apiserver/DEVELOPMENT.md
@@ -66,7 +66,10 @@ make test
 
 There are two `make` targets provide execute the end to end test (integration between Kuberay API server and Kuberay Operator):
 
-* `make e2e-test` executes all the tests defined in the [test/e2e package](./test/e2e/). It uses the cluster defined in `~/.kube/config` to submit the workloads. Make sure the apiserver is running (see [Build](#build)) before running this command, or the tests will fail.
+* `make e2e-test` executes all the tests defined in the [test/e2e package](./test/e2e/). It uses the cluster defined in `~/.kube/config` to submit the workloads. Please make sure you have done the following before running this:
+    1. Install the KubeRay Operator into the cluster by `make operator-image load-operator-image deploy-operator`
+    2. Apiserver is running (see [Build](#build))
+    3. Set the `E2E_API_SERVER_URL` environment variable with value `http://localhost:8888`, as the local apiserver will be listening on port `8888`
 * `make local-e2e-test` creates a local kind cluster, builds the Kuberay operator and API server images from the current branch and deploys the operator and API server into the kind cluster. It shuts down the kind cluster upon successful execution of the end to end test. If the tests fail the cluster will be left running and will have to manually be shutdown by executing the `make clean-cluster`
 
 The `e2e` test targets use two variables to control what version of Ray images to use in the end to end tests:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, the `DEVELOPMENT.md` does not show clearly that we need to start the apiserver before running the e2e test. Adding it in the documentation.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
