### PR TITLE
[feat][python-client]: Add suspend, resubmit, & delete logic, and improve status reporting in python client

### DIFF
--- a/clients/python-client/python_client_test/helpers.py
+++ b/clients/python-client/python_client_test/helpers.py
@@ -1,0 +1,135 @@
+import time
+from python_client import constants
+
+
+def create_job_with_cluster_selector(
+    job_name,
+    namespace,
+    cluster_name,
+    entrypoint="python -c \"import ray; ray.init(); @ray.remote\ndef hello(): return 'Hello from Ray!'; print(ray.get(hello.remote()))\"",
+    labels=None,
+):
+    job_body = {
+        "apiVersion": constants.GROUP + "/" + constants.JOB_VERSION,
+        "kind": constants.JOB_KIND,
+        "metadata": {
+            "name": job_name,
+            "namespace": namespace,
+            "labels": {
+                "app.kubernetes.io/name": job_name,
+                "app.kubernetes.io/managed-by": "kuberay",
+            },
+        },
+        "spec": {
+            "clusterSelector": {
+                "ray.io/cluster": cluster_name,
+            },
+            "entrypoint": entrypoint,
+            "submissionMode": "K8sJobMode",
+        },
+    }
+
+    # Add any additional labels if provided
+    if labels:
+        job_body["metadata"]["labels"].update(labels)
+
+    return job_body
+
+
+def create_job_with_ray_cluster_spec(
+    job_name,
+    namespace,
+    entrypoint="python -c \"import ray; ray.init(); @ray.remote\ndef hello(): return 'Hello from Ray!'; print(ray.get(hello.remote()))\"",
+    labels=None,
+):
+    job_body = {
+        "apiVersion": constants.GROUP + "/" + constants.JOB_VERSION,
+        "kind": constants.JOB_KIND,
+        "metadata": {
+            "name": job_name,
+            "namespace": namespace,
+            "labels": {
+                "app.kubernetes.io/name": job_name,
+                "app.kubernetes.io/managed-by": "kuberay",
+            },
+        },
+        "spec": {
+            "rayClusterSpec": {
+                "headGroupSpec": {
+                    "serviceType": "ClusterIP",
+                    "replicas": 1,
+                    "rayStartParams": {
+                        "dashboard-host": "0.0.0.0",
+                    },
+                    "template": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": "ray-head",
+                                    "image": "rayproject/ray:2.48.0",
+                                    "ports": [
+                                        {"containerPort": 6379, "name": "gcs"},
+                                        {
+                                            "containerPort": 8265,
+                                            "name": "dashboard",
+                                        },
+                                        {
+                                            "containerPort": 10001,
+                                            "name": "client",
+                                        },
+                                    ],
+                                    "resources": {
+                                        "limits": {
+                                            "cpu": "1",
+                                            "memory": "2Gi",
+                                        },
+                                        "requests": {
+                                            "cpu": "500m",
+                                            "memory": "1Gi",
+                                        },
+                                    },
+                                }
+                            ]
+                        }
+                    },
+                },
+                "workerGroupSpecs": [
+                    {
+                        "groupName": "small-worker",
+                        "replicas": 1,
+                        "rayStartParams": {
+                            "num-cpus": "1",
+                        },
+                        "template": {
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "ray-worker",
+                                        "image": "rayproject/ray:2.48.0",
+                                        "resources": {
+                                            "limits": {
+                                                "cpu": "1",
+                                                "memory": "1Gi",
+                                            },
+                                            "requests": {
+                                                "cpu": "500m",
+                                                "memory": "512Mi",
+                                            },
+                                        },
+                                    }
+                                ]
+                            }
+                        },
+                    }
+                ],
+            },
+            "entrypoint": entrypoint,
+            "submissionMode": "K8sJobMode",
+            "shutdownAfterJobFinishes": True,
+        },
+    }
+
+    if labels:
+        job_body["metadata"]["labels"].update(labels)
+
+    return job_body

--- a/clients/python-client/python_client_test/test_cluster_api.py
+++ b/clients/python-client/python_client_test/test_cluster_api.py
@@ -1,7 +1,9 @@
 import unittest
-from python_client import kuberay_cluster_api
+from python_client import kuberay_cluster_api, constants
+from python_client.utils import kuberay_cluster_builder
 
 
+# Keep the original test cluster body for reference if needed
 test_cluster_body: dict = {
     "apiVersion": "ray.io/v1",
     "kind": "RayCluster",
@@ -103,26 +105,209 @@ test_cluster_body: dict = {
     }
 }
 
-class TestUtils(unittest.TestCase):
+class TestClusterApi(unittest.TestCase):
+    """Comprehensive test suite for RayClusterApi functionality."""
+
     def __init__(self, methodName: str = ...) -> None:
         super().__init__(methodName)
-
         self.api = kuberay_cluster_api.RayClusterApi()
-
-        # mock the get_ray_cluster_status method
-        self.api.get_ray_cluster_status = self.get_ray_cluster_status_mock
+        self.director = kuberay_cluster_builder.Director()
 
 
-    def test_wait_until_ray_cluster_running(self):
-        is_running: bool = self.api.wait_until_ray_cluster_running(name = "small-cluster", k8s_namespace = "default", timeout = 60, delay_between_attempts = 5)
+    def test_create_and_get_ray_cluster(self):
+        """Test creating a cluster and retrieving it."""
+        cluster_name = "test-create-cluster"
+        namespace = "default"
 
-        self.assertEqual(is_running, True)
+        # Build a small cluster using the director
+        cluster_body = self.director.build_small_cluster(
+            name=cluster_name,
+            k8s_namespace=namespace,
+            labels={"test": "create-cluster"},
+        )
 
-    def test_wait_until_ray_cluster_running_timeout(self):
-        is_running: bool = self.api.wait_until_ray_cluster_running(name = "small-cluster", k8s_namespace = "default", timeout = 60, delay_between_attempts = 5)
+        # Ensure cluster was built successfully
+        self.assertIsNotNone(cluster_body, "Cluster should be built successfully")
+        self.assertEqual(cluster_body["metadata"]["name"], cluster_name)
 
