### PR TITLE
[Test][Autoscaler] deflaky unexpected dead actors in tests by higher resource requests

### DIFF
--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go
@@ -20,24 +20,23 @@ import (
 func TestRayClusterAutoscalerV2IdleTimeout(t *testing.T) {
 	// Only test with the V2 Autoscaler
 	tc := tests[1]
+	t.Run(tc.name, func(t *testing.T) {
+		test := With(t)
+		g := gomega.NewWithT(t)
 
-	test := With(t)
-	g := gomega.NewWithT(t)
+		// Create a namespace
+		namespace := test.NewTestNamespace()
 
-	// Create a namespace
-	namespace := test.NewTestNamespace()
+		idleTimeoutShort := int32(10)
+		idleTimeoutLong := int32(30)
+		timeoutBuffer := int32(20) // Additional wait time to allow for scale down operation
 
-	idleTimeoutShort := int32(10)
-	idleTimeoutLong := int32(30)
-	timeoutBuffer := int32(20) // Additional wait time to allow for scale down operation
+		// Script for creating detached actors to trigger autoscaling
+		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
+		scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
-	// Script for creating detached actors to trigger autoscaling
-	scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
-	scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
-
-	test.T().Run(tc.name, func(_ *testing.T) {
 		groupName1 := "short-idle-timeout-group"
 		groupName2 := "long-idle-timeout-group"
 		rayClusterSpecAC := rayv1ac.RayClusterSpec().
@@ -103,20 +102,19 @@ func TestRayClusterAutoscalerV2IdleTimeout(t *testing.T) {
 // This test verifies that the autoscaler can still trigger GPU nodes for CPU tasks when no CPU-only worker group is defined.
 func TestRayClusterAutoscalerGPUNodesForCPUTasks(t *testing.T) {
 	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := gomega.NewWithT(t)
 
-		test := With(t)
-		g := gomega.NewWithT(t)
+			// Create a namespace
+			namespace := test.NewTestNamespace()
 
-		// Create a namespace
-		namespace := test.NewTestNamespace()
+			// Scripts for creating and terminating detached actors to trigger autoscaling
+			scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
+			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
-		// Scripts for creating and terminating detached actors to trigger autoscaling
-		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
-		scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
-
-		test.T().Run(tc.name, func(_ *testing.T) {
 			groupName := "gpu-group"
 
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
@@ -178,27 +176,26 @@ func TestRayClusterAutoscalerGPUNodesForCPUTasks(t *testing.T) {
 // 6. We verify that `worker1` should not be terminated, although it is idle for more than the `IdleTimeoutSeconds`, which is 6 seconds.
 func TestRayClusterAutoscalerDoNotRemoveIdlesForPlacementGroup(t *testing.T) {
 	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := gomega.NewWithT(t)
 
-		test := With(t)
-		g := gomega.NewWithT(t)
+			// Create a namespace
+			namespace := test.NewTestNamespace()
 
-		// Create a namespace
-		namespace := test.NewTestNamespace()
+			scriptsAC := newConfigMap(namespace.Name, files(test, "do_not_remove_idles_for_pg.py"))
+			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
-		scriptsAC := newConfigMap(namespace.Name, files(test, "do_not_remove_idles_for_pg.py"))
-		scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
+			workerTemplate := tc.WorkerPodTemplateGetter()
+			workerTemplate.Spec.WithInitContainers(corev1ac.Container().
+				WithName("init-sleep").
+				WithImage(GetRayImage()).
+				// delay the worker startup to make sure it takes longer than the IdleTimeoutSeconds, which is 6 seconds,
+				// and longer than the default autoscaler update interval of 5 seconds.
+				WithCommand("bash", "-c", "sleep 15"))
 
-		workerTemplate := tc.WorkerPodTemplateGetter()
-		workerTemplate.Spec.WithInitContainers(corev1ac.Container().
-			WithName("init-sleep").
-			WithImage(GetRayImage()).
-			// delay the worker startup to make sure it takes longer than the IdleTimeoutSeconds, which is 6 seconds,
-			// and longer than the default autoscaler update interval of 5 seconds.
-			WithCommand("bash", "-c", "sleep 15"))
-
-		test.T().Run(tc.name, func(_ *testing.T) {
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
 				WithRayVersion(GetRayVersion()).
@@ -240,20 +237,19 @@ func TestRayClusterAutoscalerDoNotRemoveIdlesForPlacementGroup(t *testing.T) {
 // This test verifies that the autoscaler can launch nodes to fulfill ray.autoscaler.sdk.request_resources from the user program.
 func TestRayClusterAutoscalerSDKRequestResources(t *testing.T) {
 	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := gomega.NewWithT(t)
 
-		test := With(t)
-		g := gomega.NewWithT(t)
+			// Create a namespace
+			namespace := test.NewTestNamespace()
 
-		// Create a namespace
-		namespace := test.NewTestNamespace()
+			// Mount the call_request_resources.py script as a ConfigMap
+			scriptsAC := newConfigMap(namespace.Name, files(test, "call_request_resources.py"))
+			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
-		// Mount the call_request_resources.py script as a ConfigMap
-		scriptsAC := newConfigMap(namespace.Name, files(test, "call_request_resources.py"))
-		scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
-
-		test.T().Run("Test ray.autoscaler.sdk.request_resources", func(_ *testing.T) {
 			groupName := "request-group"
 
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
@@ -300,20 +296,19 @@ func TestRayClusterAutoscalerSDKRequestResources(t *testing.T) {
 // This test verifies that a new worker node can be launched in a newly added worker group.
 func TestRayClusterAutoscalerAddNewWorkerGroup(t *testing.T) {
 	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := gomega.NewWithT(t)
 
-		test := With(t)
-		g := gomega.NewWithT(t)
+			// Create a namespace
+			namespace := test.NewTestNamespace()
 
-		// Create a namespace
-		namespace := test.NewTestNamespace()
+			// Mount the create_detached_actor.py and terminate_detached_actor.py scripts as a ConfigMap
+			scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
+			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
-		// Mount the create_detached_actor.py and terminate_detached_actor.py scripts as a ConfigMap
-		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
-		scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
-
-		test.T().Run(tc.name, func(_ *testing.T) {
 			cpuGroup := "cpu-group"
 			gpuGroup := "gpu-group"
 

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -208,7 +208,7 @@ func TestRayClusterAutoscalerWithDesiredState(t *testing.T) {
 		test := With(t)
 		g := gomega.NewWithT(t)
 
-		const maxReplica = 3
+		const maxReplica = 2
 		// Set the scale down window to a large enough value, so scale down could be disabled to avoid test flakiness.
 		const scaleDownWaitSec = 3600
 

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -16,19 +16,19 @@ import (
 
 func TestRayClusterAutoscaler(t *testing.T) {
 	for _, tc := range tests {
-		test := With(t)
-		g := gomega.NewWithT(t)
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := gomega.NewWithT(t)
 
-		// Create a namespace
-		namespace := test.NewTestNamespace()
+			// Create a namespace
+			namespace := test.NewTestNamespace()
 
-		// Scripts for creating and terminating detached actors to trigger autoscaling
-		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
-		scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
+			// Scripts for creating and terminating detached actors to trigger autoscaling
+			scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
+			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
-		test.T().Run(tc.name, func(_ *testing.T) {
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
 				WithRayVersion(GetRayVersion()).
@@ -83,20 +83,19 @@ func TestRayClusterAutoscaler(t *testing.T) {
 
 func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
 	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := gomega.NewWithT(t)
 
-		test := With(t)
-		g := gomega.NewWithT(t)
+			// Create a namespace
+			namespace := test.NewTestNamespace()
 
-		// Create a namespace
-		namespace := test.NewTestNamespace()
+			// Scripts for creating and terminating detached actors to trigger autoscaling
+			scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
+			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
-		// Scripts for creating and terminating detached actors to trigger autoscaling
-		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
-		scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
-
-		test.T().Run(tc.name, func(_ *testing.T) {
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
 				WithRayVersion(GetRayVersion()).
@@ -144,20 +143,19 @@ func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
 
 func TestRayClusterAutoscalerWithCustomResource(t *testing.T) {
 	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := gomega.NewWithT(t)
 
-		test := With(t)
-		g := gomega.NewWithT(t)
+			// Create a namespace
+			namespace := test.NewTestNamespace()
 
-		// Create a namespace
-		namespace := test.NewTestNamespace()
+			// Scripts for creating and terminating detached actors to trigger autoscaling
+			scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
+			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
-		// Scripts for creating and terminating detached actors to trigger autoscaling
-		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))
-		scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
-
-		test.T().Run(tc.name, func(_ *testing.T) {
 			groupName := "custom-resource-group"
 
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
@@ -204,24 +202,23 @@ func TestRayClusterAutoscalerWithCustomResource(t *testing.T) {
 
 func TestRayClusterAutoscalerWithDesiredState(t *testing.T) {
 	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := gomega.NewWithT(t)
 
-		test := With(t)
-		g := gomega.NewWithT(t)
+			const maxReplica = 3
+			// Set the scale down window to a large enough value, so scale down could be disabled to avoid test flakiness.
+			const scaleDownWaitSec = 3600
 
-		const maxReplica = 2
-		// Set the scale down window to a large enough value, so scale down could be disabled to avoid test flakiness.
-		const scaleDownWaitSec = 3600
+			// Create a namespace
+			namespace := test.NewTestNamespace()
 
-		// Create a namespace
-		namespace := test.NewTestNamespace()
+			// Scripts for creating and terminating detached actors to trigger autoscaling
+			scriptsAC := newConfigMap(namespace.Name, files(test, "create_concurrent_tasks.py"))
+			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
-		// Scripts for creating and terminating detached actors to trigger autoscaling
-		scriptsAC := newConfigMap(namespace.Name, files(test, "create_concurrent_tasks.py"))
-		scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
-
-		test.T().Run(tc.name, func(_ *testing.T) {
 			groupName := "custom-resource-group"
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
@@ -262,26 +259,24 @@ func TestRayClusterAutoscalerWithDesiredState(t *testing.T) {
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 			g.Expect(pods).To(gomega.HaveLen(maxReplica))
 		})
-
 	}
 }
 
 func TestRayClusterAutoscalerMinReplicasUpdate(t *testing.T) {
 	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := gomega.NewWithT(t)
 
-		test := With(t)
-		g := gomega.NewWithT(t)
+			// Create a namespace
+			namespace := test.NewTestNamespace()
 
-		// Create a namespace
-		namespace := test.NewTestNamespace()
+			// Script for creating detached actors to trigger autoscaling
+			scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py"))
+			scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
 
-		// Script for creating detached actors to trigger autoscaling
-		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py"))
-		scripts, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), scriptsAC, TestApplyOptions)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", scripts.Namespace, scripts.Name)
-
-		test.T().Run(tc.name, func(_ *testing.T) {
 			groupName := "test-group"
 
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().

--- a/ray-operator/test/e2eautoscaler/support.go
+++ b/ray-operator/test/e2eautoscaler/support.go
@@ -105,12 +105,12 @@ func headPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfigura
 				).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("300m"),
-						corev1.ResourceMemory: resource.MustParse("1G"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2G"),
 					}).
 					WithLimits(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
-						corev1.ResourceMemory: resource.MustParse("2G"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("4G"),
 					}))))
 }
 
@@ -130,12 +130,12 @@ func headPodTemplateApplyConfigurationV2() *corev1ac.PodTemplateSpecApplyConfigu
 				WithEnv(corev1ac.EnvVar().WithName(utils.RAY_ENABLE_AUTOSCALER_V2).WithValue("1")).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("300m"),
-						corev1.ResourceMemory: resource.MustParse("1G"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2G"),
 					}).
 					WithLimits(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
-						corev1.ResourceMemory: resource.MustParse("2G"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("4G"),
 					}))))
 }
 
@@ -147,11 +147,11 @@ func workerPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfigu
 				WithImage(GetRayImage()).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("300m"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("1G"),
 					}).
 					WithLimits(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("1G"),
 					}))))
 }
@@ -165,11 +165,11 @@ func workerPodTemplateApplyConfigurationV2() *corev1ac.PodTemplateSpecApplyConfi
 				WithImage(GetRayImage()).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("300m"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("1G"),
 					}).
 					WithLimits(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("1G"),
 					}))))
 }


### PR DESCRIPTION
## Why are these changes needed?

This PR does the following:
1. Raise resource requests used in autoscaler e2e tests to avoid actors being killed.
2. Clean the previous cluster before going to the next sub-test.

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/3701

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
