### PR TITLE
[Apiserver] Use Eventually from Gomega instead of wait from apimachinery

### DIFF
--- a/apiserver/go.mod
+++ b/apiserver/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
+	github.com/onsi/gomega v1.36.2
 	github.com/rs/zerolog v1.34.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7
 	k8s.io/utils v0.0.0-20241210054802-24370beab758

--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -120,7 +120,7 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
-	waitForRayJob(t, tCtx, createActorRequest.Job.Name, []rayv1api.JobStatus{rayv1api.JobStatusSucceeded})
+	waitForRayJobInExpectedStatuses(t, tCtx, createActorRequest.Job.Name, []rayv1api.JobStatus{rayv1api.JobStatusSucceeded})
 
 	// worker pod should be created as part of job execution
 	g.Eventually(func() int32 {
@@ -149,7 +149,7 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
-	waitForRayJob(t, tCtx, createActorRequest.Job.Name, []rayv1api.JobStatus{rayv1api.JobStatusSucceeded})
+	waitForRayJobInExpectedStatuses(t, tCtx, createActorRequest.Job.Name, []rayv1api.JobStatus{rayv1api.JobStatusSucceeded})
 	g.Eventually(func() int32 {
 		rayCluster, err := tCtx.GetRayClusterByName(actualCluster.Name)
 		if err != nil {

--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -131,7 +131,7 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 		}
 		t.Logf("Found ray cluster with %d available worker replicas", rayCluster.Status.AvailableWorkerReplicas)
 		return rayCluster.Status.AvailableWorkerReplicas
-	}, TestTimeoutMedium).Should(gomega.Equal(int32(1)))
+	}, TestTimeoutMedium, TestPollingInterval).Should(gomega.Equal(int32(1)))
 	// Delete actor
 	deleteActorRequest := api.CreateRayJobRequest{
 		Namespace: tCtx.GetNamespaceName(),
@@ -158,6 +158,6 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 		}
 		t.Logf("Found ray cluster with %d available worker replicas", rayCluster.Status.AvailableWorkerReplicas)
 		return rayCluster.Status.AvailableWorkerReplicas
-	}, TestTimeoutMedium).Should(gomega.Equal(int32(0)))
+	}, TestTimeoutMedium, TestPollingInterval).Should(gomega.Equal(int32(0)))
 	require.NoError(t, err, "No error expected")
 }

