### PR TITLE
feat(kubectl-plugin): Add clusterTimeout flag support for job submit

### DIFF
--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -182,7 +182,7 @@ func NewJobSubmitCommand(cmdFactory cmdutil.Factory, streams genericclioptions.I
 	cmd.Flags().StringToStringVar(&options.headNodeSelectors, "head-node-selectors", nil, "Node selectors to apply to the head pod in the cluster (e.g. --head-node-selectors topology.kubernetes.io/zone=us-east-1c)")
 	cmd.Flags().StringToStringVar(&options.workerNodeSelectors, "worker-node-selectors", nil, "Node selectors to apply to all worker pods in the cluster (e.g. --worker-node-selectors topology.kubernetes.io/zone=us-east-1c)")
 	cmd.Flags().Int32Var(&options.ttlSecondsAfterFinished, "ttl-seconds-after-finished", 0, "TTL seconds after finished.")
-	cmd.Flags().Float64Var(&options.clusterTimeout, "cluster-timeout", 120.0, "Timeout in seconds for waiting for the RayCluster to be ready")
+	cmd.Flags().Float64Var(&options.clusterTimeout, "cluster-timeout", 3600.0, "Timeout in seconds for waiting for the RayCluster to be ready")
 
 	return cmd
 }

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -76,7 +76,7 @@ type SubmitJobOptions struct {
 	verbose                  bool
 	shutdownAfterJobFinishes bool
 	ttlSecondsAfterFinished  int32
-	clusterTimeout           float64
+	clusterTimeout           int32
 }
 
 type JobInfo struct {
@@ -182,7 +182,7 @@ func NewJobSubmitCommand(cmdFactory cmdutil.Factory, streams genericclioptions.I
 	cmd.Flags().StringToStringVar(&options.headNodeSelectors, "head-node-selectors", nil, "Node selectors to apply to the head pod in the cluster (e.g. --head-node-selectors topology.kubernetes.io/zone=us-east-1c)")
 	cmd.Flags().StringToStringVar(&options.workerNodeSelectors, "worker-node-selectors", nil, "Node selectors to apply to all worker pods in the cluster (e.g. --worker-node-selectors topology.kubernetes.io/zone=us-east-1c)")
 	cmd.Flags().Int32Var(&options.ttlSecondsAfterFinished, "ttl-seconds-after-finished", 0, "TTL seconds after finished.")
-	cmd.Flags().Float64Var(&options.clusterTimeout, "cluster-timeout", 3600.0, "Timeout in seconds for waiting for the RayCluster to be ready")
+	cmd.Flags().Int32Var(&options.clusterTimeout, "cluster-timeout", 600, "Timeout in seconds for waiting for the RayCluster to be ready")
 
 	return cmd
 }
@@ -422,7 +422,7 @@ func (options *SubmitJobOptions) Run(ctx context.Context, factory cmdutil.Factor
 	currTime := clusterWaitStartTime
 	fmt.Printf("Waiting for RayCluster\n")
 	fmt.Printf("Checking Cluster Status for cluster %s...\n", options.cluster)
-	for !clusterReady && currTime.Sub(clusterWaitStartTime).Seconds() <= options.clusterTimeout {
+	for !clusterReady && currTime.Sub(clusterWaitStartTime) <= time.Duration(options.clusterTimeout)*time.Second {
 		time.Sleep(2 * time.Second)
 		currCluster, err := k8sClients.RayClient().RayV1().RayClusters(options.namespace).Get(ctx, options.cluster, v1.GetOptions{})
 		if err != nil {

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -135,7 +135,7 @@ spec:
 				ioStreams:      &testStreams,
 				fileName:       rayJobYamlPath,
 				workingDir:     "Fake/File/Path",
-				clusterTimeout: 120.0,
+				clusterTimeout: 120,
 			}
 
 			err = opts.Validate(&cobra.Command{})
@@ -185,7 +185,7 @@ func TestRayJobSubmitWithoutYamlValidate(t *testing.T) {
 				rayjobName:              tc.rayjobName,
 				workingDir:              "Fake/File/Path",
 				ttlSecondsAfterFinished: tc.ttlSecondsAfterFinished,
-				clusterTimeout:          120.0,
+				clusterTimeout:          120,
 			}
 			err := opts.Validate(&cobra.Command{})
 			if tc.expectError != "" {
@@ -229,10 +229,11 @@ func TestRayJobSubmit_AddressValidation(t *testing.T) {
 	for _, tc := range test {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := &SubmitJobOptions{
-				cmdFactory: cmdFactory,
-				ioStreams:  &testStreams,
-				rayjobName: "rayjob-sample",
-				workingDir: "Fake/File/Path",
+				cmdFactory:     cmdFactory,
+				ioStreams:      &testStreams,
+				rayjobName:     "rayjob-sample",
+				workingDir:     "Fake/File/Path",
+				clusterTimeout: 120,
 			}
 
 			cmd := &cobra.Command{}

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -131,10 +131,11 @@ spec:
 			require.NoError(t, err)
 
 			opts := &SubmitJobOptions{
-				cmdFactory: cmdFactory,
-				ioStreams:  &testStreams,
-				fileName:   rayJobYamlPath,
-				workingDir: "Fake/File/Path",
+				cmdFactory:     cmdFactory,
+				ioStreams:      &testStreams,
+				fileName:       rayJobYamlPath,
+				workingDir:     "Fake/File/Path",
+				clusterTimeout: 120.0,
 			}
 
 			err = opts.Validate(&cobra.Command{})
@@ -184,6 +185,7 @@ func TestRayJobSubmitWithoutYamlValidate(t *testing.T) {
 				rayjobName:              tc.rayjobName,
 				workingDir:              "Fake/File/Path",
 				ttlSecondsAfterFinished: tc.ttlSecondsAfterFinished,
+				clusterTimeout:          120.0,
 			}
 			err := opts.Validate(&cobra.Command{})
 			if tc.expectError != "" {
@@ -396,10 +398,11 @@ spec:
 			require.NoError(t, err)
 
 			opts := &SubmitJobOptions{
-				cmdFactory: cmdFactory,
-				ioStreams:  &testStreams,
-				fileName:   rayJobYamlPath,
-				workingDir: "Fake/File/Path",
+				cmdFactory:     cmdFactory,
+				ioStreams:      &testStreams,
+				fileName:       rayJobYamlPath,
+				workingDir:     "Fake/File/Path",
+				clusterTimeout: 120.0,
 			}
 			cmd := &cobra.Command{}
 			cmd.Flags().Int32Var(&opts.ttlSecondsAfterFinished, "ttl-seconds-after-finished", 0, "")


### PR DESCRIPTION
## Why are these changes needed?

`kubectl ray job submit` currently hardcodes `clusterTimeout` to 120s, causing failures when `RayJob` triggers slow node pool scaling (e.g., cloud environments taking \~10 min). This PR makes `clusterTimeout` configurable to better support `submissionMode: InteractiveMode` in scaling scenarios.

## Related issue number

Closes issue #3900

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
