### PR TITLE
[RayJob] Update submitter image to quay.io/kuberay/submitter:v1.5.0

### DIFF
--- a/ray-operator/config/samples/ray-job.light-weight-submitter.yaml
+++ b/ray-operator/config/samples/ray-job.light-weight-submitter.yaml
@@ -70,7 +70,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: my-custom-rayjob-submitter
-        image: kuberay/submitter:nightly
+        image: quay.io/kuberay/submitter:v1.5.0
         command: ["/submitter"]
         args: ["--runtime-env-json", '{"pip":["requests==2.26.0","pendulum==2.1.2"],"env_vars":{"counter_name":"test_counter"}}', "--", "python", "/home/ray/samples/sample_code.py"]
 


### PR DESCRIPTION
## Why are these changes needed?
So users don't need to build image by themselves.


<img width="1809" height="70" alt="image" src="https://github.com/user-attachments/assets/3ef6ad40-0596-486e-9178-95ec04eb89f2" />

<img width="1875" height="70" alt="image" src="https://github.com/user-attachments/assets/528705a1-f8cf-4f39-81b1-57585ecbf4f3" />


<img width="1879" height="65" alt="image" src="https://github.com/user-attachments/assets/cb20134d-bc2d-439c-8183-5a88c10e4996" />


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
