### PR TITLE
[doc] [apiserver] Remove wording on pagination and sort

### DIFF
--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -249,7 +249,7 @@ func (krc *KuberayAPIServerClient) ListClusters(request *api.ListClustersRequest
 	return response, nil, nil
 }
 
-// ListAllClusters finds all Clusters in all namespaces. Supports pagination, and sorting on certain fields.
+// ListAllClusters finds all Clusters in all namespaces.
 func (krc *KuberayAPIServerClient) ListAllClusters(request *api.ListAllClustersRequest) (*api.ListAllClustersResponse, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/clusters"
 	httpRequest, err := http.NewRequestWithContext(context.TODO(), "GET", getURL, nil)
@@ -455,7 +455,7 @@ func (krc *KuberayAPIServerClient) GetRayService(request *api.GetRayServiceReque
 	return response, nil, nil
 }
 
-// Finds all ray services in a given namespace. Supports pagination, and sorting on certain fields.
+// Finds all ray services in a given namespace.
 func (krc *KuberayAPIServerClient) ListRayServices(request *api.ListRayServicesRequest) (*api.ListRayServicesResponse, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/namespaces/" + request.Namespace + "/services"
 	httpRequest, err := http.NewRequestWithContext(context.TODO(), "GET", getURL, nil)
@@ -476,7 +476,7 @@ func (krc *KuberayAPIServerClient) ListRayServices(request *api.ListRayServicesR
 	return response, nil, nil
 }
 
-// Finds all ray services in a given namespace. Supports pagination, and sorting on certain fields.
+// Finds all ray services in a given namespace.
 func (krc *KuberayAPIServerClient) ListAllRayServices() (*api.ListAllRayServicesResponse, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/services"
 	httpRequest, err := http.NewRequestWithContext(context.TODO(), "GET", getURL, nil)

--- a/apiserver/pkg/server/cluster_server.go
+++ b/apiserver/pkg/server/cluster_server.go
@@ -68,7 +68,6 @@ func (s *ClusterServer) GetCluster(ctx context.Context, request *api.GetClusterR
 }
 
 // Finds all Clusters in a given namespace.
-// TODO: Supports pagination and sorting on certain fields when we have DB support. request needs to be extended.
 func (s *ClusterServer) ListCluster(ctx context.Context, request *api.ListClustersRequest) (*api.ListClustersResponse, error) {
 	if request.Namespace == "" {
 		return nil, util.NewInvalidInputError("Namespace is empty. Please specify a valid value.")
@@ -95,7 +94,6 @@ func (s *ClusterServer) ListCluster(ctx context.Context, request *api.ListCluste
 }
 
 // Finds all Clusters in all namespaces.
-// TODO: Supports pagination and sorting on certain fields when we have DB support. request needs to be extended.
 func (s *ClusterServer) ListAllClusters(ctx context.Context, request *api.ListAllClustersRequest) (*api.ListAllClustersResponse, error) {
 	// Leave the namespace empty to list all clusters in all namespaces.
 	clusters, continueToken, err := s.resourceManager.ListClusters(ctx /*namespace=*/, "", request.Continue, request.Limit)

--- a/docs/design/protobuf-grpc-service.md
+++ b/docs/design/protobuf-grpc-service.md
@@ -67,14 +67,14 @@ service ClusterService {
     };
   }
 
-  // Finds all Clusters in a given namespace. Supports pagination, and sorting on certain fields.
+  // Finds all Clusters in a given namespace.
   rpc ListCluster(ListClustersRequest) returns (ListClustersResponse) {
     option (google.api.http) = {
       get: "/apis/v1alpha2/namespaces/{namespace}/clusters"
     };
   }
 
-  // Finds all Clusters in all namespaces. Supports pagination, and sorting on certain fields.
+  // Finds all Clusters in all namespaces.
   rpc ListAllClusters(ListAllClustersRequest) returns (ListAllClustersResponse) {
     option (google.api.http) = {
       get: "/apis/v1alpha2/clusters"

--- a/proto/cluster.proto
+++ b/proto/cluster.proto
@@ -39,14 +39,14 @@ service ClusterService {
     };
   }
 
-  // Finds all Clusters in a given namespace. Supports pagination, and sorting on certain fields.
+  // Finds all Clusters in a given namespace.
   rpc ListCluster(ListClustersRequest) returns (ListClustersResponse) {
     option (google.api.http) = {
       get: "/apis/v1/namespaces/{namespace}/clusters"
     };
   }
 
-  // Finds all Clusters in all namespaces. Supports pagination, and sorting on certain fields.
+  // Finds all Clusters in all namespaces.
   rpc ListAllClusters(ListAllClustersRequest) returns (ListAllClustersResponse) {
     option (google.api.http) = {
       get: "/apis/v1/clusters"

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -39,14 +39,14 @@ service ComputeTemplateService {
     };
   }
 
-  // Finds all compute templates in a given namespace. Supports pagination, and sorting on certain fields.
+  // Finds all compute templates in a given namespace.
   rpc ListComputeTemplates(ListComputeTemplatesRequest) returns (ListComputeTemplatesResponse) {
     option (google.api.http) = {
       get: "/apis/v1/namespaces/{namespace}/compute_templates"
     };
   }
 
-  // Finds all compute templates in all namespaces. Supports pagination, and sorting on certain fields.
+  // Finds all compute templates in all namespaces.
   rpc ListAllComputeTemplates(ListAllComputeTemplatesRequest) returns (ListAllComputeTemplatesResponse) {
     option (google.api.http) = {
       get: "/apis/v1/compute_templates"
@@ -149,7 +149,7 @@ service ImageTemplateService {
     };
   }
 
-  // Not Implemented. Finds all ImageTemplates. Supports pagination, and sorting on certain fields.
+  // Not Implemented. Finds all ImageTemplates.
   rpc ListImageTemplates(ListImageTemplatesRequest) returns (ListImageTemplatesResponse) {
     option (google.api.http) = {
       get: "/apis/v1/namespaces/{namespace}/image_templates"

--- a/proto/go_client/cluster_grpc.pb.go
+++ b/proto/go_client/cluster_grpc.pb.go
@@ -23,9 +23,9 @@ type ClusterServiceClient interface {
 	CreateCluster(ctx context.Context, in *CreateClusterRequest, opts ...grpc.CallOption) (*Cluster, error)
 	// Finds a specific Cluster by ID.
 	GetCluster(ctx context.Context, in *GetClusterRequest, opts ...grpc.CallOption) (*Cluster, error)
-	// Finds all Clusters in a given namespace. Supports pagination, and sorting on certain fields.
+	// Finds all Clusters in a given namespace.
 	ListCluster(ctx context.Context, in *ListClustersRequest, opts ...grpc.CallOption) (*ListClustersResponse, error)
-	// Finds all Clusters in all namespaces. Supports pagination, and sorting on certain fields.
+	// Finds all Clusters in all namespaces.
 	ListAllClusters(ctx context.Context, in *ListAllClustersRequest, opts ...grpc.CallOption) (*ListAllClustersResponse, error)
 	// Deletes an cluster without deleting the cluster's runs and jobs. To
 	// avoid unexpected behaviors, delete an cluster's runs and jobs before
@@ -94,9 +94,9 @@ type ClusterServiceServer interface {
 	CreateCluster(context.Context, *CreateClusterRequest) (*Cluster, error)
 	// Finds a specific Cluster by ID.
 	GetCluster(context.Context, *GetClusterRequest) (*Cluster, error)
-	// Finds all Clusters in a given namespace. Supports pagination, and sorting on certain fields.
+	// Finds all Clusters in a given namespace.
 	ListCluster(context.Context, *ListClustersRequest) (*ListClustersResponse, error)
-	// Finds all Clusters in all namespaces. Supports pagination, and sorting on certain fields.
+	// Finds all Clusters in all namespaces.
 	ListAllClusters(context.Context, *ListAllClustersRequest) (*ListAllClustersResponse, error)
 	// Deletes an cluster without deleting the cluster's runs and jobs. To
 	// avoid unexpected behaviors, delete an cluster's runs and jobs before

--- a/proto/go_client/config.pb.go
+++ b/proto/go_client/config.pb.go
@@ -915,7 +915,7 @@ func (x *DeleteImageTemplateRequest) GetNamespace() string {
 	return ""
 }
 
-// ImageTemplate can be used by worker group and workspce.
+// ImageTemplate can be used by worker group and workspace.
 // They can be distinguish by different entrypoints
 type ImageTemplate struct {
 	state         protoimpl.MessageState

--- a/proto/go_client/config_grpc.pb.go
+++ b/proto/go_client/config_grpc.pb.go
@@ -23,9 +23,9 @@ type ComputeTemplateServiceClient interface {
 	CreateComputeTemplate(ctx context.Context, in *CreateComputeTemplateRequest, opts ...grpc.CallOption) (*ComputeTemplate, error)
 	// Finds a specific compute template by its name and namespace.
 	GetComputeTemplate(ctx context.Context, in *GetComputeTemplateRequest, opts ...grpc.CallOption) (*ComputeTemplate, error)
-	// Finds all compute templates in a given namespace. Supports pagination, and sorting on certain fields.
+	// Finds all compute templates in a given namespace.
 	ListComputeTemplates(ctx context.Context, in *ListComputeTemplatesRequest, opts ...grpc.CallOption) (*ListComputeTemplatesResponse, error)
-	// Finds all compute templates in all namespaces. Supports pagination, and sorting on certain fields.
+	// Finds all compute templates in all namespaces.
 	ListAllComputeTemplates(ctx context.Context, in *ListAllComputeTemplatesRequest, opts ...grpc.CallOption) (*ListAllComputeTemplatesResponse, error)
 	// Deletes a compute template by its name and namespace
 	DeleteComputeTemplate(ctx context.Context, in *DeleteComputeTemplateRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
@@ -92,9 +92,9 @@ type ComputeTemplateServiceServer interface {
 	CreateComputeTemplate(context.Context, *CreateComputeTemplateRequest) (*ComputeTemplate, error)
 	// Finds a specific compute template by its name and namespace.
 	GetComputeTemplate(context.Context, *GetComputeTemplateRequest) (*ComputeTemplate, error)
-	// Finds all compute templates in a given namespace. Supports pagination, and sorting on certain fields.
+	// Finds all compute templates in a given namespace.
 	ListComputeTemplates(context.Context, *ListComputeTemplatesRequest) (*ListComputeTemplatesResponse, error)
-	// Finds all compute templates in all namespaces. Supports pagination, and sorting on certain fields.
+	// Finds all compute templates in all namespaces.
 	ListAllComputeTemplates(context.Context, *ListAllComputeTemplatesRequest) (*ListAllComputeTemplatesResponse, error)
 	// Deletes a compute template by its name and namespace
 	DeleteComputeTemplate(context.Context, *DeleteComputeTemplateRequest) (*emptypb.Empty, error)
@@ -264,7 +264,7 @@ type ImageTemplateServiceClient interface {
 	CreateImageTemplate(ctx context.Context, in *CreateImageTemplateRequest, opts ...grpc.CallOption) (*ImageTemplate, error)
 	// Not implemented. Finds a specific ImageTemplate by ID.
 	GetImageTemplate(ctx context.Context, in *GetImageTemplateRequest, opts ...grpc.CallOption) (*ImageTemplate, error)
-	// Not Implemented. Finds all ImageTemplates. Supports pagination, and sorting on certain fields.
+	// Not Implemented. Finds all ImageTemplates.
 	ListImageTemplates(ctx context.Context, in *ListImageTemplatesRequest, opts ...grpc.CallOption) (*ListImageTemplatesResponse, error)
 	// Not implemented. Deletes an ImageTemplate.
 	DeleteImageTemplate(ctx context.Context, in *DeleteImageTemplateRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
@@ -322,7 +322,7 @@ type ImageTemplateServiceServer interface {
 	CreateImageTemplate(context.Context, *CreateImageTemplateRequest) (*ImageTemplate, error)
 	// Not implemented. Finds a specific ImageTemplate by ID.
 	GetImageTemplate(context.Context, *GetImageTemplateRequest) (*ImageTemplate, error)
-	// Not Implemented. Finds all ImageTemplates. Supports pagination, and sorting on certain fields.
+	// Not Implemented. Finds all ImageTemplates.
 	ListImageTemplates(context.Context, *ListImageTemplatesRequest) (*ListImageTemplatesResponse, error)
 	// Not implemented. Deletes an ImageTemplate.
 	DeleteImageTemplate(context.Context, *DeleteImageTemplateRequest) (*emptypb.Empty, error)

--- a/proto/go_client/serve.pb.go
+++ b/proto/go_client/serve.pb.go
@@ -211,7 +211,7 @@ type ListRayServicesRequest struct {
 
 	// Required. The namespace of the ray services to be retrieved.
 	Namespace string `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	// A page token to request the next page of results. The token is acquried
+	// A page token to request the next page of results. The token is acquired
 	// from the nextPageToken field of the response from the previous
 	// ListRayServices call or can be omitted when fetching the first page.
 	PageToken string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
@@ -345,7 +345,7 @@ type ListAllRayServicesRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// A page token to request the next page of results. The token is acquried
+	// A page token to request the next page of results. The token is acquired
 	// from the nextPageToken field of the response from the previous
 	// ListRayServices call or can be omitted when fetching the first page.
 	PageToken string `protobuf:"bytes,1,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`

--- a/proto/kuberay_api.swagger.json
+++ b/proto/kuberay_api.swagger.json
@@ -26,7 +26,7 @@
   "paths": {
     "/apis/v1/clusters": {
       "get": {
-        "summary": "Finds all Clusters in all namespaces. Supports pagination, and sorting on certain fields.",
+        "summary": "Finds all Clusters in all namespaces.",
         "operationId": "ClusterService_ListAllClusters",
         "responses": {
           "200": {
@@ -66,7 +66,7 @@
     },
     "/apis/v1/namespaces/{namespace}/clusters": {
       "get": {
-        "summary": "Finds all Clusters in a given namespace. Supports pagination, and sorting on certain fields.",
+        "summary": "Finds all Clusters in a given namespace.",
         "operationId": "ClusterService_ListCluster",
         "responses": {
           "200": {
@@ -228,7 +228,7 @@
     },
     "/apis/v1/compute_templates": {
       "get": {
-        "summary": "Finds all compute templates in all namespaces. Supports pagination, and sorting on certain fields.",
+        "summary": "Finds all compute templates in all namespaces.",
         "operationId": "ComputeTemplateService_ListAllComputeTemplates",
         "responses": {
           "200": {
@@ -292,7 +292,7 @@
     },
     "/apis/v1/namespaces/{namespace}/compute_templates": {
       "get": {
-        "summary": "Finds all compute templates in a given namespace. Supports pagination, and sorting on certain fields.",
+        "summary": "Finds all compute templates in a given namespace.",
         "operationId": "ComputeTemplateService_ListComputeTemplates",
         "responses": {
           "200": {
@@ -439,7 +439,7 @@
     },
     "/apis/v1/namespaces/{namespace}/image_templates": {
       "get": {
-        "summary": "Not Implemented. Finds all ImageTemplates. Supports pagination, and sorting on certain fields.",
+        "summary": "Not Implemented. Finds all ImageTemplates.",
         "operationId": "ImageTemplateService_ListImageTemplates",
         "responses": {
           "200": {
@@ -775,7 +775,7 @@
           },
           {
             "name": "pageToken",
-            "description": "A page token to request the next page of results. The token is acquried\nfrom the nextPageToken field of the response from the previous\nListRayServices call or can be omitted when fetching the first page.",
+            "description": "A page token to request the next page of results. The token is acquired\nfrom the nextPageToken field of the response from the previous\nListRayServices call or can be omitted when fetching the first page.",
             "in": "query",
             "required": false,
             "type": "string"
@@ -976,7 +976,7 @@
         "parameters": [
           {
             "name": "pageToken",
-            "description": "A page token to request the next page of results. The token is acquried\nfrom the nextPageToken field of the response from the previous\nListRayServices call or can be omitted when fetching the first page.",
+            "description": "A page token to request the next page of results. The token is acquired\nfrom the nextPageToken field of the response from the previous\nListRayServices call or can be omitted when fetching the first page.",
             "in": "query",
             "required": false,
             "type": "string"
@@ -1734,7 +1734,7 @@
           "title": "Output. The result image generated"
         }
       },
-      "title": "ImageTemplate can be used by worker group and workspce.\nThey can be distinguish by different entrypoints"
+      "title": "ImageTemplate can be used by worker group and workspace.\nThey can be distinguish by different entrypoints"
     },
     "protoListAllComputeTemplatesResponse": {
       "type": "object",

--- a/proto/swagger/cluster.swagger.json
+++ b/proto/swagger/cluster.swagger.json
@@ -21,7 +21,7 @@
   "paths": {
     "/apis/v1/clusters": {
       "get": {
-        "summary": "Finds all Clusters in all namespaces. Supports pagination, and sorting on certain fields.",
+        "summary": "Finds all Clusters in all namespaces.",
         "operationId": "ClusterService_ListAllClusters",
         "responses": {
           "200": {
@@ -61,7 +61,7 @@
     },
     "/apis/v1/namespaces/{namespace}/clusters": {
       "get": {
-        "summary": "Finds all Clusters in a given namespace. Supports pagination, and sorting on certain fields.",
+        "summary": "Finds all Clusters in a given namespace.",
         "operationId": "ClusterService_ListCluster",
         "responses": {
           "200": {

--- a/proto/swagger/config.swagger.json
+++ b/proto/swagger/config.swagger.json
@@ -24,7 +24,7 @@
   "paths": {
     "/apis/v1/compute_templates": {
       "get": {
-        "summary": "Finds all compute templates in all namespaces. Supports pagination, and sorting on certain fields.",
+        "summary": "Finds all compute templates in all namespaces.",
         "operationId": "ComputeTemplateService_ListAllComputeTemplates",
         "responses": {
           "200": {
@@ -88,7 +88,7 @@
     },
     "/apis/v1/namespaces/{namespace}/compute_templates": {
       "get": {
-        "summary": "Finds all compute templates in a given namespace. Supports pagination, and sorting on certain fields.",
+        "summary": "Finds all compute templates in a given namespace.",
         "operationId": "ComputeTemplateService_ListComputeTemplates",
         "responses": {
           "200": {
@@ -235,7 +235,7 @@
     },
     "/apis/v1/namespaces/{namespace}/image_templates": {
       "get": {
-        "summary": "Not Implemented. Finds all ImageTemplates. Supports pagination, and sorting on certain fields.",
+        "summary": "Not Implemented. Finds all ImageTemplates.",
         "operationId": "ImageTemplateService_ListImageTemplates",
         "responses": {
           "200": {
@@ -479,7 +479,7 @@
           "title": "Output. The result image generated"
         }
       },
-      "title": "ImageTemplate can be used by worker group and workspce.\nThey can be distinguish by different entrypoints"
+      "title": "ImageTemplate can be used by worker group and workspace.\nThey can be distinguish by different entrypoints"
     },
     "protoListAllComputeTemplatesResponse": {
       "type": "object",

--- a/proto/swagger/serve.swagger.json
+++ b/proto/swagger/serve.swagger.json
@@ -47,7 +47,7 @@
           },
           {
             "name": "pageToken",
-            "description": "A page token to request the next page of results. The token is acquried\nfrom the nextPageToken field of the response from the previous\nListRayServices call or can be omitted when fetching the first page.",
+            "description": "A page token to request the next page of results. The token is acquired\nfrom the nextPageToken field of the response from the previous\nListRayServices call or can be omitted when fetching the first page.",
             "in": "query",
             "required": false,
             "type": "string"
@@ -248,7 +248,7 @@
         "parameters": [
           {
             "name": "pageToken",
-            "description": "A page token to request the next page of results. The token is acquried\nfrom the nextPageToken field of the response from the previous\nListRayServices call or can be omitted when fetching the first page.",
+            "description": "A page token to request the next page of results. The token is acquired\nfrom the nextPageToken field of the response from the previous\nListRayServices call or can be omitted when fetching the first page.",
             "in": "query",
             "required": false,
             "type": "string"


### PR DESCRIPTION

## Why are these changes needed?

See linked issue for details.
We don't plan to support sorting for list operations, so remove it from documentation everywhere.
I also remove the comment on pagination, because pagination is a very common feature for list; open to revert if people think it necessary.

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/3408

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
