### PR TITLE
[Grafana] Allow auto-load dashboard jsons

### DIFF
--- a/install/prometheus/install.sh
+++ b/install/prometheus/install.sh
@@ -11,7 +11,10 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 
 # Install the kube-prometheus-stack v48.2.1 helm chart with `overrides.yaml` file.
 # https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-48.2.1/charts/kube-prometheus-stack
-helm --namespace prometheus-system install prometheus prometheus-community/kube-prometheus-stack --create-namespace --version 48.2.1 -f "${DIR}"/overrides.yaml
+kubectl create namespace prometheus-system
+kubectl create configmap grafana-dashboards --from-file=../../config/grafana/ --dry-run=client -o yaml | sed '/^metadata:/a\  namespace: prometheus-system\n  labels:\n    grafana_dashboard: "1"' | kubectl create -f -
+
+helm --namespace prometheus-system install prometheus prometheus-community/kube-prometheus-stack --version 48.2.1 -f "${DIR}"/overrides.yaml
 
 # set the place of monitor files
 monitor_dir="${DIR}"/../../config/prometheus

--- a/install/prometheus/install.sh
+++ b/install/prometheus/install.sh
@@ -12,7 +12,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 # Install the kube-prometheus-stack v48.2.1 helm chart with `overrides.yaml` file.
 # https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-48.2.1/charts/kube-prometheus-stack
 kubectl create namespace prometheus-system
-kubectl create configmap grafana-dashboards --from-file=../../config/grafana/ --dry-run=client -o yaml | sed '/^metadata:/a\  namespace: prometheus-system\n  labels:\n    grafana_dashboard: "1"' | kubectl create -f -
+kubectl create configmap grafana-dashboards --from-file=$DIR/../../config/grafana/ --dry-run=client -o yaml | sed '/^metadata:/a\  namespace: prometheus-system\n  labels:\n    grafana_dashboard: "1"' | kubectl create -f -
 
 helm --namespace prometheus-system install prometheus prometheus-community/kube-prometheus-stack --version 48.2.1 -f "${DIR}"/overrides.yaml
 

--- a/install/prometheus/install.sh
+++ b/install/prometheus/install.sh
@@ -12,7 +12,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 # Install the kube-prometheus-stack v48.2.1 helm chart with `overrides.yaml` file.
 # https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-48.2.1/charts/kube-prometheus-stack
 kubectl create namespace prometheus-system
-kubectl create configmap grafana-dashboards --from-file=$DIR/../../config/grafana/ --dry-run=client -o yaml | sed '/^metadata:/a\  namespace: prometheus-system\n  labels:\n    grafana_dashboard: "1"' | kubectl create -f -
+kubectl create configmap grafana-dashboards --from-file="$DIR/../../config/grafana/" --dry-run=client -o yaml | sed '/^metadata:/a\  namespace: prometheus-system\n  labels:\n    grafana_dashboard: "1"' | kubectl create -f -
 
 helm --namespace prometheus-system install prometheus prometheus-community/kube-prometheus-stack --version 48.2.1 -f "${DIR}"/overrides.yaml
 

--- a/install/prometheus/install.sh
+++ b/install/prometheus/install.sh
@@ -12,7 +12,10 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 # Install the kube-prometheus-stack v48.2.1 helm chart with `overrides.yaml` file.
 # https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-48.2.1/charts/kube-prometheus-stack
 kubectl create namespace prometheus-system
-kubectl create configmap grafana-dashboards --from-file="$DIR/../../config/grafana/" --dry-run=client -o yaml | sed '/^metadata:/a\  namespace: prometheus-system\n  labels:\n    grafana_dashboard: "1"' | kubectl create -f -
+kubectl create configmap grafana-dashboards --from-file="$DIR/../../config/grafana/" --dry-run=client -o yaml | sed -e '/^metadata:/ a\
+  namespace: prometheus-system\
+  labels:\
+    grafana_dashboard: "1"' | kubectl create -f -
 
 helm --namespace prometheus-system install prometheus prometheus-community/kube-prometheus-stack --version 48.2.1 -f "${DIR}"/overrides.yaml
 

--- a/install/prometheus/overrides.yaml
+++ b/install/prometheus/overrides.yaml
@@ -932,7 +932,7 @@ grafana:
       labelValue: "1"
       # Allow discovery in all namespaces for dashboards
       searchNamespace: ALL
-
+      folder: /var/lib/grafana/dashboards
       ## Annotations for Grafana dashboard configmaps
       ##
       annotations: {}
@@ -942,7 +942,8 @@ grafana:
         etcd:
           enabled: false
       provider:
-        allowUiUpdates: false
+        allowUiUpdates: true
+        foldersFromFilesStructure: true
     datasources:
       enabled: true
       defaultDatasourceEnabled: true

--- a/install/prometheus/overrides.yaml
+++ b/install/prometheus/overrides.yaml
@@ -932,7 +932,7 @@ grafana:
       labelValue: "1"
       # Allow discovery in all namespaces for dashboards
       searchNamespace: ALL
-      folder: /var/lib/grafana/dashboards
+
       ## Annotations for Grafana dashboard configmaps
       ##
       annotations: {}
@@ -943,7 +943,6 @@ grafana:
           enabled: false
       provider:
         allowUiUpdates: false
-        foldersFromFilesStructure: true
     datasources:
       enabled: true
       defaultDatasourceEnabled: true

--- a/install/prometheus/overrides.yaml
+++ b/install/prometheus/overrides.yaml
@@ -942,7 +942,7 @@ grafana:
         etcd:
           enabled: false
       provider:
-        allowUiUpdates: true
+        allowUiUpdates: false
         foldersFromFilesStructure: true
     datasources:
       enabled: true


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, we are making our Grafana dashboards, it makes me (and might be the same for end users) feel annoyed that we'll have to import Grafana dashboard json when trying to use them (There are six of them!). 
This PR allow users to auto load the json to grafana without further step, all can be done just by `install.sh`, improving user experience.

![image](https://github.com/user-attachments/assets/36424231-d98f-4d18-8c54-1c56a2d5ad17)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#3650
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
