### PR TITLE
 [Fix] Fix rayClusterScaleExpectation deletion to use request object when instance is nil

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -123,7 +123,7 @@ func (r *RayClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	// No match found
 	if errors.IsNotFound(err) {
 		// Clear all related expectations
-		r.rayClusterScaleExpectation.Delete(instance.Name, instance.Namespace)
+		r.rayClusterScaleExpectation.Delete(request.Name, request.Namespace)
 		cleanUpRayClusterMetrics(r.options.RayClusterMetricsManager, request.Name, request.Namespace)
 	} else {
 		logger.Error(err, "Read request instance error!")


### PR DESCRIPTION
 [Fix] Fix rayClusterScaleExpectation deletion to use request object when instance is nil

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Quick fix for `r.rayClusterScaleExpectation.Delete` with expected name and ns. Current usage may lead to a memory leak.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #4035

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
