### PR TITLE
[release] add the missing step for tagging ray-operator/v1.x.x

### DIFF
--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -116,12 +116,14 @@ Refer to a previous version bump PR for guidance, like [PR #3071](https://github
     ```bash
     # Create a tag
     git tag v1.4.0
+    git tag ray-operator/v1.4.0 # we need this tag for `go get github.com/ray-project/kuberay/ray-operator` to work.
     ```
 
 4. Push the tag to the `upstream` repository:
 
     ```bash
     git push upstream v1.4.0
+    git push upstream ray-operator/v1.4.0
     ```
 
 ---


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`github.com/ray-project/kuberay/ray-operator` has its own go mod. That requires us to have a `ray-operator/vx.x.x` tag.
This PR adds the tagging steps to the release procedures.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
