### PR TITLE
[Ray-operator] Feature flag login bash

### DIFF
--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -20,7 +20,6 @@ import (
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
-	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 )
 
 var testMemoryLimit = resource.MustParse("1Gi")
@@ -850,7 +849,8 @@ func TestBuildPod_WithCreatedByRayService(t *testing.T) {
 
 func TestBuildPod_WithFeatureFlagLoginBash(t *testing.T) {
 	ctx := context.Background()
-	features.SetFeatureGateDuringTest(t, features.RayClusterLoginBash, true)
+	os.Setenv(EnableLoginBashEnvKey, "true")
+	defer os.Unsetenv(EnableLoginBashEnvKey)
 
 	cluster := instance.DeepCopy()
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -849,8 +849,8 @@ func TestBuildPod_WithCreatedByRayService(t *testing.T) {
 
 func TestBuildPod_WithFeatureFlagLoginBash(t *testing.T) {
 	ctx := context.Background()
-	os.Setenv(EnableLoginBashEnvKey, "true")
-	defer os.Unsetenv(EnableLoginBashEnvKey)
+	os.Setenv(utils.ENABLE_LOGIN_SHELL, "true")
+	defer os.Unsetenv(utils.ENABLE_LOGIN_SHELL)
 
 	cluster := instance.DeepCopy()
 	cluster.Spec.EnableInTreeAutoscaling = &trueFlag

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -886,6 +886,43 @@ func TestBuildPod_WithFeatureFlagLoginBash(t *testing.T) {
 	}
 }
 
+func TestBuildPod_WithoutFeatureFlagLoginBash(t *testing.T) {
+	ctx := context.Background()
+
+	cluster := instance.DeepCopy()
+	cluster.Spec.EnableInTreeAutoscaling = &trueFlag
+	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
+	podTemplateSpec := DefaultHeadPodTemplate(ctx, *cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
+	headPod := BuildPod(ctx, podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", true, utils.RayServiceCRD, "")
+
+	// make sure head container with login bash.
+	headContainer := headPod.Spec.Containers[utils.RayContainerIndex]
+	assert.Equal(t, []string{"/bin/bash", "-c", "--"}, headContainer.Command)
+
+	// make sure autoscaler container with login bash.
+	index := getAutoscalerContainerIndex(headPod)
+	autoscalerContainer := headPod.Spec.Containers[index]
+	assert.Equal(t, []string{"/bin/bash", "-c", "--"}, autoscalerContainer.Command)
+
+	worker := cluster.Spec.WorkerGroupSpecs[0]
+	podName = cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
+	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, *cluster, cluster.Namespace)
+	podTemplateSpec = DefaultWorkerPodTemplate(ctx, *cluster, worker, podName, fqdnRayIP, "6379")
+	workerPod := BuildPod(ctx, podTemplateSpec, rayv1.WorkerNode, worker.RayStartParams, "6379", false, utils.RayServiceCRD, fqdnRayIP)
+
+	// make sure worker container with login bash.
+	workerContainer := workerPod.Spec.Containers[utils.RayContainerIndex]
+	assert.Equal(t, []string{"/bin/bash", "-c", "--"}, workerContainer.Command)
+
+	// make init container with login bash.
+	initContainers := workerPod.Spec.InitContainers
+	for _, initContainer := range initContainers {
+		if initContainer.Name == "wait-gcs-ready" {
+			assert.Equal(t, []string{"/bin/bash", "-c", "--"}, initContainer.Command)
+		}
+	}
+}
+
 // Check that autoscaler container overrides work as expected.
 func TestBuildPodWithAutoscalerOptions(t *testing.T) {
 	ctx := context.Background()

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1095,7 +1095,7 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instanc
 
 	// Only keep the Ray container in the Redis cleanup Job.
 	pod.Spec.Containers = []corev1.Container{pod.Spec.Containers[utils.RayContainerIndex]}
-	pod.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/bash", "-lc", "--"}
+	pod.Spec.Containers[utils.RayContainerIndex].Command = utils.GetContainerCommand()
 	pod.Spec.Containers[utils.RayContainerIndex].Args = []string{
 		"echo \"To get more information about manually deleting the storage namespace in Redis and removing the RayCluster's finalizer, please check https://docs.ray.io/en/master/cluster/kubernetes/user-guides/kuberay-gcs-ft.html for more details.\" && " +
 			"python -c " +

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3007,6 +3007,111 @@ func Test_RedisCleanup(t *testing.T) {
 	}
 }
 
+func Test_RedisCleanupWithLoginShell(t *testing.T) {
+	setupTest(t)
+
+	os.Setenv(utils.ENABLE_GCS_FT_REDIS_CLEANUP, "true")
+	defer os.Unsetenv(utils.ENABLE_GCS_FT_REDIS_CLEANUP)
+
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+	_ = batchv1.AddToScheme(newScheme)
+
+	// Prepare a RayCluster with the GCS FT enabled and Autoscaling disabled.
+	gcsFTEnabledCluster := testRayCluster.DeepCopy()
+	if gcsFTEnabledCluster.Annotations == nil {
+		gcsFTEnabledCluster.Annotations = make(map[string]string)
+	}
+	gcsFTEnabledCluster.Annotations[utils.RayFTEnabledAnnotationKey] = "true"
+	gcsFTEnabledCluster.Spec.EnableInTreeAutoscaling = nil
+	ctx := context.Background()
+
+	tests := []struct {
+		name             string
+		enableLoginShell string
+		expectedCommands []string
+	}{
+		{
+			name:             "Enable login shell",
+			enableLoginShell: "true",
+			expectedCommands: []string{"/bin/bash", "-lc", "--"},
+		},
+		{
+			name:             "Disable login shell",
+			enableLoginShell: "false",
+			expectedCommands: []string{"/bin/bash", "-c", "--"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.enableLoginShell == "true" {
+				os.Setenv(utils.ENABLE_LOGIN_SHELL, "true")
+				defer os.Unsetenv(utils.ENABLE_LOGIN_SHELL)
+			} else {
+				os.Unsetenv(utils.ENABLE_LOGIN_SHELL)
+			}
+
+			cluster := gcsFTEnabledCluster.DeepCopy()
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(newScheme).
+				WithObjects(cluster).
+				WithStatusSubresource(cluster).
+				Build()
+
+			// Initialize the reconciler
+			testRayClusterReconciler := &RayClusterReconciler{
+				Client:                     fakeClient,
+				Recorder:                   &record.FakeRecorder{},
+				Scheme:                     newScheme,
+				rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
+			}
+
+			rayClusterList := rayv1.RayClusterList{}
+			err := fakeClient.List(ctx, &rayClusterList, client.InNamespace(namespaceStr))
+			require.NoError(t, err, "Fail to get RayCluster list")
+			assert.Len(t, rayClusterList.Items, 1)
+			assert.Empty(t, rayClusterList.Items[0].Finalizers)
+
+			_, err = testRayClusterReconciler.rayClusterReconcile(ctx, cluster)
+			require.NoError(t, err)
+
+			// Check the RayCluster's finalizer
+			rayClusterList = rayv1.RayClusterList{}
+			err = fakeClient.List(ctx, &rayClusterList, client.InNamespace(namespaceStr))
+			require.NoError(t, err, "Fail to get RayCluster list")
+			assert.Len(t, rayClusterList.Items, 1)
+			assert.Len(t, rayClusterList.Items[0].Finalizers, 1)
+
+			assert.True(t, controllerutil.ContainsFinalizer(&rayClusterList.Items[0], utils.GCSFaultToleranceRedisCleanupFinalizer))
+
+			// No Pod should be created before adding the GCS FT Redis cleanup finalizer.
+			podList := corev1.PodList{}
+			err = fakeClient.List(ctx, &podList, client.InNamespace(namespaceStr))
+			require.NoError(t, err, "Fail to get Pod list")
+			assert.Empty(t, podList.Items)
+
+			// Set the RayCluster's DeletionTimestamp to trigger the Redis cleanup job.
+			cluster.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+			// Reconcile the RayCluster again. The controller should create Pods.
+			_, err = testRayClusterReconciler.rayClusterReconcile(ctx, cluster)
+			require.NoError(t, err)
+
+			// Get finalizer jobs
+			redisCleanupJobs := batchv1.JobList{}
+			err = fakeClient.List(ctx, &redisCleanupJobs, common.RayClusterRedisCleanupJobAssociationOptions(&rayClusterList.Items[0]).ToListOptions()...)
+			require.NoError(t, err, "Fail to get Pod list")
+			assert.NotEmpty(t, redisCleanupJobs.Items)
+			assert.Len(t, redisCleanupJobs.Items, 1)
+
+			// Check if it has the login shell enabled
+			assert.Equal(t, tc.expectedCommands, redisCleanupJobs.Items[0].Spec.Template.Spec.Containers[0].Command)
+		})
+	}
+}
+
 func TestReconcile_Replicas_Optional(t *testing.T) {
 	setupTest(t)
 

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -555,6 +555,9 @@ func getSubmitterTemplate(ctx context.Context, rayJobInstance *rayv1.RayJob, ray
 			return corev1.PodTemplateSpec{}, err
 		}
 		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/bash"}
+		if features.Enabled(features.RayClusterLoginBash) {
+			submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/bash", "-l"}
+		}
 		// Without the -e option, the Bash script will continue executing even if a command returns a non-zero exit code.
 		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args = []string{"-ce", strings.Join(k8sJobCommand, " ")}
 		logger.Info("No command is specified in the user-provided template. Default command is used", "command", k8sJobCommand)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -554,12 +554,9 @@ func getSubmitterTemplate(ctx context.Context, rayJobInstance *rayv1.RayJob, ray
 		if err != nil {
 			return corev1.PodTemplateSpec{}, err
 		}
-		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/bash"}
-		if common.GetEnableLoginBash() {
-			submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/bash", "-l"}
-		}
+		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = utils.GetContainerCommand()[:2]
 		// Without the -e option, the Bash script will continue executing even if a command returns a non-zero exit code.
-		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args = []string{"-ce", strings.Join(k8sJobCommand, " ")}
+		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args = []string{"-e", strings.Join(k8sJobCommand, " ")}
 		logger.Info("No command is specified in the user-provided template. Default command is used", "command", k8sJobCommand)
 	} else {
 		logger.Info("User-provided command is used", "command", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -555,7 +555,7 @@ func getSubmitterTemplate(ctx context.Context, rayJobInstance *rayv1.RayJob, ray
 			return corev1.PodTemplateSpec{}, err
 		}
 		submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/bash"}
-		if features.Enabled(features.RayClusterLoginBash) {
+		if common.GetEnableLoginBash() {
 			submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{"/bin/bash", "-l"}
 		}
 		// Without the -e option, the Bash script will continue executing even if a command returns a non-zero exit code.

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -24,10 +25,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/metrics/mocks"
 	utils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme"
-	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 )
 
 func TestCreateRayJobSubmitterIfNeed(t *testing.T) {
@@ -204,11 +205,11 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	assert.Equal(t, "test-job-id", envVar.Value)
 
 	// Test 7: Check with feature flag login bash enabled
-	features.SetFeatureGateDuringTest(t, features.RayClusterLoginBash, true)
+	os.Setenv(common.EnableLoginBashEnvKey, "true")
+	defer os.Unsetenv(common.EnableLoginBashEnvKey)
 	submitterTemplate, err = getSubmitterTemplate(ctx, rayJobInstanceWithTemplate, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/bin/bash", "-l"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	features.SetFeatureGateDuringTest(t, features.RayClusterLoginBash, false)
 }
 
 func TestUpdateStatusToSuspendingIfNeeded(t *testing.T) {

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/metrics/mocks"
 	utils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme"
@@ -173,14 +172,14 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	rayJobInstanceWithTemplate.Spec.SubmitterPodTemplate.Spec.Containers[utils.RayContainerIndex].Command = []string{}
 	submitterTemplate, err = getSubmitterTemplate(ctx, rayJobInstanceWithTemplate, nil)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"/bin/bash"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	assert.Equal(t, []string{"-ce", "if ! ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job submit --address http://test-url --no-wait --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
+	assert.Equal(t, []string{"/bin/bash", "-c"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
+	assert.Equal(t, []string{"-e", "if ! ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job submit --address http://test-url --no-wait --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 
 	// Test 3: User did not provide template, should use the image of the Ray Head
 	submitterTemplate, err = getSubmitterTemplate(ctx, rayJobInstanceWithoutTemplate, rayClusterInstance)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"/bin/bash"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	assert.Equal(t, []string{"-ce", "if ! ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job submit --address http://test-url --no-wait --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
+	assert.Equal(t, []string{"/bin/bash", "-c"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
+	assert.Equal(t, []string{"-e", "if ! ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job submit --address http://test-url --no-wait --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 	assert.Equal(t, "rayproject/ray:custom-version", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Image)
 
 	// Test 4: Check default PYTHONUNBUFFERED setting
@@ -205,11 +204,11 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	assert.Equal(t, "test-job-id", envVar.Value)
 
 	// Test 7: Check with feature flag login bash enabled
-	os.Setenv(common.EnableLoginBashEnvKey, "true")
-	defer os.Unsetenv(common.EnableLoginBashEnvKey)
+	os.Setenv(utils.ENABLE_LOGIN_SHELL, "true")
+	defer os.Unsetenv(utils.ENABLE_LOGIN_SHELL)
 	submitterTemplate, err = getSubmitterTemplate(ctx, rayJobInstanceWithTemplate, nil)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"/bin/bash", "-l"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
+	assert.Equal(t, []string{"/bin/bash", "-lc"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
 }
 
 func TestUpdateStatusToSuspendingIfNeeded(t *testing.T) {

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -158,6 +158,12 @@ const (
 	RAYJOB_DEPLOYMENT_STATUS_TRANSITION_GRACE_PERIOD_SECONDS         = "RAYJOB_DEPLOYMENT_STATUS_TRANSITION_GRACE_PERIOD_SECONDS"
 	DEFAULT_RAYJOB_DEPLOYMENT_STATUS_TRANSITION_GRACE_PERIOD_SECONDS = 300
 
+	// This environment variable for the KubeRay operator determines whether to enable
+	// a login shell by passing the -l option to the container command /bin/bash.
+	// The -l flag was added by default before KubeRay v1.4.0, but it is no longer added
+	// by default starting with v1.4.0.
+	ENABLE_LOGIN_SHELL = "ENABLE_LOGIN_SHELL"
+
 	// Ray core default configurations
 	DefaultWorkerRayGcsReconnectTimeoutS = "600"
 

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -702,3 +702,10 @@ func GetClusterType() bool {
 	}
 	return false
 }
+
+func GetContainerCommand() []string {
+	if s := os.Getenv(ENABLE_LOGIN_SHELL); strings.ToLower(s) == "true" {
+		return []string{"/bin/bash", "-lc", "--"}
+	}
+	return []string{"/bin/bash", "-c", "--"}
+}

--- a/ray-operator/pkg/features/features.go
+++ b/ray-operator/pkg/features/features.go
@@ -24,6 +24,9 @@ const (
 	//
 	// Enables new deletion policy API in RayJob
 	RayJobDeletionPolicy featuregate.Feature = "RayJobDeletionPolicy"
+
+	// Enables the bash login feature for RayCluster.
+	RayClusterLoginBash featuregate.Feature = "RayClusterLoginBash"
 )
 
 func init() {
@@ -33,6 +36,7 @@ func init() {
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	RayClusterStatusConditions: {Default: true, PreRelease: featuregate.Beta},
 	RayJobDeletionPolicy:       {Default: false, PreRelease: featuregate.Alpha},
+	RayClusterLoginBash:        {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // SetFeatureGateDuringTest is a helper method to override feature gates in tests.

--- a/ray-operator/pkg/features/features.go
+++ b/ray-operator/pkg/features/features.go
@@ -24,9 +24,6 @@ const (
 	//
 	// Enables new deletion policy API in RayJob
 	RayJobDeletionPolicy featuregate.Feature = "RayJobDeletionPolicy"
-
-	// Enables the bash login feature for RayCluster.
-	RayClusterLoginBash featuregate.Feature = "RayClusterLoginBash"
 )
 
 func init() {
@@ -36,7 +33,6 @@ func init() {
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	RayClusterStatusConditions: {Default: true, PreRelease: featuregate.Beta},
 	RayJobDeletionPolicy:       {Default: false, PreRelease: featuregate.Alpha},
-	RayClusterLoginBash:        {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // SetFeatureGateDuringTest is a helper method to override feature gates in tests.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Provide a feature flag to enable the login bash command `-l` if needed. If feature flag is not enabled, it would not apply login bash. This provide the option for the end user to choose one. For example, the `uv` rely on `PATH` if enabling the login bash might overwrite `PATH` potentially.

## Related issue number

<!-- For example: "Closes #1234" -->
Part of https://github.com/ray-project/kuberay/issues/3247

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
