### PR TITLE
[Chore][Sample-yaml] Upgrade pytorch-lightning to 1.8.5 for `ray-job.pytorch-distributed-training.yaml`

### DIFF
--- a/ray-operator/config/samples/pytorch-text-classifier/ray-job.pytorch-distributed-training.yaml
+++ b/ray-operator/config/samples/pytorch-text-classifier/ray-job.pytorch-distributed-training.yaml
@@ -12,7 +12,7 @@ spec:
       - numpy
       - datasets
       - transformers>=4.19.1
-      - pytorch-lightning==1.6.5
+      - pytorch-lightning==1.8.5
     working_dir: "https://github.com/ray-project/kuberay/archive/master.zip"
   rayClusterSpec:
     rayVersion: '2.46.0'


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fix errors for `ray-job.pytorch-distributed-training.yaml` by upgrading `pytorch-lightning` to 1.8.5.

Before:

![ksnip_20250615-185200](https://github.com/user-attachments/assets/11066c8e-8441-4f4a-a4c0-8872115e31ea)

After:

![image](https://github.com/user-attachments/assets/aa7ac55d-734e-46c4-89d9-337baaa4e20d)


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
