### PR TITLE
[Bug] [KubeRay DashBoard] RayJob table cannot get Ray Dashboard link in Pending status

### DIFF
--- a/dashboard/src/components/JobsTable/JobsTable.tsx
+++ b/dashboard/src/components/JobsTable/JobsTable.tsx
@@ -94,7 +94,7 @@ export const JobsTable = () => {
         </td>
         <td>{dayjs(row.createdAt).format("M/D/YY HH:mm:ss")}</td>
         <td className="flex">
-          {
+          {row.links.rayHeadDashboardLink && (
             <IconButton
               variant="plain"
               size="sm"
@@ -112,7 +112,7 @@ export const JobsTable = () => {
                 width={26}
               />
             </IconButton>
-          }
+          )}
           {row.links.rayGrafanaDashboardLink && (
             <IconButton
               variant="plain"
@@ -130,31 +130,33 @@ export const JobsTable = () => {
               <Image priority src={GrafanaIcon} alt="Grafana Metrics" />
             </IconButton>
           )}
-          <IconButton
-            variant="plain"
-            size="sm"
-            sx={{
-              minHeight: "1rem",
-              minWidth: "1rem",
-              px: 0.6,
-            }}
-            title="Loki Logs"
-            href={row.links.logsLink}
-            target="_blank"
-            component="a"
-          >
-            <Typography
+          {row.links.logsLink && (
+            <IconButton
+              variant="plain"
+              size="sm"
               sx={{
-                fontFamily: "monospace",
-                letterSpacing: -0.9,
-                fontSize: "small",
-                color: "#0b6bcb",
-                textDecoration: "underline",
+                minHeight: "1rem",
+                minWidth: "1rem",
+                px: 0.6,
               }}
+              title="Loki Logs"
+              href={row.links.logsLink}
+              target="_blank"
+              component="a"
             >
-              Logs
-            </Typography>
-          </IconButton>
+              <Typography
+                sx={{
+                  fontFamily: "monospace",
+                  letterSpacing: -0.9,
+                  fontSize: "small",
+                  color: "#0b6bcb",
+                  textDecoration: "underline",
+                }}
+              >
+                Logs
+              </Typography>
+            </IconButton>
+          )}
         </td>
         <td className="truncate">
           <Tooltip variant="outlined" title={row.message}>

--- a/dashboard/src/hooks/api/useListJobs.ts
+++ b/dashboard/src/hooks/api/useListJobs.ts
@@ -50,10 +50,8 @@ const convertRayJobItemToJobRow = (item: RayJobItem): JobRow => {
       item.spec.rayClusterSpec.headGroupSpec?.template?.spec?.containers?.[0].ports?.find(
         (port) => port.name === "dashboard",
       )?.containerPort;
-    if (!dashboardPort || !config.coreApiUrl) {
-      return {
-        rayHeadDashboardLink: "",
-      };
+    if (!serviceName || !dashboardPort || !config.coreApiUrl) {
+      return {};
     }
     const rayHeadDashboardLink = `${config.coreApiUrl}/namespaces/${namespace}/services/${serviceName}:${dashboardPort}/proxy/#/jobs`;
     const rayJobId = item.status?.jobId;

--- a/dashboard/src/types/table.ts
+++ b/dashboard/src/types/table.ts
@@ -44,7 +44,7 @@ export interface JobRow {
   createdAt: Date;
   message: string;
   links: {
-    rayHeadDashboardLink: string;
+    rayHeadDashboardLink?: string;
     rayGrafanaDashboardLink?: string;
     logsLink?: string;
   };


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Ray head service is not created while a RayJob is Pending, so the Ray Dashboard URL cannot be constructed. The UI showed buttons with empty/broken links, leading to a confusing UX.

<!-- Please give a short summary of the change and the problem this solves. -->

- Require `serviceName`, `dashboardPort`, and `coreApiUrl` before building the dashboard link.
- Make `rayHeadDashboardLink` optional.
- Conditionally render the Ray Dashboard icon only when `rayHeadDashboardLink` exists.
- Conditionally render the Logs button only when `logsLink` exists.

## Manual Testing
Launch API server and frontend server
```console
$ go run cmd/main.go -httpPortFlag :31888 -cors-allow-origin=*

$ yarn dev
```
Create a new Rayjob 
<img width="2509" height="726" alt="image" src="https://github.com/user-attachments/assets/9a09b48d-7b62-4a3c-bfd0-a8554e3bc110" />


## Related issue number
Closes #4121 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [X] Manual tests
  - [ ] This PR is not tested :(
