### PR TITLE
[Doc][CI] Align K8s version in Doc and CI with minimal required version

### DIFF
--- a/apiserver/hack/kind-cluster-config.yaml
+++ b/apiserver/hack/kind-cluster-config.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
+  image: kindest/node:v1.25.0@sha256:428aaa17ec82ccde0131cb2d1ca6547d13cf5fdabcc0bbecf749baa935387cbf
   kubeadmConfigPatches:
     - |
       kind: InitConfiguration

--- a/ci/kind-config-buildkite.yml
+++ b/ci/kind-config-buildkite.yml
@@ -9,6 +9,7 @@ networking:
 # https://blog.scottlowe.org/2019/07/30/adding-a-name-to-kubernetes-api-server-certificate/
 nodes:
 - role: control-plane
+  image: kindest/node:v1.25.0@sha256:428aaa17ec82ccde0131cb2d1ca6547d13cf5fdabcc0bbecf749baa935387cbf
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -110,7 +110,7 @@ cd ..
 
 ```bash
 # Step 1: Create a Kind cluster
-kind create cluster --image=kindest/node:v1.24.0
+kind create cluster --image=kindest/node:v1.25.0
 
 # Step 2: Install CRDs
 make -C ray-operator install


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
1. Current instructions in `ray-operator/DEVELOPMENT.md` used `kindest/node:v1.24.0`, which cause some e2e test to fail due to the K8s version. 
This PR update the documented version to a minimal required one.
See #2970 for more info.
3. Current CI using latest K8s version, which doesn't align with the documented version. 
This PR explicitly sets K8s version in CI pipeline.
See discussion in https://github.com/ray-project/kuberay/issues/2970#issuecomment-2887133524 for more info.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #2970

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
