### PR TITLE
[kubectl-plugin] Validate empty resouce quantity strings

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -205,11 +205,10 @@ func (options *CreateClusterOptions) Validate(cmd *cobra.Command) error {
 		}
 
 		for name, value := range resourceFields {
-			if (name == "head-ephemeral-storage" || name == "worker-ephemeral-storage") && value == "" {
-				continue
-			}
-			if err := util.ValidateResourceQuantity(value, name); err != nil {
-				return fmt.Errorf("%w", err)
+			if value != "" || cmd.Flags().Changed(name) {
+				if err := util.ValidateResourceQuantity(value, name); err != nil {
+					return fmt.Errorf("%w", err)
+				}
 			}
 		}
 	}

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -300,8 +300,10 @@ func (options *SubmitJobOptions) Validate(cmd *cobra.Command) error {
 	}
 
 	for name, value := range resourceFields {
-		if err := util.ValidateResourceQuantity(value, name); err != nil {
-			return fmt.Errorf("%w", err)
+		if value != "" || cmd.Flags().Changed(name) {
+			if err := util.ValidateResourceQuantity(value, name); err != nil {
+				return fmt.Errorf("%w", err)
+			}
 		}
 	}
 

--- a/kubectl-plugin/pkg/util/validation.go
+++ b/kubectl-plugin/pkg/util/validation.go
@@ -9,10 +9,6 @@ import (
 const tpuDocURL = "https://cloud.google.com/kubernetes-engine/docs/concepts/plan-tpus#availability"
 
 func ValidateResourceQuantity(value string, name string) error {
-	if value == "" {
-		return nil
-	}
-
 	q, err := resource.ParseQuantity(value)
 	if err != nil {
 		return fmt.Errorf("%s is not a valid resource quantity: %w", name, err)

--- a/kubectl-plugin/pkg/util/validation_test.go
+++ b/kubectl-plugin/pkg/util/validation_test.go
@@ -16,7 +16,10 @@ func TestValidateResourceQuantity(t *testing.T) {
 		{"aaa", "cpu", true},
 		{"10Gi", "memory", false},
 		{"bbb", "memory", true},
-		{"", "memory", false},
+		{"", "memory", true},
+		{"", "ephemeral-storage", true},
+		{"100Gi", "head-ephemeral-storage", false},
+		{"-100Gi", "worker-ephemeral-storage", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Follow the Kubernetes API  when user set the resources option without providing a value.

Before:
<img width="1494" height="412" alt="image" src="https://github.com/user-attachments/assets/7a7fdbcb-1d3f-480b-9a9c-c69d148992e7" />

After:
<img width="818" height="63" alt="image" src="https://github.com/user-attachments/assets/20ddbafc-f370-4382-b0d3-ab2ddda30455" />



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
