### PR TITLE
Add top-level Labels and Resources Structed fields to `HeadGroupSpec` and `WorkerGroupSpec`

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -138,6 +138,7 @@ _Appears in:_
 | `template` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | Template is the exact pod template used in K8s deployments, statefulsets, etc. |  |  |
 | `headService` _[Service](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#service-v1-core)_ | HeadService is the Kubernetes service of the head pod. |  |  |
 | `enableIngress` _boolean_ | EnableIngress indicates whether operator should create ingress object for head service or not. |  |  |
+| `labels` _object (keys:string, values:string)_ | Labels specifies the Ray node labels for the head group.<br />These labels will also be added to the Pods of this head group. |  |  |
 | `rayStartParams` _object (keys:string, values:string)_ | RayStartParams are the params of the start command: node-manager-port, object-store-memory, ... |  |  |
 | `serviceType` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#servicetype-v1-core)_ | ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod |  |  |
 
@@ -417,6 +418,7 @@ _Appears in:_
 | `minReplicas` _integer_ | MinReplicas denotes the minimum number of desired Pods for this worker group. | 0 |  |
 | `maxReplicas` _integer_ | MaxReplicas denotes the maximum number of desired Pods for this worker group, and the default value is maxInt32. | 2147483647 |  |
 | `idleTimeoutSeconds` _integer_ | IdleTimeoutSeconds denotes the number of seconds to wait before the v2 autoscaler terminates an idle worker pod of this type.<br />This value is only used with the Ray Autoscaler enabled and defaults to the value set by the AutoscalingConfig if not specified for this worker group. |  |  |
+| `labels` _object (keys:string, values:string)_ | Labels specifies the Ray node labels for this worker group.<br />These labels will also be added to the Pods of this worker group. |  |  |
 | `rayStartParams` _object (keys:string, values:string)_ | RayStartParams are the params of the start command: address, object-store-memory, ... |  |  |
 | `template` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | Template is a pod template for the worker |  |  |
 | `scaleStrategy` _[ScaleStrategy](#scalestrategy)_ | ScaleStrategy defines which pods to remove |  |  |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -138,7 +138,7 @@ _Appears in:_
 | `template` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | Template is the exact pod template used in K8s deployments, statefulsets, etc. |  |  |
 | `headService` _[Service](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#service-v1-core)_ | HeadService is the Kubernetes service of the head pod. |  |  |
 | `enableIngress` _boolean_ | EnableIngress indicates whether operator should create ingress object for head service or not. |  |  |
-| `labels` _object (keys:string, values:string)_ | Labels specifies the Ray node labels for the head group.<br />These labels will also be added to the Pods of this head group. |  |  |
+| `labels` _object (keys:string, values:string)_ | Labels specifies the Ray node labels for the head group.<br />These labels will also be added to the Pods of this head group and override the `--labels`<br />argument passed to `rayStartParams`. |  |  |
 | `rayStartParams` _object (keys:string, values:string)_ | RayStartParams are the params of the start command: node-manager-port, object-store-memory, ... |  |  |
 | `serviceType` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#servicetype-v1-core)_ | ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod |  |  |
 
@@ -418,7 +418,7 @@ _Appears in:_
 | `minReplicas` _integer_ | MinReplicas denotes the minimum number of desired Pods for this worker group. | 0 |  |
 | `maxReplicas` _integer_ | MaxReplicas denotes the maximum number of desired Pods for this worker group, and the default value is maxInt32. | 2147483647 |  |
 | `idleTimeoutSeconds` _integer_ | IdleTimeoutSeconds denotes the number of seconds to wait before the v2 autoscaler terminates an idle worker pod of this type.<br />This value is only used with the Ray Autoscaler enabled and defaults to the value set by the AutoscalingConfig if not specified for this worker group. |  |  |
-| `labels` _object (keys:string, values:string)_ | Labels specifies the Ray node labels for this worker group.<br />These labels will also be added to the Pods of this worker group. |  |  |
+| `labels` _object (keys:string, values:string)_ | Labels specifies the Ray node labels for this worker group.<br />These labels will also be added to the Pods of this worker group and override the `--labels`<br />argument passed to `rayStartParams`. |  |  |
 | `rayStartParams` _object (keys:string, values:string)_ | RayStartParams are the params of the start command: address, object-store-memory, ... |  |  |
 | `template` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | Template is a pod template for the worker |  |  |
 | `scaleStrategy` _[ScaleStrategy](#scalestrategy)_ | ScaleStrategy defines which pods to remove |  |  |

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -631,9 +631,21 @@ spec:
                             type: object
                         type: object
                     type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   rayStartParams:
                     additionalProperties:
                       type: string
+                    type: object
+                  resources:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     type: object
                   serviceType:
                     type: string
@@ -4332,6 +4344,10 @@ spec:
                     idleTimeoutSeconds:
                       format: int32
                       type: integer
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     maxReplicas:
                       default: 2147483647
                       format: int32
@@ -4352,6 +4368,14 @@ spec:
                       default: 0
                       format: int32
                       type: integer
+                    resources:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
                     scaleStrategy:
                       properties:
                         workersToDelete:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -681,9 +681,21 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       rayStartParams:
                         additionalProperties:
                           type: string
+                        type: object
+                      resources:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         type: object
                       serviceType:
                         type: string
@@ -4382,6 +4394,10 @@ spec:
                         idleTimeoutSeconds:
                           format: int32
                           type: integer
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
                         maxReplicas:
                           default: 2147483647
                           format: int32
@@ -4402,6 +4418,14 @@ spec:
                           default: 0
                           format: int32
                           type: integer
+                        resources:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
                         scaleStrategy:
                           properties:
                             workersToDelete:

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -611,9 +611,21 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       rayStartParams:
                         additionalProperties:
                           type: string
+                        type: object
+                      resources:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         type: object
                       serviceType:
                         type: string
@@ -4312,6 +4324,10 @@ spec:
                         idleTimeoutSeconds:
                           format: int32
                           type: integer
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
                         maxReplicas:
                           default: 2147483647
                           format: int32
@@ -4332,6 +4348,14 @@ spec:
                           default: 0
                           format: int32
                           type: integer
+                        resources:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
                         scaleStrategy:
                           properties:
                             workersToDelete:

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -76,10 +76,12 @@ type HeadGroupSpec struct {
 	// +optional
 	EnableIngress *bool `json:"enableIngress,omitempty"`
 	// Resources specifies the resource quantities for the head group.
+	// These values override the resources passed to `rayStartParams` for the group.
 	// +optional
 	Resources corev1.ResourceList `json:"resources,omitempty"`
 	// Labels specifies the Ray node labels for the head group.
-	// These labels will also be added to the Pods of this head group.
+	// These labels will also be added to the Pods of this head group and override the `--labels`
+	// argument passed to `rayStartParams`.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
@@ -114,10 +116,12 @@ type WorkerGroupSpec struct {
 	// +optional
 	IdleTimeoutSeconds *int32 `json:"idleTimeoutSeconds,omitempty"`
 	// Resources specifies the resource quantities for this worker group.
+	// These values override the resources passed to `rayStartParams` for the group.
 	// +optional
 	Resources corev1.ResourceList `json:"resources,omitempty"`
 	// Labels specifies the Ray node labels for this worker group.
-	// These labels will also be added to the Pods of this worker group.
+	// These labels will also be added to the Pods of this worker group and override the `--labels`
+	// argument passed to `rayStartParams`.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 	// RayStartParams are the params of the start command: address, object-store-memory, ...

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -75,6 +75,13 @@ type HeadGroupSpec struct {
 	// EnableIngress indicates whether operator should create ingress object for head service or not.
 	// +optional
 	EnableIngress *bool `json:"enableIngress,omitempty"`
+	// Resources specifies the resource quantities for the head group.
+	// +optional
+	Resources corev1.ResourceList `json:"resources,omitempty"`
+	// Labels specifies the Ray node labels for the head group.
+	// These labels will also be added to the Pods of this head group.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
 	// RayStartParams are the params of the start command: node-manager-port, object-store-memory, ...
 	// +optional
 	RayStartParams map[string]string `json:"rayStartParams"`
@@ -106,6 +113,13 @@ type WorkerGroupSpec struct {
 	// This value is only used with the Ray Autoscaler enabled and defaults to the value set by the AutoscalingConfig if not specified for this worker group.
 	// +optional
 	IdleTimeoutSeconds *int32 `json:"idleTimeoutSeconds,omitempty"`
+	// Resources specifies the resource quantities for this worker group.
+	// +optional
+	Resources corev1.ResourceList `json:"resources,omitempty"`
+	// Labels specifies the Ray node labels for this worker group.
+	// These labels will also be added to the Pods of this worker group.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
 	// RayStartParams are the params of the start command: address, object-store-memory, ...
 	// +optional
 	RayStartParams map[string]string `json:"rayStartParams"`

--- a/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
@@ -179,6 +179,20 @@ func (in *HeadGroupSpec) DeepCopyInto(out *HeadGroupSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = make(corev1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.RayStartParams != nil {
 		in, out := &in.RayStartParams, &out.RayStartParams
 		*out = make(map[string]string, len(*in))
@@ -826,6 +840,20 @@ func (in *WorkerGroupSpec) DeepCopyInto(out *WorkerGroupSpec) {
 		in, out := &in.IdleTimeoutSeconds, &out.IdleTimeoutSeconds
 		*out = new(int32)
 		**out = **in
+	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = make(corev1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.RayStartParams != nil {
 		in, out := &in.RayStartParams, &out.RayStartParams

--- a/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayclusters.yaml
@@ -631,9 +631,21 @@ spec:
                             type: object
                         type: object
                     type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   rayStartParams:
                     additionalProperties:
                       type: string
+                    type: object
+                  resources:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
                     type: object
                   serviceType:
                     type: string
@@ -4332,6 +4344,10 @@ spec:
                     idleTimeoutSeconds:
                       format: int32
                       type: integer
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     maxReplicas:
                       default: 2147483647
                       format: int32
@@ -4352,6 +4368,14 @@ spec:
                       default: 0
                       format: int32
                       type: integer
+                    resources:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
                     scaleStrategy:
                       properties:
                         workersToDelete:

--- a/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayjobs.yaml
@@ -681,9 +681,21 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       rayStartParams:
                         additionalProperties:
                           type: string
+                        type: object
+                      resources:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         type: object
                       serviceType:
                         type: string
@@ -4382,6 +4394,10 @@ spec:
                         idleTimeoutSeconds:
                           format: int32
                           type: integer
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
                         maxReplicas:
                           default: 2147483647
                           format: int32
@@ -4402,6 +4418,14 @@ spec:
                           default: 0
                           format: int32
                           type: integer
+                        resources:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
                         scaleStrategy:
                           properties:
                             workersToDelete:

--- a/ray-operator/config/crd/bases/ray.io_rayservices.yaml
+++ b/ray-operator/config/crd/bases/ray.io_rayservices.yaml
@@ -611,9 +611,21 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       rayStartParams:
                         additionalProperties:
                           type: string
+                        type: object
+                      resources:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         type: object
                       serviceType:
                         type: string
@@ -4312,6 +4324,10 @@ spec:
                         idleTimeoutSeconds:
                           format: int32
                           type: integer
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
                         maxReplicas:
                           default: 2147483647
                           format: int32
@@ -4332,6 +4348,14 @@ spec:
                           default: 0
                           format: int32
                           type: integer
+                        resources:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
                         scaleStrategy:
                           properties:
                             workersToDelete:

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -1051,13 +1051,15 @@ func createPodSpec(cpu, memory string) corev1.PodSpec {
 
 func createRayClusterTemplate(
 	head struct {
-		cpu    string
-		memory string
+		resources corev1.ResourceList
+		cpu       string
+		memory    string
 	},
 	workers []struct {
 		replicas    *int32
 		minReplicas *int32
 		suspend     *bool
+		resources   corev1.ResourceList
 		cpu         string
 		memory      string
 		numOfHosts  int32
@@ -1066,6 +1068,7 @@ func createRayClusterTemplate(
 	cluster := &rayv1.RayCluster{
 		Spec: rayv1.RayClusterSpec{
 			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Resources: head.resources,
 				Template: corev1.PodTemplateSpec{
 					Spec: createPodSpec(head.cpu, head.memory),
 				},
@@ -1079,6 +1082,7 @@ func createRayClusterTemplate(
 			Replicas:    w.replicas,
 			MinReplicas: w.minReplicas,
 			Suspend:     w.suspend,
+			Resources:   w.resources,
 			Template: corev1.PodTemplateSpec{
 				Spec: createPodSpec(w.cpu, w.memory),
 			},
@@ -1090,8 +1094,9 @@ func createRayClusterTemplate(
 
 func TestCalculateResources(t *testing.T) {
 	headStruct := struct {
-		cpu    string
-		memory string
+		resources corev1.ResourceList
+		cpu       string
+		memory    string
 	}{
 		cpu:    "1",
 		memory: "100Mi",
@@ -1128,6 +1133,7 @@ func TestCalculateResources(t *testing.T) {
 				replicas    *int32
 				minReplicas *int32
 				suspend     *bool
+				resources   corev1.ResourceList
 				cpu         string
 				memory      string
 				numOfHosts  int32
@@ -1161,6 +1167,7 @@ func TestCalculateResources(t *testing.T) {
 				replicas    *int32
 				minReplicas *int32
 				suspend     *bool
+				resources   corev1.ResourceList
 				cpu         string
 				memory      string
 				numOfHosts  int32
@@ -1202,6 +1209,7 @@ func TestCalculateResources(t *testing.T) {
 				replicas    *int32
 				minReplicas *int32
 				suspend     *bool
+				resources   corev1.ResourceList
 				cpu         string
 				memory      string
 				numOfHosts  int32
@@ -1226,6 +1234,96 @@ func TestCalculateResources(t *testing.T) {
 				minResources: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
+		{
+			name: "Top-level Head Resources should take precedence",
+			cluster: createRayClusterTemplate(
+				struct {
+					resources corev1.ResourceList
+					cpu       string
+					memory    string
+				}{
+					cpu:    "1",
+					memory: "100Mi",
+					resources: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("5"),
+						corev1.ResourceMemory: resource.MustParse("500Mi"),
+					},
+				},
+				[]struct {
+					replicas    *int32
+					minReplicas *int32
+					suspend     *bool
+					resources   corev1.ResourceList
+					cpu         string
+					memory      string
+					numOfHosts  int32
+				}{
+					{
+						numOfHosts:  1,
+						replicas:    ptr.To[int32](2),
+						minReplicas: ptr.To[int32](1),
+						cpu:         "1",
+						memory:      "1Gi",
+					},
+				},
+			),
+			expected: struct {
+				desiredResources corev1.ResourceList
+				minResources     corev1.ResourceList
+			}{
+				desiredResources: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("7"),
+					corev1.ResourceMemory: resource.MustParse("2548Mi"),
+				},
+				minResources: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("6"),
+					corev1.ResourceMemory: resource.MustParse("1524Mi"),
+				},
+			},
+		},
+		{
+			name: "Top-level Worker Resources should take precedence",
+			cluster: createRayClusterTemplate(
+				headStruct,
+				[]struct {
+					replicas    *int32
+					minReplicas *int32
+					suspend     *bool
+					resources   corev1.ResourceList
+					cpu         string
+					memory      string
+					numOfHosts  int32
+				}{
+					{
+						numOfHosts:  1,
+						replicas:    ptr.To[int32](3),
+						minReplicas: ptr.To[int32](2),
+						cpu:         "1",
+						memory:      "1Gi",
+						resources: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+							"TPU":                 resource.MustParse("4"),
+						},
+					},
+				},
+			),
+			expected: struct {
+				desiredResources corev1.ResourceList
+				minResources     corev1.ResourceList
+			}{
+				desiredResources: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("13"),
+					corev1.ResourceMemory: resource.MustParse("12388Mi"),
+					"TPU":                 resource.MustParse("12"),
+				},
+				minResources: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("9"),
+					corev1.ResourceMemory: resource.MustParse("8292Mi"),
+					"TPU":                 resource.MustParse("8"),
 				},
 			},
 		},

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/headgroupspec.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/headgroupspec.go
@@ -13,6 +13,8 @@ type HeadGroupSpecApplyConfiguration struct {
 	Template       *corev1.PodTemplateSpecApplyConfiguration `json:"template,omitempty"`
 	HeadService    *apicorev1.Service                        `json:"headService,omitempty"`
 	EnableIngress  *bool                                     `json:"enableIngress,omitempty"`
+	Resources      *apicorev1.ResourceList                   `json:"resources,omitempty"`
+	Labels         map[string]string                         `json:"labels,omitempty"`
 	RayStartParams map[string]string                         `json:"rayStartParams,omitempty"`
 	ServiceType    *apicorev1.ServiceType                    `json:"serviceType,omitempty"`
 }
@@ -44,6 +46,28 @@ func (b *HeadGroupSpecApplyConfiguration) WithHeadService(value apicorev1.Servic
 // If called multiple times, the EnableIngress field is set to the value of the last call.
 func (b *HeadGroupSpecApplyConfiguration) WithEnableIngress(value bool) *HeadGroupSpecApplyConfiguration {
 	b.EnableIngress = &value
+	return b
+}
+
+// WithResources sets the Resources field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Resources field is set to the value of the last call.
+func (b *HeadGroupSpecApplyConfiguration) WithResources(value apicorev1.ResourceList) *HeadGroupSpecApplyConfiguration {
+	b.Resources = &value
+	return b
+}
+
+// WithLabels puts the entries into the Labels field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the entries provided by each call will be put on the Labels field,
+// overwriting an existing map entries in Labels field with the same key.
+func (b *HeadGroupSpecApplyConfiguration) WithLabels(entries map[string]string) *HeadGroupSpecApplyConfiguration {
+	if b.Labels == nil && len(entries) > 0 {
+		b.Labels = make(map[string]string, len(entries))
+	}
+	for k, v := range entries {
+		b.Labels[k] = v
+	}
 	return b
 }
 

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/workergroupspec.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/workergroupspec.go
@@ -3,22 +3,25 @@
 package v1
 
 import (
-	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	applyconfigurationscorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
 // WorkerGroupSpecApplyConfiguration represents a declarative configuration of the WorkerGroupSpec type for use
 // with apply.
 type WorkerGroupSpecApplyConfiguration struct {
-	Suspend            *bool                                     `json:"suspend,omitempty"`
-	GroupName          *string                                   `json:"groupName,omitempty"`
-	Replicas           *int32                                    `json:"replicas,omitempty"`
-	MinReplicas        *int32                                    `json:"minReplicas,omitempty"`
-	MaxReplicas        *int32                                    `json:"maxReplicas,omitempty"`
-	IdleTimeoutSeconds *int32                                    `json:"idleTimeoutSeconds,omitempty"`
-	RayStartParams     map[string]string                         `json:"rayStartParams,omitempty"`
-	Template           *corev1.PodTemplateSpecApplyConfiguration `json:"template,omitempty"`
-	ScaleStrategy      *ScaleStrategyApplyConfiguration          `json:"scaleStrategy,omitempty"`
-	NumOfHosts         *int32                                    `json:"numOfHosts,omitempty"`
+	Suspend            *bool                                                        `json:"suspend,omitempty"`
+	GroupName          *string                                                      `json:"groupName,omitempty"`
+	Replicas           *int32                                                       `json:"replicas,omitempty"`
+	MinReplicas        *int32                                                       `json:"minReplicas,omitempty"`
+	MaxReplicas        *int32                                                       `json:"maxReplicas,omitempty"`
+	IdleTimeoutSeconds *int32                                                       `json:"idleTimeoutSeconds,omitempty"`
+	Resources          *corev1.ResourceList                                         `json:"resources,omitempty"`
+	Labels             map[string]string                                            `json:"labels,omitempty"`
+	RayStartParams     map[string]string                                            `json:"rayStartParams,omitempty"`
+	Template           *applyconfigurationscorev1.PodTemplateSpecApplyConfiguration `json:"template,omitempty"`
+	ScaleStrategy      *ScaleStrategyApplyConfiguration                             `json:"scaleStrategy,omitempty"`
+	NumOfHosts         *int32                                                       `json:"numOfHosts,omitempty"`
 }
 
 // WorkerGroupSpecApplyConfiguration constructs a declarative configuration of the WorkerGroupSpec type for use with
@@ -75,6 +78,28 @@ func (b *WorkerGroupSpecApplyConfiguration) WithIdleTimeoutSeconds(value int32) 
 	return b
 }
 
+// WithResources sets the Resources field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Resources field is set to the value of the last call.
+func (b *WorkerGroupSpecApplyConfiguration) WithResources(value corev1.ResourceList) *WorkerGroupSpecApplyConfiguration {
+	b.Resources = &value
+	return b
+}
+
+// WithLabels puts the entries into the Labels field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the entries provided by each call will be put on the Labels field,
+// overwriting an existing map entries in Labels field with the same key.
+func (b *WorkerGroupSpecApplyConfiguration) WithLabels(entries map[string]string) *WorkerGroupSpecApplyConfiguration {
+	if b.Labels == nil && len(entries) > 0 {
+		b.Labels = make(map[string]string, len(entries))
+	}
+	for k, v := range entries {
+		b.Labels[k] = v
+	}
+	return b
+}
+
 // WithRayStartParams puts the entries into the RayStartParams field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the RayStartParams field,
@@ -92,7 +117,7 @@ func (b *WorkerGroupSpecApplyConfiguration) WithRayStartParams(entries map[strin
 // WithTemplate sets the Template field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Template field is set to the value of the last call.
-func (b *WorkerGroupSpecApplyConfiguration) WithTemplate(value *corev1.PodTemplateSpecApplyConfiguration) *WorkerGroupSpecApplyConfiguration {
+func (b *WorkerGroupSpecApplyConfiguration) WithTemplate(value *applyconfigurationscorev1.PodTemplateSpecApplyConfiguration) *WorkerGroupSpecApplyConfiguration {
 	b.Template = value
 	return b
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR lifts both resources and labels into explicit structured fields for the `HeadGroupSpec` and `WorkerGroupSpec`. When these optional fields are specified, they override their respective values in the `rayStartCommand` for Pods created by KubeRay for that group. Additionally, labels specified at the top-level `Labels` field are merged with the K8s labels on the Pod for observability.

The discussion and rationale for this change is discussed more in https://github.com/ray-project/kuberay/pull/3699.

## Related issue number

Conributes to https://github.com/ray-project/ray/issues/51564

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
