### PR TITLE
Support --address and --use-ingress flags for kubectl ray job submit

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -45,6 +45,8 @@ type SubmitJobOptions struct {
 	workerNodeSelectors      map[string]string
 	headNodeSelectors        map[string]string
 	logColor                 string
+	useIngress               bool
+	address                  string
 	image                    string
 	fileName                 string
 	workingDir               string
@@ -86,7 +88,7 @@ type JobInfo struct {
 
 var (
 	jobSubmitLong = templates.LongDesc(`
-		Submit Ray job to Ray cluster as one would using Ray CLI e.g. 'ray job submit ENTRYPOINT'. Command supports all options that 'ray job submit' supports, except '--address'.
+		Submit Ray job to Ray cluster as one would using Ray CLI e.g. 'ray job submit ENTRYPOINT'.
 		If Ray cluster is already setup, use 'kubectl ray session' instead.
 
 		If no RayJob YAML file is specified, the command will create a default RayJob for the user.
@@ -149,6 +151,8 @@ func NewJobSubmitCommand(cmdFactory cmdutil.Factory, streams genericclioptions.I
 		},
 	}
 	cmd.Flags().StringVarP(&options.fileName, "filename", "f", "", "Path and name of the Ray Job YAML file")
+	cmd.Flags().StringVar(&options.address, "address", "", "Address of the Ray cluster to connect to")
+	cmd.Flags().BoolVar(&options.useIngress, "use-ingress", false, "Skip port-forwarding and use the provided --address (e.g. an Ingress endpoint)")
 	cmd.Flags().StringVar(&options.submissionID, "submission-id", "", "ID to specify for the Ray job. If not provided, one will be generated")
 	cmd.Flags().StringVar(&options.runtimeEnv, "runtime-env", "", "Path and name to the runtime env YAML file.")
 	cmd.Flags().StringVar(&options.workingDir, "working-dir", "", "Directory containing files that your job will run in")
@@ -199,6 +203,10 @@ func (options *SubmitJobOptions) Complete(cmd *cobra.Command) error {
 
 	if options.fileName != "" {
 		options.fileName = filepath.Clean(options.fileName)
+	}
+
+	if options.address == "" {
+		options.address = dashboardAddr
 	}
 	return nil
 }
@@ -305,6 +313,14 @@ func (options *SubmitJobOptions) Validate(cmd *cobra.Command) error {
 				return fmt.Errorf("%w", err)
 			}
 		}
+	}
+
+	if options.useIngress && options.address == "" {
+		return fmt.Errorf("--use-ingress was set, but --address is missing or empty")
+	}
+
+	if !options.useIngress && options.address != "" && options.address != dashboardAddr {
+		return fmt.Errorf("--address=%q is not valid unless --use-ingress is set", options.address)
 	}
 
 	return nil
@@ -421,55 +437,59 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 		return fmt.Errorf("Timed out waiting for cluster")
 	}
 
-	svcName, err := k8sClients.GetRayHeadSvcName(ctx, options.namespace, util.RayCluster, options.cluster)
-	if err != nil {
-		return fmt.Errorf("Failed to find service name: %w", err)
-	}
-
-	// start port forward section
-	portForwardCmd := portforward.NewCmdPortForward(factory, *options.ioStreams)
-	portForwardCmd.SetArgs([]string{"service/" + svcName, fmt.Sprintf("%d:%d", 8265, 8265)})
-
-	// create new context for port-forwarding so we can cancel the context to stop the port forwarding only
-	portforwardctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		fmt.Printf("Port Forwarding service %s\n", svcName)
-		if err := portForwardCmd.ExecuteContext(portforwardctx); err != nil {
-			log.Fatalf("Error occurred while port-forwarding Ray dashboard: %v", err)
-		}
-	}()
-
-	// Wait for port forward to be ready
-	var portforwardReady bool
-	portforwardWaitStartTime := time.Now()
-	currTime = portforwardWaitStartTime
-
-	portforwardCheckRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, dashboardAddr, nil)
-	if err != nil {
-		return fmt.Errorf("Error occurred when trying to create request to probe cluster endpoint: %w", err)
-	}
-	httpClient := http.Client{
-		Timeout: 5 * time.Second,
-	}
-	fmt.Printf("Waiting for portforwarding...")
-	for !portforwardReady && currTime.Sub(portforwardWaitStartTime).Seconds() <= portforwardtimeout {
-		time.Sleep(2 * time.Second)
-		rayDashboardResponse, err := httpClient.Do(portforwardCheckRequest)
+	if !options.useIngress {
+		svcName, err := k8sClients.GetRayHeadSvcName(ctx, options.namespace, util.RayCluster, options.cluster)
 		if err != nil {
-			err = fmt.Errorf("Error occurred when waiting for portforwarding: %w", err)
-			fmt.Println(err)
+			return fmt.Errorf("Failed to find service name: %w", err)
 		}
-		if rayDashboardResponse.StatusCode >= 200 && rayDashboardResponse.StatusCode < 300 {
-			portforwardReady = true
+
+		// start port forward section
+		portForwardCmd := portforward.NewCmdPortForward(factory, *options.ioStreams)
+		portForwardCmd.SetArgs([]string{"service/" + svcName, fmt.Sprintf("%d:%d", 8265, 8265)})
+
+		// create new context for port-forwarding so we can cancel the context to stop the port forwarding only
+		portforwardctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		go func() {
+			fmt.Printf("Port Forwarding service %s\n", svcName)
+			if err := portForwardCmd.ExecuteContext(portforwardctx); err != nil {
+				log.Fatalf("Error occurred while port-forwarding Ray dashboard: %v", err)
+			}
+		}()
+
+		// Wait for port forward to be ready
+		var portforwardReady bool
+		portforwardWaitStartTime := time.Now()
+		currTime = portforwardWaitStartTime
+
+		portforwardCheckRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, options.address, nil)
+		if err != nil {
+			return fmt.Errorf("Error occurred when trying to create request to probe cluster endpoint: %w", err)
 		}
-		rayDashboardResponse.Body.Close()
-		currTime = time.Now()
+		httpClient := http.Client{
+			Timeout: 5 * time.Second,
+		}
+		fmt.Printf("Waiting for portforwarding...")
+		for !portforwardReady && currTime.Sub(portforwardWaitStartTime).Seconds() <= portforwardtimeout {
+			time.Sleep(2 * time.Second)
+			rayDashboardResponse, err := httpClient.Do(portforwardCheckRequest)
+			if err != nil {
+				err = fmt.Errorf("Error occurred when waiting for portforwarding: %w", err)
+				fmt.Println(err)
+			}
+			if rayDashboardResponse.StatusCode >= 200 && rayDashboardResponse.StatusCode < 300 {
+				portforwardReady = true
+			}
+			rayDashboardResponse.Body.Close()
+			currTime = time.Now()
+		}
+		if !portforwardReady {
+			return fmt.Errorf("Timed out waiting for port forwarding")
+		}
+		fmt.Printf("Portforwarding started on %s\n", options.address)
+	} else {
+		fmt.Printf("Using ingress at %s, skipping port forwarding\n", options.address)
 	}
-	if !portforwardReady {
-		return fmt.Errorf("Timed out waiting for port forwarding")
-	}
-	fmt.Printf("Portforwarding started on %s\n", dashboardAddr)
 
 	// If submission ID is not provided by the user, generate one.
 	if options.submissionID == "" {
@@ -608,7 +628,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 }
 
 func (options *SubmitJobOptions) raySubmitCmd() ([]string, error) {
-	raySubmitCmd := []string{"ray", "job", "submit", "--address", dashboardAddr}
+	raySubmitCmd := []string{"ray", "job", "submit", "--address", options.address}
 
 	if len(options.runtimeEnv) > 0 {
 		raySubmitCmd = append(raySubmitCmd, "--runtime-env", options.runtimeEnv)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds support for the --address and --use-ingress flags to kubectl ray job submit, enabling job submission via an Ingress endpoint instead of relying solely on port-forwarding to localhost:8265.

This makes the CLI usable in environments where a public-facing or authenticated endpoint is preferred and port-forwarding is not possible or ideal.

## Related issue number

Closes #3921

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
