### PR TITLE
[Dashboard-client] replace http method from string to constant

### DIFF
--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -167,7 +167,7 @@ func (r *RayDashboardClient) GetMultiApplicationStatus(ctx context.Context) (map
 
 // GetServeDetails gets details on all live applications on the Ray cluster.
 func (r *RayDashboardClient) GetServeDetails(ctx context.Context) (*ServeDetails, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", r.dashboardURL+ServeDetailsPath, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.dashboardURL+ServeDetailsPath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ type RayJobLogsResponse struct {
 // Note that RayJobInfo and error can't be nil at the same time.
 // Please make sure if the Ray job with JobId can't be found. Return a BadRequest error.
 func (r *RayDashboardClient) GetJobInfo(ctx context.Context, jobId string) (*RayJobInfo, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", r.dashboardURL+JobPath+jobId, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.dashboardURL+JobPath+jobId, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +282,7 @@ func (r *RayDashboardClient) GetJobInfo(ctx context.Context, jobId string) (*Ray
 }
 
 func (r *RayDashboardClient) ListJobs(ctx context.Context) (*[]RayJobInfo, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", r.dashboardURL+JobPath, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.dashboardURL+JobPath, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
@@ -90,7 +90,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 	It("Test submitting/getting rayJob", func() {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder("POST", rayDashboardClient.dashboardURL+JobPath,
+		httpmock.RegisterResponder(http.MethodPost, rayDashboardClient.dashboardURL+JobPath,
 			func(_ *http.Request) (*http.Response, error) {
 				body := &RayJobResponse{
 					JobId: expectJobId,
@@ -98,7 +98,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 				bodyBytes, _ := json.Marshal(body)
 				return httpmock.NewBytesResponse(200, bodyBytes), nil
 			})
-		httpmock.RegisterResponder("GET", rayDashboardClient.dashboardURL+JobPath+expectJobId,
+		httpmock.RegisterResponder(http.MethodGet, rayDashboardClient.dashboardURL+JobPath+expectJobId,
 			func(_ *http.Request) (*http.Response, error) {
 				body := &RayJobInfo{
 					JobStatus:  rayv1.JobStatusRunning,
@@ -108,7 +108,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 				bodyBytes, _ := json.Marshal(body)
 				return httpmock.NewBytesResponse(200, bodyBytes), nil
 			})
-		httpmock.RegisterResponder("GET", rayDashboardClient.dashboardURL+JobPath+errorJobId,
+		httpmock.RegisterResponder(http.MethodGet, rayDashboardClient.dashboardURL+JobPath+errorJobId,
 			func(_ *http.Request) (*http.Response, error) {
 				// return a string in the body
 				return httpmock.NewStringResponse(200, "Ray misbehaved and sent string, not JSON"), nil
@@ -132,7 +132,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 	It("Test stop job", func() {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder("POST", rayDashboardClient.dashboardURL+JobPath+"stop-job-1/stop",
+		httpmock.RegisterResponder(http.MethodPost, rayDashboardClient.dashboardURL+JobPath+"stop-job-1/stop",
 			func(_ *http.Request) (*http.Response, error) {
 				body := &RayJobStopResponse{
 					Stopped: true,
@@ -149,7 +149,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 		// StopJob only returns an error when JobStatus is not in terminated states (STOPPED / SUCCEEDED / FAILED)
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder("POST", rayDashboardClient.dashboardURL+JobPath+"stop-job-1/stop",
+		httpmock.RegisterResponder(http.MethodPost, rayDashboardClient.dashboardURL+JobPath+"stop-job-1/stop",
 			func(_ *http.Request) (*http.Response, error) {
 				body := &RayJobStopResponse{
 					Stopped: false,
@@ -157,7 +157,7 @@ var _ = Describe("RayFrameworkGenerator", func() {
 				bodyBytes, _ := json.Marshal(body)
 				return httpmock.NewBytesResponse(200, bodyBytes), nil
 			})
-		httpmock.RegisterResponder("GET", rayDashboardClient.dashboardURL+JobPath+"stop-job-1",
+		httpmock.RegisterResponder(http.MethodGet, rayDashboardClient.dashboardURL+JobPath+"stop-job-1",
 			func(_ *http.Request) (*http.Response, error) {
 				body := &RayJobInfo{
 					JobStatus:  rayv1.JobStatusSucceeded,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Some http method already uses constant, some doesn't. This PR replace the http method string to http method constant for consistency.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
