### PR TITLE
[Apiserver][Refactor] Use polling in autoscaler e2e test

### DIFF
--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -124,9 +124,9 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 
 	// worker pod should be created as part of job execution
 	err = wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayCluster, err00 := tCtx.GetRayClusterByName(actualCluster.Name)
-		if err00 != nil {
-			return true, err00
+		rayCluster, err := tCtx.GetRayClusterByName(actualCluster.Name)
+		if err != nil {
+			return true, err
 		}
 		t.Logf("Found ray cluster with %d available worker replicas", rayCluster.Status.AvailableWorkerReplicas)
 		return rayCluster.Status.AvailableWorkerReplicas == 1, nil
@@ -152,9 +152,9 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 	waitForRayJob(t, tCtx, createActorRequest.Job.Name, []rayv1api.JobStatus{rayv1api.JobStatusSucceeded})
 
 	err = wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayCluster, err00 := tCtx.GetRayClusterByName(actualCluster.Name)
-		if err00 != nil {
-			return true, err00
+		rayCluster, err := tCtx.GetRayClusterByName(actualCluster.Name)
+		if err != nil {
+			return true, err
 		}
 		t.Logf("Found ray cluster with %d available worker replicas", rayCluster.Status.AvailableWorkerReplicas)
 		return rayCluster.Status.AvailableWorkerReplicas == 0, nil

--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -122,7 +122,7 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 	waitForRayJob(t, tCtx, createActorRequest.Job.Name, []rayv1api.JobStatus{rayv1api.JobStatusSucceeded})
 
 	// worker pod should be created as part of job execution
-	time.Sleep(20 * time.Second)
+	time.Sleep(30 * time.Second)
 
 	// Get number of workers
 	rayCluster, err = tCtx.GetRayClusterByName(actualCluster.Name)

--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -16,7 +16,6 @@ import (
 // TestCreateClusterAutoscalerEndpoint sequentially iterates over the create cluster endpoint
 // with valid and invalid requests
 func TestCreateClusterAutoscaler(t *testing.T) {
-	t.Skip("Skip this test as it is failing on CI")
 	tCtx, err := NewEnd2EndTestingContext(t)
 	require.NoError(t, err, "No error expected when creating testing context")
 

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -799,9 +799,9 @@ func waitForRunningCluster(t *testing.T, tCtx *End2EndTestingContext, clusterNam
 	// wait for the cluster to be in a running state for 3 minutes
 	// if is not in that state, return an error
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayCluster, err00 := tCtx.GetRayClusterByName(clusterName)
-		if err00 != nil {
-			return true, err00
+		rayCluster, err := tCtx.GetRayClusterByName(clusterName)
+		if err != nil {
+			return true, err
 		}
 		t.Logf("Found cluster state of '%s' for ray cluster '%s'", rayCluster.Status.State, clusterName)
 		return rayCluster.Status.State == rayv1api.Ready, nil
@@ -813,13 +813,13 @@ func waitForDeletedCluster(t *testing.T, tCtx *End2EndTestingContext, clusterNam
 	// wait for the cluster to be deleted
 	// if is not in that state, return an error
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayCluster, err00 := tCtx.GetRayClusterByName(clusterName)
-		if err00 != nil &&
-			assert.EqualError(t, err00, "rayclusters.ray.io \""+tCtx.GetRayClusterName()+"\" not found") {
+		rayCluster, err := tCtx.GetRayClusterByName(clusterName)
+		if err != nil &&
+			assert.EqualError(t, err, "rayclusters.ray.io \""+tCtx.GetRayClusterName()+"\" not found") {
 			return true, nil
 		}
 		t.Logf("Found status of '%s' for ray cluster '%s'", rayCluster.Status.State, clusterName)
-		return false, err00
+		return false, err
 	})
 	require.NoErrorf(t, err, "No error expected when deleting ray cluster: '%s', err %v", clusterName, err)
 }

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -647,9 +647,9 @@ func waitForRayJob(t *testing.T, tCtx *End2EndTestingContext, rayJobName string,
 	// wait for the job to be in any of the expectedJobStatuses state for 3 minutes
 	// if is not in that state, return an error
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayJob, err00 := tCtx.GetRayJobByName(rayJobName)
-		if err00 != nil {
-			return true, err00
+		rayJob, err := tCtx.GetRayJobByName(rayJobName)
+		if err != nil {
+			return true, err
 		}
 		t.Logf("Found ray job with state '%s' for ray job '%s'", rayJob.Status.JobStatus, rayJobName)
 		return slices.Contains(expectedJobStatuses, rayJob.Status.JobStatus), nil
@@ -661,13 +661,13 @@ func waitForDeletedRayJob(t *testing.T, tCtx *End2EndTestingContext, jobName str
 	// wait for the job to be deleted
 	// if is not in that state, return an error
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayJob, err00 := tCtx.GetRayJobByName(jobName)
-		if err00 != nil &&
-			assert.EqualError(t, err00, "rayjobs.ray.io \""+jobName+"\" not found") {
+		rayJob, err := tCtx.GetRayJobByName(jobName)
+		if err != nil &&
+			assert.EqualError(t, err, "rayjobs.ray.io \""+jobName+"\" not found") {
 			return true, nil
 		}
 		t.Logf("Found status of '%s' for ray cluster '%s'", rayJob.Status.JobStatus, jobName)
-		return false, err00
+		return false, err
 	})
 	require.NoErrorf(t, err, "No error expected when deleting ray job: '%s', err %v", jobName, err)
 }

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -378,9 +378,9 @@ func waitForRunningService(t *testing.T, tCtx *End2EndTestingContext, serviceNam
 	// wait for the service to be in a running state for 3 minutes
 	// if is not in that state, return an error
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayService, err00 := tCtx.GetRayServiceByName(serviceName)
-		if err00 != nil {
-			return true, err00
+		rayService, err := tCtx.GetRayServiceByName(serviceName)
+		if err != nil {
+			return true, err
 		}
 		t.Logf("Found status of '%s' for ray service '%s'", rayService.Status.ServiceStatus, serviceName)
 		return rayService.Status.ServiceStatus == rayv1api.Running, nil
@@ -392,13 +392,13 @@ func waitForDeletedService(t *testing.T, tCtx *End2EndTestingContext, serviceNam
 	// wait for the service to be deleted
 	// if is not in that state, return an error
 	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayService, err00 := tCtx.GetRayServiceByName(serviceName)
-		if err00 != nil &&
-			assert.EqualError(t, err00, "rayservices.ray.io \""+serviceName+"\" not found") {
+		rayService, err := tCtx.GetRayServiceByName(serviceName)
+		if err != nil &&
+			assert.EqualError(t, err, "rayservices.ray.io \""+serviceName+"\" not found") {
 			return true, nil
 		}
 		t.Logf("Found status of '%s' for ray service '%s'", rayService.Status.ServiceStatus, serviceName)
-		return false, err00
+		return false, err
 	})
 	require.NoErrorf(t, err, "No error expected when deleting ray service: '%s', err %v", serviceName, err)
 }

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -336,9 +336,9 @@ func (e2etc *End2EndTestingContext) CreateRayClusterWithConfigMaps(t *testing.T,
 	// wait for the cluster to be in a running state for 3 minutes
 	// if is not in that state, return an error
 	err = wait.PollUntilContextTimeout(e2etc.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayCluster, err00 := e2etc.GetRayClusterByName(actualCluster.Name)
-		if err00 != nil {
-			return true, err00
+		rayCluster, err := e2etc.GetRayClusterByName(actualCluster.Name)
+		if err != nil {
+			return true, err
 		}
 		t.Logf("Found cluster state of '%s' for ray cluster '%s'", rayCluster.Status.State, clusterName)
 		return rayCluster.Status.State == rayv1api.Ready, nil
@@ -357,8 +357,8 @@ func (e2etc *End2EndTestingContext) DeleteRayCluster(t *testing.T, clusterName s
 	// wait for the cluster to be deleted for 3 minutes
 	// if is not in that state, return an error
 	err = wait.PollUntilContextTimeout(e2etc.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayCluster, err00 := e2etc.GetRayClusterByName(clusterName)
-		if err00 != nil && k8sApiErrors.IsNotFound(err00) {
+		rayCluster, err := e2etc.GetRayClusterByName(clusterName)
+		if err != nil && k8sApiErrors.IsNotFound(err) {
 			return true, nil
 		}
 		t.Logf("Found cluster state of '%s' for ray cluster '%s'", rayCluster.Status.State, clusterName)
@@ -378,8 +378,8 @@ func (e2etc *End2EndTestingContext) DeleteRayService(t *testing.T, serviceName s
 	// wait for the cluster to be deleted for 3 minutes
 	// if is not in that state, return an error
 	err = wait.PollUntilContextTimeout(e2etc.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayService, err00 := e2etc.GetRayServiceByName(serviceName)
-		if err00 != nil && k8sApiErrors.IsNotFound(err00) {
+		rayService, err := e2etc.GetRayServiceByName(serviceName)
+		if err != nil && k8sApiErrors.IsNotFound(err) {
 			return true, nil
 		}
 		t.Logf("Found service state of '%s' for ray cluster '%s'", rayService.Status.ServiceStatus, serviceName)
@@ -399,8 +399,8 @@ func (e2etc *End2EndTestingContext) DeleteRayJobByName(t *testing.T, rayJobName 
 	// wait for the cluster to be deleted for 3 minutes
 	// if is not in that state, return an error
 	err = wait.PollUntilContextTimeout(e2etc.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayJob, err00 := e2etc.GetRayJobByName(rayJobName)
-		if err00 != nil && k8sApiErrors.IsNotFound(err00) {
+		rayJob, err := e2etc.GetRayJobByName(rayJobName)
+		if err != nil && k8sApiErrors.IsNotFound(err) {
 			return true, nil
 		}
 		t.Logf("Found job state of '%s' for ray cluster '%s'", rayJob.Status.JobStatus, rayJobName)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
ApiServer is e2e flaky due to the fixed sleep time waiting for worker pod, changed to polling to deal with the flakiness, and it also speedup the test.
### Before
```
=== RUN   TestCreateClusterAutoscaler
--- PASS: TestCreateClusterAutoscaler (158.10s)
PASS
coverage: 54.2% of statements
ok      github.com/ray-project/kuberay/apiserver/test/e2e  159.198s coverage: 54.2% of statements
```
### After
```
=== RUN   TestCreateClusterAutoscaler
--- PASS: TestCreateClusterAutoscaler (119.57s)
PASS
coverage: 54.2% of statements
ok      github.com/ray-project/kuberay/apiserver/test/e2e  120.662s coverage: 54.2% of state
```
<!-- Please give a short summary of the change and the problem this solves. -->
## Related issue number
Closes #3293

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
