### PR TITLE
fix: dashboard http client tests discovered and passing

### DIFF
--- a/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go
@@ -3,6 +3,7 @@ package dashboardclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/jarcoal/httpmock"
@@ -295,6 +296,6 @@ var _ = Describe("RayFrameworkGenerator", func() {
 
 		_, err := rayDashboardClient.GetServeDetails(context.TODO())
 		Expect(err).To(HaveOccurred())
-		Expect(err).To(Equal(context.DeadlineExceeded))
+		Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
 	})
 })

--- a/ray-operator/controllers/ray/utils/dashboardclient/suite_test.go
+++ b/ray-operator/controllers/ray/utils/dashboardclient/suite_test.go
@@ -1,4 +1,4 @@
-package utils_test
+package dashboardclient
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestUtils(t *testing.T) {
+func TestDashboardClient(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Utils Suite")
+	RunSpecs(t, "Dashboard Client Suite")
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Dashboard HTTP Client tests never run in CI because it was missing setup from a `suite_test.go` file. Go test doesnt search in subdirectories so when tests moved from `./utils/` to `./utils/dashboardclient/` package the tests never ran. After adding `suite_test.go` the tests run but with a failure that also gets fixed in this PR.

Below is caught failure:
```bash
RayFrameworkGenerator Test GetServeDetails with network error
/Users/alimaazamat/kuberay/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go:289
  [FAILED] in [It] - /Users/alimaazamat/kuberay/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go:298 @ 11/03/25 11:49:35.648
• [FAILED] [0.000 seconds]
RayFrameworkGenerator [It] Test GetServeDetails with network error
/Users/alimaazamat/kuberay/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go:289

  [FAILED] Expected
      <*url.Error | 0x140003b6de0>: 
      Get "http://127.0.0.1:8090/api/serve/applications/?api_type=declarative": context deadline exceeded
      {
          Op: "Get",
          URL: "http://127.0.0.1:8090/api/serve/applications/?api_type=declarative",
          Err: <context.deadlineExceededError>{},
      }
  to equal
      <context.deadlineExceededError>: 
      context deadline exceeded
      {}
  In [It] at: /Users/alimaazamat/kuberay/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go:298 @ 11/03/25 11:49:35.648
------------------------------

Summarizing 1 Failure:
  [FAIL] RayFrameworkGenerator [It] Test GetServeDetails with network error
  /Users/alimaazamat/kuberay/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go:298

Ran 13 of 13 Specs in 0.002 seconds
FAIL! -- 12 Passed | 1 Failed | 0 Pending | 0 Skipped
--- FAIL: TestDashboardClient (0.00s)
FAIL

```
Now it passes by checking for the error correctly.


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #4172

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
