### PR TITLE
[SLI Metrics] Add metric kuberay_cluster_condition_provisioned

### DIFF
--- a/ray-operator/controllers/ray/metrics/ray_cluster_metrics.go
+++ b/ray-operator/controllers/ray/metrics/ray_cluster_metrics.go
@@ -23,7 +23,7 @@ type RayClusterMetricsObserver interface {
 type RayClusterMetricsManager struct {
 	rayClusterProvisionedDurationSeconds *prometheus.GaugeVec
 	rayClusterInfo                       *prometheus.Desc
-	rayClusterProvisionedReady           *prometheus.Desc
+	rayClusterConditionProvisioned       *prometheus.Desc
 	client                               client.Client
 	log                                  logr.Logger
 }
@@ -50,9 +50,9 @@ func NewRayClusterMetricsManager(ctx context.Context, client client.Client) *Ray
 			[]string{"name", "namespace", "owner_kind"},
 			nil,
 		),
-		rayClusterProvisionedReady: prometheus.NewDesc(
+		rayClusterConditionProvisioned: prometheus.NewDesc(
 			"kuberay_cluster_condition_provisioned",
-			"Indicates whether the RayCluster is provisioned and ready",
+			"Indicates whether the RayCluster is provisioned",
 			[]string{"name", "namespace", "condition"},
 			nil,
 		),
@@ -107,7 +107,7 @@ func (r *RayClusterMetricsManager) collectRayClusterInfo(cluster *rayv1.RayClust
 
 func (r *RayClusterMetricsManager) collectRayClusterProvisionedReady(cluster *rayv1.RayCluster, ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
-		r.rayClusterProvisionedReady,
+		r.rayClusterConditionProvisioned,
 		prometheus.GaugeValue,
 		1,
 		cluster.Name,

--- a/ray-operator/controllers/ray/metrics/ray_cluster_metrics.go
+++ b/ray-operator/controllers/ray/metrics/ray_cluster_metrics.go
@@ -81,7 +81,7 @@ func (r *RayClusterMetricsManager) Collect(ch chan<- prometheus.Metric) {
 
 	for _, rayCluster := range rayClusterList.Items {
 		r.collectRayClusterInfo(&rayCluster, ch)
-		r.collectRayClusterProvisionedReady(&rayCluster, ch)
+		r.collectRayClusterConditionProvisioned(&rayCluster, ch)
 	}
 }
 
@@ -105,7 +105,7 @@ func (r *RayClusterMetricsManager) collectRayClusterInfo(cluster *rayv1.RayClust
 	)
 }
 
-func (r *RayClusterMetricsManager) collectRayClusterProvisionedReady(cluster *rayv1.RayCluster, ch chan<- prometheus.Metric) {
+func (r *RayClusterMetricsManager) collectRayClusterConditionProvisioned(cluster *rayv1.RayCluster, ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
 		r.rayClusterConditionProvisioned,
 		prometheus.GaugeValue,

--- a/ray-operator/controllers/ray/metrics/ray_cluster_metrics_test.go
+++ b/ray-operator/controllers/ray/metrics/ray_cluster_metrics_test.go
@@ -135,8 +135,8 @@ func TestRayClusterProvisionedReady(t *testing.T) {
 				},
 			},
 			expectedMetrics: []string{
-				`kuberay_cluster_provisioned_ready{condition="true",name="provisioned-cluster",namespace="default"} 1`,
-				`kuberay_cluster_provisioned_ready{condition="false",name="unprovisioned-cluster",namespace="default"} 1`,
+				`kuberay_cluster_condition_provisioned{condition="true",name="provisioned-cluster",namespace="default"} 1`,
+				`kuberay_cluster_condition_provisioned{condition="false",name="unprovisioned-cluster",namespace="default"} 1`,
 			},
 		},
 	}

--- a/ray-operator/controllers/ray/metrics/ray_cluster_metrics_test.go
+++ b/ray-operator/controllers/ray/metrics/ray_cluster_metrics_test.go
@@ -96,14 +96,14 @@ func TestRayClusterInfo(t *testing.T) {
 	}
 }
 
