### PR TITLE
[ApiServer] Fix nil HostPath type in GetVolumeHostPathType and add unit tests.

### DIFF
--- a/apiserver/pkg/model/volumes.go
+++ b/apiserver/pkg/model/volumes.go
@@ -130,6 +130,9 @@ func GetVolumeMountPropagation(mount *corev1.VolumeMount) api.Volume_MountPropag
 }
 
 func GetVolumeHostPathType(vol *corev1.Volume) api.Volume_HostPathType {
+	if vol.VolumeSource.HostPath.Type == nil {
+		return api.Volume_DIRECTORY
+	}
 	if *vol.VolumeSource.HostPath.Type == corev1.HostPathFile {
 		return api.Volume_FILE
 	}

--- a/apiserver/pkg/model/volumes_test.go
+++ b/apiserver/pkg/model/volumes_test.go
@@ -199,3 +199,46 @@ func TestPopulateVolumes(t *testing.T) {
 		}
 	}
 }
+
+func TestGetVolumeHostPathType(t *testing.T) {
+	vol1 := corev1.Volume{
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/tmp",
+				Type: nil,
+			},
+		},
+	}
+	result1 := GetVolumeHostPathType(&vol1)
+	if result1 != api.Volume_DIRECTORY {
+		t.Errorf("Expected FILE type, got %v", result1)
+	}
+
+	typeFile := corev1.HostPathFile
+	vol2 := corev1.Volume{
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/tmp",
+				Type: &typeFile,
+			},
+		},
+	}
+	result2 := GetVolumeHostPathType(&vol2)
+	if result2 != api.Volume_FILE {
+		t.Errorf("Expected FILE type, got %v", result2)
+	}
+
+	typeDir := corev1.HostPathDirectory
+	vol3 := corev1.Volume{
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/tmp",
+				Type: &typeDir,
+			},
+		},
+	}
+	result3 := GetVolumeHostPathType(&vol3)
+	if result3 != api.Volume_DIRECTORY {
+		t.Errorf("Expected DIRECTORY type, got %v", result3)
+	}
+}


### PR DESCRIPTION
## Why are these changes needed?

The issue's phenomenon and cause are described in detail in #3957.

We fixed the issue in this PR. We first check whether vol.VolumeSource.HostPath.Type is nil before accessing its value.

## Related issue number

Closes #3957

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
