### PR TITLE
chore: move go mod download before copy source in Dockerfile

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -5,6 +5,14 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY apiserver/go.mod apiserver/go.mod
 COPY apiserver/go.sum apiserver/go.sum
+COPY proto/go.mod proto/go.mod
+COPY proto/go.sum proto/go.sum
+COPY ray-operator/go.mod ray-operator/go.mod
+COPY ray-operator/go.sum ray-operator/go.sum
+
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN cd apiserver && go mod download && cd ..
 
 # Copy the go source
 COPY proto/ proto/
@@ -12,9 +20,7 @@ COPY ray-operator/ ray-operator/
 COPY apiserver/ apiserver/
 
 WORKDIR /workspace/apiserver
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+
 
 # Build
 USER root


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

To avoid downloading dependences after changing the source file, move `go mod download` up before copying source files.

In docker build, the cache depends on the previous layer. Which means the upper layer has changed, the following layers are subject to re-build.

Usually, the modification of deps is less frequent than the modification of source code. In the origin Dockerfile,
https://github.com/ray-project/kuberay/blob/37cf2acb58c901ca1a2af2a3348ac009764a177d/apiserver/Dockerfile#L9-L17
`go mod download` is after copying the go source. Once source files has changed. the docker build will re-run `go mod download` without leveraging the cache.

Thus, move `go mod download` before the copying the go source.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
