### PR TITLE
chore: use the same Service name as the owning resource

### DIFF
--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -61,11 +61,15 @@ func BuildServiceForHeadPod(ctx context.Context, cluster rayv1.RayCluster, label
 		annotations = make(map[string]string)
 	}
 
-	defaultName, err := utils.GenerateHeadServiceName(utils.RayClusterCRD, cluster.Spec, cluster.Name)
+	defaultName := cluster.Name
+	defaultNamespace := cluster.Namespace
+	if controller := metav1.GetControllerOf(&cluster); controller != nil {
+		defaultName = controller.Name
+	}
+	defaultName, err := utils.GenerateHeadServiceName(utils.RayClusterCRD, cluster.Spec, defaultName)
 	if err != nil {
 		return nil, err
 	}
-	defaultNamespace := cluster.Namespace
 	defaultType := cluster.Spec.HeadGroupSpec.ServiceType
 
 	defaultAppProtocol := utils.DefaultServiceAppProtocol


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

For RayClusters which are created with an owner (e.g RayJob or RayService), create a service name which is the same as the owning resource.

This will not change the behaviour for RayClusters directly created.

## Related issue number

#2332 #2326 #1436 #1456

Alternative approach to #3978.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests: deployed on a test Kube cluster and manually created ingress
  - [ ] This PR is not tested :(
