### PR TITLE
[Grafana] Add flag for enabling auto load dashboards

### DIFF
--- a/install/prometheus/install.sh
+++ b/install/prometheus/install.sh
@@ -6,6 +6,10 @@ AUTO_LOAD_DASHBOARD=false
 while [[ $# -gt 0 ]]; do
   case $1 in
     --auto-load-dashboard)
+      if [[ "$2" != "true" && "$2" != "false" ]]; then
+        echo "Error: --auto-load-dashboard value must be 'true' or 'false'"
+        exit 1
+      fi
       AUTO_LOAD_DASHBOARD="$2"
       shift 2
       ;;

--- a/install/prometheus/install.sh
+++ b/install/prometheus/install.sh
@@ -1,7 +1,24 @@
 #!/bin/bash
 
+# Parse command line arguments
+AUTO_LOAD_DASHBOARD=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --auto-load-dashboard)
+      AUTO_LOAD_DASHBOARD="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option $1"
+      echo "Usage: $0 [--auto-load-dashboard true|false]"
+      exit 1
+      ;;
+  esac
+done
+
 set -x
-set errexit
+set -e
 
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
@@ -12,10 +29,14 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 # Install the kube-prometheus-stack v48.2.1 helm chart with `overrides.yaml` file.
 # https://github.com/prometheus-community/helm-charts/tree/kube-prometheus-stack-48.2.1/charts/kube-prometheus-stack
 kubectl create namespace prometheus-system
-kubectl create configmap grafana-dashboards --from-file="$DIR/../../config/grafana/" --dry-run=client -o yaml | sed -e '/^metadata:/ a\
+
+# Conditionally create grafana dashboards configmap based on the --auto-load-dashboard flag
+if [[ "$AUTO_LOAD_DASHBOARD" == "true" ]]; then
+  kubectl create configmap grafana-dashboards --from-file="$DIR/../../config/grafana/" --dry-run=client -o yaml | sed -e '/^metadata:/ a\
   namespace: prometheus-system\
   labels:\
     grafana_dashboard: "1"' | kubectl create -f -
+fi
 
 helm --namespace prometheus-system install prometheus prometheus-community/kube-prometheus-stack --version 48.2.1 -f "${DIR}"/overrides.yaml
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Some users might using different version of Ray do so we should let user decide if they want to load dashboard automatically or not. So the flag is added.

Usage: `./install/prometheus/install.sh [--auto-load-dashboard true|false]`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/pull/53256#issuecomment-2908057759
#3650 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
