### PR TITLE
Use ctrl logger and create logger in function in kai-scheduler

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/kai-scheduler/kai_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/kai-scheduler/kai_scheduler.go
@@ -10,13 +10,12 @@ package kaischeduler
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	schedulerinterface "github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/interface"
@@ -26,9 +25,7 @@ const (
 	QueueLabelName = "kai.scheduler/queue"
 )
 
-type KaiScheduler struct {
-	log logr.Logger
-}
+type KaiScheduler struct{}
 
 type KaiSchedulerFactory struct{}
 
@@ -40,12 +37,13 @@ func (k *KaiScheduler) DoBatchSchedulingOnSubmission(_ context.Context, _ *rayv1
 	return nil
 }
 
-func (k *KaiScheduler) AddMetadataToPod(_ context.Context, app *rayv1.RayCluster, _ string, pod *corev1.Pod) {
+func (k *KaiScheduler) AddMetadataToPod(ctx context.Context, app *rayv1.RayCluster, _ string, pod *corev1.Pod) {
+	logger := ctrl.LoggerFrom(ctx).WithName("kai-scheduler")
 	pod.Spec.SchedulerName = k.Name()
 
 	queue, ok := app.Labels[QueueLabelName]
 	if !ok || queue == "" {
-		k.log.Info("Queue label missing from RayCluster; pods will remain pending",
+		logger.Info("Queue label missing from RayCluster; pods will remain pending",
 			"requiredLabel", QueueLabelName,
 			"rayCluster", app.Name)
 		return
@@ -57,9 +55,7 @@ func (k *KaiScheduler) AddMetadataToPod(_ context.Context, app *rayv1.RayCluster
 }
 
 func (kf *KaiSchedulerFactory) New(_ context.Context, _ *rest.Config, _ client.Client) (schedulerinterface.BatchScheduler, error) {
-	return &KaiScheduler{
-		log: logf.Log.WithName("kai-scheduler"),
-	}, nil
+	return &KaiScheduler{}, nil
 }
 
 func (kf *KaiSchedulerFactory) AddToScheme(_ *runtime.Scheme) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Thanks @win5923 for pointing out https://github.com/ray-project/kuberay/pull/3948#discussion_r2298432267 that we should include reconcile ID when using logger, so instead of storing logger in kai-scheduler we should create new one with context so the the reconcile ID will be include.
Before:
<img width="1353" height="190" alt="image" src="https://github.com/user-attachments/assets/09fc6861-e3e5-4693-964f-57d3512d1e2b" />

After:
<img width="1144" height="184" alt="image" src="https://github.com/user-attachments/assets/c9e9fc53-7ce8-41eb-9879-e3599061429b" />

As image shown, the latter had reconcileID":"5ec43f18-2a15-4df8-84b0-d1505e0608df and more hierarchical logger name `controllers.RayCluster.kai-scheduler`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
