### PR TITLE
[Test][Autoscaler] shorter idle timeouts in autoscaler E2E tests for faster scaling down

### DIFF
--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -53,6 +53,8 @@ func TestRayClusterAutoscaler(t *testing.T) {
 		test.T().Run(tc.name, func(_ *testing.T) {
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
+				WithAutoscalerOptions(rayv1ac.AutoscalerOptions().
+					WithIdleTimeoutSeconds(10)).
 				WithRayVersion(GetRayVersion()).
 				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 					WithRayStartParams(map[string]string{"num-cpus": "0"}).
@@ -121,6 +123,8 @@ func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
 		test.T().Run(tc.name, func(_ *testing.T) {
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
+				WithAutoscalerOptions(rayv1ac.AutoscalerOptions().
+					WithIdleTimeoutSeconds(10)).
 				WithRayVersion(GetRayVersion()).
 				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 					WithRayStartParams(map[string]string{"num-cpus": "0"}).
@@ -184,6 +188,8 @@ func TestRayClusterAutoscalerWithCustomResource(t *testing.T) {
 
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
+				WithAutoscalerOptions(rayv1ac.AutoscalerOptions().
+					WithIdleTimeoutSeconds(10)).
 				WithRayVersion(GetRayVersion()).
 				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 					WithRayStartParams(map[string]string{"num-cpus": "0"}).
@@ -308,6 +314,8 @@ func TestRayClusterAutoscalerMinReplicasUpdate(t *testing.T) {
 
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
+				WithAutoscalerOptions(rayv1ac.AutoscalerOptions().
+					WithIdleTimeoutSeconds(10)).
 				WithRayVersion(GetRayVersion()).
 				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 					WithRayStartParams(map[string]string{"num-cpus": "0"}).
@@ -398,6 +406,8 @@ func TestRayClusterAutoscalerMaxReplicasUpdate(t *testing.T) {
 
 				rayClusterSpecAC := rayv1ac.RayClusterSpec().
 					WithEnableInTreeAutoscaling(true).
+					WithAutoscalerOptions(rayv1ac.AutoscalerOptions().
+						WithIdleTimeoutSeconds(10)).
 					WithRayVersion(GetRayVersion()).
 					WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 						WithRayStartParams(map[string]string{"num-cpus": "0"}).
@@ -557,6 +567,8 @@ func TestRayClusterAutoscalerGPUNodesForCPUTasks(t *testing.T) {
 
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
+				WithAutoscalerOptions(rayv1ac.AutoscalerOptions().
+					WithIdleTimeoutSeconds(10)).
 				WithRayVersion(GetRayVersion()).
 				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 					WithRayStartParams(map[string]string{"num-cpus": "0"}).


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
