### PR TITLE
[Feature] Add e2e test for setting RayCluster deletion delay in RayService

### DIFF
--- a/ray-operator/test/e2erayservice/rayservice_ha_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_ha_test.go
@@ -30,8 +30,8 @@ func TestStaticRayService(t *testing.T) {
 	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", configMap.Namespace, configMap.Name)
 
 	// Create the RayService for testing
-	rayServiceName := "test-rayservice"
-	ApplyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
+	rayServiceName := "test-rayservice-static"
+	applyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
 
 	// Create Locust RayCluster
 	KubectlApplyYAML(test, locustYamlFile, namespace.Name)
@@ -74,8 +74,8 @@ func TestAutoscalingRayService(t *testing.T) {
 	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", configMap.Namespace, configMap.Name)
 
 	// Create the RayService for testing
-	rayServiceName := "test-rayservice"
-	ApplyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
+	rayServiceName := "test-rayservice-autoscale"
+	applyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
 
 	// Get the underlying RayCluster of the RayService
 	rayService, err := GetRayService(test, namespace.Name, rayServiceName)
@@ -138,8 +138,8 @@ func TestRayServiceZeroDowntimeUpgrade(t *testing.T) {
 	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", configMap.Namespace, configMap.Name)
 
 	// Create the RayService for testing
-	rayServiceName := "test-rayservice"
-	ApplyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
+	rayServiceName := "test-rayservice-zero-downtime"
+	applyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
 
 	// Create Locust RayCluster
 	KubectlApplyYAML(test, locustYamlFile, namespace.Name)
@@ -169,7 +169,7 @@ func TestRayServiceZeroDowntimeUpgrade(t *testing.T) {
 		time.Sleep(30 * time.Second)
 
 		LogWithTimestamp(test.T(), "Updating RayService")
-		rayService, err := GetRayService(test, namespace.Name, "test-rayservice")
+		rayService, err := GetRayService(test, namespace.Name, rayServiceName)
 		g.Expect(err).NotTo(HaveOccurred())
 		rayClusterName := rayService.Status.ActiveServiceStatus.RayClusterName
 
@@ -206,8 +206,8 @@ func TestRayServiceGCSFaultTolerance(t *testing.T) {
 	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", configMap.Namespace, configMap.Name)
 
 	// Create the RayService for testing
-	rayServiceName := "test-rayservice"
-	ApplyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
+	rayServiceName := "test-rayservice-gcs"
+	applyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
 
 	g.Eventually(RayService(test, namespace.Name, rayServiceName), TestTimeoutShort).
 		Should(WithTransform(RayServicesNumEndPoints, Equal(int32(1))))
@@ -272,8 +272,8 @@ func TestRayServiceRayClusterDeletionDelaySeconds(t *testing.T) {
 	namespace := test.NewTestNamespace()
 
 	// Apply the RayService YAML with deletion delay set to 10 second
-	rayServiceName := "test-rayservice"
-	ApplyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
+	rayServiceName := "test-rayservice-deletion-delay"
+	applyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
 
 	// Save the current RayCluster name
 	rayService, err := GetRayService(test, namespace.Name, rayServiceName)

--- a/ray-operator/test/e2erayservice/rayservice_ha_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_ha_test.go
@@ -30,7 +30,7 @@ func TestStaticRayService(t *testing.T) {
 	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", configMap.Namespace, configMap.Name)
 
 	// Create the RayService for testing
-	rayServiceName := "test-rayservice-static"
+	rayServiceName := "test-rayservice"
 	applyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
 
 	// Create Locust RayCluster
@@ -74,7 +74,7 @@ func TestAutoscalingRayService(t *testing.T) {
 	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", configMap.Namespace, configMap.Name)
 
 	// Create the RayService for testing
-	rayServiceName := "test-rayservice-autoscale"
+	rayServiceName := "test-rayservice"
 	applyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
 
 	// Get the underlying RayCluster of the RayService
@@ -138,7 +138,7 @@ func TestRayServiceZeroDowntimeUpgrade(t *testing.T) {
 	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", configMap.Namespace, configMap.Name)
 
 	// Create the RayService for testing
-	rayServiceName := "test-rayservice-zero-downtime"
+	rayServiceName := "test-rayservice"
 	applyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
 
 	// Create Locust RayCluster
@@ -206,7 +206,7 @@ func TestRayServiceGCSFaultTolerance(t *testing.T) {
 	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", configMap.Namespace, configMap.Name)
 
 	// Create the RayService for testing
-	rayServiceName := "test-rayservice-gcs"
+	rayServiceName := "test-rayservice"
 	applyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
 
 	g.Eventually(RayService(test, namespace.Name, rayServiceName), TestTimeoutShort).

--- a/ray-operator/test/e2erayservice/rayservice_ha_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_ha_test.go
@@ -271,7 +271,7 @@ func TestRayServiceRayClusterDeletionDelaySeconds(t *testing.T) {
 	g := NewWithT(t)
 	namespace := test.NewTestNamespace()
 
-	// Apply the RayService YAML with deletion delay set to 10 second
+	// Apply the RayService YAML with deletion delay set to 10 seconds
 	rayServiceName := "test-rayservice-deletion-delay"
 	applyRayServiceYAMLAndWaitReady(g, test, rayserviceYamlFile, namespace.Name, rayServiceName)
 

--- a/ray-operator/test/e2erayservice/support.go
+++ b/ray-operator/test/e2erayservice/support.go
@@ -229,7 +229,7 @@ func waitingForRayClusterSwitchWithDeletionDelay(g *WithT, test Test, rayService
 		return err
 	}, deletionDelayDuration, time.Second).Should(Not(HaveOccurred()))
 
-	// Verify that the old RayCluster is eventually deleted with the grace period of 5 second
+	// Verify that the old RayCluster is eventually deleted with the grace period of 5 seconds
 	LogWithTimestamp(test.T(), "Checking that old RayCluster %s/%s is eventually deleted", rayService.Namespace, oldRayClusterName)
 	g.Eventually(func() error {
 		_, err := GetRayCluster(test, rayService.Namespace, oldRayClusterName)

--- a/ray-operator/test/e2erayservice/support.go
+++ b/ray-operator/test/e2erayservice/support.go
@@ -181,7 +181,7 @@ func RayServiceSampleYamlApplyConfiguration() *rayv1ac.RayServiceSpecApplyConfig
 								})))))))
 }
 
-func ApplyRayServiceYAMLAndWaitReady(g *WithT, t Test, filename string, namespace string, name string) {
+func applyRayServiceYAMLAndWaitReady(g *WithT, t Test, filename string, namespace string, name string) {
 	t.T().Helper()
 
 	// Apply the RayService YAML with deletion delay set to 10 second

--- a/ray-operator/test/e2erayservice/support.go
+++ b/ray-operator/test/e2erayservice/support.go
@@ -184,7 +184,7 @@ func RayServiceSampleYamlApplyConfiguration() *rayv1ac.RayServiceSpecApplyConfig
 func applyRayServiceYAMLAndWaitReady(g *WithT, t Test, filename string, namespace string, name string) {
 	t.T().Helper()
 
-	// Apply the RayService YAML with deletion delay set to 10 second
+	// Apply the RayService YAML
 	KubectlApplyYAML(t, filename, namespace)
 	rayService, err := GetRayService(t, namespace, name)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/ray-operator/test/e2erayservice/testdata/rayservice.deletiondelay.yaml
+++ b/ray-operator/test/e2erayservice/testdata/rayservice.deletiondelay.yaml
@@ -1,0 +1,65 @@
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: test-rayservice
+spec:
+  rayClusterDeletionDelaySeconds: 10
+  serveConfigV2: |
+    proxy_location: EveryNode
+    applications:
+      - name: no_ops
+        route_prefix: /
+        import_path: microbenchmarks.no_ops:app_builder
+        args:
+          num_forwards: 0
+        runtime_env:
+          working_dir: https://github.com/ray-project/serve_workloads/archive/a9f184f4d9ddb7f9a578502ae106470f87a702ef.zip
+        deployments:
+          - name: NoOp
+            num_replicas: 2
+            max_replicas_per_node: 1
+            ray_actor_options:
+              num_cpus: 1
+  rayClusterConfig:
+    rayVersion: '2.46.0'
+    headGroupSpec:
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: rayproject/ray:2.46.0
+              resources:
+                requests:
+                  cpu: 300m
+                  memory: 1G
+                limits:
+                  cpu: 500m
+                  memory: 2G
+              ports:
+                - containerPort: 6379
+                  name: gcs-server
+                - containerPort: 8265
+                  name: dashboard
+                - containerPort: 10001
+                  name: client
+                - containerPort: 8000
+                  name: serve
+    workerGroupSpecs:
+      - replicas: 1
+        minReplicas: 1
+        maxReplicas: 1
+        groupName: small-group
+        rayStartParams:
+          num-cpus: "1"
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: rayproject/ray:2.46.0
+                resources:
+                  requests:
+                    cpu: 300m
+                    memory: 1G
+                  limits:
+                    cpu: 500m
+                    memory: 1G

--- a/ray-operator/test/e2erayservice/testdata/rayservice.deletiondelay.yaml
+++ b/ray-operator/test/e2erayservice/testdata/rayservice.deletiondelay.yaml
@@ -1,7 +1,7 @@
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
-  name: test-rayservice
+  name: test-rayservice-deletion-delay
 spec:
   rayClusterDeletionDelaySeconds: 10
   serveConfigV2: |


### PR DESCRIPTION
- Add e2e test for validating if the `deletionDelaySeconds` set in rayService work

## Why are these changes needed?

We enabled setting RayClusterDeletionDelaySeconds in RayService CRD in PR https://github.com/ray-project/kuberay/pull/3864. While this is a public API and user-facing behavior change, we should add an e2e test for it

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
