### PR TITLE
Remove duplicate `test-e2e-rayservice` from Makefile

### DIFF
--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -75,10 +75,6 @@ test-e2e-autoscaler: WHAT ?= ./test/e2eautoscaler
 test-e2e-autoscaler: manifests fmt vet ## Run e2e autoscaler tests.
 	go test -timeout 30m -v $(WHAT)
 
-test-e2e-rayservice: WHAT ?= ./test/e2erayservice
-test-e2e-rayservice: manifests fmt vet ## Run e2e RayService tests.
-	go test -timeout 30m -v $(WHAT)
-
 test-e2e-upgrade: WHAT ?= ./test/e2eupgrade
 test-e2e-upgrade: manifests fmt vet ## Run e2e operator upgrade tests.
 	go test -timeout 30m -v $(WHAT)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

At some point the Makefile definition for `test-e2e-rayservice` got duplicated, this PR removes the extra definition. Without this fix,  we get warnings like this when running any make command:
```
Makefile:104: warning: overriding recipe for target 'test-e2e-rayservice'
```

## Related issue number

No issue - small bug fix

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
