### PR TITLE
[RayOperator]: hardening kuberay operator security context

### DIFF
--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -39,9 +39,13 @@ spec:
           protocol: TCP
         name: kuberay-operator
         securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
           seccompProfile:
             type: RuntimeDefault
-          allowPrivilegeEscalation: false
         livenessProbe:
           httpGet:
             path: /metrics


### PR DESCRIPTION
Adds security hardening settings to `ray-operator/config/manager/manager.yaml` to align with the Helm chart defaults and Kubernetes Pod Security Standards.

##Changes:

- Add `capabilities.drop: [ALL]` 
- Add `readOnlyRootFilesystem: true`

## Why?

The Helm chart (`helm-chart/kuberay-operator/values.yaml`) already includes these security settings by default. This PR ensures consistency between kustomize and Helm deployments.

These settings follow:
- Kubernetes Pod Security Standards (restricted profile)
- OpenShift Security Context Constraints (restricted-v2 SCC)

## Testing
- [x] Helm unit tests pass (39 tests)
- [x] E2E tests pass (core functionality)
- [x] Verified on local Kind cluster
- [x] Verified security context applied correctly
