### PR TITLE
[Feat][kubectl-plugin] Support -v flag for kubectl ray job submit

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -70,6 +70,7 @@ type SubmitJobOptions struct {
 	workerReplicas     int32
 	noWait             bool
 	dryRun             bool
+	verbose            bool
 }
 
 var (
@@ -160,6 +161,7 @@ func NewJobSubmitCommand(cmdFactory cmdutil.Factory, streams genericclioptions.I
 	cmd.Flags().StringVar(&options.workerMemory, "worker-memory", "4Gi", "amount of memory in each worker group replica")
 	cmd.Flags().StringVar(&options.workerGPU, "worker-gpu", "0", "number of GPUs in each worker group replica")
 	cmd.Flags().BoolVar(&options.dryRun, "dry-run", false, "print the generated YAML instead of creating the cluster. Only works when filename is not provided")
+	cmd.Flags().BoolVarP(&options.verbose, "verbose", "v", false, "Passing the '--verbose' flag to the 'ray job submit' command")
 
 	return cmd
 }
@@ -553,6 +555,9 @@ func (options *SubmitJobOptions) raySubmitCmd() ([]string, error) {
 	}
 	if len(options.logColor) > 0 {
 		raySubmitCmd = append(raySubmitCmd, "--log-color", options.logColor)
+	}
+	if options.verbose {
+		raySubmitCmd = append(raySubmitCmd, "--verbose")
 	}
 
 	raySubmitCmd = append(raySubmitCmd, "--working-dir", options.workingDir)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As title. Pass the `--verbose` flag to `ray job submit` command.

![image](https://github.com/user-attachments/assets/59bdee69-f48c-428d-a571-4262709955b8)


## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
