### PR TITLE
[RayJob] ClusterSelector shouldn't support SidecarMode

### DIFF
--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -177,6 +177,9 @@ func ValidateRayJobSpec(rayJob *rayv1.RayJob) error {
 		if len(clusterName) == 0 {
 			return fmt.Errorf("cluster name in ClusterSelector should not be empty")
 		}
+		if rayJob.Spec.SubmissionMode == rayv1.SidecarMode {
+			return fmt.Errorf("ClusterSelector is not supported in SidecarMode")
+		}
 	}
 
 	// InteractiveMode does not support backoffLimit > 1.

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -902,6 +902,14 @@ func TestValidateRayJobSpec(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "SidecarMode doesn't support ClusterSelector",
+			spec: rayv1.RayJobSpec{
+				SubmissionMode:  rayv1.SidecarMode,
+				ClusterSelector: map[string]string{"ray.io/cluster": "ray-cluster"},
+			},
+			expectError: true,
+		},
+		{
 			name: "failed to get cluster name in ClusterSelector map",
 			spec: rayv1.RayJobSpec{
 				ClusterSelector: map[string]string{},


### PR DESCRIPTION
## Why are these changes needed?
ClusterSelector with SidecarMode requires injecting a sidecar container into an already running Pod. However, Kubernetes does not natively support adding new containers to Pods that are already running.

Before:
The sidecar mode's RayJob CR will keep running but didn't actually submit the job.
```yaml
apiVersion: ray.io/v1
kind: RayJob
metadata:
  name: rayjob-use-existing-raycluster
spec:
  submissionMode: "SidecarMode"
  entrypoint: python -c "import ray; ray.init(); print(ray.cluster_resources())"
  # Select an existing RayCluster called "ray-cluster-kuberay" instead of creating a new one.
  clusterSelector:
    ray.io/cluster: rayjob-sidecar-mode-czhkm
```
<img width="1853" height="152" alt="image" src="https://github.com/user-attachments/assets/fe5fd7da-7d5f-4424-8b13-d00dfd51b8d7" />

After:
failed the job. (After Nary's PR: https://github.com/ray-project/kuberay/pull/3981


## Related issue number
https://github.com/ray-project/kuberay/issues/3928

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
