### PR TITLE
Support for Volcano Network Topology Aware Scheduling

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -3,6 +3,7 @@ package volcano
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -24,8 +25,10 @@ import (
 )
 
 const (
-	PodGroupName      = "podgroups.scheduling.volcano.sh"
-	QueueNameLabelKey = "volcano.sh/queue-name"
+	PodGroupName                              = "podgroups.scheduling.volcano.sh"
+	QueueNameLabelKey                         = "volcano.sh/queue-name"
+	NetworkTopologyModeLabelKey               = "volcano.sh/network-topology-mode"
+	NetworkTopologyHighestTierAllowedLabelKey = "volcano.sh/network-topology-highest-tier-allowed"
 )
 
 type VolcanoBatchScheduler struct {
@@ -118,6 +121,18 @@ func createPodGroup(
 		Status: volcanov1beta1.PodGroupStatus{
 			Phase: volcanov1beta1.PodGroupPending,
 		},
+	}
+
+	mode, modeOk := app.ObjectMeta.Labels[NetworkTopologyModeLabelKey]
+	highestTier, tierOk := app.ObjectMeta.Labels[NetworkTopologyHighestTierAllowedLabelKey]
+	if modeOk && tierOk {
+		highestTierInt, err := strconv.Atoi(highestTier)
+		if err == nil {
+			podGroup.Spec.NetworkTopology = &volcanov1beta1.NetworkTopologySpec{
+				Mode:               volcanov1beta1.NetworkTopologyMode(mode),
+				HighestTierAllowed: &highestTierInt,
+			}
+		}
 	}
 
 	if queue, ok := app.ObjectMeta.Labels[QueueNameLabelKey]; ok {

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
@@ -128,4 +129,34 @@ func TestCreatePodGroup_NumOfHosts2(t *testing.T) {
 	// 2 GPUs * 2 (num of hosts) total
 	// 2 GPUs * 2 = 4 GPUs
 	a.Equal("4", pg.Spec.MinResources.Name("nvidia.com/gpu", resource.BinarySI).String())
+}
+
+func createTestRayClusterWithLabels(labels map[string]string) rayv1.RayCluster {
+	cluster := createTestRayCluster(1)
+	if cluster.ObjectMeta.Labels == nil {
+		cluster.ObjectMeta.Labels = make(map[string]string)
+	}
+	for k, v := range labels {
+		cluster.ObjectMeta.Labels[k] = v
+	}
+	return cluster
+}
+
+func TestCreatePodGroup_NetworkTopologyBothLabels(t *testing.T) {
+	a := assert.New(t)
+
+	// Test with both network topology mode and highest tier allowed
+	cluster := createTestRayClusterWithLabels(map[string]string{
+		NetworkTopologyModeLabelKey:               "soft",
+		NetworkTopologyHighestTierAllowedLabelKey: "3",
+	})
+
+	minMember := utils.CalculateDesiredReplicas(context.Background(), &cluster) + 1
+	totalResource := utils.CalculateDesiredResources(&cluster)
+	pg := createPodGroup(&cluster, getAppPodGroupName(&cluster), minMember, totalResource)
+
+	a.Equal(cluster.Namespace, pg.Namespace)
+	a.Equal(volcanov1beta1.NetworkTopologyMode("soft"), pg.Spec.NetworkTopology.Mode)
+	a.NotNil(pg.Spec.NetworkTopology.HighestTierAllowed)
+	a.Equal(3, *pg.Spec.NetworkTopology.HighestTierAllowed)
 }


### PR DESCRIPTION


## Why are these changes needed?
Support for Volcano Network Topology Aware Scheduling

## Test
Build a image and use this image for kuberay operator

Apply a raycluster with labels
```
apiVersion: ray.io/v1
kind: RayCluster
metadata:
  name: kwok-raycluster-h100-q21-low
  labels:
    ray.io/scheduler-name: volcano # must include this.
    volcano.sh/queue-name: queue2 # must include this.
    ray.io/priority-class-name: ml-tier1 # must include this.
    volcano.sh/network-topology-mode: hard
    volcano.sh/network-topology-highest-tier-allowed: "1"
.....
```

The volcano podgroup has the field injected

```
❯ kg pg -oyaml
apiVersion: v1
items:
- apiVersion: scheduling.volcano.sh/v1beta1
  kind: PodGroup
  metadata:
    annotations:
      volcano.sh/job-allocated-hypernode: hypernode-ad1
    creationTimestamp: "2025-09-30T22:40:12Z"
    generation: 3
    name: ray-kwok-raycluster-h100-q21-low-pg
    namespace: kuberay
.....
  spec:
    minMember: 10
    minResources:
      cpu: "80"
      memory: 80Gi
      nvidia.com/h100: "80"
    networkTopology:
      highestTierAllowed: 1 <--- 
      mode: hard <----- 
```



## Related issue number

[<!-- For example: "Closes #3641 " -->](https://github.com/ray-project/kuberay/issues/3641)

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [X] Manual tests
  - [ ] This PR is not tested :(
