### PR TITLE
chore: comment out unnecessary empty `rayStartParams`

### DIFF
--- a/apiserver/test/cluster/cluster_external_redis.yaml
+++ b/apiserver/test/cluster/cluster_external_redis.yaml
@@ -75,10 +75,6 @@ spec:
       minReplicas: 1
       maxReplicas: 10
       groupName: small-group
-      # The `rayStartParams` are used to configure the `ray start` command.
-      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
-      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
-      rayStartParams: {}
       # Pod template
       template:
         spec:

--- a/benchmark/memory_benchmark/scripts/ray-cluster.benchmark.yaml.template
+++ b/benchmark/memory_benchmark/scripts/ray-cluster.benchmark.yaml.template
@@ -32,7 +32,6 @@ spec:
     minReplicas: 0
     maxReplicas: 200
     groupName: small-group
-    rayStartParams: {}
     template:
       spec:
         containers:

--- a/benchmark/perf-tests/100-raycluster/raycluster.yaml
+++ b/benchmark/perf-tests/100-raycluster/raycluster.yaml
@@ -38,7 +38,6 @@ spec:
     maxReplicas: 10
     # logical group name, for this called small-group, also can be functional
     groupName: small-group
-    rayStartParams: {}
     template:
       spec:
         containers:

--- a/benchmark/perf-tests/100-rayjob/pytorch-mnist-rayjob.yaml
+++ b/benchmark/perf-tests/100-rayjob/pytorch-mnist-rayjob.yaml
@@ -15,7 +15,6 @@ spec:
   rayClusterSpec:
     rayVersion: '2.46.0'
     headGroupSpec:
-      rayStartParams: {}
       template:
         spec:
           containers:
@@ -39,7 +38,6 @@ spec:
         minReplicas: 1
         maxReplicas: 5
         groupName: worker-group
-        rayStartParams: {}
         template:
           spec:
             containers:

--- a/benchmark/perf-tests/100-rayjob/ray-data-image-resize.yaml
+++ b/benchmark/perf-tests/100-rayjob/ray-data-image-resize.yaml
@@ -10,7 +10,6 @@ spec:
   rayClusterSpec:
     rayVersion: '2.46.0'
     headGroupSpec:
-      rayStartParams: {}
       template:
         spec:
           containers:
@@ -34,7 +33,6 @@ spec:
         minReplicas: 1
         maxReplicas: 5
         groupName: worker-group
-        rayStartParams: {}
         template:
           spec:
             containers:

--- a/benchmark/perf-tests/1000-raycluster/raycluster.yaml
+++ b/benchmark/perf-tests/1000-raycluster/raycluster.yaml
@@ -37,7 +37,6 @@ spec:
     maxReplicas: 10
     # logical group name, for this called small-group, also can be functional
     groupName: small-group
-    rayStartParams: {}
     template:
       spec:
         containers:

--- a/benchmark/perf-tests/1000-rayjob/pytorch-mnist-rayjob.yaml
+++ b/benchmark/perf-tests/1000-rayjob/pytorch-mnist-rayjob.yaml
@@ -51,7 +51,6 @@ spec:
         minReplicas: 1
         maxReplicas: 5
         groupName: worker-group
-        rayStartParams: {}
         template:
           spec:
             containers:

--- a/benchmark/perf-tests/1000-rayjob/ray-data-image-resize.yaml
+++ b/benchmark/perf-tests/1000-rayjob/ray-data-image-resize.yaml
@@ -51,7 +51,6 @@ spec:
         minReplicas: 1
         maxReplicas: 5
         groupName: worker-group
-        rayStartParams: {}
         template:
           spec:
             containers:

--- a/benchmark/perf-tests/10000-raycluster/raycluster.yaml
+++ b/benchmark/perf-tests/10000-raycluster/raycluster.yaml
@@ -36,7 +36,6 @@ spec:
     minReplicas: 1
     maxReplicas: 10
     groupName: small-group
-    rayStartParams: {}
     template:
       spec:
         containers:

