### PR TITLE
[Fix]remove broken link in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ The KubeRay repository only contains documentation related to the development an
 * [Using Prometheus and Grafana](https://docs.ray.io/en/master/cluster/kubernetes/k8s-ecosystem/prometheus-grafana.html#kuberay-prometheus-grafana)
 * [Profiling with py-spy](https://docs.ray.io/en/master/cluster/kubernetes/k8s-ecosystem/pyspy.html#kuberay-pyspy-integration)
 * [KubeRay integration with Volcano](https://docs.ray.io/en/master/cluster/kubernetes/k8s-ecosystem/volcano.html#kuberay-volcano)
-* [Kubeflow: an interactive development solution](https://docs.ray.io/en/master/cluster/kubernetes/k8s-ecosystem/kubeflow.html#kuberay-kubeflow-integration)
 * [MCAD: A Kubernetes Solution for Queuing and Gang Dispatching jobs on Single or Multi-Cluster environment](https://github.com/ray-project/kuberay/blob/master/docs/guidance/kuberay-with-MCAD.md)
 
 ## External Blog Posts

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,6 @@ by some organizations to back user interfaces for KubeRay resource management.
 * [Prometheus and Grafana](https://docs.ray.io/en/master/cluster/kubernetes/k8s-ecosystem/prometheus-grafana.html#kuberay-prometheus-grafana)
 * [Volcano](https://docs.ray.io/en/master/cluster/kubernetes/k8s-ecosystem/volcano.html)
 * [MCAD](guidance/kuberay-with-MCAD.md)
-* [Kubeflow](https://docs.ray.io/en/master/cluster/kubernetes/k8s-ecosystem/kubeflow.html)
 
 ## Security
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The kubeflow link in doc is not working.
https://docs.ray.io/en/master/cluster/kubernetes/k8s-ecosystem/kubeflow.html#kuberay-kubeflow-integration
![CleanShot 2025-05-01 at 22 45 13@2x](https://github.com/user-attachments/assets/277720d6-f871-4b2a-b2fe-1b694e0a79af)
I also couldn't find any kubeflow related topic on the Ray document website, either by global search or browsing the sidebar.
![CleanShot 2025-05-01 at 22 45 55@2x](https://github.com/user-attachments/assets/37d92420-396b-4c87-92a9-db0bf33e4a49)
Should we consider removing it?

There are also no 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