--- a/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_autoscaler_e2e_test.go
@@ -1,21 +1,21 @@
 package e2e
 
 import (
-	"context"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	api "github.com/ray-project/kuberay/proto/go_client"
 
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCreateClusterAutoscalerEndpoint sequentially iterates over the create cluster endpoint
 // with valid and invalid requests
 func TestCreateClusterAutoscaler(t *testing.T) {
+	g := gomega.NewWithT(t)
+
 	tCtx, err := NewEnd2EndTestingContext(t)
 	require.NoError(t, err, "No error expected when creating testing context")
 
@@ -123,15 +123,15 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 	waitForRayJob(t, tCtx, createActorRequest.Job.Name, []rayv1api.JobStatus{rayv1api.JobStatusSucceeded})
 
 	// worker pod should be created as part of job execution
-	err = wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
+	g.Eventually(func() int32 {
 		rayCluster, err := tCtx.GetRayClusterByName(actualCluster.Name)
 		if err != nil {
-			return true, err
+			t.Logf("Error getting ray cluster: %v", err)
+			return -1 // Return -1 to indicate error condition
 		}
 		t.Logf("Found ray cluster with %d available worker replicas", rayCluster.Status.AvailableWorkerReplicas)
-		return rayCluster.Status.AvailableWorkerReplicas == 1, nil
-	})
-	require.NoError(t, err, "No error expected")
+		return rayCluster.Status.AvailableWorkerReplicas
+	}, TestTimeoutMedium).Should(gomega.Equal(int32(1)))
 	// Delete actor
 	deleteActorRequest := api.CreateRayJobRequest{
 		Namespace: tCtx.GetNamespaceName(),
@@ -150,14 +150,14 @@ func TestCreateClusterAutoscaler(t *testing.T) {
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
 	waitForRayJob(t, tCtx, createActorRequest.Job.Name, []rayv1api.JobStatus{rayv1api.JobStatusSucceeded})
-
-	err = wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
+	g.Eventually(func() int32 {
 		rayCluster, err := tCtx.GetRayClusterByName(actualCluster.Name)
 		if err != nil {
-			return true, err
+			t.Logf("Error getting ray cluster: %v", err)
+			return -1 // Return -1 to indicate error condition
 		}
 		t.Logf("Found ray cluster with %d available worker replicas", rayCluster.Status.AvailableWorkerReplicas)
-		return rayCluster.Status.AvailableWorkerReplicas == 0, nil
-	})
+		return rayCluster.Status.AvailableWorkerReplicas
+	}, TestTimeoutMedium).Should(gomega.Equal(int32(0)))
 	require.NoError(t, err, "No error expected")
 }

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -11,6 +11,8 @@ import (
 	api "github.com/ray-project/kuberay/proto/go_client"
 
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestCreateClusterEndpoint sequentially iterates over the create cluster endpoint

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
 

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -505,7 +505,7 @@ func TestDeleteCluster(t *testing.T) {
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
-				waitForDeletedCluster(t, tCtx, tc.Input.Name)
+				waitForClusterToDisappear(t, tCtx, tc.Input.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
 				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")

--- a/apiserver/test/e2e/config_server_e2e_test.go
+++ b/apiserver/test/e2e/config_server_e2e_test.go
@@ -5,10 +5,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestCreateTemplate sequentially iterates over the create compute endpoint

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -216,7 +216,7 @@ func TestCreateJobWithDisposableClusters(t *testing.T) {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.NotNil(t, actualJob, "A job is expected")
-				waitForRayJob(t, tCtx, tc.Input.Job.Name, []rayv1api.JobStatus{tc.ExpectedJobStatus})
+				waitForRayJobInExpectedStatuses(t, tCtx, tc.Input.Job.Name, []rayv1api.JobStatus{tc.ExpectedJobStatus})
 				tCtx.DeleteRayJobByName(t, actualJob.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
@@ -274,7 +274,7 @@ func TestDeleteJob(t *testing.T) {
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
-				waitForDeletedRayJob(t, tCtx, testJobRequest.Job.Name)
+				waitForRayJobToDisappear(t, tCtx, testJobRequest.Job.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
 				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")
@@ -643,7 +643,7 @@ func TestCreateJobWithClusterSelector(t *testing.T) {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
 				require.NotNil(t, actualJob, "A job is expected")
-				waitForRayJob(t, tCtx, tc.Input.Job.Name, []rayv1api.JobStatus{tc.ExpectedJobStatus})
+				waitForRayJobInExpectedStatuses(t, tCtx, tc.Input.Job.Name, []rayv1api.JobStatus{tc.ExpectedJobStatus})
 				tCtx.DeleteRayJobByName(t, actualJob.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
@@ -721,6 +721,6 @@ func createTestJob(t *testing.T, tCtx *End2EndTestingContext, expectedJobStatues
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, actualJob, "A job is expected")
-	waitForRayJob(t, tCtx, testJobRequest.Job.Name, expectedJobStatues)
+	waitForRayJobInExpectedStatuses(t, tCtx, testJobRequest.Job.Name, expectedJobStatues)
 	return testJobRequest
 }

--- a/apiserver/test/e2e/job_submission_e2e_test.go
+++ b/apiserver/test/e2e/job_submission_e2e_test.go
@@ -3,9 +3,9 @@ package e2e
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	api "github.com/ray-project/kuberay/proto/go_client"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateJobSubmission(t *testing.T) {

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -194,7 +194,7 @@ func TestDeleteService(t *testing.T) {
 			if tc.ExpectedError == nil {
 				require.NoError(t, err, "No error expected")
 				require.Nil(t, actualRPCStatus, "No RPC status expected")
-				waitForDeletedService(t, tCtx, testServiceRequest.Service.Name)
+				waitForServiceToDisappear(t, tCtx, testServiceRequest.Service.Name)
 			} else {
 				require.EqualError(t, err, tc.ExpectedError.Error(), "Matching error expected")
 				require.NotNil(t, actualRPCStatus, "A not nill RPC status is required")

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	// "context"
 	"net/http"
 	"testing"
 

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -1,18 +1,14 @@
 package e2e
 
 import (
-	"context"
+	// "context"
 	"net/http"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
 	api "github.com/ray-project/kuberay/proto/go_client"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestServiceServerV2 sequentially iterates over the endpoints of the service endpoints using
@@ -206,66 +202,6 @@ func TestDeleteService(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestUpdateRayService(t *testing.T) {
-	tCtx, err := NewEnd2EndTestingContext(t)
-	require.NoError(t, err)
-
-	tCtx.CreateComputeTemplate(t)
-	t.Cleanup(func() {
-		tCtx.DeleteComputeTemplate(t)
-	})
-
-	testServiceRequest := createTestServiceV2(t, tCtx)
-	serviceName := testServiceRequest.Service.Name
-	namespace := testServiceRequest.Namespace
-
-	t.Cleanup(func() {
-		tCtx.DeleteRayService(t, serviceName)
-	})
-
-	// Verify the original value before update
-	require.Equal(t, int32(1), testServiceRequest.Service.ClusterSpec.WorkerGroupSpec[0].Replicas)
-
-	// Clone the original ClusterSpec (proto.Clone avoids copying sync.Mutex)
-	oldSpec := proto.Clone(testServiceRequest.Service.ClusterSpec).(*api.ClusterSpec)
-
-	// Only modify replicas
-	oldSpec.WorkerGroupSpec[0].Replicas = 2 // Only field updated in this test
-
-	// Construct updated service from old spec
-	updatedService := &api.RayService{
-		Name:                               serviceName,
-		Namespace:                          namespace,
-		User:                               testServiceRequest.Service.User,
-		Version:                            testServiceRequest.Service.Version,
-		ServeConfig_V2:                     testServiceRequest.Service.ServeConfig_V2,
-		ServiceUnhealthySecondThreshold:    testServiceRequest.Service.ServiceUnhealthySecondThreshold,
-		DeploymentUnhealthySecondThreshold: testServiceRequest.Service.DeploymentUnhealthySecondThreshold,
-		ClusterSpec:                        oldSpec,
-	}
-
-	updateReq := &api.UpdateRayServiceRequest{
-		Service:   updatedService,
-		Namespace: namespace,
-		Name:      serviceName,
-	}
-
-	// Perform the update
-	respService, actualRPCStatus, err := tCtx.GetRayAPIServerClient().UpdateRayService(updateReq)
-	require.NoError(t, err)
-	require.Nil(t, actualRPCStatus)
-	require.NotNil(t, respService)
-
-	// Confirm update via RayService CRD
-	crdRayService, err := tCtx.GetRayServiceByName(serviceName)
-	require.NoError(t, err)
-	require.NotNil(t, crdRayService)
-
-	require.GreaterOrEqual(t, len(crdRayService.Spec.RayClusterSpec.WorkerGroupSpecs), 1)
-	require.NotNil(t, crdRayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas)
-	require.Equal(t, int32(2), *crdRayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas)
 }
 
 func TestGetAllServices(t *testing.T) {
@@ -536,19 +472,4 @@ func checkRayServiceCreatedSuccessfully(t *testing.T, tCtx *End2EndTestingContex
 	rayService, err := tCtx.GetRayServiceByName(serviceName)
 	require.NoError(t, err)
 	require.NotNil(t, rayService)
-}
-
-func waitForDeletedService(t *testing.T, tCtx *End2EndTestingContext, serviceName string) {
-	// wait for the service to be deleted
-	// if is not in that state, return an error
-	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		rayService, err := tCtx.GetRayServiceByName(serviceName)
-		if err != nil &&
-			assert.EqualError(t, err, "rayservices.ray.io \""+serviceName+"\" not found") {
-			return true, nil
-		}
-		t.Logf("Found status of '%s' for ray service '%s'", rayService.Status.ServiceStatus, serviceName)
-		return false, err
-	})
-	require.NoErrorf(t, err, "No error expected when deleting ray service: '%s', err %v", serviceName, err)
 }

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -10,22 +10,22 @@ import (
 	"time"
 
 	petnames "github.com/dustinkirkland/golang-petname"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
+	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
+	api "github.com/ray-project/kuberay/proto/go_client"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sApiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
-
-	kuberayHTTP "github.com/ray-project/kuberay/apiserver/pkg/http"
-	api "github.com/ray-project/kuberay/proto/go_client"
 
 	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 // GenericEnd2EndTest struct allows for reuse in setting up and running tests
@@ -346,15 +346,15 @@ func (e2etc *End2EndTestingContext) DeleteRayCluster(t *testing.T, clusterName s
 
 	// wait for the cluster to be deleted for 3 minutes
 	// if is not in that state, return an error
-	err = wait.PollUntilContextTimeout(e2etc.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
+	g := gomega.NewWithT(t)
+	g.Eventually(func() bool {
 		rayCluster, err := e2etc.GetRayClusterByName(clusterName)
 		if err != nil && k8sApiErrors.IsNotFound(err) {
-			return true, nil
+			return true
 		}
 		t.Logf("Found cluster state of '%s' for ray cluster '%s'", rayCluster.Status.State, clusterName)
-		return false, nil
-	})
-	require.NoErrorf(t, err, "No error expected when waiting for ray cluster: '%s' to be deleted, err %v", clusterName, err)
+		return false
+	}, TestTimeoutMedium).Should(gomega.BeTrue())
 }
 
 func (e2etc *End2EndTestingContext) DeleteRayService(t *testing.T, serviceName string) {
@@ -367,15 +367,15 @@ func (e2etc *End2EndTestingContext) DeleteRayService(t *testing.T, serviceName s
 
 	// wait for the cluster to be deleted for 3 minutes
 	// if is not in that state, return an error
-	err = wait.PollUntilContextTimeout(e2etc.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
+	g := gomega.NewWithT(t)
+	g.Eventually(func() bool {
 		rayService, err := e2etc.GetRayServiceByName(serviceName)
 		if err != nil && k8sApiErrors.IsNotFound(err) {
-			return true, nil
+			return true
 		}
-		t.Logf("Found service state of '%s' for ray cluster '%s'", rayService.Status.ServiceStatus, serviceName)
-		return false, nil
-	})
-	require.NoErrorf(t, err, "No error expected when waiting to delete ray service: '%s', err %v", serviceName, err)
+		t.Logf("Found service state of '%s' for ray service '%s'", rayService.Status.ServiceStatus, serviceName)
+		return false
+	}, TestTimeoutMedium).Should(gomega.BeTrue())
 }
 
 func (e2etc *End2EndTestingContext) DeleteRayJobByName(t *testing.T, rayJobName string) {
@@ -388,14 +388,15 @@ func (e2etc *End2EndTestingContext) DeleteRayJobByName(t *testing.T, rayJobName 
 
 	// wait for the cluster to be deleted for 3 minutes
 	// if is not in that state, return an error
-	err = wait.PollUntilContextTimeout(e2etc.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
+	g := gomega.NewWithT(t)
+	g.Eventually(func() bool {
 		rayJob, err := e2etc.GetRayJobByName(rayJobName)
 		if err != nil && k8sApiErrors.IsNotFound(err) {
-			return true, nil
+			return true
 		}
-		t.Logf("Found job state of '%s' for ray cluster '%s'", rayJob.Status.JobStatus, rayJobName)
-		return false, nil
-	})
+		t.Logf("Found job state of '%s' for ray job '%s'", rayJob.Status.JobStatus, rayJobName)
+		return false
+	}, TestTimeoutMedium).Should(gomega.BeTrue())
 	require.NoErrorf(t, err, "No error expected when waiting to delete ray job: '%s', err %v", rayJobName, err)
 }
 

--- a/apiserver/test/e2e/utils.go
+++ b/apiserver/test/e2e/utils.go
@@ -29,7 +29,7 @@ var (
 	TestPollingInterval = 500 * time.Millisecond
 )
 
-// CreateHttpRequest instantiates a http request for the  specified endpoint and host
+// CreateHttpRequest instantiates a http request for the specified endpoint and host
 func CreateHttpRequest(method string, host string, endPoint string, body io.Reader) (*http.Request, error) {
 	url := host + endPoint
 	req, err := http.NewRequestWithContext(context.TODO(), method, url, body)
@@ -41,7 +41,7 @@ func CreateHttpRequest(method string, host string, endPoint string, body io.Read
 	return req, nil
 }
 
-// MakeBodyReader creates a io.Reader from the supplied string if is not empty after
+// MakeBodyReader creates an io.Reader from the supplied string if is not empty after
 // trimming the spaces
 func MakeBodyReader(s string) io.Reader {
 	if strings.TrimSpace(s) != "" {
@@ -100,8 +100,8 @@ func waitForRunningCluster(t *testing.T, tCtx *End2EndTestingContext, clusterNam
 	waitForClusterConditions(t, tCtx, clusterName, []rayv1api.RayClusterConditionType{rayv1api.RayClusterProvisioned})
 }
 
-func waitForDeletedCluster(t *testing.T, tCtx *End2EndTestingContext, clusterName string) {
-	// wait for the cluster to be deleted
+func waitForClusterToDisappear(t *testing.T, tCtx *End2EndTestingContext, clusterName string) {
+	// wait for the cluster to disappear
 	g := gomega.NewWithT(t)
 	g.Eventually(func() bool {
 		_, err := tCtx.GetRayClusterByName(clusterName)
@@ -113,7 +113,7 @@ func waitForDeletedCluster(t *testing.T, tCtx *End2EndTestingContext, clusterNam
 	}, TestTimeoutMedium, TestPollingInterval).Should(gomega.BeTrue())
 }
 
-func waitForRayJob(t *testing.T, tCtx *End2EndTestingContext, rayJobName string, expectedJobStatuses []rayv1api.JobStatus) {
+func waitForRayJobInExpectedStatuses(t *testing.T, tCtx *End2EndTestingContext, rayJobName string, expectedJobStatuses []rayv1api.JobStatus) {
 	// `expectedJobStatuses` is a slice of job statuses that we expect the job to be in
 	// wait for the job to be in any of the `expectedJobStatuses` state for 3 minutes
 	// if is not in that state, return an error
@@ -125,13 +125,13 @@ func waitForRayJob(t *testing.T, tCtx *End2EndTestingContext, rayJobName string,
 			t.Logf("Error getting ray job '%s': %v", rayJobName, err)
 			return false
 		}
-		t.Logf("Waiting for ray job '%s' to be in one of the expected conditions %s", rayJobName, expectedJobStatuses)
+		t.Logf("Waiting for ray job '%s' to be in one of the expected statuses %s", rayJobName, expectedJobStatuses)
 		return slices.Contains(expectedJobStatuses, rayJob.Status.JobStatus)
 	}, TestTimeoutMedium, TestPollingInterval).Should(gomega.BeTrue())
 }
 
-func waitForDeletedRayJob(t *testing.T, tCtx *End2EndTestingContext, jobName string) {
-	// wait for the job to be deleted
+func waitForRayJobToDisappear(t *testing.T, tCtx *End2EndTestingContext, jobName string) {
+	// wait for the job to disappear
 	// if is not in that state, return an error
 	g := gomega.NewWithT(t)
 	t.Logf("Starting to wait for ray job %s to be deleted", jobName)
@@ -147,7 +147,7 @@ func waitForDeletedRayJob(t *testing.T, tCtx *End2EndTestingContext, jobName str
 	t.Logf("Ray job %s successfully deleted", jobName)
 }
 
-func waitForDeletedService(t *testing.T, tCtx *End2EndTestingContext, serviceName string) {
+func waitForServiceToDisappear(t *testing.T, tCtx *End2EndTestingContext, serviceName string) {
 	g := gomega.NewWithT(t)
 	t.Logf("Starting to wait for service %s to be deleted", serviceName)
 	g.Eventually(func() error {

--- a/apiserver/test/e2e/utils.go
+++ b/apiserver/test/e2e/utils.go
@@ -7,19 +7,26 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+
+	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	rayv1api "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
 //go:embed resources/*.py
 var files embed.FS
+
+var (
+	TestTimeoutShort  = 1 * time.Minute
+	TestTimeoutMedium = 3 * time.Minute
+	TestTimeoutLong   = 5 * time.Minute
+)
 
 // CreateHttpRequest instantiates a http request for the  specified endpoint and host
 func CreateHttpRequest(method string, host string, endPoint string, body io.Reader) (*http.Request, error) {
@@ -70,21 +77,22 @@ func waitForClusterConditions(t *testing.T, tCtx *End2EndTestingContext, cluster
 	}
 	// wait for the cluster to be in one of the expected conditions for 3 minutes
 	// if it is not in one of those conditions, return an error
-	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
+	g := gomega.NewWithT(t)
+	g.Eventually(func() bool {
 		rayCluster, err := tCtx.GetRayClusterByName(clusterName)
 		if err != nil {
-			return true, err
+			t.Logf("Error getting ray cluster '%s': %v", clusterName, err)
+			return false
 		}
 		t.Logf("Waiting for ray cluster '%s' to be in one of the expected conditions %s", clusterName, expectedConditions)
 		for _, condition := range expectedConditions {
 			if meta.IsStatusConditionTrue(rayCluster.Status.Conditions, string(condition)) {
 				t.Logf("Found condition '%s' for ray cluster '%s'", string(condition), clusterName)
-				return true, nil
+				return true
 			}
 		}
-		return false, nil
-	})
-	require.NoErrorf(t, err, "No error expected when getting ray cluster: '%s', err %v", tCtx.GetRayClusterName(), err)
+		return false
+	}, TestTimeoutMedium).Should(gomega.BeTrue())
 }
 
 func waitForRunningCluster(t *testing.T, tCtx *End2EndTestingContext, clusterName string) {
@@ -93,13 +101,62 @@ func waitForRunningCluster(t *testing.T, tCtx *End2EndTestingContext, clusterNam
 
 func waitForDeletedCluster(t *testing.T, tCtx *End2EndTestingContext, clusterName string) {
 	// wait for the cluster to be deleted
-	err := wait.PollUntilContextTimeout(tCtx.ctx, 500*time.Millisecond, 3*time.Minute, false, func(_ context.Context) (done bool, err error) {
-		_, err = tCtx.GetRayClusterByName(clusterName)
+	g := gomega.NewWithT(t)
+	g.Eventually(func() bool {
+		_, err := tCtx.GetRayClusterByName(clusterName)
 		if err != nil && strings.Contains(err.Error(), "rayclusters.ray.io \""+tCtx.GetRayClusterName()+"\" not found") {
-			return true, nil
+			return true
 		}
 		t.Logf("Found ray cluster '%s'", clusterName)
-		return false, err
-	})
-	require.NoErrorf(t, err, "No error expected when deleting ray cluster: '%s', err %v", clusterName, err)
+		return false
+	}, TestTimeoutMedium).Should(gomega.BeTrue())
+}
+
+func waitForRayJob(t *testing.T, tCtx *End2EndTestingContext, rayJobName string, expectedJobStatuses []rayv1api.JobStatus) {
+	// `expectedJobStatuses` is a slice of job statuses that we expect the job to be in
+	// wait for the job to be in any of the `expectedJobStatuses` state for 3 minutes
+	// if is not in that state, return an error
+	g := gomega.NewWithT(t)
+
+	g.Eventually(func() bool {
+		rayJob, err := tCtx.GetRayJobByName(rayJobName)
+		if err != nil {
+			t.Logf("Error getting ray job '%s': %v", rayJobName, err)
+			return false
+		}
+		t.Logf("Waiting for ray job '%s' to be in one of the expected conditions %s", rayJobName, expectedJobStatuses)
+		return slices.Contains(expectedJobStatuses, rayJob.Status.JobStatus)
+	}, TestTimeoutMedium).Should(gomega.BeTrue())
+}
+
+func waitForDeletedRayJob(t *testing.T, tCtx *End2EndTestingContext, jobName string) {
+	// wait for the job to be deleted
+	// if is not in that state, return an error
+	g := gomega.NewWithT(t)
+	t.Logf("Starting to wait for ray job %s to be deleted", jobName)
+	g.Eventually(func() error {
+		rayJob, err := tCtx.GetRayJobByName(jobName)
+		if err != nil {
+			return err
+		}
+		t.Logf("Find rayJob with status %v", rayJob.Status.JobStatus)
+		return nil
+	}, TestTimeoutMedium).Should(gomega.MatchError("rayjobs.ray.io \"" + jobName + "\" not found"))
+
+	t.Logf("Ray job %s successfully deleted", jobName)
+}
+
+func waitForDeletedService(t *testing.T, tCtx *End2EndTestingContext, serviceName string) {
+	g := gomega.NewWithT(t)
+	t.Logf("Starting to wait for service %s to be deleted", serviceName)
+	g.Eventually(func() error {
+		rayService, err := tCtx.GetRayServiceByName(serviceName)
+		if err != nil {
+			return err
+		}
+		t.Logf("Find rayService with status %v", rayService.Status)
+		return nil
+	}, TestTimeoutMedium).Should(gomega.MatchError("rayservices.ray.io \"" + serviceName + "\" not found"))
+
+	t.Logf("Service %s successfully deleted", serviceName)
 }

--- a/apiserver/test/e2e/utils.go
+++ b/apiserver/test/e2e/utils.go
@@ -23,9 +23,10 @@ import (
 var files embed.FS
 
 var (
-	TestTimeoutShort  = 1 * time.Minute
-	TestTimeoutMedium = 3 * time.Minute
-	TestTimeoutLong   = 5 * time.Minute
+	TestTimeoutShort    = 1 * time.Minute
+	TestTimeoutMedium   = 3 * time.Minute
+	TestTimeoutLong     = 5 * time.Minute
+	TestPollingInterval = 500 * time.Millisecond
 )
 
 // CreateHttpRequest instantiates a http request for the  specified endpoint and host
@@ -92,7 +93,7 @@ func waitForClusterConditions(t *testing.T, tCtx *End2EndTestingContext, cluster
 			}
 		}
 		return false
-	}, TestTimeoutMedium).Should(gomega.BeTrue())
+	}, TestTimeoutMedium, TestPollingInterval).Should(gomega.BeTrue())
 }
 
 func waitForRunningCluster(t *testing.T, tCtx *End2EndTestingContext, clusterName string) {
@@ -109,7 +110,7 @@ func waitForDeletedCluster(t *testing.T, tCtx *End2EndTestingContext, clusterNam
 		}
 		t.Logf("Found ray cluster '%s'", clusterName)
 		return false
-	}, TestTimeoutMedium).Should(gomega.BeTrue())
+	}, TestTimeoutMedium, TestPollingInterval).Should(gomega.BeTrue())
 }
 
 func waitForRayJob(t *testing.T, tCtx *End2EndTestingContext, rayJobName string, expectedJobStatuses []rayv1api.JobStatus) {
@@ -126,7 +127,7 @@ func waitForRayJob(t *testing.T, tCtx *End2EndTestingContext, rayJobName string,
 		}
 		t.Logf("Waiting for ray job '%s' to be in one of the expected conditions %s", rayJobName, expectedJobStatuses)
 		return slices.Contains(expectedJobStatuses, rayJob.Status.JobStatus)
-	}, TestTimeoutMedium).Should(gomega.BeTrue())
+	}, TestTimeoutMedium, TestPollingInterval).Should(gomega.BeTrue())
 }
 
 func waitForDeletedRayJob(t *testing.T, tCtx *End2EndTestingContext, jobName string) {
@@ -141,7 +142,7 @@ func waitForDeletedRayJob(t *testing.T, tCtx *End2EndTestingContext, jobName str
 		}
 		t.Logf("Find rayJob with status %v", rayJob.Status.JobStatus)
 		return nil
-	}, TestTimeoutMedium).Should(gomega.MatchError("rayjobs.ray.io \"" + jobName + "\" not found"))
+	}, TestTimeoutMedium, TestPollingInterval).Should(gomega.MatchError("rayjobs.ray.io \"" + jobName + "\" not found"))
 
 	t.Logf("Ray job %s successfully deleted", jobName)
 }
@@ -156,7 +157,7 @@ func waitForDeletedService(t *testing.T, tCtx *End2EndTestingContext, serviceNam
 		}
 		t.Logf("Find rayService with status %v", rayService.Status)
 		return nil
-	}, TestTimeoutMedium).Should(gomega.MatchError("rayservices.ray.io \"" + serviceName + "\" not found"))
+	}, TestTimeoutMedium, TestPollingInterval).Should(gomega.MatchError("rayservices.ray.io \"" + serviceName + "\" not found"))
 
 	t.Logf("Service %s successfully deleted", serviceName)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Refer to #3417 
On top of that, 
- Moved some help function from e2e test file to `utils.go`.
- Set testing polling interval to `500ms` (gomega's `eventually` polling interval default is `10ms`) to minimize to log size.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #3417 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
