### PR TITLE
[Refactor] Format API server Makefile for consistency

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -1,30 +1,30 @@
 BUILD_TIME      := $(shell date "+%F %T")
-COMMIT_SHA1     := $(shell git rev-parse HEAD )
+COMMIT_SHA1     := $(shell git rev-parse HEAD)
 REPO_ROOT	    := $(shell dirname ${PWD})
 REPO_ROOT_BIN	:= $(REPO_ROOT)/bin
 
 # Image URL to use all building/pushing image targets
 IMG_REPO ?= quay.io/kuberay/apiserver
-IMG_TAG ?=latest
+IMG_TAG ?= latest
 IMG ?= $(IMG_REPO):$(IMG_TAG)
 
 # Allow for additional test flags (-v, etc)
 GO_TEST_FLAGS ?=
 # Ray docker images to use for end to end tests based upon the architecture
 # for arm64 environments (Apple silicon included) pull the architecture specific image
-ifeq (arm64,$(shell go env GOARCH))
-E2E_API_SERVER_RAY_IMAGE ?=rayproject/ray:2.9.0-py310-aarch64
+ifeq (arm64, $(shell go env GOARCH))
+	E2E_API_SERVER_RAY_IMAGE ?= rayproject/ray:2.9.0-py310-aarch64
 else
-E2E_API_SERVER_RAY_IMAGE ?=rayproject/ray:2.9.0-py310
+	E2E_API_SERVER_RAY_IMAGE ?= rayproject/ray:2.9.0-py310
 endif
 # Kuberay API Server base URL to use in end to end tests
-E2E_API_SERVER_URL ?=http://localhost:31888
+E2E_API_SERVER_URL ?= http://localhost:31888
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+ifeq (, $(shell go env GOBIN))
+	GOBIN = $(shell go env GOPATH)/bin
 else
-GOBIN=$(shell go env GOBIN)
+	GOBIN = $(shell go env GOBIN)
 endif
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
@@ -86,7 +86,7 @@ lint: golangci-lint fmt vet fumpt imports ## Run the linter.
 	test -s $(GOLANGCI_LINT) || ($(GOLANGCI_LINT) run --timeout=3m --exclude='SA1019' --no-config --allow-parallel-runners)
 
 build: fmt vet fumpt imports ## Build api server binary.
-	go build  -o ${REPO_ROOT_BIN}/kuberay-apiserver cmd/main.go
+	go build -o ${REPO_ROOT_BIN}/kuberay-apiserver cmd/main.go
 
 run: fmt vet fumpt imports lint ## Run the api server from your host.
 	go run -race cmd/main.go -localSwaggerPath ${REPO_ROOT}/proto/swagger
@@ -99,11 +99,11 @@ build-swagger: go-bindata
 
 .PHONY: test
 test: fmt vet fumpt imports ## Run all unit tests.
-	go test ./pkg/... $(GO_TEST_FLAGS) -race -coverprofile ray-kube-api-server-coverage.out  -parallel 4
+	go test ./pkg/... $(GO_TEST_FLAGS) -race -coverprofile ray-kube-api-server-coverage.out -parallel 4
 
 .PHONY: e2e-test
 e2e-test: ## Run end to end tests using a pre-exiting cluster.
-	go test ./test/e2e/... $(GO_TEST_FLAGS) -timeout 60m  -race -coverprofile ray-kube-api-server-e2e-coverage.out -count=1 -parallel 4
+	go test ./test/e2e/... $(GO_TEST_FLAGS) -timeout 60m -race -coverprofile ray-kube-api-server-e2e-coverage.out -count=1 -parallel 4
 
 .PHONY: local-e2e-test ## Run end to end tests on newly created cluster.
 local-e2e-test: operator-image cluster load-operator-image deploy-operator install load-ray-test-image e2e-test clean-cluster ## Run end to end tests, create a fresh kind cluster will all components deployed.
