### PR TITLE
[Fix] changelog-generator.py failed to parse some commit messages

### DIFF
--- a/scripts/changelog-generator.py
+++ b/scripts/changelog-generator.py
@@ -33,6 +33,8 @@ d760b9c [helm] Add memory limits and resource documentation. (#789) (#798)
 '''
 
 g = ChangelogGenerator("ray-project/kuberay")
-for pr_match in re.finditer(r"#(\d+)", payload):
-    pr_id = int(pr_match.group(1))
+for line in payload.splitlines():
+    if line.strip() == "":
+        continue
+    pr_id = int(line.split("#")[-1].strip()[:-1])
     print("* {}".format(g.generate(pr_id)))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As title.

The original script failed to handle this case because 3553 is an issue, not PR

```
22852028 [ray-operator][Bug] Rayjob is Failed or Succeed, but Raycluster status(jobDeploymentStatus) is still Running(#3553) (#3642)
```

Because the commit message always look like `... (#XXX)`, we can simply extract the PR number by splitting by `#` without using regex.

Follow-up:

See if we can resolve those cherry-picked commits automatically.

![image](https://github.com/user-attachments/assets/587f5883-f2af-4329-b2a7-5de4ba21cfe7)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
