### PR TITLE
Fix testifylint & gci lint issues in apiserver/kubectl-plugin

### DIFF
--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -630,7 +630,7 @@ func TestPopulateRayClusterSpec(t *testing.T) {
 			assert.Equal(t, "resource", value.Key)
 		default:
 			assert.Equal(t, "FIELD", value.Source.String())
-			assert.Equal(t, "", value.Name)
+			assert.Empty(t, value.Name)
 			assert.Equal(t, "path", value.Key)
 		}
 	}
@@ -645,7 +645,7 @@ func TestFromKubeToAPIComputeTemplates(t *testing.T) {
 	assert.Equal(t, uint32(4), template.Cpu, "CPU mismatch")
 	assert.Equal(t, uint32(8), template.Memory, "Memory mismatch")
 	assert.Equal(t, uint32(0), template.Gpu, "GPU mismatch")
-	assert.Equal(t, "", template.GpuAccelerator, "GPU accelerator mismatch")
+	assert.Empty(t, template.GpuAccelerator, "GPU accelerator mismatch")
 }
 
 func TestPopulateTemplate(t *testing.T) {

--- a/apiserver/pkg/util/cluster_test.go
+++ b/apiserver/pkg/util/cluster_test.go
@@ -608,8 +608,8 @@ func TestNewComputeTemplate(t *testing.T) {
 		t.Errorf("failed to build compute template: %v", err)
 	}
 
-	assert.Equal(t, "", configMap.Data["name"])
-	assert.Equal(t, "", configMap.Data["namespace"])
+	assert.Empty(t, configMap.Data["name"])
+	assert.Empty(t, configMap.Data["namespace"])
 	assert.Equal(t, "2", configMap.Data["cpu"])
 	assert.Equal(t, "8", configMap.Data["memory"])
 	assert.Equal(t, "4", configMap.Data["gpu"])

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -468,7 +468,7 @@ func TestGetJobByPaginationInNamespace(t *testing.T) {
 			require.Equal(t, response.Jobs[0].Name, testJobs[i].Job.Name)
 			continueToken = response.Continue
 		}
-		require.Equal(t, "", continueToken) // Continue token should be empty because this is the last page
+		require.Empty(t, continueToken) // Continue token should be empty because this is the last page
 	})
 
 	// Test pagination return all jobs
@@ -482,7 +482,7 @@ func TestGetJobByPaginationInNamespace(t *testing.T) {
 		require.Nil(t, actualRPCStatus, "No RPC status expected")
 		require.NotNil(t, response, "A response is expected")
 		require.Equal(t, len(response.Jobs), testJobNum)
-		require.Equal(t, "", response.Continue) // Continue token should be empty because this is the last page
+		require.Empty(t, response.Continue) // Continue token should be empty because this is the last page
 	})
 
 	t.Run("Test no pagination", func(t *testing.T) {
@@ -493,7 +493,7 @@ func TestGetJobByPaginationInNamespace(t *testing.T) {
 		require.Nil(t, actualRPCStatus, "No RPC status expected")
 		require.NotNil(t, response, "A response is expected")
 		require.Equal(t, len(response.Jobs), testJobNum)
-		require.Equal(t, "", response.Continue) // Continue token should be empty because this is the last page
+		require.Empty(t, response.Continue) // Continue token should be empty because this is the last page
 	})
 }
 

--- a/experimental/cmd/main.go
+++ b/experimental/cmd/main.go
@@ -12,7 +12,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
-
 	"k8s.io/klog/v2"
 
 	"github.com/ray-project/kuberay/experimental/pkg/grpcproxy"

--- a/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
@@ -329,7 +329,7 @@ func TestGetRayClusters(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, len(tc.expectedRayClusters), len(rayClusters.Items))
+			assert.Len(t, rayClusters.Items, len(tc.expectedRayClusters))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
After upgrading golangci-lint to v2, there are the following new lint issues for `testifylint` and `gci`:
```
$ golangci-lint run                   
experimental/cmd/main.go:15:1: File is not properly formatted (gci)

^
apiserver/pkg/model/converter_test.go:633:4: empty: use assert.Empty (testifylint)
                        assert.Equal(t, "", value.Name)
                        ^
apiserver/pkg/model/converter_test.go:648:2: empty: use assert.Empty (testifylint)
        assert.Equal(t, "", template.GpuAccelerator, "GPU accelerator mismatch")
        ^
apiserver/pkg/util/cluster_test.go:611:2: empty: use assert.Empty (testifylint)
        assert.Equal(t, "", configMap.Data["name"])
        ^
apiserver/pkg/util/cluster_test.go:612:2: empty: use assert.Empty (testifylint)
        assert.Equal(t, "", configMap.Data["namespace"])
        ^
apiserver/test/e2e/job_server_e2e_test.go:471:3: empty: use require.Empty (testifylint)
                require.Equal(t, "", continueToken) // Continue token should be empty because this is the last page
                ^
apiserver/test/e2e/job_server_e2e_test.go:485:3: empty: use require.Empty (testifylint)
                require.Equal(t, "", response.Continue) // Continue token should be empty because this is the last page
                ^
apiserver/test/e2e/job_server_e2e_test.go:496:3: empty: use require.Empty (testifylint)
                require.Equal(t, "", response.Continue) // Continue token should be empty because this is the last page
                ^
kubectl-plugin/pkg/cmd/get/get_cluster_test.go:332:4: len: use assert.Len (testifylint)
                        assert.Equal(t, len(tc.expectedRayClusters), len(rayClusters.Items))
                        ^
9 issues:
* gci: 1
* testifylint: 8
```
We address the issues for `gci` and `testifylint` in this PR.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Part of #4008
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
