### PR TITLE
Bump crd-ref-docs to v0.2.0 for Go 1.24+ compatibility

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -53,6 +53,10 @@ _Validation:_
 _Appears in:_
 - [AutoscalerOptions](#autoscaleroptions)
 
+| Field | Description |
+| --- | --- |
+| `v1` |  |
+| `v2` |  |
 
 
 #### DeletionPolicy
@@ -82,6 +86,12 @@ _Underlying type:_ _string_
 _Appears in:_
 - [DeletionPolicy](#deletionpolicy)
 
+| Field | Description |
+| --- | --- |
+| `DeleteCluster` |  |
+| `DeleteWorkers` |  |
+| `DeleteSelf` |  |
+| `DeleteNone` |  |
 
 
 #### DeletionStrategy
@@ -155,6 +165,12 @@ _Underlying type:_ _string_
 _Appears in:_
 - [RayJobSpec](#rayjobspec)
 
+| Field | Description |
+| --- | --- |
+| `K8sJobMode` |  |
+| `HTTPMode` |  |
+| `InteractiveMode` |  |
+| `SidecarMode` |  |
 
 
 #### RayCluster
@@ -333,6 +349,10 @@ _Underlying type:_ _string_
 _Appears in:_
 - [RayServiceUpgradeStrategy](#rayserviceupgradestrategy)
 
+| Field | Description |
+| --- | --- |
+| `NewCluster` | During upgrade, NewCluster strategy will create new upgraded cluster and switch to it when it becomes ready<br /> |
+| `None` | No new cluster will be created while the strategy is set to None<br /> |
 
 
 #### RedisCredential

--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -179,7 +179,7 @@ CRD_REF_DOCS = $(LOCALBIN)/crd-ref-docs
 $(CRD_REF_DOCS): $(LOCALBIN)
 .PHONY: crd-ref-docs
 crd-ref-docs: $(CRD_REF_DOCS) ## Download crd-ref-docs locally if necessary.
-	test -s $(CRD_REF_DOCS) || GOBIN=$(LOCALBIN) go install github.com/elastic/crd-ref-docs@v0.0.12
+	test -s $(CRD_REF_DOCS) || GOBIN=$(LOCALBIN) go install github.com/elastic/crd-ref-docs@v0.2.0
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The current version ([v0.0.12](https://github.com/elastic/crd-ref-docs/blob/v0.0.12/go.mod)) depends on [golang.org/x/tools@v0.19.0,](https://github.com/elastic/crd-ref-docs/blob/v0.0.12/go.mod#L11) which causes build failures under newer Go toolchains (e.g., Go 1.24+). Example error:

```
$ go version                          
go version go1.25.0 darwin/arm64

$ make api-docs
# golang.org/x/tools/internal/tokeninternal
.../golang.org/x/tools@v0.19.0/internal/tokeninternal/tokeninternal.go:64:9: invalid array length -delta * delta (constant -256 of type int64)
make: *** [crd-ref-docs] Error 1
```

Upgrading to [v0.2.0](https://github.com/elastic/crd-ref-docs/blob/v0.0.12/go.mod) provides compatibility with modern Go versions and aligns this project with the latest maintained release of crd-ref-docs.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
