### PR TITLE
[e2e] RayJob Auth Mode E2E

### DIFF
--- a/ray-operator/test/e2e/raycluster_auth_test.go
+++ b/ray-operator/test/e2e/raycluster_auth_test.go
@@ -40,13 +40,16 @@ func TestRayClusterAuthOptions(t *testing.T) {
 		headPod, err := GetHeadPod(test, rayCluster)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(headPod).NotTo(BeNil())
-		VerifyContainerAuthTokenEnvVars(test, rayCluster, headPod, utils.RayContainerIndex)
 
+		// Verify Ray container has auth token env vars
+		VerifyContainerAuthTokenEnvVars(test, rayCluster, &headPod.Spec.Containers[utils.RayContainerIndex])
+
+		// Verify worker pods have auth token env vars
 		workerPods, err := GetWorkerPods(test, rayCluster)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(workerPods).ToNot(BeEmpty())
 		for _, workerPod := range workerPods {
-			VerifyContainerAuthTokenEnvVars(test, rayCluster, &workerPod, utils.RayContainerIndex)
+			VerifyContainerAuthTokenEnvVars(test, rayCluster, &workerPod.Spec.Containers[utils.RayContainerIndex])
 		}
 
 		// TODO(andrewsykim): add job submission test with and without token once a Ray version with token support is released.

--- a/ray-operator/test/e2erayjob/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_lightweight_test.go
@@ -180,14 +180,14 @@ env_vars:
 		g.Expect(headPod).NotTo(BeNil())
 
 		// Verify Ray container has auth token env vars
-		VerifyContainerAuthTokenEnvVars(test, rayCluster, headPod, utils.RayContainerIndex)
+		VerifyContainerAuthTokenEnvVars(test, rayCluster, &headPod.Spec.Containers[utils.RayContainerIndex])
 
 		// Verify worker pods have auth token env vars
 		workerPods, err := GetWorkerPods(test, rayCluster)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(workerPods).ToNot(BeEmpty())
 		for _, workerPod := range workerPods {
-			VerifyContainerAuthTokenEnvVars(test, rayCluster, &workerPod, utils.RayContainerIndex)
+			VerifyContainerAuthTokenEnvVars(test, rayCluster, &workerPod.Spec.Containers[utils.RayContainerIndex])
 		}
 
 		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -252,14 +252,9 @@ func Gateway(t Test, namespace, name string) func() (*gwv1.Gateway, error) {
 
 // VerifyContainerAuthTokenEnvVars verifies that the specified container has the correct auth token environment variables.
 // This is a common helper function used across all auth-related E2E tests.
-func VerifyContainerAuthTokenEnvVars(t Test, rayCluster *rayv1.RayCluster, pod *corev1.Pod, containerIndex int) {
+func VerifyContainerAuthTokenEnvVars(t Test, rayCluster *rayv1.RayCluster, container *corev1.Container) {
 	t.T().Helper()
 	g := NewWithT(t.T())
-
-	g.Expect(len(pod.Spec.Containers)).To(BeNumerically(">", containerIndex),
-		"Container index %d should exist in pod", containerIndex)
-
-	container := pod.Spec.Containers[containerIndex]
 
 	// Verify RAY_AUTH_MODE environment variable
 	var rayAuthModeEnvVar *corev1.EnvVar


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR adds comprehensive E2E tests for Ray authentication token mode to ensure correct auth token propagation across three RayJob submission modes:

- RayJob K8s Job Mode: Verifies auth token in head, worker, and submitter Job pods
- RayJob HTTP Mode: Verifies auth token in head and worker pods (operator uses HTTP client with token)
- RayJob Sidecar Mode: Verifies auth token in head Ray container, submitter sidecar, and worker pods

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Part of #4203 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
