### PR TITLE
[Autoscaler] Add validation to require RayCluster v2 when using idleTimeoutSeconds

### DIFF
--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -1964,7 +1964,7 @@ func TestValidateWorkerGroupIdleTimeout(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "worker group worker-group-1 has idleTimeoutSeconds set, but RAY_enable_autoscaler_v2 environment variable is not set to 'true' in the head pod",
+			expectedErr: fmt.Sprintf("worker group worker-group-1 has idleTimeoutSeconds set, but autoscaler v2 is not enabled. Please set .spec.autoscalerOptions.version to 'v2' (or set %s environment variable to 'true' in the head pod if using KubeRay < 1.4.0)", RAY_ENABLE_AUTOSCALER_V2),
 		},
 		"should reject idleTimeoutSeconds when autoscaler version is not set": {
 			spec: rayv1.RayClusterSpec{
@@ -1982,7 +1982,7 @@ func TestValidateWorkerGroupIdleTimeout(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "worker group worker-group-1 has idleTimeoutSeconds set, but RAY_enable_autoscaler_v2 environment variable is not set to 'true' in the head pod",
+			expectedErr: fmt.Sprintf("worker group worker-group-1 has idleTimeoutSeconds set, but autoscaler v2 is not enabled. Please set .spec.autoscalerOptions.version to 'v2' (or set %s environment variable to 'true' in the head pod if using KubeRay < 1.4.0)", RAY_ENABLE_AUTOSCALER_V2),
 		},
 		"should reject idleTimeoutSeconds when AutoscalerOptions is nil": {
 			spec: rayv1.RayClusterSpec{
@@ -2000,7 +2000,7 @@ func TestValidateWorkerGroupIdleTimeout(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "worker group worker-group-1 has idleTimeoutSeconds set, but RAY_enable_autoscaler_v2 environment variable is not set to 'true' in the head pod",
+			expectedErr: fmt.Sprintf("worker group worker-group-1 has idleTimeoutSeconds set, but autoscaler v2 is not enabled. Please set .spec.autoscalerOptions.version to 'v2' (or set %s environment variable to 'true' in the head pod if using KubeRay < 1.4.0)", RAY_ENABLE_AUTOSCALER_V2),
 		},
 		"should reject idleTimeoutSeconds when env var is set to invalid value": {
 			spec: rayv1.RayClusterSpec{
@@ -2020,7 +2020,7 @@ func TestValidateWorkerGroupIdleTimeout(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "worker group worker-group-1 has idleTimeoutSeconds set, but RAY_enable_autoscaler_v2 environment variable is not set to 'true' in the head pod",
+			expectedErr: fmt.Sprintf("worker group worker-group-1 has idleTimeoutSeconds set, but autoscaler v2 is not enabled. Please set .spec.autoscalerOptions.version to 'v2' (or set %s environment variable to 'true' in the head pod if using KubeRay < 1.4.0)", RAY_ENABLE_AUTOSCALER_V2),
 		},
 		"should accept worker group with idleTimeoutSeconds when env var is set to true": {
 			spec: rayv1.RayClusterSpec{


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
V2 Autoscaling allows for configuring idleTimeoutSeconds per worker group, which needs added unit + e2e testing
EDIT: e2e testing already done in https://github.com/ray-project/kuberay/pull/2725 issue should've been closed
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#2561
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
