### PR TITLE
[RayService] auth token mode e2e test

### DIFF
--- a/ray-operator/test/e2erayservice/rayservice_auth_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_auth_test.go
@@ -61,13 +61,6 @@ func TestRayServiceAuthToken(t *testing.T) {
 	// Verify Ray container has auth token env vars
 	VerifyContainerAuthTokenEnvVars(test, rayCluster, &headPod.Spec.Containers[utils.RayContainerIndex])
 
-	workerPods, err := GetWorkerPods(test, rayCluster)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(workerPods).ToNot(BeEmpty())
-	for _, workerPod := range workerPods {
-		VerifyContainerAuthTokenEnvVars(test, rayCluster, &workerPod.Spec.Containers[utils.RayContainerIndex])
-	}
-
 	g.Expect(rayService.Status.NumServeEndpoints).To(BeNumerically(">", 0),
 		"RayService should have at least one serve endpoint")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Creates a RayService with `AuthModeToken` enabled
- Waits for the RayService and its managed RayCluster to become ready
- Verifies `RAY_AUTH_MODE` and `RAY_AUTH_TOKEN` environment variables are correctly set in head pod
- Confirms the token is sourced from a Secret via `SecretKeyRef` with the correct key

**Key implementation details:**
- Reuses `RayServiceSampleYamlApplyConfiguration()` and adds auth options and a worker group programmatically (no separate YAML file needed)
- Uses the existing `VerifyContainerAuthTokenEnvVars()` helper from `test/support/ray.go`

## Related issue number
Related to #4203

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
