### PR TITLE
[Bug]  `apiserversdk` may return incomplete response body causing `ERR_INCOMPLETE_CHUNKED_ENCODING`

### DIFF
--- a/apiserversdk/proxy.go
+++ b/apiserversdk/proxy.go
@@ -151,6 +151,17 @@ func (rrt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		}
 
 		if apiserversdkutil.IsSuccessfulStatusCode(resp.StatusCode) {
+			if resp.Body != nil {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return nil, fmt.Errorf("failed to read response body: %w", err)
+				}
+				err = resp.Body.Close()
+				if err != nil {
+					return nil, fmt.Errorf("failed to close response body: %w", err)
+				}
+				resp.Body = io.NopCloser(bytes.NewReader(body))
+			}
 			return resp, nil
 		}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When using `apiserversdk`, I encountered an issue where the frontend (browser / Next.js / Curl) reports:
> Failed to load resource: net::ERR_INCOMPLETE_CHUNKED_ENCODING

~~This happens because the `resp.Body` returned from `RoundTrip` may have already been consumed (e.g., during retry or internal draining). As a result, the caller receives an incomplete or empty body stream, which breaks clients expecting a valid chunked encoding.~~

Because the k8s api server may return chunks of items. Thanks, @machichima, for help
[Reference](https://github.com/ray-project/kuberay/pull/4061#issuecomment-3266539108)

<!-- Please give a short summary of the change and the problem this solves. -->

- Repack the response body
- Read all chunks into memory so that the downstream can read the full content.

## Manual Testing
Run curl cmd 20 times in a row
```bash
$ curl -v http://localhost:31888/apis/ray.io/v1/namespaces/default/rayjobs
// logs
*   Trying 127.0.0.1:31888...
* Connected to localhost (127.0.0.1) port 31888 (#0)
> GET /apis/ray.io/v1/namespaces/default/rayjobs HTTP/1.1
> Host: localhost:31888
> User-Agent: curl/7.81.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Audit-Id: 7dd064fb-2bae-464a-a939-7bf46fb96ff4
< Cache-Control: no-cache, private
< Content-Type: application/json
< Date: Sun, 07 Sep 2025 17:56:21 GMT
< X-Kubernetes-Pf-Flowschema-Uid: e50dc44c-0ace-4b9f-b9e6-d2b8b5eff29f
< X-Kubernetes-Pf-Prioritylevel-Uid: 8f616234-0b9c-492b-97b2-30f8d5c0aa52
< Transfer-Encoding: chunked
<
.... some data
* Connection #0 to host localhost left intact
```


## Related issue number
Closes #4060 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [X] Manual tests
  - [ ] This PR is not tested :(
