### PR TITLE
refactor tests: use testify instead of Fatal everywhere

### DIFF
--- a/apiserver/pkg/server/ray_job_submission_service_server_test.go
+++ b/apiserver/pkg/server/ray_job_submission_service_server_test.go
@@ -170,12 +170,11 @@ func TestConvertNodeInfo(t *testing.T) {
 	unixStart := time.Date(2025, 5, 3, 0, 0, 0, 0, time.UTC).Unix()
 	unixEnd := time.Date(2025, 5, 3, 0, 0, 0, 0, time.UTC).Unix()
 	// Prevent overflow when converting negative int64 to uint64
-	if unixStart < 0 || unixEnd < 0 {
-		t.Fatalf("Start or end time is negative, invalid Unix timestamp: start=%d, end=%d", unixStart, unixEnd)
-	}
+	require.GreaterOrEqual(t, unixStart, int64(0), "start time is negative, invalid Unix timestamp: start=%d", unixStart)
+	require.GreaterOrEqual(t, unixEnd, int64(0), "end time is negative, invalid Unix timestamp: end=%d", unixEnd)
 
-	startTime := uint64(unixStart)
-	endTime := uint64(unixEnd)
+	startTime := uint64(unixStart) //nolint:gosec // we've already checked the timestamp is non-negative
+	endTime := uint64(unixEnd)     //nolint:gosec // we've already checked the timestamp is non-negative
 
 	metadata := map[string]string{
 		"foo": "boo",

--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -184,9 +184,7 @@ func TestSwitchesIncompatibleWithConfigFilePresent(t *testing.T) {
 			cmd := NewCreateClusterCommand(cmdFactory, testStreams)
 			cmd.SetArgs(tc.args)
 			// Parse the flags before checking for incompatible flags
-			if err := cmd.Flags().Parse(tc.args); err != nil {
-				t.Fatalf("failed to parse flags: %v", err)
-			}
+			require.NoError(t, cmd.Flags().Parse(tc.args), "failed to parse flags")
 			err := flagsIncompatibleWithConfigFilePresent(cmd)
 			if tc.expectError != "" {
 				require.EqualError(t, err, tc.expectError)

--- a/kubectl-plugin/pkg/util/completion/completion_test.go
+++ b/kubectl-plugin/pkg/util/completion/completion_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRayResourceTypeCompletionFunc(t *testing.T) {
@@ -21,14 +22,5 @@ func checkCompletion(t *testing.T, comps, expectedComps []string, directive, exp
 	sort.Strings(comps)
 	sort.Strings(expectedComps)
 
-	if len(expectedComps) != len(comps) {
-		t.Fatalf("expected completions\n%v\nbut got\n%v", expectedComps, comps)
-	}
-
-	for i := range comps {
-		if expectedComps[i] != comps[i] {
-			t.Errorf("expected completions\n%v\nbut got\n%v", expectedComps, comps)
-			break
-		}
-	}
+	require.ElementsMatch(t, expectedComps, comps)
 }

--- a/ray-operator/controllers/ray/common/association_test.go
+++ b/ray-operator/controllers/ray/common/association_test.go
@@ -23,12 +23,8 @@ func TestRayServiceServeServiceNamespacedName(t *testing.T) {
 	svc, err := BuildServeServiceForRayService(context.Background(), *serviceInstance, *instanceWithWrongSvc)
 	require.NoError(t, err)
 	namespaced := RayServiceServeServiceNamespacedName(serviceInstance)
-	if namespaced.Name != svc.Name {
-		t.Fatalf("Expected `%v` but got `%v`", svc.Name, namespaced.Name)
-	}
-	if namespaced.Namespace != svc.Namespace {
-		t.Fatalf("Expected `%v` but got `%v`", svc.Namespace, namespaced.Namespace)
-	}
+	assert.Equal(t, svc.Name, namespaced.Name)
+	assert.Equal(t, svc.Namespace, namespaced.Namespace)
 }
 
 func TestRayServiceServeServiceNamespacedNameForUserSpecifiedServeService(t *testing.T) {
@@ -42,15 +38,9 @@ func TestRayServiceServeServiceNamespacedNameForUserSpecifiedServeService(t *tes
 	require.NoError(t, err)
 
 	namespaced := RayServiceServeServiceNamespacedName(testRayServiceWithServeService)
-	if namespaced.Namespace != svc.Namespace {
-		t.Fatalf("Expected `%v` but got `%v`", svc.Namespace, namespaced.Namespace)
-	}
-	if namespaced.Name != svc.Name {
-		t.Fatalf("Expected `%v` but got `%v`", svc.Name, namespaced.Name)
-	}
-	if namespaced.Name != "user-custom-name" {
-		t.Fatalf("Expected `%v` but got `%v`", "user-custom-name", namespaced.Name)
-	}
+	assert.Equal(t, svc.Namespace, namespaced.Namespace)
+	assert.Equal(t, svc.Name, namespaced.Name)
+	assert.Equal(t, "user-custom-name", namespaced.Name)
 }
 
 // TestRayClusterServeServiceNamespacedName tests the function for generating a NamespacedName for a RayCluster's serve service

--- a/ray-operator/controllers/ray/common/ingress_test.go
+++ b/ray-operator/controllers/ray/common/ingress_test.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,48 +84,27 @@ func TestBuildIngressForHeadService(t *testing.T) {
 	require.NoError(t, err)
 
 	// check ingress.class annotation
-	actualResult := ingress.Labels[utils.RayClusterLabelKey]
-	expectedResult := instanceWithIngressEnabled.Name
-	if !reflect.DeepEqual(expectedResult, actualResult) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
-	}
+	assert.Equal(t, instanceWithIngressEnabled.Name, ingress.Labels[utils.RayClusterLabelKey])
 
 	// `annotations.kubernetes.io/ingress.class` was deprecated in Kubernetes 1.18,
 	// and `spec.ingressClassName` is a replacement for this annotation. See
 	// kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
 	// for more details.
-	actualResult = ingress.Annotations[IngressClassAnnotationKey]
-	expectedResult = ""
-	if !reflect.DeepEqual(expectedResult, actualResult) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
-	}
+	assert.Equal(t, "", ingress.Annotations[IngressClassAnnotationKey])
 
-	actualResult = *ingress.Spec.IngressClassName
-	expectedResult = instanceWithIngressEnabled.Annotations[IngressClassAnnotationKey]
-	if !reflect.DeepEqual(expectedResult, actualResult) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
-	}
+	assert.Equal(t, instanceWithIngressEnabled.Annotations[IngressClassAnnotationKey], *ingress.Spec.IngressClassName)
 
 	// rules count
 	assert.Len(t, ingress.Spec.Rules, 1)
 
 	// paths count
-	expectedPaths := 1 // dashboard only
-	actualPaths := len(ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths)
-	if !reflect.DeepEqual(expectedPaths, actualPaths) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedPaths, actualPaths)
-	}
+	assert.Len(t, ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths, 1) // dashboard only
 
 	// path names
 	paths := ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths
 	headSvcName, err := utils.GenerateHeadServiceName(utils.RayClusterCRD, instanceWithIngressEnabled.Spec, instanceWithIngressEnabled.Name)
 	require.NoError(t, err)
 	for _, path := range paths {
-		actualResult = path.Backend.Service.Name
-		expectedResult = headSvcName
-
-		if !reflect.DeepEqual(expectedResult, actualResult) {
-			t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
-		}
+		assert.Equal(t, headSvcName, path.Backend.Service.Name)
 	}
 }

--- a/ray-operator/controllers/ray/common/rbac_test.go
+++ b/ray-operator/controllers/ray/common/rbac_test.go
@@ -1,9 +1,9 @@
 package common
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,9 +81,7 @@ func TestBuildRoleBindingSubjectAndRoleRefName(t *testing.T) {
 			rb, err := BuildRoleBinding(tc.input)
 			require.NoError(t, err)
 			got := []string{rb.Subjects[0].Name, rb.RoleRef.Name}
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("got %v, want %v", got, tc.want)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/ray-operator/controllers/ray/common/route_test.go
+++ b/ray-operator/controllers/ray/common/route_test.go
@@ -1,9 +1,9 @@
 package common
 
 import (
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,28 +45,14 @@ func TestBuildRouteForHeadService(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test name
-	var builder strings.Builder
-	builder.WriteString(instanceWithIngressEnabled.ObjectMeta.Name)
-	builder.WriteString("-head-route")
-	if builder.String() != route.Name {
-		t.Fatalf("Error generating Route name. Expected `%v` but got `%v`", builder.String(), route.Name)
-	}
+	assert.Equal(t, instanceWithIngressEnabled.ObjectMeta.Name+"-head-route", route.Name)
+
 	// Test To subject
-	expectedKind := "Service"
-	if expectedKind != route.Spec.To.Kind {
-		t.Fatalf("Error generating Route kind. Expected `%v` but got `%v`", expectedKind, route.Spec.To.Kind)
-	}
+	assert.Equal(t, "Service", route.Spec.To.Kind)
+
 	// Test Service name
-	builder.Reset()
-	builder.WriteString(instanceWithIngressEnabled.ObjectMeta.Name)
-	builder.WriteString("-head-svc")
-	if builder.String() != route.Spec.To.Name {
-		t.Fatalf("Error generating service name. Expected `%v` but got `%v`", builder.String(), route.Spec.To.Name)
-	}
+	assert.Equal(t, instanceWithIngressEnabled.ObjectMeta.Name+"-head-svc", route.Spec.To.Name)
 
 	// Test Service port
-	expectedPort := intstr.FromInt(8265)
-	if route.Spec.Port.TargetPort != expectedPort {
-		t.Fatalf("Error generating service port. Expected `%v` but got `%v`", expectedPort, route.Spec.Port.TargetPort)
-	}
+	assert.Equal(t, intstr.FromInt(8265), route.Spec.Port.TargetPort)
 }

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -131,37 +130,16 @@ func TestBuildServiceForHeadPod(t *testing.T) {
 	svc, err := BuildServiceForHeadPod(context.Background(), *instanceWithWrongSvc, nil, nil)
 	require.NoError(t, err)
 
-	actualResult := svc.Spec.Selector[utils.RayClusterLabelKey]
-	expectedResult := instanceWithWrongSvc.Name
-	if !reflect.DeepEqual(expectedResult, actualResult) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
-	}
+	assert.Equal(t, instanceWithWrongSvc.Name, svc.Spec.Selector[utils.RayClusterLabelKey])
+	assert.Equal(t, string(rayv1.HeadNode), svc.Spec.Selector[utils.RayNodeTypeLabelKey])
+	assert.Equal(t, utils.ApplicationName, svc.Spec.Selector[utils.KubernetesApplicationNameLabelKey])
 
-	actualResult = svc.Spec.Selector[utils.RayNodeTypeLabelKey]
-	expectedResult = string(rayv1.HeadNode)
-	if !reflect.DeepEqual(expectedResult, actualResult) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
-	}
-
-	actualResult = svc.Spec.Selector[utils.KubernetesApplicationNameLabelKey]
-	expectedResult = utils.ApplicationName
-	if !reflect.DeepEqual(expectedResult, actualResult) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
-	}
-
-	ports := svc.Spec.Ports
-
-	expectedResult = utils.DefaultServiceAppProtocol
-	for _, port := range ports {
-		if *port.AppProtocol != utils.DefaultServiceAppProtocol {
-			t.Fatalf("Expected `%v` but got `%v`", expectedResult, *port.AppProtocol)
-		}
+	for _, port := range svc.Spec.Ports {
+		assert.Equal(t, utils.DefaultServiceAppProtocol, *port.AppProtocol)
 	}
 
 	// BuildServiceForHeadPod should generate a headless service for a Head Pod by default.
-	if svc.Spec.ClusterIP != corev1.ClusterIPNone {
-		t.Fatalf("Expected `%v` but got `%v`", corev1.ClusterIPNone, svc.Spec.ClusterIP)
-	}
+	assert.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP)
 }
 
 // Test that default ports are applied when none are specified. The metrics