-func TestRayClusterProvisionedReady(t *testing.T) {
+func TestRayClusterConditionProvisioned(t *testing.T) {
 	tests := []struct {
 		name            string
 		clusters        []rayv1.RayCluster
 		expectedMetrics []string
 	}{
 		{
-			name: "clusters with different provisioned states",
+			name: "clusters with different provisioned status",
 			clusters: []rayv1.RayCluster{
 				{
 					ObjectMeta: metav1.ObjectMeta{

--- a/ray-operator/controllers/ray/metrics/ray_cluster_metrics_test.go
+++ b/ray-operator/controllers/ray/metrics/ray_cluster_metrics_test.go
@@ -18,7 +18,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
-func TestRayClusterMetricsManager(t *testing.T) {
+func TestRayClusterInfo(t *testing.T) {
 	tests := []struct {
 		name            string
 		clusters        []rayv1.RayCluster
@@ -91,6 +91,96 @@ func TestRayClusterMetricsManager(t *testing.T) {
 			assert.NotContains(t, body2, tc.expectedMetrics[0])
 			for _, label := range tc.expectedMetrics[1:] {
 				assert.Contains(t, body2, label)
+			}
+		})
+	}
+}
+
+func TestRayClusterProvisionedReady(t *testing.T) {
+	tests := []struct {
+		name            string
+		clusters        []rayv1.RayCluster
+		expectedMetrics []string
+	}{
+		{
+			name: "clusters with different provisioned states",
+			clusters: []rayv1.RayCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "provisioned-cluster",
+						Namespace: "default",
+					},
+					Status: rayv1.RayClusterStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(rayv1.RayClusterProvisioned),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "unprovisioned-cluster",
+						Namespace: "default",
+					},
+					Status: rayv1.RayClusterStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(rayv1.RayClusterProvisioned),
+								Status: metav1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			expectedMetrics: []string{
+				`kuberay_cluster_provisioned_ready{condition="true",name="provisioned-cluster",namespace="default"} 1`,
+				`kuberay_cluster_provisioned_ready{condition="false",name="unprovisioned-cluster",namespace="default"} 1`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			k8sScheme := runtime.NewScheme()
+			require.NoError(t, rayv1.AddToScheme(k8sScheme))
+
+			objs := make([]client.Object, len(tc.clusters))
+			for i := range tc.clusters {
+				objs[i] = &tc.clusters[i]
+			}
+			client := fake.NewClientBuilder().WithScheme(k8sScheme).WithObjects(objs...).Build()
+			manager := NewRayClusterMetricsManager(context.Background(), client)
+			reg := prometheus.NewRegistry()
+			reg.MustRegister(manager)
+
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil)
+			require.NoError(t, err)
+			rr := httptest.NewRecorder()
+			handler := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			body := rr.Body.String()
+			for _, metric := range tc.expectedMetrics {
+				assert.Contains(t, body, metric)
+			}
+
+			if len(tc.clusters) > 0 {
+				err = client.Delete(t.Context(), &tc.clusters[0])
+				require.NoError(t, err)
+			}
+
+			rr2 := httptest.NewRecorder()
+			handler.ServeHTTP(rr2, req)
+
+			assert.Equal(t, http.StatusOK, rr2.Code)
+			body2 := rr2.Body.String()
+
+			assert.NotContains(t, body2, tc.expectedMetrics[0])
+			for _, metric := range tc.expectedMetrics[1:] {
+				assert.Contains(t, body2, metric)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Implement metric kuberay_cluster_provisioned_ready [proposed in 1.4.0](https://docs.google.com/document/d/1zNiE7lVZYjhrxlTbh1UXOVpR6hh1GIeSfCfE9Lt5v6Y/edit?tab=t.0).


## End-to-end test
```
❯ k apply -f config/samples/ray-cluster.sample.yaml
raycluster.ray.io/raycluster-kuberay-bug created
❯ k apply -f config/samples/ray-service.sample.yaml
rayservice.ray.io/rayservice-sample created
❯ k apply -f config/samples/ray-job.sample.yaml
rayjob.ray.io/rayjob-sample created
configmap/ray-job-code-sample created


# HELP kuberay_cluster_condition_provisioned Indicates whether the RayCluster is provisioned and ready
# TYPE kuberay_cluster_condition_provisioned gauge
kuberay_cluster_condition_provisioned{condition="false",name="raycluster-kuberay-bug",namespace="default"} 1
kuberay_cluster_condition_provisioned{condition="true",name="rayjob-sample-vdr5x",namespace="default"} 1
kuberay_cluster_condition_provisioned{condition="true",name="rayservice-sample-n28cg",namespace="default"} 1
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