-        self.assertEqual(is_running, True)
+        try:
+            # Create the cluster
+            created_cluster = self.api.create_ray_cluster(
+                body=cluster_body, k8s_namespace=namespace
+            )
+            self.assertIsNotNone(created_cluster, "Cluster should be created successfully")
+            self.assertEqual(created_cluster["metadata"]["name"], cluster_name)
 
-    # mock the get_ray_cluster_status method
-    def get_ray_cluster_status_mock(self, name: str, k8s_namespace: str = "default", timeout: int = 5, delay_between_attempts: int = 5):
-        return test_cluster_body["status"]
+            # Get the cluster and verify it exists
+            retrieved_cluster = self.api.get_ray_cluster(
+                name=cluster_name, k8s_namespace=namespace
+            )
+            self.assertIsNotNone(retrieved_cluster, "Cluster should be retrieved successfully")
+            self.assertEqual(retrieved_cluster["metadata"]["name"], cluster_name)
+            self.assertEqual(retrieved_cluster["spec"]["rayVersion"], cluster_body["spec"]["rayVersion"])
+
+        finally:
+            # Clean up
+            self.api.delete_ray_cluster(name=cluster_name, k8s_namespace=namespace)
+
+    def test_list_ray_clusters(self):
+        """Test listing Ray clusters in a namespace."""
+        cluster_name_1 = "test-list-cluster-1"
+        cluster_name_2 = "test-list-cluster-2"
+        namespace = "default"
+        test_label = "test-list-clusters"
+
+        # Build two small clusters
+        cluster_body_1 = self.director.build_small_cluster(
+            name=cluster_name_1,
+            k8s_namespace=namespace,
+            labels={"test": test_label},
+        )
+        cluster_body_2 = self.director.build_small_cluster(
+            name=cluster_name_2,
+            k8s_namespace=namespace,
+            labels={"test": test_label},
+        )
+
+        try:
+            # Create both clusters
+            created_cluster_1 = self.api.create_ray_cluster(
+                body=cluster_body_1, k8s_namespace=namespace
+            )
+            created_cluster_2 = self.api.create_ray_cluster(
+                body=cluster_body_2, k8s_namespace=namespace
+            )
+
+            self.assertIsNotNone(created_cluster_1, "First cluster should be created")
+            self.assertIsNotNone(created_cluster_2, "Second cluster should be created")
+
+            # List all clusters
+            clusters_list = self.api.list_ray_clusters(k8s_namespace=namespace)
+            self.assertIsNotNone(clusters_list, "Should be able to list clusters")
+            self.assertIn("items", clusters_list, "Response should contain items")
+
+            # Verify our test clusters are in the list
+            cluster_names = [item["metadata"]["name"] for item in clusters_list["items"]]
+            self.assertIn(cluster_name_1, cluster_names, "First test cluster should be in the list")
+            self.assertIn(cluster_name_2, cluster_names, "Second test cluster should be in the list")
+
+            # Test listing with label selector
+            labeled_clusters = self.api.list_ray_clusters(
+                k8s_namespace=namespace,
+                label_selector=f"test={test_label}"
+            )
+            self.assertIsNotNone(labeled_clusters, "Should be able to list clusters with label selector")
+            labeled_cluster_names = [item["metadata"]["name"] for item in labeled_clusters["items"]]
+            self.assertIn(cluster_name_1, labeled_cluster_names, "First test cluster should match label")
+            self.assertIn(cluster_name_2, labeled_cluster_names, "Second test cluster should match label")
+
+        finally:
+            # Clean up both clusters
+            self.api.delete_ray_cluster(name=cluster_name_1, k8s_namespace=namespace)
+            self.api.delete_ray_cluster(name=cluster_name_2, k8s_namespace=namespace)
+
+    def test_cluster_status_and_wait_until_running(self):
+        """Test getting cluster status and waiting for cluster to be ready."""
+        cluster_name = "test-status-cluster"
+        namespace = "default"
+
+        # Build a small cluster
+        cluster_body = self.director.build_small_cluster(
+            name=cluster_name,
+            k8s_namespace=namespace,
+            labels={"test": "status-cluster"},
+        )
+
+        try:
+            # Create the cluster
+            created_cluster = self.api.create_ray_cluster(
+                body=cluster_body, k8s_namespace=namespace
+            )
+            self.assertIsNotNone(created_cluster, "Cluster should be created successfully")
+
+            # Test getting cluster status (may take some time to populate)
+            status = self.api.get_ray_cluster_status(
+                name=cluster_name,
+                k8s_namespace=namespace,
+                timeout=120,
+                delay_between_attempts=5
+            )
+            self.assertIsNotNone(status, "Cluster status should be retrieved")
+
+            # Test waiting for cluster to be running
+            is_running = self.api.wait_until_ray_cluster_running(
+                name=cluster_name,
+                k8s_namespace=namespace,
+                timeout=180,
+                delay_between_attempts=10
+            )
+            self.assertTrue(is_running, "Cluster should become ready within timeout")
+
+            # Verify final status after cluster is ready
+            final_status = self.api.get_ray_cluster_status(
+                name=cluster_name,
+                k8s_namespace=namespace,
+                timeout=10,
+                delay_between_attempts=2
+            )
+            self.assertIsNotNone(final_status, "Final status should be available")
+            self.assertIn("state", final_status, "Status should contain state field")
+            self.assertEqual(final_status["state"], "ready", "Cluster should be in ready state")
+
+        finally:
+            # Clean up
+            self.api.delete_ray_cluster(name=cluster_name, k8s_namespace=namespace)
+
+    def test_patch_ray_cluster(self):
+        """Test patching an existing Ray cluster."""
+        cluster_name = "test-patch-cluster"
+        namespace = "default"
+
+        # Build a small cluster
+        cluster_body = self.director.build_small_cluster(
+            name=cluster_name,
+            k8s_namespace=namespace,
+            labels={"test": "patch-cluster"},
+        )
+
+        try:
+            # Create the cluster
+            created_cluster = self.api.create_ray_cluster(
+                body=cluster_body, k8s_namespace=namespace
+            )
+            self.assertIsNotNone(created_cluster, "Cluster should be created successfully")
+
+            # Wait for cluster to be ready before patching
+            self.api.wait_until_ray_cluster_running(
+                name=cluster_name, k8s_namespace=namespace, timeout=180, delay_between_attempts=10
+            )
+
+            # Create a patch to update the cluster (e.g., add a label)
+            patch_data = {
+                "metadata": {
+                    "labels": {
+                        "test": "patch-cluster",
+                        "patched": "true"
+                    }
+                }
+            }
+
+            # Apply the patch
+            patch_result = self.api.patch_ray_cluster(
+                name=cluster_name,
+                ray_patch=patch_data,
+                k8s_namespace=namespace
+            )
+            self.assertTrue(patch_result, "Patch operation should succeed")
+
+            # Verify the patch was applied
+            updated_cluster = self.api.get_ray_cluster(
+                name=cluster_name, k8s_namespace=namespace
+            )
+            self.assertIsNotNone(updated_cluster, "Updated cluster should be retrieved")
+            self.assertIn("patched", updated_cluster["metadata"]["labels"], "Patched label should be present")
+            self.assertEqual(updated_cluster["metadata"]["labels"]["patched"], "true", "Patched label should have correct value")
+
+        finally:
+            # Clean up
+            self.api.delete_ray_cluster(name=cluster_name, k8s_namespace=namespace)

