### PR TITLE
[SLI Metrics] RayClusterHeadPodReady 

### DIFF
--- a/ray-operator/controllers/ray/metrics/mocks/ray_cluster_metrics_mock.go
+++ b/ray-operator/controllers/ray/metrics/mocks/ray_cluster_metrics_mock.go
@@ -39,6 +39,18 @@ func (m *MockRayClusterMetricsObserver) EXPECT() *MockRayClusterMetricsObserverM
 	return m.recorder
 }
 
+// ObserveRayClusterHeadPodReady mocks base method.
+func (m *MockRayClusterMetricsObserver) ObserveRayClusterHeadPodReady(name, namespace string, ready bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ObserveRayClusterHeadPodReady", name, namespace, ready)
+}
+
+// ObserveRayClusterHeadPodReady indicates an expected call of ObserveRayClusterHeadPodReady.
+func (mr *MockRayClusterMetricsObserverMockRecorder) ObserveRayClusterHeadPodReady(name, namespace, ready any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObserveRayClusterHeadPodReady", reflect.TypeOf((*MockRayClusterMetricsObserver)(nil).ObserveRayClusterHeadPodReady), name, namespace, ready)
+}
+
 // ObserveRayClusterProvisionedDuration mocks base method.
 func (m *MockRayClusterMetricsObserver) ObserveRayClusterProvisionedDuration(name, namespace string, duration float64) {
 	m.ctrl.T.Helper()

--- a/ray-operator/controllers/ray/metrics/ray_cluster_metrics.go
+++ b/ray-operator/controllers/ray/metrics/ray_cluster_metrics.go
@@ -56,6 +56,6 @@ func (c *RayClusterMetricsManager) ObserveRayClusterProvisionedDuration(name, na
 }
 
 func (c *RayClusterMetricsManager) ObserveRayClusterHeadPodReady(name, namespace string, ready bool) {
-	c.rayClusterHeadPodReady.DeleteLabelValues(name, namespace, strconv.FormatBool(!ready))
+	c.rayClusterHeadPodReady.WithLabelValues(name, namespace, strconv.FormatBool(!ready)).Set(0)
 	c.rayClusterHeadPodReady.WithLabelValues(name, namespace, strconv.FormatBool(ready)).Set(1)
 }

--- a/ray-operator/controllers/ray/metrics/ray_cluster_metrics.go
+++ b/ray-operator/controllers/ray/metrics/ray_cluster_metrics.go
@@ -31,7 +31,7 @@ func NewRayClusterMetricsManager() *RayClusterMetricsManager {
 		rayClusterHeadPodReady: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "kuberay_cluster_head_pod_ready",
-				Help: "The time, in seconds, when a RayCluster's head pod is ready",
+				Help: "Describes whether the ray cluster is ready to serve requests",
 			},
 			[]string{"name", "namespace", "condition"},
 		),

--- a/ray-operator/controllers/ray/metrics/ray_cluster_metrics.go
+++ b/ray-operator/controllers/ray/metrics/ray_cluster_metrics.go
@@ -1,17 +1,21 @@
 package metrics
 
 import (
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 //go:generate mockgen -destination=mocks/ray_cluster_metrics_mock.go -package=mocks github.com/ray-project/kuberay/ray-operator/controllers/ray/metrics RayClusterMetricsObserver
 type RayClusterMetricsObserver interface {
 	ObserveRayClusterProvisionedDuration(name, namespace string, duration float64)
+	ObserveRayClusterHeadPodReady(name, namespace string, ready bool)
 }
 
 // RayClusterMetricsManager implements the prometheus.Collector and RayClusterMetricsObserver interface to collect ray cluster metrics.
 type RayClusterMetricsManager struct {
 	rayClusterProvisionedDurationSeconds *prometheus.GaugeVec
+	rayClusterHeadPodReady               *prometheus.GaugeVec
 }
 
 // NewRayClusterMetricsManager creates a new RayClusterManager instance.
@@ -24,6 +28,13 @@ func NewRayClusterMetricsManager() *RayClusterMetricsManager {
 			},
 			[]string{"name", "namespace"},
 		),
+		rayClusterHeadPodReady: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "kuberay_cluster_head_pod_ready",
+				Help: "The time, in seconds, when a RayCluster's head pod is ready",
+			},
+			[]string{"name", "namespace", "condition"},
+		),
 	}
 	return manager
 }
