### PR TITLE
[CI] Upgrade operator version from v1.4.2 to v1.5.1

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -105,17 +105,17 @@
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
     - kubectl config set clusters.kind-kind.server https://docker:6443
-    # Deploy previous KubeRay operator release (v1.4.2) using helm
+    # Deploy previous KubeRay operator release (v1.3.2) using helm
     - echo Deploying KubeRay operator
     - pushd ray-operator
-    - helm install kuberay-operator kuberay/kuberay-operator --version 1.4.2
+    - helm install kuberay-operator kuberay/kuberay-operator --version 1.3.2
     - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
     # Run e2e tests and print KubeRay operator logs if tests fail
-    - echo "--- START:Running e2e Operator upgrade (v1.4.2 to v1.5.1 operator) tests"
+    - echo "--- START:Running e2e Operator upgrade (v1.3.2 to v1.5.1 operator) tests"
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
     - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m KUBERAY_TEST_UPGRADE_IMAGE=v1.5.1 go test -timeout 30m -v ./test/e2eupgrade 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-upgrade-log.tar -T - && exit 1)
-    - echo "--- END:e2e Operator upgrade (v1.4.2 to v1.5.1 operator) tests finished"
+    - echo "--- END:e2e Operator upgrade (v1.3.2 to v1.5.1 operator) tests finished"
 
 - label: 'Test Apiserver E2E (nightly operator)'
   instance_size: large


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The version of the KubeRay operator is out of date. We upgrade the version from v1.4.2 to v1.5.1 to reflect the latest release.

## Related issue number

N/A

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
