### PR TITLE
[Doc] add ray cluster uv sample yaml

### DIFF
--- a/ray-operator/config/samples/ray-cluster.uv.yaml
+++ b/ray-operator/config/samples/ray-cluster.uv.yaml
@@ -38,27 +38,7 @@ spec:
               items:
                 - key: sample_code.py
                   path: sample_code.py
-  workerGroupSpecs:
-  - replicas: 1
-    minReplicas: 1
-    maxReplicas: 5
-    groupName: small-group
-    rayStartParams: {}
-    template:
-      spec:
-        containers:
-        - name: ray-worker
-          image: rayproject/ray:2.46.0
-          env:
-           - name: RAY_RUNTIME_ENV_HOOK
-             value: ray._private.runtime_env.uv_runtime_env_hook.hook
-          resources:
-            limits:
-              cpu: "1"
-              memory: "1G"
-            requests:
-              cpu: "500m"
-              memory: "1G"
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/ray-operator/config/samples/ray-cluster.uv.yaml
+++ b/ray-operator/config/samples/ray-cluster.uv.yaml
@@ -1,0 +1,77 @@
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: raycluster-uv
+spec:
+  rayVersion: '2.46.0' # should match the Ray version in the image of the containers
+  headGroupSpec:
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.46.0
+          env:
+           - name: RAY_RUNTIME_ENV_HOOK
+             value: ray._private.runtime_env.uv_runtime_env_hook.hook
+          resources:
+            limits:
+              cpu: 1
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi
+          ports:
+          - containerPort: 6379
+            name: gcs-server
+          - containerPort: 8265 # Ray dashboard
+            name: dashboard
+          - containerPort: 10001
+            name: client
+          volumeMounts:
+          - mountPath: /home/ray/samples
+            name: code-sample
+        volumes:
+          - name: code-sample
+            configMap:
+              name: ray-uv-code-sample
+              items:
+                - key: sample_code.py
+                  path: sample_code.py
+  workerGroupSpecs:
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 5
+    groupName: small-group
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:2.46.0
+          env:
+           - name: RAY_RUNTIME_ENV_HOOK
+             value: ray._private.runtime_env.uv_runtime_env_hook.hook
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1G"
+            requests:
+              cpu: "500m"
+              memory: "1G"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ray-uv-code-sample
+data:
+  sample_code.py: |
+    import emoji
+    import ray
+
+    @ray.remote
+    def f():
+        return emoji.emojize('Python is :thumbs_up:')
+        # Execute 10 copies of f across a cluster.
+
+    print(ray.get([f.remote() for _ in range(10)]))

--- a/ray-operator/config/samples/ray-cluster.uv.yaml
+++ b/ray-operator/config/samples/ray-cluster.uv.yaml
@@ -52,6 +52,6 @@ data:
     @ray.remote
     def f():
         return emoji.emojize('Python is :thumbs_up:')
-        # Execute 10 copies of f across a cluster.
 
+    # Execute 10 copies of f across a cluster.
     print(ray.get([f.remote() for _ in range(10)]))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
In order to help users getting involved uv easier, provides this `ray-cluster.uv.yaml` as an example. It enables the runtime env hook so that `uv run ...` could work with runtime environment in the RayCluster, reference [uv + Ray: Pain-Free Python Dependencies in Clusters](https://www.anyscale.com/blog/uv-ray-pain-free-python-dependencies-in-clusters) for more information about this runtime env hook.
```
RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook
```


By the way, the `working_dir` is under `/home/ray` as default, which contains files. It might cause some errors during preparing runtime env because some limitations. Changing to folder `/home/ray/samples` could avoid this issue.
```
kubectl exec -it $HEAD_POD -- /bin/bash -c "cd samples && uv run --with emoji /home/ray/samples/sample_code.py"
```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/kuberay/issues/3039

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
