### PR TITLE
[feat][operator] validate Ray resource metadata in webhook

### DIFF
--- a/ray-operator/config/webhook/manifests.yaml
+++ b/ray-operator/config/webhook/manifests.yaml
@@ -24,3 +24,43 @@ webhooks:
     resources:
     - rayclusters
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-ray-io-v1-rayjob
+  failurePolicy: Fail
+  name: vrayjob.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rayjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-ray-io-v1-rayservice
+  failurePolicy: Fail
+  name: vrayservice.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rayservices
+  sideEffects: None

--- a/ray-operator/pkg/webhooks/v1/raycluster_webhook_test.go
+++ b/ray-operator/pkg/webhooks/v1/raycluster_webhook_test.go
@@ -1,0 +1,121 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	//+kubebuilder:scaffold:imports
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+)
+
+var _ = Describe("RayCluster validating webhook", func() {
+	Context("when name is too long", func() {
+		It("should return error", func() {
+			longName := "this-name-is-tooooooooooooooooooooooooooooooooooooooooooo-long-and-should-be-invalid"
+			rayCluster := rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      longName,
+				},
+				Spec: rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{},
+							},
+						},
+					},
+					WorkerGroupSpecs: []rayv1.WorkerGroupSpec{},
+				},
+			}
+
+			err := k8sClient.Create(context.TODO(), &rayCluster)
+			Expect(err).To(HaveOccurred())
+
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("RayCluster.ray.io \"%s\" is invalid: metadata.name", longName)))
+		})
+	})
+
+	Context("when name isn't a DNS1035 label", func() {
+		It("should return error", func() {
+			rayCluster := rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "invalid.name",
+				},
+				Spec: rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{},
+							},
+						},
+					},
+					WorkerGroupSpecs: []rayv1.WorkerGroupSpec{},
+				},
+			}
+
+			err := k8sClient.Create(context.TODO(), &rayCluster)
+			Expect(err).To(HaveOccurred())
+
+			Expect(err.Error()).To(ContainSubstring("RayCluster.ray.io \"invalid.name\" is invalid: metadata.name:"))
+		})
+	})
+
+	Context("when groupNames are not unique", func() {
+		var name, namespace string
+		var rayCluster rayv1.RayCluster
+
+		BeforeEach(func() {
+			namespace = "default"
+			name = fmt.Sprintf("test-raycluster-%d", rand.IntnRange(1000, 9000))
+		})
+
+		It("should return error", func() {
+			rayCluster = rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{},
+							},
+						},
+					},
+					WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+						{
+							GroupName: "group1",
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
+						{
+							GroupName: "group1",
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Create(context.TODO(), &rayCluster)
+			Expect(err).To(HaveOccurred())
+
+			Expect(err.Error()).To(ContainSubstring("worker group names must be unique"))
+		})
+	})
+})

--- a/ray-operator/pkg/webhooks/v1/rayjob_webhook.go
+++ b/ray-operator/pkg/webhooks/v1/rayjob_webhook.go
@@ -1,0 +1,68 @@
+package v1
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+)
+
+var rayJobLog = logf.Log.WithName("rayjob-resource")
+
+// SetupRayJobWebhookWithManager registers the webhook for RayJob in the manager.
+func SetupRayJobWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&rayv1.RayJob{}).
+		WithValidator(&RayJobWebhook{}).
+		Complete()
+}
+
+type RayJobWebhook struct{}
+
+//+kubebuilder:webhook:path=/validate-ray-io-v1-rayjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayjobs,verbs=create;update,versions=v1,name=vrayjob.kb.io,admissionReviewVersions=v1
+
+var _ webhook.CustomValidator = &RayJobWebhook{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
+func (w *RayJobWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	rayJob := obj.(*rayv1.RayJob)
+	rayJobLog.Info("validate create", "name", rayJob.Name)
+	return nil, w.validateRayJob(rayJob)
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
+func (w *RayJobWebhook) ValidateUpdate(_ context.Context, _ runtime.Object, newObj runtime.Object) (admission.Warnings, error) {
+	rayJob := newObj.(*rayv1.RayJob)
+	rayJobLog.Info("validate update", "name", rayJob.Name)
+	return nil, w.validateRayJob(rayJob)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
+func (w *RayJobWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (w *RayJobWebhook) validateRayJob(rayJob *rayv1.RayJob) error {
+	var allErrs field.ErrorList
+
+	if err := utils.ValidateRayJobMetadata(rayJob.ObjectMeta); err != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("name"), rayJob.Name, err.Error()))
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: "ray.io", Kind: "RayJob"},
+		rayJob.Name, allErrs)
+}

