### PR TITLE
docs: update dev docs to use Golang 1.24

### DIFF
--- a/kubectl-plugin/DEVELOPMENT.md
+++ b/kubectl-plugin/DEVELOPMENT.md
@@ -7,7 +7,7 @@ This section walks through how to build and test the plugin.
 | software | version  | link                         |
 |:---------|:---------|:-----------------------------|
 | kubectl  |  >= 1.23 | [download][download-kubectl] |
-| go       |  v1.22   | [download-go]                |
+| go       |  v1.24   | [download-go]                |
 
 ## IDE Setup (VS Code)
 

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -8,7 +8,7 @@ This section walks through how to build and test the operator in a running Kuber
 | software | version  |                                                                link |
 |:---------|:--------:|--------------------------------------------------------------------:|
 | kubectl  | v1.23.0+ | [download](https://kubernetes.io/docs/tasks/tools/install-kubectl/) |
-| go       |  v1.23   |                                  [download](https://golang.org/dl/) |
+| go       |  v1.24   |                                  [download](https://golang.org/dl/) |
 | docker   |  19.03+  |                        [download](https://docs.docker.com/install/) |
 
 Alternatively, you can use podman (version 4.5+) instead of docker. See [podman.io](https://podman.io/getting-started/installation) for installation instructions. The Makefile allows you to specify the container engine to use via the `ENGINE` variable. For example, to use podman, you can run `ENGINE=podman make docker-build`.
@@ -19,14 +19,14 @@ The instructions assume you have access to a running Kubernetes cluster via `kub
 
 For local development, we recommend using [Kind](https://kind.sigs.k8s.io/) to create a Kubernetes cluster.
 
-### Use go v1.23
+### Use go v1.24
 
-Currently, KubeRay uses go v1.23 for development.
+Currently, KubeRay uses go v1.24 for development.
 
 ```bash
-go install golang.org/dl/go1.23.2@latest
-go1.23.2 download
-export GOROOT=$(go1.23.2 env GOROOT)
+go install golang.org/dl/go1.24.2@latest
+go1.24.2 download
+export GOROOT=$(go1.24.2 env GOROOT)
 export PATH="$GOROOT/bin:$PATH"
 ```
 


### PR DESCRIPTION
This whole repo was upgraded to 1.24 in
https://github.com/ray-project/kuberay/pull/3461