### PR TITLE
Only try once in HTTP health check commands

### DIFF
--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -178,7 +178,7 @@ const (
 	RayAgentRayletHealthPath  = "api/local_raylet_healthz"
 	RayDashboardGCSHealthPath = "api/gcs_healthz"
 	RayServeProxyHealthPath   = "-/healthz"
-	BaseWgetHealthCommand     = "wget -T %d -q -O- http://localhost:%d/%s | grep success"
+	BaseWgetHealthCommand     = "wget --tries 1 -T %d -q -O- http://localhost:%d/%s | grep success"
 
 	// Finalizers for RayJob
 	RayJobStopJobFinalizer = "ray.io/rayjob-finalizer"


### PR DESCRIPTION
The BaseWgetHealthCommand is used to configure readiness and liveness probes that Kubernetes will execute against the ray-worker container. These checks should return fairly quickly so that _Kubernetes_ can get the result and possibly retry them. By default, wget retries _20 times_. The retrying should be left to Kubernetes, not wget, so that the command doesn't just hang for minutes while Kubernetes waits for the result.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Fixes #3468 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
