### PR TITLE
Support custom resource configuration for the submit pod

### DIFF
--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -96,6 +96,15 @@ type SubmitterConfig struct {
 	// BackoffLimit of the submitter k8s job.
 	// +optional
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
+	// +optional
+	Resources *SubmitterResources `json:"resources,omitempty"`
+}
+
+type SubmitterResources struct {
+	// +optional
+	Requests *corev1.ResourceList `json:"requests,omitempty"`
+	// +optional
+	Limits *corev1.ResourceList `json:"limits,omitempty"`
 }
 
 // RayJobSpec defines the desired state of RayJob

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -8077,6 +8077,25 @@ spec:
                   backoffLimit:
                     format: int32
                     type: integer
+                  resources:
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
                 type: object
               submitterPodTemplate:
                 properties:

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -123,8 +123,8 @@ func GetK8sJobCommand(rayJobInstance *rayv1.RayJob) ([]string, error) {
 }
 
 // GetDefaultSubmitterTemplate creates a default submitter template for the Ray job.
-func GetDefaultSubmitterTemplate(rayClusterInstance *rayv1.RayCluster) corev1.PodTemplateSpec {
-	return corev1.PodTemplateSpec{
+func GetDefaultSubmitterTemplate(rayClusterInstance *rayv1.RayCluster, rayJob *rayv1.RayJob) corev1.PodTemplateSpec {
+	pod := corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
@@ -146,4 +146,13 @@ func GetDefaultSubmitterTemplate(rayClusterInstance *rayv1.RayCluster) corev1.Po
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
+	if rayJob != nil && rayJob.Spec.SubmitterConfig != nil && rayJob.Spec.SubmitterConfig.Resources != nil {
+		if rayJob.Spec.SubmitterConfig.Resources.Requests != nil {
+			pod.Spec.Containers[0].Resources.Requests = *rayJob.Spec.SubmitterConfig.Resources.Requests
+		}
+		if rayJob.Spec.SubmitterConfig.Resources.Limits != nil {
+			pod.Spec.Containers[0].Resources.Limits = *rayJob.Spec.SubmitterConfig.Resources.Limits
+		}
+	}
+	return pod
 }

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -527,7 +527,7 @@ func getSubmitterTemplate(ctx context.Context, rayJobInstance *rayv1.RayJob, ray
 
 	// Set the default value for the optional field SubmitterPodTemplate if not provided.
 	if rayJobInstance.Spec.SubmitterPodTemplate == nil {
-		submitterTemplate = common.GetDefaultSubmitterTemplate(rayClusterInstance)
+		submitterTemplate = common.GetDefaultSubmitterTemplate(rayClusterInstance, rayJobInstance)
 		logger.Info("default submitter template is used")
 	} else {
 		submitterTemplate = *rayJobInstance.Spec.SubmitterPodTemplate.DeepCopy()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR introduces support for customizing resource requests and limits for the submit pod.

1. In CPU-constrained clusters, users may wish to reduce the submit pod's CPU request (e.g., to 400m) to avoid scheduling delays or resource exhaustion. Previously, adjusting submit pod resources required modifying the codebase and rebuilding the binary, which was inconvenient and error-prone.

2. For large-scale clusters with high task throughput, the ability to configure submit pod resources dynamically is essential for stability and operational flexibility.

3. The community-provided default `submitterTemplate` requires users to fully override the entire pod spec — including image name, startup arguments, and other fields — even when they only want to change the resource settings. This is unnecessarily complex for most use cases where only minor adjustments to resource limits are needed.

This enhancement provides a cleaner and more configurable approach to submit pod resource tuning.

We can use the rayjob like 

```
apiVersion: ray.io/v1
kind: RayJob
metadata:
  name: rayjob-sample
spec:
  submitterConfig:
    resources:
      requests:
        cpu: "250m"
        memory: "256Mi"
      limits:
        cpu: "500m"
        memory: "512Mi"
  runtimeEnvYAML: |
    pip:
      - requests==2.26.0
      - pendulum==2.1.2
    env_vars:
      counter_name: "test_counter"

  rayClusterSpec:
    rayVersion: '2.41.0' # should match the Ray version in the image of the containers
    # Ray head pod template
    headGroupSpec:
      # The `rayStartParams` are used to configure the `ray start` command.
      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
      rayStartParams: {}
      #pod template
      template:
        spec:
          containers:
            - name: ray-head
              image: harbor.weizhipin.com/arsenal-oceanus/ray:2.41.0
              ports:
                - containerPort: 6379
                  name: gcs-server
                - containerPort: 8265 # Ray dashboard
                  name: dashboard
                - containerPort: 10001
                  name: client
              resources:
                limits:
                  cpu: "1"
                requests:
                  cpu: "200m"
              volumeMounts:
                - mountPath: /home/ray/samples
                  name: code-sample
          volumes:
            # You set volumes at the Pod level, then mount them into containers inside that Pod
            - name: code-sample
              configMap:
                # Provide the name of the ConfigMap you want to mount.
                name: ray-job-code-sample
                # An array of keys from the ConfigMap to create as files
                items:
                  - key: sample_code.py
                    path: sample_code.py
    workerGroupSpecs:
      # the pod replicas in this group typed worker
      - replicas: 1
        minReplicas: 1
        maxReplicas: 5
        # logical group name, for this called small-group, also can be functional
        groupName: small-group
        rayStartParams: {}
        #pod template
        template:
          spec:
            containers:
              - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                image: harbor.weizhipin.com/arsenal-oceanus/ray:2.41.0
                resources:
                  limits:
                    cpu: "1"
                  requests:
                    cpu: "200m"

######################Ray code sample#################################
# this sample is from https://docs.ray.io/en/latest/cluster/job-submission.html#quick-start-example
# it is mounted into the container and executed to show the Ray job at work
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: ray-job-code-sample
data:
  sample_code.py: |
    import ray
    import os
    import requests

    ray.init()

    @ray.remote
    class Counter:
        def __init__(self):
            # Used to verify runtimeEnv
            self.name = os.getenv("counter_name")
            assert self.name == "test_counter"
            self.counter = 0

        def inc(self):
            self.counter += 1

        def get_counter(self):
            return "{} got {}".format(self.name, self.counter)

    counter = Counter.remote()

    for _ in range(5):
        ray.get(counter.inc.remote())
        print(ray.get(counter.get_counter.remote()))

    # Verify that the correct runtime env was used for the job.
    assert requests.__version__ == "2.26.0"
```

## Checks

- [✅ ] I've made sure the tests are passing.