@@ -219,9 +197,7 @@ func TestBuildClusterIPServiceForHeadPod(t *testing.T) {
 	svc, err := BuildServiceForHeadPod(context.Background(), *instanceWithWrongSvc, nil, nil)
 	require.NoError(t, err)
 	// BuildServiceForHeadPod should not generate a headless service for a Head Pod if ENABLE_RAY_HEAD_CLUSTER_IP_SERVICE is set.
-	if svc.Spec.ClusterIP == corev1.ClusterIPNone {
-		t.Fatalf("Not expected `%v` but got `%v`", corev1.ClusterIPNone, svc.Spec.ClusterIP)
-	}
+	assert.NotEqual(t, corev1.ClusterIPNone, svc.Spec.ClusterIP)
 }
 
 func TestBuildServiceForHeadPodWithAppNameLabel(t *testing.T) {
@@ -231,19 +207,11 @@ func TestBuildServiceForHeadPodWithAppNameLabel(t *testing.T) {
 	svc, err := BuildServiceForHeadPod(context.Background(), *instanceWithWrongSvc, labels, nil)
 	require.NoError(t, err)
 
-	actualResult := svc.Spec.Selector[utils.KubernetesApplicationNameLabelKey]
-	expectedResult := "testname"
-	if !reflect.DeepEqual(expectedResult, actualResult) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
-	}
+	assert.Equal(t, "testname", svc.Spec.Selector[utils.KubernetesApplicationNameLabelKey])
 
-	actualLength := len(svc.Spec.Selector)
 	// We have 5 default labels in `BuildServiceForHeadPod`, and `KubernetesApplicationNameLabelKey`
 	// is one of the default labels. Hence, `expectedLength` should also be 5.
-	expectedLength := 5
-	if actualLength != expectedLength {
-		t.Fatalf("Expected `%v` but got `%v`", expectedLength, actualLength)
-	}
+	assert.Len(t, svc.Spec.Selector, 5)
 }
 
 func TestBuildServiceForHeadPodWithAnnotations(t *testing.T) {
@@ -253,9 +221,7 @@ func TestBuildServiceForHeadPodWithAnnotations(t *testing.T) {
 	svc, err := BuildServiceForHeadPod(context.Background(), *instanceWithWrongSvc, nil, annotations)
 	require.NoError(t, err)
 
-	if !reflect.DeepEqual(svc.ObjectMeta.Annotations, annotations) {
-		t.Fatalf("Expected `%v` but got `%v`", annotations, svc.ObjectMeta.Annotations)
-	}
+	assert.Equal(t, annotations, svc.ObjectMeta.Annotations)
 }
 
 func TestGetPortsFromCluster(t *testing.T) {
@@ -276,11 +242,7 @@ func TestGetPortsFromCluster(t *testing.T) {
 	cPorts := instanceWithWrongSvc.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Ports
 
 	for _, cPort := range cPorts {
-		expectedResult := cPort.Name
-		actualResult := svcNames[cPort.ContainerPort]
-		if !reflect.DeepEqual(expectedResult, actualResult) {
-			t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
-		}
+		assert.Equal(t, cPort.Name, svcNames[cPort.ContainerPort])
 	}
 }
 
@@ -321,9 +283,7 @@ func TestGetServicePortsWithMetricsPort(t *testing.T) {
 			cluster := instanceWithWrongSvc.DeepCopy()
 			cluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Ports = testCase.ports
 			ports := getServicePorts(*cluster)
-			if ports[utils.MetricsPortName] != testCase.expectResult {
-				t.Fatalf("Expected `%v` but got `%v`", testCase.expectResult, ports[utils.MetricsPortName])
-			}
+			assert.Equal(t, testCase.expectResult, ports[utils.MetricsPortName])
 		})
 	}
 }
