### PR TITLE
[Feature] Remove checking CRD in Volcano scheduler initialization

### DIFF
--- a/helm-chart/kuberay-operator/templates/_helpers.tpl
+++ b/helm-chart/kuberay-operator/templates/_helpers.tpl
@@ -301,12 +301,6 @@ rules:
   - list
   - update
   - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
 {{- end -}}
 {{- if or .batchSchedulerEnabled (eq .batchSchedulerName "scheduler-plugins") }}
 - apiGroups:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Remove checking CRD in Volcano scheduler initialization so that the operator doesn’t need permission to view CRDs. See https://github.com/ray-project/kuberay/pull/3785#discussion_r2193331350 for more context

Also Remove the duplicate import `"volcano.sh/apis/pkg/apis/scheduling/v1beta1"`

## Validation
Install Volcano and kuberay-operator
```
$ kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/master/installer/volcano-development.yaml
$ helm install kuberay-operator --set image.repository=kuberay/operator --set image.tag=nightly --set batchScheduler.name=volcano  ../helm-chart/kuberay-operator
```
1. Create a queue with a capacity of 4 CPUs and 6Gi of RAM
```yaml
apiVersion: scheduling.volcano.sh/v1beta1
kind: Queue
metadata:
  name: kuberay-test-queue
spec:
  weight: 1
  capability:
    cpu: 4
    memory: 6Gi
```
2. Create a RayCluster with a head node (1 CPU + 2Gi of RAM) and two workers (1 CPU + 1Gi of RAM each), for a total of 3 CPU and 4Gi of RAM
```yaml
apiVersion: ray.io/v1
kind: RayCluster
metadata:
  name: test-cluster-0
  labels:
    ray.io/scheduler-name: volcano
    volcano.sh/queue-name: kuberay-test-queue
spec:
  rayVersion: '2.46.0'
  headGroupSpec:
    rayStartParams: {}
    template:
      spec:
        containers:
        - name: ray-head
          image: rayproject/ray:2.46.0
          resources:
            limits:
              cpu: "1"
              memory: "2Gi"
            requests:
              cpu: "1"
              memory: "2Gi"
  workerGroupSpecs:
  - groupName: worker
    rayStartParams: {}
    replicas: 2
    minReplicas: 2
    maxReplicas: 2
    template:
      spec:
        containers:
        - name: ray-head
          image: rayproject/ray:2.46.0
          resources:
            limits:
              cpu: "1"
              memory: "1Gi"
            requests:
              cpu: "1"
              memory: "1Gi"
```
3. Check the status of the queue to see allocated resources
```yaml
$ kubectl get queue kuberay-test-queue -o yaml

apiVersion: scheduling.volcano.sh/v1beta1
kind: Queue
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"scheduling.volcano.sh/v1beta1","kind":"Queue","metadata":{"annotations":{},"name":"kuberay-test-queue"},"spec":{"capability":{"cpu":4,"memory":"6Gi"},"weight":1}}
  creationTimestamp: "2025-08-29T14:39:13Z"
  generation: 2
  name: kuberay-test-queue
  resourceVersion: "896"
  uid: 7d957569-7e2b-437a-90d2-6cbb8fbeaf7c
spec:
  capability:
    cpu: 4
    memory: 6Gi
  parent: root
  reclaimable: true
  weight: 1
status:
  allocated:
    cpu: "3"
    memory: 4Gi
    pods: "3"
  reservation: {}
  state: Open
```

4. Add an additional RayCluster with the same configuration of head and worker nodes, but with a different name
```
sed 's/test-cluster-0/test-cluster-1/' ray-cluster.volcano-scheduler-queue.yaml | kubectl apply -f-
```

5. Check the status of its PodGroup to see that its phase is Pending and the last status is Unschedulable
```yaml
$ kubectl get podgroup ray-test-cluster-1-pg -o yaml

apiVersion: scheduling.volcano.sh/v1beta1
kind: PodGroup
metadata:
  creationTimestamp: "2025-08-29T14:41:35Z"
  generation: 2
  name: ray-test-cluster-1-pg
  namespace: default
  ownerReferences:
  - apiVersion: ray.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: RayCluster
    name: test-cluster-1
    uid: 5253007f-6a80-47d2-835a-7a64fcf44395
  resourceVersion: "1223"
  uid: 4496c1b3-811c-49f4-98f7-04718905866a
spec:
  minMember: 3
  minResources:
    cpu: "3"
    memory: 4Gi
  queue: kuberay-test-queue
status:
  conditions:
  - lastTransitionTime: "2025-08-29T14:41:36Z"
    message: '3/3 tasks in gang unschedulable: pod group is not ready, 3 Pending,
      3 minAvailable; Pending: 3 Unschedulable'
    reason: NotEnoughResources
    status: "True"
    transitionID: b8e34c72-fa36-4340-b3ac-27cbb5289b3f
    type: Unschedulable
  phase: Pending
```
6. See the effect this has on scheduling the pods for our new RayCluster, which are listed as Pending
```
$ kubectl get pods
NAME                                 READY   STATUS    RESTARTS   AGE
kuberay-operator-7856867bb8-p5w89    1/1     Running   0          6m5s
test-cluster-0-head-xhjzq            1/1     Running   0          5m51s
test-cluster-0-worker-worker-657t4   1/1     Running   0          5m51s
test-cluster-0-worker-worker-zzc6w   1/1     Running   0          5m51s
test-cluster-1-head-pdrz5            0/1     Pending   0          3m29s
test-cluster-1-worker-worker-78t8w   0/1     Pending   0          3m29s
test-cluster-1-worker-worker-p7kjp   0/1     Pending   0          3m29s

$ kubectl describe pod test-cluster-1-head-pdrz5 | tail -n 3
  Type     Reason            Age    From     Message
  ----     ------            ----   ----     -------
  Warning  FailedScheduling  4m20s  volcano  pod group is not ready, 3 Pending, 3 minAvailable; Pending: 3 Unschedulable
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #3854

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
