### PR TITLE
Add a grouping for 'google.golang.org/*' to avoid inconsistency between sub-projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,6 @@ updates:
       kubernetes:
         patterns:
           - "k8s.io/*"
+      google-golang:
+        patterns:
+          - "google.golang.org/*"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add a grouping for 'google.golang.org/*' to avoid inconsistency of library versions between sub-projects
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Close #3445
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

![Screenshot 2025-04-24 000058](https://github.com/user-attachments/assets/856ba169-1117-4601-b96c-5c892fd2c0b5)

Link: https://github.com/kenmcheng/kuberay/pull/16