### PR TITLE
[Fix] Dashboard lockfile referencing internal registry causes npm install to fail

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -33,7 +33,7 @@
         },
         "node_modules/@aashutoshrathi/word-wrap": {
             "version": "1.2.6",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
             "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
             "dev": true,
             "engines": {
@@ -42,7 +42,7 @@
         },
         "node_modules/@alloc/quick-lru": {
             "version": "5.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
             "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
             "dev": true,
             "engines": {
@@ -51,7 +51,7 @@
         },
         "node_modules/@babel/code-frame": {
             "version": "7.24.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@babel/code-frame/-/code-frame-7.24.2.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
             "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
             "dependencies": {
                 "@babel/highlight": "^7.24.2",
@@ -63,7 +63,7 @@
         },
         "node_modules/@babel/helper-module-imports": {
             "version": "7.24.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
             "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
             "dependencies": {
                 "@babel/types": "^7.24.0"
@@ -74,7 +74,7 @@
         },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.24.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
             "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
             "engines": {
                 "node": ">=6.9.0"
@@ -82,7 +82,7 @@
         },
         "node_modules/@babel/helper-validator-identifier": {
             "version": "7.22.20",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
             "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
             "engines": {
                 "node": ">=6.9.0"
@@ -90,7 +90,7 @@
         },
         "node_modules/@babel/highlight": {
             "version": "7.24.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@babel/highlight/-/highlight-7.24.2.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
             "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.22.20",
@@ -104,7 +104,7 @@
         },
         "node_modules/@babel/highlight/node_modules/ansi-styles": {
             "version": "3.2.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dependencies": {
                 "color-convert": "^1.9.0"
@@ -115,7 +115,7 @@
         },
         "node_modules/@babel/highlight/node_modules/chalk": {
             "version": "2.4.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/chalk/-/chalk-2.4.2.tgz",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dependencies": {
                 "ansi-styles": "^3.2.1",
@@ -128,7 +128,7 @@
         },
         "node_modules/@babel/highlight/node_modules/color-convert": {
             "version": "1.9.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/color-convert/-/color-convert-1.9.3.tgz",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "dependencies": {
                 "color-name": "1.1.3"
@@ -136,12 +136,12 @@
         },
         "node_modules/@babel/highlight/node_modules/color-name": {
             "version": "1.1.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/color-name/-/color-name-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
             "version": "1.0.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
             "engines": {
                 "node": ">=0.8.0"
@@ -149,7 +149,7 @@
         },
         "node_modules/@babel/highlight/node_modules/has-flag": {
             "version": "3.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/has-flag/-/has-flag-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
             "engines": {
                 "node": ">=4"
@@ -157,7 +157,7 @@
         },
         "node_modules/@babel/highlight/node_modules/supports-color": {
             "version": "5.5.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/supports-color/-/supports-color-5.5.0.tgz",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dependencies": {
                 "has-flag": "^3.0.0"
@@ -168,7 +168,7 @@
         },
         "node_modules/@babel/runtime": {
             "version": "7.24.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@babel/runtime/-/runtime-7.24.1.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
             "integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -179,7 +179,7 @@
         },
         "node_modules/@babel/types": {
             "version": "7.24.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@babel/types/-/types-7.24.0.tgz",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
             "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.23.4",
@@ -192,7 +192,7 @@
         },
         "node_modules/@emnapi/runtime": {
             "version": "1.3.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emnapi/runtime/-/runtime-1.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
             "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
             "optional": true,
             "dependencies": {
@@ -201,7 +201,7 @@
         },
         "node_modules/@emotion/babel-plugin": {
             "version": "11.11.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
             "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
@@ -219,7 +219,7 @@
         },
         "node_modules/@emotion/cache": {
             "version": "11.11.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/cache/-/cache-11.11.0.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
             "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
             "dependencies": {
                 "@emotion/memoize": "^0.8.1",
@@ -231,12 +231,12 @@
         },
         "node_modules/@emotion/hash": {
             "version": "0.9.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/hash/-/hash-0.9.1.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
             "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
         },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.2.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
             "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
             "dependencies": {
                 "@emotion/memoize": "^0.8.1"
@@ -244,12 +244,12 @@
         },
         "node_modules/@emotion/memoize": {
             "version": "0.8.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/memoize/-/memoize-0.8.1.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
             "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
         },
         "node_modules/@emotion/react": {
             "version": "11.11.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/react/-/react-11.11.4.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
             "integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
@@ -272,7 +272,7 @@
         },
         "node_modules/@emotion/serialize": {
             "version": "1.1.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/serialize/-/serialize-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.3.tgz",
             "integrity": "sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==",
             "dependencies": {
                 "@emotion/hash": "^0.9.1",
@@ -284,12 +284,12 @@
         },
         "node_modules/@emotion/sheet": {
             "version": "1.2.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/sheet/-/sheet-1.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
             "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
         },
         "node_modules/@emotion/styled": {
             "version": "11.11.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/styled/-/styled-11.11.0.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
             "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
             "dependencies": {
                 "@babel/runtime": "^7.18.3",
@@ -311,12 +311,12 @@
         },
         "node_modules/@emotion/unitless": {
             "version": "0.8.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/unitless/-/unitless-0.8.1.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
             "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
         },
         "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
             "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
             "peerDependencies": {
                 "react": ">=16.8.0"
@@ -324,17 +324,17 @@
         },
         "node_modules/@emotion/utils": {
             "version": "1.2.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/utils/-/utils-1.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
             "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
         },
         "node_modules/@emotion/weak-memoize": {
             "version": "0.3.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
             "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
             "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
             "dev": true,
             "dependencies": {
@@ -349,7 +349,7 @@
         },
         "node_modules/@eslint-community/regexpp": {
             "version": "4.10.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
             "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
             "dev": true,
             "engines": {
@@ -358,7 +358,7 @@
         },
         "node_modules/@eslint/eslintrc": {
             "version": "2.1.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
             "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "dependencies": {
@@ -378,7 +378,7 @@
         },
         "node_modules/@eslint/js": {
             "version": "8.57.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@eslint/js/-/js-8.57.0.tgz",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
             "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
             "dev": true,
             "engines": {
@@ -387,7 +387,7 @@
         },
         "node_modules/@floating-ui/core": {
             "version": "1.6.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@floating-ui/core/-/core-1.6.0.tgz",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
             "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
             "dependencies": {
                 "@floating-ui/utils": "^0.2.1"
@@ -395,7 +395,7 @@
         },
         "node_modules/@floating-ui/dom": {
             "version": "1.6.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@floating-ui/dom/-/dom-1.6.3.tgz",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
             "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
             "dependencies": {
                 "@floating-ui/core": "^1.0.0",
@@ -404,7 +404,7 @@
         },
         "node_modules/@floating-ui/react-dom": {
             "version": "2.0.8",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
             "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
             "dependencies": {
                 "@floating-ui/dom": "^1.6.1"
@@ -416,12 +416,12 @@
         },
         "node_modules/@floating-ui/utils": {
             "version": "0.2.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@floating-ui/utils/-/utils-0.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
             "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.14",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
             "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
             "dev": true,
             "dependencies": {
@@ -435,7 +435,7 @@
         },
         "node_modules/@humanwhocodes/module-importer": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
             "engines": {
@@ -444,13 +444,13 @@
         },
         "node_modules/@humanwhocodes/object-schema": {
             "version": "2.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
             "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
             "dev": true
         },
         "node_modules/@img/sharp-darwin-arm64": {
             "version": "0.33.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
             "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
             "cpu": [
                 "arm64"
@@ -471,7 +471,7 @@
         },
         "node_modules/@img/sharp-darwin-x64": {
             "version": "0.33.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
             "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
             "cpu": [
                 "x64"
@@ -492,7 +492,7 @@
         },
         "node_modules/@img/sharp-libvips-darwin-arm64": {
             "version": "1.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
             "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
             "cpu": [
                 "arm64"
@@ -507,7 +507,7 @@
         },
         "node_modules/@img/sharp-libvips-darwin-x64": {
             "version": "1.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
             "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
             "cpu": [
                 "x64"
@@ -522,7 +522,7 @@
         },
         "node_modules/@img/sharp-libvips-linux-arm": {
             "version": "1.0.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
             "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
             "cpu": [
                 "arm"
@@ -537,7 +537,7 @@
         },
         "node_modules/@img/sharp-libvips-linux-arm64": {
             "version": "1.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
             "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
             "cpu": [
                 "arm64"
@@ -552,7 +552,7 @@
         },
         "node_modules/@img/sharp-libvips-linux-s390x": {
             "version": "1.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
             "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
             "cpu": [
                 "s390x"
@@ -567,7 +567,7 @@
         },
         "node_modules/@img/sharp-libvips-linux-x64": {
             "version": "1.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
             "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
             "cpu": [
                 "x64"
@@ -582,7 +582,7 @@
         },
         "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
             "version": "1.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
             "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
             "cpu": [
                 "arm64"
@@ -597,7 +597,7 @@
         },
         "node_modules/@img/sharp-libvips-linuxmusl-x64": {
             "version": "1.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
             "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
             "cpu": [
                 "x64"
@@ -612,7 +612,7 @@
         },
         "node_modules/@img/sharp-linux-arm": {
             "version": "0.33.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
             "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
             "cpu": [
                 "arm"
@@ -633,7 +633,7 @@
         },
         "node_modules/@img/sharp-linux-arm64": {
             "version": "0.33.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
             "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
             "cpu": [
                 "arm64"
@@ -654,7 +654,7 @@
         },
         "node_modules/@img/sharp-linux-s390x": {
             "version": "0.33.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
             "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
             "cpu": [
                 "s390x"
@@ -675,7 +675,7 @@
         },
         "node_modules/@img/sharp-linux-x64": {
             "version": "0.33.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
             "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
             "cpu": [
                 "x64"
@@ -696,7 +696,7 @@
         },
         "node_modules/@img/sharp-linuxmusl-arm64": {
             "version": "0.33.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
             "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
             "cpu": [
                 "arm64"
@@ -717,7 +717,7 @@
         },
         "node_modules/@img/sharp-linuxmusl-x64": {
             "version": "0.33.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
             "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
             "cpu": [
                 "x64"
@@ -738,7 +738,7 @@
         },
         "node_modules/@img/sharp-wasm32": {
             "version": "0.33.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
             "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
             "cpu": [
                 "wasm32"
@@ -756,7 +756,7 @@
         },
         "node_modules/@img/sharp-win32-ia32": {
             "version": "0.33.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
             "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
             "cpu": [
                 "ia32"
@@ -774,7 +774,7 @@
         },
         "node_modules/@img/sharp-win32-x64": {
             "version": "0.33.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
             "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
             "cpu": [
                 "x64"
@@ -792,7 +792,7 @@
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
             "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "dev": true,
             "dependencies": {
@@ -809,7 +809,7 @@
         },
         "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
             "version": "6.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ansi-regex/-/ansi-regex-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
             "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
             "dev": true,
             "engines": {
@@ -818,7 +818,7 @@
         },
         "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
             "version": "7.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
             "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
             "dev": true,
             "dependencies": {
@@ -830,7 +830,7 @@
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
             "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
             "dependencies": {
@@ -844,7 +844,7 @@
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
             "engines": {
@@ -853,7 +853,7 @@
         },
         "node_modules/@jridgewell/set-array": {
             "version": "1.2.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
             "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
             "engines": {
@@ -862,13 +862,13 @@
         },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.4.15",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
             "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.25",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
             "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
             "dependencies": {
@@ -878,7 +878,7 @@
         },
         "node_modules/@mui/base": {
             "version": "5.0.0-beta.40",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@mui/base/-/base-5.0.0-beta.40.tgz",
+            "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
             "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -905,12 +905,12 @@
         },
         "node_modules/@mui/core-downloads-tracker": {
             "version": "5.15.14",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.14.tgz",
+            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.14.tgz",
             "integrity": "sha512-on75VMd0XqZfaQW+9pGjSNiqW+ghc5E2ZSLRBXwcXl/C4YzjfyjrLPhrEpKnR9Uym9KXBvxrhoHfPcczYHweyA=="
         },
         "node_modules/@mui/icons-material": {
             "version": "5.15.14",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@mui/icons-material/-/icons-material-5.15.14.tgz",
+            "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.14.tgz",
             "integrity": "sha512-vj/51k7MdFmt+XVw94sl30SCvGx6+wJLsNYjZRgxhS6y3UtnWnypMOsm3Kmg8TN+P0dqwsjy4/fX7B1HufJIhw==",
             "dependencies": {
                 "@babel/runtime": "^7.23.9"
@@ -935,7 +935,7 @@
         },
         "node_modules/@mui/joy": {
             "version": "5.0.0-beta.32",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@mui/joy/-/joy-5.0.0-beta.32.tgz",
+            "resolved": "https://registry.npmjs.org/@mui/joy/-/joy-5.0.0-beta.32.tgz",
             "integrity": "sha512-QJW5Mu2GTJUX4sXjxt4nQBugpJAiSkUT49S/bwoKCCWx8bCfsEyplTzZPK+FraweiGhGgZWExWOTAPpxH83RUQ==",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -971,7 +971,7 @@
         },
         "node_modules/@mui/material": {
             "version": "5.15.14",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@mui/material/-/material-5.15.14.tgz",
+            "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.14.tgz",
             "integrity": "sha512-kEbRw6fASdQ1SQ7LVdWR5OlWV3y7Y54ZxkLzd6LV5tmz+NpO3MJKZXSfgR0LHMP7meKsPiMm4AuzV0pXDpk/BQ==",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -1015,12 +1015,12 @@
         },
         "node_modules/@mui/material/node_modules/react-is": {
             "version": "18.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/react-is/-/react-is-18.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
             "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         },
         "node_modules/@mui/private-theming": {
             "version": "5.15.14",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@mui/private-theming/-/private-theming-5.15.14.tgz",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.14.tgz",
             "integrity": "sha512-UH0EiZckOWcxiXLX3Jbb0K7rC8mxTr9L9l6QhOZxYc4r8FHUkefltV9VDGLrzCaWh30SQiJvAEd7djX3XXY6Xw==",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -1042,7 +1042,7 @@
         },
         "node_modules/@mui/styled-engine": {
             "version": "5.15.14",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@mui/styled-engine/-/styled-engine-5.15.14.tgz",
+            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.14.tgz",
             "integrity": "sha512-RILkuVD8gY6PvjZjqnWhz8fu68dVkqhM5+jYWfB5yhlSQKg+2rHkmEwm75XIeAqI3qwOndK6zELK5H6Zxn4NHw==",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -1069,7 +1069,7 @@
         },
         "node_modules/@mui/system": {
             "version": "5.15.14",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@mui/system/-/system-5.15.14.tgz",
+            "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.14.tgz",
             "integrity": "sha512-auXLXzUaCSSOLqJXmsAaq7P96VPRXg2Rrz6OHNV7lr+kB8lobUF+/N84Vd9C4G/wvCXYPs5TYuuGBRhcGbiBGg==",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -1104,7 +1104,7 @@
         },
         "node_modules/@mui/types": {
             "version": "7.2.14",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@mui/types/-/types-7.2.14.tgz",
+            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.14.tgz",
             "integrity": "sha512-MZsBZ4q4HfzBsywtXgM1Ksj6HDThtiwmOKUXH1pKYISI9gAVXCNHNpo7TlGoGrBaYWZTdNoirIN7JsQcQUjmQQ==",
             "peerDependencies": {
                 "@types/react": "^17.0.0 || ^18.0.0"
@@ -1117,7 +1117,7 @@
         },
         "node_modules/@mui/utils": {
             "version": "5.15.14",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@mui/utils/-/utils-5.15.14.tgz",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.14.tgz",
             "integrity": "sha512-0lF/7Hh/ezDv5X7Pry6enMsbYyGKjADzvHyo3Qrc/SSlTsQ1VkbDMbH0m2t3OR5iIVLwMoxwM7yGd+6FCMtTFA==",
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
@@ -1140,17 +1140,17 @@
         },
         "node_modules/@mui/utils/node_modules/react-is": {
             "version": "18.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/react-is/-/react-is-18.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
             "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         },
         "node_modules/@next/env": {
             "version": "15.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@next/env/-/env-15.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.3.tgz",
             "integrity": "sha512-a26KnbW9DFEUsSxAxKBORR/uD9THoYoKbkpFywMN/AFvboTt94b8+g/07T8J6ACsdLag8/PDU60ov4rPxRAixw=="
         },
         "node_modules/@next/eslint-plugin-next": {
             "version": "14.1.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@next/eslint-plugin-next/-/eslint-plugin-next-14.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.1.3.tgz",
             "integrity": "sha512-VCnZI2cy77Yaj3L7Uhs3+44ikMM1VD/fBMwvTBb3hIaTIuqa+DmG4dhUDq+MASu3yx97KhgsVJbsas0XuiKyww==",
             "dev": true,
             "dependencies": {
@@ -1159,7 +1159,7 @@
         },
         "node_modules/@next/swc-darwin-arm64": {
             "version": "15.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.3.tgz",
             "integrity": "sha512-uaBhA8aLbXLqwjnsHSkxs353WrRgQgiFjduDpc7YXEU0B54IKx3vU+cxQlYwPCyC8uYEEX7THhtQQsfHnvv8dw==",
             "cpu": [
                 "arm64"
@@ -1174,7 +1174,7 @@
         },
         "node_modules/@next/swc-darwin-x64": {
             "version": "15.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.3.tgz",
             "integrity": "sha512-pVwKvJ4Zk7h+4hwhqOUuMx7Ib02u3gDX3HXPKIShBi9JlYllI0nU6TWLbPT94dt7FSi6mSBhfc2JrHViwqbOdw==",
             "cpu": [
                 "x64"
@@ -1189,7 +1189,7 @@
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
             "version": "15.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.3.tgz",
             "integrity": "sha512-50ibWdn2RuFFkOEUmo9NCcQbbV9ViQOrUfG48zHBCONciHjaUKtHcYFiCwBVuzD08fzvzkWuuZkd4AqbvKO7UQ==",
             "cpu": [
                 "arm64"
@@ -1204,7 +1204,7 @@
         },
         "node_modules/@next/swc-linux-arm64-musl": {
             "version": "15.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.3.tgz",
             "integrity": "sha512-2gAPA7P652D3HzR4cLyAuVYwYqjG0mt/3pHSWTCyKZq/N/dJcUAEoNQMyUmwTZWCJRKofB+JPuDVP2aD8w2J6Q==",
             "cpu": [
                 "arm64"
@@ -1219,7 +1219,7 @@
         },
         "node_modules/@next/swc-linux-x64-gnu": {
             "version": "15.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.3.tgz",
             "integrity": "sha512-ODSKvrdMgAJOVU4qElflYy1KSZRM3M45JVbeZu42TINCMG3anp7YCBn80RkISV6bhzKwcUqLBAmOiWkaGtBA9w==",
             "cpu": [
                 "x64"
@@ -1234,7 +1234,7 @@
         },
         "node_modules/@next/swc-linux-x64-musl": {
             "version": "15.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.3.tgz",
             "integrity": "sha512-ZR9kLwCWrlYxwEoytqPi1jhPd1TlsSJWAc+H/CJHmHkf2nD92MQpSRIURR1iNgA/kuFSdxB8xIPt4p/T78kwsg==",
             "cpu": [
                 "x64"
@@ -1249,7 +1249,7 @@
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
             "version": "15.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.3.tgz",
             "integrity": "sha512-+G2FrDcfm2YDbhDiObDU/qPriWeiz/9cRR0yMWJeTLGGX6/x8oryO3tt7HhodA1vZ8r2ddJPCjtLcpaVl7TE2Q==",
             "cpu": [
                 "arm64"
@@ -1264,7 +1264,7 @@
         },
         "node_modules/@next/swc-win32-x64-msvc": {
             "version": "15.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.3.tgz",
             "integrity": "sha512-gHYS9tc+G2W0ZC8rBL+H6RdtXIyk40uLiaos0yj5US85FNhbFEndMA2nW3z47nzOWiSvXTZ5kBClc3rD0zJg0w==",
             "cpu": [
                 "x64"
@@ -1279,7 +1279,7 @@
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dev": true,
             "dependencies": {
@@ -1292,7 +1292,7 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "dev": true,
             "engines": {
@@ -1301,7 +1301,7 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
             "dependencies": {
@@ -1314,7 +1314,7 @@
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
             "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
             "dev": true,
             "optional": true,
@@ -1324,23 +1324,23 @@
         },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@popperjs/core/-/core-2.11.8.tgz",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
         },
         "node_modules/@rushstack/eslint-patch": {
             "version": "1.7.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@rushstack/eslint-patch/-/eslint-patch-1.7.2.tgz",
+            "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.7.2.tgz",
             "integrity": "sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==",
             "dev": true
         },
         "node_modules/@swc/counter": {
             "version": "0.1.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@swc/counter/-/counter-0.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
             "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
         },
         "node_modules/@swc/helpers": {
             "version": "0.5.15",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@swc/helpers/-/helpers-0.5.15.tgz",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
             "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
             "dependencies": {
                 "tslib": "^2.8.0"
@@ -1348,13 +1348,13 @@
         },
         "node_modules/@types/json5": {
             "version": "0.0.29",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@types/json5/-/json5-0.0.29.tgz",
+            "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true
         },
         "node_modules/@types/node": {
             "version": "20.11.30",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@types/node/-/node-20.11.30.tgz",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
             "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
             "dev": true,
             "dependencies": {
@@ -1363,17 +1363,17 @@
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@types/parse-json/-/parse-json-4.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
             "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
         },
         "node_modules/@types/prop-types": {
             "version": "15.7.11",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@types/prop-types/-/prop-types-15.7.11.tgz",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
             "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
         },
         "node_modules/@types/react": {
             "version": "18.2.67",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@types/react/-/react-18.2.67.tgz",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.67.tgz",
             "integrity": "sha512-vkIE2vTIMHQ/xL0rgmuoECBCkZFZeHr49HeWSc24AptMbNRo7pwSBvj73rlJJs9fGKj0koS+V7kQB1jHS0uCgw==",
             "dependencies": {
                 "@types/prop-types": "*",
@@ -1383,7 +1383,7 @@
         },
         "node_modules/@types/react-dom": {
             "version": "18.2.22",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@types/react-dom/-/react-dom-18.2.22.tgz",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.22.tgz",
             "integrity": "sha512-fHkBXPeNtfvri6gdsMYyW+dW7RXFo6Ad09nLFK0VQWR7yGLai/Cyvyj696gbwYvBnhGtevUG9cET0pmUbMtoPQ==",
             "dev": true,
             "dependencies": {
@@ -1392,7 +1392,7 @@
         },
         "node_modules/@types/react-transition-group": {
             "version": "4.4.10",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
             "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
             "dependencies": {
                 "@types/react": "*"
@@ -1400,12 +1400,12 @@
         },
         "node_modules/@types/scheduler": {
             "version": "0.16.8",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@types/scheduler/-/scheduler-0.16.8.tgz",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
             "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
         },
         "node_modules/@typescript-eslint/parser": {
             "version": "6.21.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
             "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
             "dev": true,
             "dependencies": {
@@ -1429,7 +1429,7 @@
         },
         "node_modules/@typescript-eslint/scope-manager": {
             "version": "6.21.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
             "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
             "dev": true,
             "dependencies": {
@@ -1442,7 +1442,7 @@
         },
         "node_modules/@typescript-eslint/types": {
             "version": "6.21.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@typescript-eslint/types/-/types-6.21.0.tgz",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
             "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
             "dev": true,
             "engines": {
@@ -1451,7 +1451,7 @@
         },
         "node_modules/@typescript-eslint/typescript-estree": {
             "version": "6.21.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
             "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
             "dev": true,
             "dependencies": {
@@ -1475,7 +1475,7 @@
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
             "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
             "dependencies": {
@@ -1484,7 +1484,7 @@
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
             "version": "9.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/minimatch/-/minimatch-9.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
             "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
             "dev": true,
             "dependencies": {
@@ -1496,7 +1496,7 @@
         },
         "node_modules/@typescript-eslint/visitor-keys": {
             "version": "6.21.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
             "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
             "dev": true,
             "dependencies": {
@@ -1509,13 +1509,13 @@
         },
         "node_modules/@ungap/structured-clone": {
             "version": "1.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
             "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
             "dev": true
         },
         "node_modules/acorn": {
             "version": "8.11.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/acorn/-/acorn-8.11.3.tgz",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
             "bin": {
@@ -1527,7 +1527,7 @@
         },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "peerDependencies": {
@@ -1536,7 +1536,7 @@
         },
         "node_modules/ajv": {
             "version": "6.12.6",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ajv/-/ajv-6.12.6.tgz",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "dependencies": {
@@ -1548,7 +1548,7 @@
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "engines": {
@@ -1557,7 +1557,7 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
             "dependencies": {
@@ -1569,13 +1569,13 @@
         },
         "node_modules/any-promise": {
             "version": "1.3.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/any-promise/-/any-promise-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
             "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
             "dev": true
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/anymatch/-/anymatch-3.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dev": true,
             "dependencies": {
@@ -1588,19 +1588,19 @@
         },
         "node_modules/arg": {
             "version": "5.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/arg/-/arg-5.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
             "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
             "dev": true
         },
         "node_modules/argparse": {
             "version": "2.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/argparse/-/argparse-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
         },
         "node_modules/aria-query": {
             "version": "5.3.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/aria-query/-/aria-query-5.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
             "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
             "dev": true,
             "dependencies": {
@@ -1609,7 +1609,7 @@
         },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
             "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
             "dev": true,
             "dependencies": {
@@ -1622,7 +1622,7 @@
         },
         "node_modules/array-includes": {
             "version": "3.1.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/array-includes/-/array-includes-3.1.7.tgz",
+            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
             "integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
             "dev": true,
             "dependencies": {
@@ -1638,7 +1638,7 @@
         },
         "node_modules/array-union": {
             "version": "2.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/array-union/-/array-union-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "dev": true,
             "engines": {
@@ -1647,7 +1647,7 @@
         },
         "node_modules/array.prototype.findlast": {
             "version": "1.2.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+            "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
             "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
             "dev": true,
             "dependencies": {
@@ -1664,7 +1664,7 @@
         },
         "node_modules/array.prototype.findlastindex": {
             "version": "1.2.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
+            "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
             "integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
             "dev": true,
             "dependencies": {
@@ -1681,7 +1681,7 @@
         },
         "node_modules/array.prototype.flat": {
             "version": "1.3.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
             "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
             "dev": true,
             "dependencies": {
@@ -1696,7 +1696,7 @@
         },
         "node_modules/array.prototype.flatmap": {
             "version": "1.3.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
             "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
             "dev": true,
             "dependencies": {
@@ -1711,7 +1711,7 @@
         },
         "node_modules/array.prototype.toreversed": {
             "version": "1.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/array.prototype.toreversed/-/array.prototype.toreversed-1.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/array.prototype.toreversed/-/array.prototype.toreversed-1.1.2.tgz",
             "integrity": "sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==",
             "dev": true,
             "dependencies": {
@@ -1723,7 +1723,7 @@
         },
         "node_modules/array.prototype.tosorted": {
             "version": "1.1.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/array.prototype.tosorted/-/array.prototype.tosorted-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.3.tgz",
             "integrity": "sha512-/DdH4TiTmOKzyQbp/eadcCVexiCb36xJg7HshYOYJnNZFDj33GEv0P7GxsynpShhq4OLYJzbGcBDkLsDt7MnNg==",
             "dev": true,
             "dependencies": {
@@ -1736,7 +1736,7 @@
         },
         "node_modules/arraybuffer.prototype.slice": {
             "version": "1.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
             "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
             "dev": true,
             "dependencies": {
@@ -1755,13 +1755,13 @@
         },
         "node_modules/ast-types-flow": {
             "version": "0.0.8",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
             "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
             "dev": true
         },
         "node_modules/autoprefixer": {
             "version": "10.4.18",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/autoprefixer/-/autoprefixer-10.4.18.tgz",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.18.tgz",
             "integrity": "sha512-1DKbDfsr6KUElM6wg+0zRNkB/Q7WcKYAaK+pzXn+Xqmszm/5Xa9coeNdtP88Vi+dPzZnMjhge8GIV49ZQkDa+g==",
             "dev": true,
             "dependencies": {
@@ -1784,7 +1784,7 @@
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
             "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
             "dev": true,
             "dependencies": {
@@ -1796,7 +1796,7 @@
         },
         "node_modules/axe-core": {
             "version": "4.7.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/axe-core/-/axe-core-4.7.0.tgz",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
             "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
             "dev": true,
             "engines": {
@@ -1805,7 +1805,7 @@
         },
         "node_modules/axobject-query": {
             "version": "3.2.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/axobject-query/-/axobject-query-3.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
             "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
             "dev": true,
             "dependencies": {
@@ -1814,7 +1814,7 @@
         },
         "node_modules/babel-plugin-macros": {
             "version": "3.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
             "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
@@ -1828,13 +1828,13 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/balanced-match/-/balanced-match-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
             "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
             "dev": true,
             "engines": {
@@ -1843,7 +1843,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "dependencies": {
@@ -1853,7 +1853,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/braces/-/braces-3.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
             "dev": true,
             "dependencies": {
@@ -1865,7 +1865,7 @@
         },
         "node_modules/browserslist": {
             "version": "4.23.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/browserslist/-/browserslist-4.23.0.tgz",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
             "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
             "dev": true,
             "dependencies": {
@@ -1883,7 +1883,7 @@
         },
         "node_modules/busboy": {
             "version": "1.6.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/busboy/-/busboy-1.6.0.tgz",
+            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
             "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
             "dependencies": {
                 "streamsearch": "^1.1.0"
@@ -1894,7 +1894,7 @@
         },
         "node_modules/call-bind": {
             "version": "1.0.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/call-bind/-/call-bind-1.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
             "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
             "dev": true,
             "dependencies": {
@@ -1910,7 +1910,7 @@
         },
         "node_modules/callsites": {
             "version": "3.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/callsites/-/callsites-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "engines": {
                 "node": ">=6"
@@ -1918,7 +1918,7 @@
         },
         "node_modules/camelcase-css": {
             "version": "2.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/camelcase-css/-/camelcase-css-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
             "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
             "dev": true,
             "engines": {
@@ -1927,12 +1927,12 @@
         },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001599",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/caniuse-lite/-/caniuse-lite-1.0.30001599.tgz",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001599.tgz",
             "integrity": "sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA=="
         },
         "node_modules/chalk": {
             "version": "4.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/chalk/-/chalk-4.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "dependencies": {
@@ -1945,7 +1945,7 @@
         },
         "node_modules/chokidar": {
             "version": "3.6.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/chokidar/-/chokidar-3.6.0.tgz",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
             "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
             "dependencies": {
@@ -1966,7 +1966,7 @@
         },
         "node_modules/chokidar/node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
             "dependencies": {
@@ -1978,12 +1978,12 @@
         },
         "node_modules/client-only": {
             "version": "0.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/client-only/-/client-only-0.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
             "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
         },
         "node_modules/clsx": {
             "version": "2.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/clsx/-/clsx-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
             "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
             "engines": {
                 "node": ">=6"
@@ -1991,7 +1991,7 @@
         },
         "node_modules/color": {
             "version": "4.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/color/-/color-4.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
             "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
             "optional": true,
             "dependencies": {
@@ -2004,7 +2004,7 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/color-convert/-/color-convert-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "devOptional": true,
             "dependencies": {
@@ -2016,13 +2016,13 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/color-name/-/color-name-1.1.4.tgz",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "devOptional": true
         },
         "node_modules/color-string": {
             "version": "1.9.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/color-string/-/color-string-1.9.1.tgz",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
             "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
             "optional": true,
             "dependencies": {
@@ -2032,7 +2032,7 @@
         },
         "node_modules/commander": {
             "version": "4.1.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/commander/-/commander-4.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
             "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
             "dev": true,
             "engines": {
@@ -2041,18 +2041,18 @@
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/concat-map/-/concat-map-0.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
         },
         "node_modules/convert-source-map": {
             "version": "1.9.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
         },
         "node_modules/cosmiconfig": {
             "version": "7.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
             "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
@@ -2067,7 +2067,7 @@
         },
         "node_modules/cosmiconfig/node_modules/yaml": {
             "version": "1.10.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/yaml/-/yaml-1.10.2.tgz",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "engines": {
                 "node": ">= 6"
@@ -2075,7 +2075,7 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
             "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
             "dev": true,
             "dependencies": {
@@ -2089,7 +2089,7 @@
         },
         "node_modules/cssesc": {
             "version": "3.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/cssesc/-/cssesc-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
             "dev": true,
             "bin": {
@@ -2101,18 +2101,18 @@
         },
         "node_modules/csstype": {
             "version": "3.1.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/csstype/-/csstype-3.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
             "dev": true
         },
         "node_modules/data-view-buffer": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
             "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
             "dev": true,
             "dependencies": {
@@ -2126,7 +2126,7 @@
         },
         "node_modules/data-view-byte-length": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
             "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
             "dev": true,
             "dependencies": {
@@ -2140,7 +2140,7 @@
         },
         "node_modules/data-view-byte-offset": {
             "version": "1.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
             "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
             "dev": true,
             "dependencies": {
@@ -2154,12 +2154,12 @@
         },
         "node_modules/dayjs": {
             "version": "1.11.10",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/dayjs/-/dayjs-1.11.10.tgz",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
             "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
         },
         "node_modules/debug": {
             "version": "4.3.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/debug/-/debug-4.3.4.tgz",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
             "dependencies": {
@@ -2176,13 +2176,13 @@
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/deep-is/-/deep-is-0.1.4.tgz",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/define-data-property/-/define-data-property-1.1.4.tgz",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dev": true,
             "dependencies": {
@@ -2196,7 +2196,7 @@
         },
         "node_modules/define-properties": {
             "version": "1.2.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/define-properties/-/define-properties-1.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
             "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
             "dev": true,
             "dependencies": {
@@ -2210,7 +2210,7 @@
         },
         "node_modules/dequal": {
             "version": "2.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/dequal/-/dequal-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
             "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
             "dev": true,
             "engines": {
@@ -2219,7 +2219,7 @@
         },
         "node_modules/detect-libc": {
             "version": "2.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/detect-libc/-/detect-libc-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
             "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
             "optional": true,
             "engines": {
@@ -2228,13 +2228,13 @@
         },
         "node_modules/didyoumean": {
             "version": "1.2.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/didyoumean/-/didyoumean-1.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
             "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
             "dev": true
         },
         "node_modules/dir-glob": {
             "version": "3.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/dir-glob/-/dir-glob-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
             "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
             "dev": true,
             "dependencies": {
@@ -2246,13 +2246,13 @@
         },
         "node_modules/dlv": {
             "version": "1.1.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/dlv/-/dlv-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
             "dev": true
         },
         "node_modules/doctrine": {
             "version": "3.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/doctrine/-/doctrine-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
             "dependencies": {
@@ -2264,7 +2264,7 @@
         },
         "node_modules/dom-helpers": {
             "version": "5.2.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/dom-helpers/-/dom-helpers-5.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
             "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
             "dependencies": {
                 "@babel/runtime": "^7.8.7",
@@ -2273,25 +2273,25 @@
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true
         },
         "node_modules/electron-to-chromium": {
             "version": "1.4.710",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/electron-to-chromium/-/electron-to-chromium-1.4.710.tgz",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.710.tgz",
             "integrity": "sha512-w+9yAVHoHhysCa+gln7AzbO9CdjFcL/wN/5dd+XW/Msl2d/4+WisEaCF1nty0xbAKaxdaJfgLB2296U7zZB7BA==",
             "dev": true
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true
         },
         "node_modules/enhanced-resolve": {
             "version": "5.16.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
             "integrity": "sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==",
             "dev": true,
             "dependencies": {
@@ -2304,7 +2304,7 @@
         },
         "node_modules/error-ex": {
             "version": "1.3.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/error-ex/-/error-ex-1.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
@@ -2312,7 +2312,7 @@
         },
         "node_modules/es-abstract": {
             "version": "1.23.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/es-abstract/-/es-abstract-1.23.2.tgz",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.2.tgz",
             "integrity": "sha512-60s3Xv2T2p1ICykc7c+DNDPLDMm9t4QxCOUU0K9JxiLjM3C1zB9YVdN7tjxrFd4+AkZ8CdX1ovUga4P2+1e+/w==",
             "dev": true,
             "dependencies": {
@@ -2369,7 +2369,7 @@
         },
         "node_modules/es-define-property": {
             "version": "1.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/es-define-property/-/es-define-property-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
             "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
             "dev": true,
             "dependencies": {
@@ -2381,7 +2381,7 @@
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/es-errors/-/es-errors-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "dev": true,
             "engines": {
@@ -2390,7 +2390,7 @@
         },
         "node_modules/es-iterator-helpers": {
             "version": "1.0.18",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/es-iterator-helpers/-/es-iterator-helpers-1.0.18.tgz",
+            "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.18.tgz",
             "integrity": "sha512-scxAJaewsahbqTYrGKJihhViaM6DDZDDoucfvzNbK0pOren1g/daDQ3IAhzn+1G14rBG7w+i5N+qul60++zlKA==",
             "dev": true,
             "dependencies": {
@@ -2415,7 +2415,7 @@
         },
         "node_modules/es-object-atoms": {
             "version": "1.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
             "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
             "dev": true,
             "dependencies": {
@@ -2427,7 +2427,7 @@
         },
         "node_modules/es-set-tostringtag": {
             "version": "2.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
             "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
             "dev": true,
             "dependencies": {
@@ -2441,7 +2441,7 @@
         },
         "node_modules/es-shim-unscopables": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
             "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
             "dev": true,
             "dependencies": {
@@ -2450,7 +2450,7 @@
         },
         "node_modules/es-to-primitive": {
             "version": "1.2.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
             "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
             "dev": true,
             "dependencies": {
@@ -2464,7 +2464,7 @@
         },
         "node_modules/escalade": {
             "version": "3.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/escalade/-/escalade-3.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
             "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
             "dev": true,
             "engines": {
@@ -2473,7 +2473,7 @@
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "engines": {
                 "node": ">=10"
@@ -2481,7 +2481,7 @@
         },
         "node_modules/eslint": {
             "version": "8.57.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/eslint/-/eslint-8.57.0.tgz",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
             "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
             "dependencies": {
@@ -2533,7 +2533,7 @@
         },
         "node_modules/eslint-config-next": {
             "version": "14.1.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/eslint-config-next/-/eslint-config-next-14.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.1.3.tgz",
             "integrity": "sha512-sUCpWlGuHpEhI0pIT0UtdSLJk5Z8E2DYinPTwsBiWaSYQomchdl0i60pjynY48+oXvtyWMQ7oE+G3m49yrfacg==",
             "dev": true,
             "dependencies": {
@@ -2559,7 +2559,7 @@
         },
         "node_modules/eslint-import-resolver-node": {
             "version": "0.3.9",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
             "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
             "dev": true,
             "dependencies": {
@@ -2570,7 +2570,7 @@
         },
         "node_modules/eslint-import-resolver-node/node_modules/debug": {
             "version": "3.2.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/debug/-/debug-3.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "dependencies": {
@@ -2579,7 +2579,7 @@
         },
         "node_modules/eslint-import-resolver-typescript": {
             "version": "3.6.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
             "integrity": "sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==",
             "dev": true,
             "dependencies": {
@@ -2601,7 +2601,7 @@
         },
         "node_modules/eslint-module-utils": {
             "version": "2.8.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz",
             "integrity": "sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==",
             "dev": true,
             "dependencies": {
@@ -2618,7 +2618,7 @@
         },
         "node_modules/eslint-module-utils/node_modules/debug": {
             "version": "3.2.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/debug/-/debug-3.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "dependencies": {
@@ -2627,7 +2627,7 @@
         },
         "node_modules/eslint-plugin-import": {
             "version": "2.29.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
             "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
             "dev": true,
             "dependencies": {
@@ -2658,7 +2658,7 @@
         },
         "node_modules/eslint-plugin-import/node_modules/debug": {
             "version": "3.2.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/debug/-/debug-3.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "dependencies": {
@@ -2667,7 +2667,7 @@
         },
         "node_modules/eslint-plugin-import/node_modules/doctrine": {
             "version": "2.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/doctrine/-/doctrine-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "dependencies": {
@@ -2679,7 +2679,7 @@
         },
         "node_modules/eslint-plugin-import/node_modules/semver": {
             "version": "6.3.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/semver/-/semver-6.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
@@ -2688,7 +2688,7 @@
         },
         "node_modules/eslint-plugin-jsx-a11y": {
             "version": "6.8.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.8.0.tgz",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.8.0.tgz",
             "integrity": "sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==",
             "dev": true,
             "dependencies": {
@@ -2718,7 +2718,7 @@
         },
         "node_modules/eslint-plugin-react": {
             "version": "7.34.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/eslint-plugin-react/-/eslint-plugin-react-7.34.1.tgz",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.1.tgz",
             "integrity": "sha512-N97CxlouPT1AHt8Jn0mhhN2RrADlUAsk1/atcT2KyA/l9Q/E6ll7OIGwNumFmWfZ9skV3XXccYS19h80rHtgkw==",
             "dev": true,
             "dependencies": {
@@ -2750,7 +2750,7 @@
         },
         "node_modules/eslint-plugin-react-hooks": {
             "version": "4.6.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
             "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
             "dev": true,
             "engines": {
@@ -2762,7 +2762,7 @@
         },
         "node_modules/eslint-plugin-react/node_modules/doctrine": {
             "version": "2.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/doctrine/-/doctrine-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "dependencies": {
@@ -2774,7 +2774,7 @@
         },
         "node_modules/eslint-plugin-react/node_modules/resolve": {
             "version": "2.0.0-next.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/resolve/-/resolve-2.0.0-next.5.tgz",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
             "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
             "dev": true,
             "dependencies": {
@@ -2788,7 +2788,7 @@
         },
         "node_modules/eslint-plugin-react/node_modules/semver": {
             "version": "6.3.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/semver/-/semver-6.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
@@ -2797,7 +2797,7 @@
         },
         "node_modules/eslint-scope": {
             "version": "7.2.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
             "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "dependencies": {
@@ -2810,7 +2810,7 @@
         },
         "node_modules/eslint-visitor-keys": {
             "version": "3.4.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "engines": {
@@ -2819,7 +2819,7 @@
         },
         "node_modules/espree": {
             "version": "9.6.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/espree/-/espree-9.6.1.tgz",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
             "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "dependencies": {
@@ -2833,7 +2833,7 @@
         },
         "node_modules/esquery": {
             "version": "1.5.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/esquery/-/esquery-1.5.0.tgz",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
             "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
             "dev": true,
             "dependencies": {
@@ -2845,7 +2845,7 @@
         },
         "node_modules/esrecurse": {
             "version": "4.3.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/esrecurse/-/esrecurse-4.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "dependencies": {
@@ -2857,7 +2857,7 @@
         },
         "node_modules/estraverse": {
             "version": "5.3.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/estraverse/-/estraverse-5.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "engines": {
@@ -2866,7 +2866,7 @@
         },
         "node_modules/esutils": {
             "version": "2.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/esutils/-/esutils-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
             "engines": {
@@ -2875,13 +2875,13 @@
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
         "node_modules/fast-glob": {
             "version": "3.3.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/fast-glob/-/fast-glob-3.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
             "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
             "dev": true,
             "dependencies": {
@@ -2897,7 +2897,7 @@
         },
         "node_modules/fast-glob/node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
             "dependencies": {
@@ -2909,19 +2909,19 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
         "node_modules/fastq": {
             "version": "1.17.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/fastq/-/fastq-1.17.1.tgz",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
             "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
             "dev": true,
             "dependencies": {
@@ -2930,7 +2930,7 @@
         },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
             "dev": true,
             "dependencies": {
@@ -2942,7 +2942,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/fill-range/-/fill-range-7.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
             "dev": true,
             "dependencies": {
@@ -2954,12 +2954,12 @@
         },
         "node_modules/find-root": {
             "version": "1.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/find-root/-/find-root-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
             "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
         },
         "node_modules/find-up": {
             "version": "5.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/find-up/-/find-up-5.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
             "dependencies": {
@@ -2972,7 +2972,7 @@
         },
         "node_modules/flat-cache": {
             "version": "3.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/flat-cache/-/flat-cache-3.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
             "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dev": true,
             "dependencies": {
@@ -2986,13 +2986,13 @@
         },
         "node_modules/flatted": {
             "version": "3.3.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/flatted/-/flatted-3.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
             "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
             "dev": true
         },
         "node_modules/for-each": {
             "version": "0.3.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/for-each/-/for-each-0.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
             "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
             "dev": true,
             "dependencies": {
@@ -3001,7 +3001,7 @@
         },
         "node_modules/foreground-child": {
             "version": "3.1.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/foreground-child/-/foreground-child-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
             "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
             "dev": true,
             "dependencies": {
@@ -3014,7 +3014,7 @@
         },
         "node_modules/fraction.js": {
             "version": "4.3.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/fraction.js/-/fraction.js-4.3.7.tgz",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
             "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
             "dev": true,
             "engines": {
@@ -3023,13 +3023,13 @@
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/fsevents/-/fsevents-2.3.3.tgz",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
             "hasInstallScript": true,
@@ -3043,12 +3043,12 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/function-bind/-/function-bind-1.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
         },
         "node_modules/function.prototype.name": {
             "version": "1.1.6",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
             "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
             "dev": true,
             "dependencies": {
@@ -3063,13 +3063,13 @@
         },
         "node_modules/functions-have-names": {
             "version": "1.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
             "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
             "dev": true
         },
         "node_modules/get-intrinsic": {
             "version": "1.2.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
             "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
             "dev": true,
             "dependencies": {
@@ -3085,7 +3085,7 @@
         },
         "node_modules/get-symbol-description": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
             "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
             "dev": true,
             "dependencies": {
@@ -3099,7 +3099,7 @@
         },
         "node_modules/get-tsconfig": {
             "version": "4.7.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/get-tsconfig/-/get-tsconfig-4.7.3.tgz",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.3.tgz",
             "integrity": "sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==",
             "dev": true,
             "dependencies": {
@@ -3108,7 +3108,7 @@
         },
         "node_modules/glob": {
             "version": "10.3.10",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/glob/-/glob-10.3.10.tgz",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
             "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
             "dev": true,
             "dependencies": {
@@ -3127,7 +3127,7 @@
         },
         "node_modules/glob-parent": {
             "version": "6.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/glob-parent/-/glob-parent-6.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "dependencies": {
@@ -3139,7 +3139,7 @@
         },
         "node_modules/glob/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
             "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
             "dependencies": {
@@ -3148,7 +3148,7 @@
         },
         "node_modules/glob/node_modules/minimatch": {
             "version": "9.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/minimatch/-/minimatch-9.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
             "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
             "dev": true,
             "dependencies": {
@@ -3160,7 +3160,7 @@
         },
         "node_modules/globals": {
             "version": "13.24.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/globals/-/globals-13.24.0.tgz",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
             "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "dependencies": {
@@ -3172,7 +3172,7 @@
         },
         "node_modules/globalthis": {
             "version": "1.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/globalthis/-/globalthis-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
             "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
             "dev": true,
             "dependencies": {
@@ -3184,7 +3184,7 @@
         },
         "node_modules/globby": {
             "version": "11.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/globby/-/globby-11.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
             "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
             "dev": true,
             "dependencies": {
@@ -3201,7 +3201,7 @@
         },
         "node_modules/gopd": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/gopd/-/gopd-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
             "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
             "dev": true,
             "dependencies": {
@@ -3210,25 +3210,25 @@
         },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/graphemer/-/graphemer-1.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
         },
         "node_modules/has-bigints": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/has-bigints/-/has-bigints-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
             "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
             "dev": true
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/has-flag/-/has-flag-4.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
             "engines": {
@@ -3237,7 +3237,7 @@
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "dev": true,
             "dependencies": {
@@ -3246,7 +3246,7 @@
         },
         "node_modules/has-proto": {
             "version": "1.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/has-proto/-/has-proto-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
             "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
             "dev": true,
             "engines": {
@@ -3255,7 +3255,7 @@
         },
         "node_modules/has-symbols": {
             "version": "1.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/has-symbols/-/has-symbols-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
             "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
             "dev": true,
             "engines": {
@@ -3264,7 +3264,7 @@
         },
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dev": true,
             "dependencies": {
@@ -3276,7 +3276,7 @@
         },
         "node_modules/hasown": {
             "version": "2.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/hasown/-/hasown-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -3287,7 +3287,7 @@
         },
         "node_modules/hoist-non-react-statics": {
             "version": "3.3.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
             "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
             "dependencies": {
                 "react-is": "^16.7.0"
@@ -3295,7 +3295,7 @@
         },
         "node_modules/ignore": {
             "version": "5.3.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ignore/-/ignore-5.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
             "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
             "dev": true,
             "engines": {
@@ -3304,7 +3304,7 @@
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/import-fresh/-/import-fresh-3.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dependencies": {
                 "parent-module": "^1.0.0",
@@ -3316,7 +3316,7 @@
         },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
             "engines": {
@@ -3325,7 +3325,7 @@
         },
         "node_modules/inflight": {
             "version": "1.0.6",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/inflight/-/inflight-1.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "dev": true,
             "dependencies": {
@@ -3335,13 +3335,13 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/inherits/-/inherits-2.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
         "node_modules/internal-slot": {
             "version": "1.0.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/internal-slot/-/internal-slot-1.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
             "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
             "dev": true,
             "dependencies": {
@@ -3355,7 +3355,7 @@
         },
         "node_modules/is-array-buffer": {
             "version": "3.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
             "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
             "dev": true,
             "dependencies": {
@@ -3368,12 +3368,12 @@
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
         },
         "node_modules/is-async-function": {
             "version": "2.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-async-function/-/is-async-function-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
             "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
             "dev": true,
             "dependencies": {
@@ -3385,7 +3385,7 @@
         },
         "node_modules/is-bigint": {
             "version": "1.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-bigint/-/is-bigint-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
             "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
             "dev": true,
             "dependencies": {
@@ -3394,7 +3394,7 @@
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
             "dev": true,
             "dependencies": {
@@ -3406,7 +3406,7 @@
         },
         "node_modules/is-boolean-object": {
             "version": "1.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
             "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
             "dev": true,
             "dependencies": {
@@ -3419,7 +3419,7 @@
         },
         "node_modules/is-callable": {
             "version": "1.2.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-callable/-/is-callable-1.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
             "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
             "dev": true,
             "engines": {
@@ -3428,7 +3428,7 @@
         },
         "node_modules/is-core-module": {
             "version": "2.13.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-core-module/-/is-core-module-2.13.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
             "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
             "dependencies": {
                 "hasown": "^2.0.0"
@@ -3436,7 +3436,7 @@
         },
         "node_modules/is-data-view": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-data-view/-/is-data-view-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
             "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
             "dev": true,
             "dependencies": {
@@ -3448,7 +3448,7 @@
         },
         "node_modules/is-date-object": {
             "version": "1.0.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-date-object/-/is-date-object-1.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
             "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
             "dev": true,
             "dependencies": {
@@ -3460,7 +3460,7 @@
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-extglob/-/is-extglob-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
             "engines": {
@@ -3469,7 +3469,7 @@
         },
         "node_modules/is-finalizationregistry": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
             "integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
             "dev": true,
             "dependencies": {
@@ -3478,7 +3478,7 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
             "engines": {
@@ -3487,7 +3487,7 @@
         },
         "node_modules/is-generator-function": {
             "version": "1.0.10",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-generator-function/-/is-generator-function-1.0.10.tgz",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
             "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
             "dev": true,
             "dependencies": {
@@ -3499,7 +3499,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-glob/-/is-glob-4.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
             "dependencies": {
@@ -3511,7 +3511,7 @@
         },
         "node_modules/is-map": {
             "version": "2.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-map/-/is-map-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
             "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
             "dev": true,
             "engines": {
@@ -3520,7 +3520,7 @@
         },
         "node_modules/is-negative-zero": {
             "version": "2.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
             "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
             "dev": true,
             "engines": {
@@ -3529,7 +3529,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-number/-/is-number-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
             "engines": {
@@ -3538,7 +3538,7 @@
         },
         "node_modules/is-number-object": {
             "version": "1.0.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-number-object/-/is-number-object-1.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
             "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
             "dev": true,
             "dependencies": {
@@ -3550,7 +3550,7 @@
         },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true,
             "engines": {
@@ -3559,7 +3559,7 @@
         },
         "node_modules/is-regex": {
             "version": "1.1.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-regex/-/is-regex-1.1.4.tgz",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
             "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
             "dev": true,
             "dependencies": {
@@ -3572,7 +3572,7 @@
         },
         "node_modules/is-set": {
             "version": "2.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-set/-/is-set-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
             "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
             "dev": true,
             "engines": {
@@ -3581,7 +3581,7 @@
         },
         "node_modules/is-shared-array-buffer": {
             "version": "1.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
             "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
             "dev": true,
             "dependencies": {
@@ -3593,7 +3593,7 @@
         },
         "node_modules/is-string": {
             "version": "1.0.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-string/-/is-string-1.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
             "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
             "dev": true,
             "dependencies": {
@@ -3605,7 +3605,7 @@
         },
         "node_modules/is-symbol": {
             "version": "1.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-symbol/-/is-symbol-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
             "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
             "dev": true,
             "dependencies": {
@@ -3617,7 +3617,7 @@
         },
         "node_modules/is-typed-array": {
             "version": "1.1.13",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-typed-array/-/is-typed-array-1.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
             "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
             "dev": true,
             "dependencies": {
@@ -3629,7 +3629,7 @@
         },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-weakmap/-/is-weakmap-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
             "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
             "dev": true,
             "engines": {
@@ -3638,7 +3638,7 @@
         },
         "node_modules/is-weakref": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-weakref/-/is-weakref-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
             "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
             "dev": true,
             "dependencies": {
@@ -3647,7 +3647,7 @@
         },
         "node_modules/is-weakset": {
             "version": "2.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-weakset/-/is-weakset-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
             "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
             "dev": true,
             "dependencies": {
@@ -3660,19 +3660,19 @@
         },
         "node_modules/isarray": {
             "version": "2.0.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/isarray/-/isarray-2.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
             "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
             "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
         "node_modules/iterator.prototype": {
             "version": "1.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
             "integrity": "sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==",
             "dev": true,
             "dependencies": {
@@ -3685,7 +3685,7 @@
         },
         "node_modules/jackspeak": {
             "version": "2.3.6",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/jackspeak/-/jackspeak-2.3.6.tgz",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
             "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
             "dev": true,
             "dependencies": {
@@ -3700,7 +3700,7 @@
         },
         "node_modules/jiti": {
             "version": "1.21.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/jiti/-/jiti-1.21.0.tgz",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
             "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
             "dev": true,
             "bin": {
@@ -3709,12 +3709,12 @@
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/js-tokens/-/js-tokens-4.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
             "version": "4.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/js-yaml/-/js-yaml-4.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
             "dependencies": {
@@ -3726,30 +3726,30 @@
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/json-buffer/-/json-buffer-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
         "node_modules/json5": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/json5/-/json5-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
             "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
             "dev": true,
             "dependencies": {
@@ -3761,7 +3761,7 @@
         },
         "node_modules/jsx-ast-utils": {
             "version": "3.3.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
             "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
             "dev": true,
             "dependencies": {
@@ -3776,7 +3776,7 @@
         },
         "node_modules/keyv": {
             "version": "4.5.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/keyv/-/keyv-4.5.4.tgz",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
             "dependencies": {
@@ -3785,13 +3785,13 @@
         },
         "node_modules/language-subtag-registry": {
             "version": "0.3.22",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
+            "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
             "integrity": "sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==",
             "dev": true
         },
         "node_modules/language-tags": {
             "version": "1.0.9",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/language-tags/-/language-tags-1.0.9.tgz",
+            "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
             "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
             "dev": true,
             "dependencies": {
@@ -3803,7 +3803,7 @@
         },
         "node_modules/levn": {
             "version": "0.4.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/levn/-/levn-0.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "dependencies": {
@@ -3816,7 +3816,7 @@
         },
         "node_modules/lilconfig": {
             "version": "2.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/lilconfig/-/lilconfig-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
             "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
             "dev": true,
             "engines": {
@@ -3825,12 +3825,12 @@
         },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/locate-path/-/locate-path-6.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "dependencies": {
@@ -3842,13 +3842,13 @@
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
         },
         "node_modules/loose-envify": {
             "version": "1.4.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/loose-envify/-/loose-envify-1.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -3859,7 +3859,7 @@
         },
         "node_modules/lru-cache": {
             "version": "10.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/lru-cache/-/lru-cache-10.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
             "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
             "dev": true,
             "engines": {
@@ -3868,7 +3868,7 @@
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/merge2/-/merge2-1.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true,
             "engines": {
@@ -3877,7 +3877,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/micromatch/-/micromatch-4.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
             "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
             "dev": true,
             "dependencies": {
@@ -3890,7 +3890,7 @@
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/minimatch/-/minimatch-3.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "dependencies": {
@@ -3902,13 +3902,13 @@
         },
         "node_modules/minimist": {
             "version": "1.2.8",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/minimist/-/minimist-1.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true
         },
         "node_modules/minipass": {
             "version": "7.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/minipass/-/minipass-7.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
             "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
             "dev": true,
             "engines": {
@@ -3917,13 +3917,13 @@
         },
         "node_modules/ms": {
             "version": "2.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ms/-/ms-2.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
         "node_modules/mz": {
             "version": "2.7.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/mz/-/mz-2.7.0.tgz",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
             "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
             "dev": true,
             "dependencies": {
@@ -3934,7 +3934,7 @@
         },
         "node_modules/nanoid": {
             "version": "3.3.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/nanoid/-/nanoid-3.3.7.tgz",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
             "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -3945,13 +3945,13 @@
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/natural-compare/-/natural-compare-1.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
         "node_modules/next": {
             "version": "15.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/next/-/next-15.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/next/-/next-15.2.3.tgz",
             "integrity": "sha512-x6eDkZxk2rPpu46E1ZVUWIBhYCLszmUY6fvHBFcbzJ9dD+qRX6vcHusaqqDlnY+VngKzKbAiG2iRCkPbmi8f7w==",
             "dependencies": {
                 "@next/env": "15.2.3",
@@ -4004,7 +4004,7 @@
         },
         "node_modules/next/node_modules/postcss": {
             "version": "8.4.31",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/postcss/-/postcss-8.4.31.tgz",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
             "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
             "dependencies": {
                 "nanoid": "^3.3.6",
@@ -4017,13 +4017,13 @@
         },
         "node_modules/node-releases": {
             "version": "2.0.14",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/node-releases/-/node-releases-2.0.14.tgz",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
             "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
             "dev": true
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/normalize-path/-/normalize-path-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true,
             "engines": {
@@ -4032,7 +4032,7 @@
         },
         "node_modules/normalize-range": {
             "version": "0.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/normalize-range/-/normalize-range-0.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
             "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
             "dev": true,
             "engines": {
@@ -4041,7 +4041,7 @@
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/object-assign/-/object-assign-4.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "engines": {
                 "node": ">=0.10.0"
@@ -4049,7 +4049,7 @@
         },
         "node_modules/object-hash": {
             "version": "3.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/object-hash/-/object-hash-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
             "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
             "dev": true,
             "engines": {
@@ -4058,13 +4058,13 @@
         },
         "node_modules/object-inspect": {
             "version": "1.13.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/object-inspect/-/object-inspect-1.13.1.tgz",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
             "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
             "dev": true
         },
         "node_modules/object-keys": {
             "version": "1.1.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/object-keys/-/object-keys-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
             "dev": true,
             "engines": {
@@ -4073,7 +4073,7 @@
         },
         "node_modules/object.assign": {
             "version": "4.1.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/object.assign/-/object.assign-4.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
             "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
             "dev": true,
             "dependencies": {
@@ -4088,7 +4088,7 @@
         },
         "node_modules/object.entries": {
             "version": "1.1.8",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/object.entries/-/object.entries-1.1.8.tgz",
+            "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
             "integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
             "dev": true,
             "dependencies": {
@@ -4102,7 +4102,7 @@
         },
         "node_modules/object.fromentries": {
             "version": "2.0.8",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/object.fromentries/-/object.fromentries-2.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
             "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
             "dev": true,
             "dependencies": {
@@ -4117,7 +4117,7 @@
         },
         "node_modules/object.groupby": {
             "version": "1.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/object.groupby/-/object.groupby-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
             "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
             "dev": true,
             "dependencies": {
@@ -4131,7 +4131,7 @@
         },
         "node_modules/object.hasown": {
             "version": "1.1.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/object.hasown/-/object.hasown-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.3.tgz",
             "integrity": "sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==",
             "dev": true,
             "dependencies": {
@@ -4141,7 +4141,7 @@
         },
         "node_modules/object.values": {
             "version": "1.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/object.values/-/object.values-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
             "integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
             "dev": true,
             "dependencies": {
@@ -4155,7 +4155,7 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/once/-/once-1.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
             "dependencies": {
@@ -4164,7 +4164,7 @@
         },
         "node_modules/optionator": {
             "version": "0.9.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/optionator/-/optionator-0.9.3.tgz",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
             "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
             "dev": true,
             "dependencies": {
@@ -4181,7 +4181,7 @@
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/p-limit/-/p-limit-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
             "dependencies": {
@@ -4193,7 +4193,7 @@
         },
         "node_modules/p-locate": {
             "version": "5.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/p-locate/-/p-locate-5.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
             "dependencies": {
@@ -4205,7 +4205,7 @@
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/parent-module/-/parent-module-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dependencies": {
                 "callsites": "^3.0.0"
@@ -4216,7 +4216,7 @@
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/parse-json/-/parse-json-5.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
             "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
@@ -4230,7 +4230,7 @@
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/path-exists/-/path-exists-4.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
             "engines": {
@@ -4239,7 +4239,7 @@
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
             "engines": {
@@ -4248,7 +4248,7 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
             "engines": {
@@ -4257,12 +4257,12 @@
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/path-parse/-/path-parse-1.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "node_modules/path-scurry": {
             "version": "1.10.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/path-scurry/-/path-scurry-1.10.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
             "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
             "dev": true,
             "dependencies": {
@@ -4275,7 +4275,7 @@
         },
         "node_modules/path-type": {
             "version": "4.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/path-type/-/path-type-4.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "engines": {
                 "node": ">=8"
@@ -4283,12 +4283,12 @@
         },
         "node_modules/picocolors": {
             "version": "1.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/picocolors/-/picocolors-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
             "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/picomatch/-/picomatch-2.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
             "engines": {
@@ -4297,7 +4297,7 @@
         },
         "node_modules/pify": {
             "version": "2.3.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/pify/-/pify-2.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
             "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
             "dev": true,
             "engines": {
@@ -4306,7 +4306,7 @@
         },
         "node_modules/pirates": {
             "version": "4.0.6",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/pirates/-/pirates-4.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
             "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
             "dev": true,
             "engines": {
@@ -4315,7 +4315,7 @@
         },
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
             "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
             "dev": true,
             "engines": {
@@ -4324,7 +4324,7 @@
         },
         "node_modules/postcss": {
             "version": "8.4.37",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/postcss/-/postcss-8.4.37.tgz",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.37.tgz",
             "integrity": "sha512-7iB/v/r7Woof0glKLH8b1SPHrsX7uhdO+Geb41QpF/+mWZHU3uxxSlN+UXGVit1PawOYDToO+AbZzhBzWRDwbQ==",
             "dev": true,
             "dependencies": {
@@ -4338,7 +4338,7 @@
         },
         "node_modules/postcss-import": {
             "version": "15.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/postcss-import/-/postcss-import-15.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
             "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
             "dev": true,
             "dependencies": {
@@ -4355,7 +4355,7 @@
         },
         "node_modules/postcss-js": {
             "version": "4.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/postcss-js/-/postcss-js-4.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
             "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
             "dev": true,
             "dependencies": {
@@ -4370,7 +4370,7 @@
         },
         "node_modules/postcss-load-config": {
             "version": "4.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
             "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
             "dev": true,
             "dependencies": {
@@ -4395,7 +4395,7 @@
         },
         "node_modules/postcss-load-config/node_modules/lilconfig": {
             "version": "3.1.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/lilconfig/-/lilconfig-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.1.tgz",
             "integrity": "sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==",
             "dev": true,
             "engines": {
@@ -4404,7 +4404,7 @@
         },
         "node_modules/postcss-nested": {
             "version": "6.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/postcss-nested/-/postcss-nested-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
             "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
             "dev": true,
             "dependencies": {
@@ -4419,7 +4419,7 @@
         },
         "node_modules/postcss-selector-parser": {
             "version": "6.0.16",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
             "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
             "dev": true,
             "dependencies": {
@@ -4432,13 +4432,13 @@
         },
         "node_modules/postcss-value-parser": {
             "version": "4.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
             "engines": {
@@ -4447,7 +4447,7 @@
         },
         "node_modules/prop-types": {
             "version": "15.8.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/prop-types/-/prop-types-15.8.1.tgz",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
             "dependencies": {
                 "loose-envify": "^1.4.0",
@@ -4457,7 +4457,7 @@
         },
         "node_modules/punycode": {
             "version": "2.3.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/punycode/-/punycode-2.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "engines": {
@@ -4466,13 +4466,13 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
         "node_modules/react": {
             "version": "18.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/react/-/react-18.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
             "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -4483,7 +4483,7 @@
         },
         "node_modules/react-dom": {
             "version": "18.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/react-dom/-/react-dom-18.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
             "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -4495,12 +4495,12 @@
         },
         "node_modules/react-is": {
             "version": "16.13.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/react-is/-/react-is-16.13.1.tgz",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/react-transition-group": {
             "version": "4.4.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/react-transition-group/-/react-transition-group-4.4.5.tgz",
+            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
             "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
             "dependencies": {
                 "@babel/runtime": "^7.5.5",
@@ -4515,7 +4515,7 @@
         },
         "node_modules/read-cache": {
             "version": "1.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/read-cache/-/read-cache-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
             "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
             "dev": true,
             "dependencies": {
@@ -4524,7 +4524,7 @@
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/readdirp/-/readdirp-3.6.0.tgz",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "dev": true,
             "dependencies": {
@@ -4536,7 +4536,7 @@
         },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.6",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
             "integrity": "sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==",
             "dev": true,
             "dependencies": {
@@ -4554,12 +4554,12 @@
         },
         "node_modules/regenerator-runtime": {
             "version": "0.14.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
             "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
             "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
             "dev": true,
             "dependencies": {
@@ -4574,7 +4574,7 @@
         },
         "node_modules/resolve": {
             "version": "1.22.8",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/resolve/-/resolve-1.22.8.tgz",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
             "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
             "dependencies": {
                 "is-core-module": "^2.13.0",
@@ -4587,7 +4587,7 @@
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/resolve-from/-/resolve-from-4.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "engines": {
                 "node": ">=4"
@@ -4595,13 +4595,13 @@
         },
         "node_modules/resolve-pkg-maps": {
             "version": "1.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
             "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
             "dev": true
         },
         "node_modules/reusify": {
             "version": "1.0.4",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/reusify/-/reusify-1.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true,
             "engines": {
@@ -4611,7 +4611,7 @@
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/rimraf/-/rimraf-3.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
             "dev": true,
             "dependencies": {
@@ -4623,7 +4623,7 @@
         },
         "node_modules/rimraf/node_modules/glob": {
             "version": "7.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/glob/-/glob-7.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "dev": true,
             "dependencies": {
@@ -4640,7 +4640,7 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/run-parallel/-/run-parallel-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "dev": true,
             "dependencies": {
@@ -4649,7 +4649,7 @@
         },
         "node_modules/safe-array-concat": {
             "version": "1.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
             "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
             "dev": true,
             "dependencies": {
@@ -4664,7 +4664,7 @@
         },
         "node_modules/safe-regex-test": {
             "version": "1.0.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
             "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
             "dev": true,
             "dependencies": {
@@ -4678,7 +4678,7 @@
         },
         "node_modules/scheduler": {
             "version": "0.23.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/scheduler/-/scheduler-0.23.0.tgz",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
             "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -4686,7 +4686,7 @@
         },
         "node_modules/semver": {
             "version": "7.7.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/semver/-/semver-7.7.1.tgz",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
             "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
             "devOptional": true,
             "bin": {
@@ -4698,7 +4698,7 @@
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/set-function-length/-/set-function-length-1.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
             "dev": true,
             "dependencies": {
@@ -4715,7 +4715,7 @@
         },
         "node_modules/set-function-name": {
             "version": "2.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/set-function-name/-/set-function-name-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
             "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
             "dev": true,
             "dependencies": {
@@ -4730,7 +4730,7 @@
         },
         "node_modules/sharp": {
             "version": "0.33.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/sharp/-/sharp-0.33.5.tgz",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
             "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
             "hasInstallScript": true,
             "optional": true,
@@ -4769,7 +4769,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
             "dependencies": {
@@ -4781,7 +4781,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
             "engines": {
@@ -4790,7 +4790,7 @@
         },
         "node_modules/side-channel": {
             "version": "1.0.6",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/side-channel/-/side-channel-1.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
             "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
             "dev": true,
             "dependencies": {
@@ -4805,7 +4805,7 @@
         },
         "node_modules/signal-exit": {
             "version": "4.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/signal-exit/-/signal-exit-4.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "dev": true,
             "engines": {
@@ -4814,7 +4814,7 @@
         },
         "node_modules/simple-swizzle": {
             "version": "0.2.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
             "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
             "optional": true,
             "dependencies": {
@@ -4823,13 +4823,13 @@
         },
         "node_modules/simple-swizzle/node_modules/is-arrayish": {
             "version": "0.3.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/is-arrayish/-/is-arrayish-0.3.2.tgz",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
             "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
             "optional": true
         },
         "node_modules/slash": {
             "version": "3.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/slash/-/slash-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true,
             "engines": {
@@ -4838,7 +4838,7 @@
         },
         "node_modules/source-map": {
             "version": "0.5.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/source-map/-/source-map-0.5.7.tgz",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
             "engines": {
                 "node": ">=0.10.0"
@@ -4846,7 +4846,7 @@
         },
         "node_modules/source-map-js": {
             "version": "1.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/source-map-js/-/source-map-js-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
             "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
             "engines": {
                 "node": ">=0.10.0"
@@ -4854,7 +4854,7 @@
         },
         "node_modules/streamsearch": {
             "version": "1.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/streamsearch/-/streamsearch-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
             "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
             "engines": {
                 "node": ">=10.0.0"
@@ -4862,7 +4862,7 @@
         },
         "node_modules/string-width": {
             "version": "5.1.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/string-width/-/string-width-5.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
             "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
             "dev": true,
             "dependencies": {
@@ -4877,7 +4877,7 @@
         "node_modules/string-width-cjs": {
             "name": "string-width",
             "version": "4.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/string-width/-/string-width-4.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "dependencies": {
@@ -4891,13 +4891,13 @@
         },
         "node_modules/string-width-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
         },
         "node_modules/string-width/node_modules/ansi-regex": {
             "version": "6.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ansi-regex/-/ansi-regex-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
             "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
             "dev": true,
             "engines": {
@@ -4906,7 +4906,7 @@
         },
         "node_modules/string-width/node_modules/strip-ansi": {
             "version": "7.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
             "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
             "dev": true,
             "dependencies": {
@@ -4918,7 +4918,7 @@
         },
         "node_modules/string.prototype.matchall": {
             "version": "4.0.10",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
+            "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
             "integrity": "sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==",
             "dev": true,
             "dependencies": {
@@ -4935,7 +4935,7 @@
         },
         "node_modules/string.prototype.trim": {
             "version": "1.2.9",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
             "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
             "dev": true,
             "dependencies": {
@@ -4950,7 +4950,7 @@
         },
         "node_modules/string.prototype.trimend": {
             "version": "1.0.8",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
             "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
             "dev": true,
             "dependencies": {
@@ -4961,7 +4961,7 @@
         },
         "node_modules/string.prototype.trimstart": {
             "version": "1.0.7",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
             "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
             "dev": true,
             "dependencies": {
@@ -4972,7 +4972,7 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "dependencies": {
@@ -4985,7 +4985,7 @@
         "node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "dependencies": {
@@ -4997,7 +4997,7 @@
         },
         "node_modules/strip-bom": {
             "version": "3.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/strip-bom/-/strip-bom-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
             "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
             "dev": true,
             "engines": {
@@ -5006,7 +5006,7 @@
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
             "engines": {
@@ -5015,7 +5015,7 @@
         },
         "node_modules/styled-jsx": {
             "version": "5.1.6",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/styled-jsx/-/styled-jsx-5.1.6.tgz",
+            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
             "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
             "dependencies": {
                 "client-only": "0.0.1"
@@ -5037,12 +5037,12 @@
         },
         "node_modules/stylis": {
             "version": "4.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/stylis/-/stylis-4.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
             "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
         },
         "node_modules/sucrase": {
             "version": "3.35.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/sucrase/-/sucrase-3.35.0.tgz",
+            "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
             "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
             "dev": true,
             "dependencies": {
@@ -5064,7 +5064,7 @@
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/supports-color/-/supports-color-7.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
             "dependencies": {
@@ -5076,7 +5076,7 @@
         },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "engines": {
                 "node": ">= 0.4"
@@ -5096,7 +5096,7 @@
         },
         "node_modules/tailwindcss": {
             "version": "3.4.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/tailwindcss/-/tailwindcss-3.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
             "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
             "dev": true,
             "dependencies": {
@@ -5133,7 +5133,7 @@
         },
         "node_modules/tapable": {
             "version": "2.2.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/tapable/-/tapable-2.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "dev": true,
             "engines": {
@@ -5142,13 +5142,13 @@
         },
         "node_modules/text-table": {
             "version": "0.2.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/text-table/-/text-table-0.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
         },
         "node_modules/thenify": {
             "version": "3.3.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/thenify/-/thenify-3.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
             "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
             "dev": true,
             "dependencies": {
@@ -5157,7 +5157,7 @@
         },
         "node_modules/thenify-all": {
             "version": "1.6.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/thenify-all/-/thenify-all-1.6.0.tgz",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
             "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
             "dev": true,
             "dependencies": {
@@ -5169,7 +5169,7 @@
         },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
             "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
             "engines": {
                 "node": ">=4"
@@ -5177,7 +5177,7 @@
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
             "dependencies": {
@@ -5189,7 +5189,7 @@
         },
         "node_modules/ts-api-utils": {
             "version": "1.3.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
             "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
             "dev": true,
             "engines": {
@@ -5201,13 +5201,13 @@
         },
         "node_modules/ts-interface-checker": {
             "version": "0.1.13",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+            "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
             "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
             "dev": true
         },
         "node_modules/tsconfig-paths": {
             "version": "3.15.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
             "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
             "dev": true,
             "dependencies": {
@@ -5219,12 +5219,12 @@
         },
         "node_modules/tslib": {
             "version": "2.8.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/tslib/-/tslib-2.8.1.tgz",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/type-check": {
             "version": "0.4.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/type-check/-/type-check-0.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "dependencies": {
@@ -5236,7 +5236,7 @@
         },
         "node_modules/type-fest": {
             "version": "0.20.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/type-fest/-/type-fest-0.20.2.tgz",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
             "engines": {
@@ -5245,7 +5245,7 @@
         },
         "node_modules/typed-array-buffer": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
             "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
             "dev": true,
             "dependencies": {
@@ -5259,7 +5259,7 @@
         },
         "node_modules/typed-array-byte-length": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
             "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
             "dev": true,
             "dependencies": {
@@ -5275,7 +5275,7 @@
         },
         "node_modules/typed-array-byte-offset": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
             "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
             "dev": true,
             "dependencies": {
@@ -5292,7 +5292,7 @@
         },
         "node_modules/typed-array-length": {
             "version": "1.0.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/typed-array-length/-/typed-array-length-1.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.5.tgz",
             "integrity": "sha512-yMi0PlwuznKHxKmcpoOdeLwxBoVPkqZxd7q2FgMkmD3bNwvF5VW0+UlUQ1k1vmktTu4Yu13Q0RIxEP8+B+wloA==",
             "dev": true,
             "dependencies": {
@@ -5309,7 +5309,7 @@
         },
         "node_modules/typescript": {
             "version": "5.4.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/typescript/-/typescript-5.4.2.tgz",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
             "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
             "dev": true,
             "bin": {
@@ -5322,7 +5322,7 @@
         },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
             "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
             "dev": true,
             "dependencies": {
@@ -5334,13 +5334,13 @@
         },
         "node_modules/undici-types": {
             "version": "5.26.5",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/undici-types/-/undici-types-5.26.5.tgz",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
         },
         "node_modules/update-browserslist-db": {
             "version": "1.0.13",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
             "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
             "dev": true,
             "dependencies": {
@@ -5356,7 +5356,7 @@
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/uri-js/-/uri-js-4.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "dependencies": {
@@ -5373,13 +5373,13 @@
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/which/-/which-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
             "dependencies": {
@@ -5394,7 +5394,7 @@
         },
         "node_modules/which-boxed-primitive": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
             "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
             "dev": true,
             "dependencies": {
@@ -5407,7 +5407,7 @@
         },
         "node_modules/which-builtin-type": {
             "version": "1.1.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/which-builtin-type/-/which-builtin-type-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.3.tgz",
             "integrity": "sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==",
             "dev": true,
             "dependencies": {
@@ -5430,7 +5430,7 @@
         },
         "node_modules/which-collection": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/which-collection/-/which-collection-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
             "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
             "dev": true,
             "dependencies": {
@@ -5445,7 +5445,7 @@
         },
         "node_modules/which-typed-array": {
             "version": "1.1.15",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/which-typed-array/-/which-typed-array-1.1.15.tgz",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
             "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
             "dev": true,
             "dependencies": {
@@ -5461,7 +5461,7 @@
         },
         "node_modules/wrap-ansi": {
             "version": "8.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
             "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
             "dev": true,
             "dependencies": {
@@ -5476,7 +5476,7 @@
         "node_modules/wrap-ansi-cjs": {
             "name": "wrap-ansi",
             "version": "7.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "dependencies": {
@@ -5490,13 +5490,13 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
         },
         "node_modules/wrap-ansi-cjs/node_modules/string-width": {
             "version": "4.2.3",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/string-width/-/string-width-4.2.3.tgz",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "dependencies": {
@@ -5510,7 +5510,7 @@
         },
         "node_modules/wrap-ansi/node_modules/ansi-regex": {
             "version": "6.0.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ansi-regex/-/ansi-regex-6.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
             "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
             "dev": true,
             "engines": {
@@ -5519,7 +5519,7 @@
         },
         "node_modules/wrap-ansi/node_modules/ansi-styles": {
             "version": "6.2.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
             "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
             "dev": true,
             "engines": {
@@ -5528,7 +5528,7 @@
         },
         "node_modules/wrap-ansi/node_modules/strip-ansi": {
             "version": "7.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
             "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
             "dev": true,
             "dependencies": {
@@ -5540,13 +5540,13 @@
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/wrappy/-/wrappy-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
         },
         "node_modules/yaml": {
             "version": "2.4.1",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/yaml/-/yaml-2.4.1.tgz",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
             "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
             "dev": true,
             "bin": {
@@ -5558,7 +5558,7 @@
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
-            "resolved": "https://artifactory.rbx.com/artifactory/api/npm/npm-all/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
             "engines": {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When running `npm install`, I encountered the following issue:  
![CleanShot 2025-04-30 at 00 04 26@2x](https://github.com/user-attachments/assets/39de7fa0-b49c-46e3-9ad3-722af03d4dcd)

This occurred because `https://artifactory.rbx.com/artifactory` is not accessible to engineers outside of Roblox.  
To resolve this, I replaced `https://artifactory.rbx.com/artifactory/api/npm/npm-all/` with the public registry `https://registry.npmjs.org/`.

After the change, `npm install` worked as expected. 
![CleanShot 2025-04-30 at 00 10 25@2x](https://github.com/user-attachments/assets/4ed9c4f0-c169-458e-a741-0d45ab075045) 
I believe this fix is appropriate since most contributors cannot access the internal Artifactory.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
