### PR TITLE
Add default Ray node label info to Ray Pod environment

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -1048,11 +1048,6 @@ func addDefaultRayNodeLabels(pod *corev1.Pod) {
 			Name:  "RAY_NODE_MARKET_TYPE",
 			Value: getRayMarketTypeFromNodeSelector(pod),
 		},
-		// used to set the ray.io/node-group node label
-		corev1.EnvVar{
-			Name:  "RAY_NODE_GROUP",
-			Value: pod.Labels[utils.RayNodeGroupLabelKey],
-		},
 		// uses downward api to set the ray.io/availability-zone node label
 		corev1.EnvVar{
 			Name: "RAY_NODE_ZONE",

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -493,7 +493,7 @@ func BuildPod(ctx context.Context, podTemplateSpec corev1.PodTemplateSpec, rayNo
 		initLivenessAndReadinessProbe(&pod.Spec.Containers[utils.RayContainerIndex], rayNodeType, creatorCRDType)
 	}
 
-	// add downward API environment variables for Ray default node labels
+	// Add downward API environment variables for Ray's default node labels for Ray label-based scheduling.
 	addDefaultRayNodeLabels(&pod)
 
 	return pod

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1955,10 +1955,10 @@ func TestAddDefaultRayNodeLabels_GKESpot(t *testing.T) {
 	}
 
 	addDefaultRayNodeLabels(pod)
-	envs := pod.Spec.Containers[0].Env
-	assertEnvContains(t, envs, "RAY_NODE_MARKET_TYPE", "spot")
-	assertEnvFromFieldRef(t, envs, "RAY_NODE_REGION", "metadata.labels['topology.kubernetes.io/region']")
-	assertEnvFromFieldRef(t, envs, "RAY_NODE_ZONE", "metadata.labels['topology.kubernetes.io/zone']")
+	rayContainer := pod.Spec.Containers[utils.RayContainerIndex]
+	checkContainerEnv(t, rayContainer, "RAY_NODE_MARKET_TYPE", "spot")
+	checkContainerEnv(t, rayContainer, "RAY_NODE_REGION", "metadata.labels['topology.kubernetes.io/region']")
+	checkContainerEnv(t, rayContainer, "RAY_NODE_ZONE", "metadata.labels['topology.kubernetes.io/zone']")
 }
 
 func TestAddDefaultRayNodeLabels_EKSSpot(t *testing.T) {
@@ -1981,33 +1981,8 @@ func TestAddDefaultRayNodeLabels_EKSSpot(t *testing.T) {
 	}
 
 	addDefaultRayNodeLabels(pod)
-	envs := pod.Spec.Containers[0].Env
-	assertEnvContains(t, envs, "RAY_NODE_MARKET_TYPE", "spot")
-	assertEnvContains(t, envs, "RAY_NODE_GROUP", "test-worker-group-2")
-	assertEnvFromFieldRef(t, envs, "RAY_NODE_REGION", "metadata.labels['topology.kubernetes.io/region']")
-	assertEnvFromFieldRef(t, envs, "RAY_NODE_ZONE", "metadata.labels['topology.kubernetes.io/zone']")
-}
-
-func assertEnvContains(t *testing.T, envs []corev1.EnvVar, name, expectedValue string) {
-	for _, envVar := range envs {
-		if envVar.Name == name {
-			assert.Equal(t, expectedValue, envVar.Value, "unexpected value in Environment %s", name)
-			return
-		}
-	}
-	t.Errorf("env var %s not found", name)
-}
-
-func assertEnvFromFieldRef(t *testing.T, envs []corev1.EnvVar, name, expectedFieldPath string) {
-	for _, envVar := range envs {
-		if envVar.Name == name {
-			if envVar.ValueFrom != nil && envVar.ValueFrom.FieldRef != nil {
-				assert.Equal(t, expectedFieldPath, envVar.ValueFrom.FieldRef.FieldPath, "unexpected FieldPath for %s", name)
-				return
-			}
-			t.Errorf("env var %s does not have ValueFrom.FieldRef", name)
-			return
-		}
-	}
-	t.Errorf("env var %s not found", name)
+	rayContainer := pod.Spec.Containers[utils.RayContainerIndex]
+	checkContainerEnv(t, rayContainer, "RAY_NODE_MARKET_TYPE", "spot")
+	checkContainerEnv(t, rayContainer, "RAY_NODE_REGION", "metadata.labels['topology.kubernetes.io/region']")
+	checkContainerEnv(t, rayContainer, "RAY_NODE_ZONE", "metadata.labels['topology.kubernetes.io/zone']")
 }

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1935,6 +1935,182 @@ func TestSetAutoscalerV2EnvVars(t *testing.T) {
 	}
 }
 
