### PR TITLE
[Feature] add retry for http client

### DIFF
--- a/apiserver/pkg/http/client_test.go
+++ b/apiserver/pkg/http/client_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestUnmarshalHttpResponseOK(t *testing.T) {
-	client := NewKuberayAPIServerClient("baseurl", nil /*httpClient*/)
+	client := NewKuberayAPIServerClient("baseurl", nil /*httpClient*/, 3 /*maxRetry*/)
 	client.executeHttpRequest = func(_ *http.Request, _ string) ([]byte, *rpcStatus.Status, error) {
 		resp := &api.ListClustersResponse{
 			Clusters: []*api.Cluster{
@@ -39,7 +39,7 @@ func TestUnmarshalHttpResponseOK(t *testing.T) {
 
 // Unmarshal response fails and check error returned.
 func TestUnmarshalHttpResponseFails(t *testing.T) {
-	client := NewKuberayAPIServerClient("baseurl", nil /*httpClient*/)
+	client := NewKuberayAPIServerClient("baseurl", nil /*httpClient*/, 3 /* maxRetry */)
 	client.executeHttpRequest = func(_ *http.Request, _ string) ([]byte, *rpcStatus.Status, error) {
 		// Intentionall returning a bad response.
 		return []byte("helloworld"), nil, nil

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -92,7 +92,7 @@ func newEnd2EndTestingContext(t *testing.T, options ...contextOption) (*End2EndT
 func withHttpClient() contextOption {
 	return func(_ *testing.T, testingContext *End2EndTestingContext) error {
 		testingContext.apiServerHttpClient = &http.Client{Timeout: time.Duration(10) * time.Second}
-		testingContext.kuberayAPIServerClient = kuberayHTTP.NewKuberayAPIServerClient(testingContext.apiServerBaseURL, testingContext.apiServerHttpClient)
+		testingContext.kuberayAPIServerClient = kuberayHTTP.NewKuberayAPIServerClient(testingContext.apiServerBaseURL, testingContext.apiServerHttpClient, 3 /*maxRetry*/)
 		return nil
 	}
 }


### PR DESCRIPTION
- Enable retry in `executeRequest` in `pkg/http/client.go`
- Add unit test to ensure the retry function works as expected

## Why are these changes needed?

Currently, the apiserver http client does not support retry. This PR enables the retry feature in http client.

## Related issue number

Part of #3344

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
