### PR TITLE
[RayCluster] wait-gcs-ready container support overwrite container cmd

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -242,7 +242,7 @@ func DefaultWorkerPodTemplate(ctx context.Context, instance rayv1.RayCluster, wo
 			Name:            "wait-gcs-ready",
 			Image:           podTemplate.Spec.Containers[utils.RayContainerIndex].Image,
 			ImagePullPolicy: podTemplate.Spec.Containers[utils.RayContainerIndex].ImagePullPolicy,
-			Command:         []string{"/bin/bash", "-lc", "--"},
+			Command:         podTemplate.Spec.Containers[utils.RayContainerIndex].Command,
 			Args: []string{
 				fmt.Sprintf(`
 					SECONDS=0
@@ -285,6 +285,9 @@ func DefaultWorkerPodTemplate(ctx context.Context, instance rayv1.RayCluster, wo
 					corev1.ResourceMemory: resource.MustParse("256Mi"),
 				},
 			},
+		}
+		if !isOverwriteRayContainerCmd(instance) {
+			initContainer.Command = []string{"/bin/bash", "-lc", "--"}
 		}
 		podTemplate.Spec.InitContainers = append(podTemplate.Spec.InitContainers, initContainer)
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

According to https://github.com/ray-project/kuberay/issues/3247, the `-l` overwrite the `PATH` resulting in `uv` not working properly. If trying to apply `overwrite-container-cmd` to remove `-l`, it not affect on init container `wait-gcs-ready`.

## Related issue number

<!-- For example: "Closes #1234" -->
Part of https://github.com/ray-project/kuberay/issues/3247

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
