### PR TITLE
Correct `sumGPUs` to include MIGs in count

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -854,7 +853,7 @@ func addWellKnownAcceleratorResources(rayStartParams map[string]string, resource
 
 		// Scan for resource keys of gpus
 		if _, ok := rayStartParams["num-gpus"]; !ok {
-			if isGPUResourceKey(resourceKeyString) && !resourceValue.IsZero() {
+			if utils.IsGPUResourceKey(resourceKeyString) && !resourceValue.IsZero() {
 				rayStartParams["num-gpus"] = strconv.FormatInt(resourceValue.Value(), 10)
 			}
 		}
@@ -1026,15 +1025,4 @@ func findMemoryReqOrLimit(container corev1.Container) (res *resource.Quantity) {
 		return mem
 	}
 	return nil
-}
-
-func isGPUResourceKey(key string) bool {
-	// ending with "gpu" like "nvidia.com/gpu"
-	if strings.HasSuffix(key, "gpu") {
-		return true
-	}
-	// Nvidia Multi-Instance GPU in the form of "nvidia.com/mig-<slice_count>g.<memory_size>gb" like "nvidia.com/mig-2g.32gb"
-	// reference: https://github.com/NVIDIA/k8s-device-plugin#configuration-option-details
-	match, _ := regexp.MatchString(`nvidia\.com/mig-\d+g\.\d+gb$`, key)
-	return match
 }

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1833,52 +1833,6 @@ func TestGenerateRayStartCommand(t *testing.T) {
 	}
 }
 
-func TestIsGPUResourceKey(t *testing.T) {
-	tests := []struct {
-		name        string
-		resourceKey string
-		expected    bool
-	}{
-		{
-			name:        "nvidia gpu",
-			resourceKey: "nvidia.com/gpu",
-			expected:    true,
-		},
-		{
-			name:        "amd gpu",
-			resourceKey: "amd.com/gpu",
-			expected:    true,
-		},
-		{
-			name:        "nvidia MIG",
-			resourceKey: "nvidia.com/mig-12g.128gb",
-			expected:    true,
-		},
-		{
-			name:        "nvidia MIG bad format",
-			resourceKey: "nvidia.com/gpu-mig-12g.128gb",
-			expected:    false,
-		},
-		{
-			name:        "cpu",
-			resourceKey: "cpu",
-			expected:    false,
-		},
-		{
-			name:        "memory",
-			resourceKey: "memory",
-			expected:    false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := isGPUResourceKey(tt.resourceKey)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestSetAutoscalerV2EnvVars(t *testing.T) {
 	tests := map[string]struct {
 		podTemplate     *corev1.PodTemplateSpec

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1576,7 +1576,7 @@ func sumGPUs(resources map[corev1.ResourceName]resource.Quantity) resource.Quant
 	totalGPUs := resource.Quantity{}
 
 	for key, val := range resources {
-		if strings.HasSuffix(string(key), "gpu") && !val.IsZero() {
+		if utils.IsGPUResourceKey(string(key)) && !val.IsZero() {
 			totalGPUs.Add(val)
 		}
 	}

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3165,7 +3165,7 @@ func TestSumGPUs(t *testing.T) {
 			input: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceCPU:                 resource.MustParse("1"),
 				nvidiaGPUResourceName:              resource.MustParse("3"),
-				nvidiaMIG1g10gbResourceName:		resource.MustParse("2"),
+				nvidiaMIG1g10gbResourceName:        resource.MustParse("2"),
 				corev1.ResourceName("foo.bar/gpu"): resource.MustParse("2"),
 				googleTPUResourceName:              resource.MustParse("1"),
 			},
@@ -3174,15 +3174,15 @@ func TestSumGPUs(t *testing.T) {
 		{
 			name: "multiple MIG types specified",
 			input: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:    			resource.MustParse("1"),
-				nvidiaGPUResourceName:			resource.MustParse("1"),
-				nvidiaMIG1g10gbResourceName:	resource.MustParse("2"),
-				nvidiaMIG2g20gbResourceName:	resource.MustParse("3"),
-				nvidiaMIG3g40gbResourceName:	resource.MustParse("4"),
-				googleTPUResourceName: 			resource.MustParse("1"),
+				corev1.ResourceCPU:          resource.MustParse("1"),
+				nvidiaGPUResourceName:       resource.MustParse("1"),
+				nvidiaMIG1g10gbResourceName: resource.MustParse("2"),
+				nvidiaMIG2g20gbResourceName: resource.MustParse("3"),
+				nvidiaMIG3g40gbResourceName: resource.MustParse("4"),
+				googleTPUResourceName:       resource.MustParse("1"),
 			},
 			expected: resource.MustParse("10"),
-		},		
+		},
 	}
 
 	for _, tc := range tests {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3134,6 +3134,9 @@ func TestReconcile_NumOfHosts(t *testing.T) {
 
 func TestSumGPUs(t *testing.T) {
 	nvidiaGPUResourceName := corev1.ResourceName("nvidia.com/gpu")
+	nvidiaMIG1g10gbResourceName := corev1.ResourceName("nvidia.com/mig-1g.10gb")
+	nvidiaMIG2g20gbResourceName := corev1.ResourceName("nvidia.com/mig-2g.20gb")
+	nvidiaMIG3g40gbResourceName := corev1.ResourceName("nvidia.com/mig-3g.40gb")
 	googleTPUResourceName := corev1.ResourceName("google.com/tpu")
 
 	tests := []struct {
@@ -3162,11 +3165,24 @@ func TestSumGPUs(t *testing.T) {
 			input: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceCPU:                 resource.MustParse("1"),
 				nvidiaGPUResourceName:              resource.MustParse("3"),
+				nvidiaMIG1g10gbResourceName:		resource.MustParse("2"),
 				corev1.ResourceName("foo.bar/gpu"): resource.MustParse("2"),
 				googleTPUResourceName:              resource.MustParse("1"),
 			},
-			expected: resource.MustParse("5"),
+			expected: resource.MustParse("7"),
 		},
+		{
+			name: "multiple MIG types specified",
+			input: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    			resource.MustParse("1"),
+				nvidiaGPUResourceName:			resource.MustParse("1"),
+				nvidiaMIG1g10gbResourceName:	resource.MustParse("2"),
+				nvidiaMIG2g20gbResourceName:	resource.MustParse("3"),
+				nvidiaMIG3g40gbResourceName:	resource.MustParse("4"),
+				googleTPUResourceName: 			resource.MustParse("1"),
+			},
+			expected: resource.MustParse("10"),
+		},		
 	}
 
 	for _, tc := range tests {

--- a/ray-operator/controllers/ray/utils/resources.go
+++ b/ray-operator/controllers/ray/utils/resources.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+func IsGPUResourceKey(key string) bool {
+	// ending with "gpu" like "nvidia.com/gpu"
+	if strings.HasSuffix(key, "gpu") {
+		return true
+	}
+	// Nvidia Multi-Instance GPU in the form of "nvidia.com/mig-<slice_count>g.<memory_size>gb" like "nvidia.com/mig-2g.32gb"
+	// reference: https://github.com/NVIDIA/k8s-device-plugin#configuration-option-details
+	match, _ := regexp.MatchString(`nvidia\.com/mig-\d+g\.\d+gb$`, key)
+	return match
+}

--- a/ray-operator/controllers/ray/utils/resources_test.go
+++ b/ray-operator/controllers/ray/utils/resources_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsGPUResourceKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		resourceKey string
+		expected    bool
+	}{
+		{
+			name:        "nvidia gpu",
+			resourceKey: "nvidia.com/gpu",
+			expected:    true,
+		},
+		{
+			name:        "amd gpu",
+			resourceKey: "amd.com/gpu",
+			expected:    true,
+		},
+		{
+			name:        "nvidia MIG",
+			resourceKey: "nvidia.com/mig-12g.128gb",
+			expected:    true,
+		},
+		{
+			name:        "nvidia MIG bad format",
+			resourceKey: "nvidia.com/gpu-mig-12g.128gb",
+			expected:    false,
+		},
+		{
+			name:        "cpu",
+			resourceKey: "cpu",
+			expected:    false,
+		},
+		{
+			name:        "memory",
+			resourceKey: "memory",
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsGPUResourceKey(tt.resourceKey)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Why are these changes needed?
`desiredGPU` count is incorrect when using MIGs like `nvidia.com/mig-2g.20gb`

## Related issue number
Closes #3925

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
