### PR TITLE
[RayCluster] make auth token secret name consistency

### DIFF
--- a/ray-operator/config/samples/ray-cluster.auth-manual.yaml
+++ b/ray-operator/config/samples/ray-cluster.auth-manual.yaml
@@ -14,7 +14,7 @@ spec:
           - name: RAY_AUTH_MODE
             value: token
           # You can create the secret manually with the following command:
-          # kubectl create secret generic ray-cluster-with-manual-auth --from-literal=auth_token='raycluster_secret' -n default
+          # kubectl create secret generic ray-cluster-with-auth --from-literal=auth_token='raycluster_secret' -n default
           # And then use the following valueFrom to reference the secret:
           - name: RAY_AUTH_TOKEN
             valueFrom:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The secret name in the auth token sample yaml is not consistence between the command for generation and the secret mount.

This PR makes the secret name in the command is identical to the secret name in the secret mount.

### screenshot:
before auth:
<img width="1715" height="815" alt="auth before" src="https://github.com/user-attachments/assets/68f58d17-cbe2-43c0-8068-903b3ae8c097" />

after auth:
<img width="1681" height="816" alt="auth after" src="https://github.com/user-attachments/assets/c9c98edd-cee9-4c25-913f-7ddf2c4605cd" />


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
