### PR TITLE
[CI] Fix: /etc/docker/daemon.json: No such file or directory

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -53,7 +53,7 @@ jobs:
       working-directory: ${{env.working-directory}}
 
     - name: Set up Docker
-      uses: docker-practice/actions-setup-docker@master
+      uses: docker/setup-docker-action@v4
 
     - name: Build Docker Image - Apiserver
       run: |
@@ -123,7 +123,7 @@ jobs:
       working-directory: ${{env.working-directory}}
 
     - name: Set up Docker
-      uses: docker-practice/actions-setup-docker@master
+      uses: docker/setup-docker-action@v4
 
     - name: Build Docker Image - Operator
       run: |

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -66,7 +66,7 @@ jobs:
         working-directory: ${{env.working-directory}}
 
       - name: Set up Docker
-        uses: docker-practice/actions-setup-docker@master
+        uses: docker/setup-docker-action@v4
 
       - name: Build Docker Image - Apiserver
         run: |
@@ -167,7 +167,7 @@ jobs:
         working-directory: ${{env.working-directory}}
 
       - name: Set up Docker
-        uses: docker-practice/actions-setup-docker@master
+        uses: docker/setup-docker-action@v4
 
       - name: Build Docker Image - security proxy
         run: |
@@ -245,7 +245,7 @@ jobs:
       working-directory: ${{env.working-directory}}
 
     - name: Set up Docker
-      uses: docker-practice/actions-setup-docker@master
+      uses: docker/setup-docker-action@v4
 
     - name: Build Docker Image - Operator
       run: |
@@ -343,7 +343,7 @@ jobs:
     name: Python Client Test
     steps:
       - name: Set up Docker
-        uses: docker-practice/actions-setup-docker@master
+        uses: docker/setup-docker-action@v4
 
       - name: Install Kind
         run: |


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The current CI workflow is failing during the Docker setup step.
https://github.com/ray-project/kuberay/actions/runs/14908277500/job/41875886165?pr=3535


According to https://github.com/actions/runner-images/issues/11408#issuecomment-2621122468,  switch to using `docker/setup-docker-action@v4` instead of `docker-practice/actions-setup-docker@master`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
