### PR TITLE
[flaky] RayJob fails when head Pod is deleted when job is running

### DIFF
--- a/ray-operator/test/e2erayjob/rayjob_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_test.go
@@ -310,11 +310,10 @@ env_vars:
 		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
 		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-			Should(WithTransform(RayJobReason, Equal(rayv1.JobDeploymentStatusTransitionGracePeriodExceeded)))
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-			Should(WithTransform(func(job *rayv1.RayJob) string { return job.Status.Message },
-				MatchRegexp("The RayJob submitter finished at .* but the ray job did not reach terminal state within .*")))
-
+			Should(WithTransform(RayJobReason, Or(
+				Equal(rayv1.JobDeploymentStatusTransitionGracePeriodExceeded),
+				Equal(rayv1.SubmissionFailed),
+			)))
 		// Cleanup
 		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Why are these changes needed?
when head pod is deleted, there will be 2 possiblilities we failed the rayjob.

1. https://github.com/ray-project/kuberay/blob/87de75fe1c8f2827857f14571a5ac09c96654dde/ray-operator/controllers/ray/rayjob_controller.go#L1174

2. https://github.com/ray-project/kuberay/blob/87de75fe1c8f2827857f14571a5ac09c96654dde/ray-operator/controllers/ray/rayjob_controller.go#L1027


I think it would be better to make the behavior deterministic, but it’s okay to make this a low priority.