--- a/clients/python-client/python_client_test/test_job_api.py
+++ b/clients/python-client/python_client_test/test_job_api.py
@@ -1,10 +1,12 @@
 import time
 import unittest
-from python_client import kuberay_job_api, kuberay_cluster_api, constants
+from python_client import kuberay_job_api, kuberay_cluster_api
 from python_client.utils import kuberay_cluster_builder
+from helpers import create_job_with_cluster_selector, create_job_with_ray_cluster_spec
 
+namespace = "default"
 
-class TestUtils(unittest.TestCase):
+class TestJobApi(unittest.TestCase):
     def __init__(self, methodName: str = ...) -> None:
         super().__init__(methodName)
 
@@ -14,22 +16,17 @@ class TestUtils(unittest.TestCase):
 
     def test_submit_ray_job_to_existing_cluster(self):
         """Test submitting a job to an existing cluster using clusterSelector."""
-        # Create a cluster using the director
         cluster_name = "premade"
-        namespace = "default"
 
-        # Build a small cluster
         cluster_body = self.director.build_small_cluster(
             name=cluster_name,
             k8s_namespace=namespace,
             labels={"ray.io/cluster": cluster_name},
         )
 
-        # Ensure cluster was built successfully
         self.assertIsNotNone(cluster_body, "Cluster should be built successfully")
         self.assertEqual(cluster_body["metadata"]["name"], cluster_name)
 
-        # Create the cluster in Kubernetes
         created_cluster = self.cluster_api.create_ray_cluster(
             body=cluster_body, k8s_namespace=namespace
         )
@@ -39,27 +36,11 @@ class TestUtils(unittest.TestCase):
         self.cluster_api.wait_until_ray_cluster_running(cluster_name, namespace, 60, 10)
         job_name = "premade-cluster-job"
         try:
