### PR TITLE
[RayJob] Remove updateJobStatus call

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -152,7 +152,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		rayJobInstance.Status.Reason = rayv1.ValidationFailed
 		rayJobInstance.Status.Message = err.Error()
 
-		// This is one of the only 3 places where we update the RayJob status. This will directly
+		// This is one of the only 2 places where we update the RayJob status. This will directly
 		// update the JobDeploymentStatus to ValidationFailed if there's validation error.
 		if err = r.updateRayJobStatus(ctx, originalRayJobInstance, rayJobInstance); err != nil {
 			logger.Info("Failed to update RayJob status", "error", err)
@@ -204,13 +204,11 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		if clientURL := rayJobInstance.Status.DashboardURL; clientURL == "" {
 			if rayClusterInstance.Status.State != rayv1.Ready {
 				logger.Info("Wait for the RayCluster.Status.State to be ready before submitting the job.", "RayCluster", rayClusterInstance.Name, "State", rayClusterInstance.Status.State)
-				// This is one of only 3 places where we update the RayJob status. For observability
-				// while waiting for the RayCluster to become ready, we lift the cluster status.
+				// The nonready RayCluster status should be reflected in the RayJob's status.
+				// Breaking from the switch statement will drop directly to the status update code
+				// and return a default requeue duration and no error.
 				rayJobInstance.Status.RayClusterStatus = rayClusterInstance.Status
-				if err = r.updateRayJobStatus(ctx, originalRayJobInstance, rayJobInstance); err != nil {
-					logger.Info("Failed to update RayJob status", "error", err)
-				}
-				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
+				break
 			}
 
 			if clientURL, err = utils.FetchHeadServiceURL(ctx, r.Client, rayClusterInstance, utils.DashboardPortName); err != nil || clientURL == "" {
@@ -425,7 +423,7 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	}
 	checkBackoffLimitAndUpdateStatusIfNeeded(ctx, rayJobInstance)
 
-	// This is one of the only 3 places where we update the RayJob status. Please do NOT add any
+	// This is one of the only 2 places where we update the RayJob status. Please do NOT add any
 	// code between `checkBackoffLimitAndUpdateStatusIfNeeded` and the following code.
 	if err = r.updateRayJobStatus(ctx, originalRayJobInstance, rayJobInstance); err != nil {
 		logger.Info("Failed to update RayJob status", "error", err)


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fast follow to #4191, see [Kai Hsun's comment](https://github.com/ray-project/kuberay/pull/4191#discussion_r2535888727).

1. We want fewer calls to `updateRayJobStatus`
2. We can drop out of the switch statement to go through the normal call at the end of the func
3. It didn't look like we could do this before since it was returning err, but that err was previously always nil.
    - NB: Without the `updateRayJobStatus` call (removed in this PR), the err is always nil, as the previous assignment to err is on L199 and guarded.

## Related issue number

none

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
