### PR TITLE
[Doc] Increase head node memory limit for RayService sample to avoid OOM

### DIFF
--- a/ray-operator/config/samples/ray-service.sample.yaml
+++ b/ray-operator/config/samples/ray-service.sample.yaml
@@ -77,7 +77,7 @@ spec:
             resources:
               limits:
                 cpu: 2
-                memory: 2Gi
+                memory: 5Gi
               requests:
                 cpu: 2
                 memory: 2Gi


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The head node of [the rayservice sample](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-service.sample.yaml) typically uses around 3.5GB of memory, as shown in the image below. With the current settings (2GB), this can lead to **OOM**. We should increase the memory limit to prevent this issue.
<img width="1901" height="745" alt="Screenshot 2025-09-20 at 5 15 27 PM" src="https://github.com/user-attachments/assets/b11d5fd0-bfc7-49c2-bca1-2061f711ccda" />

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
