### PR TITLE
[Test][Autoscaler] deflaky autoscaler idle timeout e2e tests by a longer timeout

### DIFF
--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go
@@ -29,7 +29,7 @@ func TestRayClusterAutoscalerV2IdleTimeout(t *testing.T) {
 
 		idleTimeoutShort := int32(10)
 		idleTimeoutLong := int32(30)
-		timeoutBuffer := int32(20) // Additional wait time to allow for scale down operation
+		timeoutBuffer := int32(30) // Additional wait time to allow for scale down operation
 
 		// Script for creating detached actors to trigger autoscaling
 		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))


### PR DESCRIPTION
Give [the test case](https://github.com/ray-project/kuberay/issues/3701#issuecomment-2926750602) more time to scale down.

The original flaky rate of this test is about 10% on my mac. Now it can pass 100 times without flaky.

```sh
▶ while go test -count=1 ./... -run=TestRayClusterAutoscalerV2IdleTimeout; do :; done

ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	96.222s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.784s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.683s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.702s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.944s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.898s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.874s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	95.137s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.967s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.632s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.951s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.076s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.656s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.324s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.028s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.483s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.926s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.547s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.739s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.546s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.204s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.733s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.741s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.087s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.840s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	95.212s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.311s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.097s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.837s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.502s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.673s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.628s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.149s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.693s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.718s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.852s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	100.106s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	99.967s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.824s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.861s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.826s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	99.891s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	100.224s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	99.747s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.722s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.875s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.979s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.820s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.729s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.135s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.008s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.684s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.573s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.000s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.948s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.640s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.807s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.770s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.443s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.611s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.000s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.444s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.981s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.819s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.534s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.819s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.978s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.461s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.839s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.908s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.694s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.981s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.709s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.628s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.826s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.665s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.121s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.974s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.413s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.389s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.958s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.449s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.588s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.958s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.440s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	99.825s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.965s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.219s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.679s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.074s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.842s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.743s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.833s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.164s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	99.851s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	99.330s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	94.670s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.857s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	100.949s
ok  	github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler	93.538s
```

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #3701 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
