### PR TITLE
[Feature][APIServer] Support decimal memory values in KubeRay APIServer

### DIFF
--- a/apiserver/pkg/model/converter.go
+++ b/apiserver/pkg/model/converter.go
@@ -404,14 +404,14 @@ func convertEnvVariables(cenv []corev1.EnvVar, header bool) *api.EnvironmentVari
 
 func FromKubeToAPIComputeTemplate(configMap *corev1.ConfigMap) *api.ComputeTemplate {
 	cpu, _ := strconv.ParseUint(configMap.Data["cpu"], 10, 32)
-	memory, _ := strconv.ParseUint(configMap.Data["memory"], 10, 32)
+	memory, _ := strconv.ParseFloat(configMap.Data["memory"], 32)
 	gpu, _ := strconv.ParseUint(configMap.Data["gpu"], 10, 32)
 
 	runtime := &api.ComputeTemplate{}
 	runtime.Name = configMap.Name
 	runtime.Namespace = configMap.Namespace
 	runtime.Cpu = uint32(cpu)
-	runtime.Memory = uint32(memory)
+	runtime.Memory = float32(memory)
 	runtime.Gpu = uint32(gpu)
 	runtime.GpuAccelerator = configMap.Data["gpu_accelerator"]
 

--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -179,7 +179,7 @@ func buildHeadPodTemplate(imageVersion string, envs *api.EnvironmentVariables, s
 
 	// calculate resources
 	cpu := fmt.Sprint(computeRuntime.GetCpu())
-	memory := fmt.Sprintf("%d%s", computeRuntime.GetMemory(), "Gi")
+	memory := fmt.Sprintf("%.2fGi", computeRuntime.GetMemory())
 
 	// build volume and volumeMounts
 	volMounts := buildVolumeMounts(spec.Volumes)
@@ -433,7 +433,7 @@ func buildWorkerPodTemplate(imageVersion string, envs *api.EnvironmentVariables,
 
 	// calculate resources
 	cpu := fmt.Sprint(computeRuntime.GetCpu())
-	memory := fmt.Sprintf("%d%s", computeRuntime.GetMemory(), "Gi")
+	memory := fmt.Sprintf("%.2fGi", computeRuntime.GetMemory())
 
 	// build volume and volumeMounts
 	volMounts := buildVolumeMounts(spec.Volumes)
@@ -850,13 +850,12 @@ func NewComputeTemplate(runtime *api.ComputeTemplate) (*corev1.ConfigMap, error)
 
 	// Create data map
 	dmap := map[string]string{
-		"name":               runtime.Name,
-		"namespace":          runtime.Namespace,
-		"cpu":                strconv.FormatUint(uint64(runtime.Cpu), 10),
-		"memory":             strconv.FormatUint(uint64(runtime.Memory), 10),
-		"gpu":                strconv.FormatUint(uint64(runtime.Gpu), 10),
-		"gpu_accelerator":    runtime.GpuAccelerator,
-		"extended_resources": string(extendedResourcesJSON),
+		"name":            runtime.Name,
+		"namespace":       runtime.Namespace,
+		"cpu":             strconv.FormatUint(uint64(runtime.Cpu), 10),
+		"memory":          strconv.FormatFloat(float64(runtime.Memory), 'f', -1, 32),
+		"gpu":             strconv.FormatUint(uint64(runtime.Gpu), 10),
+		"gpu_accelerator": runtime.GpuAccelerator,
 	}
 	// Add tolerations in defined
 	if len(runtime.Tolerations) > 0 {

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -121,7 +121,7 @@ message ComputeTemplate {
   // Required. Number of cpus
   uint32 cpu = 3 [(google.api.field_behavior) = REQUIRED];
   // Required. Number of memory
-  uint32 memory = 4 [(google.api.field_behavior) = REQUIRED];
+  float memory = 4 [(google.api.field_behavior) = REQUIRED];
   // Optional. Number of gpus
   uint32 gpu = 5;
   // Optional. The detail gpu accelerator type


### PR DESCRIPTION


## Why are these changes needed?
### Implementation Details

- **File Modified**: `apiserver/pkg/util/cluster.go`
- **Key Change**: Updated the `buildWorkerPodTemplate` function to use `resource.MustParse(memory)` for memory value conversion. This method natively supports decimal inputs (e.g., `2.3`), enabling precise memory configuration.

### Testing & Validation
1. Compute Template Creation:
Successfully created a compute template with memory: 2.3 via the APIServer API. The resulting ConfigMap in Kubernetes stored the value as "2.3".

```shell
curl -X POST 'kuberay-apiserver-service.zenap.svc.cluster.local:8888/apis/v1/namespaces/zenap/compute_templates' \
--header 'Content-Type: application/json' \
--data '{
  "name": "default-templatecc5-zhs2",
  "namespace": "zenap",
  "cpu": 2,
  "memory": 2.3,
  "security_context": {
    "fsGroup": 3000,
    "fsGroupChangePolicy": "OnRootMismatch"
  }
}'
```
<img width="807" height="338" alt="image" src="https://github.com/user-attachments/assets/4ce0feff-f463-458f-b549-6f255c75444a" />

2. Ray Cluster Deployment:
Deployed a Ray cluster using the template. Kubernetes YAML output confirmed the memory value was correctly parsed to 2469606195200m (equivalent to 2.3GB).

<img width="871" height="341" alt="image" src="https://github.com/user-attachments/assets/a2fd3a5d-c951-438d-979c-243eaa90288f" />


3. Dashboard Verification:
The Ray dashboard displayed the memory allocation as 2.30GB for both head and worker nodes, with usage metrics aligning with the configured value.
<img width="2524" height="587" alt="image" src="https://github.com/user-attachments/assets/7677c6b7-c3b6-4ecc-99ad-fe26f2cd1d38" />


## Related issue number

Fixes the limitation where memory configurations in KubeRay APIServer only supported integer values.  Closes #3955

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
