### PR TITLE
[apiserver] ListAllServices with pagination

### DIFF
--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -481,14 +481,18 @@ func (krc *KuberayAPIServerClient) ListRayServices(request *api.ListRayServicesR
 	return response, nil, nil
 }
 
-// Finds all ray services in a given namespace.
-func (krc *KuberayAPIServerClient) ListAllRayServices() (*api.ListAllRayServicesResponse, *rpcStatus.Status, error) {
+// Finds all ray services in all namespaces.
+func (krc *KuberayAPIServerClient) ListAllRayServices(request *api.ListAllRayServicesRequest) (*api.ListAllRayServicesResponse, *rpcStatus.Status, error) {
 	getURL := krc.baseURL + "/apis/v1/services"
 	httpRequest, err := http.NewRequestWithContext(context.TODO(), "GET", getURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create http request for url '%s': %w", getURL, err)
 	}
 
+	q := httpRequest.URL.Query()
+	q.Set("pageSize", strconv.FormatInt(int64(request.PageSize), 10))
+	q.Set("pageToken", request.PageToken)
+	httpRequest.URL.RawQuery = q.Encode()
 	httpRequest.Header.Add("Accept", "application/json")
 
 	bodyBytes, status, err := krc.executeHttpRequest(httpRequest, getURL)

--- a/apiserver/pkg/manager/resource_manager.go
+++ b/apiserver/pkg/manager/resource_manager.go
@@ -3,6 +3,8 @@ package manager
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -298,22 +300,81 @@ func (r *ResourceManager) ListServices(ctx context.Context, namespace string, pa
 	return rayServices, rayServiceList.Continue, nil
 }
 
-func (r *ResourceManager) ListAllServices(ctx context.Context) ([]*rayv1api.RayService, error) {
+// ListAllServices retrieves Ray services across all namespaces with pagination support
+// pageToken format: "namespace[:continueToken]" where continueToken is optional
+// pageSize controls max number of services returned in a single call
+func (r *ResourceManager) ListAllServices(ctx context.Context, pageToken string, pageSize int32) ([]*rayv1api.RayService, string /*nextPageToken*/, error) {
 	rayServices := make([]*rayv1api.RayService, 0)
 
-	namespaces, err := r.getKubernetesNamespaceClient().List(ctx, metav1.ListOptions{})
+	// Get all namespaces and sort them for consistent pagination
+	namespaceList, err := r.getKubernetesNamespaceClient().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, util.Wrap(err, "Failed to fetch all Kubernetes namespaces")
+		return nil, "", util.Wrap(err, "Failed to fetch all Kubernetes namespaces")
 	}
 
-	for _, namespace := range namespaces.Items {
-		servicesByNamespace, _, err := r.ListServices(ctx, namespace.Name, "" /*pageToken*/, 0 /*pageSize*/)
+	// Extract and sort namespace names
+	sortedNamespaceList := make([]string, 0, len(namespaceList.Items))
+	for _, ns := range namespaceList.Items {
+		sortedNamespaceList = append(sortedNamespaceList, ns.Name)
+	}
+	sort.Strings(sortedNamespaceList)
+
+	// Parse pageToken to determine starting point
+	startNamespaceIdx := 0
+	continueToken := ""
+	if pageToken != "" {
+		tokens := strings.SplitN(pageToken, ":", 2)
+
+		// Extract namespace from token
+		namespaceToken := tokens[0]
+		found := false
+		for i, name := range sortedNamespaceList {
+			if name == namespaceToken {
+				startNamespaceIdx = i
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return nil, "", util.NewInvalidInputError("Invalid namespace in page token: %s", namespaceToken)
+		}
+
+		// Extract continue token if present
+		if len(tokens) == 2 {
+			continueToken = tokens[1]
+		}
+	}
+
+	// Collect services across namespaces up to page size
+	remainingCount := pageSize
+	var nextPageToken string
+	for i := startNamespaceIdx; i < len(sortedNamespaceList) && remainingCount > 0; i++ {
+		namespace := sortedNamespaceList[i]
+		servicesByNamespace, nextContinueToken, err := r.ListServices(ctx, namespace, continueToken, remainingCount)
 		if err != nil {
-			return nil, util.Wrap(err, "List All Rayservices failed")
+			return nil, "", util.Wrap(err, fmt.Sprintf("Failed to list services in namespace %s", namespace))
 		}
 		rayServices = append(rayServices, servicesByNamespace...)
+
+		//nolint:gosec // The conversion is safe since servicesByNamespace is limited by remainingCount (which is int32)
+		remainingCount -= int32(len(servicesByNamespace))
+		continueToken = ""
+
+		// Determine if we need to create a next page token
+		if nextContinueToken != "" {
+			// More services in this namespace - create token with continue value
+			nextPageToken = namespace + ":" + nextContinueToken
+			return rayServices, nextPageToken, nil
+		} else if remainingCount == 0 && i+1 < len(sortedNamespaceList) {
+			// Page is full, but more namespaces exist - create token to start at next namespace
+			nextPageToken = sortedNamespaceList[i+1]
+			return rayServices, nextPageToken, nil
+		}
 	}
-	return rayServices, nil
+
+	// No more results - return empty token
+	return rayServices, "", nil
 }
 
 func (r *ResourceManager) DeleteService(ctx context.Context, serviceName, namespace string) error {

--- a/apiserver/pkg/server/serve_server.go
+++ b/apiserver/pkg/server/serve_server.go
@@ -109,7 +109,7 @@ func (s *RayServiceServer) ListRayServices(ctx context.Context, request *api.Lis
 }
 
 func (s *RayServiceServer) ListAllRayServices(ctx context.Context, request *api.ListAllRayServicesRequest) (*api.ListAllRayServicesResponse, error) {
-	services, nextPageToken, err := s.resourceManager.ListAllServices(ctx, request.PageToken, request.PageSize)
+	services, nextPageToken, err := s.resourceManager.ListServices(ctx, "" /*namespace*/, request.PageToken, request.PageSize)
 	if err != nil {
 		return nil, util.Wrap(err, "list all services failed.")
 	}

--- a/apiserver/pkg/server/serve_server.go
+++ b/apiserver/pkg/server/serve_server.go
@@ -108,12 +108,12 @@ func (s *RayServiceServer) ListRayServices(ctx context.Context, request *api.Lis
 	}, nil
 }
 
-func (s *RayServiceServer) ListAllRayServices(ctx context.Context, _ *api.ListAllRayServicesRequest) (*api.ListAllRayServicesResponse, error) {
-	services, err := s.resourceManager.ListAllServices(ctx)
+func (s *RayServiceServer) ListAllRayServices(ctx context.Context, request *api.ListAllRayServicesRequest) (*api.ListAllRayServicesResponse, error) {
+	services, nextPageToken, err := s.resourceManager.ListAllServices(ctx, request.PageToken, request.PageSize)
 	if err != nil {
 		return nil, util.Wrap(err, "list all services failed.")
 	}
-	serviceEventMap := make(map[string][]corev1.Event)
+	serviceEventMap := make(map[string][]corev1.Event, len(services))
 	for _, service := range services {
 		serviceEvents, err := s.resourceManager.GetServiceEvents(ctx, *service)
 		if err != nil {
@@ -123,7 +123,8 @@ func (s *RayServiceServer) ListAllRayServices(ctx context.Context, _ *api.ListAl
 		serviceEventMap[service.Name] = serviceEvents
 	}
 	return &api.ListAllRayServicesResponse{
-		Services: model.FromCrdToAPIServices(services, serviceEventMap),
+		Services:      model.FromCrdToAPIServices(services, serviceEventMap),
+		NextPageToken: nextPageToken,
 	}, nil
 }
 

--- a/apiserver/pkg/server/serve_server.go
+++ b/apiserver/pkg/server/serve_server.go
@@ -113,7 +113,7 @@ func (s *RayServiceServer) ListAllRayServices(ctx context.Context, request *api.
 	if err != nil {
 		return nil, util.Wrap(err, "list all services failed.")
 	}
-	serviceEventMap := make(map[string][]corev1.Event, len(services))
+	serviceEventMap := make(map[string][]corev1.Event)
 	for _, service := range services {
 		serviceEvents, err := s.resourceManager.GetServiceEvents(ctx, *service)
 		if err != nil {

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -296,7 +296,7 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 				t.Logf("Got service: namespace=%s, name=%s", service.Namespace, service.Name)
 				key := targetService{namespace: service.Namespace, service: service.Name}
 				seen, exist := gotServices[key]
-				
+
 				// Check if this service is in expectedServices list
 				if !exist {
 					t.Fatalf("ListAllRayServices returned an unexpected service: namespace=%s, name=%s",
@@ -308,7 +308,7 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 					t.Fatalf("ListAllRayServices returned duplicated service: namespace=%s, name=%s",
 						key.namespace, key.service)
 				}
-				
+
 				gotServices[key] = true
 			}
 		}
@@ -347,7 +347,7 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 			t.Logf("Got service: namespace=%s, name=%s", service.Namespace, service.Name)
 			key := targetService{namespace: service.Namespace, service: service.Name}
 			seen, exist := gotServices[key]
-			
+
 			// Check if this service is in expectedServices list
 			if !exist {
 				t.Fatalf("ListAllRayServices returned an unexpected service: namespace=%s, name=%s",

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -295,18 +295,20 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 			for _, service := range response.Services {
 				t.Logf("Got service: namespace=%s, name=%s", service.Namespace, service.Name)
 				key := targetService{namespace: service.Namespace, service: service.Name}
-				seen, ok := gotServices[key]
-				// service not found in expectedServices list
-				if !ok {
+				seen, exist := gotServices[key]
+				
+				// Check if this service is in expectedServices list
+				if !exist {
 					t.Fatalf("ListAllRayServices returned an unexpected service: namespace=%s, name=%s",
 						key.namespace, key.service)
 				}
 
-				// key already marked true (duplicate service)
+				// Check if we've already seen this service before (duplicate)
 				if seen {
 					t.Fatalf("ListAllRayServices returned duplicated service: namespace=%s, name=%s",
 						key.namespace, key.service)
 				}
+				
 				gotServices[key] = true
 			}
 		}
@@ -344,14 +346,15 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 		for _, service := range response.Services {
 			t.Logf("Got service: namespace=%s, name=%s", service.Namespace, service.Name)
 			key := targetService{namespace: service.Namespace, service: service.Name}
-			seen, ok := gotServices[key]
-			// service not found in expectedServices list
-			if !ok {
+			seen, exist := gotServices[key]
+			
+			// Check if this service is in expectedServices list
+			if !exist {
 				t.Fatalf("ListAllRayServices returned an unexpected service: namespace=%s, name=%s",
 					key.namespace, key.service)
 			}
 
-			// key already marked true (duplicate service)
+			// Check if we've already seen this service before (duplicate)
 			if seen {
 				t.Fatalf("ListAllRayServices returned duplicated service: namespace=%s, name=%s",
 					key.namespace, key.service)

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -225,10 +225,13 @@ func TestGetAllServices(t *testing.T) {
 	require.Equal(t, tCtx.GetNamespaceName(), response.Services[0].Namespace)
 }
 
-func createOneServiceInEachNamespace(t *testing.T, numberOfNamespaces int) ([]*End2EndTestingContext, []string) {
-	tCtxs := make([]*End2EndTestingContext, numberOfNamespaces)
-	serviceNames := make([]string, 0, numberOfNamespaces)
+func TestGetAllServicesWithPagination(t *testing.T) {
+	const numberOfNamespaces = 3
 
+	tCtxs := make([]*End2EndTestingContext, numberOfNamespaces)
+	expectedServiceNames := make([]string, 0, numberOfNamespaces)
+
+	// Create Services for each namespace
 	for i := 0; i < numberOfNamespaces; i++ {
 		tCtx, err := NewEnd2EndTestingContext(t)
 		require.NoError(t, err, "No error expected when creating testing context")
@@ -244,18 +247,8 @@ func createOneServiceInEachNamespace(t *testing.T, numberOfNamespaces int) ([]*E
 		})
 
 		tCtxs[i] = tCtx
-		serviceNames = append(serviceNames, testServiceRequest.Service.Name)
+		expectedServiceNames = append(expectedServiceNames, testServiceRequest.Service.Name)
 	}
-
-	return tCtxs, serviceNames
-}
-
-func TestGetAllServicesWithPagination(t *testing.T) {
-	const numberOfNamespaces = 3
-
-	var tCtxs []*End2EndTestingContext
-	var expectedServiceNames []string
-	tCtxs, expectedServiceNames = createOneServiceInEachNamespace(t, numberOfNamespaces)
 
 	var pageToken string
 	tCtx := tCtxs[0]
@@ -291,7 +284,7 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 		}
 	}
 	// Ensure we found all services
-	for i := 0; i < numberOfNamespaces; i++ {
+	for i := range numberOfNamespaces {
 		if !gotServices[i] {
 			t.Errorf("ListAllRayServices did not return expected service %s from namespace %s",
 				expectedServiceNames[i], tCtxs[i].GetNamespaceName())

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -298,16 +298,14 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 				seen, exist := gotServices[key]
 
 				// Check if this service is in expectedServices list
-				if !exist {
-					t.Fatalf("ListAllRayServices returned an unexpected service: namespace=%s, name=%s",
-						key.namespace, key.service)
-				}
+				require.True(t, exist,
+					"ListAllRayServices returned an unexpected service: namespace=%s, name=%s",
+					key.namespace, key.service)
 
 				// Check if we've already seen this service before (duplicate)
-				if seen {
-					t.Fatalf("ListAllRayServices returned duplicated service: namespace=%s, name=%s",
-						key.namespace, key.service)
-				}
+				require.False(t, seen,
+					"ListAllRayServices returned duplicated service: namespace=%s, name=%s",
+					key.namespace, key.service)
 
 				gotServices[key] = true
 			}
@@ -315,10 +313,9 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 
 		// Check all services were found
 		for _, expectedService := range expectedServices {
-			if !gotServices[expectedService] {
-				t.Errorf("ListAllRayServices did not return expected service %s from namespace %s",
-					expectedService.service, expectedService.namespace)
-			}
+			require.True(t, gotServices[expectedService],
+				"ListAllRayServices did not return expected service %s from namespace %s",
+				expectedService.service, expectedService.namespace)
 		}
 	})
 
@@ -349,25 +346,21 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 			seen, exist := gotServices[key]
 
 			// Check if this service is in expectedServices list
-			if !exist {
-				t.Fatalf("ListAllRayServices returned an unexpected service: namespace=%s, name=%s",
-					key.namespace, key.service)
-			}
+			require.True(t, exist, "ListAllRayServices returned an unexpected service: namespace=%s, name=%s",
+				key.namespace, key.service)
 
 			// Check if we've already seen this service before (duplicate)
-			if seen {
-				t.Fatalf("ListAllRayServices returned duplicated service: namespace=%s, name=%s",
-					key.namespace, key.service)
-			}
+			require.False(t, seen, "ListAllRayServices returned duplicated service: namespace=%s, name=%s",
+				key.namespace, key.service)
+
 			gotServices[key] = true
 		}
 
 		// Check all services were found
 		for _, expectedService := range expectedServices {
-			if !gotServices[expectedService] {
-				t.Errorf("ListAllRayServices did not return expected service %s from namespace %s",
-					expectedService.service, expectedService.namespace)
-			}
+			require.True(t, gotServices[expectedService],
+				"ListAllRayServices did not return expected service %s from namespace %s",
+				expectedService.service, expectedService.namespace)
 		}
 	})
 }

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -280,18 +280,18 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 			require.NotEmpty(t, response.Services, "A list of service is required")
 			require.Len(t, response.Services, 1)
 
-			for _, service := range response.Services {
-				gotServices[targetService{
-					namespace: service.Namespace,
-					service:   service.Name,
-				}] = true
-			}
-
 			pageToken = response.NextPageToken
 			if i == totalServices-1 {
 				require.Empty(t, pageToken, "No continue token is expected")
 			} else {
 				require.NotEmpty(t, pageToken, "A continue token is expected")
+			}
+
+			for _, service := range response.Services {
+				gotServices[targetService{
+					namespace: service.Namespace,
+					service:   service.Name,
+				}] = true
 			}
 		}
 

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -264,7 +264,7 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 
 	var pageToken string
 	tCtx := tCtxs[0]
-	
+
 	// Test pagination with limit less than the total number of services in all namespaces.
 	t.Run("Test pagination return part of the result services", func(t *testing.T) {
 		pageToken = ""
@@ -294,10 +294,20 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 
 			for _, service := range response.Services {
 				t.Logf("Got service: namespace=%s, name=%s", service.Namespace, service.Name)
-				gotServices[targetService{
-					namespace: service.Namespace,
-					service:   service.Name,
-				}] = true
+				key := targetService{namespace: service.Namespace, service: service.Name}
+				seen, ok := gotServices[key]
+				// service not found in expectedServices list
+				if !ok {
+					t.Fatalf("ListAllRayServices returned an unexpected service: namespace=%s, name=%s",
+						key.namespace, key.service)
+				}
+
+				// key already marked true (duplicate service)
+				if seen {
+					t.Fatalf("ListAllRayServices returned duplicated service: namespace=%s, name=%s",
+						key.namespace, key.service)
+				}
+				gotServices[key] = true
 			}
 		}
 
@@ -333,10 +343,20 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 
 		for _, service := range response.Services {
 			t.Logf("Got service: namespace=%s, name=%s", service.Namespace, service.Name)
-			gotServices[targetService{
-				namespace: service.Namespace,
-				service:   service.Name,
-			}] = true
+			key := targetService{namespace: service.Namespace, service: service.Name}
+			seen, ok := gotServices[key]
+			// service not found in expectedServices list
+			if !ok {
+				t.Fatalf("ListAllRayServices returned an unexpected service: namespace=%s, name=%s",
+					key.namespace, key.service)
+			}
+
+			// key already marked true (duplicate service)
+			if seen {
+				t.Fatalf("ListAllRayServices returned duplicated service: namespace=%s, name=%s",
+					key.namespace, key.service)
+			}
+			gotServices[key] = true
 		}
 
 		// Check all services were found

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -216,7 +216,7 @@ func TestGetAllServices(t *testing.T) {
 		tCtx.DeleteRayService(t, testServiceRequest.Service.Name)
 	})
 
-	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllRayServices()
+	response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllRayServices(&api.ListAllRayServicesRequest{})
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, actualRPCStatus, "No RPC status expected")
 	require.NotNil(t, response, "A response is expected")

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -264,7 +264,8 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 
 	var pageToken string
 	tCtx := tCtxs[0]
-	// Test pagination with limit 1, which is less than the total number of services in all namespaces.
+	
+	// Test pagination with limit less than the total number of services in all namespaces.
 	t.Run("Test pagination return part of the result services", func(t *testing.T) {
 		pageToken = ""
 		gotServices := make(map[targetService]bool, totalServices)
@@ -307,7 +308,7 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 		}
 	})
 
-	// Test pagination with limit 7, which is larger than the total number of services in all namespaces.
+	// Test pagination with limit larger than the total number of services in all namespaces.
 	t.Run("Test pagination return all result services", func(t *testing.T) {
 		pageToken = ""
 		gotServices := make(map[targetService]bool, totalServices)

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -267,7 +267,10 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 	// Test pagination with limit 1, which is less than the total number of services in all namespaces.
 	t.Run("Test pagination return part of the result services", func(t *testing.T) {
 		pageToken = ""
-		gotServices := make(map[targetService]bool)
+		gotServices := make(map[targetService]bool, totalServices)
+		for _, expectedService := range expectedServices {
+			gotServices[expectedService] = false
+		}
 
 		for i := 0; i < totalServices; i++ {
 			response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllRayServices(&api.ListAllRayServicesRequest{
@@ -307,7 +310,10 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 	// Test pagination with limit 7, which is larger than the total number of services in all namespaces.
 	t.Run("Test pagination return all result services", func(t *testing.T) {
 		pageToken = ""
-		gotServices := make(map[targetService]bool)
+		gotServices := make(map[targetService]bool, totalServices)
+		for _, expectedService := range expectedServices {
+			gotServices[expectedService] = false
+		}
 
 		response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllRayServices(&api.ListAllRayServicesRequest{
 			PageToken: pageToken,

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -346,11 +346,13 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 			seen, exist := gotServices[key]
 
 			// Check if this service is in expectedServices list
-			require.True(t, exist, "ListAllRayServices returned an unexpected service: namespace=%s, name=%s",
+			require.True(t, exist,
+				"ListAllRayServices returned an unexpected service: namespace=%s, name=%s",
 				key.namespace, key.service)
 
 			// Check if we've already seen this service before (duplicate)
-			require.False(t, seen, "ListAllRayServices returned duplicated service: namespace=%s, name=%s",
+			require.False(t, seen,
+				"ListAllRayServices returned duplicated service: namespace=%s, name=%s",
 				key.namespace, key.service)
 
 			gotServices[key] = true
@@ -448,9 +450,9 @@ func TestGetServicesInNamespaceWithPagination(t *testing.T) {
 
 		// Check all services created have been returned.
 		for idx := 0; idx < serviceCount; idx++ {
-			if !gotServices[idx] {
-				t.Errorf("ListServices did not return expected services %s", expectedServiceNames[idx])
-			}
+			require.True(t, gotServices[idx],
+				"ListServices did not return expected services %s",
+				expectedServiceNames[idx])
 		}
 	})
 
@@ -483,9 +485,9 @@ func TestGetServicesInNamespaceWithPagination(t *testing.T) {
 
 		// Check all services created have been returned.
 		for idx := 0; idx < serviceCount; idx++ {
-			if !gotServices[idx] {
-				t.Errorf("ListServices did not return expected services %s", expectedServiceNames[idx])
-			}
+			require.True(t, gotServices[idx],
+				"ListServices did not return expected services %s",
+				expectedServiceNames[idx])
 		}
 	})
 }

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -293,7 +293,6 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 			}
 
 			for _, service := range response.Services {
-				t.Logf("Got service: namespace=%s, name=%s", service.Namespace, service.Name)
 				key := targetService{namespace: service.Namespace, service: service.Name}
 				seen, exist := gotServices[key]
 
@@ -341,7 +340,6 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 		t.Logf("Got %d services in response, expected %d", len(response.Services), totalServices)
 
 		for _, service := range response.Services {
-			t.Logf("Got service: namespace=%s, name=%s", service.Namespace, service.Name)
 			key := targetService{namespace: service.Namespace, service: service.Name}
 			seen, exist := gotServices[key]
 

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -282,8 +282,7 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 			require.Nil(t, actualRPCStatus, "No RPC status expected")
 			require.NotNil(t, response, "A response is expected")
 			require.NotEmpty(t, response.Services, "A list of service is required")
-			require.Len(t, response.Services, 1)
-			t.Logf("Got %d services in response, expected %d", len(response.Services), 1)
+			require.Len(t, response.Services, 1, "Got %d services in response, expected %d", len(response.Services), 1)
 
 			pageToken = response.NextPageToken
 			if i == totalServices-1 {
@@ -335,9 +334,8 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 		require.Nil(t, actualRPCStatus, "No RPC status expected")
 		require.NotNil(t, response, "A response is expected")
 		require.NotEmpty(t, response.Services, "A list of services is required")
-		require.Len(t, response.Services, totalServices)
+		require.Len(t, response.Services, totalServices, "Got %d services in response, expected %d", len(response.Services), totalServices)
 		require.Empty(t, response.NextPageToken, "Page token should be empty")
-		t.Logf("Got %d services in response, expected %d", len(response.Services), totalServices)
 
 		for _, service := range response.Services {
 			key := targetService{namespace: service.Namespace, service: service.Name}

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -283,6 +283,7 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 			require.NotNil(t, response, "A response is expected")
 			require.NotEmpty(t, response.Services, "A list of service is required")
 			require.Len(t, response.Services, 1)
+			t.Logf("Got %d services in response, expected %d", len(response.Services), 1)
 
 			pageToken = response.NextPageToken
 			if i == totalServices-1 {
@@ -292,6 +293,7 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 			}
 
 			for _, service := range response.Services {
+				t.Logf("Got service: namespace=%s, name=%s", service.Namespace, service.Name)
 				gotServices[targetService{
 					namespace: service.Namespace,
 					service:   service.Name,
@@ -327,8 +329,10 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 		require.NotEmpty(t, response.Services, "A list of services is required")
 		require.Len(t, response.Services, totalServices)
 		require.Empty(t, response.NextPageToken, "Page token should be empty")
+		t.Logf("Got %d services in response, expected %d", len(response.Services), totalServices)
 
 		for _, service := range response.Services {
+			t.Logf("Got service: namespace=%s, name=%s", service.Namespace, service.Name)
 			gotServices[targetService{
 				namespace: service.Namespace,
 				service:   service.Name,

--- a/proto/go_client/serve.pb.go
+++ b/proto/go_client/serve.pb.go
@@ -413,6 +413,7 @@ type ListAllRayServicesResponse struct {
 	// The total number of RayServices for the given query.
 	TotalSize int32 `protobuf:"varint,2,opt,name=total_size,json=totalSize,proto3" json:"total_size,omitempty"`
 	// The token to list the next page of RayServices.
+	// If there is no more service, this field will be empty.
 	NextPageToken string `protobuf:"bytes,3,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
 }
 

--- a/proto/kuberay_api.swagger.json
+++ b/proto/kuberay_api.swagger.json
@@ -2034,7 +2034,7 @@
         },
         "nextPageToken": {
           "type": "string",
-          "description": "The token to list the next page of RayServices.",
+          "description": "The token to list the next page of RayServices.\n\nIf there are no more clusters, this field will be empty.",
           "readOnly": true
         }
       }

--- a/proto/kuberay_api.swagger.json
+++ b/proto/kuberay_api.swagger.json
@@ -2034,7 +2034,7 @@
         },
         "nextPageToken": {
           "type": "string",
-          "description": "The token to list the next page of RayServices.\n\nIf there are no more clusters, this field will be empty.",
+          "description": "The token to list the next page of RayServices.\nIf there is no more service, this field will be empty.",
           "readOnly": true
         }
       }

--- a/proto/serve.proto
+++ b/proto/serve.proto
@@ -135,6 +135,7 @@ message ListAllRayServicesResponse {
   // The total number of RayServices for the given query.
   int32 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // The token to list the next page of RayServices.
+  // If there is no more service, this field will be empty.
   string next_page_token = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 

--- a/proto/swagger/serve.swagger.json
+++ b/proto/swagger/serve.swagger.json
@@ -556,7 +556,7 @@
         },
         "nextPageToken": {
           "type": "string",
-          "description": "The token to list the next page of RayServices.",
+          "description": "The token to list the next page of RayServices.\n\nIf there are no more clusters, this field will be empty.",
           "readOnly": true
         }
       }

--- a/proto/swagger/serve.swagger.json
+++ b/proto/swagger/serve.swagger.json
@@ -556,7 +556,7 @@
         },
         "nextPageToken": {
           "type": "string",
-          "description": "The token to list the next page of RayServices.\n\nIf there are no more clusters, this field will be empty.",
+          "description": "The token to list the next page of RayServices.\nIf there is no more service, this field will be empty.",
           "readOnly": true
         }
       }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR implements pagination for listing all ray services. 

- delete `ListAllServices` in resource_manager
- `ListAllRayServices` in serve_server reuses `ListAllServices ` in resource_manager
- An e2e test `TestGetAllServicesWithPagination` is added to validate the functionality.
- print service content or size for debugging purpose

```
~/Doc/G/kuberay/apiserver feature/pagi..all-services *6 !2 ?8 > go test -v ./test/e2e/...  -timeout 60m  -race 
-coverprofile ray-kube-api-server-e2e-coverage.out -count=1 -parallel 4 -run TestGetAllServicesWithPagination
=== RUN   TestGetAllServicesWithPagination
=== RUN   TestGetAllServicesWithPagination/Test_pagination_return_part_of_the_result_services
=== RUN   TestGetAllServicesWithPagination/Test_pagination_return_all_result_services
--- PASS: TestGetAllServicesWithPagination (5.29s)
    --- PASS: TestGetAllServicesWithPagination/Test_pagination_return_part_of_the_result_services (1.19s)
    --- PASS: TestGetAllServicesWithPagination/Test_pagination_return_all_result_services (1.21s)
PASS
coverage: 39.9% of statements
ok      github.com/ray-project/kuberay/apiserver/test/e2e       6.834s  coverage: 39.9% of statements
```

## Related issue number

Closes #3289 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
