### PR TITLE
[Fix] Fix Errors When Creating RayCluster via Direct CR Without Specifying HostPath type

### DIFF
--- a/apiserver/pkg/model/volumes.go
+++ b/apiserver/pkg/model/volumes.go
@@ -130,7 +130,7 @@ func GetVolumeMountPropagation(mount *corev1.VolumeMount) api.Volume_MountPropag
 }
 
 func GetVolumeHostPathType(vol *corev1.Volume) api.Volume_HostPathType {
-	if *vol.VolumeSource.HostPath.Type == corev1.HostPathFile {
+	if vol.VolumeSource.HostPath.Type == nil || *vol.VolumeSource.HostPath.Type == corev1.HostPathFile {
 		return api.Volume_FILE
 	}
 	return api.Volume_DIRECTORY

--- a/apiserver/pkg/model/volumes_test.go
+++ b/apiserver/pkg/model/volumes_test.go
@@ -199,3 +199,49 @@ func TestPopulateVolumes(t *testing.T) {
 		}
 	}
 }
+
+func TestGetVolumeHostPathType(t *testing.T) {
+	// Test case 1: HostPath type is nil
+	vol1 := corev1.Volume{
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/tmp",
+				Type: nil,
+			},
+		},
+	}
+	result1 := GetVolumeHostPathType(&vol1)
+	if result1 != api.Volume_FILE {
+		t.Errorf("Expected FILE type, got %v", result1)
+	}
+
+	// Test case 2: HostPath type is HostPathFile
+	typeFile := corev1.HostPathFile
+	vol2 := corev1.Volume{
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/tmp",
+				Type: &typeFile,
+			},
+		},
+	}
+	result2 := GetVolumeHostPathType(&vol2)
+	if result2 != api.Volume_FILE {
+		t.Errorf("Expected FILE type, got %v", result2)
+	}
+
+	// Test case 3: HostPath type is HostPathDirectory
+	typeDir := corev1.HostPathDirectory
+	vol3 := corev1.Volume{
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/tmp",
+				Type: &typeDir,
+			},
+		},
+	}
+	result3 := GetVolumeHostPathType(&vol3)
+	if result3 != api.Volume_DIRECTORY {
+		t.Errorf("Expected DIRECTORY type, got %v", result3)
+	}
+}


### PR DESCRIPTION

## Why are these changes needed?

Make it compatible with the scenario where the user does not explicitly configure HostPath.Type, treating "type not specified" as HostPathFile, consistent with the behavior in the API server. This change will enhance the robustness and fault tolerance of the code.

## Related issue number

Closes #3957

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
