### PR TITLE
[Flaky] Test Autoscaler E2E Part 2 (nightly operator) is flaky

### DIFF
--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go
@@ -29,7 +29,7 @@ func TestRayClusterAutoscalerV2IdleTimeout(t *testing.T) {
 
 		idleTimeoutShort := int32(10)
 		idleTimeoutLong := int32(30)
-		timeoutBuffer := int32(30) // Additional wait time to allow for scale down operation
+		timeoutBuffer := int32(100) // Additional wait time to allow for scale down operation
 
 		// Script for creating detached actors to trigger autoscaling
 		scriptsAC := newConfigMap(namespace.Name, files(test, "create_detached_actor.py", "terminate_detached_actor.py"))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current e2e test `raycluster_autoscaler_part2_test` is flaky. In the test case [TestRayClusterAutoscalerV2IdleTimeout](https://github.com/ray-project/kuberay/blob/master/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go#L20), logs show that the autoscaler takes ~84 seconds to scale down(10 seconds idle + 74 seconds scale down), whereas the test script sets a 40-second timeout(10 seconds idle + 30 seconds buffer), causing failures. This PR increases the timeout buffer from 30 seconds to 100 seconds to reduce flakiness.

<img width="817" height="600" alt="截圖 2025-08-15 上午11 20 27" src="https://github.com/user-attachments/assets/8dc46993-e8a9-4c6a-9ae8-88dc3e6c57ad" />
 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #3940 
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
