### PR TITLE
[CI] Fix autoscaler e2e test flakiness caused by timeout

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -55,7 +55,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=15m go test -timeout 60m -v ./test/e2eautoscaler 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-autoscaler-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2eautoscaler 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-autoscaler-log.tar -T - && exit 1)
     - echo "--- END:Autoscaler e2e (nightly operator) tests finished"
 
 - label: 'Test E2E Operator Version Upgrade (v1.3.0)'

--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -55,7 +55,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2eautoscaler 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-autoscaler-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=15m go test -timeout 60m -v ./test/e2eautoscaler 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-autoscaler-log.tar -T - && exit 1)
     - echo "--- END:Autoscaler e2e (nightly operator) tests finished"
 
 - label: 'Test E2E Operator Version Upgrade (v1.3.0)'

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -350,7 +350,7 @@ func TestRayClusterAutoscalerMinReplicasUpdate(t *testing.T) {
 			}
 
 			// Verify that the Autoscaler scales up to 5 Pods
-			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutLong).
 				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(5))))
 
 			// Check that replicas is set to 5

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -312,7 +312,7 @@ func TestRayClusterAutoscalerMinReplicasUpdate(t *testing.T) {
 				WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
 					WithReplicas(1).
 					WithMinReplicas(0).
-					WithMaxReplicas(5).
+					WithMaxReplicas(3).
 					WithGroupName(groupName).
 					WithRayStartParams(map[string]string{"num-cpus": "1"}).
 					WithTemplate(tc.WorkerPodTemplateGetter()))
@@ -340,21 +340,21 @@ func TestRayClusterAutoscalerMinReplicasUpdate(t *testing.T) {
 			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
 				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(2))))
 
-			// Create detached actors to trigger autoscaling to 5 Pods
+			// Create detached actors to trigger autoscaling to 3 Pods
 			headPod, err := GetHeadPod(test, rayCluster)
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 			LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
 
-			for i := 0; i < 5; i++ {
+			for i := 0; i < 3; i++ {
 				ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/create_detached_actor.py", fmt.Sprintf("actor%d", i)})
 			}
 
-			// Verify that the Autoscaler scales up to 5 Pods
+			// Verify that the Autoscaler scales up to 3 Pods
 			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutLong).
-				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(5))))
+				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.Equal(int32(3))))
 
-			// Check that replicas is set to 5
-			g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(GetRayClusterWorkerGroupReplicaSum, gomega.Equal(int32(5))))
+			// Check that replicas is set to 3
+			g.Expect(GetRayCluster(test, rayCluster.Namespace, rayCluster.Name)).To(gomega.WithTransform(GetRayClusterWorkerGroupReplicaSum, gomega.Equal(int32(3))))
 		})
 	}
 }
@@ -368,13 +368,13 @@ func TestRayClusterAutoscalerMaxReplicasUpdate(t *testing.T) {
 		actorCount       int
 	}{
 		{
-			name:       "Scale up maxReplicas from 3 to 5",
-			initialMax: 3,
-			updatedMax: 5,
+			name:       "Scale up maxReplicas from 2 to 3",
+			initialMax: 2,
+			updatedMax: 3,
 		},
 		{
-			name:       "Scale down maxReplicas from 3 to 1",
-			initialMax: 3,
+			name:       "Scale down maxReplicas from 2 to 1",
+			initialMax: 2,
 			updatedMax: 1,
 		},
 	}
@@ -698,7 +698,7 @@ func TestRayClusterAutoscalerSDKRequestResources(t *testing.T) {
 				WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
 					WithReplicas(0).
 					WithMinReplicas(0).
-					WithMaxReplicas(5).
+					WithMaxReplicas(2).
 					WithGroupName(groupName).
 					WithRayStartParams(map[string]string{"num-cpus": "1"}).
 					WithTemplate(tc.WorkerPodTemplateGetter()))
@@ -720,12 +720,12 @@ func TestRayClusterAutoscalerSDKRequestResources(t *testing.T) {
 
 			// Trigger resource request via ray.autoscaler.sdk.request_resources
 			ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
-				"python", "/home/ray/test_scripts/call_request_resources.py", "--num-cpus=3",
+				"python", "/home/ray/test_scripts/call_request_resources.py", "--num-cpus=1",
 			})
 
-			// Autoscaler should create 3 workers
+			// Autoscaler should create 1 workers
 			g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.BeNumerically("==", 3)))
+				Should(gomega.WithTransform(RayClusterDesiredWorkerReplicas, gomega.BeNumerically("==", 1)))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- [TestRayClusterAutoscalerMinReplicasUpdate](https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/9295#0196fa36-b342-4938-a610-5b0c2a17d4a8)
```
raycluster_autoscaler_test.go:354:
    Timed out after 300.000s.
    Expected
        <int32>: 4
    to equal
        <int32>: 5
```
- [TestRayClusterAutoscalerMaxReplicasUpdate/Create_a_RayCluster_with_autoscaling_enabled(Scale_up_maxReplicas_from_3_to_5)](https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/9298#0196faa6-dc79-4916-b021-75395686cfe7)
```
    raycluster_autoscaler_test.go:443: 
        Timed out after 600.000s.
        Expected
            <int32>: 4
        to equal
            <int32>: 5
```

- Given the recent failures in TestRayClusterAutoscalerMinReplicasUpdate and TestRayClusterAutoscalerMaxReplicasUpdate, it’s clear that tests involving scaling up to 5 worker pods are more prone to timeouts

To address this:
- Tests that scale up to 5 worker pods now explicitly use TestTimeoutLong in their g.Eventually blocks to reduce flakiness.
- Additionally, the duration of TestTimeoutLong has been increased from 10 minutes (600s) to 15 minutes (900s) to provide more headroom for long-running autoscaler convergence scenarios.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #3667

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
