### PR TITLE
fix ray-service.different-port.yaml

### DIFF
--- a/ray-operator/config/samples/ray-service.different-port.yaml
+++ b/ray-operator/config/samples/ray-service.different-port.yaml
@@ -60,6 +60,9 @@ spec:
                 requests:
                   cpu: 2
                   memory: 2Gi
+              ports:
+                - containerPort: 9000
+                  name: serve
     workerGroupSpecs:
       # the pod replicas in this group typed worker
       - replicas: 1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

[PR 3262](https:github.com/ray-project/kuberay/pull/3262) cleaned up the `ports` field in the YAML files. However, the `ray-service.different-port.yaml` should at least retain the configuration for the `serve` port, as this YAML is specifically demonstrating how to customize the serve port.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
