### PR TITLE
[RayService][Test] create curl pod waiting until running

### DIFF
--- a/ray-operator/test/e2erayservice/rayservice_ha_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_ha_test.go
@@ -10,7 +10,6 @@ import (
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
-	"github.com/ray-project/kuberay/ray-operator/test/sampleyaml"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
@@ -268,7 +267,7 @@ func TestRayServiceGCSFaultTolerance(t *testing.T) {
 	// Kill gcs server
 	ExecPodCmd(test, oldHeadPod, common.RayHeadContainer, []string{"pkill", "gcs_server"})
 	// wait for head pod not to be ready
-	g.Eventually(HeadPod(test, rayServiceUnderlyingRayCluster), TestTimeoutShort).Should(WithTransform(sampleyaml.IsPodRunningAndReady, BeFalse()))
+	g.Eventually(HeadPod(test, rayServiceUnderlyingRayCluster), TestTimeoutShort).Should(WithTransform(IsPodRunningAndReady, BeFalse()))
 
 	startTime := time.Now()
 	// Run Locust test
@@ -285,6 +284,6 @@ func TestRayServiceGCSFaultTolerance(t *testing.T) {
 	g.Expect(newHeadPod.Name).To(Equal(oldHeadPodName))
 	g.Expect(newHeadPod.Status.ContainerStatuses[0].RestartCount).To(Equal(int32(1)))
 	// Verify that all pods are running
-	g.Expect(GetHeadPod(test, rayServiceUnderlyingRayCluster)).Should(WithTransform(sampleyaml.IsPodRunningAndReady, BeTrue()))
-	g.Expect(GetWorkerPods(test, rayServiceUnderlyingRayCluster)).Should(WithTransform(sampleyaml.AllPodsRunningAndReady, BeTrue()))
+	g.Expect(GetHeadPod(test, rayServiceUnderlyingRayCluster)).Should(WithTransform(IsPodRunningAndReady, BeTrue()))
+	g.Expect(GetWorkerPods(test, rayServiceUnderlyingRayCluster)).Should(WithTransform(AllPodsRunningAndReady, BeTrue()))
 }

--- a/ray-operator/test/e2erayservice/rayservice_in_place_update_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_in_place_update_test.go
@@ -10,7 +10,6 @@ import (
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
-	"github.com/ray-project/kuberay/ray-operator/test/sampleyaml"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
@@ -41,14 +40,8 @@ func TestRayServiceInPlaceUpdate(t *testing.T) {
 	curlPodName := "curl-pod"
 	curlContainerName := "curl-container"
 
-	curlPod, err := CreateCurlPod(test, curlPodName, curlContainerName, namespace.Name)
+	curlPod, err := CreateCurlPod(g, test, curlPodName, curlContainerName, namespace.Name)
 	g.Expect(err).NotTo(HaveOccurred())
-	// Wait until curl pod is created
-	g.Eventually(func(g Gomega) *corev1.Pod {
-		updatedCurlPod, err := test.Client().Core().CoreV1().Pods(curlPod.Namespace).Get(test.Ctx(), curlPod.Name, metav1.GetOptions{})
-		g.Expect(err).NotTo(HaveOccurred())
-		return updatedCurlPod
-	}, TestTimeoutShort).Should(WithTransform(sampleyaml.IsPodRunningAndReady, BeTrue()))
 
 	LogWithTimestamp(test.T(), "Sending requests to the RayService to make sure it is ready to serve requests")
 	stdout, _ := CurlRayServicePod(test, rayService, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)
@@ -111,14 +104,8 @@ func TestUpdateServeConfigAndRayClusterSpec(t *testing.T) {
 	curlPodName := "curl-pod"
 	curlContainerName := "curl-container"
 
-	curlPod, err := CreateCurlPod(test, curlPodName, curlContainerName, namespace.Name)
+	curlPod, err := CreateCurlPod(g, test, curlPodName, curlContainerName, namespace.Name)
 	g.Expect(err).NotTo(HaveOccurred())
-	// Wait until curl pod is created
-	g.Eventually(func(g Gomega) *corev1.Pod {
-		updatedCurlPod, err := test.Client().Core().CoreV1().Pods(curlPod.Namespace).Get(test.Ctx(), curlPod.Name, metav1.GetOptions{})
-		g.Expect(err).NotTo(HaveOccurred())
-		return updatedCurlPod
-	}, TestTimeoutShort).Should(WithTransform(sampleyaml.IsPodRunningAndReady, BeTrue()))
 
 	LogWithTimestamp(test.T(), "Sending requests to the RayService to make sure it is ready to serve requests")
 	stdout, _ := CurlRayServicePod(test, rayService, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)
@@ -214,14 +201,8 @@ func TestUpdateServeConfigAndRayClusterSpecWithUpgradeDisabled(t *testing.T) {
 	curlPodName := "curl-pod"
 	curlContainerName := "curl-container"
 
-	curlPod, err := CreateCurlPod(test, curlPodName, curlContainerName, namespace.Name)
+	curlPod, err := CreateCurlPod(g, test, curlPodName, curlContainerName, namespace.Name)
 	g.Expect(err).NotTo(HaveOccurred())
-	// Wait until curl pod is created
-	g.Eventually(func(g Gomega) *corev1.Pod {
-		updatedCurlPod, err := test.Client().Core().CoreV1().Pods(curlPod.Namespace).Get(test.Ctx(), curlPod.Name, metav1.GetOptions{})
-		g.Expect(err).NotTo(HaveOccurred())
-		return updatedCurlPod
-	}, TestTimeoutShort).Should(WithTransform(sampleyaml.IsPodRunningAndReady, BeTrue()))
 
 	LogWithTimestamp(test.T(), "Sending requests to the RayService to make sure it is ready to serve requests")
 	stdout, _ := CurlRayServicePod(test, rayService, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)

--- a/ray-operator/test/e2erayservice/rayservice_redeploy_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_redeploy_test.go
@@ -4,12 +4,10 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
-	"github.com/ray-project/kuberay/ray-operator/test/sampleyaml"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
@@ -41,14 +39,8 @@ func TestRedeployRayServe(t *testing.T) {
 
 	LogWithTimestamp(test.T(), "Creating curl pod %s/%s", namespace.Name, curlPodName)
 
-	curlPod, err := CreateCurlPod(test, curlPodName, curlContainerName, namespace.Name)
+	curlPod, err := CreateCurlPod(g, test, curlPodName, curlContainerName, namespace.Name)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Eventually(func(g Gomega) *corev1.Pod {
-		updatedCurlPod, err := test.Client().Core().CoreV1().Pods(curlPod.Namespace).Get(test.Ctx(), curlPod.Name, metav1.GetOptions{})
-		g.Expect(err).NotTo(HaveOccurred())
-		return updatedCurlPod
-	}, TestTimeoutShort).Should(WithTransform(sampleyaml.IsPodRunningAndReady, BeTrue()))
-	LogWithTimestamp(test.T(), "Curl pod %s/%s is running and ready", namespace.Name, curlPodName)
 
 	LogWithTimestamp(test.T(), "Sending requests to the RayService to make sure it is ready to serve requests")
 	stdout, _ := CurlRayServicePod(test, rayService, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)

--- a/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
-	"github.com/ray-project/kuberay/ray-operator/test/sampleyaml"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
@@ -44,14 +43,8 @@ func TestOldHeadPodFailDuringUpgrade(t *testing.T) {
 
 	LogWithTimestamp(test.T(), "Creating curl pod %s/%s", namespace.Name, curlPodName)
 
-	curlPod, err := CreateCurlPod(test, curlPodName, curlContainerName, namespace.Name)
+	curlPod, err := CreateCurlPod(g, test, curlPodName, curlContainerName, namespace.Name)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Eventually(func(g Gomega) *corev1.Pod {
-		updatedCurlPod, err := test.Client().Core().CoreV1().Pods(curlPod.Namespace).Get(test.Ctx(), curlPod.Name, metav1.GetOptions{})
-		g.Expect(err).NotTo(HaveOccurred())
-		return updatedCurlPod
-	}, TestTimeoutShort).Should(WithTransform(sampleyaml.IsPodRunningAndReady, BeTrue()))
-	LogWithTimestamp(test.T(), "Curl pod %s/%s is running and ready", namespace.Name, curlPodName)
 
 	LogWithTimestamp(test.T(), "Sending requests to the RayService to make sure it is ready to serve requests")
 	stdout, _ := CurlRayServicePod(test, rayService, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)

--- a/ray-operator/test/e2eupgrade/rayservice_operator_upgrade_test.go
+++ b/ray-operator/test/e2eupgrade/rayservice_operator_upgrade_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
 	e2e "github.com/ray-project/kuberay/ray-operator/test/e2erayservice"
-	"github.com/ray-project/kuberay/ray-operator/test/sampleyaml"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
@@ -54,14 +53,8 @@ func TestZeroDowntimeUpgradeAfterOperatorUpgrade(t *testing.T) {
 	curlContainerName := "curl-container"
 
 	test.T().Logf("Creating curl pod %s/%s", namespace.Name, curlPodName)
-	curlPod, err := CreateCurlPod(test, curlPodName, curlContainerName, namespace.Name)
+	curlPod, err := CreateCurlPod(g, test, curlPodName, curlContainerName, namespace.Name)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Eventually(func(g Gomega) *corev1.Pod {
-		updatedCurlPod, err := test.Client().Core().CoreV1().Pods(curlPod.Namespace).Get(test.Ctx(), curlPod.Name, metav1.GetOptions{})
-		g.Expect(err).NotTo(HaveOccurred())
-		return updatedCurlPod
-	}, TestTimeoutShort).Should(WithTransform(sampleyaml.IsPodRunningAndReady, BeTrue()))
-	test.T().Logf("Curl pod %s/%s is running and ready", namespace.Name, curlPodName)
 
 	// Validate RayService is able to serve requests
 	test.T().Logf("Sending requests to the RayService to make sure it is ready to serve requests")

--- a/ray-operator/test/sampleyaml/support.go
+++ b/ray-operator/test/sampleyaml/support.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
@@ -24,27 +23,6 @@ func GetSampleYAMLDir(t Test) string {
 	require.NoError(t.T(), err)
 	assert.True(t.T(), info.IsDir())
 	return sampleYAMLDir
-}
-
-func IsPodRunningAndReady(pod *corev1.Pod) bool {
-	if pod.Status.Phase != corev1.PodRunning {
-		return false
-	}
-	for _, condition := range pod.Status.Conditions {
-		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-	return false
-}
-
-func AllPodsRunningAndReady(pods []corev1.Pod) bool {
-	for _, pod := range pods {
-		if !IsPodRunningAndReady(&pod) {
-			return false
-		}
-	}
-	return true
 }
 
 func SubmitJobsToAllPods(t Test, rayCluster *rayv1.RayCluster) func(Gomega) {

--- a/ray-operator/test/support/support.go
+++ b/ray-operator/test/support/support.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -48,4 +49,25 @@ func init() {
 	gomega.SetDefaultConsistentlyPollingInterval(1 * time.Second)
 	// Disable object truncation on test results
 	format.MaxLength = 0
+}
+
+func IsPodRunningAndReady(pod *v1.Pod) bool {
+	if pod.Status.Phase != v1.PodRunning {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == v1.PodReady && condition.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func AllPodsRunningAndReady(pods []v1.Pod) bool {
+	for _, pod := range pods {
+		if !IsPodRunningAndReady(&pod) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`CreateCurlPod` need to wait for pod is ready and running. put the waiting logic inside the function for easier to use.

## Related issue number

<!-- For example: "Closes #1234" -->
Close https://github.com/ray-project/kuberay/issues/3613

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
