### PR TITLE
[Bug] Fix health probes to use custom ports from rayStartParams

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -337,17 +337,27 @@ func DefaultWorkerPodTemplate(ctx context.Context, instance rayv1.RayCluster, wo
 	return podTemplate
 }
 
-func initLivenessAndReadinessProbe(rayContainer *corev1.Container, rayNodeType rayv1.RayNodeType, creatorCRDType utils.CRDType) {
+func initLivenessAndReadinessProbe(rayContainer *corev1.Container, rayNodeType rayv1.RayNodeType, creatorCRDType utils.CRDType, rayStartParams map[string]string) {
+
+	getPort := func(key string, defaultVal int) int {
+		if portStr, ok := rayStartParams[key]; ok {
+			if port, err := strconv.Atoi(portStr); err == nil {
+				return port
+			}
+		}
+		return defaultVal
+	}
+
 	rayAgentRayletHealthCommand := fmt.Sprintf(
 		utils.BaseWgetHealthCommand,
 		utils.DefaultReadinessProbeTimeoutSeconds,
-		utils.DefaultDashboardAgentListenPort,
+		getPort("dashboard-agent-listen-port", utils.DefaultDashboardAgentListenPort),
 		utils.RayAgentRayletHealthPath,
 	)
 	rayDashboardGCSHealthCommand := fmt.Sprintf(
 		utils.BaseWgetHealthCommand,
 		utils.DefaultReadinessProbeFailureThreshold,
-		utils.DefaultDashboardPort,
+		getPort("dashboard-port", utils.DefaultDashboardPort),
 		utils.RayDashboardGCSHealthPath,
 	)
 
@@ -493,7 +503,7 @@ func BuildPod(ctx context.Context, podTemplateSpec corev1.PodTemplateSpec, rayNo
 		// Configure the readiness and liveness probes for the Ray container. These probes
 		// play a crucial role in KubeRay health checks. Without them, certain failures,
 		// such as the Raylet process crashing, may go undetected.
-		initLivenessAndReadinessProbe(&pod.Spec.Containers[utils.RayContainerIndex], rayNodeType, creatorCRDType)
+		initLivenessAndReadinessProbe(&pod.Spec.Containers[utils.RayContainerIndex], rayNodeType, creatorCRDType, rayStartParams)
 	}
 
 	return pod


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What this PR does / why we need it:**
This PR fixes an issue where the liveness and readiness probes in Ray pods were hardcoded to use default ports, ignoring custom port configurations specified in `rayStartParams`. This caused probe failures when users customized ports like `dashboard-port` or `dashboard-agent-listen-port`.

**Which issue(s) this PR fixes:**
Fixes health probe failures when custom ports are configured in rayStartParams.

**Special notes for your reviewer:**
The fix extracts port values from `rayStartParams` with fallback to default values, ensuring probes use the correct ports that Ray processes are actually listening on.