### PR TITLE
[Feature] [KubeRay Dashboard] hidden the grafana dashboard if link is not provided

### DIFF
--- a/dashboard/src/components/ClustersTable/ClustersTable.tsx
+++ b/dashboard/src/components/ClustersTable/ClustersTable.tsx
@@ -123,21 +123,23 @@ export const ClustersTable = () => {
               />
             </IconButton>
           )}
-          <IconButton
-            variant="plain"
-            size="sm"
-            sx={{
-              minHeight: "1rem",
-              minWidth: "1rem",
-              px: 0.5,
-            }}
-            title="Grafana Metrics"
-            href={row.links.rayGrafanaDashboardLink}
-            target="_blank"
-            component="a"
-          >
-            <Image priority src={GrafanaIcon} alt="Grafana Metrics" />
-          </IconButton>
+          {row.links.rayGrafanaDashboardLink && (
+            <IconButton
+              variant="plain"
+              size="sm"
+              sx={{
+                minHeight: "1rem",
+                minWidth: "1rem",
+                px: 0.5,
+              }}
+              title="Grafana Metrics"
+              href={row.links.rayGrafanaDashboardLink}
+              target="_blank"
+              component="a"
+            >
+              <Image priority src={GrafanaIcon} alt="Grafana Metrics" />
+            </IconButton>
+          )}
         </td>
       </>
     );

--- a/dashboard/src/components/JobsTable/JobsTable.tsx
+++ b/dashboard/src/components/JobsTable/JobsTable.tsx
@@ -120,21 +120,23 @@ export const JobsTable = () => {
               />
             </IconButton>
           )}
-          <IconButton
-            variant="plain"
-            size="sm"
-            sx={{
-              minHeight: "1rem",
-              minWidth: "1rem",
-              px: 0.5,
-            }}
-            title="Grafana Metrics"
-            href={row.links.rayGrafanaDashboardLink}
-            target="_blank"
-            component="a"
-          >
-            <Image priority src={GrafanaIcon} alt="Grafana Metrics" />
-          </IconButton>
+          {row.links.rayGrafanaDashboardLink && (
+            <IconButton
+              variant="plain"
+              size="sm"
+              sx={{
+                minHeight: "1rem",
+                minWidth: "1rem",
+                px: 0.5,
+              }}
+              title="Grafana Metrics"
+              href={row.links.rayGrafanaDashboardLink}
+              target="_blank"
+              component="a"
+            >
+              <Image priority src={GrafanaIcon} alt="Grafana Metrics" />
+            </IconButton>
+          )}
           <IconButton
             variant="plain"
             size="sm"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
[Spec](https://docs.google.com/document/d/1rSDVEsCXPKYNupmfaZw8ywW8XcSrlo5SrgU0gV9pxDs/edit?tab=t.0)

In the KubeRay Dashboard, the Grafana icon in the cluster table currently has no functionality if the Grafana link is not configured. This may confuse users since the icon appears clickable but leads nowhere.

### Expected Behavior

- If the Grafana link is not provided, the Grafana icon should be hidden from the dashboard table.

- If the Grafana link is configured, the icon should remain visible and functional.

<!-- Please give a short summary of the change and the problem this solves. -->

### Manual Testing
Launch api server and frontend server
```bash
$ go run cmd/main.go -httpPortFlag :31888 -cors-allow-origin=*

$ yarn dev
```

Upload the rayjob sample
```bash
$ kubectl apply -f ray-operator/config/samples/ray-job.sample.yaml
```

Check the rayjob dashboard
<img width="1672" height="683" alt="image" src="https://github.com/user-attachments/assets/b9e5b7a0-67d3-46cb-82ac-e473b698f435" />

Check the raycluster dashboard
<img width="1700" height="874" alt="image" src="https://github.com/user-attachments/assets/d64f621e-eda8-4b95-ac89-e6f9e0bdda28" />

The Grafana Dashboard Icon is not displayed

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #4093 
## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