-            # Create job spec with clusterSelector
-            job_body = {
-                "apiVersion": constants.GROUP + "/" + constants.JOB_VERSION,
-                "kind": constants.JOB_KIND,
-                "metadata": {
-                    "name": job_name,
-                    "namespace": namespace,
-                    "labels": {
-                        "app.kubernetes.io/name": job_name,
-                        "app.kubernetes.io/managed-by": "kuberay",
-                    },
-                },
-                "spec": {
-                    "clusterSelector": {
-                        "ray.io/cluster": cluster_name,
-                    },
-                    "entrypoint": 'python -c "import time; time.sleep(20)"',
-                    "submissionMode": "K8sJobMode",
-                },
-            }
-
+            job_body = create_job_with_cluster_selector(
+                job_name,
+                namespace,
+                cluster_name,
+            )
             submitted_job = self.api.submit_job(
                 job=job_body,
                 k8s_namespace=namespace,
@@ -81,63 +62,41 @@ class TestUtils(unittest.TestCase):
 
     def test_get_job_status(self):
         """Test getting job status for a running job."""
-        # Create a cluster using the director
         cluster_name = "status-test-cluster"
-        namespace = "default"
 
-        # Build a small cluster
         cluster_body = self.director.build_small_cluster(
             name=cluster_name,
             k8s_namespace=namespace,
             labels={"ray.io/cluster": cluster_name},
         )
 
-        # Create the cluster in Kubernetes
         created_cluster = self.cluster_api.create_ray_cluster(
             body=cluster_body, k8s_namespace=namespace
         )
         self.assertIsNotNone(created_cluster, "Cluster should be created successfully")
 
-        # Wait for cluster to be running
         self.cluster_api.wait_until_ray_cluster_running(cluster_name, namespace, 60, 10)
 
         job_name = "status-test-job"
         try:
-            # Create job spec with clusterSelector
-            job_body = {
-                "apiVersion": constants.GROUP + "/" + constants.JOB_VERSION,
-                "kind": constants.JOB_KIND,
-                "metadata": {
-                    "name": job_name,
-                    "namespace": namespace,
-                    "labels": {
-                        "app.kubernetes.io/name": job_name,
-                        "app.kubernetes.io/managed-by": "kuberay",
-                    },
-                },
-                "spec": {
-                    "clusterSelector": {
-                        "ray.io/cluster": cluster_name,
-                    },
-                    "entrypoint": 'python -c "import time; time.sleep(30)"',
-                    "submissionMode": "K8sJobMode",
-                },
-            }
+            job_body = create_job_with_cluster_selector(
+                job_name,
+                namespace,
+                cluster_name,
+            )
 
-            # Submit the job
             submitted_job = self.api.submit_job(
                 job=job_body,
                 k8s_namespace=namespace,
             )
             self.assertIsNotNone(submitted_job, "Job should be submitted successfully")
 
-            # Test getting job status - should return status after some time
             status = self.api.get_job_status(
                 job_name, namespace, timeout=30, delay_between_attempts=2
             )
             self.assertIsNotNone(status, "Job status should be retrieved")
 
-            # Check for expected fields in the status (based on actual output)
+            # Verify expected status fields
             self.assertIn(
                 "jobDeploymentStatus",
                 status,
@@ -148,17 +107,13 @@ class TestUtils(unittest.TestCase):
                 "rayClusterName", status, "Status should contain rayClusterName field"
             )
 
-            # Wait for job to finish
             self.api.wait_until_job_finished(job_name, namespace, 60, 5)
 
-            # Test getting final status
             final_status = self.api.get_job_status(
                 job_name, namespace, timeout=10, delay_between_attempts=1
             )
             self.assertIsNotNone(final_status, "Final job status should be retrieved")
 
-            # Check that the job completed successfully (based on the logs showing SUCCEEDED)
-            # The actual jobStatus might be in rayJobInfo or a different field
             self.assertIn(
                 "jobDeploymentStatus",
                 final_status,
@@ -166,7 +121,6 @@ class TestUtils(unittest.TestCase):
             )
 
         finally:
-            # Clean up
             self.cluster_api.delete_ray_cluster(
                 name=cluster_name, k8s_namespace=namespace
             )
@@ -174,66 +128,43 @@ class TestUtils(unittest.TestCase):
 
     def test_wait_until_job_finished(self):
         """Test waiting for job completion."""
-        # Create a cluster using the director
         cluster_name = "wait-test-cluster"
-        namespace = "default"
 
-        # Build a small cluster
         cluster_body = self.director.build_small_cluster(
             name=cluster_name,
             k8s_namespace=namespace,
             labels={"ray.io/cluster": cluster_name},
         )
 
-        # Create the cluster in Kubernetes
         created_cluster = self.cluster_api.create_ray_cluster(
             body=cluster_body, k8s_namespace=namespace
         )
         self.assertIsNotNone(created_cluster, "Cluster should be created successfully")
 
-        # Wait for cluster to be running
         self.cluster_api.wait_until_ray_cluster_running(
             cluster_name, namespace, 180, 10
         )
 
         job_name = "wait-test-job"
         try:
-            # Create job spec with clusterSelector - short running job
-            job_body = {
-                "apiVersion": constants.GROUP + "/" + constants.JOB_VERSION,
-                "kind": constants.JOB_KIND,
-                "metadata": {
-                    "name": job_name,
-                    "namespace": namespace,
-                    "labels": {
-                        "app.kubernetes.io/name": job_name,
-                        "app.kubernetes.io/managed-by": "kuberay",
-                    },
-                },
-                "spec": {
-                    "clusterSelector": {
-                        "ray.io/cluster": cluster_name,
-                    },
-                    "entrypoint": "python -c \"print('Hello from Ray job'); import time; time.sleep(5)\"",
-                    "submissionMode": "K8sJobMode",
-                },
-            }
+            job_body = create_job_with_cluster_selector(
+                job_name,
+                namespace,
+                cluster_name,
+            )
 
-            # Submit the job
             submitted_job = self.api.submit_job(
                 job=job_body,
                 k8s_namespace=namespace,
             )
             self.assertIsNotNone(submitted_job, "Job should be submitted successfully")
 
-            # Test waiting for job completion
             result = self.api.wait_until_job_finished(
                 job_name, namespace, timeout=180, delay_between_attempts=2
             )
             self.assertTrue(result, "Job should complete successfully within timeout")
 
         finally:
-            # Clean up
             self.cluster_api.delete_ray_cluster(
                 name=cluster_name, k8s_namespace=namespace
             )
@@ -241,201 +172,90 @@ class TestUtils(unittest.TestCase):
 
     def test_delete_job(self):
         """Test deleting a job."""
-        # Create a cluster using the director
         cluster_name = "delete-test-cluster"
-        namespace = "default"
 
-        # Build a small cluster
         cluster_body = self.director.build_small_cluster(
             name=cluster_name,
             k8s_namespace=namespace,
             labels={"ray.io/cluster": cluster_name},
         )
 
-        # Create the cluster in Kubernetes
         created_cluster = self.cluster_api.create_ray_cluster(
             body=cluster_body, k8s_namespace=namespace
         )
         self.assertIsNotNone(created_cluster, "Cluster should be created successfully")
 
-        # Wait for cluster to be running
         self.cluster_api.wait_until_ray_cluster_running(cluster_name, namespace, 60, 10)
 
         job_name = "delete-test-job"
         try:
-            # Create job spec with clusterSelector
-            job_body = {
-                "apiVersion": constants.GROUP + "/" + constants.JOB_VERSION,
-                "kind": constants.JOB_KIND,
-                "metadata": {
-                    "name": job_name,
-                    "namespace": namespace,
-                    "labels": {
-                        "app.kubernetes.io/name": job_name,
-                        "app.kubernetes.io/managed-by": "kuberay",
-                    },
-                },
-                "spec": {
-                    "clusterSelector": {
-                        "ray.io/cluster": cluster_name,
-                    },
-                    "entrypoint": "python -c \"print('Job to be deleted'); import time; time.sleep(10)\"",
-                    "submissionMode": "K8sJobMode",
-                },
-            }
+            job_body = create_job_with_cluster_selector(
+                job_name,
+                namespace,
+                cluster_name,
+            )
 
-            # Submit the job
             submitted_job = self.api.submit_job(
                 job=job_body,
                 k8s_namespace=namespace,
             )
             self.assertIsNotNone(submitted_job, "Job should be submitted successfully")
 
-            # Wait for job to finish
             self.api.wait_until_job_finished(job_name, namespace, 60, 5)
 
-            # Test deleting the job
             delete_result = self.api.delete_job(job_name, namespace)
             self.assertTrue(delete_result, "Job should be deleted successfully")
 
         finally:
-            # Clean up cluster
             self.cluster_api.delete_ray_cluster(
                 name=cluster_name, k8s_namespace=namespace
             )
 
     def test_get_job_status_nonexistent_job(self):
         """Test getting status for a non-existent job."""
-        # Test getting status for a job that doesn't exist
         status = self.api.get_job_status(
-            "nonexistent-job", "default", timeout=2, delay_between_attempts=2
+            "nonexistent-job", namespace, timeout=2, delay_between_attempts=2
         )
         self.assertIsNone(status, "Status should be None for non-existent job")
 
     def test_wait_until_job_finished_nonexistent_job(self):
         """Test waiting for completion of a non-existent job."""
-        # Test waiting for a job that doesn't exist
         result = self.api.wait_until_job_finished(
-            "nonexistent-job", "default", timeout=2, delay_between_attempts=2
+            "nonexistent-job", namespace, timeout=2, delay_between_attempts=2
         )
         self.assertFalse(result, "Should return False for non-existent job")
 
     def test_delete_job_nonexistent_job(self):
         """Test deleting a non-existent job."""
-        # Test deleting a job that doesn't exist
-        result = self.api.delete_job("nonexistent-job", "default")
+        result = self.api.delete_job("nonexistent-job", namespace)
         self.assertFalse(result, "Should return False for non-existent job")
 
     def test_submit_job_invalid_spec(self):
         """Test submitting a job with invalid specification."""
-        # Test submitting a job with invalid spec
         invalid_job = {
             "apiVersion": "invalid/version",
             "kind": "InvalidKind",
             "metadata": {
                 "name": "invalid-job",
-                "namespace": "default",
+                "namespace": namespace,
             },
             "spec": {
                 "invalidField": "invalidValue",
             },
         }
 
-        result = self.api.submit_job(job=invalid_job, k8s_namespace="default")
+        result = self.api.submit_job(job=invalid_job, k8s_namespace=namespace)
         self.assertIsNone(result, "Should return None for invalid job specification")
 
     def test_submit_job_with_ray_cluster_spec(self):
         """Test submitting a job with rayClusterSpec - KubeRay will create and manage the cluster lifecycle."""
         job_name = "cluster-spec-job"
-        namespace = "default"
 
         try:
-            # Create job spec with rayClusterSpec - KubeRay will create the cluster automatically
-            job_body = {
-                "apiVersion": constants.GROUP + "/" + constants.JOB_VERSION,
-                "kind": constants.JOB_KIND,
-                "metadata": {
-                    "name": job_name,
-                    "namespace": namespace,
-                    "labels": {
-                        "app.kubernetes.io/name": job_name,
-                        "app.kubernetes.io/managed-by": "kuberay",
-                    },
-                },
-                "spec": {
-                    "rayClusterSpec": {
-                        "headGroupSpec": {
-                            "serviceType": "ClusterIP",
-                            "replicas": 1,
-                            "rayStartParams": {
-                                "dashboard-host": "0.0.0.0",
-                            },
-                            "template": {
-                                "spec": {
-                                    "containers": [
-                                        {
-                                            "name": "ray-head",
-                                            "image": "rayproject/ray:2.48.0",
-                                            "ports": [
-                                                {"containerPort": 6379, "name": "gcs"},
-                                                {
-                                                    "containerPort": 8265,
-                                                    "name": "dashboard",
-                                                },
-                                                {
-                                                    "containerPort": 10001,
-                                                    "name": "client",
-                                                },
-                                            ],
-                                            "resources": {
-                                                "limits": {
-                                                    "cpu": "1",
-                                                    "memory": "2Gi",
-                                                },
-                                                "requests": {
-                                                    "cpu": "500m",
-                                                    "memory": "1Gi",
-                                                },
-                                            },
-                                        }
-                                    ]
-                                }
-                            },
-                        },
-                        "workerGroupSpecs": [
-                            {
-                                "groupName": "small-worker",
-                                "replicas": 1,
-                                "rayStartParams": {
-                                    "num-cpus": "1",
-                                },
-                                "template": {
-                                    "spec": {
-                                        "containers": [
-                                            {
-                                                "name": "ray-worker",
-                                                "image": "rayproject/ray:2.48.0",
-                                                "resources": {
-                                                    "limits": {
-                                                        "cpu": "1",
-                                                        "memory": "1Gi",
-                                                    },
-                                                    "requests": {
-                                                        "cpu": "500m",
-                                                        "memory": "512Mi",
-                                                    },
-                                                },
-                                            }
-                                        ]
-                                    }
-                                },
-                            }
-                        ],
-                    },
-                    "entrypoint": "python -c \"import ray; ray.init(); print('Hello from Ray job with auto-managed cluster'); import time; time.sleep(10); print('Job completed successfully')\"",
-                    "submissionMode": "K8sJobMode",
-                },
-            }
+            job_body = create_job_with_ray_cluster_spec(
+                job_name=job_name,
+                namespace=namespace,
+            )
 
             submitted_job = self.api.submit_job(
                 job=job_body,
@@ -445,7 +265,7 @@ class TestUtils(unittest.TestCase):
             self.assertIsNotNone(submitted_job, "Job should be submitted successfully")
             self.assertEqual(submitted_job["metadata"]["name"], job_name)
 
-            # Verify that rayClusterSpec is present in the submitted job
+            # Verify rayClusterSpec structure
             self.assertIn(
                 "rayClusterSpec",
                 submitted_job["spec"],
@@ -462,11 +282,9 @@ class TestUtils(unittest.TestCase):
                 "rayClusterSpec should have workerGroupSpecs",
             )
 
-            # Wait for job to finish - this will also wait for cluster creation and job completion
             result = self.api.wait_until_job_finished(job_name, namespace, 300, 10)
             self.assertTrue(result, "Job should complete successfully within timeout")
 
-            # Get final job status to verify completion
             final_status = self.api.get_job_status(
                 job_name, namespace, timeout=10, delay_between_attempts=1
             )
@@ -478,91 +296,34 @@ class TestUtils(unittest.TestCase):
             )
 
         finally:
-            # Clean up - delete the job (cluster will be automatically cleaned up by KubeRay)
             self.api.delete_job(job_name, namespace)
 
     def test_suspend_job(self):
         """Test stopping a running job."""
         job_name = "stop-test-job"
-        namespace = "default"
 
         try:
-            job_body = {
-                "apiVersion": constants.GROUP + "/" + constants.JOB_VERSION,
-                "kind": constants.JOB_KIND,
-                "metadata": {
-                    "name": job_name,
-                    "namespace": namespace,
-                    "labels": {
-                        "app.kubernetes.io/name": job_name,
-                        "app.kubernetes.io/managed-by": "kuberay",
-                    },
-                },
-                "spec": {
-                    "rayClusterSpec": {
-                        "headGroupSpec": {
-                            "serviceType": "ClusterIP",
-                            "replicas": 1,
-                            "rayStartParams": {
-                                "dashboard-host": "0.0.0.0",
-                            },
-                            "template": {
-                                "spec": {
-                                    "containers": [
-                                        {
-                                            "name": "ray-head",
-                                            "image": "rayproject/ray:2.48.0",
-                                            "resources": {
-                                                "limits": {
-                                                    "cpu": "1",
-                                                    "memory": "2Gi",
-                                                },
-                                                "requests": {
-                                                    "cpu": "500m",
-                                                    "memory": "1Gi",
-                                                },
-                                            },
-                                        }
-                                    ]
-                                }
-                            },
-                        },
-                    },
-                    "entrypoint": "python -c \"import time; print('Job is running...'); time.sleep(60)\"",
-                    "submissionMode": "K8sJobMode",
-                    "shutdownAfterJobFinishes": True,
-                },
-            }
+            job_body = create_job_with_ray_cluster_spec(
+                job_name=job_name,
+                namespace=namespace,
+            )
 
-            # Submit the job
             submitted_job = self.api.submit_job(
                 job=job_body,
                 k8s_namespace=namespace,
             )
             self.assertIsNotNone(submitted_job, "Job should be submitted successfully")
 
-            # Wait for job to be running (cluster creation + job start)
-            time.sleep(20)
+            result = self.api.wait_until_job_running(
+                job_name, namespace, timeout=120, delay_between_attempts=5
+            )
+            self.assertTrue(result, "Job should reach running state before suspension")
 
-            # Test stopping the job
             stop_result = self.api.suspend_job(job_name, namespace)
             self.assertTrue(stop_result, "Job should be suspended successfully")
 
-            # Wait a bit for the status to update
-            time.sleep(10)
-
-            # Verify the job status shows suspended
-            status = self.api.get_job_status(
-                job_name, namespace, timeout=30, delay_between_attempts=2
-            )
-            self.assertIsNotNone(status, "Status should be available")
-            # Check if jobDeploymentStatus is Suspended
-            if "jobDeploymentStatus" in status:
-                self.assertEqual(
-                    status["jobDeploymentStatus"],
-                    "Suspended",
-                    "Job deployment status should be Suspended",
-                )
+            suspended = self.wait_for_job_status(job_name, namespace, "Suspended", timeout=30)
+            self.assertTrue(suspended, "Job deployment status should be Suspended")
 
         finally:
             self.api.delete_job(job_name, namespace)
@@ -570,278 +331,227 @@ class TestUtils(unittest.TestCase):
     def test_resubmit_job(self):
         """Test resubmitting a suspended job."""
         job_name = "resubmit-test-job"
-        namespace = "default"
 
         try:
-            job_body = {
-                "apiVersion": constants.GROUP + "/" + constants.JOB_VERSION,
-                "kind": constants.JOB_KIND,
-                "metadata": {
-                    "name": job_name,
-                    "namespace": namespace,
-                    "labels": {
-                        "app.kubernetes.io/name": job_name,
-                        "app.kubernetes.io/managed-by": "kuberay",
-                    },
-                },
-                "spec": {
-                    "rayClusterSpec": {
-                        "headGroupSpec": {
-                            "serviceType": "ClusterIP",
-                            "replicas": 1,
-                            "rayStartParams": {
-                                "dashboard-host": "0.0.0.0",
-                            },
-                            "template": {
-                                "spec": {
-                                    "containers": [
-                                        {
-                                            "name": "ray-head",
-                                            "image": "rayproject/ray:2.48.0",
-                                            "resources": {
-                                                "limits": {
-                                                    "cpu": "1",
-                                                    "memory": "2Gi",
-                                                },
-                                                "requests": {
-                                                    "cpu": "500m",
-                                                    "memory": "1Gi",
-                                                },
-                                            },
-                                        }
-                                    ]
-                                }
-                            },
-                        },
-                    },
-                    "entrypoint": "python -c \"import time; print('Job running'); time.sleep(10); print('Job completed')\"",
-                    "submissionMode": "K8sJobMode",
-                    "shutdownAfterJobFinishes": True,
-                },
-            }
+            job_body = create_job_with_ray_cluster_spec(
+                job_name=job_name,
+                namespace=namespace,
+            )
 
-            # Submit the job
             submitted_job = self.api.submit_job(
                 job=job_body,
                 k8s_namespace=namespace,
             )
             self.assertIsNotNone(submitted_job, "Job should be submitted successfully")
 
-            # Wait a bit for job to start
-            import time
+            result = self.api.wait_until_job_running(
+                job_name, namespace, timeout=120, delay_between_attempts=5
+            )
+            self.assertTrue(result, "Job should reach running state before suspension")
 
-            time.sleep(15)
-
-            # Stop the job
             stop_result = self.api.suspend_job(job_name, namespace)
             self.assertTrue(stop_result, "Job should be suspended successfully")
 
-            # Wait for suspended status
-            time.sleep(15)
+            suspended = self.wait_for_job_status(job_name, namespace, "Suspended", timeout=30)
+            self.assertTrue(suspended, "Job should be in Suspended status before resubmission")
 
-            # Verify suspended status before resubmission
-            status = self.api.get_job_status(
-                job_name, namespace, timeout=30, delay_between_attempts=2
-            )
-            self.assertIsNotNone(status, "Status should be available")
-            if "jobDeploymentStatus" in status:
-                self.assertEqual(
-                    status["jobDeploymentStatus"],
-                    "Suspended",
-                    "Job should be in Suspended status before resubmission",
-                )
-
-            # Test resubmitting the job
             resubmit_result = self.api.resubmit_job(job_name, namespace)
             self.assertTrue(resubmit_result, "Job should be resubmitted successfully")
 
-            # Wait for job to complete after resubmission
             result = self.api.wait_until_job_finished(
                 job_name, namespace, timeout=120, delay_between_attempts=5
             )
             self.assertTrue(result, "Resubmitted job should complete successfully")
 
         finally:
-            # Clean up - delete the job (cluster will be automatically cleaned up by KubeRay)
             self.api.delete_job(job_name, namespace)
 
     def test_stop_and_resubmit_job(self):
         """Test the full stop and resubmit cycle."""
         job_name = "stop-resubmit-job"
-        namespace = "default"
 
         try:
-            # Create job spec with rayClusterSpec for automatic cluster management
-            job_body = {
-                "apiVersion": constants.GROUP + "/" + constants.JOB_VERSION,
-                "kind": constants.JOB_KIND,
-                "metadata": {
-                    "name": job_name,
-                    "namespace": namespace,
-                    "labels": {
-                        "app.kubernetes.io/name": job_name,
-                        "app.kubernetes.io/managed-by": "kuberay",
-                    },
-                },
-                "spec": {
-                    "rayClusterSpec": {
-                        "headGroupSpec": {
-                            "serviceType": "ClusterIP",
-                            "replicas": 1,
-                            "rayStartParams": {
-                                "dashboard-host": "0.0.0.0",
-                            },
-                            "template": {
-                                "spec": {
-                                    "containers": [
-                                        {
-                                            "name": "ray-head",
-                                            "image": "rayproject/ray:2.48.0",
-                                            "resources": {
-                                                "limits": {
-                                                    "cpu": "1",
-                                                    "memory": "2Gi",
-                                                },
-                                                "requests": {
-                                                    "cpu": "500m",
-                                                    "memory": "1Gi",
-                                                },
-                                            },
-                                        }
-                                    ]
-                                }
-                            },
-                        },
-                    },
-                    "entrypoint": "python -c \"import time; print('Job started'); time.sleep(10); print('Job finished')\"",
-                    "submissionMode": "K8sJobMode",
-                    "shutdownAfterJobFinishes": True,
-                },
-            }
+            job_body = create_job_with_ray_cluster_spec(
+                job_name=job_name,
+                namespace=namespace,
+            )
 
-            # Submit the job
             submitted_job = self.api.submit_job(
                 job=job_body,
                 k8s_namespace=namespace,
             )
             self.assertIsNotNone(submitted_job, "Job should be submitted successfully")
 
-            # Wait for job to be running
-            import time
+            result = self.api.wait_until_job_running(
+                job_name, namespace, timeout=120, delay_between_attempts=5
+            )
+            self.assertTrue(result, "Job should reach running state before suspension, completion, or failure")
 
-            time.sleep(15)  # Give time for cluster creation and job start
-
-            # Stop the job
             stop_result = self.api.suspend_job(job_name, namespace)
             self.assertTrue(stop_result, "Job should be suspended successfully")
 
-            # Wait for suspended status
-            time.sleep(15)
+            suspended = self.wait_for_job_status(job_name, namespace, "Suspended", timeout=30)
+            self.assertTrue(suspended, "Job should reach Suspended status within 30 seconds")
 
-            # Verify suspended status
-            status = self.api.get_job_status(
-                job_name, namespace, timeout=30, delay_between_attempts=2
-            )
-            self.assertIsNotNone(status, "Status should be available")
-            if "jobDeploymentStatus" in status:
-                self.assertEqual(
-                    status["jobDeploymentStatus"],
-                    "Suspended",
-                    "Job should be in Suspended status",
-                )
-
-            # Resubmit the job
             resubmit_result = self.api.resubmit_job(job_name, namespace)
             self.assertTrue(resubmit_result, "Job should be resubmitted successfully")
 
-            # Wait for job to complete
             result = self.api.wait_until_job_finished(
                 job_name, namespace, timeout=120, delay_between_attempts=5
             )
             self.assertTrue(result, "Resubmitted job should complete successfully")
 
         finally:
-            # Clean up
             self.api.delete_job(job_name, namespace)
 
     def test_suspend_job_nonexistent(self):
         """Test stopping a non-existent job."""
-        result = self.api.suspend_job("nonexistent-job", "default")
+        result = self.api.suspend_job("nonexistent-job", namespace)
         self.assertFalse(result, "Should return False for non-existent job")
 
     def test_resubmit_job_nonexistent(self):
         """Test resubmitting a non-existent job."""
-        result = self.api.resubmit_job("nonexistent-job", "default")
+        result = self.api.resubmit_job("nonexistent-job", namespace)
         self.assertFalse(result, "Should return False for non-existent job")
 
     def test_wait_until_job_running(self):
         """Test waiting for a job to reach running state."""
         job_name = "wait-running-test-job"
-        namespace = "default"
 
         try:
-            job_body = {
-                "apiVersion": constants.GROUP + "/" + constants.JOB_VERSION,
-                "kind": constants.JOB_KIND,
-                "metadata": {
-                    "name": job_name,
-                    "namespace": namespace,
-                    "labels": {
-                        "app.kubernetes.io/name": job_name,
-                        "app.kubernetes.io/managed-by": "kuberay",
-                    },
-                },
-                "spec": {
-                    "rayClusterSpec": {
-                        "headGroupSpec": {
-                            "serviceType": "ClusterIP",
-                            "replicas": 1,
-                            "rayStartParams": {
-                                "dashboard-host": "0.0.0.0",
-                            },
-                            "template": {
-                                "spec": {
-                                    "containers": [
-                                        {
-                                            "name": "ray-head",
-                                            "image": "rayproject/ray:2.48.0",
-                                            "resources": {
-                                                "limits": {
-                                                    "cpu": "1",
-                                                    "memory": "2Gi",
-                                                },
-                                                "requests": {
-                                                    "cpu": "500m",
-                                                    "memory": "1Gi",
-                                                },
-                                            },
-                                        }
-                                    ]
-                                }
-                            },
-                        },
-                    },
-                    "entrypoint": "python -c \"import time; print('Job running'); time.sleep(30)\"",
-                    "submissionMode": "K8sJobMode",
-                    "shutdownAfterJobFinishes": True,
-                },
-            }
+            job_body = create_job_with_ray_cluster_spec(
+                job_name=job_name,
+                namespace=namespace,
+            )
 
-            # Submit the job
             submitted_job = self.api.submit_job(
                 job=job_body,
                 k8s_namespace=namespace,
             )
             self.assertIsNotNone(submitted_job, "Job should be submitted successfully")
 
-            # Test waiting for running state
             result = self.api.wait_until_job_running(
                 job_name, namespace, timeout=60, delay_between_attempts=3
             )
             self.assertTrue(result, "Job should reach running state")
 
-            # Wait for job to complete
             self.api.wait_until_job_finished(job_name, namespace, 60, 5)
 
         finally:
             self.api.delete_job(job_name, namespace)
+
+    def test_get_job(self):
+        """Test getting a job."""
+        job_name = "get-test-job"
+
+        try:
+            job_body = create_job_with_ray_cluster_spec(
+                job_name=job_name,
+                namespace=namespace,
+            )
+
+            submitted_job = self.api.submit_job(
+                job=job_body,
+                k8s_namespace=namespace,
+            )
+            self.assertIsNotNone(submitted_job, "Job should be submitted successfully")
+
+            status = self.api.get_job_status(
+                job_name, namespace, timeout=30, delay_between_attempts=2
+            )
+            self.assertIsNotNone(status, "Job status should be available")
+
+            job = self.api.get_job(job_name, namespace)
+            self.assertIsNotNone(job, "Job should be retrieved successfully")
+            self.assertEqual(job["metadata"]["name"], job_name)
+        finally:
+            self.api.delete_job(job_name, namespace)
+
+    def test_list_jobs(self):
+        """Test listing all jobs in a namespace."""
+        created_jobs = []
+
+        try:
+            initial_result = self.api.list_jobs(k8s_namespace=namespace)
+            self.assertIsNotNone(initial_result, "List jobs should return a result")
+            self.assertIn("items", initial_result, "Result should contain 'items' field")
+            initial_count = len(initial_result.get("items", []))
+
+            test_jobs = [
+                {
+                    "name": "list-test-job-1",
+                    "type": "cluster_spec"
+                },
+                {
+                    "name": "list-test-job-2",
+                    "type": "cluster_spec"
+                },
+                {
+                    "name": "list-test-job-3",
+                    "type": "cluster_spec"
+                }
+            ]
+
+            for job_info in test_jobs:
+                job_body = create_job_with_ray_cluster_spec(
+                    job_name=job_info["name"],
+                    namespace=namespace,
+                )
+
+                submitted_job = self.api.submit_job(
+                    job=job_body,
+                    k8s_namespace=namespace,
+                )
+                self.assertIsNotNone(submitted_job, f"Job {job_info['name']} should be submitted successfully")
+                created_jobs.append(job_info["name"])
+
+                status = self.api.get_job_status(
+                    job_info["name"], namespace, timeout=10, delay_between_attempts=1
+                )
+                self.assertIsNotNone(status, f"Job {job_info['name']} status should be available")
+
+            result = self.api.list_jobs(k8s_namespace=namespace)
+            self.assertIsNotNone(result, "List jobs should return a result")
+            self.assertIn("items", result, "Result should contain 'items' field")
+
+            items = result.get("items", [])
+            current_count = len(items)
+
+            self.assertGreaterEqual(
+                current_count,
+                initial_count + len(test_jobs),
+                f"Should have at least {len(test_jobs)} more jobs than initially"
+            )
+
+            job_names_in_list = [item.get("metadata", {}).get("name") for item in items]
+            for job_name in created_jobs:
+                self.assertIn(
+                    job_name,
+                    job_names_in_list,
+                    f"Job {job_name} should be in the list"
+                )
+
+        finally:
+            for job_name in created_jobs:
+                try:
+                    self.api.delete_job(job_name, namespace)
+                except Exception as e:
+                    print(f"Failed to delete job {job_name}: {e}")
+
+    def wait_for_job_status(
+        self, job_name, namespace, expected_status, timeout=60, check_interval=3
+    ):
+        """Wait for a job to reach a specific status with polling."""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            status = self.api.get_job_status(
+                job_name, namespace, timeout=5, delay_between_attempts=1
+            )
+            current_status = status.get("jobDeploymentStatus") if status else None
+
+            if current_status == expected_status:
+                return True
+
+            time.sleep(check_interval)
+
+        return False

--- a/clients/python-client/python_client_test/test_utils.py
+++ b/clients/python-client/python_client_test/test_utils.py
@@ -1,6 +1,5 @@
 import unittest
 import copy
-import re
 from python_client.utils import kuberay_cluster_utils, kuberay_cluster_builder
 
 


### PR DESCRIPTION
## Why are these changes needed?
The RayJob API for the python client had no functionality to suspend, resubmit, or delete a RayJob CR. Also, the status reporting would report the status as unknown when a descriptive status could be retrieved from the `jobDeploymentStatus`.

## Related issue number
N/A

## Verification Steps
Prerequisite:
* Kind cluster running
* Kuberay Operator installed

From your terminal build a new whl file
```bash
cd clients/python-client/
poetry build
```
In a jupyter notebook with the whl file in your current dir
```
%pip install ./python_client-0.0.0.dev0-py3-none-any.whl --force-reinstall
```
Define the RayJob body
```python
from python_client import kuberay_job_api, constants

job_body = {
    "apiVersion": constants.GROUP + "/" + constants.JOB_VERSION,
    "kind": constants.JOB_KIND,
    "metadata": {
        "name": "test-job",
        "namespace": "default",
        "labels": {
            "app.kubernetes.io/name": "test-job",
            "app.kubernetes.io/managed-by": "kuberay",
        },
    },
    "spec": {
        "rayClusterSpec": {
            "headGroupSpec": {
                "serviceType": "ClusterIP",
                "replicas": 1,
                "rayStartParams": {
                    "dashboard-host": "0.0.0.0",
                },
                "template": {
                    "spec": {
                        "containers": [
                            {
                                "name": "ray-head",
                                "image": "rayproject/ray:2.48.0",
                                "resources": {
                                    "limits": {
                                        "cpu": "1",
                                        "memory": "2Gi",
                                    },
                                    "requests": {
                                        "cpu": "500m",
                                        "memory": "1Gi",
                                    },
                                },
                            }
                        ]
                    }
                },
            },
        },
        "entrypoint": "python -c \"import time; print('Job started'); time.sleep(60); print('Job finished')\"",
        "submissionMode": "K8sJobMode",
        "shutdownAfterJobFinishes": True,
    },
}
```
Initialize the RayJobAPI
```python
job_api = kuberay_job_api.RayjobApi()
```
Submit the Job, play around with checking the status intermittently, suspending it, resubmitting it, and deletion. 
```python
job_api.submit_job(job=job_body, k8s_namespace="default")
job_api.get_job_status("test-job", "default")

job_api.suspend_job("test-job", "default")
job_api.get_job_status("test-job", "default")

job_api.resubmit_job("test-job", "default")
job_api.get_job_status("test-job", "default")

job_api.delete_job("test-job", "default")
```

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
