### PR TITLE
[Feature] More configability for ingresses

### DIFF
--- a/ray-operator/apis/config/v1alpha1/configuration_types.go
+++ b/ray-operator/apis/config/v1alpha1/configuration_types.go
@@ -88,8 +88,15 @@ type Configuration struct {
 	// EnableMetrics indicates whether KubeRay operator should emit control plane metrics.
 	EnableMetrics bool `json:"enableMetrics,omitempty"`
 
+	// Host used for Ray Dashboard ingresses. The host will be the same for all `RayClusters` and they
+	// will be differentiated by their paths.
 	IngressHost        string                    `json:"ingressHost,omitempty"`
+
+	// TLS configuration for the Ray Dashboard ingresses. Applies to all `RayClusters`.
 	IngressTLS         []networkingv1.IngressTLS `json:"ingressTLS,omitempty"`
+
+	// Default annotations for the Ray Dashboard ingresses. Annotations on the `RayCluster` will override
+	// these on a case-by-case basis.
 	IngressAnnotations map[string]string         `json:"ingressAnnotations,omitempty"`
 }
 

--- a/ray-operator/apis/config/v1alpha1/configuration_types.go
+++ b/ray-operator/apis/config/v1alpha1/configuration_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -86,6 +87,10 @@ type Configuration struct {
 
 	// EnableMetrics indicates whether KubeRay operator should emit control plane metrics.
 	EnableMetrics bool `json:"enableMetrics,omitempty"`
+
+	IngressHost        string                    `json:"ingressHost,omitempty"`
+	IngressTLS         []networkingv1.IngressTLS `json:"ingressTLS,omitempty"`
+	IngressAnnotations map[string]string         `json:"ingressAnnotations,omitempty"`
 }
 
 func (config Configuration) GetDashboardClient(mgr manager.Manager) func(rayCluster *rayv1.RayCluster, url string) (dashboardclient.RayDashboardClientInterface, error) {

--- a/ray-operator/apis/config/v1alpha1/configuration_types.go
+++ b/ray-operator/apis/config/v1alpha1/configuration_types.go
@@ -27,11 +27,19 @@ type Configuration struct {
 	// there is only one active instance of the operator.
 	EnableLeaderElection *bool `json:"enableLeaderElection,omitempty"`
 
+	// Default annotations for the Ray Dashboard ingresses. Annotations on the `RayCluster` will override
+	// these on a case-by-case basis.
+	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`
+
 	metav1.TypeMeta `json:",inline"`
 
 	// LogStdoutEncoder is the encoder to use when logging to stdout. Valid values are "json" and "console".
 	// Defaults to `json` if empty.
 	LogStdoutEncoder string `json:"logStdoutEncoder,omitempty"`
+
+	// Host used for Ray Dashboard ingresses. The host will be the same for all `RayClusters` and they
+	// will be differentiated by their paths.
+	IngressHost string `json:"ingressHost,omitempty"`
 
 	// ProbeAddr is the address the probe endpoint binds to.
 	ProbeAddr string `json:"probeAddr,omitempty"`
@@ -66,6 +74,9 @@ type Configuration struct {
 	// to inject into every Head pod.
 	HeadSidecarContainers []corev1.Container `json:"headSidecarContainers,omitempty"`
 
+	// TLS configuration for the Ray Dashboard ingresses. Applies to all `RayClusters`.
+	IngressTLS []networkingv1.IngressTLS `json:"ingressTLS,omitempty"`
+
 	// DefaultContainerEnvs specifies default environment variables to inject into all Ray containers
 	DefaultContainerEnvs []corev1.EnvVar `json:"defaultContainerEnvs,omitempty"`
 
@@ -87,17 +98,6 @@ type Configuration struct {
 
 	// EnableMetrics indicates whether KubeRay operator should emit control plane metrics.
 	EnableMetrics bool `json:"enableMetrics,omitempty"`
-
-	// Host used for Ray Dashboard ingresses. The host will be the same for all `RayClusters` and they
-	// will be differentiated by their paths.
-	IngressHost string `json:"ingressHost,omitempty"`
-
-	// TLS configuration for the Ray Dashboard ingresses. Applies to all `RayClusters`.
-	IngressTLS []networkingv1.IngressTLS `json:"ingressTLS,omitempty"`
-
-	// Default annotations for the Ray Dashboard ingresses. Annotations on the `RayCluster` will override
-	// these on a case-by-case basis.
-	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`
 }
 
 func (config Configuration) GetDashboardClient(mgr manager.Manager) func(rayCluster *rayv1.RayCluster, url string) (dashboardclient.RayDashboardClientInterface, error) {

--- a/ray-operator/apis/config/v1alpha1/configuration_types.go
+++ b/ray-operator/apis/config/v1alpha1/configuration_types.go
@@ -90,14 +90,14 @@ type Configuration struct {
 
 	// Host used for Ray Dashboard ingresses. The host will be the same for all `RayClusters` and they
 	// will be differentiated by their paths.
-	IngressHost        string                    `json:"ingressHost,omitempty"`
+	IngressHost string `json:"ingressHost,omitempty"`
 
 	// TLS configuration for the Ray Dashboard ingresses. Applies to all `RayClusters`.
-	IngressTLS         []networkingv1.IngressTLS `json:"ingressTLS,omitempty"`
+	IngressTLS []networkingv1.IngressTLS `json:"ingressTLS,omitempty"`
 
 	// Default annotations for the Ray Dashboard ingresses. Annotations on the `RayCluster` will override
 	// these on a case-by-case basis.
-	IngressAnnotations map[string]string         `json:"ingressAnnotations,omitempty"`
+	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`
 }
 
 func (config Configuration) GetDashboardClient(mgr manager.Manager) func(rayCluster *rayv1.RayCluster, url string) (dashboardclient.RayDashboardClientInterface, error) {

--- a/ray-operator/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -6,6 +6,7 @@ package v1alpha1
 
 import (
 	"k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -47,6 +48,20 @@ func (in *Configuration) DeepCopyInto(out *Configuration) {
 		*out = make([]v1.EnvVar, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.IngressTLS != nil {
+		in, out := &in.IngressTLS, &out.IngressTLS
+		*out = make([]networkingv1.IngressTLS, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.IngressAnnotations != nil {
+		in, out := &in.IngressAnnotations, &out.IngressAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 }

--- a/ray-operator/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -28,6 +28,13 @@ func (in *Configuration) DeepCopyInto(out *Configuration) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.IngressAnnotations != nil {
+		in, out := &in.IngressAnnotations, &out.IngressAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	out.TypeMeta = in.TypeMeta
 	if in.WorkerSidecarContainers != nil {
 		in, out := &in.WorkerSidecarContainers, &out.WorkerSidecarContainers
@@ -43,13 +50,6 @@ func (in *Configuration) DeepCopyInto(out *Configuration) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.DefaultContainerEnvs != nil {
-		in, out := &in.DefaultContainerEnvs, &out.DefaultContainerEnvs
-		*out = make([]v1.EnvVar, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
 	if in.IngressTLS != nil {
 		in, out := &in.IngressTLS, &out.IngressTLS
 		*out = make([]networkingv1.IngressTLS, len(*in))
@@ -57,11 +57,11 @@ func (in *Configuration) DeepCopyInto(out *Configuration) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.IngressAnnotations != nil {
-		in, out := &in.IngressAnnotations, &out.IngressAnnotations
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+	if in.DefaultContainerEnvs != nil {
+		in, out := &in.DefaultContainerEnvs, &out.DefaultContainerEnvs
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -15,7 +15,7 @@ const IngressClassAnnotationKey = "kubernetes.io/ingress.class"
 
 // BuildIngressForHeadService Builds the ingress for head service dashboard.
 // This is used to expose dashboard for external traffic.
-func BuildIngressForHeadService(ctx context.Context, cluster rayv1.RayCluster) (*networkingv1.Ingress, error) {
+func BuildIngressForHeadService(ctx context.Context, cluster rayv1.RayCluster, ingressTLS []networkingv1.IngressTLS, host string, defaultAnnotations map[string]string) (*networkingv1.Ingress, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	labels := map[string]string{
@@ -32,7 +32,7 @@ func BuildIngressForHeadService(ctx context.Context, cluster rayv1.RayCluster) (
 	excludeSet := map[string]struct{}{
 		IngressClassAnnotationKey: {},
 	}
-	annotation := map[string]string{}
+	annotation := defaultAnnotations
 	for key, value := range cluster.Annotations {
 		if _, ok := excludeSet[key]; !ok {
 			annotation[key] = value
@@ -73,8 +73,10 @@ func BuildIngressForHeadService(ctx context.Context, cluster rayv1.RayCluster) (
 			Annotations: annotation,
 		},
 		Spec: networkingv1.IngressSpec{
+			TLS: ingressTLS,
 			Rules: []networkingv1.IngressRule{
 				{
+					Host: host,
 					IngressRuleValue: networkingv1.IngressRuleValue{
 						HTTP: &networkingv1.HTTPIngressRuleValue{
 							Paths: paths,

--- a/ray-operator/controllers/ray/common/ingress.go
+++ b/ray-operator/controllers/ray/common/ingress.go
@@ -15,7 +15,7 @@ const IngressClassAnnotationKey = "kubernetes.io/ingress.class"
 
 // BuildIngressForHeadService Builds the ingress for head service dashboard.
 // This is used to expose dashboard for external traffic.
-func BuildIngressForHeadService(ctx context.Context, cluster rayv1.RayCluster, ingressTLS []networkingv1.IngressTLS, host string, defaultAnnotations map[string]string) (*networkingv1.Ingress, error) {
+func BuildIngressForHeadService(ctx context.Context, cluster rayv1.RayCluster, host string, ingressTLS []networkingv1.IngressTLS, defaultAnnotations map[string]string) (*networkingv1.Ingress, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	labels := map[string]string{

--- a/ray-operator/controllers/ray/common/ingress_test.go
+++ b/ray-operator/controllers/ray/common/ingress_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -74,13 +75,13 @@ var instanceWithIngressEnabledWithoutIngressClass = &rayv1.RayCluster{
 
 // only throw warning message and rely on Kubernetes to assign default ingress class
 func TestBuildIngressForHeadServiceWithoutIngressClass(t *testing.T) {
-	ingress, err := BuildIngressForHeadService(context.Background(), *instanceWithIngressEnabledWithoutIngressClass)
+	ingress, err := BuildIngressForHeadService(context.Background(), *instanceWithIngressEnabledWithoutIngressClass, "", []networkingv1.IngressTLS{}, map[string]string{})
 	assert.NotNil(t, ingress)
 	require.NoError(t, err)
 }
 
 func TestBuildIngressForHeadService(t *testing.T) {
-	ingress, err := BuildIngressForHeadService(context.Background(), *instanceWithIngressEnabled)
+	ingress, err := BuildIngressForHeadService(context.Background(), *instanceWithIngressEnabled, "", []networkingv1.IngressTLS{}, map[string]string{})
 	require.NoError(t, err)
 
 	// check ingress.class annotation

--- a/ray-operator/controllers/ray/common/ingress_test.go
+++ b/ray-operator/controllers/ray/common/ingress_test.go
@@ -115,10 +115,10 @@ func TestBuildIngressForHeadService(t *testing.T) {
 	}
 
 	// check host
-	assert.Equal(t, ingress.Spec.Rules[0].Host, "")
+	assert.Equal(t, "", ingress.Spec.Rules[0].Host)
 
 	// tls count
-	assert.Len(t, ingress.Spec.TLS, 0)
+	assert.Empty(t, ingress.Spec.TLS)
 }
 
 func TestBuildIngressForHeadServiceWithControllerConfigs(t *testing.T) {
@@ -135,9 +135,9 @@ func TestBuildIngressForHeadServiceWithControllerConfigs(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, *ingress.Spec.IngressClassName, ingressClass)
-	assert.Equal(t, ingress.Annotations, map[string]string{
+	assert.Equal(t, map[string]string{
 		"annotation0": "value2", "annotation1": "value2",
-	})
+	}, ingress.Annotations)
 	assert.Equal(t, ingress.Spec.Rules[0].Host, host)
 	assert.Equal(t, ingress.Spec.TLS, tls)
 }
@@ -148,10 +148,10 @@ func TestBuildIngressForHeadServiceClusterSpecificAnnotationsTakePrecedence(t *t
 	require.NoError(t, err)
 
 	delete(annotations, IngressClassAnnotationKey)
-	assert.Equal(t, ingress.Annotations, map[string]string{
+	assert.Equal(t, map[string]string{
 		"annotation0": "value", // Overridden by cluster annotation
 		"annotation1": "value",
 		"annotation2": "value2",
-	})
+	}, ingress.Annotations)
 	assert.Equal(t, instanceWithIngressEnabled.Annotations[IngressClassAnnotationKey], *ingress.Spec.IngressClassName)
 }

--- a/ray-operator/controllers/ray/common/ingress_test.go
+++ b/ray-operator/controllers/ray/common/ingress_test.go
@@ -122,10 +122,10 @@ func TestBuildIngressForHeadService(t *testing.T) {
 }
 
 func TestBuildIngressForHeadServiceWithControllerConfigs(t *testing.T) {
-	host := "ray-host"
+	host := "ray.example.com"
 	tls := []networkingv1.IngressTLS{
 		{
-			Hosts:      []string{"ray-host"},
+			Hosts:      []string{host},
 			SecretName: "ray-tls-secret",
 		},
 	}
@@ -138,7 +138,7 @@ func TestBuildIngressForHeadServiceWithControllerConfigs(t *testing.T) {
 	assert.Equal(t, ingress.Annotations, map[string]string{
 		"annotation0": "value2", "annotation1": "value2",
 	})
-	assert.Equal(t, ingress.Spec.Rules[0].Host, "ray-host")
+	assert.Equal(t, ingress.Spec.Rules[0].Host, host)
 	assert.Equal(t, ingress.Spec.TLS, tls)
 }
 
@@ -149,7 +149,7 @@ func TestBuildIngressForHeadServiceClusterSpecificAnnotationsTakePrecedence(t *t
 
 	delete(annotations, IngressClassAnnotationKey)
 	assert.Equal(t, ingress.Annotations, map[string]string{
-		"annotation0": "value",
+		"annotation0": "value", // Overridden by cluster annotation
 		"annotation1": "value",
 		"annotation2": "value2",
 	})

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -88,6 +88,9 @@ type RayClusterReconcilerOptions struct {
 	WorkerSidecarContainers  []corev1.Container
 	DefaultContainerEnvs     []corev1.EnvVar
 	IsOpenShift              bool
+	IngressHost              string
+	IngressTLS               []networkingv1.IngressTLS
+	IngressAnnotations       map[string]string
 }
 
 // Reconcile reads that state of the cluster for a RayCluster object and makes changes based on it
@@ -474,7 +477,7 @@ func (r *RayClusterReconciler) reconcileIngressKubernetes(ctx context.Context, i
 	}
 
 	if len(headIngresses.Items) == 0 {
-		ingress, err := common.BuildIngressForHeadService(ctx, *instance)
+		ingress, err := common.BuildIngressForHeadService(ctx, *instance, r.options.IngressHost, r.options.IngressTLS, r.options.IngressAnnotations)
 		if err != nil {
 			return err
 		}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -84,13 +84,13 @@ type RayClusterReconciler struct {
 type RayClusterReconcilerOptions struct {
 	RayClusterMetricsManager *metrics.RayClusterMetricsManager
 	BatchSchedulerManager    *batchscheduler.SchedulerManager
+	IngressAnnotations       map[string]string
+	IngressHost              string
 	HeadSidecarContainers    []corev1.Container
 	WorkerSidecarContainers  []corev1.Container
 	DefaultContainerEnvs     []corev1.EnvVar
-	IsOpenShift              bool
-	IngressHost              string
 	IngressTLS               []networkingv1.IngressTLS
-	IngressAnnotations       map[string]string
+	IsOpenShift              bool
 }
 
 // Reconcile reads that state of the cluster for a RayCluster object and makes changes based on it

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -273,6 +273,9 @@ func main() {
 		RayClusterMetricsManager: rayClusterMetricsManager,
 		BatchSchedulerManager:    batchSchedulerManager,
 		DefaultContainerEnvs:     config.DefaultContainerEnvs,
+		IngressHost:              config.IngressHost,
+		IngressTLS:               config.IngressTLS,
+		IngressAnnotations:       config.IngressAnnotations,
 	}
 	exitOnError(ray.NewReconciler(ctx, mgr, rayClusterOptions).SetupWithManager(mgr, config.ReconcileConcurrency),
 		"unable to create controller", "controller", "RayCluster")

--- a/ray-operator/main_test.go
+++ b/ray-operator/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -100,6 +101,42 @@ workerSidecarContainers:
 				},
 				QPS:   ptr.To(configapi.DefaultQPS),
 				Burst: ptr.To(configapi.DefaultBurst),
+			},
+			expectErr: false,
+		},
+		{
+			name: "config with ingress options",
+			configData: `apiVersion: config.ray.io/v1alpha1
+kind: Configuration
+ingressHost: ray.example.com
+ingressTLS:
+- hosts:
+  - ray.example.com
+  secretName: ray-tls-secret
+ingressAnnotations:
+  annotation0: value0
+  annotation1: value1
+`,
+			expectedConfig: configapi.Configuration{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Configuration",
+					APIVersion: "config.ray.io/v1alpha1",
+				},
+				MetricsAddr:          ":8080",
+				ProbeAddr:            ":8082",
+				EnableLeaderElection: ptr.To(true),
+				ReconcileConcurrency: 1,
+				IngressHost:          "ray.example.com",
+				IngressTLS: []networkingv1.IngressTLS{
+					{
+						Hosts:      []string{"ray.example.com"},
+						SecretName: "ray-tls-secret",
+					},
+				},
+				IngressAnnotations: map[string]string{
+					"annotation0": "value0",
+					"annotation1": "value1",
+				},
 			},
 			expectErr: false,
 		},

--- a/ray-operator/main_test.go
+++ b/ray-operator/main_test.go
@@ -137,6 +137,8 @@ ingressAnnotations:
 					"annotation0": "value0",
 					"annotation1": "value1",
 				},
+				QPS:   ptr.To(configapi.DefaultQPS),
+				Burst: ptr.To(configapi.DefaultBurst),
 			},
 			expectErr: false,
 		},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There are scenarios where having the kuberay operator automatically create ingresses is very useful. Currently the configration options avialable are quite limitted, so this PR adds some extra configurability. For me its important to be able to configure this on the helm level, so that I can set it in one place and it will work for all `RayClusters` in our kubernetes cluster.

## Related issue number
This PR does not exactly address any particular issue, but there are a few related issues:
1. https://github.com/ray-project/kuberay/issues/1475
2. https://github.com/ray-project/kuberay/issues/1436
3. https://github.com/ray-project/kuberay/issues/648

I've implemented this PR to solve my variant of this problem. I can't say for certain if it solves the problems of the authors of these other issues, but I hope it does. 

## Checks

- [x] I've made sure the tests are passing - at least the unit tests are passing; I had some e2e test failures when I tried to run on `master`
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests  - currently using this change internally
  - [ ] This PR is not tested :(


Hopefully this approach makes sense. If not I'm happy to discuss. 