### PR TITLE
[Bug][kubectl-plugin] Wrong behavior for InteractiveMode RayJob with BackoffLimit set

### DIFF
--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -680,6 +680,33 @@ func TestValidateRayJobSpec(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "BackoffLimit is incompatible with InteractiveMode",
+			spec: rayv1.RayJobSpec{
+				BackoffLimit:   ptr.To[int32](1),
+				SubmissionMode: rayv1.InteractiveMode,
+				RayClusterSpec: createBasicRayClusterSpec(),
+			},
+			expectError: true,
+		},
+		{
+			name: "BackoffLimit is 0 and SubmissionMode is InteractiveMode",
+			spec: rayv1.RayJobSpec{
+				BackoffLimit:   ptr.To[int32](0),
+				SubmissionMode: rayv1.InteractiveMode,
+				RayClusterSpec: createBasicRayClusterSpec(),
+			},
+			expectError: false,
+		},
+		{
+			name: "BackoffLimit is nil and SubmissionMode is InteractiveMode",
+			spec: rayv1.RayJobSpec{
+				BackoffLimit:   nil,
+				SubmissionMode: rayv1.InteractiveMode,
+				RayClusterSpec: createBasicRayClusterSpec(),
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Why are these changes needed?

Currently, when using `InteractiveMode` in a `RayJob` and setting `backoffLimit` to a value greater than 1, the job's deployment status incorrectly transitions to `Running`. According to [this discussion](https://github.com/ray-project/kuberay/issues/3525#issuecomment-2848333674), `InteractiveMode` should not be used with `backoffLimit`.

To enforce this constraint, a validation check is added during job submission.

## What does this PR do?

- Adds validation logic to prevent `backoffLimit` from being used with `InteractiveMode`.

### Code Change
In `func (options *SubmitJobOptions) Validate() error`:
Add the condition
```go
if submissionMode == rayv1.InteractiveMode && options.RayJob.Spec.BackoffLimit != nil {
  return fmt.Errorf("BackoffLimit cannot co-exist with InteractiveMode")
}
```

#### Manual Testing

`rayjob.yaml`
```yaml
apiVersion: ray.io/v1
kind: RayJob
metadata:
  name: my-rayjob
  namespace: default
spec:
  rayClusterSpec:
    headGroupSpec:
      rayStartParams:
        dashboard-host: 0.0.0.0
      template:
        spec:
          containers:
            - image: rayproject/ray:2.41.0
              name: ray-head
              ...
    rayVersion: 2.41.0
    workerGroupSpecs:
      - groupName: default-group
        ...
  submissionMode: InteractiveMode
  backoffLimit: 2
````

Run the following command:
```bash
$ kubectl ray job submit --working-dir . -f rayjob.yaml -- python task1.py
```
Given that `rayjob.yaml` contains a RayJob with both `InteractiveMode` and `BackoffLimit`, the output from console is:
```console
Error: BackoffLimit cannot co-exist with InteractiveMode
```

## Related issue number
Closes #3525 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
