### PR TITLE
[Test][Autoscaler] Add an E2E test for placement groups

### DIFF
--- a/ray-operator/test/e2eautoscaler/check_placement_group_ready.py
+++ b/ray-operator/test/e2eautoscaler/check_placement_group_ready.py
@@ -1,0 +1,10 @@
+import ray
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--name', type=str, default='detached_pg')
+args = parser.parse_args()
+
+ray.init(namespace="pg_namespace")
+pg = ray.util.get_placement_group(args.name)
+ray.get(pg.ready())

--- a/ray-operator/test/e2eautoscaler/create_detached_placement_group.py
+++ b/ray-operator/test/e2eautoscaler/create_detached_placement_group.py
@@ -1,0 +1,13 @@
+import ray
+import argparse
+from ray.util.placement_group import placement_group
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--name', type=str, default='detached_pg')
+parser.add_argument('--num-cpus-per-bundle', type=int, default=1)
+parser.add_argument('--num-bundles', type=int, default=1)
+parser.add_argument('--strategy', type=str, default='STRICT_PACK')
+args = parser.parse_args()
+
+ray.init(namespace="pg_namespace")
+pg = placement_group([{"CPU": args.num_cpus_per_bundle}] * args.num_bundles, strategy=args.strategy, lifetime="detached", name=args.name)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

This PR adds autoscaler e2e tests for basic placement group scenarios:

1. Test that the autoscaler can launch nodes for placement groups (STRICT_PACK, PACK, STRICT_SPREAD, SPREAD).
2. Test that the autoscaler can recover nodes for placement groups if nodes are dead.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/3619

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
