### PR TITLE
[RayCluster] Fix for multi-host indexing worker creation

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -915,7 +915,7 @@ func (r *RayClusterReconciler) reconcileMultiHostWorkerGroup(ctx context.Context
 		for i := 0; i < replicasToCreate; i++ {
 			replicaName := utils.GenerateRayWorkerReplicaGroupName(worker.GroupName)
 			for j := 0; j < int(worker.NumOfHosts); j++ {
-				if err := r.createWorkerPodWithIndex(ctx, *instance, *worker, replicaName, j); err != nil {
+				if err := r.createWorkerPodWithIndex(ctx, *instance, *worker.DeepCopy(), replicaName, j); err != nil {
 					return errstd.Join(utils.ErrFailedCreateWorkerPod, err)
 				}
 			}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Worker pods won't be properly created when multi-host indexing is enabled. Resources like volume mounts aren't properly added during creation.

Example error:
```
"error":"FailedCreateWorkerPod\nPod \"ray-tpu-multihost-cluster-tpu-group-worker-dqb9m\" is invalid: [ spec.containers[ 0 ] .volumeMounts[ 0 ] .name: Not found: \"shared-mem\", spec.initContainers[ 0 ] .volumeMounts[ 0 ] .name: Not found: \"shared-mem\"]" }
```
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
