### PR TITLE
[RayService][Bug] Remove erroneous `cacheServeConfig` call in `applyServeTargetCapacity`

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1361,13 +1361,12 @@ func (r *RayServiceReconciler) applyServeTargetCapacity(ctx context.Context, ray
 		return err
 	}
 
-	// Update the status fields and cache new Serve config.
+	// Update the TargetCapacity status fields.
 	if rayClusterInstance.Name == rayServiceInstance.Status.ActiveServiceStatus.RayClusterName {
 		rayServiceInstance.Status.ActiveServiceStatus.TargetCapacity = ptr.To(goalTargetCapacity)
 	} else if rayClusterInstance.Name == rayServiceInstance.Status.PendingServiceStatus.RayClusterName {
 		rayServiceInstance.Status.PendingServiceStatus.TargetCapacity = ptr.To(goalTargetCapacity)
 	}
-	r.cacheServeConfig(rayServiceInstance, rayClusterInstance.Name)
 
 	return nil
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes a bug in the `NewClusterWithIncrementalUpgrade` strategy where the Active (old) cluster's Serve configuration cache was incorrectly updated to the new ServeConfigV2 during an upgrade. The expected behavior is that the active cluster's Serve config will remain unchanged during the upgrade.

The `applyServeTargetCapacity` function previously called cacheServeConfig. During an upgrade, this caused the Active cluster's cache to be overwritten with the new RayService Spec configuration on the next `applyServeTargetCapacity` call, even though `updateServeDeployment` was blocked for the active cluster. This resulted in the controller attempting to reconcile the Active cluster against the new configuration instead of simply scaling it down.

## Related issue number

https://github.com/ray-project/kuberay/issues/4189

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
