### PR TITLE
[Docs] Correct command to load KubeRay operator image

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -136,7 +136,7 @@ security-proxy-image: ## Build the security proxy image to be loaded in your kin
 .PHONY: deploy-operator
 deploy-operator: ## Deploy operator via helm into the K8s cluster specified in ~/.kube/config.
 # Note that you should make your operatorimage available by either pushing it to an image registry, such as DockerHub or Quay, or by loading the image into the Kubernetes cluster.
-# If you are using a Kind cluster for development, you can run `make load-image` to load the newly built image into the Kind cluster.
+# If you are using a Kind cluster for development, you can run `make load-operator-image` to load the newly built image into the Kind cluster.
 	helm upgrade --install raycluster ../helm-chart/kuberay-operator --wait \
 	--set image.tag=${OPERATOR_IMAGE_TAG} --set image.pullPolicy=IfNotPresent
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
To load the KubeRay operator image into a `kind` cluster, the correct phony target is `load-operator-image` (not `load-image`, which is used for loading the API server image).

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
N/A

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
