### PR TITLE
[kubectl-plugin] Use a more Golang-native approach to retrieve the CR status for testing

### DIFF
--- a/kubectl-plugin/test/e2e/client.go
+++ b/kubectl-plugin/test/e2e/client.go
@@ -1,0 +1,61 @@
+package e2e
+
+import (
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	rayclient "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned"
+)
+
+type Client interface {
+	Core() kubernetes.Interface
+	Ray() rayclient.Interface
+	Config() rest.Config
+}
+
+type testClient struct {
+	core   kubernetes.Interface
+	ray    rayclient.Interface
+	config rest.Config
+}
+
+var _ Client = (*testClient)(nil)
+
+func (t *testClient) Core() kubernetes.Interface {
+	return t.core
+}
+
+func (t *testClient) Ray() rayclient.Interface {
+	return t.ray
+}
+
+func (t *testClient) Config() rest.Config {
+	return t.config
+}
+
+func newTestClient() (Client, error) {
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	rayClient, err := rayclient.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &testClient{
+		core:   kubeClient,
+		ray:    rayClient,
+		config: *cfg,
+	}, nil
+}

--- a/kubectl-plugin/test/e2e/kubectl_ray_cluster_get_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_cluster_get_test.go
@@ -14,16 +14,16 @@ var _ = Describe("Calling ray plugin `get` command", func() {
 	var testClient Client
 
 	BeforeEach(func() {
-		namespace = createTestNamespace()
-		ctx = context.Background()
-
 		var err error
 		testClient, err = newTestClient()
 		Expect(err).NotTo(HaveOccurred())
 
+		namespace = createTestNamespace(testClient)
+		ctx = context.Background()
+
 		deployTestRayCluster(namespace)
 		DeferCleanup(func() {
-			deleteTestNamespace(namespace)
+			deleteTestNamespace(namespace, testClient)
 			namespace = ""
 		})
 	})

--- a/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go
@@ -21,12 +21,17 @@ const (
 
 var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 	var namespace string
+	var testClient Client
 
 	BeforeEach(func() {
-		namespace = createTestNamespace()
+		var err error
+		testClient, err = newTestClient()
+		Expect(err).NotTo(HaveOccurred())
+
+		namespace = createTestNamespace(testClient)
 		deployTestRayCluster(namespace)
 		DeferCleanup(func() {
-			deleteTestNamespace(namespace)
+			deleteTestNamespace(namespace, testClient)
 			namespace = ""
 		})
 	})
@@ -47,7 +52,7 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 		cmdOutputJobID := extractRayJobID(string(output))
 
 		// Use kubectl to check status of the rayjob
-		getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete")
+		getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete", testClient)
 	})
 
 	It("succeed in submitting RayJob with runtime environment set with working dir", func() {
@@ -68,7 +73,7 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 		cmdOutputJobID := extractRayJobID(string(output))
 
 		// Use kubectl to check status of the rayjob
-		getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete")
+		getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete", testClient)
 	})
 
 	It("succeed in submitting RayJob with headNodeSelectors and workerNodeSelectors", func() {
@@ -94,7 +99,7 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 		// Retrieve the Job ID from the output
 		cmdOutputJobID := extractRayJobID(string(output))
 
-		rayJob := getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete")
+		rayJob := getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete", testClient)
 		// Retrieve Job Head Node Selectors
 		Expect(rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector["kubernetes.io/os"]).To(Equal("linux"))
 		// Retrieve Job Worker Node Selectors
@@ -122,7 +127,7 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 		// Retrieve the Job ID from the output
 		cmdOutputJobID := extractRayJobID(string(output))
 
-		rayJob := getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete")
+		rayJob := getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete", testClient)
 		Expect(rayJob.Spec.TTLSecondsAfterFinished).To(Equal(int32(0)))
 		Expect(rayJob.Spec.ShutdownAfterJobFinishes).To(BeTrue())
 	})
@@ -147,7 +152,7 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 		// Retrieve the Job ID from the output
 		cmdOutputJobID := extractRayJobID(string(output))
 
-		rayJob := getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete")
+		rayJob := getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete", testClient)
 		Expect(rayJob.Spec.TTLSecondsAfterFinished).To(Equal(int32(0)))
 		Expect(rayJob.Spec.ShutdownAfterJobFinishes).To(BeFalse())
 	})
@@ -168,7 +173,7 @@ var _ = Describe("Calling ray plugin `job submit` command on Ray Job", func() {
 		// Retrieve the Job ID from the output
 		cmdOutputJobID := extractRayJobID(string(output))
 
-		rayJob := getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete")
+		rayJob := getAndCheckRayJob(namespace, rayJobName, cmdOutputJobID, "SUCCEEDED", "Complete", testClient)
 		Expect(rayJob.Spec.TTLSecondsAfterFinished).To(Equal(int32(10)))
 		Expect(rayJob.Spec.ShutdownAfterJobFinishes).To(BeTrue())
 	})

