### PR TITLE
Revert "Bump crd-ref-docs to v0.2.0 for Go 1.24+ compatibility"

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -53,10 +53,6 @@ _Validation:_
 _Appears in:_
 - [AutoscalerOptions](#autoscaleroptions)
 
-| Field | Description |
-| --- | --- |
-| `v1` |  |
-| `v2` |  |
 
 
 #### DeletionPolicy
@@ -86,12 +82,6 @@ _Underlying type:_ _string_
 _Appears in:_
 - [DeletionPolicy](#deletionpolicy)
 
-| Field | Description |
-| --- | --- |
-| `DeleteCluster` |  |
-| `DeleteWorkers` |  |
-| `DeleteSelf` |  |
-| `DeleteNone` |  |
 
 
 #### DeletionStrategy
@@ -165,12 +155,6 @@ _Underlying type:_ _string_
 _Appears in:_
 - [RayJobSpec](#rayjobspec)
 
-| Field | Description |
-| --- | --- |
-| `K8sJobMode` |  |
-| `HTTPMode` |  |
-| `InteractiveMode` |  |
-| `SidecarMode` |  |
 
 
 #### RayCluster
@@ -349,10 +333,6 @@ _Underlying type:_ _string_
 _Appears in:_
 - [RayServiceUpgradeStrategy](#rayserviceupgradestrategy)
 
-| Field | Description |
-| --- | --- |
-| `NewCluster` | During upgrade, NewCluster strategy will create new upgraded cluster and switch to it when it becomes ready<br /> |
-| `None` | No new cluster will be created while the strategy is set to None<br /> |
 
 
 #### RedisCredential

--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -179,7 +179,7 @@ CRD_REF_DOCS = $(LOCALBIN)/crd-ref-docs
 $(CRD_REF_DOCS): $(LOCALBIN)
 .PHONY: crd-ref-docs
 crd-ref-docs: $(CRD_REF_DOCS) ## Download crd-ref-docs locally if necessary.
-	test -s $(CRD_REF_DOCS) || GOBIN=$(LOCALBIN) go install github.com/elastic/crd-ref-docs@v0.2.0
+	test -s $(CRD_REF_DOCS) || GOBIN=$(LOCALBIN) go install github.com/elastic/crd-ref-docs@v0.0.12
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Reverts ray-project/kuberay#4029, since we have to support go 1.24.6 first, then we can bump crd-ref-docs to v0.2.0

https://github.com/ray-project/kuberay/blob/3858146ac12efee0ee383443b3aeb387646034c0/ray-operator/go.mod#L3
