### PR TITLE
Fix issue where unescaped semicolons caused task execution failures.

### DIFF
--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -116,6 +116,7 @@ func GetK8sJobCommand(rayJobInstance *rayv1.RayJob) ([]string, error) {
 	}
 
 	// "--" is used to separate the entrypoint from the Ray Job CLI command and its arguments.
+	entrypoint = strings.ReplaceAll(entrypoint, ";", "\\;")
 	k8sJobCommand = append(k8sJobCommand, "--", entrypoint, ";", "fi", ";")
 	k8sJobCommand = append(k8sJobCommand, jobFollowCommand...)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Closes #3561

<!-- Please give a short summary of the change and the problem this solves. -->

My rayjob full yaml is 
```
apiVersion: ray.io/v1
kind: RayJob
metadata:
  name: rayjob-sample
spec:
  entrypoint: echo aaa ; python /home/ray/samples/sample_code.py
  runtimeEnvYAML: |
    pip:
      - requests==2.26.0
      - pendulum==2.1.2
    env_vars:
      counter_name: "test_counter"

  rayClusterSpec:
    rayVersion: '2.41.0' # should match the Ray version in the image of the containers
    headGroupSpec:
      rayStartParams: {}
      template:
        spec:
          containers:
            - name: ray-head
              image: harbor.weizhipin.com/arsenal-oceanus/ray:2.41.0
              ports:
                - containerPort: 6379
                  name: gcs-server
                - containerPort: 8265 # Ray dashboard
                  name: dashboard
                - containerPort: 10001
                  name: client
              resources:
                limits:
                  cpu: "1"
                requests:
                  cpu: "200m"
              volumeMounts:
                - mountPath: /home/ray/samples
                  name: code-sample
          volumes:
            - name: code-sample
              configMap:
                # Provide the name of the ConfigMap you want to mount.
                name: ray-job-code-sample
                # An array of keys from the ConfigMap to create as files
                items:
                  - key: sample_code.py
                    path: sample_code.py
    workerGroupSpecs:
      - replicas: 1
        minReplicas: 1
        maxReplicas: 5
        # logical group name, for this called small-group, also can be functional
        groupName: small-group
        rayStartParams: {}
        #pod template
        template:
          spec:
            containers:
              - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                image: harbor.weizhipin.com/arsenal-oceanus/ray:2.41.0
                resources:
                  limits:
                    cpu: "1"
                  requests:
                    cpu: "200m"

######################Ray code sample#################################
# this sample is from https://docs.ray.io/en/latest/cluster/job-submission.html#quick-start-example
# it is mounted into the container and executed to show the Ray job at work
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: ray-job-code-sample
data:
  sample_code.py: |
    import ray
    import os
    import requests

    ray.init()

    @ray.remote
    class Counter:
        def __init__(self):
            # Used to verify runtimeEnv
            self.name = os.getenv("counter_name")
            assert self.name == "test_counter"
            self.counter = 0

        def inc(self):
            self.counter += 1

        def get_counter(self):
            return "{} got {}".format(self.name, self.counter)

    counter = Counter.remote()

    for _ in range(5):
        ray.get(counter.inc.remote())
        print(ray.get(counter.get_counter.remote()))

    # Verify that the correct runtime env was used for the job.
    assert requests.__version__ == "2.26.0"
```

The output is :
```
2025-05-26 00:42:02,166	INFO cli.py:39 -- Job submission server address: http://rayjob-sample-jnk9b-head-svc.default.svc.cluster.local:8265
2025-05-26 00:42:02,690	SUCC cli.py:63 -- ------------------------------------------------
2025-05-26 00:42:02,690	SUCC cli.py:64 -- Job 'rayjob-sample-wrgb2' submitted successfully
2025-05-26 00:42:02,690	SUCC cli.py:65 -- ------------------------------------------------
2025-05-26 00:42:02,690	INFO cli.py:289 -- Next steps
2025-05-26 00:42:02,690	INFO cli.py:290 -- Query the logs of the job:
2025-05-26 00:42:02,690	INFO cli.py:292 -- ray job logs rayjob-sample-wrgb2
2025-05-26 00:42:02,690	INFO cli.py:294 -- Query the status of the job:
2025-05-26 00:42:02,690	INFO cli.py:296 -- ray job status rayjob-sample-wrgb2
2025-05-26 00:42:02,690	INFO cli.py:298 -- Request the job to be stopped:
2025-05-26 00:42:02,690	INFO cli.py:300 -- ray job stop rayjob-sample-wrgb2
python: can't open file '/home/ray/samples/sample_code.py': [Errno 2] No such file or directory
```

After this PR ,the rayjob can work and succeed

## Checks

- [✅ ] I've made sure the tests are passing.