@@ -368,9 +328,7 @@ func TestUserSpecifiedHeadService(t *testing.T) {
 	}
 
 	// BuildServiceForHeadPod should respect the ClusterIP specified by users.
-	if headService.Spec.ClusterIP != userClusterIP {
-		t.Fatalf("Expected `%v` but got `%v`", userClusterIP, headService.Spec.ClusterIP)
-	}
+	assert.Equal(t, userClusterIP, headService.Spec.ClusterIP)
 
 	// The selector field should only use the keys from the five default labels.  The values should be updated with the values from the template labels.
 	// The user-provided HeadService labels should be ignored for the purposes of the selector field. The user-provided Selector field should be ignored.
@@ -511,41 +469,12 @@ func TestBuildServiceForHeadPodPortsOrder(t *testing.T) {
 func TestBuildHeadlessServiceForRayCluster(t *testing.T) {
 	svc := BuildHeadlessServiceForRayCluster(*instanceForSvc)
 
-	actualSelector := svc.Spec.Selector[utils.RayClusterLabelKey]
-	expectedSelector := instanceForSvc.Name
-	if !reflect.DeepEqual(expectedSelector, actualSelector) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedSelector, actualSelector)
-	}
-
-	actualSelector = svc.Spec.Selector[utils.RayNodeTypeLabelKey]
-	expectedSelector = string(rayv1.WorkerNode)
-	if !reflect.DeepEqual(expectedSelector, actualSelector) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedSelector, actualSelector)
-	}
-
-	actualLabel := svc.Labels[utils.RayClusterHeadlessServiceLabelKey]
-	expectedLabel := instanceForSvc.Name
-	if !reflect.DeepEqual(expectedLabel, actualLabel) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedLabel, actualLabel)
-	}
-
-	actualType := svc.Spec.Type
-	expectedType := corev1.ServiceTypeClusterIP
-	if !reflect.DeepEqual(expectedType, actualType) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedType, actualType)
-	}
-
-	actualClusterIP := svc.Spec.ClusterIP
-	expectedClusterIP := corev1.ClusterIPNone
-	if !reflect.DeepEqual(expectedClusterIP, actualClusterIP) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedClusterIP, actualClusterIP)
-	}
-
-	actualPublishNotReadyAddresses := svc.Spec.PublishNotReadyAddresses
-	expectedPublishNotReadyAddresses := true
-	if !reflect.DeepEqual(expectedClusterIP, actualClusterIP) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedPublishNotReadyAddresses, actualPublishNotReadyAddresses)
-	}
+	assert.Equal(t, instanceForSvc.Name, svc.Spec.Selector[utils.RayClusterLabelKey])
+	assert.Equal(t, string(rayv1.WorkerNode), svc.Spec.Selector[utils.RayNodeTypeLabelKey])
+	assert.Equal(t, instanceForSvc.Name, svc.Labels[utils.RayClusterHeadlessServiceLabelKey])
+	assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
+	assert.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP)
+	assert.True(t, svc.Spec.PublishNotReadyAddresses)
 
 	expectedName := fmt.Sprintf("%s-%s", instanceForSvc.Name, utils.HeadlessServiceSuffix)
 	validateNameAndNamespaceForUserSpecifiedService(svc, serviceInstance.ObjectMeta.Namespace, expectedName, t)
