### PR TITLE
[apiserver] Add retry and timeout to apiserver V2

### DIFF
--- a/apiserversdk/config.go
+++ b/apiserversdk/config.go
@@ -1,0 +1,17 @@
+package apiserversdk
+
+import "time"
+
+// Compatible with apiserver V1
+const (
+	// Max retry times for HTTP Client
+	HTTPClientDefaultMaxRetry = 3
+
+	// Retry backoff settings
+	HTTPClientDefaultBackoffBase = float64(2)
+	HTTPClientDefaultInitBackoff = 500 * time.Millisecond
+	HTTPClientDefaultMaxBackoff  = 10 * time.Second
+
+	// Overall timeout for retries
+	HTTPClientDefaultOverallTimeout = 30 * time.Second
+)

--- a/apiserversdk/config.go
+++ b/apiserversdk/config.go
@@ -2,7 +2,7 @@ package apiserversdk
 
 import "time"
 
-// Compatible with apiserver V1
+// TODO: Make apiserver configs compatible with V1
 const (
 	// Max retry times for HTTP Client
 	HTTPClientDefaultMaxRetry = 3

--- a/apiserversdk/proxy.go
+++ b/apiserversdk/proxy.go
@@ -108,7 +108,7 @@ func (rrt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 
 	var resp *http.Response
 	var err error
-	for attempt := 0; attempt <= rrt.retries; attempt++ {
+	for attempt := 0; attempt < rrt.retries; attempt++ {
 		if attempt == 0 && req.Body != nil && req.GetBody == nil {
 			bodyBytes, err := io.ReadAll(req.Body)
 			if err != nil {
@@ -146,7 +146,7 @@ func (rrt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			return resp, nil
 		}
 
-		if attempt < rrt.retries && resp.Body != nil {
+		if attempt < rrt.retries-1 && resp.Body != nil {
 			_, _ = io.Copy(io.Discard, resp.Body)
 			resp.Body.Close()
 		}

--- a/apiserversdk/proxy.go
+++ b/apiserversdk/proxy.go
@@ -30,8 +30,8 @@ func NewMux(config MuxConfig) (*http.ServeMux, error) {
 		return nil, fmt.Errorf("failed to parse url from config: %w", err)
 	}
 	proxy := httputil.NewSingleHostReverseProxy(u)
-	baseTransport, err := rest.TransportFor(config.KubernetesConfig)
-	if err != nil { // rest.TransportFor provides the auth to the K8s API server.
+	baseTransport, err := rest.TransportFor(config.KubernetesConfig) // rest.TransportFor provides the auth to the K8s API server.
+	if err != nil {
 		return nil, fmt.Errorf("failed to get transport for config: %w", err)
 	}
 	proxy.Transport = newRetryRoundTripper(baseTransport, HTTPClientDefaultMaxRetry)

--- a/apiserversdk/proxy.go
+++ b/apiserversdk/proxy.go
@@ -170,11 +170,8 @@ func (rrt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		// TODO: merge common utils for apiserver v1 and v2
 		if deadline, ok := ctx.Deadline(); ok {
 			remaining := time.Until(deadline)
-			if remaining <= 0 {
+			if remaining <= 0 || sleepDuration > remaining {
 				return resp, fmt.Errorf("retry timeout exceeded context deadline")
-			}
-			if sleepDuration > remaining {
-				sleepDuration = remaining
 			}
 		}
 

--- a/apiserversdk/proxy.go
+++ b/apiserversdk/proxy.go
@@ -122,7 +122,6 @@ func (rrt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		if err != nil {
 			return nil, fmt.Errorf("failed to close request body: %w", err)
 		}
-		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 	}
 
 	for attempt := 0; attempt <= rrt.maxRetries; attempt++ {

--- a/apiserversdk/proxy.go
+++ b/apiserversdk/proxy.go
@@ -156,6 +156,7 @@ func (rrt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			sleepDuration = HTTPClientDefaultMaxBackoff
 		}
 
+		// TODO: merge common utils for apiserver v1 and v2
 		if deadline, ok := ctx.Deadline(); ok {
 			remaining := time.Until(deadline)
 			if remaining <= 0 {
@@ -175,6 +176,7 @@ func isSuccessfulStatusCode(statusCode int) bool {
 	return 200 <= statusCode && statusCode < 300
 }
 
+// TODO: merge common utils for apiserver v1 and v2
 func retryableHTTPStatusCodes(statusCode int) bool {
 	switch statusCode {
 	case http.StatusRequestTimeout, // 408

--- a/apiserversdk/proxy.go
+++ b/apiserversdk/proxy.go
@@ -142,7 +142,7 @@ func (rrt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			return resp, nil
 		}
 
-		if !retryableHTTPStatusCodes(resp.StatusCode) {
+		if !isRetryableHTTPStatusCodes(resp.StatusCode) {
 			return resp, nil
 		}
 
@@ -181,7 +181,7 @@ func isSuccessfulStatusCode(statusCode int) bool {
 }
 
 // TODO: merge common utils for apiserver v1 and v2
-func retryableHTTPStatusCodes(statusCode int) bool {
+func isRetryableHTTPStatusCodes(statusCode int) bool {
 	switch statusCode {
 	case http.StatusRequestTimeout, // 408
 		http.StatusTooManyRequests,     // 429

--- a/apiserversdk/proxy.go
+++ b/apiserversdk/proxy.go
@@ -155,6 +155,7 @@ func (rrt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			}
 		}
 
+		// TODO: move to HTTP util function in independent util file
 		sleepDuration := HTTPClientDefaultInitBackoff * time.Duration(math.Pow(HTTPClientDefaultBackoffBase, float64(attempt)))
 		if sleepDuration > HTTPClientDefaultMaxBackoff {
 			sleepDuration = HTTPClientDefaultMaxBackoff
@@ -176,6 +177,7 @@ func (rrt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	return resp, err
 }
 
+// TODO: move HTTP util function into independent util file / folder
 func isSuccessfulStatusCode(statusCode int) bool {
 	return 200 <= statusCode && statusCode < 300
 }

--- a/apiserversdk/proxy.go
+++ b/apiserversdk/proxy.go
@@ -27,7 +27,7 @@ type MuxConfig struct {
 func NewMux(config MuxConfig) (*http.ServeMux, error) {
 	u, err := url.Parse(config.KubernetesConfig.Host) // parse the K8s API server URL from the KubernetesConfig.
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse url from config: %w", err)
+		return nil, fmt.Errorf("failed to parse url %s from config: %w", config.KubernetesConfig.Host, err)
 	}
 	proxy := httputil.NewSingleHostReverseProxy(u)
 	baseTransport, err := rest.TransportFor(config.KubernetesConfig) // rest.TransportFor provides the auth to the K8s API server.

--- a/apiserversdk/proxy.go
+++ b/apiserversdk/proxy.go
@@ -112,7 +112,7 @@ func (rrt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	var resp *http.Response
 	var err error
 
-	if req.Body != nil && req.GetBody == nil {
+	if req.Body != nil {
 		/* Reuse request body in each attempt */
 		bodyBytes, err = io.ReadAll(req.Body)
 		if err != nil {
@@ -128,7 +128,7 @@ func (rrt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	for attempt := 0; attempt <= rrt.maxRetries; attempt++ {
 		/* Try up to (rrt.maxRetries + 1) times: initial attempt + retries */
 
-		if attempt > 0 && req.GetBody != nil {
+		if bodyBytes != nil {
 			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 		}
 

--- a/apiserversdk/proxy_test.go
+++ b/apiserversdk/proxy_test.go
@@ -3,9 +3,11 @@ package apiserversdk
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -325,3 +327,58 @@ var _ = Describe("kuberay service", Ordered, func() {
 		})
 	})
 })
+
+var _ = Describe("retryRoundTripper", func() {
+	It("should retry failed requests and eventually succeed", func() {
+		var attempts int32
+		mock := &mockRoundTripper{
+			fn: func(_ *http.Request) (*http.Response, error) {
+				count := atomic.AddInt32(&attempts, 1)
+				if count < 3 {
+					return &http.Response{
+						StatusCode: http.StatusInternalServerError,
+						Body:       io.NopCloser(strings.NewReader("internal error")),
+					}, nil
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("ok")),
+				}, nil
+			},
+		}
+		retrier := newRetryRoundTripper(mock, 5)
+		req, _ := http.NewRequest(http.MethodGet, "http://test", nil)
+		resp, err := retrier.RoundTrip(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(attempts).To(Equal(int32(3)))
+	})
+
+	It("should respect context timeout and stop retrying", func() {
+		mock := &mockRoundTripper{
+			fn: func(_ *http.Request) (*http.Response, error) {
+				time.Sleep(100 * time.Millisecond)
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader("internal error")),
+				}, nil
+			},
+		}
+		retrier := newRetryRoundTripper(mock, 5)
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://test", nil)
+		resp, err := retrier.RoundTrip(req)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("retry timeout exceeded context deadline"))
+		Expect(resp).ToNot(BeNil())
+	})
+})
+
+type mockRoundTripper struct {
+	fn func(*http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.fn(req)
+}

--- a/apiserversdk/proxy_test.go
+++ b/apiserversdk/proxy_test.go
@@ -346,7 +346,7 @@ var _ = Describe("retryRoundTripper", func() {
 				}, nil
 			},
 		}
-		retrier := newRetryRoundTripper(mock, 5)
+		retrier := newRetryRoundTripper(mock, 5 /*retries*/)
 		req, _ := http.NewRequest(http.MethodGet, "http://test", nil)
 		resp, err := retrier.RoundTrip(req)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Add retry logic and timeout to apiserver v2:
1. Timeout is set to long timeout (30 seconds) to prevent unbounded request
2. The retry logic determines if a http status code is retryable

Wrap errors with more informations

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #3606 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
