### PR TITLE
[WIP][Autoscaler] Use spec not env for v2 Autoscaler

### DIFF
--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -609,10 +609,17 @@ func validateWorkerGroupIdleTimeout(workerGroup rayv1.WorkerGroupSpec, spec *ray
 		}
 
 		// idleTimeoutSeconds only allowed on autoscaler v2
-		envVar, exists := EnvVarByName(RAY_ENABLE_AUTOSCALER_V2, spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Env)
-		if !exists || (envVar.Value != "1" && envVar.Value != "true") {
-			return fmt.Errorf("worker group %s has idleTimeoutSeconds set, but %s environment variable is not set to 'true' in the head pod", workerGroup.GroupName, RAY_ENABLE_AUTOSCALER_V2)
+		// Check spec field first (>= 1.4.0), then fall back to env var (< 1.4.0)
+		if IsAutoscalingV2Enabled(spec) {
+			return nil
 		}
+
+		envVar, exists := EnvVarByName(RAY_ENABLE_AUTOSCALER_V2, spec.HeadGroupSpec.Template.Spec.Containers[RayContainerIndex].Env)
+		if exists && (envVar.Value == "1" || envVar.Value == "true") {
+			return nil
+		}
+
+		return fmt.Errorf("worker group %s has idleTimeoutSeconds set, but autoscaler v2 is not enabled. Please set .spec.autoscalerOptions.version to 'v2' or set %s environment variable to 'true' in the head pod", workerGroup.GroupName, RAY_ENABLE_AUTOSCALER_V2)
 	}
 
 	return nil

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_part2_test.go
@@ -42,6 +42,8 @@ func TestRayClusterAutoscalerV2IdleTimeout(t *testing.T) {
 		rayClusterSpecAC := rayv1ac.RayClusterSpec().
 			WithEnableInTreeAutoscaling(true).
 			WithRayVersion(GetRayVersion()).
+			WithAutoscalerOptions(rayv1ac.AutoscalerOptions().
+				WithVersion(rayv1.AutoscalerVersionV2)).
 			WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 				WithRayStartParams(map[string]string{"num-cpus": "0"}).
 				WithTemplate(tc.HeadPodTemplateGetter())).

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestRayClusterAutoscaler(t *testing.T) {
-	for _, tc := range tests {
+	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			test := With(t)
 			g := gomega.NewWithT(t)
@@ -31,7 +31,15 @@ func TestRayClusterAutoscaler(t *testing.T) {
 
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
-				WithRayVersion(GetRayVersion()).
+				WithRayVersion(GetRayVersion())
+
+			// Add autoscaler version for V2 test (tests[1])
+			if i == 1 {
+				rayClusterSpecAC = rayClusterSpecAC.WithAutoscalerOptions(
+					rayv1ac.AutoscalerOptions().WithVersion(rayv1.AutoscalerVersionV2))
+			}
+
+			rayClusterSpecAC = rayClusterSpecAC.
 				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 					WithRayStartParams(map[string]string{"num-cpus": "0"}).
 					WithTemplate(tc.HeadPodTemplateGetter())).
@@ -82,7 +90,7 @@ func TestRayClusterAutoscaler(t *testing.T) {
 }
 
 func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
-	for _, tc := range tests {
+	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			test := With(t)
 			g := gomega.NewWithT(t)
@@ -98,7 +106,15 @@ func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
 
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
-				WithRayVersion(GetRayVersion()).
+				WithRayVersion(GetRayVersion())
+
+			// Add autoscaler version for V2 test (tests[1])
+			if i == 1 {
+				rayClusterSpecAC = rayClusterSpecAC.WithAutoscalerOptions(
+					rayv1ac.AutoscalerOptions().WithVersion(rayv1.AutoscalerVersionV2))
+			}
+
+			rayClusterSpecAC = rayClusterSpecAC.
 				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 					WithRayStartParams(map[string]string{"num-cpus": "0"}).
 					WithTemplate(tc.HeadPodTemplateGetter())).
@@ -142,7 +158,7 @@ func TestRayClusterAutoscalerWithFakeGPU(t *testing.T) {
 }
 
 func TestRayClusterAutoscalerWithCustomResource(t *testing.T) {
-	for _, tc := range tests {
+	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			test := With(t)
 			g := gomega.NewWithT(t)
@@ -160,7 +176,15 @@ func TestRayClusterAutoscalerWithCustomResource(t *testing.T) {
 
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
-				WithRayVersion(GetRayVersion()).
+				WithRayVersion(GetRayVersion())
+
+			// Add autoscaler version for V2 test (tests[1])
+			if i == 1 {
+				rayClusterSpecAC = rayClusterSpecAC.WithAutoscalerOptions(
+					rayv1ac.AutoscalerOptions().WithVersion(rayv1.AutoscalerVersionV2))
+			}
+
+			rayClusterSpecAC = rayClusterSpecAC.
 				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 					WithRayStartParams(map[string]string{"num-cpus": "0"}).
 					WithTemplate(tc.HeadPodTemplateGetter())).
@@ -201,7 +225,7 @@ func TestRayClusterAutoscalerWithCustomResource(t *testing.T) {
 }
 
 func TestRayClusterAutoscalerWithDesiredState(t *testing.T) {
-	for _, tc := range tests {
+	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			test := With(t)
 			g := gomega.NewWithT(t)
@@ -222,7 +246,15 @@ func TestRayClusterAutoscalerWithDesiredState(t *testing.T) {
 			groupName := "custom-resource-group"
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
-				WithRayVersion(GetRayVersion()).
+				WithRayVersion(GetRayVersion())
+
+			// Add autoscaler version for V2 test (tests[1])
+			if i == 1 {
+				rayClusterSpecAC = rayClusterSpecAC.WithAutoscalerOptions(
+					rayv1ac.AutoscalerOptions().WithVersion(rayv1.AutoscalerVersionV2))
+			}
+
+			rayClusterSpecAC = rayClusterSpecAC.
 				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 					WithRayStartParams(map[string]string{"num-cpus": "0"}).
 					WithTemplate(tc.HeadPodTemplateGetter())).
@@ -263,7 +295,7 @@ func TestRayClusterAutoscalerWithDesiredState(t *testing.T) {
 }
 
 func TestRayClusterAutoscalerMinReplicasUpdate(t *testing.T) {
-	for _, tc := range tests {
+	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			test := With(t)
 			g := gomega.NewWithT(t)
@@ -281,7 +313,15 @@ func TestRayClusterAutoscalerMinReplicasUpdate(t *testing.T) {
 
 			rayClusterSpecAC := rayv1ac.RayClusterSpec().
 				WithEnableInTreeAutoscaling(true).
-				WithRayVersion(GetRayVersion()).
+				WithRayVersion(GetRayVersion())
+
+			// Add autoscaler version for V2 test (tests[1])
+			if i == 1 {
+				rayClusterSpecAC = rayClusterSpecAC.WithAutoscalerOptions(
+					rayv1ac.AutoscalerOptions().WithVersion(rayv1.AutoscalerVersionV2))
+			}
+
+			rayClusterSpecAC = rayClusterSpecAC.
 				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 					WithRayStartParams(map[string]string{"num-cpus": "0"}).
 					WithTemplate(tc.HeadPodTemplateGetter())).
@@ -355,7 +395,7 @@ func TestRayClusterAutoscalerMaxReplicasUpdate(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
+	for i, tc := range tests {
 		for _, rtc := range replicaTests {
 			t.Run(fmt.Sprintf("%s(%s)", tc.name, rtc.name), func(t *testing.T) {
 				test := With(t)
@@ -371,7 +411,15 @@ func TestRayClusterAutoscalerMaxReplicasUpdate(t *testing.T) {
 
 				rayClusterSpecAC := rayv1ac.RayClusterSpec().
 					WithEnableInTreeAutoscaling(true).
-					WithRayVersion(GetRayVersion()).
+					WithRayVersion(GetRayVersion())
+
+				// Add autoscaler version for V2 test (tests[1])
+				if i == 1 {
+					rayClusterSpecAC = rayClusterSpecAC.WithAutoscalerOptions(
+						rayv1ac.AutoscalerOptions().WithVersion(rayv1.AutoscalerVersionV2))
+				}
+
+				rayClusterSpecAC = rayClusterSpecAC.
 					WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
 						WithRayStartParams(map[string]string{"num-cpus": "0"}).
 						WithTemplate(tc.HeadPodTemplateGetter())).

--- a/ray-operator/test/e2eautoscaler/support.go
+++ b/ray-operator/test/e2eautoscaler/support.go
@@ -114,7 +114,6 @@ func headPodTemplateApplyConfigurationV2() *corev1ac.PodTemplateSpecApplyConfigu
 					corev1ac.ContainerPort().WithName(utils.DashboardPortName).WithContainerPort(utils.DefaultDashboardPort),
 					corev1ac.ContainerPort().WithName(utils.ClientPortName).WithContainerPort(utils.DefaultClientPort),
 				).
-				WithEnv(corev1ac.EnvVar().WithName(utils.RAY_ENABLE_AUTOSCALER_V2).WithValue("1")).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("1"),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Based on docs https://docs.ray.io/en/master/cluster/kubernetes/user-guides/configuring-autoscaling.html and https://github.com/ray-project/kuberay/pull/3578 and this comment https://github.com/ray-project/kuberay/pull/3578#issuecomment-2870191539 we prefer using spec version not the env var as the source of truth for the Autoscaler version. If both env var and spec are set, even if they match it is invalid. We should migrate away from using the env var.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
