### PR TITLE
[apiserver] reduce the possibility of flaky test in TestAPIServerClie…

### DIFF
--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -734,6 +734,9 @@ func (krc *KuberayAPIServerClient) executeRequest(httpRequest *http.Request, URL
 		select {
 		case <-time.After(sleep):
 			// continue to the next retry after backoff
+			if err := ctx.Err(); err != nil && errors.Is(err, context.DeadlineExceeded) {
+				return nil, lastStatus, fmt.Errorf("overall timeout reached simultaneously with waking up: %w", ctx.Err())
+			}
 		case <-ctx.Done():
 			return nil, lastStatus, fmt.Errorf("overall timeout reached: %w", ctx.Err())
 		}

--- a/apiserver/pkg/http/client_test.go
+++ b/apiserver/pkg/http/client_test.go
@@ -306,10 +306,10 @@ func TestAPIServerClientOverallTimeout(t *testing.T) {
 	retryCfg := RetryConfig{
 		MaxRetry:      util.HTTPClientDefaultMaxRetry,
 		BackoffFactor: util.HTTPClientDefaultBackoffBase,
-		InitBackoff:   1 * time.Millisecond,
-		MaxBackoff:    50 * time.Millisecond,
+		InitBackoff:   50 * time.Millisecond,
+		MaxBackoff:    2500 * time.Millisecond,
 		// Set short overall timeout so that the timeout error will be raised
-		OverallTimeout: 1 * time.Millisecond,
+		OverallTimeout: 50 * time.Millisecond,
 	}
 
 	client := NewKuberayAPIServerClient("baseurl", mockClient, retryCfg)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR tries to reduce the possibility of flaky test in TestAPIServerClientBackoff. 

It did the following:
- increase the timeout in the test to reduce the chance of timeout event not being fired.
- put the timeout check after sleep because `select ... case` doesn't guarantee which one execute first. I guess it also make sense to return the timeout error if timeout and sleep happened simultaneously instead of going to next sleep.

However, there is still some extremely case that might cause a flaky test. If the goroutine underneath that firing the timeout event hasn't gotten a change to execute even if it has over the designated time. There is no timeout fired event then failed the test.

### reproduce
add some code for debug:
<img width="774" height="86" alt="flaky code 01" src="https://github.com/user-attachments/assets/f8d23b9a-87aa-49f0-b75f-a8f3cfae4cfe" />
<img width="845" height="128" alt="flaky code 02" src="https://github.com/user-attachments/assets/86e28bd3-f070-4990-b516-8a76c56178a4" />

reproduction(it uses script to run 10000 time of test and with limited cpu):
<img width="874" height="684" alt="flaky reproduce" src="https://github.com/user-attachments/assets/be60d7d9-dcb5-455c-aa90-6219055394a1" />

### result after applying pr.
<img width="503" height="108" alt="flaky fixed" src="https://github.com/user-attachments/assets/5e779351-a135-428a-9404-d0eb026d9aa3" />


## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/kuberay/issues/3964

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
