### PR TITLE
feat plugin: support enabling autoscaler both v1 and v2

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -214,6 +214,7 @@ func TestRayClusterCreateClusterRun(t *testing.T) {
 		workerMemory: "1Gi",
 		workerGPU:    "1",
 		workerTPU:    "0",
+		autoscaler:   generation.AutoscalerV2,
 	}
 
 	t.Run("should error when the Ray cluster already exists", func(t *testing.T) {
@@ -268,6 +269,7 @@ func TestNewCreateClusterCommand(t *testing.T) {
 				"--worker-node-selectors", fmt.Sprintf("app=ray,env=dev,%s=tpu-v5,%s=2x4", util.NodeSelectorGKETPUAccelerator, util.NodeSelectorGKETPUTopology),
 				"--labels", "app=ray,env=dev",
 				"--annotations", "ttl-hours=24,owner=chthulu",
+				"--autoscaler", "v2",
 				"--dry-run",
 				"--wait",
 				"--timeout", "10s",

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"os"
 	"strconv"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
@@ -25,20 +26,17 @@ const (
 )
 
 type RayClusterConfig struct {
-	Namespace   *string           `yaml:"namespace,omitempty"`
-	Name        *string           `yaml:"name,omitempty"`
-	Labels      map[string]string `yaml:"labels,omitempty"`
-	Annotations map[string]string `yaml:"annotations,omitempty"`
-
-	RayVersion     *string `yaml:"ray-version,omitempty"`
-	Image          *string `yaml:"image,omitempty"`
-	ServiceAccount *string `yaml:"service-account,omitempty"`
-
-	Head *Head `yaml:"head,omitempty"`
-
-	GKE *GKE `yaml:"gke,omitempty"`
-
-	WorkerGroups []WorkerGroup `yaml:"worker-groups,omitempty"`
+	Namespace      *string           `yaml:"namespace,omitempty"`
+	Name           *string           `yaml:"name,omitempty"`
+	Labels         map[string]string `yaml:"labels,omitempty"`
+	Annotations    map[string]string `yaml:"annotations,omitempty"`
+	RayVersion     *string           `yaml:"ray-version,omitempty"`
+	Image          *string           `yaml:"image,omitempty"`
+	ServiceAccount *string           `yaml:"service-account,omitempty"`
+	Head           *Head             `yaml:"head,omitempty"`
+	GKE            *GKE              `yaml:"gke,omitempty"`
+	Autoscaler     *Autoscaler       `yaml:"autoscaler,omitempty"`
+	WorkerGroups   []WorkerGroup     `yaml:"worker-groups,omitempty"`
 }
 
 type Head struct {
@@ -61,6 +59,40 @@ type WorkerGroup struct {
 	RayStartParams   map[string]string `yaml:"ray-start-params,omitempty"`
 	NodeSelectors    map[string]string `yaml:"node-selectors,omitempty"`
 	Replicas         int32             `yaml:"replicas"`
+}
+
+type AutoscalerVersion string
+
+const (
+	AutoscalerV1 AutoscalerVersion = "v1"
+	AutoscalerV2 AutoscalerVersion = "v2"
+)
+
+// String is used both by fmt.Print and by Cobra in help text
+func (e *AutoscalerVersion) String() string {
+	return string(*e)
+}
+
+// Set must have pointer receiver so it doesn't change the value of a copy
+func (e *AutoscalerVersion) Set(v string) error {
+	val := strings.ToLower(v)
+
+	switch val {
+	case string(AutoscalerV1), string(AutoscalerV2):
+		*e = AutoscalerVersion(val)
+		return nil
+	default:
+		return fmt.Errorf("must be one of %q or %q", AutoscalerV1, AutoscalerV2)
+	}
+}
+
+// Type is only used in help text
+func (e *AutoscalerVersion) Type() string {
+	return "enum"
+}
+
+type Autoscaler struct {
+	Version AutoscalerVersion `yaml:"version,omitempty"`
 }
 
 // GKE is a struct that contains the GKE specific configuration
@@ -250,6 +282,11 @@ func (rayClusterConfig *RayClusterConfig) generateRayClusterSpec() *rayv1ac.RayC
 							corev1ac.ContainerPort().WithContainerPort(8265).WithName("dashboard"),
 							corev1ac.ContainerPort().WithContainerPort(10001).WithName("client")))))).
 		WithWorkerGroupSpecs(workerGroupSpecs...)
