### PR TITLE
Add more grouping to dependabot.yml to resolve inconsistencies when bumping versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,13 @@ updates:
       kubernetes:
         patterns:
           - "k8s.io/*"
+          - "sigs.k8s.io/*"
       google-golang:
         patterns:
           - "google.golang.org/*"
+      github-dependencies:
+        patterns:
+          - "github.com/*"
+      all-dependencies: # for all other dependencies not listed above
+        patterns:
+          - "*"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR is intended to mitigate the inconsistencies when dependabot submit a PR for version bump.

#### What are added:
- kubernetes group: add a pattern of "sigs.k8s.io/*"
- add `github-dependencies` group for modules with "github.com/" prefix
- add `all-dependencies` group for miscellaneous modules
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
part of fixes of #3445 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
