### PR TITLE
Add example in GKE to enable Ray resource isolation using cgroupsv2 and writable cgroup containers

### DIFF
--- a/ray-operator/config/samples/ray-cluster-resource-isolation.gke.yaml
+++ b/ray-operator/config/samples/ray-cluster-resource-isolation.gke.yaml
@@ -17,11 +17,11 @@ spec:
           image: rayproject/ray:2.52.0
           resources:
             limits:
-              cpu: 4
-              memory: 16G
+              cpu: 2
+              memory: 8G
             requests:
-              cpu: 4
-              memory: 16G
+              cpu: 2
+              memory: 8G
           ports:
           - containerPort: 6379
             name: gcs-server
@@ -48,10 +48,10 @@ spec:
           image: rayproject/ray:2.52.0
           resources:
             limits:
-              cpu: 4
-              memory: 16G
+              cpu: 2
+              memory: 8G
             requests:
-              cpu: 4
-              memory: 16G
+              cpu: 2
+              memory: 8G
         nodeSelector:
           node.gke.io/enable-writable-cgroups: "true"


### PR DESCRIPTION
## Why are these changes needed?

https://github.com/ray-project/kuberay/issues/4221

## Related issue number

https://github.com/ray-project/kuberay/issues/4221

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