--- a/kubectl-plugin/test/e2e/kubectl_ray_log_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_log_test.go
@@ -19,10 +19,14 @@ var _ = Describe("Calling ray plugin `log` command on Ray Cluster", func() {
 	var namespace string
 
 	BeforeEach(func() {
-		namespace = createTestNamespace()
+		var err error
+		testClient, err := newTestClient()
+		Expect(err).NotTo(HaveOccurred())
+
+		namespace = createTestNamespace(testClient)
 		deployTestRayCluster(namespace)
 		DeferCleanup(func() {
-			deleteTestNamespace(namespace)
+			deleteTestNamespace(namespace, testClient)
 			namespace = ""
 		})
 	})

--- a/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
@@ -18,15 +18,15 @@ var _ = Describe("Calling ray plugin `session` command", Ordered, func() {
 	var testClient Client
 
 	BeforeEach(func() {
-		namespace = createTestNamespace()
-
 		var err error
 		testClient, err = newTestClient()
 		Expect(err).NotTo(HaveOccurred())
 
+		namespace = createTestNamespace(testClient)
+
 		deployTestRayCluster(namespace)
 		DeferCleanup(func() {
-			deleteTestNamespace(namespace)
+			deleteTestNamespace(namespace, testClient)
 			namespace = ""
 		})
 	})

--- a/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
@@ -10,13 +10,20 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Calling ray plugin `session` command", Ordered, func() {
 	var namespace string
+	var testClient Client
 
 	BeforeEach(func() {
 		namespace = createTestNamespace()
+
+		var err error
+		testClient, err = newTestClient()
+		Expect(err).NotTo(HaveOccurred())
+
 		deployTestRayCluster(namespace)
 		DeferCleanup(func() {
 			deleteTestNamespace(namespace)
@@ -90,22 +97,19 @@ var _ = Describe("Calling ray plugin `session` command", Ordered, func() {
 		}, 3*time.Second, 500*time.Millisecond).ShouldNot(HaveOccurred())
 
 		// Get the current head pod name
-		cmd := exec.Command("kubectl", "get", "--namespace", namespace, "pod/raycluster-kuberay-head", "-o", "jsonpath={.metadata.uid}")
-		output, err := cmd.CombinedOutput()
+		oldPod, err := testClient.Core().CoreV1().Pods(namespace).Get(ctx, "raycluster-kuberay-head", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		oldPodUID := string(output)
+		oldPodUID := string(oldPod.UID)
 		var newPodUID string
 
 		// Delete the pod
-		cmd = exec.Command("kubectl", "delete", "--namespace", namespace, "pod/raycluster-kuberay-head")
-		err = cmd.Run()
+		err = testClient.Core().CoreV1().Pods(namespace).Delete(ctx, "raycluster-kuberay-head", metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// Wait for the new pod to be created
 		Eventually(func() error {
-			cmd := exec.Command("kubectl", "get", "--namespace", namespace, "pod/raycluster-kuberay-head", "-o", "jsonpath={.metadata.uid}")
-			output, err := cmd.CombinedOutput()
-			newPodUID = string(output)
+			newPod, err := testClient.Core().CoreV1().Pods(namespace).Get(ctx, "raycluster-kuberay-head", metav1.GetOptions{})
+			newPodUID = string(newPod.UID)
 			if err != nil {
 				return err
 			}
@@ -116,7 +120,7 @@ var _ = Describe("Calling ray plugin `session` command", Ordered, func() {
 		}, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 		// Wait for the new pod to be ready
-		cmd = exec.Command("kubectl", "wait", "--namespace", namespace, "pod/raycluster-kuberay-head", "--for=condition=Ready", "--timeout=120s")
+		cmd := exec.Command("kubectl", "wait", "--namespace", namespace, "pod/raycluster-kuberay-head", "--for=condition=Ready", "--timeout=120s")
 		err = cmd.Run()
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
- Use a Golang-native way to get/create/delete some ray and core resources. (e.g. `Ray().RayV1().RayClusters(namespace).List()`)

## Why are these changes needed?

Currently, kubectl-plugin uses kubectl command to get results for testing. We should use a more Golang native solution to get K8s resources.

https://github.com/ray-project/kuberay/blob/837c3fa1e3a8adf09b9e51b6a2632a283139c232/kubectl-plugin/test/e2e/kubectl_ray_job_submit_test.go#L49

## Related issue number

Closes #3626

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
