### PR TITLE
fix: kustomize download fails for Apple Silicon (arm64) architecture

### DIFF
--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -163,7 +163,7 @@ controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessar
 KUSTOMIZE = $(LOCALBIN)/kustomize
 $(KUSTOMIZE): $(LOCALBIN)
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-	test -s $(KUSTOMIZE) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v5@v5.3.0
+	test -s $(KUSTOMIZE) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v5@v5.7.1
 
 ENVTEST = $(LOCALBIN)/setup-envtest
 $(ENVTEST): $(LOCALBIN)


### PR DESCRIPTION
## Why are these changes needed?
Environment:
	•	macOS: `15.3.1`
	•	Architecture: `arm64`

When running the following commands:
```
cd ray-operator
make kustomize
./bin/kustomize
```
The `kustomize` process is immediately killed with no error message.

<img width="1619" height="155" alt="image" src="https://github.com/user-attachments/assets/2e7f6dbd-8908-40d0-8536-c2e84c99c9e9" />



## Solution
Install the latest kustomize version.
https://github.com/kubernetes-sigs/kustomize

## Related issue number


## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
