### PR TITLE
[Fix][kubectl-plugin] Remove filepath.Clean for ray job submit workingDir

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -241,9 +241,6 @@ func (options *SubmitJobOptions) Validate() error {
 		return fmt.Errorf("working directory is required, use --working-dir or set with runtime env")
 	}
 
-	// Changed working dir clean to here instead of complete since calling Clean on empty string return "." and it would be dificult to determine if that is actually user input or not.
-	options.workingDir = filepath.Clean(options.workingDir)
-
 	resourceFields := map[string]string{
 		"head-cpu":      options.headCPU,
 		"head-gpu":      options.headGPU,


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Remove the `filepath.Clean` for `workingDir` argument for `ray job submit` because it it not neccessary a filepath. It can be a remote URL or GCS address.

Before:

![image](https://github.com/user-attachments/assets/8eaf8108-e644-44e6-a950-681d4f472c01)

Note that it's `https:/`, not `https://`

After:

![image](https://github.com/user-attachments/assets/e21e367a-80db-47a8-ad58-51beb5ea396a)


## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
