### PR TITLE
Remove fmt.Println, convert to log

### DIFF
--- a/ray-operator/controllers/ray/common/association.go
+++ b/ray-operator/controllers/ray/common/association.go
@@ -40,13 +40,13 @@ func RayClusterHeadlessServiceListOptions(instance *rayv1.RayCluster) []client.L
 	}
 }
 
-func RayClusterHeadServiceListOptions(instance *rayv1.RayCluster) []client.ListOption {
+func RayClusterHeadServiceListOptions(ctx context.Context, instance *rayv1.RayCluster) []client.ListOption {
 	return []client.ListOption{
 		client.InNamespace(instance.Namespace),
 		client.MatchingLabels(map[string]string{
 			utils.RayClusterLabelKey:  instance.Name,
 			utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
-			utils.RayIDLabelKey:       utils.CheckLabel(utils.GenerateIdentifier(instance.Name, rayv1.HeadNode)),
+			utils.RayIDLabelKey:       utils.CheckLabel(ctx, utils.GenerateIdentifier(instance.Name, rayv1.HeadNode)),
 		}),
 	}
 }

--- a/ray-operator/controllers/ray/common/association_test.go
+++ b/ray-operator/controllers/ray/common/association_test.go
@@ -144,6 +144,8 @@ func TestRayClusterHeadlessServiceListOptions(t *testing.T) {
 }
 
 func TestRayClusterHeadServiceListOptions(t *testing.T) {
+	ctx := context.Background()
+
 	instance := rayv1.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "raycluster",
@@ -151,7 +153,7 @@ func TestRayClusterHeadServiceListOptions(t *testing.T) {
 		},
 	}
 
-	labels := HeadServiceLabels(instance)
+	labels := HeadServiceLabels(ctx, instance)
 	delete(labels, utils.KubernetesCreatedByLabelKey)
 	delete(labels, utils.KubernetesApplicationNameLabelKey)
 
@@ -159,7 +161,7 @@ func TestRayClusterHeadServiceListOptions(t *testing.T) {
 		client.InNamespace(instance.Namespace),
 		client.MatchingLabels(labels),
 	}
-	result := RayClusterHeadServiceListOptions(&instance)
+	result := RayClusterHeadServiceListOptions(ctx, &instance)
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("Expected %v, got %v", expected, result)
 	}

