### PR TITLE
[Feature] Separate controller namespace and CRD namespaces for KubeRay-Operator Dashboard

### DIFF
--- a/config/grafana/KubeRay-Operator.json
+++ b/config/grafana/KubeRay-Operator.json
@@ -126,7 +126,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "workqueue_depth{namespace=\"$namespace\", pod=\"$ControllerPod\"}",
+          "expr": "workqueue_depth{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}",
           "instant": false,
           "legendFormat": "{{controller}}",
           "range": true,
@@ -222,7 +222,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "irate(controller_runtime_reconcile_total{namespace=\"$namespace\", pod=\"$ControllerPod\", controller=\"$Controller\"}[$__rate_interval])",
+          "expr": "irate(controller_runtime_reconcile_total{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\", controller=\"$Controller\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{controller}} - {{result}}",
           "range": true,
@@ -365,7 +365,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"$namespace\", pod=\"$ControllerPod\", controller=~\"$Controller\"}[5m])) by (pod,le,controller))",
+          "expr": "histogram_quantile(0.50, sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\", controller=~\"$Controller\"}[5m])) by (pod,le,controller))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -380,7 +380,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"$namespace\", pod=\"$ControllerPod\", controller=~\"$Controller\"}[5m])) by (pod,le,controller))",
+          "expr": "histogram_quantile(0.95, sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\", controller=~\"$Controller\"}[5m])) by (pod,le,controller))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{controller}} - P95",
@@ -394,7 +394,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"$namespace\", pod=\"$ControllerPod\", controller=~\"$Controller\"}[5m])) by (pod,le,controller))",
+          "expr": "histogram_quantile(0.99, sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\", controller=~\"$Controller\"}[5m])) by (pod,le,controller))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{controller}} - P99",
@@ -2100,6 +2100,37 @@
         "type": "query"
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "default"
+          ],
+          "value": [
+            "default"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(controller_runtime_active_workers{},namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "ControllerNamespace",
+        "options": [],
+        "query": {
+          "query": "label_values(controller_runtime_active_workers{},namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "current": {
           "selected": false,
           "text": "raycluster",
@@ -2109,14 +2140,14 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(controller_runtime_active_workers{namespace=\"$namespace\", pod=\"$ControllerPod\"},controller)",
+        "definition": "label_values(controller_runtime_active_workers{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"},controller)",
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "Controller",
         "options": [],
         "query": {
-          "query": "label_values(controller_runtime_active_workers{namespace=\"$namespace\", pod=\"$ControllerPod\"},controller)",
+          "query": "label_values(controller_runtime_active_workers{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"},controller)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -2135,14 +2166,14 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(controller_runtime_active_workers{namespace=\"$namespace\"},pod)",
+        "definition": "label_values(controller_runtime_active_workers{namespace=\"$ControllerNamespace\"},pod)",
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "ControllerPod",
         "options": [],
         "query": {
-          "query": "label_values(controller_runtime_active_workers{namespace=\"$namespace\"},pod)",
+          "query": "label_values(controller_runtime_active_workers{namespace=\"$ControllerNamespace\"},pod)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- In multi-tenancy deployments, the KubeRay operator usually runs in a dedicated namespace, while CRD instances (RayCluster, RayService, RayJob) live in tenant namespaces.
- The current KubeRay Operator Grafana dashboard filters controller-runtime metrics and CRD metrics with the same namespace variable, so it can’t correctly display operator metrics when operator and CRDs are in different namespaces.
- This PR introduces a new dashboard variable ControllerNamespace and switches all controller-runtime queries to use it, leaving CRD queries on the existing namespace variable.

Result: the dashboard works for both single-tenant and multi-tenant setups without breaking existing users.
<img width="1552" height="987" alt="Screenshot 2025-09-20 at 8 50 28 PM" src="https://github.com/user-attachments/assets/65621c9e-cacd-42eb-8863-b6270170e067" />

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #4013 
## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
