### PR TITLE
refactor: remove unnecessary type args when type can be inferred

### DIFF
--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -277,7 +277,7 @@ var ClusterSpecAutoscalerTest = rayv1api.RayCluster{
 		},
 		EnableInTreeAutoscaling: ptr.To(true),
 		AutoscalerOptions: &rayv1api.AutoscalerOptions{
-			IdleTimeoutSeconds: ptr.To[int32](int32(60)),
+			IdleTimeoutSeconds: ptr.To(int32(60)),
 			UpscalingMode:      (*rayv1api.UpscalingMode)(ptr.To("Default")),
 			ImagePullPolicy:    (*corev1.PullPolicy)(ptr.To("Always")),
 			Resources: &corev1.ResourceRequirements{
@@ -406,7 +406,7 @@ var ServiceV2Test = rayv1api.RayService{
 }
 
 var autoscalerOptions = &rayv1api.AutoscalerOptions{
-	IdleTimeoutSeconds: ptr.To[int32](int32(60)),
+	IdleTimeoutSeconds: ptr.To(int32(60)),
 	UpscalingMode:      (*rayv1api.UpscalingMode)(ptr.To("Default")),
 	Image:              ptr.To("Some Image"),
 	ImagePullPolicy:    (*corev1.PullPolicy)(ptr.To("Always")),

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -339,7 +339,7 @@ func setupTest(t *testing.T) {
 			},
 			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 				{
-					Replicas:    ptr.To[int32](expectReplicaNum),
+					Replicas:    ptr.To(expectReplicaNum),
 					MinReplicas: ptr.To[int32](0),
 					MaxReplicas: ptr.To[int32](10000),
 					NumOfHosts:  expectNumOfHostNum,
@@ -1938,7 +1938,7 @@ func TestCalculateStatusWithoutDesiredReplicas(t *testing.T) {
 func TestCalculateStatusWithSuspendedWorkerGroups(t *testing.T) {
 	setupTest(t)
 
-	testRayCluster.Spec.WorkerGroupSpecs[0].Suspend = ptr.To[bool](true)
+	testRayCluster.Spec.WorkerGroupSpecs[0].Suspend = ptr.To(true)
 	testRayCluster.Spec.WorkerGroupSpecs[0].MinReplicas = ptr.To[int32](100)
 	testRayCluster.Spec.WorkerGroupSpecs[0].MaxReplicas = ptr.To[int32](100)
 	testRayCluster.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests = corev1.ResourceList{

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -481,8 +481,8 @@ func checkBackoffLimitAndUpdateStatusIfNeeded(ctx context.Context, rayJob *rayv1
 		succeededCount++
 	}
 
-	rayJob.Status.Failed = ptr.To[int32](failedCount)
-	rayJob.Status.Succeeded = ptr.To[int32](succeededCount)
+	rayJob.Status.Failed = ptr.To(failedCount)
+	rayJob.Status.Succeeded = ptr.To(succeededCount)
 
 	if rayJob.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailed && rayJob.Spec.BackoffLimit != nil && *rayJob.Status.Failed < *rayJob.Spec.BackoffLimit+1 {
 		if rayJob.Status.Reason == rayv1.DeadlineExceeded {
@@ -692,7 +692,7 @@ func (r *RayJobReconciler) suspendWorkerGroups(ctx context.Context, rayJobInstan
 	}
 
 	for i := range cluster.Spec.WorkerGroupSpecs {
-		cluster.Spec.WorkerGroupSpecs[i].Suspend = ptr.To[bool](true)
+		cluster.Spec.WorkerGroupSpecs[i].Suspend = ptr.To(true)
 	}
 
 	if err := r.Update(ctx, &cluster); err != nil {

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -540,7 +540,7 @@ var _ = Context("RayJob with different submission modes", func() {
 			namespace := "default"
 			activeDeadlineSeconds := int32(3)
 			rayJob := rayJobTemplate("rayjob-deadline", namespace)
-			rayJob.Spec.ActiveDeadlineSeconds = ptr.To[int32](activeDeadlineSeconds)
+			rayJob.Spec.ActiveDeadlineSeconds = ptr.To(activeDeadlineSeconds)
 
 			It("Verify RayJob spec", func() {
 				// In this test, RayJob passes through the following states: New -> Initializing -> Complete (because of ActiveDeadlineSeconds).

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -878,7 +878,7 @@ func TestIsAutoscalingEnabled(t *testing.T) {
 
 	cluster = &rayv1.RayCluster{
 		Spec: rayv1.RayClusterSpec{
-			EnableInTreeAutoscaling: ptr.To[bool](true),
+			EnableInTreeAutoscaling: ptr.To(true),
 		},
 	}
 	assert.True(t, IsAutoscalingEnabled(&cluster.Spec))
@@ -890,7 +890,7 @@ func TestIsAutoscalingEnabled(t *testing.T) {
 	job = &rayv1.RayJob{
 		Spec: rayv1.RayJobSpec{
 			RayClusterSpec: &rayv1.RayClusterSpec{
-				EnableInTreeAutoscaling: ptr.To[bool](true),
+				EnableInTreeAutoscaling: ptr.To(true),
 			},
 		},
 	}
@@ -903,7 +903,7 @@ func TestIsAutoscalingEnabled(t *testing.T) {
 	service = &rayv1.RayService{
 		Spec: rayv1.RayServiceSpec{
 			RayClusterSpec: rayv1.RayClusterSpec{
-				EnableInTreeAutoscaling: ptr.To[bool](true),
+				EnableInTreeAutoscaling: ptr.To(true),
 			},
 		},
 	}

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -501,7 +501,7 @@ func TestValidateRayClusterSpecSuspendingWorkerGroup(t *testing.T) {
 			},
 		},
 	}
-	workerGroupSpecSuspended.Suspend = ptr.To[bool](true)
+	workerGroupSpecSuspended.Suspend = ptr.To(true)
 
 	tests := []struct {
 		rayCluster   *rayv1.RayCluster
@@ -540,7 +540,7 @@ func TestValidateRayClusterSpecSuspendingWorkerGroup(t *testing.T) {
 				Spec: rayv1.RayClusterSpec{
 					HeadGroupSpec:           headGroupSpec,
 					WorkerGroupSpecs:        []rayv1.WorkerGroupSpec{workerGroupSpecSuspended},
-					EnableInTreeAutoscaling: ptr.To[bool](true),
+					EnableInTreeAutoscaling: ptr.To(true),
 				},
 			},
 			featureGate:  true,
@@ -758,7 +758,7 @@ func TestValidateRayJobSpecWithFeatureGate(t *testing.T) {
 			spec: rayv1.RayJobSpec{
 				DeletionPolicy: ptr.To(rayv1.DeleteWorkersDeletionPolicy),
 				RayClusterSpec: &rayv1.RayClusterSpec{
-					EnableInTreeAutoscaling: ptr.To[bool](true),
+					EnableInTreeAutoscaling: ptr.To(true),
 					HeadGroupSpec:           headGroupSpecWithOneContainer,
 				},
 			},


### PR DESCRIPTION
## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
