### PR TITLE
[TEST] Improve unit test coverage for apiserver `pkg/model`

### DIFF
--- a/apiserver/pkg/model/converter.go
+++ b/apiserver/pkg/model/converter.go
@@ -89,7 +89,7 @@ func contains(s []string, str string) bool {
 }
 
 func FromCrdToAPIClusters(clusters []*rayv1api.RayCluster, clusterEventsMap map[string][]corev1.Event) []*api.Cluster {
-	apiClusters := make([]*api.Cluster, 0)
+	apiClusters := make([]*api.Cluster, 0, len(clusters))
 	for _, cluster := range clusters {
 		apiClusters = append(apiClusters, FromCrdToAPICluster(cluster, clusterEventsMap[cluster.Name]))
 	}
@@ -436,7 +436,7 @@ func FromKubeToAPIComputeTemplate(configMap *corev1.ConfigMap) *api.ComputeTempl
 }
 
 func FromKubeToAPIComputeTemplates(configMaps []*corev1.ConfigMap) []*api.ComputeTemplate {
-	apiComputeTemplates := make([]*api.ComputeTemplate, 0)
+	apiComputeTemplates := make([]*api.ComputeTemplate, 0, len(configMaps))
 	for _, configMap := range configMaps {
 		apiComputeTemplates = append(apiComputeTemplates, FromKubeToAPIComputeTemplate(configMap))
 	}
@@ -444,7 +444,7 @@ func FromKubeToAPIComputeTemplates(configMaps []*corev1.ConfigMap) []*api.Comput
 }
 
 func FromCrdToAPIJobs(jobs []*rayv1api.RayJob) []*api.RayJob {
-	apiJobs := make([]*api.RayJob, 0)
+	apiJobs := make([]*api.RayJob, 0, len(jobs))
 	for _, job := range jobs {
 		apiJobs = append(apiJobs, FromCrdToAPIJob(job))
 	}

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -206,6 +206,7 @@ var workerSpecTest = rayv1api.WorkerGroupSpec{
 				{
 					Name:  "ray-worker",
 					Image: "blublinsky1/ray310:2.5.0",
+					ImagePullPolicy: "Always",
 					Env: []corev1.EnvVar{
 						{
 							Name:  "AWS_KEY",
@@ -541,6 +542,9 @@ func TestPopulateWorkerNodeSpec(t *testing.T) {
 	if groupSpec.ImagePullSecret != "foo" {
 		t.Errorf("failed to convert image pull secret")
 	}
+	if groupSpec.ImagePullPolicy != "Always" {
+		t.Errorf("failed to convert image pull policy")
+	}
 	if !reflect.DeepEqual(groupSpec.Annotations, expectedAnnotations) {
 		t.Errorf("failed to convert annotations, got %v, expected %v", groupSpec.Annotations, expectedAnnotations)
 	}
@@ -566,6 +570,11 @@ func TestAutoscalerOptions(t *testing.T) {
 	assert.Len(t, options.Envs.Values, 1)
 	assert.Len(t, options.Envs.ValuesFrom, 2)
 	assert.Len(t, options.Volumes, 2)
+}
+
+func TestNilAutoscalerOptions(t *testing.T) {
+	options := convertAutoscalingOptions(nil)
+	assert.Nil(t, options)
 }
 
 func TestPopulateRayClusterSpec(t *testing.T) {

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -629,6 +629,15 @@ func TestPopulateRayClusterSpec(t *testing.T) {
 	}
 }
 
+func TestFromKubeToAPIComputeTemplates(t *testing.T) {
+	configMaps := []*corev1.ConfigMap{&configMapWithoutTolerations}
+	template := FromKubeToAPIComputeTemplates(configMaps)[0]
+	assert.Equal(t, uint32(4), template.Cpu, "CPU mismatch")
+	assert.Equal(t, uint32(8), template.Memory, "Memory mismatch")
+	assert.Equal(t, uint32(0), template.Gpu, "GPU mismatch")
+	assert.Equal(t, "", template.GpuAccelerator, "GPU accelerator mismatch")
+}
+
 func TestPopulateTemplate(t *testing.T) {
 	template := FromKubeToAPIComputeTemplate(&configMapWithoutTolerations)
 	if len(template.Tolerations) != 0 {

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -670,6 +670,16 @@ func tolerationToString(toleration *api.PodToleration) string {
 	return "Key: " + toleration.Key + " Operator: " + toleration.Operator + " Effect: " + toleration.Effect
 }
 
+func TestFromCrdToAPIJob(t *testing.T) {
+	jobs := []*rayv1api.RayJob{&JobNewClusterTest}
+	job := FromCrdToAPIJobs(jobs)[0]
+	assert.Equal(t, "test", job.Name)
+	assert.Equal(t, "test", job.Namespace)
+	assert.Equal(t, "user", job.User)
+	assert.Equal(t, "python /home/ray/samples/sample_code.py", job.Entrypoint)
+	assert.Equal(t, "123", job.Metadata["job_submission_id"])
+}
+
 func TestPopulateJob(t *testing.T) {
 	job := FromCrdToAPIJob(&JobNewClusterTest)
 	fmt.Printf("jobWithCluster = %#v\n", job)

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -204,8 +204,8 @@ var workerSpecTest = rayv1api.WorkerGroupSpec{
 			},
 			Containers: []corev1.Container{
 				{
-					Name:  "ray-worker",
-					Image: "blublinsky1/ray310:2.5.0",
+					Name:            "ray-worker",
+					Image:           "blublinsky1/ray310:2.5.0",
 					ImagePullPolicy: "Always",
 					Env: []corev1.EnvVar{
 						{
@@ -575,6 +575,16 @@ func TestAutoscalerOptions(t *testing.T) {
 func TestNilAutoscalerOptions(t *testing.T) {
 	options := convertAutoscalingOptions(nil)
 	assert.Nil(t, options)
+}
+
+func TestFromCrdToAPIClusters(t *testing.T) {
+	clusters := []*rayv1api.RayCluster{&ClusterSpecTest}
+	clusterEventsMap := map[string][]corev1.Event{}
+	cluster := FromCrdToAPIClusters(clusters, clusterEventsMap)[0]
+	if len(cluster.Annotations) != 1 {
+		t.Errorf("failed to convert cluster's annotations")
+	}
+	assert.Equal(t, "nginx", cluster.Annotations["kubernetes.io/ingress.class"])
 }
 
 func TestPopulateRayClusterSpec(t *testing.T) {

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -670,7 +670,7 @@ func tolerationToString(toleration *api.PodToleration) string {
 	return "Key: " + toleration.Key + " Operator: " + toleration.Operator + " Effect: " + toleration.Effect
 }
 
-func TestFromCrdToAPIJob(t *testing.T) {
+func TestFromCrdToAPIJobs(t *testing.T) {
 	jobs := []*rayv1api.RayJob{&JobNewClusterTest}
 	job := FromCrdToAPIJobs(jobs)[0]
 	assert.Equal(t, "test", job.Name)

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -580,11 +580,14 @@ func TestNilAutoscalerOptions(t *testing.T) {
 func TestFromCrdToAPIClusters(t *testing.T) {
 	clusters := []*rayv1api.RayCluster{&ClusterSpecTest}
 	clusterEventsMap := map[string][]corev1.Event{}
-	cluster := FromCrdToAPIClusters(clusters, clusterEventsMap)[0]
-	if len(cluster.Annotations) != 1 {
+	apiClusters := FromCrdToAPIClusters(clusters, clusterEventsMap)
+	assert.Len(t, apiClusters, 1)
+
+	apiCluster := apiClusters[0]
+	if len(apiCluster.Annotations) != 1 {
 		t.Errorf("failed to convert cluster's annotations")
 	}
-	assert.Equal(t, "nginx", cluster.Annotations["kubernetes.io/ingress.class"])
+	assert.Equal(t, "nginx", apiCluster.Annotations["kubernetes.io/ingress.class"])
 }
 
 func TestPopulateRayClusterSpec(t *testing.T) {
@@ -631,7 +634,10 @@ func TestPopulateRayClusterSpec(t *testing.T) {
 
 func TestFromKubeToAPIComputeTemplates(t *testing.T) {
 	configMaps := []*corev1.ConfigMap{&configMapWithoutTolerations}
-	template := FromKubeToAPIComputeTemplates(configMaps)[0]
+	templates := FromKubeToAPIComputeTemplates(configMaps)
+	assert.Len(t, templates, 1)
+
+	template := templates[0]
 	assert.Equal(t, uint32(4), template.Cpu, "CPU mismatch")
 	assert.Equal(t, uint32(8), template.Memory, "Memory mismatch")
 	assert.Equal(t, uint32(0), template.Gpu, "GPU mismatch")
@@ -672,12 +678,15 @@ func tolerationToString(toleration *api.PodToleration) string {
 
 func TestFromCrdToAPIJobs(t *testing.T) {
 	jobs := []*rayv1api.RayJob{&JobNewClusterTest}
-	job := FromCrdToAPIJobs(jobs)[0]
-	assert.Equal(t, "test", job.Name)
-	assert.Equal(t, "test", job.Namespace)
-	assert.Equal(t, "user", job.User)
-	assert.Equal(t, "python /home/ray/samples/sample_code.py", job.Entrypoint)
-	assert.Equal(t, "123", job.Metadata["job_submission_id"])
+	apiJobs := FromCrdToAPIJobs(jobs)
+	assert.Len(t, apiJobs, 1)
+
+	apiJob := apiJobs[0]
+	assert.Equal(t, "test", apiJob.Name)
+	assert.Equal(t, "test", apiJob.Namespace)
+	assert.Equal(t, "user", apiJob.User)
+	assert.Equal(t, "python /home/ray/samples/sample_code.py", apiJob.Entrypoint)
+	assert.Equal(t, "123", apiJob.Metadata["job_submission_id"])
 }
 
 func TestPopulateJob(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Changes
1. Fix linting issues
2. Add a test case for `nil` input in `convertAutoscalingOptions`
3. Add a test for the `ImagePullPolicy` field in `PopulateWorkerNodeSpec`
4. Add unit tests for functions that convert slices of K8s-native CRD objects into KubeRay’s internal API representations:
    * `FromCrdToAPIClusters`
    * `FromKubeToAPIComputeTemplates`
    * `FromCrdToAPIJobs`

## Why are these changes needed?
To ensure high confidence in code quality before releasing the APIServer to the public, we aim to improve unit test coverage. Currently, the `pkg/model` package within the APIServer has low unit test coverage, as shown below:

### Before
![Screenshot 2025-04-18 at 12 07 54 AM](https://github.com/user-attachments/assets/d2c75d43-7b43-48f0-b494-c7e183af1f33)

### After
After adding new tests above, the unit test coverage boosts from 74.7% to 79.3%.
<img width="947" alt="Screenshot 2025-04-19 at 12 22 55 PM" src="https://github.com/user-attachments/assets/e6ae56a8-7746-4f5e-a8c2-8f6d8b04a249" />


## Related issue number
https://github.com/ray-project/kuberay/issues/3316
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
