### PR TITLE
[CI] fix missing Go module release step

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -175,6 +175,17 @@ jobs:
           quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ steps.vars.outputs.sha_short }}
           quay.io/${{env.REPO_ORG}}/${{env.REPO_NAME}}:${{ env.tag }}
 
+    - name: Create ray-operator tag
+      uses: actions/github-script@v6
+      with:
+        script: |
+          await github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: 'refs/tags/ray-operator/${{ env.tag }}',
+            sha: '${{ github.sha }}'
+          })
+
   release_dashboard_image:
     env:
       working-directory: ./dashboard


### PR DESCRIPTION
We need to push a git tag named `ray-operator/vX.Y.Z` to publish Go modules to https://pkg.go.dev/github.com/ray-project/kuberay/ray-operator?tab=versions

This reverts #3249.