### PR TITLE
[RayCluster][Expectation] Add a test to ensure expectations work well during scaling down

### DIFF
--- a/ray-operator/test/e2e/raycluster_test.go
+++ b/ray-operator/test/e2e/raycluster_test.go
@@ -1,10 +1,12 @@
 package e2e
 
 import (
+	"os/exec"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -141,4 +143,69 @@ func TestRayClusterWithResourceQuota(t *testing.T) {
 	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to have ReplicaFailure condition", rayCluster.Namespace, rayCluster.Name)
 	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutShort).
 		Should(WithTransform(StatusCondition(rayv1.RayClusterReplicaFailure), MatchConditionContainsMessage(metav1.ConditionTrue, utils.ErrFailedCreateHeadPod.Error(), "forbidden: exceeded quota")))
+}
+
+func TestRayClusterScalingDown(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+
+	// Create a namespace
+	namespace := test.NewTestNamespace()
+
+	rayClusterAC := rayv1ac.RayCluster("raycluster-scaling-down", namespace.Name).
+		WithSpec(rayv1ac.RayClusterSpec().
+			WithRayVersion(GetRayVersion()).
+			WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+				WithRayStartParams(map[string]string{"dashboard-host": "0.0.0.0"}).
+				WithTemplate(headPodTemplateApplyConfiguration().WithFinalizers("test.kuberay.io/finalizers"))).
+			WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
+				WithReplicas(2).
+				WithMinReplicas(1).
+				WithMaxReplicas(5).
+				WithGroupName("small-group").
+				WithRayStartParams(map[string]string{"num-cpus": "1"}).
+				WithTemplate(workerPodTemplateApplyConfiguration().WithFinalizers("test.kuberay.io/finalizers"))))
+
+	rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", namespace.Name, rayCluster.Name)
+
+	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", namespace.Name, rayCluster.Name)
+	g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
+
+	headPod, err := GetHeadPod(test, rayCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	workerPods, err := GetWorkerPods(test, rayCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	allPods := append([]corev1.Pod{*headPod}, workerPods...)
+
+	LogWithTimestamp(test.T(), "Scaling down replicas of RayCluster %s/%s by 1", namespace.Name, rayCluster.Name)
+	rayClusterAC.Spec.WorkerGroupSpecs[0].WithReplicas(1)
+	rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred(), "Failed to scale down RayCluster")
+
+	time.Sleep(5 * time.Second)
+
+	headPod, err = GetHeadPod(test, rayCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(headPod.DeletionTimestamp).To(BeNil(), "Head pod should not have deletionTimestamp")
+
+	workerPods, err = GetWorkerPods(test, rayCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	deletingCount := 0
+	for _, pod := range workerPods {
+		if pod.DeletionTimestamp != nil {
+			deletingCount++
+		}
+	}
+	g.Expect(deletingCount).To(Equal(1), "Should have only one worker pod having deletionTimestamp")
+
+	LogWithTimestamp(test.T(), "Removing finalizers from pods")
+	for _, pod := range allPods {
+		//nolint:gosec // pod name is safe
+		cmd := exec.Command("kubectl", "patch", "--namespace", namespace.Name, "pod", pod.Name, "-p", `{"metadata":{"finalizers":[]}}`, "--type=merge")
+		err = cmd.Run()
+		g.Expect(err).NotTo(HaveOccurred(), "Failed to remove finalizer from pod %s/%s", namespace.Name, pod.Name)
+	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Add an end to end test to ensure #3520 fix the problem that all worker pods was added with `deletionTimestamps`

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #3533 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

## Munaul test

I've run the test suite for continuous 10 times without failure by running the following script under `kuberay/ray-operator`:
```bash
#!/bin/bash

for i in {1..10}; do
  echo "Run #$i"
  go test -timeout 30m -count=1 -v ./test/e2e -run 'TestRayClusterScalingDown'
done
```
```
=== RUN   TestRayClusterScalingDown
Modified Ray Image to: rayproject/ray:2.41.0-aarch64 for ARM chips
Modified Ray Image to: rayproject/ray:2.41.0-aarch64 for ARM chips
    raycluster_test.go:171: [2025-05-08T00:15:34+08:00] Created RayCluster test-ns-gsrwk/raycluster-scaling-down successfully
    raycluster_test.go:173: [2025-05-08T00:15:34+08:00] Waiting for RayCluster test-ns-gsrwk/raycluster-scaling-down to become ready
    raycluster_test.go:183: [2025-05-08T00:15:55+08:00] Scaling down replicas of RayCluster test-ns-gsrwk/raycluster-scaling-down by 1
    raycluster_test.go:204: [2025-05-08T00:16:00+08:00] Removing finalizers from pods
    test.go:114: [2025-05-08T00:16:00+08:00] Retrieving Pod Container test-ns-gsrwk/raycluster-scaling-down-head/ray-head logs
    test.go:102: [2025-05-08T00:16:00+08:00] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2025-05-08T00:16:00+08:00] Output directory has been created at: /var/folders/8n/8nvksnv52h18kybn1kfxby500000gn/T/TestRayClusterScalingDown1658465927/001
    test.go:114: [2025-05-08T00:16:00+08:00] Retrieving Pod Container test-ns-gsrwk/raycluster-scaling-down-small-group-worker-6sx6m/ray-worker logs
--- PASS: TestRayClusterScalingDown (26.41s)
PASS
ok  	github.com/ray-project/kuberay/ray-operator/test/e2e	26.811s
```

In contrast, I run the test suite before #3520 and found the test failed everytime. Besides, the error message shows that the `deletionTimestamp` was added to all worker pods when scaling down without #3520.
```shell
raycluster_test.go:202: 
Should have only one worker pod having deletionTimestamp
Expected
    <int>: 2
to equal
    <int>: 1
```