@@ -555,29 +484,10 @@ func TestBuildServeServiceForRayService(t *testing.T) {
 	svc, err := BuildServeServiceForRayService(context.Background(), *serviceInstance, *instanceWithWrongSvc)
 	require.NoError(t, err)
 
-	actualResult := svc.Spec.Selector[utils.RayClusterLabelKey]
-	expectedResult := instanceWithWrongSvc.Name
-	if !reflect.DeepEqual(expectedResult, actualResult) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
-	}
-
-	actualLabel := svc.Labels[utils.RayOriginatedFromCRNameLabelKey]
-	expectedLabel := serviceInstance.Name
-	if !reflect.DeepEqual(expectedLabel, actualLabel) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedLabel, actualLabel)
-	}
-
-	actualLabel = svc.Labels[utils.RayOriginatedFromCRDLabelKey]
-	expectedLabel = utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD)
-	if !reflect.DeepEqual(expectedLabel, actualLabel) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedLabel, actualLabel)
-	}
-
-	actualType := svc.Spec.Type
-	expectedType := corev1.ServiceTypeClusterIP
-	if !reflect.DeepEqual(expectedType, actualType) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedType, actualType)
-	}
+	assert.Equal(t, instanceWithWrongSvc.Name, svc.Spec.Selector[utils.RayClusterLabelKey])
+	assert.Equal(t, serviceInstance.Name, svc.Labels[utils.RayOriginatedFromCRNameLabelKey])
+	assert.Equal(t, utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD), svc.Labels[utils.RayOriginatedFromCRDLabelKey])
+	assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
 
 	expectedName := fmt.Sprintf("%s-%s-%s", serviceInstance.Name, "serve", "svc")
 	validateNameAndNamespaceForUserSpecifiedService(svc, serviceInstance.ObjectMeta.Namespace, expectedName, t)
