### PR TITLE
wait ttl seconds added

### DIFF
--- a/apiserver/pkg/util/job.go
+++ b/apiserver/pkg/util/job.go
@@ -100,8 +100,8 @@ func NewRayJob(apiJob *api.RayJob, computeTemplateMap map[string]*api.ComputeTem
 		rayJob.Spec.ActiveDeadlineSeconds = &apiJob.ActiveDeadlineSeconds
 	}
 
-	if apiJob.WaitingTTLSeconds > 0 {
-		rayJob.Spec.WaitingTTLSeconds = &apiJob.WaitingTTLSeconds
+	if apiJob.WaitingTtlSeconds > 0 {
+		rayJob.Spec.WaitingTtlSeconds = &apiJob.WaitingTtlSeconds
 	}
 
 	return &RayJob{rayJob}, nil

--- a/apiserver/pkg/util/job.go
+++ b/apiserver/pkg/util/job.go
@@ -100,6 +100,10 @@ func NewRayJob(apiJob *api.RayJob, computeTemplateMap map[string]*api.ComputeTem
 		rayJob.Spec.ActiveDeadlineSeconds = &apiJob.ActiveDeadlineSeconds
 	}
 
+	if apiJob.WaitingTTLSeconds > 0 {
+		rayJob.Spec.WaitingTTLSeconds = &apiJob.WaitingTTLSeconds
+	}
+
 	return &RayJob{rayJob}, nil
 }
 

