### PR TITLE
[Experimental] Fix Makefile tool check: replace `-s` with `test -s`

### DIFF
--- a/experimental/Makefile
+++ b/experimental/Makefile
@@ -92,7 +92,7 @@ GOBINDATA_VERSION ?= v4.0.2
 .PHONY: gofumpt
 gofumpt: $(GOFUMPT) ## Download gofumpt locally if necessary.
 $(GOFUMPT): $(REPO_ROOT_BIN)
-	-s $(GOFUMPT) || GOBIN=$(REPO_ROOT_BIN) go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
+	test -s $(GOFUMPT) || GOBIN=$(REPO_ROOT_BIN) go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci_lint locally if necessary.

--- a/experimental/Makefile
+++ b/experimental/Makefile
@@ -97,12 +97,12 @@ $(GOFUMPT): $(REPO_ROOT_BIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci_lint locally if necessary.
 $(GOLANGCI_LINT): $(REPO_ROOT_BIN)
-	-s $(GOLANGCI_LINT) || (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(REPO_ROOT_BIN)/ $(GOLANGCI_LINT_VERSION))
+	test -s $(GOLANGCI_LINT) || (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(REPO_ROOT_BIN)/ $(GOLANGCI_LINT_VERSION))
 
 .PHONY: go-bindata
 go-bindata: $(GOBINDATA) ## Download the go-bindata executable if necessary.
 $(GOBINDATA): $(REPO_ROOT_BIN)
-	-s $(GOBINDATA) || GOBIN=$(REPO_ROOT_BIN) go install github.com/kevinburke/go-bindata/v4/...@$(GOBINDATA_VERSION)
+	test -s $(GOBINDATA) || GOBIN=$(REPO_ROOT_BIN) go install github.com/kevinburke/go-bindata/v4/...@$(GOBINDATA_VERSION)
 
 .PHONY: dev-tools
 dev-tools: golangci-lint gofumpt go-bindata ## Install all development tools


### PR DESCRIPTION
## Why are these changes needed?

The current `experimental/Makefile` uses `-s $(CMD)` to check whether
tool binaries (e.g., `golangci-lint`, `go-bindata`) exist.

However, `-s` is not a valid shell command, and running the Makefile produces:
`bash: s: command not found`

This breaks the development tool installation workflow.

## What do these changes do?

This PR replaces `-s $(CMD)` with the correct check:
```make 
test -s $(CMD) || <install command>
```

This ensures the Makefile properly verifies whether the binary exists
and installs it if missing. The fix also makes the Makefile consistent
with the style used in other parts of the KubeRay repo.

## How was this tested?

- Ran `make dev-tools` locally after the change.
- Verified that:
  - `golangci-lint` and `go-bindata` are correctly installed into `bin/` if missing.
  - No `bash: s: command not found` errors appear.
  - Subsequent runs of `make dev-tools` skip installation if binaries exist.

## Related issue number

N/A

## Checks

- [x] I've run `make dev-tools` to verify the fix works.
- [x] The PR only touches the `experimental/Makefile`.
- [x] The change improves developer experience without affecting runtime behavior.
