### PR TITLE
Add pr-dependabot.yaml to solve PR check failures

### DIFF
--- a/.github/workflows/pr-dependabot.yaml
+++ b/.github/workflows/pr-dependabot.yaml
@@ -1,0 +1,60 @@
+name: update-files-for-dependabot-PR
+
+# This action runs on PRs opened by dependabot.
+on:
+  pull_request:
+    branches:
+      - dependabot/**
+  push:
+    branches:
+      - dependabot/**
+  workflow_dispatch:
+
+permissions:
+  contents: write # Allow to update the PR.
+
+# Update modules and generated code. Commit changes if any are found.
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.23'
+    - name: Update go modules for proto
+      working-directory: './proto'
+      run: go mod tidy
+    - name: Update go modules for experimental
+      working-directory: './experimental'
+      run: go mod tidy
+    - name: Update go modules for kubectl plugin
+      working-directory: './kubectl-plugin'
+      run: go mod tidy
+    - name: Update go modules for apiserver
+      working-directory: './apiserver'
+      run: go mod tidy
+    - name: Update go modules for ray operator
+      working-directory: './ray-operator'
+      run: go mod tidy
+    - name: Update generated code
+      working-directory: './ray-operator'
+      run: ./hack/update-codegen.sh
+    - name: Update CRDs/RBAC files
+      working-directory: './ray-operator'
+      run: |
+        make manifests && make sync
+    - name: commit and push the changes
+      run: |
+        if ! git diff --exit-code; then
+              git config user.name "$(git log -1 --pretty=%an)"
+              git config user.email "$(git log -1 --pretty=%ae)"
+              git add .
+              git commit -m "Update generated code and modules"
+              git push
+        else
+              echo "No changes to commit"
+        fi

--- a/.github/workflows/pr-dependabot.yaml
+++ b/.github/workflows/pr-dependabot.yaml
@@ -31,15 +31,16 @@ jobs:
     - name: Update go modules for experimental
       working-directory: './experimental'
       run: go mod tidy
+    - name: Update go modules for ray operator
+      working-directory: './ray-operator'
+      run: go mod tidy         
     - name: Update go modules for kubectl plugin
       working-directory: './kubectl-plugin'
       run: go mod tidy
     - name: Update go modules for apiserver
       working-directory: './apiserver'
       run: go mod tidy
-    - name: Update go modules for ray operator
-      working-directory: './ray-operator'
-      run: go mod tidy
+
     - name: Update generated code
       working-directory: './ray-operator'
       run: ./hack/update-codegen.sh
@@ -47,6 +48,10 @@ jobs:
       working-directory: './ray-operator'
       run: |
         make manifests && make sync
+    - name: Update update mock files for apiserver
+      working-directory: './apiserver'
+      run: make generate
+
     - name: commit and push the changes
       run: |
         if ! git diff --exit-code; then

--- a/.github/workflows/pr-dependabot.yaml
+++ b/.github/workflows/pr-dependabot.yaml
@@ -33,7 +33,7 @@ jobs:
       run: go mod tidy
     - name: Update go modules for ray operator
       working-directory: './ray-operator'
-      run: go mod tidy         
+      run: go mod tidy
     - name: Update go modules for kubectl plugin
       working-directory: './kubectl-plugin'
       run: go mod tidy


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In the current setup of dependabot, if k8s modules get updated in one component, other componets may be afftected which causing check fails. The `pr-dependabot.yaml` configures github action to submit a make-up commit for updating generated code and dependent component modeules in sync with version bump. The following commands will be triggered:
1. cd ./proto && go mod tidy
2. cd ./experimental && go mod tidy
3. cd ./ray-operator && go mod tidy
4. cd ./kubectl-plugin && go mod tidy
5. cd ./apiserver && go mod tidy
7. cd ./ray-operator && ./hack/update-codegen.sh
8. cd ./ray-operator && make manifests && make sync
9. cd ./apiserver && make generate

After catching up, those change will be submitted as a new commit by Dependabot
<!-- Please give a short summary of the change and the problem this solves. -->

### Caveat
However, during my test, this follow-up commit wouldn't be checked by Github action with the current setup, so the code integrity might be compromised. I also check how other repo handle this situation, and none of follow-up commits (repos in the reference section) gets checked properly by Github action.

## Related issue number
part of fixes of #3445
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

My test was conducted in the https://github.com/kenmcheng/kuberay/pull/25. However, it's a litte messy since I asked Dependabot to force-push in order to obtain a proper configuration.

## References
1. https://github.com/kubernetes-sigs/kueue/blob/main/.github/workflows/sync-dependabot.yaml
2. https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/.github/workflows/pr-dependabot.yaml
3. https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/.github/workflows/dependabot-code-gen.yml