### PR TITLE
[Refactor][kubectl-plugin] Share common struct for cluster-related CLI options to reduce duplication

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -94,9 +94,9 @@ func NewCreateWorkerGroupCommand(cmdFactory cmdutil.Factory, streams genericclio
 	cmd.Flags().StringVar(&options.WorkerCPU, "worker-cpu", "2", "number of CPUs in each replica")
 	cmd.Flags().StringVar(&options.WorkerGPU, "worker-gpu", "0", "number of GPUs in each replica")
 	cmd.Flags().StringVar(&options.workerTPU, "worker-tpu", "0", "number of TPUs in each replica")
-	cmd.Flags().StringVar(&options.workerMemory, "worker-memory", "4Gi", "amount of memory in each replica")
+	cmd.Flags().StringVar(&options.WorkerMemory, "worker-memory", "4Gi", "amount of memory in each replica")
 	cmd.Flags().StringToStringVar(&options.rayStartParams, "worker-ray-start-params", make(map[string]string), "a map of arguments to the Ray workers' 'ray start' entrypoint, e.g. '--worker-ray-start-params metrics-export-port=8080,num-cpus=2'")
-	cmd.Flags().StringToStringVar(&options.workerNodeSelectors, "worker-node-selectors", make(map[string]string), "Node selectors to apply to all worker pods in this worker group (e.g. --worker-node-selectors cloud.google.com/gke-accelerator=nvidia-l4,cloud.google.com/gke-nodepool=my-node-pool)")
+	cmd.Flags().StringToStringVar(&options.WorkerNodeSelectors, "worker-node-selectors", make(map[string]string), "Node selectors to apply to all worker pods in this worker group (e.g. --worker-node-selectors cloud.google.com/gke-accelerator=nvidia-l4,cloud.google.com/gke-nodepool=my-node-pool)")
 
 	return cmd
 }