@@ -587,25 +497,10 @@ func TestBuildServeServiceForRayCluster(t *testing.T) {
 	svc, err := BuildServeServiceForRayCluster(context.Background(), *instanceForSvc)
 	require.NoError(t, err)
 
-	actualResult := svc.Spec.Selector[utils.RayClusterLabelKey]
-	expectedResult := instanceForSvc.Name
-	if !reflect.DeepEqual(expectedResult, actualResult) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedResult, actualResult)
-	}
-
-	actualLabel := svc.Labels[utils.RayOriginatedFromCRNameLabelKey]
-	expectedLabel := instanceForSvc.Name
-	assert.Equal(t, expectedLabel, actualLabel)
-
-	actualLabel = svc.Labels[utils.RayOriginatedFromCRDLabelKey]
-	expectedLabel = utils.RayOriginatedFromCRDLabelValue(utils.RayClusterCRD)
-	assert.Equal(t, expectedLabel, actualLabel)
-
-	actualType := svc.Spec.Type
-	expectedType := instanceForSvc.Spec.HeadGroupSpec.ServiceType
-	if !reflect.DeepEqual(expectedType, actualType) {
-		t.Fatalf("Expected `%v` but got `%v`", expectedType, actualType)
-	}
+	assert.Equal(t, instanceForSvc.Name, svc.Spec.Selector[utils.RayClusterLabelKey])
+	assert.Equal(t, instanceForSvc.Name, svc.Labels[utils.RayOriginatedFromCRNameLabelKey])
+	assert.Equal(t, utils.RayOriginatedFromCRDLabelValue(utils.RayClusterCRD), svc.Labels[utils.RayOriginatedFromCRDLabelKey])
+	assert.Equal(t, instanceForSvc.Spec.HeadGroupSpec.ServiceType, svc.Spec.Type)
 
 	expectedName := fmt.Sprintf("%s-%s-%s", instanceForSvc.Name, "serve", "svc")
 	validateNameAndNamespaceForUserSpecifiedService(svc, serviceInstance.ObjectMeta.Namespace, expectedName, t)
