### PR TITLE
[RayCluster] Improved the efficiency when checking rayclusters' expectations

### DIFF
--- a/ray-operator/controllers/ray/expectations/scale_expectations.go
+++ b/ray-operator/controllers/ray/expectations/scale_expectations.go
@@ -70,44 +70,47 @@ func (r *rayClusterScaleExpectationImpl) ExpectScalePod(namespace, rayClusterNam
 	}
 }
 
+func (r *rayClusterScaleExpectationImpl) isPodScaled(ctx context.Context, rp *rayPod) bool {
+	pod := &corev1.Pod{}
+	switch rp.action {
+	case Create:
+		if err := r.Get(ctx, types.NamespacedName{Name: rp.name, Namespace: rp.namespace}, pod); err == nil {
+			return true
+		}
+		// Tolerating extreme case:
+		//   The first reconciliation created a Pod. If the Pod was quickly deleted from etcd by another component
+		//   before the second reconciliation. This would lead to never satisfying the expected condition.
+		//   Avoid this by setting a timeout.
+		return rp.recordTimestamp.Add(ExpectationsTimeout).Before(time.Now())
+	case Delete:
+		if err := r.Get(ctx, types.NamespacedName{Name: rp.name, Namespace: rp.namespace}, pod); err != nil {
+			return errors.IsNotFound(err)
+		}
+	}
+	return false
+}
+
 func (r *rayClusterScaleExpectationImpl) IsSatisfied(ctx context.Context, namespace, rayClusterName, group string) (isSatisfied bool) {
 	items, err := r.itemsCache.ByIndex(GroupIndex, fmt.Sprintf("%s/%s/%s", namespace, rayClusterName, group))
 	if err != nil {
 		// An error occurs when there is no corresponding IndexFunc for GroupIndex. This should be a fatal error.
 		panic(err)
 	}
-	isSatisfied = true
 	for i := range items {
 		rp := items[i].(*rayPod)
-		pod := &corev1.Pod{}
-		isPodSatisfied := false
-		switch rp.action {
-		case Create:
-			if err := r.Get(ctx, types.NamespacedName{Name: rp.name, Namespace: namespace}, pod); err == nil {
-				isPodSatisfied = true
-			} else {
-				// Tolerating extreme case:
-				//   The first reconciliation created a Pod. If the Pod was quickly deleted from etcd by another component
-				//   before the second reconciliation. This would lead to never satisfying the expected condition.
-				//   Avoid this by setting a timeout.
-				isPodSatisfied = rp.recordTimestamp.Add(ExpectationsTimeout).Before(time.Now())
-			}
-		case Delete:
-			if err := r.Get(ctx, types.NamespacedName{Name: rp.name, Namespace: namespace}, pod); err != nil {
-				isPodSatisfied = errors.IsNotFound(err)
-			}
+		isPodSatisfied := r.isPodScaled(ctx, rp)
+
+		if !isPodSatisfied {
+			return false
 		}
+
 		// delete satisfied item in cache
-		if isPodSatisfied {
-			if err := r.itemsCache.Delete(items[i]); err != nil {
-				// Fatal error in KeyFunc.
-				panic(err)
-			}
-		} else {
-			isSatisfied = false
+		if err := r.itemsCache.Delete(items[i]); err != nil {
+			// Fatal error in KeyFunc.
+			panic(err)
 		}
 	}
-	return isSatisfied
+	return true
 }
 
 func (r *rayClusterScaleExpectationImpl) Delete(rayClusterName, namespace string) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The current implementation of `IsSatisfied` in `scale_expectation.go` , will iterate through all pods in itemsCache. This is not necessary. When one pod fails to meet the expectation, we can return directly. `fast-fail` means return earlier once a pod's scaling result is not as expected.

Current code:
```
	for i := range items {
		rp := items[i].(*rayPod)
		pod := &corev1.Pod{}
		isPodSatisfied := false
		// check if pod is scaled correctly
                ...
		if isPodSatisfied {
			if err := r.itemsCache.Delete(items[i]); err != nil {
				panic(err)
			}
		} else {
			// Here we can return directly. No need to continue.
			// It is inefficient especially when
			// we have created lots of pods and few of them are synced from kube-apiserver
			isSatisfied = false
		}
	}
```

For example, we may create 10 pods, and expect to successfully get the 10 pods. If none of the pods is ready, no need to iterate through the 10 pods every time. Just find one pod is missing and then break.

I also refactored the code, reduced nested `if-else` conditions. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
