### PR TITLE
[Doc][Fix] correct the indention of storageClass in ray-cluster.persistent-redis.yaml

### DIFF
--- a/ray-operator/config/samples/ray-cluster.persistent-redis.yaml
+++ b/ray-operator/config/samples/ray-cluster.persistent-redis.yaml
@@ -124,13 +124,13 @@ kind: PersistentVolumeClaim
 metadata:
   name: redis-data
 spec:
+  # choose a storageClassName provided by your Kubernetes:
+  # storageClassName: standard-rwo
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
       storage: 8Gi
-      # choose a storageClassName provided by your Kubernetes:
-      #storageClassName: standard-rwo
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
## Why are these changes needed?

The indention is incorrect. The storageClass should be at the direct level under the spec.

## Related issue number

Resolve 1.4.0 document release blocker

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