@@ -697,12 +592,8 @@ func TestUserSpecifiedServeService(t *testing.T) {
 	expectedPortName := utils.ServingPortName
 	expectedPortNumber := int32(8000)
 	for _, port := range ports {
-		if port.Name != utils.ServingPortName {
-			t.Fatalf("Expected `%v` but got `%v`", expectedPortName, port.Name)
-		}
-		if port.Port != expectedPortNumber {
-			t.Fatalf("Expected `%v` but got `%v`", expectedPortNumber, port.Port)
-		}
+		assert.Equal(t, expectedPortName, port.Name)
+		assert.Equal(t, expectedPortNumber, port.Port)
 	}
 
 	validateServiceTypeForUserSpecifiedService(svc, userType, t)

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -527,9 +527,7 @@ func TestReconcile_RemoveWorkersToDelete_RandomDelete(t *testing.T) {
 
 			// Check if the workersToDelete are deleted.
 			for _, pod := range podList.Items {
-				if contains(tc.workersToDelete, pod.Name) {
-					t.Fatalf("WorkersToDelete is not actually deleted, %s", pod.Name)
-				}
+				assert.NotContainsf(t, tc.workersToDelete, pod.Name, "WorkersToDelete is not actually deleted, %s", pod.Name)
 			}
 			numRandomDelete := expectedNumWorkersToDelete - (len(tc.workersToDelete) - len(nonExistentPodSet))
 			assert.Equal(t, tc.numRandomDelete, numRandomDelete)
@@ -624,9 +622,7 @@ func TestReconcile_RemoveWorkersToDelete_NoRandomDelete(t *testing.T) {
 
 			// Check if the workersToDelete are deleted.
 			for _, pod := range podList.Items {
-				if contains(tc.workersToDelete, pod.Name) {
-					t.Fatalf("WorkersToDelete is not actually deleted, %s", pod.Name)
-				}
+				assert.NotContainsf(t, tc.workersToDelete, pod.Name, "WorkersToDelete is not actually deleted, %s", pod.Name)
 			}
 		})
 	}
