### PR TITLE
chore operator: improve `TestIsAutoscalingEnabled` test

### DIFF
--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -872,42 +872,39 @@ func TestErrRayClusterReplicaFailureReason(t *testing.T) {
 }
 
 func TestIsAutoscalingEnabled(t *testing.T) {
-	// Test: RayCluster
-	cluster := &rayv1.RayCluster{}
-	assert.False(t, IsAutoscalingEnabled(&cluster.Spec))
-
-	cluster = &rayv1.RayCluster{
-		Spec: rayv1.RayClusterSpec{
-			EnableInTreeAutoscaling: ptr.To(true),
+	tests := map[string]struct {
+		spec     *rayv1.RayClusterSpec
+		expected bool
+	}{
+		"should be false when spec is nil": {
+			spec:     nil,
+			expected: false,
 		},
-	}
-	assert.True(t, IsAutoscalingEnabled(&cluster.Spec))
-
-	// Test: RayJob
-	job := &rayv1.RayJob{}
-	assert.False(t, IsAutoscalingEnabled(job.Spec.RayClusterSpec))
-
-	job = &rayv1.RayJob{
-		Spec: rayv1.RayJobSpec{
-			RayClusterSpec: &rayv1.RayClusterSpec{
+		"should be false when enableInTreeAutoscaling is nil": {
+			spec: &rayv1.RayClusterSpec{
+				EnableInTreeAutoscaling: nil,
+			},
+			expected: false,
+		},
+		"should be false when enableInTreeAutoscaling is false": {
+			spec: &rayv1.RayClusterSpec{
+				EnableInTreeAutoscaling: ptr.To(false),
+			},
+			expected: false,
+		},
+		"should be true when enableInTreeAutoscaling is true": {
+			spec: &rayv1.RayClusterSpec{
 				EnableInTreeAutoscaling: ptr.To(true),
 			},
+			expected: true,
 		},
 	}
-	assert.True(t, IsAutoscalingEnabled(job.Spec.RayClusterSpec))
 
-	// Test: RayService
-	service := &rayv1.RayService{}
-	assert.False(t, IsAutoscalingEnabled(&service.Spec.RayClusterSpec))
-
-	service = &rayv1.RayService{
-		Spec: rayv1.RayServiceSpec{
-			RayClusterSpec: rayv1.RayClusterSpec{
-				EnableInTreeAutoscaling: ptr.To(true),
-			},
-		},
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsAutoscalingEnabled(tc.spec))
+		})
 	}
-	assert.True(t, IsAutoscalingEnabled(&service.Spec.RayClusterSpec))
 }
 
 func TestIsGCSFaultToleranceEnabled(t *testing.T) {


### PR DESCRIPTION
Test different cases that actually trigger different code paths under test instead of using different Ray custom resources. The test's call sites always pass `RayClusterSpec` so creating RayService and RayJobs is irrelevant.

Remove unnecessary type args when the type can be inferred.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
