### PR TITLE
[WIP][Don't Merge] fix RayJob entrypoint command error

### DIFF
--- a/ray-operator/config/samples/ray-job.sample.yaml
+++ b/ray-operator/config/samples/ray-job.sample.yaml
@@ -7,7 +7,7 @@ spec:
   # The default value is "K8sJobMode", meaning RayJob will submit the Ray job via a submitter Kubernetes Job.
   # The alternative value is "HTTPMode", indicating that KubeRay will submit the Ray job by sending an HTTP request to the RayCluster.
   # submissionMode: "K8sJobMode"
-  entrypoint: python /home/ray/samples/sample_code.py
+  entrypoint: echo $HOSTNAME && echo 'Second command' ; echo $HOSTNAME
   # shutdownAfterJobFinishes specifies whether the RayCluster should be deleted after the RayJob finishes. Default is false.
   # shutdownAfterJobFinishes: false
 

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -162,7 +162,8 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 	}
 
 	// "--" is used to separate the entrypoint from the Ray Job CLI command and its arguments.
-	cmd = append(cmd, "--", entrypoint, ";")
+	// Use "sh -c" to properly handle shell operators like && and ;
+	cmd = append(cmd, "--", "sh", "-c", strconv.Quote(entrypoint), ";")
 	if submissionMode == rayv1.K8sJobMode {
 		cmd = append(cmd, "fi", ";")
 		cmd = append(cmd, jobFollowCommand...)

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -163,7 +163,8 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 
 	// "--" is used to separate the entrypoint from the Ray Job CLI command and its arguments.
 	// Use "sh -c" to properly handle shell operators like && and ;
-	cmd = append(cmd, "--", "sh", "-c", strconv.Quote(entrypoint), ";")
+	// cmd = append(cmd, "--", "bash", "-c", strconv.Quote(entrypoint), ";")
+	cmd = append(cmd, "--", "bash", "-c", entrypoint, ";")
 	if submissionMode == rayv1.K8sJobMode {
 		cmd = append(cmd, "fi", ";")
 		cmd = append(cmd, jobFollowCommand...)


### PR DESCRIPTION
## Why are these changes needed?
This works now.
```yaml
apiVersion: ray.io/v1
kind: RayJob
metadata:
  name: rayjob-sample-2
spec:
  entrypoint: echo 'First command' && echo 'Second command' ; echo 'Third command'
  runtimeEnvYAML: |
    pip:
      - requests==2.26.0
      - pendulum==2.1.2
    env_vars:
      counter_name: "test_counter"

  rayClusterSpec:
    rayVersion: '2.46.0' # should match the Ray version in the image of the containers
    headGroupSpec:
      rayStartParams: {}
      template:
        spec:
          containers:
          - name: ray-head
            image: rayproject/ray:2.46.0
            ports:
            - containerPort: 6379
              name: gcs-server
            - containerPort: 8265 # Ray dashboard
              name: dashboard
            - containerPort: 10001
              name: client
            resources:
              limits:
                cpu: "1"
              requests:
                cpu: "200m"
    workerGroupSpecs:
    # the pod replicas in this group typed worker
    - replicas: 1
      minReplicas: 1
      maxReplicas: 5
      # logical group name, for this called small-group, also can be functional
      groupName: small-group
      # The `rayStartParams` are used to configure the `ray start` command.
      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
      rayStartParams: {}
      #pod template
      template:
        spec:
          containers:
          - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
            image: rayproject/ray:2.46.0
            resources:
              limits:
                cpu: "1"
              requests:
                cpu: "200m"
```
The arguments will be as follows.
```yaml
    Args:
      if ! ray job status --address http://rayjob-sample-2-l8x65-head-svc.default.svc.cluster.local:8265 rayjob-sample-2-6p457 >/dev/null 2>&1 ;
then ray job submit --address http://rayjob-sample-2-l8x65-head-svc.default.svc.cluster.local:8265 --no-wait --runtime-env-json
 "{\"env_vars\":{\"counter_name\":\"test_counter\"},\"pip\":[\"requests==2.26.0\",\"pendulum==2.1.2\"]}"
 --submission-id rayjob-sample-2-6p457
 -- sh -c "echo 'First command' && echo 'Second command' ; echo 'Third command'" ;
 fi ; ray job logs --address http://rayjob-sample-2-l8x65-head-svc.default.svc.cluster.local:8265 --follow 
```

and the echo behavior is what we want!

<img width="1233" height="427" alt="image" src="https://github.com/user-attachments/assets/61d202a4-9bba-4145-8421-38d027bc5b6e" />


## Related issue number
https://github.com/ray-project/kuberay/issues/3802


## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
