### PR TITLE
[Feature][Kubectl-plugin] Make flags override yaml file for kubectl ray job submit

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -283,108 +283,8 @@ func (options *SubmitJobOptions) Validate(cmd *cobra.Command) error {
 			options.runtimeEnvJson = string(runtimeJson)
 		}
 
-		if cmd.Flags().Changed("name") {
-			options.RayJob.Name = options.rayjobName
-		}
-
-		if cmd.Flags().Changed("ray-version") {
-			options.RayJob.Spec.RayClusterSpec.RayVersion = options.rayVersion
-		}
-		if cmd.Flags().Changed("image") {
-			options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Image = options.image
-		}
-
-		if cmd.Flags().Changed("head-cpu") {
-			q, _ := resource.ParseQuantity(options.headCPU)
-			if options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits == nil {
-				options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits = make(corev1.ResourceList)
-			}
-			if options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests == nil {
-				options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests = make(corev1.ResourceList)
-			}
-			options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits["cpu"] = q
-			options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests["cpu"] = q
-		}
-
-		if cmd.Flags().Changed("head-memory") {
-			q, _ := resource.ParseQuantity(options.headMemory)
-			if options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits == nil {
-				options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits = make(corev1.ResourceList)
-			}
-			if options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests == nil {
-				options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests = make(corev1.ResourceList)
-			}
-			options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits["memory"] = q
-			options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests["memory"] = q
-		}
-		if cmd.Flags().Changed("head-gpu") {
-			q, _ := resource.ParseQuantity(options.headGPU)
-			if options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits == nil {
-				options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits = make(corev1.ResourceList)
-			}
-			if options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests == nil {
-				options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests = make(corev1.ResourceList)
-			}
-			options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceName(util.ResourceNvidiaGPU)] = q
-			options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(util.ResourceNvidiaGPU)] = q
-		}
-		if cmd.Flags().Changed("worker-replicas") {
-			for i := range options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs {
-				options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Replicas = &options.workerReplicas
-			}
-		}
-		if cmd.Flags().Changed("worker-cpu") {
-			q, _ := resource.ParseQuantity(options.workerCPU)
-			for i := range options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs {
-				if options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Limits == nil {
-					options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Limits = make(corev1.ResourceList)
-				}
-				if options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Requests == nil {
-					options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Requests = make(corev1.ResourceList)
-				}
-				options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Limits["cpu"] = q
-				options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Requests["cpu"] = q
-			}
-		}
-		if cmd.Flags().Changed("worker-memory") {
-			q, _ := resource.ParseQuantity(options.workerMemory)
-			for i := range options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs {
-				if options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Limits == nil {
-					options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Limits = make(corev1.ResourceList)
-				}
-				if options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Requests == nil {
-					options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Requests = make(corev1.ResourceList)
-				}
-				options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Limits["memory"] = q
-				options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Requests["memory"] = q
-			}
-		}
-		if cmd.Flags().Changed("worker-gpu") {
-			q, _ := resource.ParseQuantity(options.workerGPU)
-			for i := range options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs {
-				if options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Limits == nil {
-					options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0].Resources.Limits = make(corev1.ResourceList)
-				}
-				options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Limits[corev1.ResourceName(util.ResourceNvidiaGPU)] = q
-				options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(util.ResourceNvidiaGPU)] = q
-			}
-		}
-		if cmd.Flags().Changed("head-node-selectors") {
-			if options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector == nil {
-				options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector = make(map[string]string)
-			}
-			maps.Copy(options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector, options.headNodeSelectors)
-		}
-		if cmd.Flags().Changed("worker-node-selectors") {
-			if options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector == nil {
-				options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector = make(map[string]string)
-			}
-			maps.Copy(options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector, options.workerNodeSelectors)
-		}
-
-		if cmd.Flags().Changed("ttl-seconds-after-finished") {
-			options.RayJob.Spec.TTLSecondsAfterFinished = options.ttlSecondsAfterFinished
-			options.RayJob.Spec.ShutdownAfterJobFinishes = options.shutdownAfterJobFinishes
+		if err := options.applyOverridesToRayJob(cmd); err != nil {
+			return err
 		}
 
 		if options.RayJob.Spec.TTLSecondsAfterFinished < 0 {
@@ -766,6 +666,127 @@ func (options *SubmitJobOptions) raySubmitCmd() ([]string, error) {
 	raySubmitCmd = append(raySubmitCmd, entryPointSanitized...)
 
 	return raySubmitCmd, nil
+}
+
+func (options *SubmitJobOptions) applyOverridesToRayJob(cmd *cobra.Command) error {
+	if cmd.Flags().Changed("name") {
+		options.RayJob.Name = options.rayjobName
+	}
+
+	if cmd.Flags().Changed("ray-version") {
+		options.RayJob.Spec.RayClusterSpec.RayVersion = options.rayVersion
+	}
+	if cmd.Flags().Changed("image") {
+		options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Image = options.image
+	}
+
+	if options.RayJob.Spec.RayClusterSpec == nil {
+		options.RayJob.Spec.RayClusterSpec = &rayv1.RayClusterSpec{}
+	}
+
+	rayClusterSpec := options.RayJob.Spec.RayClusterSpec
+
+	if rayClusterSpec.HeadGroupSpec.Template.Spec.Containers == nil {
+		rayClusterSpec.HeadGroupSpec.Template.Spec.Containers = []corev1.Container{{}}
+	}
+
+	headContainer := &options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0]
+
+	err := overrideContainerResourceIfChanged(cmd, "head-cpu", options.headCPU, headContainer, "cpu")
+	if err != nil {
+		return fmt.Errorf("failed to override head CPU resource: %w", err)
+	}
+	err = overrideContainerResourceIfChanged(cmd, "head-memory", options.headMemory, headContainer, "memory")
+	if err != nil {
+		return fmt.Errorf("failed to override head memory resource: %w", err)
+	}
+	err = overrideContainerResourceIfChanged(cmd, "head-gpu", options.headGPU, headContainer, util.ResourceNvidiaGPU)
+	if err != nil {
+		return fmt.Errorf("failed to override head GPU resource: %w", err)
+	}
+
+	if cmd.Flags().Changed("head-node-selectors") {
+		if headContainer.Resources.Limits == nil {
+			headContainer.Resources.Limits = make(corev1.ResourceList)
+		}
+		if headContainer.Resources.Requests == nil {
+			headContainer.Resources.Requests = make(corev1.ResourceList)
+		}
+		if options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector == nil {
+			options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector = make(map[string]string)
+		}
+		maps.Copy(options.RayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector, options.headNodeSelectors)
+	}
+
+	if len(rayClusterSpec.WorkerGroupSpecs) == 0 {
+		rayClusterSpec.WorkerGroupSpecs = []rayv1.WorkerGroupSpec{
+			{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{}},
+					},
+				},
+			},
+		}
+	}
+
+	if cmd.Flags().Changed("worker-replicas") {
+		for i := range options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs {
+			options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Replicas = &options.workerReplicas
+		}
+	}
+
+	for i := range options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs {
+		if rayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers == nil {
+			rayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers = []corev1.Container{{}}
+		}
+		workerContainer := &options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Containers[0]
+
+		err = overrideContainerResourceIfChanged(cmd, "worker-cpu", options.workerCPU, workerContainer, "cpu")
+		if err != nil {
+			return fmt.Errorf("failed to override worker CPU resource: %w", err)
+		}
+		err = overrideContainerResourceIfChanged(cmd, "worker-memory", options.workerMemory, workerContainer, "memory")
+		if err != nil {
+			return fmt.Errorf("failed to override worker memory resource: %w", err)
+		}
+		err = overrideContainerResourceIfChanged(cmd, "worker-gpu", options.workerGPU, workerContainer, util.ResourceNvidiaGPU)
+		if err != nil {
+			return fmt.Errorf("failed to override worker GPU resource: %w", err)
+		}
+
+		if cmd.Flags().Changed("worker-node-selectors") {
+			if options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.NodeSelector == nil {
+				options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.NodeSelector = make(map[string]string)
+			}
+			maps.Copy(options.RayJob.Spec.RayClusterSpec.WorkerGroupSpecs[i].Template.Spec.NodeSelector, options.workerNodeSelectors)
+		}
+	}
+
+	if cmd.Flags().Changed("ttl-seconds-after-finished") {
+		options.RayJob.Spec.TTLSecondsAfterFinished = options.ttlSecondsAfterFinished
+		options.RayJob.Spec.ShutdownAfterJobFinishes = options.shutdownAfterJobFinishes
+	}
+	return nil
+}
+
+func overrideContainerResourceIfChanged(cmd *cobra.Command, flagName, value string, container *corev1.Container, resourceName string) error {
+	if !cmd.Flags().Changed(flagName) {
+		return nil
+	}
+	q, err := resource.ParseQuantity(value)
+	if err != nil {
+		return err
+	}
+	if container.Resources.Limits == nil {
+		container.Resources.Limits = make(corev1.ResourceList)
+	}
+	if container.Resources.Requests == nil {
+		container.Resources.Requests = make(corev1.ResourceList)
+	}
+	container.Resources.Limits[corev1.ResourceName(resourceName)] = q
+	container.Resources.Requests[corev1.ResourceName(resourceName)] = q
+	return nil
 }
 
 // Decode RayJob YAML if we decide to submit job using kube client

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -243,14 +243,6 @@ func (options *SubmitJobOptions) Validate(cmd *cobra.Command) error {
 		"worker-memory": options.workerMemory,
 	}
 
