### PR TITLE
[SLI Metrics] Add metric kuberay_job_info

### DIFF
--- a/ray-operator/controllers/ray/metrics/ray_job_metrics_test.go
+++ b/ray-operator/controllers/ray/metrics/ray_job_metrics_test.go
@@ -1,0 +1,93 @@
+package metrics
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+)
+
+func TestMetricRayJobInfo(t *testing.T) {
+	tests := []struct {
+		name            string
+		rayJobs         []rayv1.RayJob
+		expectedMetrics []string
+	}{
+		{
+			name: "two jobs and delete one later",
+			rayJobs: []rayv1.RayJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ray-job-1",
+						Namespace: "ns1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ray-job-2",
+						Namespace: "ns2",
+					},
+				},
+			},
+			expectedMetrics: []string{
+				`kuberay_job_info{name="ray-job-1",namespace="ns1"} 1`,
+				`kuberay_job_info{name="ray-job-2",namespace="ns2"} 1`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			k8sScheme := runtime.NewScheme()
+			require.NoError(t, rayv1.AddToScheme(k8sScheme))
+
+			objs := make([]client.Object, len(tc.rayJobs))
+			for i := range tc.rayJobs {
+				objs[i] = &tc.rayJobs[i]
+			}
+			client := fake.NewClientBuilder().WithScheme(k8sScheme).WithObjects(objs...).Build()
+			manager := NewRayJobMetricsManager(context.Background(), client)
+			reg := prometheus.NewRegistry()
+			reg.MustRegister(manager)
+
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil)
+			require.NoError(t, err)
+			rr := httptest.NewRecorder()
+			handler := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			body := rr.Body.String()
+			for _, label := range tc.expectedMetrics {
+				assert.Contains(t, body, label)
+			}
+
+			if len(tc.rayJobs) > 0 {
+				err = client.Delete(t.Context(), &tc.rayJobs[0])
+				require.NoError(t, err)
+			}
+
+			rr2 := httptest.NewRecorder()
+			handler.ServeHTTP(rr2, req)
+
+			assert.Equal(t, http.StatusOK, rr2.Code)
+			body2 := rr2.Body.String()
+
+			assert.NotContains(t, body2, tc.expectedMetrics[0])
+			for _, label := range tc.expectedMetrics[1:] {
+				assert.Contains(t, body2, label)
+			}
+		})
+	}
+}

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -235,8 +235,9 @@ func main() {
 	var rayClusterMetricManager *metrics.RayClusterMetricsManager
 	var rayJobMetricsManager *metrics.RayJobMetricsManager
 	if config.EnableMetrics {
-		rayClusterMetricManager = metrics.NewRayClusterMetricsManager(ctx, mgr.GetClient())
-		rayJobMetricsManager = metrics.NewRayJobMetricsManager()
+		mgrClient := mgr.GetClient()
+		rayClusterMetricManager = metrics.NewRayClusterMetricsManager(ctx, mgrClient)
+		rayJobMetricsManager = metrics.NewRayJobMetricsManager(ctx, mgrClient)
 		ctrlmetrics.Registry.MustRegister(
 			rayClusterMetricManager,
 			rayJobMetricsManager,


### PR DESCRIPTION
## Why are these changes needed?
This PR implement metric kuberay_job_info [proposed in 1.4.0](https://docs.google.com/document/d/1zNiE7lVZYjhrxlTbh1UXOVpR6hh1GIeSfCfE9Lt5v6Y/edit?tab=t.0).

## End-to-end test
```shell
$ curl -s localhost:8080/metrics | rg "kuberay_job_info"
# HELP kuberay_job_info Metadata information about RayJob custom resources
# TYPE kuberay_job_info gauge
kuberay_job_info{name="rayjob-fail-sample",namespace="test"} 1
kuberay_job_info{name="rayjob-sample",namespace="test"} 1
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
