### PR TITLE
[Bug] [KubeRay Dashboard] Misclassifies RayCluster type

### DIFF
--- a/dashboard/src/utils/v2/filter.ts
+++ b/dashboard/src/utils/v2/filter.ts
@@ -79,10 +79,14 @@ export const filterCluster = (
 };
 
 export const clusterIsRayJob = (cluster: ClusterRow): boolean => {
-  if (!cluster.labels) {
-    return false;
+  // Prefer official KubeRay label to determine whether a RayCluster originates from a RayJob
+  const labels = cluster.labels || {};
+  const originatedFrom = labels["ray.io/originated-from-crd"];
+  if (originatedFrom?.toLowerCase() === "rayjob") {
+    return true;
   }
 
-  const jobType = cluster.labels["mlp.rbx.com/component"];
-  return jobType === "rayjob" || jobType === "rayllmbatchinference";
+  // Backward compatibility: support legacy custom labels if present
+  const comp = labels["mlp.rbx.com/component"];
+  return comp === "rayjob" || comp === "rayllmbatchinference";
 };


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The dashboard function `clusterIsRayJob` (dashboard/src/utils/v2/filter.ts) relies on the legacy custom label `mlp.rbx.com/component` to detect RayJob-originated clusters. As a result, RayJob-created clusters that only include the official KubeRay label `ray.io/originated-from-crd=RayJob` are not recognized as RayJobs in the UI.

<!-- Please give a short summary of the change and the problem this solves. -->
Update `clusterIsRayJob` to:
- Check `labels["ray.io/originated-from-crd"] === "RayJob"` (case-insensitive).
- Fall back to `mlp.rbx.com/component` for legacy environments.

## Manual Testing
Launch API server and frontend server
```console
$ go run cmd/main.go -httpPortFlag :31888 -cors-allow-origin=*

$ yarn dev
```
Create only RayCluster
```bash
$ k apply -f ray-operator/config/samples/ray-cluster.sample.yaml
```

Create RayCluster + RayJob
```bash
$ k apply -f ray-operator/config/samples/ray-job.sample.yaml
```

RayCluster - all
<img width="2153" height="915" alt="image" src="https://github.com/user-attachments/assets/c7deabba-b934-4070-b7b1-3268c8426afd" />

RayCluster - Cluster
<img width="2168" height="609" alt="image" src="https://github.com/user-attachments/assets/83bcafbb-e25e-4211-9a9b-a4dfa9688649" />

RayCluster - Job
<img width="2151" height="714" alt="image" src="https://github.com/user-attachments/assets/f42e01c9-1711-493e-b019-99b30e476b2b" />


## Related issue number
Closes #4134 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
