### PR TITLE
[Feature] Dependabot send out issue if package upgrade failure

### DIFF
--- a/.github/workflows/dependabot-notifier.yaml
+++ b/.github/workflows/dependabot-notifier.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   monitor-dependabot:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Wait for checks to complete

--- a/.github/workflows/dependabot-notifier.yaml
+++ b/.github/workflows/dependabot-notifier.yaml
@@ -1,0 +1,102 @@
+name: Dependabot Upgrade Monitor
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  monitor-dependabot:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for checks to complete
+        uses: WyriHaximus/github-action-wait-for-status@v1.8.0
+        with:
+          ignoreActions: monitor-dependabot
+          checkInterval: 60
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Check if PR is failing
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const { data: checkRunsData } = await github.rest.checks.listForRef({
+              owner,
+              repo,
+              ref: sha,
+            });
+            const checkRuns = checkRunsData.check_runs;
+            if (checkRuns.length === 0) {
+              core.setFailed("No status checks found for this PR.");
+              return;
+            }
+            const failedChecks = checkRuns.filter(
+              check => check.status === 'completed' && check.conclusion !== 'success'
+            );
+            if (failedChecks.length > 0) {
+              console.log("Some checks failed:");
+              failedChecks.forEach(check => {
+                console.log(`- ${check.name}: ${check.conclusion}`);
+              });
+              core.setFailed("Some required checks did not pass.");
+            } else {
+              console.log("All checks passed.");
+            }
+      - name: Create issue on failure
+        if: failure() && github.event.action == 'opened'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Dependabot upgrade failed: #${context.issue.number} - ${context.payload.pull_request.title}`,
+              body: `
+              🚨 **Dependabot Upgrade Failed**
+
+              The following Dependabot pull request could not be merged automatically due to failed or incomplete status checks:
+
+              - **PR:** [#${context.issue.number}](${context.payload.pull_request.html_url})
+              - **Status:** Not mergeable
+
+              Please review the PR and resolve any conflicts or CI issues to proceed with the upgrade.`,
+              labels: ["dependencies", "enhancement", "go"],
+            });
+
+      - name: Assign maintainers on success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Step 1: Get collaborators
+            const collaborators = await github.paginate(
+              github.rest.repos.listCollaborators,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                affiliation: 'direct',
+                per_page: 100
+              }
+            );
+
+            // Step 2: Filter maintainers
+            const maintainers = collaborators
+              .filter(user => user.permissions.admin)
+              .map(user => user.login);
+
+            // Step 3: Assign to the PR
+            if (maintainers.length > 0) {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                assignees: maintainers,
+              });
+            } else {
+              console.warn("No maintainers found to assign.");
+            }

--- a/.github/workflows/dependabot-notifier.yaml
+++ b/.github/workflows/dependabot-notifier.yaml
@@ -73,30 +73,10 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Step 1: Get collaborators
-            const collaborators = await github.paginate(
-              github.rest.repos.listCollaborators,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                affiliation: 'direct',
-                per_page: 100
-              }
-            );
-
-            // Step 2: Filter maintainers
-            const maintainers = collaborators
-              .filter(user => user.permissions.admin)
-              .map(user => user.login);
-
-            // Step 3: Assign to the PR
-            if (maintainers.length > 0) {
-              await github.rest.issues.addAssignees({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                assignees: maintainers,
-              });
-            } else {
-              console.warn("No maintainers found to assign.");
-            }
+            const maintainers = ["dentiny", "kevin85421", "MortalHappiness", "rueian"];
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: maintainers,
+            });

--- a/.github/workflows/dependabot-notifier.yaml
+++ b/.github/workflows/dependabot-notifier.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   monitor-dependabot:
     if: github.event.pull_request.user.login == 'dependabot[bot]'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, failed upgrades require manual checking by maintainers. This change aims to improve the process by:

- Automatically assigning the repo maintainer if the upgrade succeeds

- Automatically creates an issue if the upgrade fails

<!-- Please give a short summary of the change and the problem this solves. -->

### Manual Testing
> **I have removed the condition specific to Dependabot, because I cannot trigger Dependabot manually**

#### Verified the pipeline with a successful case → auto-assigns all maintainers
<img width="1138" alt="image" src="https://github.com/user-attachments/assets/cf7f28c6-1523-488e-bd5b-cc679c5144a6" />

#### Verified the pipeline with a failure case → auto-creates an issue
-  If Dependabot fails in the pipeline

<img width="947" alt="image" src="https://github.com/user-attachments/assets/e2808842-3ab3-4aa5-98db-c314feb5126a" />


- The new issue will look like
<img width="956" alt="image" src="https://github.com/user-attachments/assets/f8173fc4-7ed4-442a-a3c5-a2b4b679e482" />


#### Verified the pipeline with a failure case that includes `reCommit` → does not auto-create an issue
After the dependabot reopened the issue or re-committed the issue and the pipeline failure, it won't reCreate an issue
<img width="947" alt="image" src="https://github.com/user-attachments/assets/e70e6b5a-72b5-4681-be87-54a5c7671264" />


## Related issue number
Closes #3484 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
