### PR TITLE
[Helm] Add gcsFaultToleranceOptions in RayCluster chart

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -20,6 +20,21 @@ spec:
   autoscalerOptions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.gcsFaultTolerance.enabled }}
+  gcsFaultToleranceOptions:
+    redisAddress: {{ .Values.gcsFaultTolerance.redisAddress | quote }}
+    {{- with .Values.gcsFaultTolerance.externalStorageNamespace }}
+    externalStorageNamespace: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.gcsFaultTolerance.redisPassword }}
+    redisPassword:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.gcsFaultTolerance.redisUsername }}
+    redisUsername:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
   headGroupSpec:
     {{- with .Values.head.headService }}
     headService:

--- a/helm-chart/ray-cluster/tests/raycluster_test.yaml
+++ b/helm-chart/ray-cluster/tests/raycluster_test.yaml
@@ -97,6 +97,33 @@ tests:
               seccompProfile:
                 type: RuntimeDefault
 
+  - it: Should add GCS fault tolerance options when `gcsFaultTolerance.enabled` is `true`
+    set:
+      gcsFaultTolerance:
+        enabled: true
+        redisAddress: "test-redis:6379"
+        externalStorageNamespace: "test-gcs-namespace"
+        redisPassword:
+          valueFrom:
+            secretKeyRef:
+              name: redis-secret
+              key: password
+        redisUsername:
+          value: "test-user"
+    asserts:
+      - equal:
+          path: spec.gcsFaultToleranceOptions
+          value:
+            redisAddress: "test-redis:6379"
+            externalStorageNamespace: "test-gcs-namespace"
+            redisPassword:
+              valueFrom:
+                secretKeyRef:
+                  name: redis-secret
+                  key: password
+            redisUsername:
+              value: "test-user"
+
   # ===========================================================================
   # Test Head Group
   # ===========================================================================

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -16,6 +16,30 @@ fullnameOverride: ""
 imagePullSecrets: []
   # - name: an-existing-secret
 
+# gcsFaultTolerance specifies configuration for GCS fault tolerance.
+# See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/kuberay-gcs-ft.html#kuberay-gcs-ft
+# for more details.
+gcsFaultTolerance:
+  enabled: false
+  # In most cases, you don't need to set `externalStorageNamespace` because KubeRay will
+  # automatically set it to the UID of RayCluster. Only modify this annotation if you fully understand
+  # the behaviors of the Ray GCS FT and RayService to avoid misconfiguration.
+  # externalStorageNamespace: "my-raycluster-storage"
+  # redisAddress: "redis:6379"
+  # redisPassword:
+    # value: ""
+    # valueFrom: {}
+    #   secretKeyRef:
+    #       name: redis-password-secret
+    #       key: password
+  # redisUsername:
+    # value: ""
+    # valueFrom: {}
+    #   secretKeyRef:
+    #     name: redis-username-secret
+    #     key: username
+
+
 # common defined values shared between the head and worker
 common:
   # containerEnv specifies environment variables for the Ray head and worker containers.

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -27,14 +27,16 @@ gcsFaultTolerance:
   # externalStorageNamespace: "my-raycluster-storage"
   # redisAddress: "redis:6379"
   # redisPassword:
-    # value: ""
-    # valueFrom: {}
+    # Reference to a secret key containing the Redis password
+    # Secret must be manually created in the namespace
+    # valueFrom:
     #   secretKeyRef:
     #       name: redis-password-secret
     #       key: password
   # redisUsername:
-    # value: ""
-    # valueFrom: {}
+    # Reference to a secret key containing the Redis username
+    # Secret must be manually created in the namespace
+    # valueFrom:
     #   secretKeyRef:
     #     name: redis-username-secret
     #     key: username


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As title.

### E2E test:

Enable `gcsFaultTolerance` and set `redisPassword` and `redisAddress` in RayCluster chart.
```yaml
gcsFaultTolerance:
  enabled: true
  redisAddress: "redis:6379"
  redisPassword:
    # value: ""
    valueFrom: 
      secretKeyRef:
          name: redis-password-secret
          key: password
```

```
helm install ray-cluster ./helm-chart/ray-cluster
```

<img width="534" height="404" alt="image" src="https://github.com/user-attachments/assets/9edba2cc-0d82-4ac9-a1ba-39cfda14a858" />


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #3776

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