@@ -135,7 +135,7 @@ security-proxy-image: ## Build the security proxy image to be loaded in your kin
 
 .PHONY: deploy-operator
 deploy-operator: ## Deploy operator via helm into the K8s cluster specified in ~/.kube/config.
-# Note that you should make your operatorimage available by either pushing it to an image registry, such as DockerHub or Quay, or by loading the image into the Kubernetes cluster.
+# Note that you should make your operator image available by either pushing it to an image registry, such as DockerHub or Quay, or by loading the image into the Kubernetes cluster.
 # If you are using a Kind cluster for development, you can run `make load-operator-image` to load the newly built image into the Kind cluster.
 	helm upgrade --install raycluster ../helm-chart/kuberay-operator --wait \
 	--set image.tag=${OPERATOR_IMAGE_TAG} --set image.pullPolicy=IfNotPresent
@@ -146,20 +146,20 @@ undeploy-operator: ## Undeploy operator via helm from the K8s cluster specified 
 
 .PHONY: load-operator-image
 load-operator-image: ## Load the operator image to the kind cluster created with make cluster.
-ifneq (${OPERATOR_IMAGE_TAG}, latest)
+ifneq ($(OPERATOR_IMAGE_TAG), latest)
 	$(ENGINE) pull quay.io/kuberay/operator:$(OPERATOR_IMAGE_TAG)
 endif
 	$(KIND) load docker-image quay.io/kuberay/operator:$(OPERATOR_IMAGE_TAG) -n $(KIND_CLUSTER_NAME)
 
 .PHONY: load-security-proxy-image
 load-security-proxy-image: ## Load the security proxy image to the kind cluster created with make cluster.
-ifneq (${SECURITY_IMAGE_TAG}, latest)
+ifneq ($(SECURITY_IMAGE_TAG), latest)
 	$(ENGINE) pull kuberay/security-proxy:$(SECURITY_IMAGE_TAG)
 endif
 	$(KIND) load docker-image kuberay/security-proxy:$(SECURITY_IMAGE_TAG) -n $(KIND_CLUSTER_NAME)
 
 .PHONY: load-ray-test-image
-load-ray-test-image: ## Load the ray test images
+load-ray-test-image: ## Load the ray test images.
 	$(ENGINE) pull $(E2E_API_SERVER_RAY_IMAGE)
 	$(KIND) load docker-image $(E2E_API_SERVER_RAY_IMAGE) -n $(KIND_CLUSTER_NAME)
 
@@ -255,10 +255,10 @@ $(GOBINDATA): $(REPO_ROOT_BIN)
 	test -s $(GOBINDATA) || GOBIN=$(REPO_ROOT_BIN) go install github.com/kevinburke/go-bindata/v4/...@$(GOBINDATA_VERSION)
 
 .PHONY: dev-tools
-dev-tools: kind golangci-lint gofumpt kustomize goimports go-bindata ## Install all development tools
+dev-tools: kind golangci-lint gofumpt kustomize goimports go-bindata ## Install all development tools.
 
 .PHONY: clean-dev-tools
-clean-dev-tools: ## Remove all development tools
+clean-dev-tools: ## Remove all development tools.
 	rm -f $(REPO_ROOT_BIN)/golangci-lint
 	rm -f $(REPO_ROOT_BIN)/gofumpt
 	rm -f $(REPO_ROOT_BIN)/kustomize

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -64,7 +64,7 @@ clear-local-apiserver: clean-cluster
 
 ##@ Development
 
-.PHONY:
+.PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
## Changes
* Remove redundant spaces and add missing ones
* Correct inconsistent indentations
* Add missing periods in automatic help documentation comments\
* Add missing `.PHONY`

## Why are these changes needed?
The current `Makefile` contains several formatting inconsistencies that affect readability and maintainability. Cleaning up these issues improves clarity.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/kuberay/issues/3384
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
