### PR TITLE
[CI] Pin Docker api version to avoid API version mismatch

### DIFF
--- a/.buildkite/setup-env.sh
+++ b/.buildkite/setup-env.sh
@@ -3,6 +3,9 @@
 # Install Go
 export PATH=$PATH:/usr/local/go/bin
 
+# Pin Docker API version
+export DOCKER_API_VERSION=1.43
+
 # Install kind
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-amd64
 chmod +x ./kind


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<img width="1848" height="128" alt="image" src="https://github.com/user-attachments/assets/3afbc061-6e2e-4dc5-8af7-833bb65aca51" />

https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/11540/steps/canvas?sid=019a73f0-c8d9-4044-81a2-3d280c8caa39

Pin the docker api version using environment variable to match the server’s supported version.

Ref: https://stackoverflow.com/questions/62079794/error-response-from-daemon-client-version-1-40-is-too-new-maximum-supported-ap

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
