### PR TITLE
[Feature] [ApiServer] Allow DELETE endpoints when using --cors-allow-origin

### DIFF
--- a/apiserver/cmd/main.go
+++ b/apiserver/cmd/main.go
@@ -155,6 +155,11 @@ func startHttpProxy() {
 		klog.Info("Enabling CORS with Access-Control-Allow-Origin:", *corsAllowOrigin)
 		c := cors.New(cors.Options{
 			AllowedOrigins: []string{*corsAllowOrigin},
+			AllowedMethods: []string{
+				http.MethodGet, http.MethodPost,
+				http.MethodPut, http.MethodPatch,
+				http.MethodDelete, http.MethodOptions,
+			},
 		})
 		corsHandler = c.Handler
 	} else {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When the HTTP proxy is started with `--cors-allow-origin`, browsers fail to call DELETE endpoints due to CORS.
<!-- Please give a short summary of the change and the problem this solves. -->

### Manual Testing
1. start api server and kuberay dashboard
```
$ go run cmd/main.go -httpPortFlag :31888 -cors-allow-origin=*
$ yarn dev
```
2.  Create raycluster and delete it from UI
```
$ k apply -f ray-operator/config/samples/ray-cluster.sample.yaml
```
<img width="2499" height="1189" alt="image" src="https://github.com/user-attachments/assets/e91d0359-b4f9-41e0-9d9c-611916741b91" />


## Related issue number
Closes #4258 
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [X] Manual tests
  - [ ] This PR is not tested :(