+
+	if rayClusterConfig.Autoscaler != nil && rayClusterConfig.Autoscaler.Version != "" {
+		rayClusterSpec.WithEnableInTreeAutoscaling(true).
+			WithAutoscalerOptions(rayv1ac.AutoscalerOptions().WithVersion(rayv1.AutoscalerVersion(rayClusterConfig.Autoscaler.Version)))
+	}
 
 	if rayClusterConfig.ServiceAccount != nil && *rayClusterConfig.ServiceAccount != "" {
 		rayClusterSpec.HeadGroupSpec.Template.Spec.ServiceAccountName = ptr.To(*rayClusterConfig.ServiceAccount)

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -62,6 +62,9 @@ func TestGenerateRayClusterApplyConfig(t *testing.T) {
 				},
 			},
 		},
+		Autoscaler: &Autoscaler{
+			Version: AutoscalerV2,
+		},
 	}
 
 	result := testRayClusterConfig.GenerateRayClusterApplyConfig()
@@ -78,6 +81,10 @@ func TestGenerateRayClusterApplyConfig(t *testing.T) {
 			Annotations: annotations,
 		},
 		Spec: &rayv1ac.RayClusterSpecApplyConfiguration{
+			EnableInTreeAutoscaling: ptr.To(true),
+			AutoscalerOptions: &rayv1ac.AutoscalerOptionsApplyConfiguration{
+				Version: ptr.To(rayv1.AutoscalerVersionV2),
+			},
 			RayVersion: ptr.To(util.RayVersion),
 			HeadGroupSpec: &rayv1ac.HeadGroupSpecApplyConfiguration{
 				RayStartParams: map[string]string{"dashboard-host": "1.2.3.4", "num-cpus": "0"},
@@ -284,6 +291,9 @@ func TestConvertRayClusterApplyConfigToYaml(t *testing.T) {
 			"american": "goldfinch",
 			"piping":   "plover",
 		},
+		Autoscaler: &Autoscaler{
+			Version: AutoscalerV1,
+		},
 		RayVersion: ptr.To(util.RayVersion),
 		Image:      ptr.To(util.RayImage),
 		Head: &Head{
@@ -322,6 +332,9 @@ metadata:
   name: test-ray-cluster
   namespace: default
 spec:
+  enableInTreeAutoscaling: true
+  autoscalerOptions:
+    version: v1
   headGroupSpec:
     rayStartParams:
       num-cpus: "0"
@@ -438,6 +451,9 @@ func TestGenerateResources(t *testing.T) {
 
 func TestGenerateRayClusterSpec(t *testing.T) {
 	testRayClusterConfig := RayClusterConfig{
+		Autoscaler: &Autoscaler{
+			Version: AutoscalerV2,
+		},
 		RayVersion:     ptr.To("1.2.3"),
 		Image:          ptr.To("rayproject/ray:1.2.3"),
 		ServiceAccount: ptr.To("my-service-account"),
@@ -479,6 +495,10 @@ func TestGenerateRayClusterSpec(t *testing.T) {
 	}
 
 	expected := &rayv1ac.RayClusterSpecApplyConfiguration{
+		EnableInTreeAutoscaling: ptr.To(true),
+		AutoscalerOptions: &rayv1ac.AutoscalerOptionsApplyConfiguration{
+			Version: ptr.To(rayv1.AutoscalerVersionV2),
+		},
 		RayVersion: ptr.To("1.2.3"),
 		HeadGroupSpec: &rayv1ac.HeadGroupSpecApplyConfiguration{
 			RayStartParams: map[string]string{"softmax": "GELU"},


### PR DESCRIPTION
[autoscaler docs]

<details>
<summary>Usage</summary>

```bash
$ kubectl ray create cluster sample-cluster --help | grep autoscaler
...
Flags:
...
--autoscaler enum                          autoscaler to use, supports: "none", "v1", "v2" (default none)

$ kubectl ray create cluster sample-cluster --autoscaler foo --dry-run
Error: invalid argument "foo" for "--autoscaler" flag: must be one of "none", "v1", or "v2"

$ kubectl ray create cluster sample-cluster --autoscaler none --dry-run
apiVersion: ray.io/v1
kind: RayCluster
metadata:
  name: sample-cluster
  namespace: default
spec:
  headGroupSpec:
    rayStartParams:
      dashboard-host: 0.0.0.0
    template:
      spec:
        containers:
        - image: rayproject/ray:2.41.0
          name: ray-head
          ports:
          - containerPort: 6379
            name: gcs-server
          - containerPort: 8265
            name: dashboard
          - containerPort: 10001
            name: client
          resources:
            limits:
              memory: 4Gi
            requests:
              cpu: "2"
              memory: 4Gi
  rayVersion: 2.41.0
  workerGroupSpecs:
  - groupName: default-group
    numOfHosts: 1
    rayStartParams:
      metrics-export-port: "8080"
    replicas: 1
    template:
      spec:
        containers:
        - image: rayproject/ray:2.41.0
          name: ray-worker
          resources:
            limits:
              memory: 4Gi
            requests:
              cpu: "2"
              memory: 4Gi

$ kubectl ray create cluster sample-cluster --autoscaler v1 --dry-run
apiVersion: ray.io/v1
kind: RayCluster
metadata:
  name: sample-cluster
  namespace: default
spec:
  enableInTreeAutoscaling: true  # important part added
  headGroupSpec:
    rayStartParams:
      dashboard-host: 0.0.0.0
    template:
      spec:
        containers:
        - image: rayproject/ray:2.41.0
          name: ray-head
          ports:
          - containerPort: 6379
            name: gcs-server
          - containerPort: 8265
            name: dashboard
          - containerPort: 10001
            name: client
          resources:
            limits:
              memory: 4Gi
            requests:
              cpu: "2"
              memory: 4Gi
  rayVersion: 2.41.0
  workerGroupSpecs:
  - groupName: default-group
    numOfHosts: 1
    rayStartParams:
      metrics-export-port: "8080"
    replicas: 1
    template:
      spec:
        containers:
        - image: rayproject/ray:2.41.0
          name: ray-worker
          resources:
            limits:
              memory: 4Gi
            requests:
              cpu: "2"
              memory: 4Gi

$ kubectl ray create cluster sample-cluster --autoscaler v2 --dry-run
apiVersion: ray.io/v1
kind: RayCluster
metadata:
  name: sample-cluster
  namespace: default
spec:
  enableInTreeAutoscaling: true  # important part added
  headGroupSpec:
    rayStartParams:
      dashboard-host: 0.0.0.0
    template:
      spec:
        containers:
        - env:
          - name: RAY_enable_autoscaler_v2  # important part added
            value: "1"
          image: rayproject/ray:2.41.0
          name: ray-head
          ports:
          - containerPort: 6379
            name: gcs-server
          - containerPort: 8265
            name: dashboard
          - containerPort: 10001
            name: client
          resources:
            limits:
              memory: 4Gi
            requests:
              cpu: "2"
              memory: 4Gi
        restartPolicy: Never  # important part added
  rayVersion: 2.41.0
  workerGroupSpecs:
  - groupName: default-group
    numOfHosts: 1
    rayStartParams:
      metrics-export-port: "8080"
    replicas: 1
    template:
      spec:
        containers:
        - image: rayproject/ray:2.41.0
          name: ray-worker
          resources:
            limits:
              memory: 4Gi
            requests:
              cpu: "2"
              memory: 4Gi
        restartPolicy: Never  # important part added
```
</details>

[autoscaler docs]: https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html


## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