--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -19,23 +19,15 @@ import (
 )
 
 type CreateWorkerGroupOptions struct {
-	cmdFactory          cmdutil.Factory
-	ioStreams           *genericclioptions.IOStreams
-	namespace           string
-	clusterName         string
-	groupName           string
-	rayStartParams      map[string]string
-	workerNodeSelectors map[string]string
-	rayVersion          string
-	image               string
-	workerCPU           string
-	workerGPU           string
-	workerTPU           string
-	workerMemory        string
-	workerReplicas      int32
-	numOfHosts          int32
-	workerMinReplicas   int32
-	workerMaxReplicas   int32
+	rayStartParams map[string]string
+	clusterName    string
+	groupName      string
+	image          string
+	workerTPU      string
+	util.KubectlPluginCommonOptions
+	numOfHosts        int32
+	workerMinReplicas int32
+	workerMaxReplicas int32
 }
 
 var (
@@ -60,8 +52,10 @@ var (
 
 func NewCreateWorkerGroupOptions(cmdFactory cmdutil.Factory, streams genericclioptions.IOStreams) *CreateWorkerGroupOptions {
 	return &CreateWorkerGroupOptions{
-		cmdFactory: cmdFactory,
-		ioStreams:  &streams,
+		KubectlPluginCommonOptions: util.KubectlPluginCommonOptions{
+			CmdFactory: cmdFactory,
+			IoStreams:  &streams,
+		},
 	}
 }
 
@@ -91,14 +85,14 @@ func NewCreateWorkerGroupCommand(cmdFactory cmdutil.Factory, streams genericclio
 
 	cmd.Flags().StringVarP(&options.clusterName, "ray-cluster", "c", "", "Ray cluster to add a worker group to")
 	cobra.CheckErr(cmd.MarkFlagRequired("ray-cluster"))
-	cmd.Flags().StringVar(&options.rayVersion, "ray-version", util.RayVersion, "Ray version to use")
-	cmd.Flags().StringVar(&options.image, "image", fmt.Sprintf("rayproject/ray:%s", options.rayVersion), "container image to use")
-	cmd.Flags().Int32Var(&options.workerReplicas, "worker-replicas", 1, "desired replicas")
+	cmd.Flags().StringVar(&options.RayVersion, "ray-version", util.RayVersion, "Ray version to use")
+	cmd.Flags().StringVar(&options.image, "image", fmt.Sprintf("rayproject/ray:%s", options.RayVersion), "container image to use")
+	cmd.Flags().Int32Var(&options.WorkerReplicas, "worker-replicas", 1, "desired replicas")
 	cmd.Flags().Int32Var(&options.numOfHosts, "num-of-hosts", 1, "number of hosts in the worker group per replica")
 	cmd.Flags().Int32Var(&options.workerMinReplicas, "worker-min-replicas", 1, "minimum number of replicas")
 	cmd.Flags().Int32Var(&options.workerMaxReplicas, "worker-max-replicas", 10, "maximum number of replicas")
-	cmd.Flags().StringVar(&options.workerCPU, "worker-cpu", "2", "number of CPUs in each replica")
-	cmd.Flags().StringVar(&options.workerGPU, "worker-gpu", "0", "number of GPUs in each replica")
+	cmd.Flags().StringVar(&options.WorkerCPU, "worker-cpu", "2", "number of CPUs in each replica")
+	cmd.Flags().StringVar(&options.WorkerGPU, "worker-gpu", "0", "number of GPUs in each replica")
 	cmd.Flags().StringVar(&options.workerTPU, "worker-tpu", "0", "number of TPUs in each replica")
 	cmd.Flags().StringVar(&options.workerMemory, "worker-memory", "4Gi", "amount of memory in each replica")
 	cmd.Flags().StringToStringVar(&options.rayStartParams, "worker-ray-start-params", make(map[string]string), "a map of arguments to the Ray workers' 'ray start' entrypoint, e.g. '--worker-ray-start-params metrics-export-port=8080,num-cpus=2'")
@@ -112,10 +106,10 @@ func (options *CreateWorkerGroupOptions) Complete(cmd *cobra.Command, args []str
 	if err != nil {
 		return fmt.Errorf("failed to get namespace: %w", err)
 	}
-	options.namespace = namespace
+	options.Namespace = namespace
 
-	if options.namespace == "" {
-		options.namespace = "default"
+	if options.Namespace == "" {
+		options.Namespace = "default"
 	}
 
 	if options.rayStartParams == nil {
@@ -128,14 +122,14 @@ func (options *CreateWorkerGroupOptions) Complete(cmd *cobra.Command, args []str
 	options.groupName = args[0]
 
 	if options.image == "" {
-		options.image = fmt.Sprintf("rayproject/ray:%s", options.rayVersion)
+		options.image = fmt.Sprintf("rayproject/ray:%s", options.RayVersion)
 	}
 
 	return nil
 }
 
 func (options *CreateWorkerGroupOptions) Validate() error {
-	if err := util.ValidateTPU(&options.workerTPU, &options.numOfHosts, options.workerNodeSelectors); err != nil {
+	if err := util.ValidateTPU(&options.workerTPU, &options.numOfHosts, options.WorkerNodeSelectors); err != nil {
 		return fmt.Errorf("%w", err)
 	}
 	return nil
@@ -147,7 +141,7 @@ func (options *CreateWorkerGroupOptions) Run(ctx context.Context, factory cmduti
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	rayCluster, err := k8sClient.RayClient().RayV1().RayClusters(options.namespace).Get(ctx, options.clusterName, metav1.GetOptions{})
+	rayCluster, err := k8sClient.RayClient().RayV1().RayClusters(options.Namespace).Get(ctx, options.clusterName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting Ray cluster: %w", err)
 	}
@@ -156,7 +150,7 @@ func (options *CreateWorkerGroupOptions) Run(ctx context.Context, factory cmduti
 
 	newRayCluster.Spec.WorkerGroupSpecs = append(newRayCluster.Spec.WorkerGroupSpecs, createWorkerGroupSpec(options))
 
-	newRayCluster, err = k8sClient.RayClient().RayV1().RayClusters(options.namespace).Update(ctx, newRayCluster, metav1.UpdateOptions{FieldManager: util.FieldManager})
+	newRayCluster, err = k8sClient.RayClient().RayV1().RayClusters(options.Namespace).Update(ctx, newRayCluster, metav1.UpdateOptions{FieldManager: util.FieldManager})
 	if err != nil {
 		return fmt.Errorf("error updating Ray cluster with new worker group: %w", err)
 	}
@@ -174,21 +168,21 @@ func createWorkerGroupSpec(options *CreateWorkerGroupOptions) rayv1.WorkerGroupS
 					Image: options.image,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse(options.workerCPU),
-							corev1.ResourceMemory: resource.MustParse(options.workerMemory),
+							corev1.ResourceCPU:    resource.MustParse(options.WorkerCPU),
+							corev1.ResourceMemory: resource.MustParse(options.WorkerMemory),
 						},
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse(options.workerCPU),
-							corev1.ResourceMemory: resource.MustParse(options.workerMemory),
+							corev1.ResourceCPU:    resource.MustParse(options.WorkerCPU),
+							corev1.ResourceMemory: resource.MustParse(options.WorkerMemory),
 						},
 					},
 				},
 			},
-			NodeSelector: options.workerNodeSelectors,
+			NodeSelector: options.WorkerNodeSelectors,
 		},
 	}
 
-	gpuResource := resource.MustParse(options.workerGPU)
+	gpuResource := resource.MustParse(options.WorkerGPU)
 	if !gpuResource.IsZero() {
 		podTemplate.Spec.Containers[0].Resources.Requests[corev1.ResourceName(util.ResourceNvidiaGPU)] = gpuResource
 		podTemplate.Spec.Containers[0].Resources.Limits[corev1.ResourceName(util.ResourceNvidiaGPU)] = gpuResource
@@ -201,7 +195,7 @@ func createWorkerGroupSpec(options *CreateWorkerGroupOptions) rayv1.WorkerGroupS
 	}
 	return rayv1.WorkerGroupSpec{
 		GroupName:      options.groupName,
-		Replicas:       &options.workerReplicas,
+		Replicas:       &options.WorkerReplicas,
 		NumOfHosts:     options.numOfHosts,
 		MinReplicas:    &options.workerMinReplicas,
 		MaxReplicas:    &options.workerMaxReplicas,

--- a/kubectl-plugin/pkg/cmd/create/create_workergroup_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup_test.go
@@ -23,20 +23,22 @@ func TestCreateWorkerGroupSpec(t *testing.T) {
 		{
 			name: "default worker group spec",
 			options: &CreateWorkerGroupOptions{
+				KubectlPluginCommonOptions: util.KubectlPluginCommonOptions{
+					WorkerReplicas: 3,
+					WorkerCPU:      "2",
+					WorkerMemory:   "5Gi",
+					WorkerGPU:      "1",
+					WorkerNodeSelectors: map[string]string{
+						"worker-node-selector": "worker-node-selector-value",
+					},
+				},
 				groupName:         "example-group",
 				image:             "DEADBEEF",
-				workerReplicas:    3,
 				numOfHosts:        2,
 				workerMinReplicas: 1,
 				workerMaxReplicas: 5,
-				workerCPU:         "2",
-				workerMemory:      "5Gi",
-				workerGPU:         "1",
 				workerTPU:         "1",
 				rayStartParams:    map[string]string{"dashboard-host": "0.0.0.0", "num-cpus": "2"},
-				workerNodeSelectors: map[string]string{
-					"worker-node-selector": "worker-node-selector-value",
-				},
 			},
 			expected: rayv1.WorkerGroupSpec{
 				RayStartParams: map[string]string{"dashboard-host": "0.0.0.0", "num-cpus": "2"},
@@ -97,10 +99,12 @@ func TestCreateWorkerGroupCommandComplete(t *testing.T) {
 				"namespace": "test-namespace",
 			},
 			expected: &CreateWorkerGroupOptions{
-				namespace:  "test-namespace",
-				groupName:  "example-group",
-				image:      "rayproject/ray:latest",
-				rayVersion: "latest",
+				KubectlPluginCommonOptions: util.KubectlPluginCommonOptions{
+					Namespace:  "test-namespace",
+					RayVersion: "latest",
+				},
+				groupName: "example-group",
+				image:     "rayproject/ray:latest",
 			},
 		},
 		{
@@ -124,10 +128,12 @@ func TestCreateWorkerGroupCommandComplete(t *testing.T) {
 				"namespace": "",
 			},
 			expected: &CreateWorkerGroupOptions{
-				namespace:  "default",
-				groupName:  "example-group",
-				image:      "rayproject/ray:latest",
-				rayVersion: "latest",
+				KubectlPluginCommonOptions: util.KubectlPluginCommonOptions{
+					Namespace:  "default",
+					RayVersion: "latest",
+				},
+				groupName: "example-group",
+				image:     "rayproject/ray:latest",
 			},
 		},
 		{
@@ -138,10 +144,12 @@ func TestCreateWorkerGroupCommandComplete(t *testing.T) {
 				"worker-ray-start-params": "dashboard-host=0.0.0.0,num-cpus=2",
 			},
 			expected: &CreateWorkerGroupOptions{
-				namespace:  "test-namespace",
-				groupName:  "example-group",
-				image:      "rayproject/ray:latest",
-				rayVersion: "latest",
+				KubectlPluginCommonOptions: util.KubectlPluginCommonOptions{
+					Namespace:  "test-namespace",
+					RayVersion: "latest",
+				},
+				groupName: "example-group",
+				image:     "rayproject/ray:latest",
 				rayStartParams: map[string]string{
 					"dashboard-host": "0.0.0.0",
 					"num-cpus":       "2",
@@ -156,10 +164,12 @@ func TestCreateWorkerGroupCommandComplete(t *testing.T) {
 				"worker-ray-start-params": "",
 			},
 			expected: &CreateWorkerGroupOptions{
-				namespace:      "test-namespace",
+				KubectlPluginCommonOptions: util.KubectlPluginCommonOptions{
+					Namespace:  "test-namespace",
+					RayVersion: "latest",
+				},
 				groupName:      "example-group",
 				image:          "rayproject/ray:latest",
-				rayVersion:     "latest",
 				rayStartParams: map[string]string{},
 			},
 		},
@@ -170,10 +180,12 @@ func TestCreateWorkerGroupCommandComplete(t *testing.T) {
 				"namespace": "test-namespace",
 			},
 			expected: &CreateWorkerGroupOptions{
-				namespace:      "test-namespace",
-				groupName:      "example-group",
+				KubectlPluginCommonOptions: util.KubectlPluginCommonOptions{
+					Namespace:  "test-namespace",
+					RayVersion: "latest",
+				},
 				image:          "rayproject/ray:latest",
-				rayVersion:     "latest",
+				groupName:      "example-group",
 				rayStartParams: map[string]string{},
 			},
 		},
@@ -187,7 +199,9 @@ func TestCreateWorkerGroupCommandComplete(t *testing.T) {
 			}
 
 			options := &CreateWorkerGroupOptions{
-				rayVersion: "latest",
+				KubectlPluginCommonOptions: util.KubectlPluginCommonOptions{
+					RayVersion: "latest",
+				},
 			}
 
 			err := options.Complete(cmd, tt.args)
@@ -197,7 +211,7 @@ func TestCreateWorkerGroupCommandComplete(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.expectedError)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tt.expected.namespace, options.namespace)
+				assert.Equal(t, tt.expected.Namespace, options.Namespace)
 				assert.Equal(t, tt.expected.groupName, options.groupName)
 				assert.Equal(t, tt.expected.image, options.image)
 			}

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
@@ -24,11 +25,11 @@ func TestRayJobSubmitComplete(t *testing.T) {
 	fakeSubmitJobOptions.fileName = "fake/path/to/rayjob.yaml"
 
 	cmd := &cobra.Command{}
-	cmd.Flags().StringVarP(&fakeSubmitJobOptions.namespace, "namespace", "n", "", "")
+	cmd.Flags().StringVarP(&fakeSubmitJobOptions.Namespace, "namespace", "n", "", "")
 
 	err := fakeSubmitJobOptions.Complete(cmd)
 	require.NoError(t, err)
-	assert.Equal(t, "default", fakeSubmitJobOptions.namespace)
+	assert.Equal(t, "default", fakeSubmitJobOptions.Namespace)
 	assert.Equal(t, "fake/path/to/env/yaml", fakeSubmitJobOptions.runtimeEnv)
 }
 
@@ -131,8 +132,10 @@ spec:
 			require.NoError(t, err)
 
 			opts := &SubmitJobOptions{
-				cmdFactory: cmdFactory,
-				ioStreams:  &testStreams,
+				KubectlPluginCommonOptions: util.KubectlPluginCommonOptions{
+					CmdFactory: cmdFactory,
+					IoStreams:  &testStreams,
+				},
 				fileName:   rayJobYamlPath,
 				workingDir: "Fake/File/Path",
 			}
@@ -179,8 +182,10 @@ func TestRayJobSubmitWithoutYamlValidate(t *testing.T) {
 	for _, tc := range test {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := &SubmitJobOptions{
-				cmdFactory:              cmdFactory,
-				ioStreams:               &testStreams,
+				KubectlPluginCommonOptions: util.KubectlPluginCommonOptions{
+					CmdFactory: cmdFactory,
+					IoStreams:  &testStreams,
+				},
 				rayjobName:              tc.rayjobName,
 				workingDir:              "Fake/File/Path",
 				ttlSecondsAfterFinished: tc.ttlSecondsAfterFinished,
@@ -336,8 +341,10 @@ spec:
 			require.NoError(t, err)
 
 			opts := &SubmitJobOptions{
-				cmdFactory: cmdFactory,
-				ioStreams:  &testStreams,
+				KubectlPluginCommonOptions: util.KubectlPluginCommonOptions{
+					CmdFactory: cmdFactory,
+					IoStreams:  &testStreams,
+				},
 				fileName:   rayJobYamlPath,
 				workingDir: "Fake/File/Path",
 			}

--- a/kubectl-plugin/pkg/util/types.go
+++ b/kubectl-plugin/pkg/util/types.go
@@ -1,5 +1,10 @@
 package util
 
+import (
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
 type ResourceType string
 
 const (
@@ -7,3 +12,15 @@ const (
 	RayJob     ResourceType = "rayjob"
 	RayService ResourceType = "rayservice"
 )
+
+type KubectlPluginCommonOptions struct {
+	CmdFactory          cmdutil.Factory
+	IoStreams           *genericiooptions.IOStreams
+	Namespace           string
+	WorkerNodeSelectors map[string]string
+	RayVersion          string
+	WorkerCPU           string
+	WorkerGPU           string
+	WorkerMemory        string
+	WorkerReplicas      int32
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, both `SubmitJobOptions` and `CreateWorkerGroupOptions` structs contain many overlapping fields related to Ray cluster configuration, such as resource specs (CPU, GPU, memory), image, version, and selectors.

Maintaining these separately leads to duplicated code and increases the risk of inconsistency when updating argument definitions.
<!-- Please give a short summary of the change and the problem this solves. -->

- Create a struct `KubectlPluginCommonOptions` in `kubectl-plugin/pkg/util/types.go`
- Extract the common part of  `SubmitJobOptions` and `CreateWorkerGroupOptions`.

The following element has been moved to `kubectl-plugin/pkg/util/types.go`
```
- CmdFactory          cmdutil.Factory
- IoStreams           *genericiooptions.IOStreams
- Namespace           string
- WorkerNodeSelectors map[string]string
- RayVersion          string
- WorkerCPU           string
- WorkerGPU           string
- WorkerMemory        string
- WorkerReplicas      int32
```
### Manual Testing
- Create workergroup
```bash
$ kubectl ray create cluster abc
$ kubectl ray create workergroup example-group --ray-cluster abc
```
![image](https://github.com/user-attachments/assets/9547e96b-3c4f-4dfb-8e15-989096d86b8f)

- Create rayjob
```bash
$ cd kubectl-plugin/test/e2e
$ kubectl ray job submit --name rayjob-sample --runtime-env testdata/rayjob-submit-working-dir/runtime-env-sample.yaml --head-cpu 1 --head-memory 2Gi --worker-cpu 1 --worker-memory 2Gi --head-node-selectors kubernetes.io/os=linux --worker-node-selectors kubernetes.io/os=linux -- python entrypoint-python-sample.py
```
![image](https://github.com/user-attachments/assets/fde1adb0-5c4e-4b3f-b54b-89ca2e05aa01)


## Related issue number
Closes #3582 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
