### PR TITLE
Use RayClusterSpec as input for `GetDefaultSubmitterTemplate`

### DIFF
--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -172,11 +172,11 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 }
 
 // GetDefaultSubmitterTemplate creates a default submitter template for the Ray job.
-func GetDefaultSubmitterTemplate(rayClusterInstance *rayv1.RayCluster) corev1.PodTemplateSpec {
+func GetDefaultSubmitterTemplate(rayClusterSpec *rayv1.RayClusterSpec) corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
-				GetDefaultSubmitterContainer(rayClusterInstance),
+				GetDefaultSubmitterContainer(rayClusterSpec),
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
@@ -184,11 +184,11 @@ func GetDefaultSubmitterTemplate(rayClusterInstance *rayv1.RayCluster) corev1.Po
 }
 
 // GetDefaultSubmitterContainer creates a default submitter container for the Ray job.
-func GetDefaultSubmitterContainer(rayClusterInstance *rayv1.RayCluster) corev1.Container {
+func GetDefaultSubmitterContainer(rayClusterSpec *rayv1.RayClusterSpec) corev1.Container {
 	return corev1.Container{
 		Name: utils.SubmitterContainerName,
 		// Use the image of the Ray head to be defensive against version mismatch issues
-		Image: rayClusterInstance.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Image,
+		Image: rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Image,
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -234,6 +234,6 @@ func TestGetDefaultSubmitterTemplate(t *testing.T) {
 			},
 		},
 	}
-	template := GetDefaultSubmitterTemplate(rayCluster)
+	template := GetDefaultSubmitterTemplate(&rayCluster.Spec)
 	assert.Equal(t, template.Spec.Containers[0].Image, rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Image)
 }

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -562,7 +562,7 @@ func getSubmitterTemplate(ctx context.Context, rayJobInstance *rayv1.RayJob, ray
 
 	// Set the default value for the optional field SubmitterPodTemplate if not provided.
 	if rayJobInstance.Spec.SubmitterPodTemplate == nil {
-		submitterTemplate = common.GetDefaultSubmitterTemplate(rayClusterInstance)
+		submitterTemplate = common.GetDefaultSubmitterTemplate(&rayClusterInstance.Spec)
 		logger.Info("default submitter template is used")
 	} else {
 		submitterTemplate = *rayJobInstance.Spec.SubmitterPodTemplate.DeepCopy()
@@ -578,7 +578,7 @@ func getSubmitterTemplate(ctx context.Context, rayJobInstance *rayv1.RayJob, ray
 
 // getSubmitterContainer builds the submitter container for the Ray job Sidecar mode.
 func getSubmitterContainer(rayJobInstance *rayv1.RayJob, rayClusterInstance *rayv1.RayCluster) (corev1.Container, error) {
-	var submitterContainer corev1.Container = common.GetDefaultSubmitterContainer(rayClusterInstance)
+	var submitterContainer corev1.Container = common.GetDefaultSubmitterContainer(&rayClusterInstance.Spec)
 
 	if err := configureSubmitterContainer(&submitterContainer, rayJobInstance, rayv1.SidecarMode); err != nil {
 		return corev1.Container{}, err

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -357,7 +357,7 @@ var _ = Context("RayJob with different submission modes", func() {
 			namespace := "default"
 			rayJob := rayJobTemplate("rayjob-invalid-test", namespace)
 			rayCluster := &rayv1.RayCluster{Spec: *rayJob.Spec.RayClusterSpec}
-			template := common.GetDefaultSubmitterTemplate(rayCluster)
+			template := common.GetDefaultSubmitterTemplate(&rayCluster.Spec)
 			template.Spec.RestartPolicy = "" // Make it invalid to create a submitter. Ref: https://github.com/ray-project/kuberay/pull/2389#issuecomment-2359564334
 			rayJob.Spec.SubmitterPodTemplate = &template
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In certain scenarios, such as calculating resources for a RayJob, we need to obtain the default submitter template. 

However, since the RayJob does not provide access to the RayCluster instance, we cannot rely solely on RayJob to retrieve the default submitter template.

By using the RayClusterSpec from the RayCluster instance instead, this change preserves the original behavior while ensuring the necessary information is available.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