--- a/ray-operator/pkg/webhooks/v1/rayjob_webhook_test.go
+++ b/ray-operator/pkg/webhooks/v1/rayjob_webhook_test.go
@@ -1,0 +1,71 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	//+kubebuilder:scaffold:imports
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+)
+
+var _ = Describe("RayJob validating webhook", func() {
+	Context("when name is too long", func() {
+		It("should return error", func() {
+			longName := "this-name-is-tooooooooooooooooooooooooooooooooooooooooooo-long-and-should-be-invalid"
+			rayJob := rayv1.RayJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      longName,
+				},
+				Spec: rayv1.RayJobSpec{
+					RayClusterSpec: &rayv1.RayClusterSpec{
+						HeadGroupSpec: rayv1.HeadGroupSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Create(context.TODO(), &rayJob)
+			Expect(err).To(HaveOccurred())
+
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("RayJob.ray.io \"%s\" is invalid: metadata.name", longName)))
+		})
+	})
+
+	Context("when name isn't a DNS1035 label", func() {
+		It("should return error", func() {
+			rayJob := rayv1.RayJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "invalid.name",
+				},
+				Spec: rayv1.RayJobSpec{
+					RayClusterSpec: &rayv1.RayClusterSpec{
+						HeadGroupSpec: rayv1.HeadGroupSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Create(context.TODO(), &rayJob)
+			Expect(err).To(HaveOccurred())
+
+			Expect(err.Error()).To(ContainSubstring("RayJob.ray.io \"invalid.name\" is invalid: metadata.name:"))
+		})
+	})
+})

--- a/ray-operator/pkg/webhooks/v1/rayservice_webhook.go
+++ b/ray-operator/pkg/webhooks/v1/rayservice_webhook.go
@@ -1,0 +1,68 @@
+package v1
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+)
+
+var rayServiceLog = logf.Log.WithName("rayservice-resource")
+
+// SetupRayServiceWebhookWithManager registers the webhook for RayService in the manager.
+func SetupRayServiceWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&rayv1.RayService{}).
+		WithValidator(&RayServiceWebhook{}).
+		Complete()
+}
+
+type RayServiceWebhook struct{}
+
+//+kubebuilder:webhook:path=/validate-ray-io-v1-rayservice,mutating=false,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayservices,verbs=create;update,versions=v1,name=vrayservice.kb.io,admissionReviewVersions=v1
+
+var _ webhook.CustomValidator = &RayServiceWebhook{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
+func (w *RayServiceWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	rayService := obj.(*rayv1.RayService)
+	rayServiceLog.Info("validate create", "name", rayService.Name)
+	return nil, w.validateRayService(rayService)
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
+func (w *RayServiceWebhook) ValidateUpdate(_ context.Context, _ runtime.Object, newObj runtime.Object) (admission.Warnings, error) {
+	rayService := newObj.(*rayv1.RayService)
+	rayServiceLog.Info("validate update", "name", rayService.Name)
+	return nil, w.validateRayService(rayService)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
+func (w *RayServiceWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (w *RayServiceWebhook) validateRayService(rayService *rayv1.RayService) error {
+	var allErrs field.ErrorList
+
+	if err := utils.ValidateRayServiceMetadata(rayService.ObjectMeta); err != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("name"), rayService.Name, err.Error()))
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: "ray.io", Kind: "RayService"},
+		rayService.Name, allErrs)
+}

--- a/ray-operator/pkg/webhooks/v1/rayservice_webhook_test.go
+++ b/ray-operator/pkg/webhooks/v1/rayservice_webhook_test.go
@@ -1,0 +1,71 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	//+kubebuilder:scaffold:imports
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+)
+
+var _ = Describe("RayService validating webhook", func() {
+	Context("when name is too long", func() {
+		It("should return error", func() {
+			longName := "this-name-is-tooooooooooooooooooooooooooooooooooooooooooo-long-and-should-be-invalid"
+			rayService := rayv1.RayService{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      longName,
+				},
+				Spec: rayv1.RayServiceSpec{
+					RayClusterSpec: rayv1.RayClusterSpec{
+						HeadGroupSpec: rayv1.HeadGroupSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Create(context.TODO(), &rayService)
+			Expect(err).To(HaveOccurred())
+
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("RayService.ray.io \"%s\" is invalid: metadata.name", longName)))
+		})
+	})
+
+	Context("when name isn't a DNS1035 label", func() {
+		It("should return error", func() {
+			rayService := rayv1.RayService{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "invalid.name",
+				},
+				Spec: rayv1.RayServiceSpec{
+					RayClusterSpec: rayv1.RayClusterSpec{
+						HeadGroupSpec: rayv1.HeadGroupSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Create(context.TODO(), &rayService)
+			Expect(err).To(HaveOccurred())
+
+			Expect(err.Error()).To(ContainSubstring("RayService.ray.io \"invalid.name\" is invalid: metadata.name:"))
+		})
+	})
+})


### PR DESCRIPTION
when the Ray resource is created or updated. For users who opt into installing the webhooks, this validation makes the K8s API fail the resource creation or update request immediately in a synchronous way that's more obvious.

We refactor the RayCluster webhook to use the same validation functions that the RayCluster controller uses. We also add tests for RayJob and RayService webhooks.

follow up to https://github.com/ray-project/kuberay/pull/3083#issuecomment-2694462235

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
