### PR TITLE
[Test][Autoscaler] add fake single-host TPU tests

### DIFF
--- a/ray-operator/test/e2eautoscaler/create_detached_actor.py
+++ b/ray-operator/test/e2eautoscaler/create_detached_actor.py
@@ -1,17 +1,34 @@
+import json
+from typing import Optional
 import ray
-import sys
 import argparse
 
 parser = argparse.ArgumentParser()
+
+class ParseKeyValueAction(argparse.Action):
+    def __call__(self, parser: argparse.ArgumentParser, namespace: argparse.Namespace, values: str, option_string: Optional[str] = None):
+        setattr(namespace, self.dest, dict())
+        for item in values.split(","):
+            try:
+                key, value = item.split("=")
+                try:
+                    value = float(value)
+                except ValueError:
+                    raise argparse.ArgumentError(self, f"invalid value for key {key}, expected a float: {value}")
+                getattr(namespace, self.dest)[key] = value
+            except ValueError:
+                raise argparse.ArgumentError(self, f"invalid key=value pair, expected format KEY1=VALUE1,KEY2=VALUE2,...: {item}")
+
+
 parser.add_argument('name')
-parser.add_argument('--num-cpus', type=float, default=1)
-parser.add_argument('--num-gpus', type=float, default=0)
-parser.add_argument('--num-custom-resources', type=float, default=0)
+parser.add_argument('--num-cpus', type=float, default=1, help="number of CPUs")
+parser.add_argument('--num-gpus', type=float, default=0, help="number of GPUs")
+parser.add_argument('--custom-resources', action=ParseKeyValueAction, type=str, default={}, help="Ray custom resources as key=value pairs where value is a float, e.g. TPU=2,CustomResource=1.5", metavar="KEY1=VALUE1,KEY2=VALUE2,")
 args = parser.parse_args()
 
 # set max_restarts=-1 as a workaround to restart unexpected death in tests.
 # TODO (rueian): Remove the max_restarts workaround when https://github.com/ray-project/ray/issues/40864 is fixed.
-@ray.remote(max_restarts=-1, num_cpus=args.num_cpus, num_gpus=args.num_gpus, resources={"CustomResource": args.num_custom_resources})
+@ray.remote(max_restarts=-1, num_cpus=args.num_cpus, num_gpus=args.num_gpus, resources=args.custom_resources)
 class Actor:
     pass
 


### PR DESCRIPTION
Modify `create_detached_actor.py` to easily parse CLI custom resources as key=value pairs.

contributes to #2173
depends on https://github.com/ray-project/ray/pull/53938


## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
