### PR TITLE
[ray-operator][Bug] Rayjob is Failed or Succeed, but Raycluster status(jobDeploymentStatus) is still Running(#3553)

### DIFF
--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -70,9 +70,10 @@ func IsJobDeploymentTerminal(status JobDeploymentStatus) bool {
 type JobFailedReason string
 
 const (
-	SubmissionFailed JobFailedReason = "SubmissionFailed"
-	DeadlineExceeded JobFailedReason = "DeadlineExceeded"
-	AppFailed        JobFailedReason = "AppFailed"
+	SubmissionFailed             JobFailedReason = "SubmissionFailed"
+	DeadlineExceeded             JobFailedReason = "DeadlineExceeded"
+	AppFailed                    JobFailedReason = "AppFailed"
+	SubmitterGracePeriodExceeded JobFailedReason = "SubmitterGracePeriodExceeded"
 )
 
 type JobSubmissionMode string

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -148,6 +148,12 @@ const (
 	// If set to true, the RayJob CR itself will be deleted if shutdownAfterJobFinishes is set to true. Note that all resources created by the RayJob CR will be deleted, including the K8s Job.
 	DELETE_RAYJOB_CR_AFTER_JOB_FINISHES = "DELETE_RAYJOB_CR_AFTER_JOB_FINISHES"
 
+	// If this environment variable is set,
+	// when JobStatus reaches the final state but JobDeploymentStatus is still Running,
+	// wait for the graceful exit time and then transfer JobDeploymentStatus to the final state, thereby releasing pod resources.
+	// unit second
+	SUBMITTER_GRACE_PERIOD_TIME = "SUBMITTER_GRACE_PERIOD_TIME"
+
 	// Ray core default configurations
 	DefaultWorkerRayGcsReconnectTimeoutS = "600"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Rayjob is Failed, but Raycluster status(jobDeploymentStatus) is still Running, so if I depend on rayjob status to release the cluster quota, when new task dequeued because quota is satisfied, In fact, the task cannot be scheduled
<!-- Please give a short summary of the change and the problem this solves. -->
If the submitter doesn't complete after a grace period—configurable via a KubeRay operator environment variable—following a transition of JobStatus to a terminal state (e.g., JobStatusFailed), we can transition JobDeploymentStatus to SubmitterGracePeriodExceeded
## Related issue number
#3553 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
