### PR TITLE
[CI] Bump Go version to 1.23 to support E2E Operator Version Upgrade tests in Buildkite

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -54,7 +54,7 @@
 
 - label: 'Test E2E Operator Version Upgrade (v1.3.0)'
   instance_size: large
-  image: golang:1.22
+  image: golang:1.23
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When I was checking the E2E test status on Buildkite, I noticed that the `go.mod` for `E2E Operator Version Upgrade` requires Go version 1.23.

Before:
![image](https://github.com/user-attachments/assets/36cee548-8519-43b5-a14d-85165d18865d)

After:
![image](https://github.com/user-attachments/assets/8a9e5929-b182-4c99-b383-bd98a93064a2)



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
