### PR TITLE
Check that token Secrets are owned by RayCluster

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -376,6 +376,10 @@ func (r *RayClusterReconciler) reconcileAuthSecret(ctx context.Context, instance
 		return err
 	}
 
+	if !metav1.IsControlledBy(secret, instance) {
+		return fmt.Errorf("secret %s/%s is not controlled by RayCluster %s", secret.Namespace, secret.Name, instance.Name)
+	}
+
 	return nil
 }
 

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -937,6 +937,10 @@ func GetRayDashboardClientFunc(mgr manager.Manager, useKubernetesProxy bool) fun
 				return nil, fmt.Errorf("failed to get auth secret %s/%s: %w", rayCluster.Namespace, secretName, err)
 			}
 
+			if !metav1.IsControlledBy(secret, rayCluster) {
+				return nil, fmt.Errorf("auth secret %s/%s is not owned by RayCluster %s", rayCluster.Namespace, secretName, rayCluster.Name)
+			}
+
 			tokenBytes, exists := secret.Data[RAY_AUTH_TOKEN_SECRET_KEY]
 			if !exists {
 				return nil, fmt.Errorf("auth token key '%q' not found in secret %s/%s", RAY_AUTH_TOKEN_SECRET_KEY, rayCluster.Namespace, secretName)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Only mount token Secrets that have owner references to the RayCluster. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
