### PR TITLE
[Fix] [KubeRay Dashboard] The current filter status is not shown in the status filter 

### DIFF
--- a/dashboard/src/components/ClearableSelect.tsx
+++ b/dashboard/src/components/ClearableSelect.tsx
@@ -5,10 +5,9 @@ import Select, { SelectProps, SelectStaticProps } from "@mui/joy/Select";
 import React from "react";
 
 // ClearableSelect is a single select component that offers a clear button
-export default function ClearableSelect<
-  OptionValue extends object,
-  D extends React.ElementType = "button",
->(props: SelectProps<OptionValue, false, D>) {
+export default function ClearableSelect<D extends React.ElementType = "button">(
+  props: SelectProps<string, false, D>,
+) {
   const action: SelectStaticProps["action"] = React.useRef(null);
   return (
     <Select

--- a/dashboard/src/components/FrontendTable/FrontendTableToolbar.tsx
+++ b/dashboard/src/components/FrontendTable/FrontendTableToolbar.tsx
@@ -58,7 +58,7 @@ export const FrontendTableToolbar: React.FC<FrontendTableToolbarProps> = ({
           size="sm"
           placeholder="Filter by status"
           slotProps={{ button: { sx: { whiteSpace: "nowrap" } } }}
-          value={statusFilter ? { value: statusFilter } : null}
+          value={statusFilter}
           onChange={(e, newValue) => setStatusFilter(newValue)}
         >
           {statuses.map((status, index) => (


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently, when selecting a filter status from the dropdown, the filtering works correctly but the selected status is not displayed as the current filter.

## Manual Testing
Launch the frontend and api server
```console
$ go run cmd/main.go -httpPortFlag :31888 -cors-allow-origin=*

$ yarn dev
```
### Ray Cluster
<img width="1211" height="744" alt="image" src="https://github.com/user-attachments/assets/f6e6dc22-2bf3-42d5-9116-c49671e821d2" />

### RayJob
<img width="1277" height="446" alt="image" src="https://github.com/user-attachments/assets/1513f732-af63-4637-ba3a-2da64440e480" />


## Related issue number
Closes #4107 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [X] Manual tests
  - [ ] This PR is not tested :(
