### PR TITLE
[Chore] Remove duplicate `test-e2e-rayservice` in Makefile

### DIFF
--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -88,7 +88,7 @@ test-e2e-incremental-upgrade: manifests fmt vet ## Run e2e RayService incrementa
 	go test -timeout 30m -v $(WHAT)
 
 test-e2e-rayjob-submitter: WHAT ?= ./test/e2erayjobsubmitter
-test-e2e-rayjob-submitter: manifests fmt vet ## Run e2e tests.
+test-e2e-rayjob-submitter: manifests fmt vet ## Run e2e light weight submitter tests.
 	go test -timeout 30m -v $(WHAT)
 
 test-sampleyaml: WHAT ?= ./test/sampleyaml
@@ -96,11 +96,7 @@ test-sampleyaml: manifests fmt vet
 	go test -timeout 30m -v $(WHAT)
 
 test-e2e-rayjob: WHAT ?= ./test/e2erayjob
-test-e2e-rayjob: manifests fmt vet ## Run e2e tests.
-	go test -timeout 30m -v $(WHAT)
-
-test-e2e-rayservice: WHAT ?= ./test/e2erayservice
-test-e2e-rayservice: manifests fmt vet ## Run e2e tests.
+test-e2e-rayjob: manifests fmt vet ## Run e2e RayJob tests.
 	go test -timeout 30m -v $(WHAT)
 
 sync: helm api-docs


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There is a duplicate `test-e2e-rayservice` command in the `Makefile` which will lead to this **Warning** when running make commands:
```zsh
$ make test
Makefile:104: warning: overriding commands for target `test-e2e-rayservice'
Makefile:80: warning: ignoring old commands for target `test-e2e-rayservice'
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