-	for name, value := range resourceFields {
-		if value != "" || cmd.Flags().Changed(name) {
-			if err := util.ValidateResourceQuantity(value, name); err != nil {
-				return fmt.Errorf("%w", err)
-			}
-		}
-	}
-
 	// Take care of case where there is a filename input
 	if options.fileName != "" {
 		info, err := os.Stat(options.fileName)
@@ -407,6 +399,14 @@ func (options *SubmitJobOptions) Validate(cmd *cobra.Command) error {
 
 	if options.workingDir == "" {
 		return fmt.Errorf("working directory is required, use --working-dir or set with runtime env")
+	}
+
+	for name, value := range resourceFields {
+		if value != "" || cmd.Flags().Changed(name) {
+			if err := util.ValidateResourceQuantity(value, name); err != nil {
+				return fmt.Errorf("%w", err)
+			}
+		}
 	}
 
 	return nil

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -4,15 +4,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/utils/ptr"
 
+	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
@@ -195,18 +198,66 @@ func TestRayJobSubmitWithoutYamlValidate(t *testing.T) {
 	}
 }
 
-func TestRayJobSubmitCmdFlagsOverrideYaml(t *testing.T) {
+func getExpectedFieldValue(job rayv1.RayJob, path string) any {
+	switch path {
+	case "ShutdownAfterJobFinishes":
+		return job.Spec.ShutdownAfterJobFinishes
+	case "TTLSecondsAfterFinished":
+		return job.Spec.TTLSecondsAfterFinished
+	case "RayJobName":
+		return job.ObjectMeta.Name
+	case "RayVersion":
+		return job.Spec.RayClusterSpec.RayVersion
+	case "headGroupResourceRequestCPU":
+		cpu := job.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+		v, _ := cpu.AsInt64()
+		return v
+	case "headGroupResourceRequestMemory":
+		memory := job.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
+		return memory.String()
+	case "headGroupResourceRequestGPU":
+		gpu := job.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Requests[util.ResourceNvidiaGPU]
+		v, _ := gpu.AsInt64()
+		return v
+	case "workerReplicas":
+		return job.Spec.RayClusterSpec.WorkerGroupSpecs[0].Replicas
+	case "workerGroupResourceRequestCPU":
+		cpu := job.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+		v, _ := cpu.AsInt64()
+		return v
+	case "workerGroupResourceRequestMemory":
+		memory := job.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
+		return memory.String()
+	case "workerGroupResourceRequestGPU":
+		gpu := job.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests[util.ResourceNvidiaGPU]
+		v, _ := gpu.AsInt64()
+		return v
+	case "HeadGroupNodeSelector":
+		return job.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector
+	case "WorkerGroupNodeSelector":
+		return job.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector
+	default:
+		panic(fmt.Sprintf("unsupported path: %v", path))
+	}
+}
+
+func TestRayJobSubmitCmdFlagsOverrideSpecYaml(t *testing.T) {
 	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
 	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
 
 	fakeDir := t.TempDir()
 
+	type ExpectedField struct {
+		Expected any
+		Field    string
+	}
+
 	tests := []struct {
-		name        string
-		yamlContent string
-		flagMap     map[string]any
-		expectSpec  map[string]any
-		expectError string
+		flagMap      map[string]any
+		name         string
+		yamlContent  string
+		expectError  string
+		expectFields []ExpectedField
 	}{
 		{
 			name: "Both shutdownAfterJobFinishes and ttlSecondsAfterFinished are not set in yaml",
@@ -219,9 +270,9 @@ spec:
 			flagMap: map[string]any{
 				"ttl-seconds-after-finished": 20,
 			},
-			expectSpec: map[string]any{
-				"ShutdownAfterJobFinishes": true,
-				"TTLSecondsAfterFinished":  int32(20),
+			expectFields: []ExpectedField{
+				{Field: "ShutdownAfterJobFinishes", Expected: true},
+				{Field: "TTLSecondsAfterFinished", Expected: int32(20)},
 			},
 		},
 		{
@@ -237,9 +288,9 @@ spec:
 			flagMap: map[string]any{
 				"ttl-seconds-after-finished": 20,
 			},
-			expectSpec: map[string]any{
-				"ShutdownAfterJobFinishes": true,
-				"TTLSecondsAfterFinished":  int32(20),
+			expectFields: []ExpectedField{
+				{Field: "ShutdownAfterJobFinishes", Expected: true},
+				{Field: "TTLSecondsAfterFinished", Expected: int32(20)},
 			},
 		},
 		{
@@ -254,9 +305,9 @@ spec:
 			flagMap: map[string]any{
 				"ttl-seconds-after-finished": 20,
 			},
-			expectSpec: map[string]any{
-				"ShutdownAfterJobFinishes": true,
-				"TTLSecondsAfterFinished":  int32(20),
+			expectFields: []ExpectedField{
+				{Field: "ShutdownAfterJobFinishes", Expected: true},
+				{Field: "TTLSecondsAfterFinished", Expected: int32(20)},
 			},
 		},
 		{
@@ -271,9 +322,9 @@ spec:
 			flagMap: map[string]any{
 				"ttl-seconds-after-finished": 20,
 			},
-			expectSpec: map[string]any{
-				"ShutdownAfterJobFinishes": true,
-				"TTLSecondsAfterFinished":  int32(20),
+			expectFields: []ExpectedField{
+				{Field: "ShutdownAfterJobFinishes", Expected: true},
+				{Field: "TTLSecondsAfterFinished", Expected: int32(20)},
 			},
 		},
 		{
@@ -289,9 +340,9 @@ spec:
 			flagMap: map[string]any{
 				"ttl-seconds-after-finished": 200,
 			},
-			expectSpec: map[string]any{
-				"ShutdownAfterJobFinishes": true,
-				"TTLSecondsAfterFinished":  int32(200),
+			expectFields: []ExpectedField{
+				{Field: "ShutdownAfterJobFinishes", Expected: true},
+				{Field: "TTLSecondsAfterFinished", Expected: int32(200)},
 			},
 		},
 		{
@@ -305,9 +356,9 @@ spec:
 			flagMap: map[string]any{
 				"ttl-seconds-after-finished": 0,
 			},
-			expectSpec: map[string]any{
-				"ShutdownAfterJobFinishes": true,
-				"TTLSecondsAfterFinished":  int32(0),
+			expectFields: []ExpectedField{
+				{Field: "ShutdownAfterJobFinishes", Expected: true},
+				{Field: "TTLSecondsAfterFinished", Expected: int32(0)},
 			},
 		},
 		{
@@ -325,6 +376,387 @@ spec:
 			},
 			expectError: "--ttl-seconds-after-finished must be greater than or equal to 0",
 		},
+		{
+			name: "Override ShutdownAfterJobFinishes and TTLSecondsAfterFinished",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'`,
+			flagMap: map[string]any{
+				"ttl-seconds-after-finished": 20,
+			},
+			expectFields: []ExpectedField{
+				{Field: "ShutdownAfterJobFinishes", Expected: true},
+				{Field: "TTLSecondsAfterFinished", Expected: int32(20)},
+			},
+		},
+		{
+			name: "Override metadata.name via flag",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'`,
+			flagMap: map[string]any{
+				"name": "rayjob-sample-override",
+			},
+			expectFields: []ExpectedField{
+				{Field: "RayJobName", Expected: "rayjob-sample-override"},
+			},
+		},
+		{
+			name: "Override ray version",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'
+  rayClusterSpec:
+    rayVersion: "2.46.0"`,
+			flagMap: map[string]any{
+				"ray-version": "1.0.0",
+			},
+			expectFields: []ExpectedField{
+				{Field: "RayVersion", Expected: "1.0.0"},
+			},
+		},
+		{
+			name: "Override head-cpu count",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'
+  rayClusterSpec:
+  headGroupSpec:
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:latest
+          resources:
+            requests:
+              cpu: "20"
+              memory: "40Gi"
+              nvidia.com/gpu: "10"`,
+			flagMap: map[string]any{
+				"head-cpu": 40,
+			},
+			expectFields: []ExpectedField{
+				{Field: "headGroupResourceRequestCPU", Expected: int64(40)},
+			},
+		},
+		{
+			name: "Override head-memory size",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'
+  rayClusterSpec:
+    headGroupSpec:
+      template:
+       spec:
+        containers:
+          - name: ray-head
+            image: rayproject/ray:latest
+            resources:
+             requests:
+              cpu: "20"
+              memory: "40Gi"
+              nvidia.com/gpu: "10"`,
+			flagMap: map[string]any{
+				"head-memory": "80Gi",
+			},
+			expectFields: []ExpectedField{
+				{Field: "headGroupResourceRequestMemory", Expected: "80Gi"},
+			},
+		},
+		{
+			name: "Override head-gpu count",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'
+  rayClusterSpec:
+    headGroupSpec:
+      template:
+       spec:
+        containers:
+          - name: ray-head
+            image: rayproject/ray:latest
+            resources:
+             requests:
+              cpu: "20"
+              memory: "40Gi"
+              nvidia.com/gpu: "10"`,
+			flagMap: map[string]any{
+				"head-gpu": 20,
+			},
+			expectFields: []ExpectedField{
+				{Field: "headGroupResourceRequestGPU", Expected: int64(20)},
+			},
+		},
+		{
+			name: "Override worker-replicas",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'
+  rayClusterSpec:
+    workerGroupSpecs:
+    - groupName: ray-worker-group
+      replicas: 2`,
+			flagMap: map[string]any{
+				"worker-replicas": 5,
+			},
+			expectFields: []ExpectedField{
+				{Field: "workerReplicas", Expected: ptr.To(int32(5))},
+			},
+		},
+		{
+			name: "Override worker-cpu count",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'
+  rayClusterSpec:
+    workerGroupSpecs:
+      - groupName: ray-worker-group
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: rayproject/ray:latest
+                resources:
+                  requests:
+                    cpu: "20"
+                    memory: "40Gi"
+                    nvidia.com/gpu: "10"`,
+			flagMap: map[string]any{
+				"worker-cpu": 40,
+			},
+			expectFields: []ExpectedField{
+				{Field: "workerGroupResourceRequestCPU", Expected: int64(40)},
+			},
+		},
+		{
+			name: "Override worker-memory size",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'
+  rayClusterSpec:
+    workerGroupSpecs:
+      - groupName: ray-worker-group
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: rayproject/ray:latest
+                resources:
+                  requests:
+                    cpu: "20"
+                    memory: "40Gi"
+                    nvidia.com/gpu: "10"`,
+			flagMap: map[string]any{
+				"worker-memory": "80Gi",
+			},
+			expectFields: []ExpectedField{
+				{Field: "workerGroupResourceRequestMemory", Expected: "80Gi"},
+			},
+		},
+		{
+			name: "Override worker-gpu count",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'
+  rayClusterSpec:
+    workerGroupSpecs:
+      - groupName: ray-worker-group
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: rayproject/ray:latest
+                resources:
+                  requests:
+                    cpu: "20"
+                    memory: "40Gi"
+                    nvidia.com/gpu: "10"`,
+			flagMap: map[string]any{
+				"worker-gpu": 20,
+			},
+			expectFields: []ExpectedField{
+				{Field: "workerGroupResourceRequestGPU", Expected: int64(20)},
+			},
+		},
+		{
+			name: "Override head and worker resources together",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'
+  rayClusterSpec:
+    headGroupSpec:
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: rayproject/ray:latest
+            resources:
+              requests:
+                cpu: "20"
+                memory: "40Gi"
+                nvidia.com/gpu: "10"
+    workerGroupSpecs:
+      - groupName: ray-worker-group
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: rayproject/ray:latest
+                resources:
+                  requests:
+                    cpu: "20"
+                    memory: "40Gi"
+                    nvidia.com/gpu: "10"`,
+			flagMap: map[string]any{
+				"head-cpu":      40,
+				"head-memory":   "80Gi",
+				"head-gpu":      20,
+				"worker-cpu":    40,
+				"worker-memory": "80Gi",
+				"worker-gpu":    20,
+			},
+			expectFields: []ExpectedField{
+				{Field: "headGroupResourceRequestCPU", Expected: int64(40)},
+				{Field: "headGroupResourceRequestMemory", Expected: "80Gi"},
+				{Field: "headGroupResourceRequestGPU", Expected: int64(20)},
+				{Field: "workerGroupResourceRequestCPU", Expected: int64(40)},
+				{Field: "workerGroupResourceRequestMemory", Expected: "80Gi"},
+				{Field: "workerGroupResourceRequestGPU", Expected: int64(20)},
+			},
+		},
+		{
+			name: "Override worker-node-selectors",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'
+  rayClusterSpec:
+    workerGroupSpecs:
+    - groupName: ray-worker-group
+      template:
+        spec:
+          nodeSelector:
+            ray.io/ray-node-type: worker`,
+			flagMap: map[string]any{
+				"worker-node-selectors": map[string]string{
+					"ray.io/ray-node-type": "worker1",
+					"custom-label":         "custom-value",
+				},
+			},
+			expectFields: []ExpectedField{
+				{Field: "WorkerGroupNodeSelector", Expected: map[string]string{
+					"ray.io/ray-node-type": "worker1",
+					"custom-label":         "custom-value",
+				}},
+			},
+		},
+		{
+			name: "Override head-node-selectors",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'
+  rayClusterSpec:
+    headGroupSpec:
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            nodeSelector:
+              ray.io/ray-node-type: head`,
+			flagMap: map[string]any{
+				"head-node-selectors": map[string]string{
+					"ray.io/ray-node-type": "head1",
+					"custom-label":         "custom-value",
+				},
+			},
+			expectFields: []ExpectedField{
+				{Field: "HeadGroupNodeSelector", Expected: map[string]string{
+					"ray.io/ray-node-type": "head1",
+					"custom-label":         "custom-value",
+				}},
+			},
+		},
+		{
+			name: "Override head and worker node-selectors together",
+			yamlContent: `apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sample
+spec:
+  submissionMode: 'InteractiveMode'
+  rayClusterSpec:
+    headGroupSpec:
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            nodeSelector:
+              ray.io/ray-node-type: head
+    workerGroupSpecs:
+    - groupName: ray-worker-group
+      template:
+        spec:
+          nodeSelector:
+            ray.io/ray-node-type: worker`,
+			flagMap: map[string]any{
+				"head-node-selectors": map[string]string{
+					"ray.io/ray-node-type": "head1",
+					"custom-head-label":    "custom-head-value",
+				},
+				"worker-node-selectors": map[string]string{
+					"ray.io/ray-node-type": "worker1",
+					"custom-worker-label":  "custom-worker-value",
+				},
+			},
+			expectFields: []ExpectedField{
+				{Field: "HeadGroupNodeSelector", Expected: map[string]string{
+					"ray.io/ray-node-type": "head1",
+					"custom-head-label":    "custom-head-value",
+				}},
+				{Field: "WorkerGroupNodeSelector", Expected: map[string]string{
+					"ray.io/ray-node-type": "worker1",
+					"custom-worker-label":  "custom-worker-value",
+				}},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -335,21 +767,42 @@ spec:
 			_, err = file.Write([]byte(tc.yamlContent))
 			require.NoError(t, err)
 
-			opts := &SubmitJobOptions{
+			options := &SubmitJobOptions{
 				cmdFactory: cmdFactory,
 				ioStreams:  &testStreams,
 				fileName:   rayJobYamlPath,
 				workingDir: "Fake/File/Path",
 			}
 			cmd := &cobra.Command{}
-			cmd.Flags().Int32Var(&opts.ttlSecondsAfterFinished, "ttl-seconds-after-finished", 0, "")
+			cmd.Flags().StringVar(&options.rayjobName, "name", "", "")
+			cmd.Flags().StringVar(&options.rayVersion, "ray-version", util.RayVersion, "")
+			cmd.Flags().StringVar(&options.image, "image", fmt.Sprintf("rayproject/ray:%s", options.rayVersion), "")
+			cmd.Flags().Int32Var(&options.ttlSecondsAfterFinished, "ttl-seconds-after-finished", 0, "")
+			cmd.Flags().StringVar(&options.headCPU, "head-cpu", "2", "")
+			cmd.Flags().StringVar(&options.headMemory, "head-memory", "4Gi", "")
+			cmd.Flags().StringVar(&options.headGPU, "head-gpu", "0", "")
+			cmd.Flags().Int32Var(&options.workerReplicas, "worker-replicas", 1, "")
+			cmd.Flags().StringVar(&options.workerCPU, "worker-cpu", "2", "")
+			cmd.Flags().StringVar(&options.workerMemory, "worker-memory", "4Gi", "")
+			cmd.Flags().StringVar(&options.workerGPU, "worker-gpu", "0", "")
+			cmd.Flags().StringToStringVar(&options.headNodeSelectors, "head-node-selectors", nil, "")
+			cmd.Flags().StringToStringVar(&options.workerNodeSelectors, "worker-node-selectors", nil, "")
 
 			args := []string{}
 			for flag, value := range tc.flagMap {
-				if v, ok := value.(bool); ok && v {
-					args = append(args, fmt.Sprintf("--%s", flag))
-				} else {
-					args = append(args, fmt.Sprintf("--%s=%v", flag, value))
+				switch v := value.(type) {
+				case bool:
+					if v {
+						args = append(args, fmt.Sprintf("--%s", flag))
+					}
+				case map[string]string:
+					var kvPairs []string
+					for k, val := range v {
+						kvPairs = append(kvPairs, fmt.Sprintf("%s=%s", k, val))
+					}
+					args = append(args, fmt.Sprintf("--%s=%s", flag, strings.Join(kvPairs, ",")))
+				default:
+					args = append(args, fmt.Sprintf("--%s=%v", flag, v))
 				}
 			}
 
@@ -357,18 +810,16 @@ spec:
 			err = cmd.ParseFlags(args)
 			require.NoError(t, err)
 
-			err = opts.Validate(cmd)
+			err = options.Validate(cmd)
 			if tc.expectError != "" {
 				require.EqualError(t, err, tc.expectError)
 			} else {
 				require.NoError(t, err)
 			}
 
-			if tc.expectSpec != nil {
-				for field, expected := range tc.expectSpec {
-					actual := reflect.ValueOf(opts.RayJob.Spec).FieldByName(field).Interface()
-					require.Equal(t, expected, actual)
-				}
+			for _, field := range tc.expectFields {
+				actual := getExpectedFieldValue(*options.RayJob, field.Field)
+				require.Equal(t, field.Expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have access to it, we will shortly find a reviewer and assign them to your PR -->

## Why are these changes needed?
The expected behavior is that if both filename and flags are provided by the user, then use the filename as the base to construct a RayJob object and override the values in that object with the flags.

So if the user provides a YAML file with headCPU set to 2 in it, and specifies the flag --head-cpu 3, then the resulting RayJob should set head CPU to 3.
See https://github.com/ray-project/kuberay/pull/3627#discussion_r2096743843.

<!-- Please give a short summary of the change and the problem this solves. -->
### Summary
#### [job_submit.go](https://github.com/ray-project/kuberay/pull/3926/files#diff-e047a56a850b598213936c0577bfc6c6568ac9ee3626852e3d0139d2dcda95f3)
- Add `applyOverridesToRayJob` to override the flags which is given by the user.
#### [job_submit_test.go](https://github.com/ray-project/kuberay/pull/3926/files#diff-627046dc309ec860c21e92cf67410ce9e5eed553cb548f261c6f5bd144812911)
-  Not using reflect anymore
- Add `getExpectedFieldValue` to handle different field in `rayClusterSpec`
- Add additional testcase in `TestRayJobSubmitCmdFlagsOverrideSpecYaml`

### Manual Testing
`my_yaml.yaml`
```yaml
apiVersion: ray.io/v1
kind: RayJob
metadata:
  name: rayjob-sample
spec:
  submissionMode: 'InteractiveMode'
  shutdownAfterJobFinishes: false 
  ttlSecondsAfterFinished: 2
  rayClusterSpec:
    rayVersion: '2.41.0'
    headGroupSpec:
      rayStartParams: {}
      template:
        spec:
          containers:
            - name: ray-head
              image: rayproject/ray:2.41.0
              ports:
                - containerPort: 6379
                  name: gcs-server
                - containerPort: 8265
                  name: dashboard
                - containerPort: 10001
                  name: client
              resources:
                limits:
                  cpu: "1"
                requests:
                  cpu: "200m"
    workerGroupSpecs:
      - replicas: 1
        minReplicas: 1
        maxReplicas: 5
        groupName: small-group
        rayStartParams: {}
        template:
          spec:
            containers:
              - name: ray-worker
                image: rayproject/ray:2.41.0
                resources:
                  limits:
                    cpu: "1"
                  requests:
                    cpu: "200m"
```
Run Command -> head CPUs
```bash
$ cd kubectl-plugin
$ go build -o ./test/e2e/r cmd/kubectl-ray.go 
$ cd kubectl-plugin/test/e2e

## put `my_yaml.yaml` in `kubectl-plugin/test/e2e/testdata`

$ ./r job submit -f testdata/my_yaml.yaml --runtime-env testdata/rayjob-submit-working-dir/runtime-env-sample.yaml --head-cpu 4 -- python entrypoint-python-sample
```
Check the head pod CPUs should be 4000m
```bash
$ ./r get node

NAME                                           CPUS   GPUS   TPUS   MEMORY   CLUSTER               TYPE     WORKER GROUP   AGE
rayjob-sample-6qh9h-head-t8qzh                 4      0      0      0        rayjob-sample-6qh9h   head     headgroup      4s
rayjob-sample-6qh9h-small-group-worker-9j674   200m   0      0      0        rayjob-sample-6qh9h   worker   small-group    4s
```

Run Command -> head Memory
```bash
$ ./r job submit -f testdata/my_yaml.yaml --runtime-env testdata/rayjob-submit-working-dir/runtime-env-sample.yaml --head-memory 8Gi -- python entrypoint-python-sample.py

# Check the head pod memory should be 8 GiB
$ ./r get node
NAME                                           CPUS   GPUS   TPUS   MEMORY   CLUSTER               TYPE     WORKER GROUP   AGE
rayjob-sample-85vwz-head-fpg2v                 200m   0      0      8Gi      rayjob-sample-85vwz   head     headgroup      35s
rayjob-sample-85vwz-small-group-worker-dx2pf   200m   0      0      0        rayjob-sample-85vwz   worker   small-group    34s
```

Run Command -> worker memory
```bash
$ ./r job submit -f testdata/my_yaml.yaml --runtime-env testdata/rayjob-submit-working-dir/runtime-env-sample.yaml --worker-memory 6Gi -- python entrypoint-python-sample.py

# Check the worker pod memory should be 6GiB
```bash
$ ./r get node
NAME                                           CPUS   GPUS   TPUS   MEMORY   CLUSTER               TYPE     WORKER GROUP   AGE
rayjob-sample-5qdvm-head-chj6g                 200m   0      0      0        rayjob-sample-5qdvm   head     headgroup      14s
rayjob-sample-5qdvm-small-group-worker-4ntm4   200m   0      0      6Gi      rayjob-sample-5qdvm   worker   small-group    14s
```

## Related issue number
Closes #3639 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