--- a/benchmark/perf-tests/10000-rayjob/pytorch-mnist-rayjob.yaml
+++ b/benchmark/perf-tests/10000-rayjob/pytorch-mnist-rayjob.yaml
@@ -51,7 +51,6 @@ spec:
         minReplicas: 1
         maxReplicas: 5
         groupName: worker-group
-        rayStartParams: {}
         template:
           spec:
             containers:

--- a/benchmark/perf-tests/10000-rayjob/ray-data-image-resize.yaml
+++ b/benchmark/perf-tests/10000-rayjob/ray-data-image-resize.yaml
@@ -51,7 +51,6 @@ spec:
         minReplicas: 1
         maxReplicas: 5
         groupName: worker-group
-        rayStartParams: {}
         template:
           spec:
             containers:

--- a/benchmark/perf-tests/5000-raycluster/raycluster.yaml
+++ b/benchmark/perf-tests/5000-raycluster/raycluster.yaml
@@ -36,7 +36,6 @@ spec:
     minReplicas: 1
     maxReplicas: 10
     groupName: small-group
-    rayStartParams: {}
     template:
       spec:
         containers:

--- a/benchmark/perf-tests/5000-rayjob/pytorch-mnist-rayjob.yaml
+++ b/benchmark/perf-tests/5000-rayjob/pytorch-mnist-rayjob.yaml
@@ -51,7 +51,6 @@ spec:
         minReplicas: 1
         maxReplicas: 5
         groupName: worker-group
-        rayStartParams: {}
         template:
           spec:
             containers:

--- a/benchmark/perf-tests/5000-rayjob/ray-data-image-resize.yaml
+++ b/benchmark/perf-tests/5000-rayjob/ray-data-image-resize.yaml
@@ -51,7 +51,6 @@ spec:
         minReplicas: 1
         maxReplicas: 5
         groupName: worker-group
-        rayStartParams: {}
         template:
           spec:
             containers:

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -38,7 +38,6 @@ spec:
         {{ $key }}: {{ $val | quote }}
       {{- end }}
     {{- else }}
-    rayStartParams: {}
     {{- end }}
     template:
       metadata:
@@ -165,7 +164,6 @@ spec:
       {{ $key }}: {{ $val | quote }}
       {{- end }}
     {{- else }}
-    rayStartParams: {}
     {{- end }}
     template:
       metadata:
@@ -293,7 +291,6 @@ spec:
         {{ $key }}: {{ $val | quote }}
       {{- end }}
     {{- else }}
-    rayStartParams: {}
     {{- end }}
     template:
       metadata:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -58,7 +58,6 @@ head:
   # in the headGroupSpec. See https://github.com/ray-project/kuberay/pull/1128 for more details.
   serviceAccountName: ""
   restartPolicy: ""
-  rayStartParams: {}
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
   containerEnv: []
@@ -141,7 +140,6 @@ worker:
   labels: {}
   serviceAccountName: ""
   restartPolicy: ""
-  rayStartParams: {}
   initContainers: []
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
@@ -220,7 +218,6 @@ additionalWorkerGroups:
     labels: {}
     serviceAccountName: ""
     restartPolicy: ""
-    rayStartParams: {}
     # containerEnv specifies environment variables for the Ray container,
     # Follows standard K8s container env schema.
     containerEnv: []

--- a/kubectl-plugin/test/e2e/testdata/ray-job.interactive-mode-no-runtime-env.yaml
+++ b/kubectl-plugin/test/e2e/testdata/ray-job.interactive-mode-no-runtime-env.yaml
@@ -7,7 +7,6 @@ spec:
   rayClusterSpec:
     rayVersion: '2.46.0'
     headGroupSpec:
-      rayStartParams: {}
       template:
         spec:
           containers:
@@ -30,7 +29,6 @@ spec:
         minReplicas: 1
         maxReplicas: 5
         groupName: small-group
-        rayStartParams: {}
         template:
           spec:
             containers:

