### PR TITLE
Bump security proxy golang version to 1.23.6

### DIFF
--- a/experimental/Makefile
+++ b/experimental/Makefile
@@ -57,7 +57,7 @@ fumpt: gofumpt ## Run gofmtumpt against code.
 
 .PHONY: lint
 lint: golangci-lint fmt vet fumpt ## Run the linter.
-	$(GOLANGCI_LINT) run  --timeout=3m --no-config
+	$(GOLANGCI_LINT) run --timeout=3m --no-config
 
 build: fmt vet fumpt lint ## Build api server binary.
 	go build  -o ${REPO_ROOT_BIN}/kuberay-apiserver-proxy cmd/main.go
@@ -85,7 +85,7 @@ GOBINDATA ?= $(REPO_ROOT_BIN)/go-bindata
 ## Tool Versions
 GOFUMPT_VERSION ?= v0.3.1
 GOIMPORTS_VERSION ?= v0.14.0
-GOLANGCI_LINT_VERSION ?= v1.54.1
+GOLANGCI_LINT_VERSION ?= v2.1.2
 KIND_VERSION ?= v0.19.0
 GOBINDATA_VERSION ?= v4.0.2
 

--- a/experimental/cmd/main.go
+++ b/experimental/cmd/main.go
@@ -63,7 +63,7 @@ func main() {
 			if err != nil {
 				klog.Fatal("cannot dial server: ", err)
 			}
-			defer cc.Close()
+			defer cc.Close() // nolint:errcheck
 			klog.Info("connecting to GRPC server ", cc.Target())
 
 			// set up listener

--- a/experimental/go.mod
+++ b/experimental/go.mod
@@ -1,6 +1,6 @@
 module github.com/ray-project/kuberay/security
 
-go 1.20
+go 1.23.6
 
 require (
 	google.golang.org/grpc v1.64.1

--- a/experimental/go.sum
+++ b/experimental/go.sum
@@ -1,6 +1,7 @@
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=

--- a/experimental/pkg/httpproxy/support.go
+++ b/experimental/pkg/httpproxy/support.go
@@ -53,6 +53,6 @@ func modifyRequest(r *http.Request, upstream *url.URL) {
 	if err != nil {
 		klog.Info("failed reading request body ", err)
 	}
-	defer r.Body.Close()
+	defer r.Body.Close() // nolint:errcheck
 	r.Body = io.NopCloser(bytes.NewReader(body))
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The golang version used in `experimental/Dockerfile` is `1.23.6`, which is different from `1.20` used in `experimental/go.mod`. Bump the golang version to `1.23.6` to keep them consistent.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