--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -20,7 +20,7 @@ func BuildIngressForHeadService(ctx context.Context, cluster rayv1.RayCluster) (
 
 	labels := map[string]string{
 		utils.RayClusterLabelKey:                cluster.Name,
-		utils.RayIDLabelKey:                     utils.CheckLabel(utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode)),
+		utils.RayIDLabelKey:                     utils.CheckLabel(ctx, utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode)),
 		utils.KubernetesApplicationNameLabelKey: utils.ApplicationName,
 		utils.KubernetesCreatedByLabelKey:       utils.ComponentName,
 	}

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1006,7 +1006,7 @@ func TestHeadPodTemplate_WithAutoscalingEnabled(t *testing.T) {
 	// Repeat ServiceAccountName check with long cluster name.
 	cluster.Name = longString(t) // 200 chars long
 	podTemplateSpec = DefaultHeadPodTemplate(ctx, *cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
-	assert.Equal(t, shortString(t), podTemplateSpec.Spec.ServiceAccountName)
+	assert.Equal(t, shortString(ctx, t), podTemplateSpec.Spec.ServiceAccountName)
 }
 
 func TestDefaultHeadPodTemplate_Autoscaling(t *testing.T) {

--- a/ray-operator/controllers/ray/common/rbac.go
+++ b/ray-operator/controllers/ray/common/rbac.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +57,7 @@ func BuildRole(cluster *rayv1.RayCluster) (*rbacv1.Role, error) {
 }
 
 // BuildRole
-func BuildRoleBinding(cluster *rayv1.RayCluster) (*rbacv1.RoleBinding, error) {
+func BuildRoleBinding(ctx context.Context, cluster *rayv1.RayCluster) (*rbacv1.RoleBinding, error) {
 	serviceAccountName := utils.GetHeadGroupServiceAccountName(cluster)
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -72,7 +73,7 @@ func BuildRoleBinding(cluster *rayv1.RayCluster) (*rbacv1.RoleBinding, error) {
 			{
 				Kind: rbacv1.ServiceAccountKind,
 				// Clip name for consistency with the function reconcileAutoscalerServiceAccount.
-				Name:      utils.CheckName(serviceAccountName),
+				Name:      utils.CheckName(ctx, serviceAccountName),
 				Namespace: cluster.Namespace,
 			},
 		},
@@ -80,7 +81,7 @@ func BuildRoleBinding(cluster *rayv1.RayCluster) (*rbacv1.RoleBinding, error) {
 			APIGroup: rbacv1.GroupName,
 			Kind:     "Role",
 			// Clip name for consistency with the function reconcileAutoscalerRole.
-			Name: utils.CheckName(cluster.Name),
+			Name: utils.CheckName(ctx, cluster.Name),
 		},
 	}
 

--- a/ray-operator/controllers/ray/common/rbac_test.go
+++ b/ray-operator/controllers/ray/common/rbac_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,8 @@ import (
 
 // Test subject and role ref names in the function BuildRoleBinding.
 func TestBuildRoleBindingSubjectAndRoleRefName(t *testing.T) {
+	ctx := context.Background()
+
 	tests := []struct {
 		name  string
 		input *rayv1.RayCluster
@@ -70,15 +73,15 @@ func TestBuildRoleBindingSubjectAndRoleRefName(t *testing.T) {
 				},
 			},
 			want: []string{
-				shortString(t), // 50 chars long, truncated by utils.CheckName
-				shortString(t),
+				shortString(ctx, t), // 50 chars long, truncated by utils.CheckName
+				shortString(ctx, t),
 			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			rb, err := BuildRoleBinding(tc.input)
+			rb, err := BuildRoleBinding(ctx, tc.input)
 			require.NoError(t, err)
 			got := []string{rb.Subjects[0].Name, rb.RoleRef.Name}
 			assert.Equal(t, tc.want, got)

--- a/ray-operator/controllers/ray/common/route.go
+++ b/ray-operator/controllers/ray/common/route.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -11,10 +12,10 @@ import (
 
 // BuildRouteForHeadService Builds the Route (OpenShift) for head service dashboard.
 // This is used to expose dashboard and remote submit service apis or external traffic.
-func BuildRouteForHeadService(cluster rayv1.RayCluster) (*routev1.Route, error) {
+func BuildRouteForHeadService(ctx context.Context, cluster rayv1.RayCluster) (*routev1.Route, error) {
 	labels := map[string]string{
 		utils.RayClusterLabelKey:                cluster.Name,
-		utils.RayIDLabelKey:                     utils.CheckLabel(utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode)),
+		utils.RayIDLabelKey:                     utils.CheckLabel(ctx, utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode)),
 		utils.KubernetesApplicationNameLabelKey: utils.ApplicationName,
 		utils.KubernetesCreatedByLabelKey:       utils.ComponentName,
 	}

--- a/ray-operator/controllers/ray/common/route_test.go
+++ b/ray-operator/controllers/ray/common/route_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +42,7 @@ var instanceWithRouteEnabled = &rayv1.RayCluster{
 }
 
 func TestBuildRouteForHeadService(t *testing.T) {
-	route, err := BuildRouteForHeadService(*instanceWithRouteEnabled)
+	route, err := BuildRouteForHeadService(context.Background(), *instanceWithRouteEnabled)
 	require.NoError(t, err)
 
 	// Test name

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -20,11 +20,11 @@ func getEnableRayHeadClusterIPService() bool {
 }
 
 // HeadServiceLabels returns the default labels for a cluster's head service.
-func HeadServiceLabels(cluster rayv1.RayCluster) map[string]string {
+func HeadServiceLabels(ctx context.Context, cluster rayv1.RayCluster) map[string]string {
 	return map[string]string{
 		utils.RayClusterLabelKey:                cluster.Name,
 		utils.RayNodeTypeLabelKey:               string(rayv1.HeadNode),
-		utils.RayIDLabelKey:                     utils.CheckLabel(utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode)),
+		utils.RayIDLabelKey:                     utils.CheckLabel(ctx, utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode)),
 		utils.KubernetesApplicationNameLabelKey: utils.ApplicationName,
 		utils.KubernetesCreatedByLabelKey:       utils.ComponentName,
 	}
@@ -39,7 +39,7 @@ func BuildServiceForHeadPod(ctx context.Context, cluster rayv1.RayCluster, label
 		labels = make(map[string]string)
 	}
 
-	defaultLabels := HeadServiceLabels(cluster)
+	defaultLabels := HeadServiceLabels(ctx, cluster)
 
 	// selector consists of *only* the keys in defaultLabels, updated with the values in labels if they exist
 	selector := make(map[string]string)
@@ -161,7 +161,7 @@ func BuildHeadServiceForRayService(ctx context.Context, rayService rayv1.RayServ
 		utils.RayOriginatedFromCRNameLabelKey: rayService.Name,
 		utils.RayOriginatedFromCRDLabelKey:    utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
 		utils.RayNodeTypeLabelKey:             string(rayv1.HeadNode),
-		utils.RayIDLabelKey:                   utils.CheckLabel(utils.GenerateIdentifier(rayService.Name, rayv1.HeadNode)),
+		utils.RayIDLabelKey:                   utils.CheckLabel(ctx, utils.GenerateIdentifier(rayService.Name, rayv1.HeadNode)),
 	}
 
 	return service, nil

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -289,6 +289,7 @@ func TestGetServicePortsWithMetricsPort(t *testing.T) {
 }
 
 func TestUserSpecifiedHeadService(t *testing.T) {
+	ctx := context.Background()
 	// Use any RayCluster instance as a base for the test.
 	testRayClusterWithHeadService := instanceWithWrongSvc.DeepCopy()
 
@@ -332,7 +333,7 @@ func TestUserSpecifiedHeadService(t *testing.T) {
 
 	// The selector field should only use the keys from the five default labels.  The values should be updated with the values from the template labels.
 	// The user-provided HeadService labels should be ignored for the purposes of the selector field. The user-provided Selector field should be ignored.
-	defaultLabels := HeadServiceLabels(*testRayClusterWithHeadService)
+	defaultLabels := HeadServiceLabels(ctx, *testRayClusterWithHeadService)
 	// Make sure this test isn't spuriously passing. Check that RayClusterLabelKey is in the default labels.
 	if _, ok := defaultLabels[utils.RayClusterLabelKey]; !ok {
 		t.Errorf("utils.RayClusterLabelKey=%s should be in the default labels", utils.RayClusterLabelKey)

--- a/ray-operator/controllers/ray/common/test_utils.go
+++ b/ray-operator/controllers/ray/common/test_utils.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,8 +24,8 @@ func longString(t *testing.T) string {
 
 // Clip the above string using utils.CheckName
 // to a string of length 50.
-func shortString(t *testing.T) string {
-	result := utils.CheckName(longString(t))
+func shortString(ctx context.Context, t *testing.T) string {
+	result := utils.CheckName(ctx, longString(t))
 	// Confirm length.
 	assert.Len(t, result, 50)
 	return result

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1010,6 +1010,8 @@ func TestReconcile_PodEvicted_DiffLess0_OK(t *testing.T) {
 func TestReconcileHeadService(t *testing.T) {
 	setupTest(t)
 
+	ctx := context.Background()
+
 	// Create a new scheme with CRDs, Pod, Service schemes.
 	newScheme := runtime.NewScheme()
 	_ = rayv1.AddToScheme(newScheme)
@@ -1024,7 +1026,7 @@ func TestReconcileHeadService(t *testing.T) {
 			Labels: map[string]string{
 				utils.RayClusterLabelKey:  cluster.Name,
 				utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
-				utils.RayIDLabelKey:       utils.CheckLabel(utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode)),
+				utils.RayIDLabelKey:       utils.CheckLabel(ctx, utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode)),
 			},
 		},
 	}
@@ -1034,11 +1036,10 @@ func TestReconcileHeadService(t *testing.T) {
 	// Initialize a fake client with newScheme and runtimeObjects.
 	runtimeObjects := []runtime.Object{cluster}
 	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(runtimeObjects...).Build()
-	ctx := context.TODO()
 	headServiceSelector := labels.SelectorFromSet(map[string]string{
 		utils.RayClusterLabelKey:  cluster.Name,
 		utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
-		utils.RayIDLabelKey:       utils.CheckLabel(utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode)),
+		utils.RayIDLabelKey:       utils.CheckLabel(ctx, utils.GenerateIdentifier(cluster.Name, rayv1.HeadNode)),
 	})
 
 	// Initialize RayCluster reconciler.
@@ -1415,6 +1416,8 @@ func TestGetHeadPodIPAndNameFromGetRayClusterHeadPod(t *testing.T) {
 func TestGetHeadServiceIPAndName(t *testing.T) {
 	setupTest(t)
 
+	ctx := context.Background()
+
 	headServiceIP := "1.2.3.4"
 	headService, err := common.BuildServiceForHeadPod(context.Background(), *testRayCluster, nil, nil)
 	if err != nil {
@@ -1429,7 +1432,7 @@ func TestGetHeadServiceIPAndName(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "unexpectedExtraHeadService",
 			Namespace: namespaceStr,
-			Labels:    common.HeadServiceLabels(*testRayCluster),
+			Labels:    common.HeadServiceLabels(ctx, *testRayCluster),
 		},
 	}
 

--- a/ray-operator/controllers/ray/suite_helpers_test.go
+++ b/ray-operator/controllers/ray/suite_helpers_test.go
@@ -2,7 +2,6 @@ package ray
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"reflect"
 	"time"
@@ -232,7 +231,6 @@ func checkServeApplicationExists(ctx context.Context, rayService *rayv1.RayServi
 			return false, err
 		}
 		for appName := range rayService.Status.ActiveServiceStatus.Applications {
-			fmt.Println("checkServeApplicationExists: appName", appName)
 			if appName == serveAppName {
 				return true, nil
 			}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -158,7 +158,7 @@ func CheckRouteName(ctx context.Context, s string, n string) string {
 	}
 
 	// Pass through CheckName for remaining string validations
-	return CheckName(s)
+	return CheckName(ctx, s)
 }
 
 // PodName returns the value that should be used for a Pod's Name or GenerateName
@@ -181,13 +181,14 @@ func PodName(prefix string, nodeType rayv1.RayNodeType, isGenerateName bool) str
 }
 
 // CheckName makes sure the name does not start with a numeric value and the total length is < 63 char
-func CheckName(s string) string {
+func CheckName(ctx context.Context, s string) string {
+	log := ctrl.LoggerFrom(ctx)
 	maxLength := 50 // 63 - (max(8,6) + 5 ) // 6 to 8 char are consumed at the end with "-head-" or -worker- + 5 generated.
 
 	if len(s) > maxLength {
 		// shorten the name
 		offset := int(math.Abs(float64(maxLength) - float64(len(s))))
-		fmt.Printf("pod name is too long: len = %v, we will shorten it by offset = %v", len(s), offset)
+		log.Info("pod name is too long, we will shorten it by offset", "nameLength", len(s), "offset", offset)
 		s = s[offset:]
 	}
 
@@ -198,7 +199,6 @@ func CheckName(s string) string {
 
 	// cannot start with a punctuation
 	if unicode.IsPunct(rune(s[0])) {
-		fmt.Println(s)
 		s = "r" + s[1:]
 	}
 
@@ -206,24 +206,24 @@ func CheckName(s string) string {
 }
 
 // TrimJobName uses CheckLabel to trim Kubernetes job to constrains
-func TrimJobName(jobName string) string {
-	return CheckLabel(jobName)
+func TrimJobName(ctx context.Context, jobName string) string {
+	return CheckLabel(ctx, jobName)
 }
 
 // CheckLabel makes sure the label value does not start with a punctuation and the total length is < 63 char
-func CheckLabel(s string) string {
+func CheckLabel(ctx context.Context, s string) string {
+	log := ctrl.LoggerFrom(ctx)
 	maxLength := 63
 
 	if len(s) > maxLength {
 		// shorten the name
 		offset := int(math.Abs(float64(maxLength) - float64(len(s))))
-		fmt.Printf("label value is too long: len = %v, we will shorten it by offset = %v\n", len(s), offset)
+		log.Info("label value is too long, we will shorten it by offset", "labelLength", len(s), "offset", offset)
 		s = s[offset:]
 	}
 
 	// cannot start with a punctuation
 	if unicode.IsPunct(rune(s[0])) {
-		fmt.Println(s)
 		s = "r" + s[1:]
 	}
 

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -156,6 +156,8 @@ func TestPodName(t *testing.T) {
 }
 
 func TestCheckName(t *testing.T) {
+	ctx := context.Background()
+
 	tests := []struct {
 		name     string
 		input    string
@@ -180,7 +182,7 @@ func TestCheckName(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			str := CheckName(test.input)
+			str := CheckName(ctx, test.input)
 			if str != test.expected {
 				t.Logf("expected: %q", test.expected)
 				t.Logf("actual: %q", str)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I work on some code that integrates with kuberay and we noticed some printlns in the output. I have removed unnecessary printlns and moved useful ones to use the logger so the output will be uniform. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
