### PR TITLE
[RayCluster] grant pods and pods/resize patch permissions for IPPR

### DIFF
--- a/helm-chart/kuberay-operator/templates/_helpers.tpl
+++ b/helm-chart/kuberay-operator/templates/_helpers.tpl
@@ -131,6 +131,7 @@ rules:
   - ""
   resources:
   - events
+  - pods/resize
   - pods/status
   - services
   verbs:

--- a/helm-chart/kuberay-operator/templates/_helpers.tpl
+++ b/helm-chart/kuberay-operator/templates/_helpers.tpl
@@ -131,7 +131,6 @@ rules:
   - ""
   resources:
   - events
-  - pods/resize
   - pods/status
   - services
   verbs:
@@ -164,6 +163,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods/resize
+  verbs:
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/ray-operator/config/rbac/role.yaml
+++ b/ray-operator/config/rbac/role.yaml
@@ -16,6 +16,7 @@ rules:
   - ""
   resources:
   - events
+  - pods/resize
   - pods/status
   - services
   verbs:

--- a/ray-operator/config/rbac/role.yaml
+++ b/ray-operator/config/rbac/role.yaml
@@ -16,7 +16,6 @@ rules:
   - ""
   resources:
   - events
-  - pods/resize
   - pods/status
   - services
   verbs:
@@ -49,6 +48,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods/resize
+  verbs:
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/ray-operator/controllers/ray/common/rbac.go
+++ b/ray-operator/controllers/ray/common/rbac.go
@@ -42,7 +42,12 @@ func BuildRole(cluster *rayv1.RayCluster) (*rbacv1.Role, error) {
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     []string{"get", "list", "watch", "patch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods/resize"},
+				Verbs:     []string{"patch"},
 			},
 			{
 				APIGroups: []string{"ray.io"},

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -95,6 +95,7 @@ type RayClusterReconcilerOptions struct {
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods/resize,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -95,7 +95,7 @@ type RayClusterReconcilerOptions struct {
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=pods/resize,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods/resize,verbs=patch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update


### PR DESCRIPTION

## Why are these changes needed?

This PR adds `pods patch` and `pods/resize patch` rbac permissions to KubeRay operator and the generated service account for RayClusters. This will allow the Ray autoscaler to perform IPPR.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