+func TestGetPodMarketTypeFromNodeSelector(t *testing.T) {
+	tests := []struct {
+		name         string
+		nodeSelector map[string]string
+		expectedType utils.PodMarketType
+	}{
+		{
+			name:         "GKE spot instance",
+			nodeSelector: map[string]string{utils.GKESpotLabel: "true"},
+			expectedType: utils.SpotMarketType,
+		},
+		{
+			name:         "EKS spot instance",
+			nodeSelector: map[string]string{utils.EKSCapacityTypeLabel: "SPOT"},
+			expectedType: utils.SpotMarketType,
+		},
+		{
+			name:         "on-demand instance (no selector provided)",
+			nodeSelector: nil,
+			expectedType: utils.OnDemandMarketType,
+		},
+		{
+			name:         "on-demand instance (non-spot selector provided)",
+			nodeSelector: map[string]string{"some-label": "value"},
+			expectedType: utils.OnDemandMarketType,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualType := getPodMarketTypeFromNodeSelector(tt.nodeSelector)
+			if actualType != tt.expectedType {
+				t.Errorf("got market-type %v, but expected %v", actualType, tt.expectedType)
+			}
+		})
+	}
+}
+
+func TestGetPodMarketTypeFromNodeAffinity(t *testing.T) {
+	tests := []struct {
+		name         string
+		nodeAffinity *corev1.NodeAffinity
+		expectedType utils.PodMarketType
+	}{
+		{
+			name: "GKE spot instance from nodeAffinity",
+			nodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      utils.GKESpotLabel,
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"true"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedType: utils.SpotMarketType,
+		},
+		{
+			name: "EKS spot instance from nodeAffinity",
+			nodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      utils.EKSCapacityTypeLabel,
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"SPOT"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedType: utils.SpotMarketType,
+		},
+		{
+			name:         "nil nodeAffinity",
+			nodeAffinity: nil,
+			expectedType: utils.OnDemandMarketType,
+		},
+		{
+			name: "nodeAffinity with other selectors provided",
+			nodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      "region",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"us-west4"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedType: utils.OnDemandMarketType,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualType := getPodMarketTypeFromNodeAffinity(tt.nodeAffinity)
+			if actualType != tt.expectedType {
+				t.Errorf("got market-type %v, but expected %v", actualType, tt.expectedType)
+			}
+		})
+	}
+}
+
+func TestGetPodMarketType(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *corev1.Pod
+		expectedType utils.PodMarketType
+	}{
+		{
+			name: "GKE spot instance from nodeSelector",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						utils.GKESpotLabel: "true",
+					},
+				},
+			},
+			expectedType: utils.SpotMarketType,
+		},
+		{
+			name: "EKS spot from nodeAffinity when nodeSelector missing",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "eks-spot"},
+				Spec: corev1.PodSpec{
+					NodeSelector: nil,
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      utils.EKSCapacityTypeLabel,
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"SPOT"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedType: utils.SpotMarketType,
+		},
+		{
+			name:         "No nodeSelectors or nodeAffinity provided",
+			pod:          &corev1.Pod{},
+			expectedType: utils.OnDemandMarketType,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			marketType := getPodMarketType(tt.pod)
+			if marketType != tt.expectedType {
+				t.Errorf("got market-type of %v, but expected %v", marketType, tt.expectedType)
+			}
+		})
+	}
+}
+
 func TestAddDefaultRayNodeLabels_GKESpot(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1982,7 +2158,7 @@ func TestAddDefaultRayNodeLabels_EKSSpot(t *testing.T) {
 
 	addDefaultRayNodeLabels(pod)
 	rayContainer := pod.Spec.Containers[utils.RayContainerIndex]
-	checkContainerEnv(t, rayContainer, "RAY_NODE_MARKET_TYPE", "spot")
-	checkContainerEnv(t, rayContainer, "RAY_NODE_REGION", "metadata.labels['topology.kubernetes.io/region']")
-	checkContainerEnv(t, rayContainer, "RAY_NODE_ZONE", "metadata.labels['topology.kubernetes.io/zone']")
+	checkContainerEnv(t, rayContainer, utils.RayNodeMarketType, "spot")
+	checkContainerEnv(t, rayContainer, utils.RayNodeRegion, "metadata.labels['topology.kubernetes.io/region']")
+	checkContainerEnv(t, rayContainer, utils.RayNodeZone, "metadata.labels['topology.kubernetes.io/zone']")
 }

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -225,11 +225,13 @@ const (
 	// Minus 6 since we append 6 characters to the RayJob name to create the cluster (GenerateRayClusterName).
 	MaxRayJobNameLength = MaxRayClusterNameLength - 6
 
-	RayNodeMarketType    = "RAY_NODE_MARKET_TYPE"
-	RayNodeZone          = "RAY_NODE_ZONE"
-	RayNodeRegion        = "RAY_NODE_REGION"
-	GKESpotLabel         = "cloud.google.com/gke-spot"
-	EKSCapacityTypeLabel = "eks.amazonaws.com/capacityType"
+	RayNodeMarketType      = "RAY_NODE_MARKET_TYPE"
+	RayNodeZone            = "RAY_NODE_ZONE"
+	RayNodeRegion          = "RAY_NODE_REGION"
+	GKESpotLabel           = "cloud.google.com/gke-spot"
+	EKSCapacityTypeLabel   = "eks.amazonaws.com/capacityType"
+	K8sTopologyRegionLabel = "topology.kubernetes.io/region"
+	K8sTopologyZoneLabel   = "topology.kubernetes.io/zone"
 )
 
 type PodMarketType string

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -224,6 +224,19 @@ const (
 	// MaxRayJobNameLength is the maximum RayJob name to make sure it pass the RayCluster validation
 	// Minus 6 since we append 6 characters to the RayJob name to create the cluster (GenerateRayClusterName).
 	MaxRayJobNameLength = MaxRayClusterNameLength - 6
+
+	RayNodeMarketType    = "RAY_NODE_MARKET_TYPE"
+	RayNodeZone          = "RAY_NODE_ZONE"
+	RayNodeRegion        = "RAY_NODE_REGION"
+	GKESpotLabel         = "cloud.google.com/gke-spot"
+	EKSCapacityTypeLabel = "eks.amazonaws.com/capacityType"
+)
+
+type PodMarketType string
+
+const (
+	SpotMarketType     PodMarketType = "spot"
+	OnDemandMarketType PodMarketType = "on-demand"
 )
 
 type ServiceType string


### PR DESCRIPTION
Add default Ray node label info to Ray Pod environment

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds market-type information for different cloud providers to the Ray pod environment based on the provided `nodeSelector` value. This PR also adds environment variables to pass region and zone information using downward API (https://github.com/kubernetes/kubernetes/pull/127092). These environment variables will be used in Ray core to set default Ray node labels.

I'll add a comment below with my manual test results with propagating `topology.k8s.io/region` and `topology.k8s.io/zone` on a GKE v1.33 alpha cluster.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/51564

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