--- a/kubectl-plugin/test/e2e/testdata/ray-job.interactive-mode.yaml
+++ b/kubectl-plugin/test/e2e/testdata/ray-job.interactive-mode.yaml
@@ -16,7 +16,6 @@ spec:
   rayClusterSpec:
     rayVersion: '2.46.0' # should match the Ray version in the image of the containers
     headGroupSpec:
-      rayStartParams: {}
       template:
         spec:
           containers:
@@ -39,7 +38,6 @@ spec:
         minReplicas: 1
         maxReplicas: 5
         groupName: small-group
-        rayStartParams: {}
         template:
           spec:
             containers:

--- a/ray-operator/config/samples/ray-cluster.embed-grafana.yaml
+++ b/ray-operator/config/samples/ray-cluster.embed-grafana.yaml
@@ -8,8 +8,6 @@ spec:
     rayStartParams: {}
     # pod template
     template:
-      metadata:
-        labels: {}
       spec:
         containers:
         - name: ray-head

--- a/ray-operator/config/samples/ray-cluster.sample.yaml
+++ b/ray-operator/config/samples/ray-cluster.sample.yaml
@@ -9,8 +9,8 @@ spec:
   rayVersion: '2.46.0' # should match the Ray version in the image of the containers
   # Ray head pod template
   headGroupSpec:
+    # rayStartParams is optional with RayCluster CRD from KubeRay 1.4.0 or later but required in earlier versions.
     rayStartParams: {}
-    #pod template
     template:
       spec:
         containers:
@@ -37,8 +37,8 @@ spec:
     maxReplicas: 5
     # logical group name, for this called small-group, also can be functional
     groupName: workergroup
+    # rayStartParams is optional with RayCluster CRD from KubeRay 1.4.0 or later but required in earlier versions.
     rayStartParams: {}
-    #pod template
     template:
       spec:
         containers:

--- a/ray-operator/config/samples/ray-cluster.tpu-v4-multihost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v4-multihost.yaml
@@ -47,12 +47,12 @@ spec:
           - containerPort: 8081
             name: mxla
   workerGroupSpecs:
-  - rayStartParams: {}
-    replicas: 1
+  - replicas: 1
     minReplicas: 1
     maxReplicas: 1
     numOfHosts: 2
     groupName: tpu-group
+    rayStartParams: {}
     template:
       spec:
         containers:

--- a/ray-operator/config/samples/ray-cluster.tpu-v4-singlehost.yaml
+++ b/ray-operator/config/samples/ray-cluster.tpu-v4-singlehost.yaml
@@ -43,12 +43,12 @@ spec:
           - containerPort: 8000
             name: serve
   workerGroupSpecs:
-  - rayStartParams: {}
-    replicas: 1
+  - replicas: 1
     minReplicas: 1
     maxReplicas: 1
     numOfHosts: 1
     groupName: tpu-group
+    rayStartParams: {}
     template:
       spec:
         containers:

--- a/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
+++ b/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
@@ -33,10 +33,10 @@ spec:
               memory: "2Gi"
   workerGroupSpecs:
   - groupName: worker
-    rayStartParams: {}
     replicas: 2
     minReplicas: 2
     maxReplicas: 2
+    rayStartParams: {}
     template:
       spec:
         containers:

--- a/ray-operator/config/samples/ray-cluster.yunikorn-scheduler.yaml
+++ b/ray-operator/config/samples/ray-cluster.yunikorn-scheduler.yaml
@@ -24,10 +24,10 @@ spec:
               memory: "2Gi"
   workerGroupSpecs:
   - groupName: worker
-    rayStartParams: {}
     replicas: 2
     minReplicas: 2
     maxReplicas: 2
+    rayStartParams: {}
     template:
       spec:
         containers:

--- a/ray-operator/config/samples/ray-data-image-resize/ray-data-image-resize-gcsfusecsi-job.yaml
+++ b/ray-operator/config/samples/ray-data-image-resize/ray-data-image-resize-gcsfusecsi-job.yaml
@@ -66,8 +66,8 @@ spec:
     - groupName: worker-group
       maxReplicas: 3
       minReplicas: 1
-      rayStartParams: {}
       replicas: 3
+      rayStartParams: {}
       template:
         metadata:
           annotations:

