### PR TITLE
Add e2e test for rayService deletion delay

### DIFF
--- a/ray-operator/test/e2erayservice/rayservice_raycluster_delete_in_seconds_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_raycluster_delete_in_seconds_test.go
@@ -1,0 +1,52 @@
+package e2erayservice
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
+	. "github.com/ray-project/kuberay/ray-operator/test/support"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRayClusterDeletionDelayInSeconds(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+
+	// Create a namespace
+	namespace := test.NewTestNamespace()
+	rayServiceName := "rayservice-sample"
+
+	rayServiceAC := rayv1ac.RayService(rayServiceName, namespace.Name).WithSpec(RayServiceSampleYamlApplyConfiguration())
+
+	rayService, err := test.Client().Ray().RayV1().RayServices(namespace.Name).Apply(test.Ctx(), rayServiceAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(rayService).NotTo(BeNil())
+
+	LogWithTimestamp(test.T(), "Waiting for RayService %s/%s to be ready", rayService.Namespace, rayService.Name)
+	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).
+		Should(WithTransform(IsRayServiceReady, BeTrue()))
+
+	// Get the latest RayService
+	rayService, err = GetRayService(test, namespace.Name, rayServiceName)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(rayService).NotTo(BeNil())
+
+	err = test.Client().Ray().RayV1().RayServices(namespace.Name).Delete(test.Ctx(), rayService.Name, metav1.DeleteOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var oldRayCluster *rayv1.RayCluster
+	oldRayCluster, err = GetRayCluster(test, namespace.Name, rayService.Status.ActiveServiceStatus.RayClusterName)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	oldRayCluster.Finalizers = nil
+	_, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Update(
+		test.Ctx(),
+		oldRayCluster,
+		metav1.UpdateOptions{},
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+	waitingForRayClusterSwitchWithDeletionDelay(g, test, rayService, oldRayCluster.Name, 20)
+
+}

--- a/ray-operator/test/e2erayservice/support.go
+++ b/ray-operator/test/e2erayservice/support.go
@@ -98,7 +98,9 @@ func curlHeadPodWithRayServicePath(t Test,
 }
 
 func RayServiceSampleYamlApplyConfiguration() *rayv1ac.RayServiceSpecApplyConfiguration {
-	return rayv1ac.RayServiceSpec().WithServeConfigV2(`applications:
+	return rayv1ac.RayServiceSpec().
+		WithRayClusterDeletionDelaySeconds(int32(2)).
+		WithServeConfigV2(`applications:
       - name: fruit_app
         import_path: fruit.deployment_graph
         route_prefix: /fruit


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Resolves issue https://github.com/ray-project/kuberay/issues/3870

<!-- Please give a short summary of the change and the problem this solves. -->
Adds e2e test for rayservice deletionDelay

## Related issue number
Closes https://github.com/ray-project/kuberay/issues/3870
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
  - [x] Needs to be tested in CI pipeline where the e2e test can run.