### PR TITLE
[1/N] [Lint] Group imports by sections

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,6 +55,7 @@ linters-settings:
       - fieldalignment
   lll:
     line-length: 120
+
 linters:
   enable:
     - asciicheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,7 +55,6 @@ linters-settings:
       - fieldalignment
   lll:
     line-length: 120
-
 linters:
   enable:
     - asciicheck

--- a/kubectl-plugin/cmd/kubectl-ray.go
+++ b/kubectl-plugin/cmd/kubectl-ray.go
@@ -3,9 +3,10 @@ package main
 import (
 	"os"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/cmd"
 	flag "github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/cmd"
 )
 
 func main() {

--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -5,18 +5,17 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
 	"k8s.io/utils/ptr"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/generation"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util/templates"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/generation"
 
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
 	rayclient "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned"

--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -7,18 +7,18 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/generation"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/utils/ptr"
 
-	kubefake "k8s.io/client-go/kubernetes/fake"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/generation"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayClientFake "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/fake"

--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -5,19 +5,18 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util/templates"
 )
 
 type CreateWorkerGroupOptions struct {

--- a/kubectl-plugin/pkg/cmd/delete/delete.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete.go
@@ -7,16 +7,16 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
+
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/completion"
-	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util/templates"
 )
 
 type DeleteOptions struct {

--- a/kubectl-plugin/pkg/cmd/delete/delete_test.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete_test.go
@@ -3,12 +3,13 @@ package kubectlraydelete
 import (
 	"testing"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 )
 
 func TestComplete(t *testing.T) {

--- a/kubectl-plugin/pkg/cmd/get/get.go
+++ b/kubectl-plugin/pkg/cmd/get/get.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 func NewGetCommand(cmdFactory cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {

--- a/kubectl-plugin/pkg/cmd/get/get_cluster.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster.go
@@ -7,15 +7,16 @@ import (
 	"io"
 	"time"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/completion"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/completion"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )

--- a/kubectl-plugin/pkg/cmd/get/get_nodes.go
+++ b/kubectl-plugin/pkg/cmd/get/get_nodes.go
@@ -7,9 +7,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/completion"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -19,6 +16,10 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/completion"
 )
 
 type GetNodesOptions struct {

--- a/kubectl-plugin/pkg/cmd/get/get_nodes_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_nodes_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,6 +17,7 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"

--- a/kubectl-plugin/pkg/cmd/get/get_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/get/get_workergroup.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/completion"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -17,6 +14,10 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/completion"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )

--- a/kubectl-plugin/pkg/cmd/get/get_workergroup_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_workergroup_test.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +19,9 @@ import (
 	kubetesting "k8s.io/client-go/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/utils/ptr"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayClientFake "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/fake"

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/shlex"
+	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -22,11 +24,9 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 	"sigs.k8s.io/yaml"
 
-	"github.com/google/shlex"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/generation"
-	"github.com/spf13/cobra"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayscheme "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme"

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,6 +27,8 @@ import (
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 )
 
 // Mocked NewSPDYExecutor

--- a/kubectl-plugin/pkg/cmd/ray.go
+++ b/kubectl-plugin/pkg/cmd/ray.go
@@ -1,11 +1,10 @@
 package cmd
 
 import (
+	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-
-	"github.com/spf13/cobra"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/cmd/create"
 	kubectlraydelete "github.com/ray-project/kuberay/kubectl-plugin/pkg/cmd/delete"

--- a/kubectl-plugin/pkg/cmd/scale/scale_cluster.go
+++ b/kubectl-plugin/pkg/cmd/scale/scale_cluster.go
@@ -7,13 +7,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 )
 
 type ScaleClusterOptions struct {

--- a/kubectl-plugin/pkg/cmd/scale/scale_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/scale/scale_cluster_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +15,8 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/utils/ptr"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayClientFake "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/fake"

--- a/kubectl-plugin/pkg/cmd/session/session.go
+++ b/kubectl-plugin/pkg/cmd/session/session.go
@@ -8,13 +8,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/completion"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/completion"
 )
 
 type appPort struct {

--- a/kubectl-plugin/pkg/cmd/session/session_test.go
+++ b/kubectl-plugin/pkg/cmd/session/session_test.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +12,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 )
 
 func TestCompleteFoo(t *testing.T) {

--- a/kubectl-plugin/pkg/cmd/version/version.go
+++ b/kubectl-plugin/pkg/cmd/version/version.go
@@ -7,10 +7,11 @@ import (
 	"os"
 	"runtime/debug"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client"
 )
 
 var Version = "development"

--- a/kubectl-plugin/pkg/cmd/version/version_test.go
+++ b/kubectl-plugin/pkg/cmd/version/version_test.go
@@ -7,11 +7,12 @@ import (
 	"runtime/debug"
 	"testing"
 
-	clientfake "github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	clientfake "github.com/ray-project/kuberay/kubectl-plugin/pkg/util/client/fake"
 )
 
 func createBuildInfo(revision, time string) *debug.BuildInfo {

--- a/kubectl-plugin/pkg/util/client/client.go
+++ b/kubectl-plugin/pkg/util/client/client.go
@@ -7,13 +7,14 @@ import (
 	"time"
 
 	dockerparser "github.com/novln/docker-parser"
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayclient "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned"

--- a/kubectl-plugin/pkg/util/client/client_test.go
+++ b/kubectl-plugin/pkg/util/client/client_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -15,6 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	kubeFake "k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayClientFake "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/fake"

--- a/kubectl-plugin/pkg/util/client/fake/fake_client.go
+++ b/kubectl-plugin/pkg/util/client/fake/fake_client.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 
 	rayclient "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned"
 )

--- a/kubectl-plugin/pkg/util/completion/completion.go
+++ b/kubectl-plugin/pkg/util/completion/completion.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/completion"
 

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -6,15 +6,13 @@ import (
 	"os"
 	"strconv"
 
-	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
-
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
-	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
-	"k8s.io/utils/ptr"
-
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 


### PR DESCRIPTION
## Why are these changes needed?
Typically we group imports by at least three sections.
1. Standard – All Go standard library imports.
2. Default – Third-party libraries (anything not in standard or custom prefix).
3. Prefix – `github.com/ray-project/kuberay` in our case

There are multiple tools help us do this. For example, we can use gci with the following configuration
```
gci:
  sections:
    - standard
    - default
    - prefix(github.com/ray-project/kuberay)
  skip-generated: true
```
To keep changes minimal, I only modify kubectl-plugin in this PR. Also since we have wrongly configured local prefix as `github.com/ray-project/kuberay/ray-operator` instead of `github.com/ray-project/kuberay`, the linter will separate `github.com/ray-project/kuberay/ray-operator` with other `github.com/ray-project/kuberay` packages. 
See: https://github.com/ray-project/kuberay/blob/master/.golangci.yml#L10
I will fix this in the follow-up PRs.

Note: I haven't enabled the new lint rule since it will try to modify all lint errors, which avoid me keeping changes minimal.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
