### PR TITLE
[RayCluster] add annotation to enable non-login bash

### DIFF
--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -45,6 +45,10 @@ const (
 	// `KUBERAY_GEN_RAY_START_CMD`.
 	RayOverwriteContainerCmdAnnotationKey = "ray.io/overwrite-container-cmd"
 
+	// If this annotation is set to "true", the KubeRay operator will use the bash without `-l` in command.
+	// This is useful for some container images that do not want PATH being overwrite.
+	RayNonLoginBashCmdAnnotationKey = "ray.io/non-login-bash-cmd"
+
 	// Finalizers for GCS fault tolerance
 	GCSFaultToleranceRedisCleanupFinalizer = "ray.io/gcs-ft-redis-cleanup-finalizer"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

According to https://github.com/ray-project/kuberay/issues/3247, the `-l` overwrite the PATH resulting in uv not working properly. Introduce an annotation `ray.io/non-login-bash-cmd` to  `-l` from the command.

## Related issue number

<!-- For example: "Closes #1234" -->
Part of https://github.com/ray-project/kuberay/issues/3247

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