@@ -674,10 +670,8 @@ func TestReconcile_RandomDelete_OK(t *testing.T) {
 	assert.Len(t, podList.Items, int(localExpectReplicaNum),
 		"Replica number is wrong after reconcile expect %d actual %d", expectReplicaNum, len(podList.Items))
 
-	for i := 0; i < len(podList.Items); i++ {
-		if contains(workersToDelete, podList.Items[i].Name) {
-			t.Fatalf("WorkersToDelete is not actually deleted, %s", podList.Items[i].Name)
-		}
+	for _, pod := range podList.Items {
+		assert.NotContainsf(t, workersToDelete, pod.Name, "WorkersToDelete is not actually deleted, %s", pod.Name)
 	}
 }
 
@@ -1157,16 +1151,6 @@ func TestReconcileHeadlessService(t *testing.T) {
 	})
 	require.NoError(t, err, "Fail to get service list")
 	assert.Len(t, serviceList.Items, 1, "Service list len is wrong")
-}
-
-func contains(slice []string, item string) bool {
-	set := make(map[string]struct{}, len(slice))
-	for _, s := range slice {
-		set[s] = struct{}{}
-	}
-
-	_, ok := set[item]
-	return ok
 }
 
 func getNotFailedPodItemNum(podList corev1.PodList) int {

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -215,9 +215,7 @@ func TestCheckRouteName(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			name := CheckRouteName(context.Background(), tc.routeName, tc.namespace)
-			if name != tc.want {
-				t.Fatalf("got %s, want %s", name, tc.want)
-			}
+			assert.Equal(t, tc.want, name)
 		})
 	}
 }
@@ -343,10 +341,7 @@ func TestGetHeadGroupServiceAccountName(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := GetHeadGroupServiceAccountName(tc.input)
-			if got != tc.want {
-				t.Fatalf("got %s, want %s", got, tc.want)
-			}
+			assert.Equal(t, tc.want, GetHeadGroupServiceAccountName(tc.input))
 		})
 	}
 }

--- a/ray-operator/test/e2e/raycluster_gcs_ft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcs_ft_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
@@ -305,9 +306,7 @@ func TestGcsFaultToleranceAnnotations(t *testing.T) {
 			namespace := test.NewTestNamespace()
 
 			redisPassword := ""
-			if tc.redisPasswordEnv != "" && tc.redisPasswordInRayStartParams != "" && tc.redisPasswordInRayStartParams != "$REDIS_PASSWORD" {
-				t.Fatalf("redisPasswordEnv and redisPasswordInRayStartParams are both set")
-			}
+			require.False(t, tc.redisPasswordEnv != "" && tc.redisPasswordInRayStartParams != "" && tc.redisPasswordInRayStartParams != "$REDIS_PASSWORD", "redisPasswordEnv and redisPasswordInRayStartParams are both set")
 
 			switch {
 			case tc.redisPasswordEnv != "":


### PR DESCRIPTION
follow up to #3593

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
