### PR TITLE
fix: dashboard build for kuberay 1.5.0

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -9,7 +9,10 @@ WORKDIR /app
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
-  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+if [ -f yarn.lock ]; then \
+    corepack enable && corepack prepare yarn@4.9.2 --activate && \
+    yarn config set nodeLinker node-modules && \
+    yarn install --immutable; \
   elif [ -f package-lock.json ]; then npm ci; \
   elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
   else echo "Lockfile not found." && exit 1; \
@@ -28,7 +31,11 @@ COPY . .
 # ENV NEXT_TELEMETRY_DISABLED 1
 
 RUN \
-  if [ -f yarn.lock ]; then yarn run build; \
+  if [ -f yarn.lock ];  then \
+    corepack enable && corepack prepare yarn@4.9.2 --activate && \
+    yarn config set nodeLinker node-modules && \
+    yarn install --immutable && \
+    yarn run build; \
   elif [ -f package-lock.json ]; then npm run build; \
   elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
   else echo "Lockfile not found." && exit 1; \


### PR DESCRIPTION
# failed release action
https://github.com/ray-project/kuberay/actions/runs/18928357346/job/54039962351

# solution
## Dockerfile Changes Summary

### Root Cause
- **Version conflict**: `package.json` specifies `"packageManager": "yarn@4.9.2"` but `node:18-alpine` ships with Yarn 1.22.22 by default
- Build failed because Yarn 1.22.22 detected version mismatch and exited with error

### Changes in `deps` Stage

**Before:**
```dockerfile
RUN if [ -f yarn.lock ]; then yarn --frozen-lockfile;
```

**After:**
```dockerfile
RUN if [ -f yarn.lock ]; then \
    corepack enable && \
    corepack prepare yarn@4.9.2 --activate && \
    yarn config set nodeLinker node-modules && \
    yarn install --immutable;
```

### Changes in `builder` Stage

**Before:**
```dockerfile
RUN if [ -f yarn.lock ]; then yarn run build;
```

**After:**
```dockerfile
RUN if [ -f yarn.lock ]; then \
    corepack enable && \
    corepack prepare yarn@4.9.2 --activate && \
    yarn config set nodeLinker node-modules && \
    yarn install --immutable && \
    yarn run build;
```

### Key Modifications

1. **Enable Corepack**: `corepack enable` - Activates Node.js's built-in package manager version controller
2. **Prepare Yarn 4.9.2**: `corepack prepare yarn@4.9.2 --activate` - Downloads and activates the correct Yarn version
3. **Configure node-modules linker**: `yarn config set nodeLinker node-modules` - Use traditional node_modules instead of PnP (required by Next.js build)
4. **Update flag**: Changed `--frozen-lockfile` → `--immutable` (Yarn 4 standard)
5. **Duplicate setup in builder**: Both stages require identical Corepack setup due to Docker multi-stage isolation

### Why Each Stage Needs Setup
- Multi-stage builds reset the environment at each `FROM` statement
- `COPY --from=deps` only transfers files, not environment configuration
- Each stage must independently activate Corepack + Yarn 4.9.2

### Screenshot
<img width="1062" height="509" alt="image" src="https://github.com/user-attachments/assets/f3ca0800-7d36-48cb-bf67-3f94a813b8c3" />

<img width="1090" height="513" alt="image" src="https://github.com/user-attachments/assets/a67350f4-f4c7-48c8-9688-9c4dcdb0a144" />
