### PR TITLE
[Feature] Add a util function to update all Pods to Running

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -87,6 +87,15 @@ func rayClusterTemplate(name string, namespace string) *rayv1.RayCluster {
 	}
 }
 
+func updateAllPodsToRunning(ctx context.Context, podList corev1.PodList, podFilters []client.ListOption, podLabel string) {
+	for _, pod := range podList.Items {
+		pod.Status.Phase = corev1.PodRunning
+		Expect(k8sClient.Status().Update(ctx, &pod)).Should(Succeed())
+	}
+
+	Eventually(isAllPodsRunningByFilters).WithContext(ctx).WithArguments(podList, podFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), fmt.Sprintf("All %s should be running.", podLabel))
+}
+
 var _ = Context("Inside the default namespace", func() {
 	Describe("Static RayCluster", Ordered, func() {
 		ctx := context.Background()
@@ -154,21 +163,8 @@ var _ = Context("Inside the default namespace", func() {
 			// See https://book.kubebuilder.io/reference/envtest.html
 
 			// Note that this test assumes that headPods and workerPods are up-to-date.
-			for _, headPod := range headPods.Items {
-				headPod.Status.Phase = corev1.PodRunning
-				Expect(k8sClient.Status().Update(ctx, &headPod)).Should(Succeed())
-			}
-
-			Eventually(
-				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(headPods, headFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "Head Pod should be running.")
-
-			for _, workerPod := range workerPods.Items {
-				workerPod.Status.Phase = corev1.PodRunning
-				Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(Succeed())
-			}
-
-			Eventually(
-				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(workerPods, workerFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "All worker Pods should be running.")
+			updateAllPodsToRunning(ctx, headPods, headFilters, "Head Pods")
+			updateAllPodsToRunning(ctx, workerPods, workerFilters, "Worker Pods")
 		})
 
 		It("RayCluster's .status.state should be updated to 'ready' shortly after all Pods are Running", func() {
@@ -290,13 +286,7 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(headPods, headFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "Head Pod should be running.")
 
-			for _, workerPod := range workerPods.Items {
-				workerPod.Status.Phase = corev1.PodRunning
-				Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(Succeed())
-			}
-
-			Eventually(
-				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(workerPods, workerFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "All worker Pods should be running.")
+			updateAllPodsToRunning(ctx, workerPods, workerFilters, "Worker Pods")
 		})
 
 		It("RayCluster's .status.state and .status.head.ServiceIP should be updated shortly after all Pods are Running", func() {
@@ -384,13 +374,7 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(headPods, headFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "Head Pod should be running.")
 
-			for _, workerPod := range workerPods.Items {
-				workerPod.Status.Phase = corev1.PodRunning
-				Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(Succeed())
-			}
-
-			Eventually(
-				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(workerPods, workerFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "All worker Pods should be running.")
+			updateAllPodsToRunning(ctx, workerPods, workerFilters, "Worker Pods")
 		})
 
 		It("RayCluster's .status.state and .status.head.ServiceIP should be updated shortly after all Pods are Running", func() {
@@ -943,24 +927,14 @@ var _ = Context("Inside the default namespace", func() {
 		It("Update all Pods to Running", func() {
 			// Note that this test assumes that headPods and workerPods are up-to-date.
 			Eventually(listResourceFunc(ctx, &headPods, headFilters...), time.Second*3, time.Millisecond*500).Should(Equal(numHeadPods), "headPods: %v", headPods.Items)
-			for _, headPod := range headPods.Items {
-				headPod.Status.Phase = corev1.PodRunning
-				Expect(k8sClient.Status().Update(ctx, &headPod)).Should(Succeed())
-			}
-			Eventually(
-				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(headPods, headFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "Head Pod should be running.")
+
+			updateAllPodsToRunning(ctx, headPods, headFilters, "Head Pods")
 
 			Eventually(
 				listResourceFunc(ctx, &workerPods, workerFilters...),
 				time.Second*3, time.Millisecond*500).Should(Equal(numWorkerPods), fmt.Sprintf("workerGroup %v", workerPods.Items))
 
-			for _, workerPod := range workerPods.Items {
-				workerPod.Status.Phase = corev1.PodRunning
-				Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(Succeed())
-			}
-
-			Eventually(
-				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(workerPods, workerFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "All worker Pods should be running.")
+			updateAllPodsToRunning(ctx, workerPods, workerFilters, "Worker Pods")
 		})
 
 		It("RayCluster's .status.state transitions to 'ready' when all worker Pods are Running and check pod counts are correct", func() {
@@ -1127,21 +1101,8 @@ var _ = Context("Inside the default namespace", func() {
 		})
 
 		It("Update all Pods to Running", func() {
-			for _, headPod := range headPods.Items {
-				headPod.Status.Phase = corev1.PodRunning
-				Expect(k8sClient.Status().Update(ctx, &headPod)).Should(Succeed())
-			}
-
-			Eventually(
-				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(headPods, headFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "Head Pod should be running.")
-
-			for _, workerPod := range workerPods.Items {
-				workerPod.Status.Phase = corev1.PodRunning
-				Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(Succeed())
-			}
-
-			Eventually(
-				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(workerPods, workerFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "All worker Pods should be running.")
+			updateAllPodsToRunning(ctx, headPods, headFilters, "Head Pods")
+			updateAllPodsToRunning(ctx, workerPods, workerFilters, "Worker Pods")
 		})
 
 		It("RayCluster's .status.state should be updated to 'ready' shortly after all Pods are Running", func() {

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -322,13 +322,7 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(headPods, headFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "Head Pod should be running.")
 
-			for _, workerPod := range workerPods.Items {
-				workerPod.Status.Phase = corev1.PodRunning
-				Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(Succeed())
-			}
-
-			Eventually(
-				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(workerPods, workerFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "All worker Pods should be running.")
+			updatePodsTo(ctx, workerPods, corev1.PodRunning, "All Worker Pods should be running.")
 		})
 
 		It("RayCluster's .status.state and .status.head.ServiceIP should be updated shortly after all Pods are Running", func() {
@@ -416,14 +410,7 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				isAllPodsRunningByFilters).WithContext(ctx).WithArguments(headPods, headFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "Head Pod should be running.")
 
-			updatePodsTo(ctx, workerPods, corev1.PodRunning, "All worker Pods should be running.")
-			// for _, workerPod := range workerPods.Items {
-			// 	workerPod.Status.Phase = corev1.PodRunning
-			// 	Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(Succeed())
-			// }
-
-			// Eventually(
-			// 	isAllPodsRunningByFilters).WithContext(ctx).WithArguments(workerPods, workerFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "All worker Pods should be running.")
+			updatePodsTo(ctx, workerPods, corev1.PodRunning, "All Worker Pods should be running.")
 		})
 
 		It("RayCluster's .status.state and .status.head.ServiceIP should be updated shortly after all Pods are Running", func() {
@@ -977,25 +964,12 @@ var _ = Context("Inside the default namespace", func() {
 			// Note that this test assumes that headPods and workerPods are up-to-date.
 			Eventually(listResourceFunc(ctx, &headPods, headFilters...), time.Second*3, time.Millisecond*500).Should(Equal(numHeadPods), "headPods: %v", headPods.Items)
 			updatePodsTo(ctx, headPods, corev1.PodRunning, "All Head Pods should be running.")
-			// for _, headPod := range headPods.Items {
-			// 	headPod.Status.Phase = corev1.PodRunning
-			// 	Expect(k8sClient.Status().Update(ctx, &headPod)).Should(Succeed())
-			// }
-			// Eventually(
-			// 	isAllPodsRunningByFilters).WithContext(ctx).WithArguments(headPods, headFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "Head Pod should be running.")
 
 			Eventually(
 				listResourceFunc(ctx, &workerPods, workerFilters...),
 				time.Second*3, time.Millisecond*500).Should(Equal(numWorkerPods), fmt.Sprintf("workerGroup %v", workerPods.Items))
 
 			updatePodsTo(ctx, workerPods, corev1.PodRunning, "All Worker Pods should be running.")
-			// for _, workerPod := range workerPods.Items {
-			// 	workerPod.Status.Phase = corev1.PodRunning
-			// 	Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(Succeed())
-			// }
-
-			// Eventually(
-			// 	isAllPodsRunningByFilters).WithContext(ctx).WithArguments(workerPods, workerFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "All worker Pods should be running.")
 		})
 
 		It("RayCluster's .status.state transitions to 'ready' when all worker Pods are Running and check pod counts are correct", func() {
@@ -1164,21 +1138,6 @@ var _ = Context("Inside the default namespace", func() {
 		It("Update all Pods to Running", func() {
 			updatePodsTo(ctx, headPods, corev1.PodRunning, "All Head Pods should be running.")
 			updatePodsTo(ctx, workerPods, corev1.PodRunning, "All Worker Pods should be running.")
-			// for _, headPod := range headPods.Items {
-			// 	headPod.Status.Phase = corev1.PodRunning
-			// 	Expect(k8sClient.Status().Update(ctx, &headPod)).Should(Succeed())
-			// }
-
-			// Eventually(
-			// 	isAllPodsRunningByFilters).WithContext(ctx).WithArguments(headPods, headFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "Head Pod should be running.")
-
-			// for _, workerPod := range workerPods.Items {
-			// 	workerPod.Status.Phase = corev1.PodRunning
-			// 	Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(Succeed())
-			// }
-
-			// Eventually(
-			// 	isAllPodsRunningByFilters).WithContext(ctx).WithArguments(workerPods, workerFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "All worker Pods should be running.")
 		})
 
 		It("RayCluster's .status.state should be updated to 'ready' shortly after all Pods are Running", func() {

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -186,21 +186,6 @@ var _ = Context("Inside the default namespace", func() {
 			// Note that this test assumes that headPods and workerPods are up-to-date.
 			updatePodsTo(ctx, headPods, corev1.PodRunning, "All Head Pods should be running.")
 			updatePodsTo(ctx, workerPods, corev1.PodRunning, "All worker Pods should be running.")
-			// for _, headPod := range headPods.Items {
-			// 	headPod.Status.Phase = corev1.PodRunning
-			// 	Expect(k8sClient.Status().Update(ctx, &headPod)).Should(Succeed())
-			// }
-
-			// Eventually(
-			// 	isAllPodsRunningByFilters).WithContext(ctx).WithArguments(headPods, headFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "Head Pod should be running.")
-
-			// for _, workerPod := range workerPods.Items {
-			// 	workerPod.Status.Phase = corev1.PodRunning
-			// 	Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(Succeed())
-			// }
-
-			// Eventually(
-			// 	isAllPodsRunningByFilters).WithContext(ctx).WithArguments(workerPods, workerFilters).WithTimeout(time.Second*3).WithPolling(time.Millisecond*500).Should(BeTrue(), "All worker Pods should be running.")
 		})
 
 		It("RayCluster's .status.state should be updated to 'ready' shortly after all Pods are Running", func() {
@@ -698,14 +683,8 @@ var _ = Context("Inside the default namespace", func() {
 
 			// We need to also manually update Pod statuses back to "Running" or else they will always stay as Pending.
 			// This is because we don't run kubelets in the unit tests to update the status subresource.
-			for _, headPod := range headPods.Items {
-				headPod.Status.Phase = corev1.PodRunning
-				Expect(k8sClient.Status().Update(ctx, &headPod)).Should(Succeed())
-			}
-			for _, workerPod := range workerPods.Items {
-				workerPod.Status.Phase = corev1.PodRunning
-				Expect(k8sClient.Status().Update(ctx, &workerPod)).Should(Succeed())
-			}
+			updatePodsTo(ctx, headPods, corev1.PodRunning, "All Head Pods should be running.")
+			updatePodsTo(ctx, workerPods, corev1.PodRunning, "All Worker Pods should be running.")
 		})
 
 		By("RayCluster's .status.state should be updated back to 'ready' after being un-suspended", func() {


### PR DESCRIPTION
## Why are these changes needed?

This PR introduces a utility function `updateAllPodsToRunning` that centralizes the logic for updating pod statuses to Running for env tests

The function handles:
- Updating pod status phase to Running
- Verifying all pods are running via polling
- Providing descriptive error messages with pod label context
- Refactored existing test cases to use this utility function, replacing duplicate pod status update logic

Example usage:
```go
updateAllPodsToRunning(ctx, headPods, headFilters, "Head Pods")
updateAllPodsToRunning(ctx, workerPods, workerFilters, "Worker Pods")
```


## Related issue number
Closes #3549 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
