### PR TITLE
[Fix][kubectl-plugin] Fix kubectl ray job submit command shadows the error of ray job sumit

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -507,7 +507,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 		rayJobID = options.submissionID
 		// Wait for command to finish when using predefined submission ID
 		if cmdErr := <-cmdErrChan; cmdErr != nil {
-			return fmt.Errorf("ray job submit command failed: %w", cmdErr)
+			return fmt.Errorf("Ray job submit command failed: %w", cmdErr)
 		}
 	} else {
 		// Create a channel to receive rayJobID from the API
@@ -536,17 +536,17 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 		select {
 		case cmdErr := <-cmdErrChan:
 			if cmdErr != nil {
-				return fmt.Errorf("ray job submit command failed: %w", cmdErr)
+				return fmt.Errorf("Ray job submit command failed: %w", cmdErr)
 			}
 			// Command finished successfully, wait for job ID
 			if jobID, ok := <-rayJobIDChan; ok {
 				rayJobID = jobID
 			} else {
-				return fmt.Errorf("submit failed: timeout waiting for job ID from API after %v seconds", jobIDTimeout)
+				return fmt.Errorf("Timeout waiting for job ID from API after %v seconds", jobIDTimeout)
 			}
 		case jobID, ok := <-rayJobIDChan:
 			if !ok {
-				return fmt.Errorf("submit failed: timeout waiting for job ID from API after %v seconds", jobIDTimeout)
+				return fmt.Errorf("Timeout waiting for job ID from API after %v seconds", jobIDTimeout)
 			}
 			rayJobID = jobID
 		}
@@ -567,6 +567,10 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	if options.noWait {
 		fmt.Printf("Ray job submitted with ID %s\n", rayJobID)
 		return nil
+	}
+	// Wait for Ray job submit to finish.
+	if err := <-cmdErrChan; err != nil {
+		return fmt.Errorf("Ray job submit command failed: %w", err)
 	}
 	// Wait for the Ray job to finish
 	watcher, err := k8sClients.RayClient().RayV1().


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See #3675 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

#3675 
<!-- For example: "Closes #1234" -->

## Root Cause
The root cause is that the `stderr/stdout` scanners are not started immediately after `cmd.Start()` and call `Text()` before `Scan()`, so the subprocess’s error output is never consumed before it exits.

My solution is to immediately launch proper `Scan(), Text()` loops for `stdout` and `stderr` right after `cmd.Start()`, then call `cmd.Wait()` to capture and report the actual CLI errors.

## Manual tests
Before : 
```log
$ kubectl ray job submit  --working-dir . --name my-rayjob  -- python task.py | ts '[%Y-%m-%d %H:%M:%S]'
[2025-05-25 12:45:18] Submitted RayJob my-rayjob.
[2025-05-25 12:45:22] Waiting for RayCluster
[2025-05-25 12:45:22] Checking Cluster Status for cluster my-rayjob-7xp6v...
[2025-05-25 12:45:24] Cluster is not ready
[2025-05-25 12:45:26] Cluster is not ready
[2025-05-25 12:45:28] Cluster is not ready
[2025-05-25 12:45:30] Cluster is not ready
[2025-05-25 12:45:32] Cluster is not ready
[2025-05-25 12:45:34] Cluster is not ready
[2025-05-25 12:45:36] Cluster is not ready
[2025-05-25 12:45:38] Cluster is not ready
[2025-05-25 12:45:40] Waiting for portforwarding...Port Forwarding service my-rayjob-7xp6v-head-svc
[2025-05-25 12:45:40] Forwarding from 127.0.0.1:8265 -> 8265
[2025-05-25 12:45:40] Forwarding from [::1]:8265 -> 8265
[2025-05-25 12:45:42] Handling connection for 8265
[2025-05-25 12:45:42] Portforwarding started on http://localhost:8265
[2025-05-25 12:45:42] Ray command: [ray job submit --address http://localhost:8265 --working-dir . -- python task.py]
E0525 12:45:42.240628 2392410 portforward.go:404] "Unhandled Error" err="error copying from local connection to remote stream: writeto tcp4 127.0.0.1:8265->127.0.0.1:54932: read tcp4 127.0.0.1:8265->127.0.0.1:54932: read: connection reset by peer" logger="UnhandledError"
[2025-05-25 12:45:42] Running Ray submit job command...
[2025-05-25 12:45:42] Handling connection for 8265
[2025-05-25 12:45:42] Handling connection for 8265
[2025-05-25 12:45:42] Handling connection for 8265
[2025-05-25 12:45:43] Handling connection for 8265
[2025-05-25 12:45:44] Handling connection for 8265
Error: submit failed: timeout waiting for job ID from API after 60  <-----
```
After : 
```log
$ kubectl ray job submit --working-dir . --name my-rayjob  -- python task.py | ts '[%Y-%m-%d %H:%M:%S]'
[2025-05-25 14:52:29] Submitted RayJob my-rayjob.
[2025-05-25 14:52:33] Waiting for RayCluster
[2025-05-25 14:52:33] Checking Cluster Status for cluster my-rayjob-q7z26...
[2025-05-25 14:52:35] Cluster is not ready
[2025-05-25 14:52:37] Cluster is not ready
[2025-05-25 14:52:39] Cluster is not ready
[2025-05-25 14:52:41] Cluster is not ready
[2025-05-25 14:52:43] Cluster is not ready
[2025-05-25 14:52:45] Cluster is not ready
[2025-05-25 14:52:47] Cluster is not ready
[2025-05-25 14:52:49] Cluster is not ready
[2025-05-25 14:52:51] Waiting for portforwarding...Port Forwarding service my-rayjob-q7z26-head-svc
[2025-05-25 14:52:51] Forwarding from 127.0.0.1:8265 -> 8265
[2025-05-25 14:52:51] Forwarding from [::1]:8265 -> 8265
[2025-05-25 14:52:53] Handling connection for 8265
[2025-05-25 14:52:53] Portforwarding started on http://localhost:8265
[2025-05-25 14:52:53] Ray command: [ray job submit --address http://localhost:8265 --working-dir . -- python task.py]
[2025-05-25 14:52:53] Running Ray submit job command...
[2025-05-25 14:52:53] Handling connection for 8265
[2025-05-25 14:52:53] Handling connection for 8265
[2025-05-25 14:52:53] Handling connection for 8265
[2025-05-25 14:52:54] Handling connection for 8265
2025-05-25 14:52:54,632	INFO dashboard_sdk.py:338 -- Uploading package gcs://_ray_pkg_f0e703dc4137c465.zip.
2025-05-25 14:52:54,633	INFO packaging.py:575 -- Creating a file package for local module '.'.
2025-05-25 14:52:54,871	WARNING packaging.py:417 -- File /home/leo-liao/code/open-source/develop/kuberay/.git/objects/pack/pack-9898c38b0e9eb5501aa3365eb2e0256dc4b84c93.pack is very large (152.30MiB). Consider adding this file to the 'excludes' list to skip uploading it: `ray.init(..., runtime_env={'excludes': ['/home/leo-liao/code/open-source/develop/kuberay/.git/objects/pack/pack-9898c38b0e9eb5501aa3365eb2e0256dc4b84c93.pack']})`
2025-05-25 14:52:55,121	WARNING packaging.py:417 -- File /home/leo-liao/code/open-source/develop/kuberay/apiserver/pkg/swagger/datafile.go is very large (10.72MiB). Consider adding this file to the 'excludes' list to skip uploading it: `ray.init(..., runtime_env={'excludes': ['/home/leo-liao/code/open-source/develop/kuberay/apiserver/pkg/swagger/datafile.go']})`
[2025-05-25 14:52:55] Handling connection for 8265
Traceback (most recent call last):
  File "/home/leo-liao/code/open-source/develop/kuberay-env/bin/ray", line 8, in <module>
[2025-05-25 14:52:55] 2025-05-25 14:52:53,632	INFO cli.py:41 -- Job submission server address: http://localhost:8265
    sys.exit(main())
             ^^^^^^
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/ray/scripts/scripts.py", line 2800, in main
    return cli()
           ^^^^^
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/ray/dashboard/modules/job/cli_utils.py", line 54, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/ray/autoscaler/_private/cli_logger.py", line 823, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/ray/dashboard/modules/job/cli.py", line 278, in submit
    job_id = client.submit_job(
             ^^^^^^^^^^^^^^^^^^
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/ray/dashboard/modules/job/sdk.py", line 210, in submit_job
    self._upload_working_dir_if_needed(runtime_env)
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/ray/dashboard/modules/dashboard_sdk.py", line 398, in _upload_working_dir_if_needed
    upload_working_dir_if_needed(runtime_env, upload_fn=_upload_fn)
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/ray/_private/runtime_env/working_dir.py", line 98, in upload_working_dir_if_needed
    upload_fn(working_dir, excludes=excludes)
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/ray/dashboard/modules/dashboard_sdk.py", line 391, in _upload_fn
    self._upload_package_if_needed(
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/ray/dashboard/modules/dashboard_sdk.py", line 377, in _upload_package_if_needed
    self._upload_package(
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/ray/dashboard/modules/dashboard_sdk.py", line 358, in _upload_package
    self._raise_error(r)
  File "/home/leo-liao/code/open-source/develop/kuberay-env/lib/python3.12/site-packages/ray/dashboard/modules/dashboard_sdk.py", line 283, in _raise_error
    raise RuntimeError(
RuntimeError: Request failed with status code 500: Traceback (most recent call last): <-----
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/modules/job/job_head.py", line 313, in upload_package
    data = await req.read()
  File "/home/ray/anaconda3/lib/python3.9/site-packages/aiohttp/web_request.py", line 669, in read
    raise HTTPRequestEntityTooLarge(
aiohttp.web_exceptions.HTTPRequestEntityTooLarge: Request Entity Too Large
.
Error: ray job submit command failed: exit status 1
```

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
