### PR TITLE
dashboard: allow changing the dashboard api url using an env var

### DIFF
--- a/dashboard/src/utils/constants.ts
+++ b/dashboard/src/utils/constants.ts
@@ -1,11 +1,11 @@
 export const ALL_NAMESPACES = "all"
 // I'm developing in the stage cluster, so I'm directly using the deployed backend
 const development = {
-  url: "http://localhost:31888/apis/v1",
+  url: process.env.NEXT_PUBLIC_API_URL || "http://localhost:31888/apis/v1",
 };
 
 const production = {
-  url: "http://localhost:31888/apis/v1",
+  url: process.env.NEXT_PUBLIC_API_URL || "http://localhost:31888/apis/v1",
 };
 
 export const config =


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The new KubeRay Dashboard doesn't support replacing the API URL using an env var, which means it can't be easily hosted.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [x] This PR is not tested :(
