### PR TITLE
[RayJob] avoid RayCluster resource leak in k8s job mode(#3903)

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -1044,7 +1044,7 @@ func (r *RayJobReconciler) checkSubmitterAndUpdateStatusIfNeeded(ctx context.Con
 			shouldUpdate = true
 			rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
 			rayJob.Status.Reason = rayv1.AppFailed
-			rayJob.Status.Message = "Ray head pod is terminated, and sidecar mode's restart policy is never."
+			rayJob.Status.Message = "Ray head pod not found."
 			return
 		}
 

--- a/ray-operator/test/e2erayjob/rayjob_sidecar_mode_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_sidecar_mode_test.go
@@ -191,7 +191,7 @@ env_vars:
 			Should(WithTransform(RayJobReason, Equal(rayv1.AppFailed)))
 		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(func(job *rayv1.RayJob) string { return job.Status.Message },
-				ContainSubstring("Ray head pod is terminated, and sidecar mode's restart policy is never.")))
+				Equal("Ray head pod not found.")))
 
 		// Cleanup
 		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})

--- a/ray-operator/test/e2erayjob/rayjob_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_test.go
@@ -308,7 +308,7 @@ env_vars:
 			Should(WithTransform(RayJobReason, Equal(rayv1.AppFailed)))
 		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(func(job *rayv1.RayJob) string { return job.Status.Message },
-				ContainSubstring("Submitter completed but Ray job not found in RayCluster.")))
+				Equal("Submitter completed but Ray job not found in RayCluster.")))
 
 		// Cleanup
 		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})


### PR DESCRIPTION
## Why are these changes needed?
We should avoid RayCluster resource leak when using RayJob, see [1] for more details.

[1] https://github.com/ray-project/kuberay/issues/3860#issue-3222182118

update from Han-Ju:
1. This PR handles k8s job mode's resource leak case.
2. sidecar mode should fail when head pod is deleted.

## Related issue number
https://github.com/ray-project/kuberay/issues/3860#top
https://github.com/ray-project/kuberay/issues/3903

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