--- a/ray-operator/config/samples/ray-job.interactive-mode.yaml
+++ b/ray-operator/config/samples/ray-job.interactive-mode.yaml
@@ -36,8 +36,8 @@ spec:
     rayVersion: 2.46.0
     workerGroupSpecs:
     - groupName: default-group
-      rayStartParams: {}
       replicas: 1
+      rayStartParams: {}
       template:
         spec:
           containers:

--- a/ray-operator/config/samples/ray-service.mobilenet.yaml
+++ b/ray-operator/config/samples/ray-service.mobilenet.yaml
@@ -20,9 +20,6 @@ spec:
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
-      # The `rayStartParams` are used to configure the `ray start` command.
-      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
-      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
       rayStartParams: {}
       #pod template
       template:
@@ -44,9 +41,6 @@ spec:
       maxReplicas: 5
       # logical group name, for this called small-group, also can be functional
       groupName: worker
-      # The `rayStartParams` are used to configure the `ray start` command.
-      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
-      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
       rayStartParams: {}
       #pod template
       template:

--- a/ray-operator/config/samples/ray-service.stable-diffusion.yaml
+++ b/ray-operator/config/samples/ray-service.stable-diffusion.yaml
@@ -15,9 +15,6 @@ spec:
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
-      # The `rayStartParams` are used to configure the `ray start` command.
-      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
-      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
       rayStartParams: {}
       # Pod template
       template:

--- a/ray-operator/config/samples/ray-service.text-ml.yaml
+++ b/ray-operator/config/samples/ray-service.text-ml.yaml
@@ -34,9 +34,6 @@ spec:
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
-      # The `rayStartParams` are used to configure the `ray start` command.
-      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
-      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
       rayStartParams: {}
       #pod template
       template:
@@ -58,9 +55,6 @@ spec:
       maxReplicas: 5
       # logical group name, for this called small-group, also can be functional
       groupName: small-group
-      # The `rayStartParams` are used to configure the `ray start` command.
-      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
-      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
       rayStartParams: {}
       #pod template
       template:

--- a/ray-operator/config/samples/ray-service.text-summarizer.yaml
+++ b/ray-operator/config/samples/ray-service.text-summarizer.yaml
@@ -14,9 +14,6 @@ spec:
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
-      # The `rayStartParams` are used to configure the `ray start` command.
-      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
-      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
       rayStartParams: {}
       # Pod template
       template:

--- a/ray-operator/test/e2erayservice/testdata/locust-cluster.burst.yaml
+++ b/ray-operator/test/e2erayservice/testdata/locust-cluster.burst.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   rayVersion: '2.46.0'
   headGroupSpec:
-    rayStartParams: {}
     template:
       spec:
         containers:

--- a/ray-operator/test/e2erayservice/testdata/locust-cluster.const-rate.yaml
+++ b/ray-operator/test/e2erayservice/testdata/locust-cluster.const-rate.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   rayVersion: '2.46.0'
   headGroupSpec:
-    rayStartParams: {}
     template:
       spec:
         containers:

--- a/ray-operator/test/e2erayservice/testdata/rayservice.autoscaling.yaml
+++ b/ray-operator/test/e2erayservice/testdata/rayservice.autoscaling.yaml
@@ -59,7 +59,6 @@ spec:
         minReplicas: 0
         maxReplicas: 5
         groupName: small-group
-        rayStartParams: {}
         template:
           spec:
             containers:

--- a/ray-operator/test/e2erayservice/testdata/rayservice.static.yaml
+++ b/ray-operator/test/e2erayservice/testdata/rayservice.static.yaml
@@ -22,7 +22,6 @@ spec:
   rayClusterConfig:
     rayVersion: '2.46.0'
     headGroupSpec:
-      rayStartParams: {}
       template:
         spec:
           containers:


### PR DESCRIPTION
in example YAMLs and tests. `rayStartParams` is optional after #3202
released in 1.4.0. We comment out with an explanation instead of removing
entirely so users with older RayCluster CRD versions have a hint about the
incompatibility.

contributes to #3580

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