--- a/apiserver/pkg/util/job_test.go
+++ b/apiserver/pkg/util/job_test.go
@@ -21,6 +21,7 @@ var apiJobNewCluster = &api.RayJob{
 	ShutdownAfterJobFinishes: true,
 	ClusterSpec:              rayCluster.ClusterSpec,
 	ActiveDeadlineSeconds:    120,
+	WaitingTtlSeconds:        120,
 }
 
 var apiJobExistingCluster = &api.RayJob{

--- a/dashboard/src/types/v2/api/rayjob.ts
+++ b/dashboard/src/types/v2/api/rayjob.ts
@@ -21,6 +21,7 @@ type JobSubmissionMode =
 
 interface RayJobAPISpec extends RayJobSpec {
   activeDeadlineSeconds: number;
+  waitingTtlSeconds: number;
   backoffLimit: number;
   submitterConfig: SubmitterConfig;
   managedBy: string;

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -235,6 +235,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `activeDeadlineSeconds` _integer_ | ActiveDeadlineSeconds is the duration in seconds that the RayJob may be active before<br />KubeRay actively tries to terminate the RayJob; value must be positive integer. |  |  |
+| `ttlSecondsAfterFinished` _integer_ | TTLSecondsAfterFinished is the TTL to clean up RayCluster.<br />It's only working when ShutdownAfterJobFinishes set to true. |  |  |
 | `backoffLimit` _integer_ | Specifies the number of retries before marking this job failed.<br />Each retry creates a new RayCluster. | 0 |  |
 | `rayClusterSpec` _[RayClusterSpec](#rayclusterspec)_ | RayClusterSpec is the cluster template to run the job |  |  |
 | `submitterPodTemplate` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | SubmitterPodTemplate is the template for the pod that will run `ray job submit`. |  |  |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -235,7 +235,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `activeDeadlineSeconds` _integer_ | ActiveDeadlineSeconds is the duration in seconds that the RayJob may be active before<br />KubeRay actively tries to terminate the RayJob; value must be positive integer. |  |  |
-| `ttlSecondsAfterFinished` _integer_ | TTLSecondsAfterFinished is the TTL to clean up RayCluster.<br />It's only working when ShutdownAfterJobFinishes set to true. |  |  |
+| `waitingTtlSeconds` _integer_ | WaitingTtlSeconds is the TTL to clean up RayJob when it is waiting to be scheduled. |  |  |
 | `backoffLimit` _integer_ | Specifies the number of retries before marking this job failed.<br />Each retry creates a new RayCluster. | 0 |  |
 | `rayClusterSpec` _[RayClusterSpec](#rayclusterspec)_ | RayClusterSpec is the cluster template to run the job |  |  |
 | `submitterPodTemplate` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | SubmitterPodTemplate is the template for the pod that will run `ray job submit`. |  |  |

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -47,6 +47,9 @@ spec:
             type: object
           spec:
             properties:
+              waitingTtlSeconds:
+                format: int32
+                type: integer
               activeDeadlineSeconds:
                 format: int32
                 type: integer
@@ -710,6 +713,9 @@ spec:
                             type: object
                           spec:
                             properties:
+                              waitingTtlSeconds:
+                                format: int32
+                                type: integer
                               activeDeadlineSeconds:
                                 format: int64
                                 type: integer
@@ -4434,6 +4440,9 @@ spec:
                               type: object
                             spec:
                               properties:
+                                waitingTtlSeconds:
+                                  format: int32
+                                  type: integer
                                 activeDeadlineSeconds:
                                   format: int64
                                   type: integer
@@ -8125,6 +8134,9 @@ spec:
                     type: object
                   spec:
                     properties:
+                      waitingTtlSeconds:
+                        format: int32
+                        type: integer
                       activeDeadlineSeconds:
                         format: int64
                         type: integer
@@ -12433,6 +12445,9 @@ spec:
                             type: object
                           spec:
                             properties:
+                              waitingTtlSeconds:
+                                format: int32
+                                type: integer
                               activeDeadlineSeconds:
                                 format: int64
                                 type: integer
@@ -16141,6 +16156,9 @@ spec:
                               type: object
                             spec:
                               properties:
+                                waitingTtlSeconds:
+                                  format: int32
+                                  type: integer
                                 activeDeadlineSeconds:
                                   format: int64
                                   type: integer
@@ -19824,6 +19842,9 @@ spec:
                     type: object
                   spec:
                     properties:
+                      waitingTtlSeconds:
+                        format: int32
+                        type: integer
                       activeDeadlineSeconds:
                         format: int64
                         type: integer

--- a/proto/go_client/job.pb.go
+++ b/proto/go_client/job.pb.go
@@ -544,6 +544,8 @@ type RayJob struct {
 	// KubeRay actively tries to terminate the RayJob; value must be positive integer.
 	// If not set, the job may run indefinitely until it completes, fails, or is manually stopped.
 	ActiveDeadlineSeconds int32 `protobuf:"varint,25,opt,name=activeDeadlineSeconds,proto3" json:"activeDeadlineSeconds,omitempty"`
+	// Optional waitingTtlSeconds is the duration in seconds before RayJob must come into active state
+	WaitingTTLSeconds int32 `protobuf:"varint,60,opt,name=waiting_ttl_seconds,json=waitingTtlSeconds,proto3" json:"waiting_ttl_seconds,omitempty"`
 	// Output. The time that the job created.
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// Output. The time that the job deleted.
@@ -710,6 +712,14 @@ func (x *RayJob) GetActiveDeadlineSeconds() int32 {
 	if x != nil {
 		return x.ActiveDeadlineSeconds
 	}
+	return 0
+}
+
+func (x *RayJob) GetWaitingTTLSeconds() int32 {
+	if x != nil {
+		return x.WaitingTTLSeconds
+	}
+
 	return 0
 }
 

--- a/proto/go_client/job.pb.go
+++ b/proto/go_client/job.pb.go
@@ -545,7 +545,7 @@ type RayJob struct {
 	// If not set, the job may run indefinitely until it completes, fails, or is manually stopped.
 	ActiveDeadlineSeconds int32 `protobuf:"varint,25,opt,name=activeDeadlineSeconds,proto3" json:"activeDeadlineSeconds,omitempty"`
 	// Optional waitingTtlSeconds is the duration in seconds before RayJob must come into active state
-	WaitingTTLSeconds int32 `protobuf:"varint,60,opt,name=waiting_ttl_seconds,json=waitingTtlSeconds,proto3" json:"waiting_ttl_seconds,omitempty"`
+	WaitingTtlSeconds int32 `protobuf:"varint,60,opt,name=waiting_ttl_seconds,json=waitingTtlSeconds,proto3" json:"waiting_ttl_seconds,omitempty"`
 	// Output. The time that the job created.
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// Output. The time that the job deleted.
@@ -715,9 +715,13 @@ func (x *RayJob) GetActiveDeadlineSeconds() int32 {
 	return 0
 }
 
-func (x *RayJob) GetWaitingTTLSeconds() int32 {
+/* <<<<<<<<<<<<<<  ✨ Windsurf Command ⭐ >>>>>>>>>>>>>>>> */
+// GetWaitingTtlSeconds returns the waitingTtlSeconds of the Ray job.
+// If the ray job is nil, it returns 0.
+/* <<<<<<<<<<  ad50ff48-1fce-40c2-ab17-65e3badaee66  >>>>>>>>>>> */
+func (x *RayJob) GetWaitingTtlSeconds() int32 {
 	if x != nil {
-		return x.WaitingTTLSeconds
+		return x.WaitingTtlSeconds
 	}
 
 	return 0

--- a/proto/go_client/job.pb.go
+++ b/proto/go_client/job.pb.go
@@ -715,15 +715,12 @@ func (x *RayJob) GetActiveDeadlineSeconds() int32 {
 	return 0
 }
 
-/* <<<<<<<<<<<<<<  ✨ Windsurf Command ⭐ >>>>>>>>>>>>>>>> */
 // GetWaitingTtlSeconds returns the waitingTtlSeconds of the Ray job.
 // If the ray job is nil, it returns 0.
-/* <<<<<<<<<<  ad50ff48-1fce-40c2-ab17-65e3badaee66  >>>>>>>>>>> */
 func (x *RayJob) GetWaitingTtlSeconds() int32 {
 	if x != nil {
 		return x.WaitingTtlSeconds
 	}
-
 	return 0
 }
 

--- a/proto/job.proto
+++ b/proto/job.proto
@@ -166,6 +166,10 @@ message RayJob {
   // KubeRay actively tries to terminate the RayJob; value must be positive integer.
   // If not set, the job may run indefinitely until it completes, fails, or is manually stopped.
   int32 activeDeadlineSeconds = 25;
+  // Optional waitingTtlSeconds is the duration in seconds before RayJob must come into active state
+  // Kuberay will try to terminate the RayJob if job is not in active state before waitingTtlSeconds
+  // If not set, the job may run indefinitely until it comes to active state
+  int32 waitingTtlSeconds = 60;
   // Output. The time that the job created.
   google.protobuf.Timestamp created_at = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Output. The time that the job deleted.

--- a/proto/kuberay_api.swagger.json
+++ b/proto/kuberay_api.swagger.json
@@ -1949,6 +1949,11 @@
           "format": "int32",
           "description": "Optional activeDeadlineSeconds is the duration in seconds that the RayJob may be active before\nKubeRay actively tries to terminate the RayJob; value must be positive integer.\nIf not set, the job may run indefinitely until it completes, fails, or is manually stopped."
         },
+        "waitingTtlSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional waitingTtlSeconds is the TTL to clean up RayJob when it is waiting to be scheduled."
+        },
         "createdAt": {
           "type": "string",
           "format": "date-time",

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -73,6 +73,7 @@ type JobFailedReason string
 const (
 	SubmissionFailed                                 JobFailedReason = "SubmissionFailed"
 	DeadlineExceeded                                 JobFailedReason = "DeadlineExceeded"
+	JobDeploymentFailed                              JobFailedReason = "JobDeploymentFailed"
 	AppFailed                                        JobFailedReason = "AppFailed"
 	JobDeploymentStatusTransitionGracePeriodExceeded JobFailedReason = "JobDeploymentStatusTransitionGracePeriodExceeded"
 	ValidationFailed                                 JobFailedReason = "ValidationFailed"
@@ -129,6 +130,8 @@ type RayJobSpec struct {
 	// KubeRay actively tries to terminate the RayJob; value must be positive integer.
 	// +optional
 	ActiveDeadlineSeconds *int32 `json:"activeDeadlineSeconds,omitempty"`
+	// Time to wait for the job to come into a running state after the job is submitted.
+	WaitingTTLSeconds *int32 `json:"waitingTTLSeconds,omitempty"`
 	// Specifies the number of retries before marking this job failed.
 	// Each retry creates a new RayCluster.
 	// +kubebuilder:default:=0

--- a/ray-operator/apis/ray/v1/rayjob_types.go
+++ b/ray-operator/apis/ray/v1/rayjob_types.go
@@ -131,7 +131,7 @@ type RayJobSpec struct {
 	// +optional
 	ActiveDeadlineSeconds *int32 `json:"activeDeadlineSeconds,omitempty"`
 	// Time to wait for the job to come into a running state after the job is submitted.
-	WaitingTTLSeconds *int32 `json:"waitingTTLSeconds,omitempty"`
+	WaitingTtlSeconds *int32 `json:"waitingTtlSeconds,omitempty"`
 	// Specifies the number of retries before marking this job failed.
 	// Each retry creates a new RayCluster.
 	// +kubebuilder:default:=0

--- a/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
@@ -439,8 +439,8 @@ func (in *RayJobSpec) DeepCopyInto(out *RayJobSpec) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.WaitingTTLSeconds != nil {
-		in, out := &in.WaitingTTLSeconds, &out.WaitingTTLSeconds
+	if in.WaitingTtlSeconds != nil {
+		in, out := &in.WaitingTtlSeconds, &out.WaitingTtlSeconds
 		*out = new(int32)
 		**out = **in
 	}

--- a/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
+++ b/ray-operator/apis/ray/v1/zz_generated.deepcopy.go
@@ -439,6 +439,11 @@ func (in *RayJobSpec) DeepCopyInto(out *RayJobSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.WaitingTTLSeconds != nil {
+		in, out := &in.WaitingTTLSeconds, &out.WaitingTTLSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	if in.BackoffLimit != nil {
 		in, out := &in.BackoffLimit, &out.BackoffLimit
 		*out = new(int32)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -184,6 +184,10 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			break
 		}
 
+		if shouldUpdate := checkWaitingTtlSecondsAndUpdateStatusIfNeeded(ctx, rayJobInstance); shouldUpdate {
+			break
+		}
+
 		if r.options.BatchSchedulerManager != nil {
 			if scheduler, err := r.options.BatchSchedulerManager.GetScheduler(); err == nil {
 				if err := scheduler.DoBatchSchedulingOnSubmission(ctx, rayJobInstance); err != nil {
@@ -239,6 +243,10 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		}
 
 		if shouldUpdate := checkActiveDeadlineAndUpdateStatusIfNeeded(ctx, rayJobInstance); shouldUpdate {
+			break
+		}
+
+		if shouldUpdate := checkWaitingTtlSecondsAndUpdateStatusIfNeeded(ctx, rayJobInstance); shouldUpdate {
 			break
 		}
 
@@ -1157,6 +1165,19 @@ func checkActiveDeadlineAndUpdateStatusIfNeeded(ctx context.Context, rayJob *ray
 	rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
 	rayJob.Status.Reason = rayv1.DeadlineExceeded
 	rayJob.Status.Message = fmt.Sprintf("The RayJob has passed the activeDeadlineSeconds. StartTime: %v. ActiveDeadlineSeconds: %d", rayJob.Status.StartTime, *rayJob.Spec.ActiveDeadlineSeconds)
+	return true
+}
+
+func checkWaitingTtlSecondsAndUpdateStatusIfNeeded(ctx context.Context, rayJob *rayv1.RayJob) bool {
+	logger := ctrl.LoggerFrom(ctx)
+	if rayJob.Spec.WaitingTTLSeconds == nil || time.Now().Before(rayJob.Status.StartTime.Add(time.Duration(*rayJob.Spec.WaitingTTLSeconds)*time.Second)) {
+		return false
+	}
+
+	logger.Info("The RayJob has passed the waitingTTLSeconds. Transition the status to `Failed`.", "StartTime", rayJob.Status.StartTime, "WaitingTTLSeconds", *rayJob.Spec.WaitingTTLSeconds)
+	rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
+	rayJob.Status.Reason = rayv1.JobDeploymentFailed
+	rayJob.Status.Message = fmt.Sprintf("The RayJob has passed the waitingTTLSeconds. StartTime: %v. WaitingTTLSeconds: %d", rayJob.Status.StartTime, *rayJob.Spec.WaitingTTLSeconds)
 	return true
 }
 

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -1170,14 +1170,14 @@ func checkActiveDeadlineAndUpdateStatusIfNeeded(ctx context.Context, rayJob *ray
 
 func checkWaitingTtlSecondsAndUpdateStatusIfNeeded(ctx context.Context, rayJob *rayv1.RayJob) bool {
 	logger := ctrl.LoggerFrom(ctx)
-	if rayJob.Spec.WaitingTTLSeconds == nil || time.Now().Before(rayJob.Status.StartTime.Add(time.Duration(*rayJob.Spec.WaitingTTLSeconds)*time.Second)) {
+	if rayJob.Spec.WaitingTtlSeconds == nil || time.Now().Before(rayJob.Status.StartTime.Add(time.Duration(*rayJob.Spec.WaitingTtlSeconds)*time.Second)) {
 		return false
 	}
 
-	logger.Info("The RayJob has passed the waitingTTLSeconds. Transition the status to `Failed`.", "StartTime", rayJob.Status.StartTime, "WaitingTTLSeconds", *rayJob.Spec.WaitingTTLSeconds)
+	logger.Info("The RayJob has passed the waitingTTLSeconds. Transition the status to `Failed`.", "StartTime", rayJob.Status.StartTime, "WaitingTtlSeconds", *rayJob.Spec.WaitingTtlSeconds)
 	rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
 	rayJob.Status.Reason = rayv1.JobDeploymentFailed
-	rayJob.Status.Message = fmt.Sprintf("The RayJob has passed the waitingTTLSeconds. StartTime: %v. WaitingTTLSeconds: %d", rayJob.Status.StartTime, *rayJob.Spec.WaitingTTLSeconds)
+	rayJob.Status.Message = fmt.Sprintf("The RayJob has passed the waitingTTLSeconds. StartTime: %v. WaitingTtlSeconds: %d", rayJob.Status.StartTime, *rayJob.Spec.WaitingTtlSeconds)
 	return true
 }
 

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -221,6 +221,9 @@ func ValidateRayJobSpec(rayJob *rayv1.RayJob) error {
 	if rayJob.Spec.ActiveDeadlineSeconds != nil && *rayJob.Spec.ActiveDeadlineSeconds <= 0 {
 		return fmt.Errorf("The RayJob spec is invalid: activeDeadlineSeconds must be a positive integer")
 	}
+	if rayJob.Spec.WaitingTTLSeconds != nil && *rayJob.Spec.WaitingTTLSeconds <= 0 {
+		return fmt.Errorf("The RayJob spec is invalid: waitingTtlSeconds must be a positive integer")
+	}
 	if rayJob.Spec.BackoffLimit != nil && *rayJob.Spec.BackoffLimit < 0 {
 		return fmt.Errorf("The RayJob spec is invalid: backoffLimit must be a positive integer")
 	}

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -221,7 +221,7 @@ func ValidateRayJobSpec(rayJob *rayv1.RayJob) error {
 	if rayJob.Spec.ActiveDeadlineSeconds != nil && *rayJob.Spec.ActiveDeadlineSeconds <= 0 {
 		return fmt.Errorf("The RayJob spec is invalid: activeDeadlineSeconds must be a positive integer")
 	}
-	if rayJob.Spec.WaitingTTLSeconds != nil && *rayJob.Spec.WaitingTTLSeconds <= 0 {
+	if rayJob.Spec.WaitingTtlSeconds != nil && *rayJob.Spec.WaitingTtlSeconds <= 0 {
 		return fmt.Errorf("The RayJob spec is invalid: waitingTtlSeconds must be a positive integer")
 	}
 	if rayJob.Spec.BackoffLimit != nil && *rayJob.Spec.BackoffLimit < 0 {

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobspec.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobspec.go
@@ -11,6 +11,7 @@ import (
 // with apply.
 type RayJobSpecApplyConfiguration struct {
 	ActiveDeadlineSeconds    *int32                                    `json:"activeDeadlineSeconds,omitempty"`
+	WaitingTTLSeconds        *int32                                    `json:"waitingTtlSeconds,omitempty"`
 	BackoffLimit             *int32                                    `json:"backoffLimit,omitempty"`
 	RayClusterSpec           *RayClusterSpecApplyConfiguration         `json:"rayClusterSpec,omitempty"`
 	SubmitterPodTemplate     *corev1.PodTemplateSpecApplyConfiguration `json:"submitterPodTemplate,omitempty"`
@@ -42,6 +43,14 @@ func RayJobSpec() *RayJobSpecApplyConfiguration {
 // If called multiple times, the ActiveDeadlineSeconds field is set to the value of the last call.
 func (b *RayJobSpecApplyConfiguration) WithActiveDeadlineSeconds(value int32) *RayJobSpecApplyConfiguration {
 	b.ActiveDeadlineSeconds = &value
+	return b
+}
+
+// WithWaitingTTLSeconds sets the WithWaitingTTLSeconds field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the WithWaitingTTLSeconds field is set to the value of the last call.
+func (b *RayJobSpecApplyConfiguration) WithWaitingTTLSeconds(value int32) *RayJobSpecApplyConfiguration {
+	b.WaitingTTLSeconds = &value
 	return b
 }
 

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobspec.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayjobspec.go
@@ -11,7 +11,7 @@ import (
 // with apply.
 type RayJobSpecApplyConfiguration struct {
 	ActiveDeadlineSeconds    *int32                                    `json:"activeDeadlineSeconds,omitempty"`
-	WaitingTTLSeconds        *int32                                    `json:"waitingTtlSeconds,omitempty"`
+	WaitingTtlSeconds        *int32                                    `json:"waitingTtlSeconds,omitempty"`
 	BackoffLimit             *int32                                    `json:"backoffLimit,omitempty"`
 	RayClusterSpec           *RayClusterSpecApplyConfiguration         `json:"rayClusterSpec,omitempty"`
 	SubmitterPodTemplate     *corev1.PodTemplateSpecApplyConfiguration `json:"submitterPodTemplate,omitempty"`
@@ -46,11 +46,11 @@ func (b *RayJobSpecApplyConfiguration) WithActiveDeadlineSeconds(value int32) *R
 	return b
 }
 
-// WithWaitingTTLSeconds sets the WithWaitingTTLSeconds field in the declarative configuration to the given value
+// WithWaitingTtlSeconds sets the WithWaitingTtlSeconds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the WithWaitingTTLSeconds field is set to the value of the last call.
-func (b *RayJobSpecApplyConfiguration) WithWaitingTTLSeconds(value int32) *RayJobSpecApplyConfiguration {
-	b.WaitingTTLSeconds = &value
+// If called multiple times, the WithWaitingTtlSeconds field is set to the value of the last call.
+func (b *RayJobSpecApplyConfiguration) WithWaitingTtlSeconds(value int32) *RayJobSpecApplyConfiguration {
+	b.WaitingTtlSeconds = &value
 	return b
 }
 

--- a/ray-operator/test/e2erayjob/rayjob_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_test.go
@@ -274,7 +274,7 @@ env_vars:
 			To(WithTransform(RayJobReason, Equal(rayv1.DeadlineExceeded)))
 	})
 
-	test.T().Run("RayJob has passed WaitingTTLSeconds", func(_ *testing.T) {
+	test.T().Run("RayJob has passed WaitingTtlSeconds", func(_ *testing.T) {
 		rayJobAC := rayv1ac.RayJob("long-running", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithRayClusterSpec(NewRayClusterSpec(MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).
@@ -282,7 +282,7 @@ env_vars:
 				WithShutdownAfterJobFinishes(true).
 				WithTTLSecondsAfterFinished(600).
 				WithActiveDeadlineSeconds(5).
-				WithWaitingTTLSeconds(5).
+				WithWaitingTtlSeconds(2).
 				WithSubmitterPodTemplate(JobSubmitterPodTemplateApplyConfiguration()))
 
 		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
@@ -354,13 +354,13 @@ env_vars:
 				WithManagedBy("kueue.x-k8s.io/multikueue"))
 
 		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
-		g.Expect(err).NotTo(HaveOccurred())
+		//g.Expect(err).NotTo(HaveOccurred())
 		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
 		// Should not to be able to change managedBy field as it's immutable
 		rayJobAC.Spec.WithManagedBy(utils.KubeRayController)
 		_, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
-		g.Expect(err).To(HaveOccurred())
+		//g.Expect(err).To(HaveOccurred())
 		g.Eventually(RayJob(test, *rayJobAC.Namespace, *rayJobAC.Name)).
 			Should(WithTransform(RayJobManagedBy, Equal(ptr.To("kueue.x-k8s.io/multikueue"))))
 

--- a/ray-operator/test/e2erayjob/rayjob_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_test.go
@@ -354,13 +354,13 @@ env_vars:
 				WithManagedBy("kueue.x-k8s.io/multikueue"))
 
 		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
-		//g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred())
 		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
 		// Should not to be able to change managedBy field as it's immutable
 		rayJobAC.Spec.WithManagedBy(utils.KubeRayController)
 		_, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
-		//g.Expect(err).To(HaveOccurred())
+		g.Expect(err).To(HaveOccurred())
 		g.Eventually(RayJob(test, *rayJobAC.Namespace, *rayJobAC.Name)).
 			Should(WithTransform(RayJobManagedBy, Equal(ptr.To("kueue.x-k8s.io/multikueue"))))
 


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Added a param WaitingTtlSeconds to Ray job. WaitingTtlSeconds is the TTL to mark RayJob as failed when it is waiting to be scheduled.

## Related issue number

Closes #4037 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
