### PR TITLE
chore CI: use Go 1.24 everywhere

### DIFF
--- a/.github/workflows/consistency-check.yaml
+++ b/.github/workflows/consistency-check.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           # Use the same go version with build job
-          go-version: v1.22
+          go-version: v1.24
 
       - name: Check golang version
         working-directory: ./ray-operator
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           # Use the same go version with build job
-          go-version: v1.22
+          go-version: v1.24
 
       - name: Check golang version
         working-directory: ./ray-operator
@@ -75,7 +75,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           # Use the same go version with build job
-          go-version: v1.22
+          go-version: v1.24
 
       - name: Update CRD/RBAC YAML files
         working-directory: ./ray-operator

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: v1.22
+        go-version: v1.24
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -90,7 +90,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: v1.22
+        go-version: v1.24
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: v1.22
+          go-version: v1.24
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -133,7 +133,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: v1.22
+          go-version: v1.24
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -207,7 +207,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: v1.22
+        go-version: v1.24
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -320,7 +320,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: v1.22
+          go-version: v1.24
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2


### PR DESCRIPTION
to be consistent with `go.mod`s.


## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
