### PR TITLE
[RayJob] light weight job submitter upgrade to 1.5.1 to support auth token mode

### DIFF
--- a/ray-operator/config/samples/ray-job.light-weight-submitter.yaml
+++ b/ray-operator/config/samples/ray-job.light-weight-submitter.yaml
@@ -70,7 +70,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: my-custom-rayjob-submitter
-        image: quay.io/kuberay/submitter:v1.5.0
+        image: quay.io/kuberay/submitter:v1.5.1
         command: ["/submitter"]
         args: ["--runtime-env-json", '{"pip":["requests==2.26.0","pendulum==2.1.2"],"env_vars":{"counter_name":"test_counter"}}', "--", "python", "/home/ray/samples/sample_code.py"]
 


### PR DESCRIPTION
## Why are these changes needed?
As title.
