### PR TITLE
fix: fix too short timeout causing cascading failures

### DIFF
--- a/ray-operator/config/samples/ray-cluster.auth.yaml
+++ b/ray-operator/config/samples/ray-cluster.auth.yaml
@@ -79,7 +79,7 @@ spec:
               command:
               - bash
               - -c
-              - wget -T 2 -q -O- http://localhost:52365/api/local_raylet_healthz | grep success && wget -T 10 -q -O- http://localhost:8443/api/gcs_healthz | grep success
+              - wget -T 10 -q -O- http://localhost:52365/api/local_raylet_healthz | grep success && wget -T 10 -q -O- http://localhost:8443/api/gcs_healthz | grep success
             failureThreshold: 10
             initialDelaySeconds: 10
             periodSeconds: 5
@@ -90,7 +90,7 @@ spec:
               command:
               - bash
               - -c
-              - wget -T 2 -q -O- http://localhost:52365/api/local_raylet_healthz | grep success && wget -T 10 -q -O- http://localhost:8443/api/gcs_healthz | grep success
+              - wget -T 10 -q -O- http://localhost:52365/api/local_raylet_healthz | grep success && wget -T 10 -q -O- http://localhost:8443/api/gcs_healthz | grep success
             failureThreshold: 120
             initialDelaySeconds: 30
             periodSeconds: 5


### PR DESCRIPTION
## Why are these changes needed?

Hello, 

The 2 second timeout on liveness probes it way too short. it is causing cascading failures when the container is busy and cannot reply immediately. this is especially bad if you have cpu limits configured on the ray pods, which restricts how much cpu the container can use.

In addition to that, TCP takes 2-3 seconds to detect a lost packet and retry. You should NEVER have a timeout below 5 seconds in any production software.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [X] This PR is not tested in CI (hopefully your test suite will run once the PR is opened ? :) )
  - [X] This PR has been tested in production