@@ -31,13 +42,20 @@ func NewRayClusterMetricsManager() *RayClusterMetricsManager {
 // Describe implements prometheus.Collector interface Describe method.
 func (c *RayClusterMetricsManager) Describe(ch chan<- *prometheus.Desc) {
 	c.rayClusterProvisionedDurationSeconds.Describe(ch)
+	c.rayClusterHeadPodReady.Describe(ch)
 }
 
 // Collect implements prometheus.Collector interface Collect method.
 func (c *RayClusterMetricsManager) Collect(ch chan<- prometheus.Metric) {
 	c.rayClusterProvisionedDurationSeconds.Collect(ch)
+	c.rayClusterHeadPodReady.Collect(ch)
 }
 
 func (c *RayClusterMetricsManager) ObserveRayClusterProvisionedDuration(name, namespace string, duration float64) {
 	c.rayClusterProvisionedDurationSeconds.WithLabelValues(name, namespace).Set(duration)
+}
+
+func (c *RayClusterMetricsManager) ObserveRayClusterHeadPodReady(name, namespace string, ready bool) {
+	c.rayClusterHeadPodReady.DeleteLabelValues(name, namespace, strconv.FormatBool(!ready))
+	c.rayClusterHeadPodReady.WithLabelValues(name, namespace, strconv.FormatBool(ready)).Set(1)
 }

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1632,8 +1632,8 @@ func emitRayClusterProvisionedDuration(RayClusterMetricsObserver metrics.RayClus
 	}
 }
 
-func emitRayClusterHeadPodReady(RayClusterMetricsObserver metrics.RayClusterMetricsObserver, clusterName, namespace string, newStatus rayv1.RayClusterStatus) {
-	ready := meta.IsStatusConditionTrue(newStatus.Conditions, string(rayv1.HeadPodReady))
+func emitRayClusterHeadPodReady(RayClusterMetricsObserver metrics.RayClusterMetricsObserver, clusterName, namespace string, status rayv1.RayClusterStatus) {
+	ready := meta.IsStatusConditionTrue(status.Conditions, string(rayv1.HeadPodReady))
 	RayClusterMetricsObserver.ObserveRayClusterHeadPodReady(clusterName, namespace, ready)
 }
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1621,6 +1621,7 @@ func emitRayClusterMetrics(rayClusterMetricsManager *metrics.RayClusterMetricsMa
 		return
 	}
 	emitRayClusterProvisionedDuration(rayClusterMetricsManager, clusterName, namespace, oldStatus, newStatus, creationTimestamp)
+	emitRayClusterHeadPodReady(rayClusterMetricsManager, clusterName, namespace, newStatus)
 }
 
 func emitRayClusterProvisionedDuration(RayClusterMetricsObserver metrics.RayClusterMetricsObserver, clusterName, namespace string, oldStatus, newStatus rayv1.RayClusterStatus, creationTimestamp time.Time) {
@@ -1629,6 +1630,11 @@ func emitRayClusterProvisionedDuration(RayClusterMetricsObserver metrics.RayClus
 		meta.IsStatusConditionTrue(newStatus.Conditions, string(rayv1.RayClusterProvisioned)) {
 		RayClusterMetricsObserver.ObserveRayClusterProvisionedDuration(clusterName, namespace, time.Since(creationTimestamp).Seconds())
 	}
+}
+
+func emitRayClusterHeadPodReady(RayClusterMetricsObserver metrics.RayClusterMetricsObserver, clusterName, namespace string, newStatus rayv1.RayClusterStatus) {
+	ready := meta.IsStatusConditionTrue(newStatus.Conditions, string(rayv1.HeadPodReady))
+	RayClusterMetricsObserver.ObserveRayClusterHeadPodReady(clusterName, namespace, ready)
 }
 
 // sumGPUs sums the GPUs in the given resource list.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Implement metric `kuberay_cluster_head_pod_ready` [proposed in 1.4.0](https://docs.google.com/document/d/1zNiE7lVZYjhrxlTbh1UXOVpR6hh1GIeSfCfE9Lt5v6Y/edit?tab=t.0).
### Manual test: 
```bash
❯ curl -s localhost:8080/metrics | grep  kuberay_cluster_head_pod_ready
# HELP Describes whether the ray cluster is ready to serve requests
# TYPE kuberay_cluster_head_pod_ready gauge
kuberay_cluster_head_pod_ready{condition="false",name="raycluster-kuberay",namespace="default"} 1
kuberay_cluster_head_pod_ready{condition="true",name="raycluster-kuberay",namespace="default"} 0
❯ curl -s localhost:8080/metrics | grep  kuberay_cluster_head_pod_ready
# HELP Describes whether the ray cluster is ready to serve requests
# TYPE kuberay_cluster_head_pod_ready gauge
kuberay_cluster_head_pod_ready{condition="false",name="raycluster-kuberay",namespace="default"} 0
kuberay_cluster_head_pod_ready{condition="true",name="raycluster-kuberay",namespace="default"} 1
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
