### PR TITLE
[Test] Fix unknown field warning by adding FieldValidationIgnore to Update call

### DIFF
--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -332,7 +332,7 @@ func TestRayClusterAutoscalerMinReplicasUpdate(t *testing.T) {
 			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 			rayCluster.Spec.WorkerGroupSpecs[0].MinReplicas = ptr.To(int32(2))
-			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(test.Ctx(), rayCluster, metav1.UpdateOptions{})
+			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(test.Ctx(), rayCluster, metav1.UpdateOptions{FieldValidation: metav1.FieldValidationIgnore})
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 			LogWithTimestamp(test.T(), "Updated RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
 
@@ -435,7 +435,7 @@ func TestRayClusterAutoscalerMaxReplicasUpdate(t *testing.T) {
 				rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				rayCluster.Spec.WorkerGroupSpecs[0].MaxReplicas = ptr.To(rtc.updatedMax)
-				rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(test.Ctx(), rayCluster, metav1.UpdateOptions{})
+				rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(test.Ctx(), rayCluster, metav1.UpdateOptions{FieldValidation: metav1.FieldValidationIgnore})
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 
 				// Check that replicas is set to the updatedMax


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- The following warning was being emitted during tests using the Update() method on RayCluster:
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/0d6582ca-953a-4e0d-a38f-45b95e5ff89f" />

- This is because `.Update()` sends the full object including fields like `creationTimestamp`, which are managed by the Kubernetes API server and not expected in the spec. Unlike Apply(), the Update method doesn't omit empty or unset fields.

```go
UpdateOptions{FieldValidation: metav1.FieldValidationIgnore}
```
- to the Update() call, which suppresses warnings about unknown fields while preserving the intended behavior.

#### ref
- https://github.com/kubernetes-sigs/controller-runtime/blob/7dfd3bb8edf29e12173a8c9b5843c2dced106955/pkg/client/options.go#L737-L753

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
