### PR TITLE
[Refactor] Improve developer experience of API server e2e-test

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -57,7 +57,7 @@ help: ## Display this help.
 ##@ Deployment
 
 .PHONY: start-local-apiserver ## Build and start apiserver from scratch.
-start-local-apiserver: operator-image cluster load-operator-image deploy-operator install run
+start-local-apiserver: operator-image cluster load-operator-image deploy-operator install
 
 .PHONY: clean-local-apiserver ## Clear local apiserver.
 clear-local-apiserver: clean-cluster
@@ -111,7 +111,7 @@ e2e-test: ## Run end to end tests using a pre-exiting cluster.
 	go test ./test/e2e/... $(GO_TEST_FLAGS) -timeout 60m -race -coverprofile ray-kube-api-server-e2e-coverage.out -count=1 -parallel 4
 
 .PHONY: local-e2e-test ## Run end to end tests on newly created cluster.
-local-e2e-test: operator-image cluster load-operator-image deploy-operator install load-ray-test-image e2e-test clean-cluster ## Run end to end tests, create a fresh kind cluster will all components deployed.
+local-e2e-test: start-local-apiserver load-ray-test-image e2e-test clean-cluster ## Run end to end tests, create a fresh kind cluster will all components deployed.
 
 ##@ Testing Setup
 KIND_CONFIG ?= hack/kind-cluster-config.yaml


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
## Changes
* Remove `run` from the `start-local-apiserver` target
* Simplify prerequisites for the `local-e2e-test` target by replacing multiple dependencies with a single `start-local-apiserver` target

## Why are these changes needed?
There are currently two ways to run API server e2e tests:
1. Run `make start-local-apiserver` followed by `make e2e-test`
This approach is useful during test development, allowing quick iterations without rebuilding the operator image, restarting the kind cluster, and redeploying the API server within the cluster.

2. Run `make local-e2e-test`
This is a convenient all-in-one command for running the full e2e test workflow, including the cluster setup, running the e2e test, and tearing down the cluster.

However, the existing setup includes redundant dependencies that may confuse developers and make it harder to choose the best workflow. This PR streamlines the local e2e test process and improve the overall developer experience.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/kuberay/issues/3384

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
