### PR TITLE
Revert "Fix issue where unescaped semicolons caused task execution failures. (#3691)"

### DIFF
--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -116,7 +116,6 @@ func GetK8sJobCommand(rayJobInstance *rayv1.RayJob) ([]string, error) {
 	}
 
 	// "--" is used to separate the entrypoint from the Ray Job CLI command and its arguments.
-	entrypoint = strings.ReplaceAll(entrypoint, ";", "\\;")
 	k8sJobCommand = append(k8sJobCommand, "--", entrypoint, ";", "fi", ";")
 	k8sJobCommand = append(k8sJobCommand, jobFollowCommand...)
 


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This reverts PR #3691

See https://github.com/ray-project/kuberay/issues/3764#issuecomment-2969057408 for the reason of reverting this PR.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #3764

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
