### PR TITLE
Remove unecessary raycluster log in kai-scheduler logger

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/kai-scheduler/kai_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/kai-scheduler/kai_scheduler.go
@@ -44,8 +44,7 @@ func (k *KaiScheduler) AddMetadataToPod(ctx context.Context, app *rayv1.RayClust
 	queue, ok := app.Labels[QueueLabelName]
 	if !ok || queue == "" {
 		logger.Info("Queue label missing from RayCluster; pods will remain pending",
-			"requiredLabel", QueueLabelName,
-			"rayCluster", app.Name)
+			"requiredLabel", QueueLabelName)
 		return
 	}
 	if pod.Labels == nil {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Quick follow up for #3995 , remove the app.name (rayCluster) in logger since logger already include rayCluster.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
