### PR TITLE
[Fix][Operator] Explictly wait for pod not found for satisfying the delete scale exectation

### DIFF
--- a/ray-operator/controllers/ray/expectations/scale_expectations.go
+++ b/ray-operator/controllers/ray/expectations/scale_expectations.go
@@ -95,8 +95,6 @@ func (r *rayClusterScaleExpectationImpl) IsSatisfied(ctx context.Context, namesp
 		case Delete:
 			if err := r.Get(ctx, types.NamespacedName{Name: rp.name, Namespace: namespace}, pod); err != nil {
 				isPodSatisfied = errors.IsNotFound(err)
-			} else {
-				isPodSatisfied = pod.DeletionTimestamp != nil
 			}
 		}
 		// delete satisfied item in cache


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Explicitly wait for the pod to become "not found" instead of also relying on the deletion timestamp. This is because in the RayCluster reconciler, when we call `r.List(ctx, &workerPods, ...)`, we still get pods that are in the process of being deleted. However, since we don't check the deletion timestamp in our reconciler, we mistakenly treat these as running pods, which leads to incorrect deletion logic.

### Details

* Assume there are 5 running worker pods
* User requested to scale down to 4 pods

Before this PR:

* In the first reconcilation, there are no expectations, so `IsSatisfied` is `true`
  https://github.com/ray-project/kuberay/blob/022ff0de8c1af20f8001f7927ea83c01b453d727/ray-operator/controllers/ray/raycluster_controller.go#L706
* We get running pods using `r.List` https://github.com/ray-project/kuberay/blob/022ff0de8c1af20f8001f7927ea83c01b453d727/ray-operator/controllers/ray/raycluster_controller.go#L714-L717
  https://github.com/ray-project/kuberay/blob/022ff0de8c1af20f8001f7927ea83c01b453d727/ray-operator/controllers/ray/raycluster\_controller.go#L782-L787
* `numExpectedPods` is 4 and `len(runningPods.Items)` is 5 so diff is `-1`. We randomly select a pod for deletion and add a "delete expectation"
  https://github.com/ray-project/kuberay/blob/022ff0de8c1af20f8001f7927ea83c01b453d727/ray-operator/controllers/ray/raycluster_controller.go#L795
  https://github.com/ray-project/kuberay/blob/022ff0de8c1af20f8001f7927ea83c01b453d727/ray-operator/controllers/ray/raycluster_controller.go#L844
* In the next reconcilation, we call `IsSatisfied` again. If this pod is in the process of deletion, that is, the deletion timestamp is set but `r.Get` can still get the pod, we treat it as satisfied (L99) https://github.com/ray-project/kuberay/blob/022ff0de8c1af20f8001f7927ea83c01b453d727/ray-operator/controllers/ray/expectations/scale_expectations.go#L95-L100
* `r.List` still gets 5 running pods and the diff is `-1`. We find another pod for deletion, which is incorrect.

After this PR:

* We no longer use the deletion timestamp. We only wait for `r.Get` to return `NotFoundError`
* So in the second reconcilation, if the pod is still being deleted, `IsSatisfied` will be `false` and reconciliation will not proceed
  https://github.com/ray-project/kuberay/blob/022ff0de8c1af20f8001f7927ea83c01b453d727/ray-operator/controllers/ray/raycluster_controller.go#L706-L708

## Testing

Tested manually. Before this PR, the issue can be almost 100% reproduced. After this PR, I ran 10 times consecutively and there is no such issue.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes: ray-project/kuberay#3286

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
