### PR TITLE
use ImplementationSpecific

### DIFF
--- a/ray-operator/config/samples/ray-cluster.separate-ingress.yaml
+++ b/ray-operator/config/samples/ray-cluster.separate-ingress.yaml
@@ -59,4 +59,4 @@ spec:
             port: # port number should match the port specified for dashboard in the RayCluster setting above
               number: 8265
         path: /raycluster-ingress/(.*) # (.*) is regex
-        pathType: Exact # Matches the URL path exactly and with case sensitivity.
+        pathType: ImplementationSpecific # Matches the URL path exactly and with case sensitivity.


### PR DESCRIPTION
## Why are these changes needed?
When I tried to apply ray-operator/config/samples/ray-cluster.separate-ingress.yaml, I got 
```
Error from server (BadRequest): error when creating "ray-cluster.separate-ingress.yaml": admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: ingress contains invalid paths: path /raycluster-ingress/(.*) cannot be used with pathType Exact
```
According to ingress-nginx's documentation.
> When the ingress resource path contains other characters (like on rewrite configurations), the pathType value should be "ImplementationSpecific".

## Related issue number
N/A

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [X] Manual tests
  - [ ] This PR is not tested :(
