### PR TITLE
Chore: fix indentation issues in RayJob sample YAML

### DIFF
--- a/ray-operator/config/samples/ray-job.sample.yaml
+++ b/ray-operator/config/samples/ray-job.sample.yaml
@@ -95,17 +95,18 @@ spec:
                 cpu: "1"
               requests:
                 cpu: "200m"
-                # SubmitterPodTemplate is the template for the pod that will run the `ray job submit` command against the RayCluster.
-                # If SubmitterPodTemplate is specified, the first container is assumed to be the submitter container.
-                # submitterPodTemplate:
-                #   spec:
-                #     restartPolicy: Never
-                #     containers:
-                #       - name: my-custom-rayjob-submitter-pod
-                #         image: rayproject/ray:2.46.0
-                #         # If Command is not specified, the correct command will be supplied at runtime using the RayJob spec `entrypoint` field.
-                #         # Specifying Command is not recommended.
-                #         # command: ["sh", "-c", "ray job submit --address=http://$RAY_DASHBOARD_ADDRESS --submission-id=$RAY_JOB_SUBMISSION_ID -- echo hello world"]
+
+  # SubmitterPodTemplate is the template for the pod that will run the `ray job submit` command against the RayCluster.
+  # If SubmitterPodTemplate is specified, the first container is assumed to be the submitter container.
+  # submitterPodTemplate:
+  #   spec:
+  #     restartPolicy: Never
+  #     containers:
+  #       - name: my-custom-rayjob-submitter-pod
+  #         image: rayproject/ray:2.46.0
+  #         # If Command is not specified, the correct command will be supplied at runtime using the RayJob spec `entrypoint` field.
+  #         # Specifying Command is not recommended.
+  #         # command: ["sh", "-c", "ray job submit --address=http://$RAY_DASHBOARD_ADDRESS --submission-id=$RAY_JOB_SUBMISSION_ID -- echo hello world"]
 
 
 ######################Ray code sample#################################


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, the `submitterPodTemplate` comment was placed inside the `workerGroupSpecs.template.spec.containers.requests`, which could mislead users or cause errors when applying the RayJob YAML. This PR moves the comment to the correct location under the `RayJob.spec` to avoid confusion or misconfiguration.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
