### PR TITLE
[Refactor] Eliminate redundant range variable capture with Go 1.22 scoped iteration

### DIFF
--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -448,7 +448,6 @@ func TestCreateClusterEndpoint(t *testing.T) {
 	}
 	// Execute tests sequentially
 	for _, tc := range tests {
-
 		t.Run(tc.Name, func(t *testing.T) {
 			actualCluster, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateCluster(tc.Input)
 			if tc.ExpectedError == nil {
@@ -520,7 +519,6 @@ func TestDeleteCluster(t *testing.T) {
 	}
 	// Execute tests sequentially
 	for _, tc := range tests {
-
 		t.Run(tc.Name, func(t *testing.T) {
 			actualRPCStatus, err := tCtx.GetRayAPIServerClient().DeleteCluster(tc.Input)
 			if tc.ExpectedError == nil {
@@ -798,7 +796,6 @@ func TestGetClustersByNameInNamespace(t *testing.T) {
 	}
 	// Execute tests sequentially
 	for _, tc := range tests {
-
 		t.Run(tc.Name, func(t *testing.T) {
 			actualCluster, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetCluster(tc.Input)
 			if tc.ExpectedError == nil {

--- a/apiserver/test/e2e/config_server_e2e_test.go
+++ b/apiserver/test/e2e/config_server_e2e_test.go
@@ -115,7 +115,6 @@ func TestCreateTemplate(t *testing.T) {
 	}
 	// Execute tests sequentially
 	for _, tc := range tests {
-
 		t.Run(tc.Name, func(t *testing.T) {
 			actualTemplate, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateComputeTemplate(tc.Input)
 			if tc.ExpectedError != nil {
@@ -178,7 +177,6 @@ func TestDeleteTemplate(t *testing.T) {
 	}
 	// Execute tests sequentially
 	for _, tc := range tests {
-
 		t.Run(tc.Name, func(t *testing.T) {
 			actualRPCStatus, err := tCtx.GetRayAPIServerClient().DeleteComputeTemplate(tc.Input)
 			if tc.ExpectedError != nil {
@@ -295,7 +293,6 @@ func TestGetTemplateByNameInNamespace(t *testing.T) {
 	}
 	// Execute tests sequentially
 	for _, tc := range tests {
-
 		t.Run(tc.Name, func(t *testing.T) {
 			actualTemplate, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetComputeTemplate(tc.Input)
 			if tc.ExpectedError != nil {

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -208,7 +208,6 @@ func TestCreateJobWithDisposableClusters(t *testing.T) {
 	}
 	// Execute tests sequentially
 	for _, tc := range tests {
-
 		t.Run(tc.Name, func(t *testing.T) {
 			actualJob, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayJob(tc.Input)
 			if tc.ExpectedError == nil {
@@ -268,7 +267,6 @@ func TestDeleteJob(t *testing.T) {
 	}
 	// Execute tests sequentially
 	for _, tc := range tests {
-
 		t.Run(tc.Name, func(t *testing.T) {
 			actualRPCStatus, err := tCtx.GetRayAPIServerClient().DeleteRayJob(tc.Input)
 			if tc.ExpectedError == nil {
@@ -549,7 +547,6 @@ func TestGetJob(t *testing.T) {
 	}
 	// Execute tests sequentially
 	for _, tc := range tests {
-
 		t.Run(tc.Name, func(t *testing.T) {
 			actualJob, actualRPCStatus, err := tCtx.GetRayAPIServerClient().GetRayJob(tc.Input)
 			if tc.ExpectedError == nil {

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -130,7 +130,6 @@ func TestCreateServiceV2(t *testing.T) {
 	}
 	// Execute tests sequentially
 	for _, tc := range tests {
-
 		t.Run(tc.Name, func(t *testing.T) {
 			actualService, actualRPCStatus, err := tCtx.GetRayAPIServerClient().CreateRayService(tc.Input)
 			if tc.ExpectedError == nil {
@@ -189,7 +188,6 @@ func TestDeleteService(t *testing.T) {
 	}
 	// Execute tests sequentially
 	for _, tc := range tests {
-
 		t.Run(tc.Name, func(t *testing.T) {
 			actualRPCStatus, err := tCtx.GetRayAPIServerClient().DeleteRayService(tc.Input)
 			if tc.ExpectedError == nil {


### PR DESCRIPTION
## Why are these changes needed?
Since the release of [Go 1.22](https://go.dev/blog/go1.22), per-iteration scoping for range variables has rendered manual capture of loop variables redundant. This refactor removes unnecessary variable captures, resulting in cleaner, more idiomatic code.

## Related issue number

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests