### PR TITLE
[CI] Use golang:1.24-bookworm (Debian 12) in CI for Python-3.11 support (#3949)

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -1,6 +1,6 @@
 - label: 'Test E2E (nightly operator)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -20,7 +20,7 @@
 
 - label: 'Test E2E rayservice (nightly operator)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -40,7 +40,7 @@
 
 - label: 'Test Autoscaler E2E Part 1 (nightly operator)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -60,7 +60,7 @@
 
 - label: 'Test Autoscaler E2E Part 2 (nightly operator)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -80,7 +80,7 @@
 
 - label: 'Test E2E Operator Version Upgrade (v1.3.0)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -99,7 +99,7 @@
 
 - label: 'Test Apiserver E2E (nightly operator)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml

--- a/.buildkite/test-kubectl-plugin-e2e.yml
+++ b/.buildkite/test-kubectl-plugin-e2e.yml
@@ -1,6 +1,6 @@
 - label: 'Test E2E (kubectl-plugin)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml

--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -1,6 +1,6 @@
 - label: 'Test Sample YAMLs (nightly operator)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -21,7 +21,7 @@
 
 - label: 'Test Sample YAMLs (latest release)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml


### PR DESCRIPTION
## Why are these changes needed?

Fix the buildkite pipeline

<img width="759" height="330" alt="image" src="https://github.com/user-attachments/assets/e63c19a3-3ce5-4c45-bd24-0dc8b8086bf9" />


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
