### PR TITLE
[Feature] [kubectl-plugin] Expose setting `shutdownAfterJobFinishes` and `ttlSecondsAfterFinished` in ray job submit

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -40,40 +40,42 @@ const (
 )
 
 type SubmitJobOptions struct {
-	cmdFactory         cmdutil.Factory
-	dashboardClient    utils.RayDashboardClientInterface
-	ioStreams          *genericiooptions.IOStreams
-	RayJob             *rayv1.RayJob
-	logColor           string
-	image              string
-	fileName           string
-	workingDir         string
-	runtimeEnv         string
-	headers            string
-	verify             string
-	cluster            string
-	runtimeEnvJson     string
-	entryPointResource string
-	metadataJson       string
-	logStyle           string
-	submissionID       string
-	rayjobName         string
-	rayVersion         string
-	entryPoint         string
-	headCPU            string
-	headMemory         string
-	headGPU            string
-	workerCPU          string
-	workerMemory       string
-	workerGPU          string
-	namespace          string
-	entryPointMemory   int
-	entryPointGPU      float32
-	workerReplicas     int32
-	entryPointCPU      float32
-	noWait             bool
-	dryRun             bool
-	verbose            bool
+	cmdFactory               cmdutil.Factory
+	dashboardClient          utils.RayDashboardClientInterface
+	ioStreams                *genericiooptions.IOStreams
+	RayJob                   *rayv1.RayJob
+	logColor                 string
+	image                    string
+	fileName                 string
+	workingDir               string
+	runtimeEnv               string
+	headers                  string
+	verify                   string
+	cluster                  string
+	runtimeEnvJson           string
+	entryPointResource       string
+	metadataJson             string
+	logStyle                 string
+	submissionID             string
+	rayjobName               string
+	rayVersion               string
+	entryPoint               string
+	headCPU                  string
+	headMemory               string
+	headGPU                  string
+	workerCPU                string
+	workerMemory             string
+	workerGPU                string
+	namespace                string
+	entryPointMemory         int
+	entryPointGPU            float32
+	workerReplicas           int32
+	entryPointCPU            float32
+	noWait                   bool
+	dryRun                   bool
+	verbose                  bool
+	shutdownAfterJobFinishes bool
+	ttlSecondsAfterFinished  int32
 }
 
 type JobInfo struct {
@@ -171,6 +173,8 @@ func NewJobSubmitCommand(cmdFactory cmdutil.Factory, streams genericclioptions.I
 	cmd.Flags().StringVar(&options.workerGPU, "worker-gpu", "0", "number of GPUs in each worker group replica")
 	cmd.Flags().BoolVar(&options.dryRun, "dry-run", false, "print the generated YAML instead of creating the cluster. Only works when filename is not provided")
 	cmd.Flags().BoolVarP(&options.verbose, "verbose", "v", false, "Passing the '--verbose' flag to the 'ray job submit' command")
+	cmd.Flags().BoolVar(&options.shutdownAfterJobFinishes, "shutdown-after-job-finishes", false, "Shutdown the cluster after the job finishes")
+	cmd.Flags().Int32Var(&options.ttlSecondsAfterFinished, "ttl-seconds-after-finished", 0, "TTL seconds after finished. Only works when filename is not provided")
 
 	return cmd
 }
@@ -254,8 +258,17 @@ func (options *SubmitJobOptions) Validate() error {
 			}
 			options.runtimeEnvJson = string(runtimeJson)
 		}
+
+		if !options.RayJob.Spec.ShutdownAfterJobFinishes && options.RayJob.Spec.TTLSecondsAfterFinished != 0 {
+			return fmt.Errorf("ttl-seconds-after-finished is only supported when shutdown-after-job-finishes is set to true")
+		}
+
 	} else if strings.TrimSpace(options.rayjobName) == "" {
 		return fmt.Errorf("Must set either yaml file (--filename) or set Ray job name (--name)")
+	} else if options.fileName == "" {
+		if !options.shutdownAfterJobFinishes && options.ttlSecondsAfterFinished != 0 {
+			return fmt.Errorf("ttl-seconds-after-finished is only supported when shutdown-after-job-finishes is set to true")
+		}
 	}
 
 	if options.workingDir == "" {
@@ -289,9 +302,11 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	if options.fileName == "" {
 		// Genarate the Ray job.
 		rayJobObject := generation.RayJobYamlObject{
-			RayJobName:     options.rayjobName,
-			Namespace:      options.namespace,
-			SubmissionMode: "InteractiveMode",
+			RayJobName:               options.rayjobName,
+			Namespace:                options.namespace,
+			ShutdownAfterJobFinishes: options.shutdownAfterJobFinishes,
+			TTLSecondsAfterFinished:  options.ttlSecondsAfterFinished,
+			SubmissionMode:           "InteractiveMode",
 			// Prior to kuberay 1.2.2, the entry point is required. To maintain
 			// backwards compatibility with 1.2.x, we submit the entry point
 			// here, even though it will be ignored.

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -30,7 +30,7 @@ func TestRayJobSubmitComplete(t *testing.T) {
 	assert.Equal(t, "fake/path/to/env/yaml", fakeSubmitJobOptions.runtimeEnv)
 }
 
-func TestRayJobSubmitValidate(t *testing.T) {
+func TestRayJobSubmitWithYamlValidate(t *testing.T) {
 	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
 	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
 
@@ -71,6 +71,29 @@ spec:
   submissionMode: 'InteractiveMode'
   backoffLimit: 0`,
 		},
+		{
+			name: "shutdownAfterJobFinishes is false and ttlSecondsAfterFinished is not zero",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  shutdownAfterJobFinishes: false
+  ttlSecondsAfterFinished: 10
+  submissionMode: 'InteractiveMode'`,
+			expectError: "ttl-seconds-after-finished is only supported when shutdown-after-job-finishes is set to true",
+		},
+		{
+			name: "shutdownAfterJobFinishes is false and ttlSecondsAfterFinished is not zero",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  shutdownAfterJobFinishes: true
+  ttlSecondsAfterFinished: 10
+  submissionMode: 'InteractiveMode'`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -90,6 +113,52 @@ spec:
 			}
 
 			err = opts.Validate()
+			if tc.expectError != "" {
+				require.EqualError(t, err, tc.expectError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRayJobSubmitWithoutYamlValidate(t *testing.T) {
+	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+
+	test := []struct {
+		name                     string
+		rayjobName               string
+		expectError              string
+		ttlSecondsAfterFinished  int32
+		shutdownAfterJobFinishes bool
+	}{
+		{
+			name:                     "shutdownAfterJobFinishes is false and ttlSecondsAfterFinished is not zero",
+			rayjobName:               "rayjob-sample",
+			shutdownAfterJobFinishes: false,
+			ttlSecondsAfterFinished:  10,
+			expectError:              "ttl-seconds-after-finished is only supported when shutdown-after-job-finishes is set to true",
+		},
+		{
+			name:                     "shutdownAfterJobFinishes is true and ttlSecondsAfterFinished is not zero",
+			rayjobName:               "rayjob-sample",
+			shutdownAfterJobFinishes: true,
+			ttlSecondsAfterFinished:  10,
+		},
+	}
+
+	for _, tc := range test {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &SubmitJobOptions{
+				cmdFactory:               cmdFactory,
+				ioStreams:                &testStreams,
+				rayjobName:               tc.rayjobName,
+				workingDir:               "Fake/File/Path",
+				shutdownAfterJobFinishes: tc.shutdownAfterJobFinishes,
+				ttlSecondsAfterFinished:  tc.ttlSecondsAfterFinished,
+			}
+			err := opts.Validate()
 			if tc.expectError != "" {
 				require.EqualError(t, err, tc.expectError)
 			} else {

--- a/kubectl-plugin/pkg/util/generation/generation.go
+++ b/kubectl-plugin/pkg/util/generation/generation.go
@@ -122,6 +122,8 @@ type RayJobYamlObject struct {
 	SubmissionMode string
 	Entrypoint     string
 	RayClusterConfig
+	TTLSecondsAfterFinished  int32
+	ShutdownAfterJobFinishes bool
 }
 
 func (rayClusterConfig *RayClusterConfig) GenerateRayClusterApplyConfig() *rayv1ac.RayClusterApplyConfiguration {
@@ -138,6 +140,8 @@ func (rayJobObject *RayJobYamlObject) GenerateRayJobApplyConfig() *rayv1ac.RayJo
 		WithSpec(rayv1ac.RayJobSpec().
 			WithSubmissionMode(rayv1.JobSubmissionMode(rayJobObject.SubmissionMode)).
 			WithEntrypoint(rayJobObject.Entrypoint).
+			WithTTLSecondsAfterFinished(rayJobObject.TTLSecondsAfterFinished).
+			WithShutdownAfterJobFinishes(rayJobObject.ShutdownAfterJobFinishes).
 			WithRayClusterSpec(rayJobObject.generateRayClusterSpec()))
 
 	return rayJobApplyConfig

--- a/kubectl-plugin/pkg/util/generation/generation_test.go
+++ b/kubectl-plugin/pkg/util/generation/generation_test.go
@@ -164,9 +164,11 @@ func TestGenerateRayClusterApplyConfig(t *testing.T) {
 
 func TestGenerateRayJobApplyConfig(t *testing.T) {
 	testRayJobYamlObject := RayJobYamlObject{
-		RayJobName:     "test-ray-job",
-		Namespace:      "default",
-		SubmissionMode: "InteractiveMode",
+		RayJobName:               "test-ray-job",
+		Namespace:                "default",
+		SubmissionMode:           "InteractiveMode",
+		TTLSecondsAfterFinished:  100,
+		ShutdownAfterJobFinishes: true,
 		RayClusterConfig: RayClusterConfig{
 			RayVersion: ptr.To(util.RayVersion),
 			Image:      ptr.To(util.RayImage),
@@ -204,8 +206,10 @@ func TestGenerateRayJobApplyConfig(t *testing.T) {
 			Namespace: ptr.To("default"),
 		},
 		Spec: &rayv1ac.RayJobSpecApplyConfiguration{
-			SubmissionMode: ptr.To(rayv1.JobSubmissionMode(testRayJobYamlObject.SubmissionMode)),
-			Entrypoint:     ptr.To(""),
+			SubmissionMode:           ptr.To(rayv1.JobSubmissionMode(testRayJobYamlObject.SubmissionMode)),
+			Entrypoint:               ptr.To(""),
+			TTLSecondsAfterFinished:  ptr.To(int32(100)),
+			ShutdownAfterJobFinishes: ptr.To(true),
 			RayClusterSpec: &rayv1ac.RayClusterSpecApplyConfiguration{
 				RayVersion: ptr.To(util.RayVersion),
 				HeadGroupSpec: &rayv1ac.HeadGroupSpecApplyConfiguration{

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -144,6 +144,10 @@ func ValidateRayJobSpec(rayJob *rayv1.RayJob) error {
 		return fmt.Errorf("a RayJob with shutdownAfterJobFinishes set to false is not allowed to be suspended")
 	}
 
+	if !rayJob.Spec.ShutdownAfterJobFinishes && rayJob.Spec.TTLSecondsAfterFinished != 0 {
+		return fmt.Errorf("a RayJob with shutdownAfterJobFinishes set to false cannot have TTLSecondsAfterFinished is non-zero")
+	}
+
 	isClusterSelectorMode := len(rayJob.Spec.ClusterSelector) != 0
 	if rayJob.Spec.Suspend && isClusterSelectorMode {
 		return fmt.Errorf("the ClusterSelector mode doesn't support the suspend operation")

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -799,6 +799,24 @@ func TestValidateRayJobSpec(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "ShutdownAfterJobFinishes is false and TTLSecondsAfterFinished is not zero",
+			spec: rayv1.RayJobSpec{
+				ShutdownAfterJobFinishes: false,
+				TTLSecondsAfterFinished:  5,
+				RayClusterSpec:           createBasicRayClusterSpec(),
+			},
+			expectError: true,
+		},
+		{
+			name: "ShutdownAfterJobFinishes is true and TTLSecondsAfterFinished is not zero",
+			spec: rayv1.RayJobSpec{
+				ShutdownAfterJobFinishes: true,
+				TTLSecondsAfterFinished:  5,
+				RayClusterSpec:           createBasicRayClusterSpec(),
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently shutdownAfterJobFinishes and ttlSecondsAfterFinished aren't being exposed in kubectl ray job submit, although they are available in the [CRD](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/rayjob-quick-start.html#rayjob-configuration).
<!-- Please give a short summary of the change and the problem this solves. -->

### Ray Operator

- Add support for `shutdownAfterJobFinishes` and `ttlSecondsAfterFinished` in RayJob spec.

- Implement validation logic: if `shutdownAfterJobFinishes` is False, then `ttlSecondsAfterFinished` must be 0 or unset.

- Add corresponding unit tests.

### kubectl-plugin
- Add `shutdownAfterJobFinishes` and `ttlSecondsAfterFinished` flags to the rayjob submit command.

- Implement validation logic: if `shutdownAfterJobFinishes` is False, then `ttlSecondsAfterFinished` must be 0 or unset.

- Add corresponding unit tests.

## Related issue number
Closes #3560 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
