### PR TITLE
Add seccompProfile to KubeRay operator deployment for PSS compliance

### DIFF
--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -22,6 +22,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kuberay-operator
       containers:
       - command:
@@ -37,6 +39,8 @@ spec:
           protocol: TCP
         name: kuberay-operator
         securityContext:
+          seccompProfile:
+            type: RuntimeDefault
           allowPrivilegeEscalation: false
         livenessProbe:
           httpGet:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR adds a `seccompProfile` set to `RuntimeDefault` in the KubeRay operator Deployment manifest at both the pod and container levels.

This change resolves Pod Security Standards (PSS) warnings observed in Kubeflow deployments by ensuring the operator runs with the recommended seccomp configuration. This aligns with Kubernetes security best practices and improves compliance in restricted environments.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
- part of https://github.com/kubeflow/manifests/pull/3200

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
