### PR TITLE
[e2e] Enhance RayCluster Auth E2E

### DIFF
--- a/ray-operator/test/e2e/raycluster_auth_test.go
+++ b/ray-operator/test/e2e/raycluster_auth_test.go
@@ -74,9 +74,7 @@ func TestRayClusterAuthOptions(t *testing.T) {
 					authToken, submissionId),
 			}
 
-			stdout, stderr := ExecPodCmd(test, headPod, headPod.Spec.Containers[utils.RayContainerIndex].Name, submitCmd)
-			LogWithTimestamp(test.T(), "Job submission stdout: %s", stdout.String())
-			LogWithTimestamp(test.T(), "Job submission stderr: %s", stderr.String())
+			stdout, _ := ExecPodCmd(test, headPod, headPod.Spec.Containers[utils.RayContainerIndex].Name, submitCmd)
 
 			// Verify job was submitted successfully
 			g.Expect(stdout.String()).To(ContainSubstring(submissionId), "Job submission should succeed with valid auth token")
@@ -107,12 +105,10 @@ func TestRayClusterAuthOptions(t *testing.T) {
 					incorrectToken, submissionId),
 			}
 
-			stdout, stderr := ExecPodCmd(test, headPod, headPod.Spec.Containers[utils.RayContainerIndex].Name, submitCmd)
-			LogWithTimestamp(test.T(), "Job submission stdout with incorrect auth: %s", stdout.String())
-			LogWithTimestamp(test.T(), "Job submission stderr with incorrect auth: %s", stderr.String())
+			_, stderr := ExecPodCmd(test, headPod, headPod.Spec.Containers[utils.RayContainerIndex].Name, submitCmd, true)
 
 			// Verify response indicates authentication failure
-			g.Expect(stderr.String()).To(ContainSubstring("Unauthorized"), "Job submission should fail with Unauthorized when auth token is incorrect")
+			g.Expect(stderr.String()).To(ContainSubstring("Unauthenticated"), "Job submission should fail with Unauthorized when auth token is incorrect")
 
 			LogWithTimestamp(test.T(), "Job submission correctly rejected with incorrect auth token")
 		})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR enhances the E2E tests for RayCluster token-based authentication to validate the feature works correctly end-to-end by using `Ray Jobs CLI` to verify that the job submission:
- Succeeds with valid auth token
- Fails with "Unauthenticated" when token is incorrect

## Related issue number
Part of https://github.com/ray-project/kuberay/issues/4203

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
