### PR TITLE
[refactor] Combine TestCalculateMinReplicas and TestCalculateMaxReplicas into a single test

### DIFF
--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -545,13 +545,16 @@ func TestGetWorkerGroupDesiredReplicas(t *testing.T) {
 	assert.Equal(t, GetWorkerGroupDesiredReplicas(ctx, workerGroupSpec), replicas*numOfHosts)
 }
 
-func TestCalculateMinReplicas(t *testing.T) {
+func TestCalculateReplicas(t *testing.T) {
 	suspend := true
 
 	tests := []struct {
 		name     string
 		specs    []rayv1.WorkerGroupSpec
-		expected int32
+		expected struct {
+			minReplicas int32
+			maxReplicas int32
+		}
 	}{
 		{
 			name: "Single group with one host",
@@ -559,9 +562,16 @@ func TestCalculateMinReplicas(t *testing.T) {
 				{
 					NumOfHosts:  1,
 					MinReplicas: ptr.To[int32](2),
+					MaxReplicas: ptr.To[int32](3),
 				},
 			},
-			expected: 2,
+			expected: struct {
+				minReplicas int32
+				maxReplicas int32
+			}{
+				minReplicas: 2,
+				maxReplicas: 3,
+			},
 		},
 		{
 			name: "Single group with four hosts",
@@ -569,9 +579,16 @@ func TestCalculateMinReplicas(t *testing.T) {
 				{
 					NumOfHosts:  4,
 					MinReplicas: ptr.To[int32](2),
+					MaxReplicas: ptr.To[int32](3),
 				},
 			},
-			expected: 8,
+			expected: struct {
+				minReplicas int32
+				maxReplicas int32
+			}{
+				minReplicas: 8,
+				maxReplicas: 12,
+			},
 		},
 		{
 			name: "Two worker groups: one with a single host, one with two hosts",
@@ -579,13 +596,21 @@ func TestCalculateMinReplicas(t *testing.T) {
 				{
 					NumOfHosts:  1,
 					MinReplicas: ptr.To[int32](4),
+					MaxReplicas: ptr.To[int32](4),
 				},
 				{
 					NumOfHosts:  2,
 					MinReplicas: ptr.To[int32](3),
+					MaxReplicas: ptr.To[int32](3),
 				},
 			},
-			expected: 10,
+			expected: struct {
+				minReplicas int32
+				maxReplicas int32
+			}{
+				minReplicas: 10,
+				maxReplicas: 10,
+			},
 		},
 		{
 			name: "Two groups with suspended",
@@ -593,87 +618,23 @@ func TestCalculateMinReplicas(t *testing.T) {
 				{
 					NumOfHosts:  1,
 					MinReplicas: ptr.To[int32](3),
+					MaxReplicas: ptr.To[int32](3),
 					Suspend:     &suspend,
 				},
 				{
 					NumOfHosts:  1,
 					MinReplicas: ptr.To[int32](1),
-					Suspend:     &suspend,
-				},
-			},
-			expected: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cluster := &rayv1.RayCluster{
-				Spec: rayv1.RayClusterSpec{
-					WorkerGroupSpecs: tt.specs,
-				},
-			}
-			assert.Equal(t, tt.expected, CalculateMinReplicas(cluster))
-		})
-	}
-}
-
-func TestCalculateMaxReplicas(t *testing.T) {
-	suspend := true
-
-	tests := []struct {
-		name     string
-		specs    []rayv1.WorkerGroupSpec
-		expected int32
-	}{
-		{
-			name: "Single group with one host",
-			specs: []rayv1.WorkerGroupSpec{
-				{
-					NumOfHosts:  1,
-					MaxReplicas: ptr.To[int32](3),
-				},
-			},
-			expected: 3,
-		},
-		{
-			name: "Single group with four hosts",
-			specs: []rayv1.WorkerGroupSpec{
-				{
-					NumOfHosts:  4,
-					MaxReplicas: ptr.To[int32](3),
-				},
-			},
-			expected: 12,
-		},
-		{
-			name: "Two worker groups: one with a single host, one with two hosts",
-			specs: []rayv1.WorkerGroupSpec{
-				{
-					NumOfHosts:  1,
-					MaxReplicas: ptr.To[int32](4),
-				},
-				{
-					NumOfHosts:  2,
-					MaxReplicas: ptr.To[int32](3),
-				},
-			},
-			expected: 10,
-		},
-		{
-			name: "Two groups with suspended",
-			specs: []rayv1.WorkerGroupSpec{
-				{
-					NumOfHosts:  1,
-					MaxReplicas: ptr.To[int32](3),
-					Suspend:     &suspend,
-				},
-				{
-					NumOfHosts:  1,
 					MaxReplicas: ptr.To[int32](1),
 					Suspend:     &suspend,
 				},
 			},
-			expected: 0,
+			expected: struct {
+				minReplicas int32
+				maxReplicas int32
+			}{
+				minReplicas: 0,
+				maxReplicas: 0,
+			},
 		},
 	}
 
@@ -684,7 +645,11 @@ func TestCalculateMaxReplicas(t *testing.T) {
 					WorkerGroupSpecs: tt.specs,
 				},
 			}
-			assert.Equal(t, tt.expected, CalculateMaxReplicas(cluster))
+
+			// Check min replicas
+			assert.Equal(t, tt.expected.minReplicas, CalculateMinReplicas(cluster))
+			// Check max replicas
+			assert.Equal(t, tt.expected.maxReplicas, CalculateMaxReplicas(cluster))
 		})
 	}
 }

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -545,7 +545,7 @@ func TestGetWorkerGroupDesiredReplicas(t *testing.T) {
 	assert.Equal(t, GetWorkerGroupDesiredReplicas(ctx, workerGroupSpec), replicas*numOfHosts)
 }
 
-func TestCalculateReplicas(t *testing.T) {
+func TestCalculateMinAndMaxReplicas(t *testing.T) {
 	suspend := true
 
 	tests := []struct {


### PR DESCRIPTION
## Why are these changes needed?

This PR combines `TestCalculateMinReplicas` and `TestCalculateMaxReplicas` into a single test `TestCalculateReplicas`, as both tests share similar logic and test cases. 

```
~/Doc/G/kuberay/ray-operator refector/fuse-tests *9 ?9 > go test -v ./controllers/ray/utils -run TestCalculateReplicas
=== RUN   TestCalculateReplicas
=== RUN   TestCalculateReplicas/Single_group_with_one_host
=== RUN   TestCalculateReplicas/Single_group_with_four_hosts
=== RUN   TestCalculateReplicas/Two_worker_groups:_one_with_a_single_host,_one_with_two_hosts
=== RUN   TestCalculateReplicas/Two_groups_with_suspended
--- PASS: TestCalculateReplicas (0.00s)
    --- PASS: TestCalculateReplicas/Single_group_with_one_host (0.00s)
    --- PASS: TestCalculateReplicas/Single_group_with_four_hosts (0.00s)
    --- PASS: TestCalculateReplicas/Two_worker_groups:_one_with_a_single_host,_one_with_two_hosts (0.00s)
    --- PASS: TestCalculateReplicas/Two_groups_with_suspended (0.00s)
PASS
ok      github.com/ray-project/kuberay/ray-operator/controllers/ray/utils       0.369s
```
## Related issue number

Closes #3548 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
