### PR TITLE
Get details of only declarative serve apps

### DIFF
--- a/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"net/http"
 	"strings"
 
@@ -19,6 +20,7 @@ import (
 var (
 	// Multi-application URL paths
 	ServeDetailsPath = "/api/serve/applications/"
+	APITypeParam = "declarative"
 	DeployPathV2     = "/api/serve/applications/"
 	// Job URL paths
 	JobPath = "/api/jobs/"
@@ -85,9 +87,19 @@ func (r *RayDashboardClient) GetMultiApplicationStatus(ctx context.Context) (map
 	return r.ConvertServeDetailsToApplicationStatuses(serveDetails)
 }
 
-// GetServeDetails gets details on all live applications on the Ray cluster.
+// GetServeDetails gets details on all declarative applications on the Ray cluster.
 func (r *RayDashboardClient) GetServeDetails(ctx context.Context) (*utiltypes.ServeDetails, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.dashboardURL+ServeDetailsPath, nil)
+
+	serveDetailsURL, err := url.Parse(r.dashboardURL + ServeDetailsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse dashboard URL: %w", err)
+	}
+	q := serveDetailsURL.Query()
+	q.Set("api_type", APITypeParam)
+	serveDetailsURL.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", serveDetailsURL.String(), nil)
+
 	if err != nil {
 		return nil, err
 	}

--- a/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go
@@ -172,4 +172,129 @@ var _ = Describe("RayFrameworkGenerator", func() {
 		err := rayDashboardClient.StopJob(context.TODO(), "stop-job-1")
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	It("Test GetServeDetails URL construction with query parameters", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		// Mock the response
+		expectedResponse := &utiltypes.ServeDetails{
+			Applications: map[string]utiltypes.ServeApplicationDetails{
+				"app1": {
+					ServeApplicationStatus: utiltypes.ServeApplicationStatus{
+						Name:   "app1",
+						Status: "RUNNING",
+					},
+					Deployments: map[string]utiltypes.ServeDeploymentDetails{},
+				},
+			},
+			DeployMode: "MULTI_APP",
+		}
+		responseBytes, _ := json.Marshal(expectedResponse)
+
+		// Register responder that checks the URL includes the query parameter
+		httpmock.RegisterResponder(http.MethodGet, rayDashboardClient.dashboardURL+ServeDetailsPath,
+			func(req *http.Request) (*http.Response, error) {
+				// Verify the query parameter is present
+				Expect(req.URL.Query().Get("api_type")).To(Equal("declarative"))
+				return httpmock.NewBytesResponse(200, responseBytes), nil
+			})
+
+		details, err := rayDashboardClient.GetServeDetails(context.TODO())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(details.Applications).To(HaveKey("app1"))
+		Expect(details.DeployMode).To(Equal("MULTI_APP"))
+	})
+
+	It("Test GetServeDetails with invalid dashboard URL", func() {
+		invalidClient := &RayDashboardClient{
+			dashboardURL: "://invalid-url",
+			client:       &http.Client{},
+		}
+
+		_, err := invalidClient.GetServeDetails(context.TODO())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to parse dashboard URL"))
+	})
+
+	It("Test GetServeDetails with HTTP 400 Bad Request", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		// Test 400 Bad Request (might happen with older Ray versions)
+		httpmock.RegisterResponder(http.MethodGet, rayDashboardClient.dashboardURL+ServeDetailsPath,
+			func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(400, "Bad Request: unknown parameter api_type"), nil
+			})
+
+		_, err := rayDashboardClient.GetServeDetails(context.TODO())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("GetServeDetails fail: 400"))
+		Expect(err.Error()).To(ContainSubstring("Bad Request: unknown parameter api_type"))
+	})
+
+	It("Test GetServeDetails with HTTP 500 Internal Server Error", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder(http.MethodGet, rayDashboardClient.dashboardURL+ServeDetailsPath,
+			func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(500, "Internal Server Error"), nil
+			})
+
+		_, err := rayDashboardClient.GetServeDetails(context.TODO())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("GetServeDetails fail: 500"))
+	})
+
+	It("Test GetServeDetails with invalid JSON response", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder(http.MethodGet, rayDashboardClient.dashboardURL+ServeDetailsPath,
+			func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(200, "invalid json response"), nil
+			})
+
+		_, err := rayDashboardClient.GetServeDetails(context.TODO())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("GetServeDetails failed. Failed to unmarshal bytes"))
+		Expect(err.Error()).To(ContainSubstring("invalid json response"))
+	})
+
+	It("Test GetServeDetails with empty response", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		// Test with empty but valid JSON
+		emptyResponse := &utiltypes.ServeDetails{
+			Applications: map[string]utiltypes.ServeApplicationDetails{},
+			DeployMode:   "",
+		}
+		responseBytes, _ := json.Marshal(emptyResponse)
+
+		httpmock.RegisterResponder(http.MethodGet, rayDashboardClient.dashboardURL+ServeDetailsPath,
+			func(req *http.Request) (*http.Response, error) {
+				// Verify the query parameter is present
+				Expect(req.URL.Query().Get("api_type")).To(Equal("declarative"))
+				return httpmock.NewBytesResponse(200, responseBytes), nil
+			})
+
+		details, err := rayDashboardClient.GetServeDetails(context.TODO())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(details.Applications).To(BeEmpty())
+		Expect(details.DeployMode).To(Equal(""))
+	})
+
+	It("Test GetServeDetails with network error", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder(http.MethodGet, rayDashboardClient.dashboardURL+ServeDetailsPath,
+			httpmock.NewErrorResponder(context.DeadlineExceeded))
+
+		_, err := rayDashboardClient.GetServeDetails(context.TODO())
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Equal(context.DeadlineExceeded))
+	})
 })


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As part of this PR I am trying to address Problem 2 raised in issue https://github.com/ray-project/ray/issues/44226.

The main aim is to enable KubeRay to exclusively check the status of only DECLARATIVE Serve apps.
The solution would be build on top of this https://github.com/ray-project/ray/pull/45522

Based on my current understanding, it seems KubeRay should only operate on the DECLARATIVE Serve apps
Thus my solution will involve two key steps:

1.  Update the `/api/serve/applications/` endpoint to read the APIType from the request body and pass it on to the controller controller.get_serve_instance_details - Ray [PR](https://github.com/ray-project/ray/pull/56458)
2. (**This PR**) Modify KubeRay to explicitly pass Declarative as the APIType when calling the /api/serve/applications/

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
