### PR TITLE
[Feat] Add e2e test for applying `ray-job.interactive-mode.yaml`

### DIFF
--- a/ray-operator/config/samples/ray-job.interactive-mode.yaml
+++ b/ray-operator/config/samples/ray-job.interactive-mode.yaml
@@ -2,7 +2,6 @@ apiVersion: ray.io/v1
 kind: RayJob
 metadata:
   name: rayjob-interactive-mode
-  namespace: default
 spec:
   # InteractiveMode means KubeRay doesn't submit the job for you.
   # KubeRay will create the RayJob and transition it to the Waiting state.
@@ -39,6 +38,8 @@ spec:
     - groupName: default-group
       rayStartParams: {}
       replicas: 1
+      minReplicas: 1
+      maxReplicas: 5
       template:
         spec:
           containers:

--- a/ray-operator/config/samples/ray-job.interactive-mode.yaml
+++ b/ray-operator/config/samples/ray-job.interactive-mode.yaml
@@ -38,8 +38,6 @@ spec:
     - groupName: default-group
       rayStartParams: {}
       replicas: 1
-      minReplicas: 1
-      maxReplicas: 5
       template:
         spec:
           containers:

--- a/ray-operator/test/sampleyaml/rayjob_test.go
+++ b/ray-operator/test/sampleyaml/rayjob_test.go
@@ -47,7 +47,7 @@ func TestRayJob(t *testing.T) {
 	}
 }
 
-func TestRayJobMode(t *testing.T) {
+func TestRayJobInteractiveMode(t *testing.T) {
 	tests := []struct {
 		name string
 	}{

--- a/ray-operator/test/sampleyaml/rayjob_test.go
+++ b/ray-operator/test/sampleyaml/rayjob_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
@@ -33,49 +34,74 @@ func TestRayJob(t *testing.T) {
 			test := With(t)
 			g := NewWithT(t)
 			g.ConfigureWithT(WithRayJobResourceLogger(test))
-
 			yamlFilePath := path.Join(GetSampleYAMLDir(test), tt.name)
 			namespace := test.NewTestNamespace()
 			rayJobFromYaml := DeserializeRayJobYAML(test, yamlFilePath)
 			KubectlApplyYAML(test, yamlFilePath, namespace.Name)
 
-			rayJob, err := GetRayJob(test, namespace.Name, rayJobFromYaml.Name)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(rayJob).NotTo(BeNil())
-
-			// Wait for RayCluster name to be populated
-			g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
-				Should(WithTransform(RayJobClusterName, Not(BeEmpty())))
-
-			rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(rayJob).NotTo(BeNil())
-
-			LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to be ready", namespace.Name, rayJob.Status.RayClusterName)
-			g.Eventually(RayCluster(test, namespace.Name, rayJob.Status.RayClusterName), TestTimeoutMedium).
-				Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
-			rayCluster, err := GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
-			g.Expect(err).NotTo(HaveOccurred())
-
-			// Check if the RayCluster created correct number of pods
-			var desiredWorkerPods int32
-			if rayCluster.Spec.WorkerGroupSpecs != nil {
-				for _, workerGroupSpec := range rayCluster.Spec.WorkerGroupSpecs {
-					desiredWorkerPods += (*workerGroupSpec.Replicas * workerGroupSpec.NumOfHosts)
-				}
-			}
-			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutShort).Should(HaveLen(int(desiredWorkerPods)))
-			g.Expect(GetRayCluster(test, namespace.Name, rayCluster.Name)).To(WithTransform(RayClusterDesiredWorkerReplicas, Equal(desiredWorkerPods)))
-
-			// Check if the head pod is ready
-			g.Eventually(HeadPod(test, rayCluster), TestTimeoutShort).Should(WithTransform(IsPodRunningAndReady, BeTrue()))
-
-			// Check if all worker pods are ready
-			g.Eventually(WorkerPods(test, rayCluster), TestTimeoutShort).Should(WithTransform(AllPodsRunningAndReady, BeTrue()))
+			checkRayJobCluster(test, g, rayJobFromYaml, namespace)
 
 			g.Eventually(RayJob(test, namespace.Name, rayJobFromYaml.Name), TestTimeoutMedium).Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
-
 			g.Eventually(RayJob(test, namespace.Name, rayJobFromYaml.Name), TestTimeoutMedium).Should(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)))
 		})
 	}
+}
+
+func TestRayJobMode(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "ray-job.interactive-mode.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test := With(t)
+			g := NewWithT(t)
+			g.ConfigureWithT(WithRayJobResourceLogger(test))
+			yamlFilePath := path.Join(GetSampleYAMLDir(test), tt.name)
+			namespace := test.NewTestNamespace()
+			rayJobFromYaml := DeserializeRayJobYAML(test, yamlFilePath)
+			KubectlApplyYAML(test, yamlFilePath, namespace.Name)
+			checkRayJobCluster(test, g, rayJobFromYaml, namespace)
+		})
+	}
+}
+
+func checkRayJobCluster(test Test, g *WithT, rayJobFromYaml *rayv1.RayJob, namespace *corev1.Namespace) {
+	rayJob, err := GetRayJob(test, namespace.Name, rayJobFromYaml.Name)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(rayJob).NotTo(BeNil())
+
+	// Wait for RayCluster name to be populated
+	g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
+		Should(WithTransform(RayJobClusterName, Not(BeEmpty())))
+
+	rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(rayJob).NotTo(BeNil())
+
+	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to be ready", namespace.Name, rayJob.Status.RayClusterName)
+	g.Eventually(RayCluster(test, namespace.Name, rayJob.Status.RayClusterName), TestTimeoutMedium).
+		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
+	rayCluster, err := GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Check if the RayCluster created correct number of pods
+	var desiredWorkerPods int32
+	if rayCluster.Spec.WorkerGroupSpecs != nil {
+		for _, workerGroupSpec := range rayCluster.Spec.WorkerGroupSpecs {
+			desiredWorkerPods += (*workerGroupSpec.Replicas * workerGroupSpec.NumOfHosts)
+		}
+	}
+	g.Eventually(WorkerPods(test, rayCluster), TestTimeoutShort).Should(HaveLen(int(desiredWorkerPods)))
+	g.Expect(GetRayCluster(test, namespace.Name, rayCluster.Name)).To(WithTransform(RayClusterDesiredWorkerReplicas, Equal(desiredWorkerPods)))
+
+	// Check if the head pod is ready
+	g.Eventually(HeadPod(test, rayCluster), TestTimeoutShort).Should(WithTransform(IsPodRunningAndReady, BeTrue()))
+
+	// Check if all worker pods are ready
+	g.Eventually(WorkerPods(test, rayCluster), TestTimeoutShort).Should(WithTransform(AllPodsRunningAndReady, BeTrue()))
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There is no testing for [ray-job.interactive-mode.yaml](https://github.com/ray-project/kuberay/blob/v1.4.0-rc.1/ray-operator/config/samples/ray-job.interactive-mode.yaml)
<!-- Please give a short summary of the change and the problem this solves. -->

### Manual testing

```bash
$ helm repo update
$ helm install kuberay-operator kuberay/kuberay-operator --version v1.4.0-rc.1
$ kubectl apply -f ray-operator/config/samples/ray-job.interactive-mode.yaml
```

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #3778 
## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
