### PR TITLE
[Autoscaler] validate idleTimeoutSeconds for AutoscalerOptions

### DIFF
--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -104,10 +104,8 @@ func ValidateRayClusterSpec(spec *rayv1.RayClusterSpec, annotations map[string]s
 		if err := validateRayGroupLabels(workerGroup.GroupName, workerGroup.RayStartParams, workerGroup.Labels); err != nil {
 			return err
 		}
-		if workerGroup.IdleTimeoutSeconds != nil {
-			if err := validateIdleTimeoutSeconds(*workerGroup.IdleTimeoutSeconds, fmt.Sprintf("worker group %s: idleTimeoutSeconds", workerGroup.GroupName), spec); err != nil {
-				return err
-			}
+		if err := validateWorkerGroupIdleTimeout(workerGroup, spec); err != nil {
+			return err
 		}
 	}
 
@@ -196,10 +194,10 @@ func ValidateRayClusterSpec(spec *rayv1.RayClusterSpec, annotations map[string]s
 		}
 	}
 
-	// Validate AutoscalerOptions.IdleTimeoutSeconds
+	// Validate AutoscalerOptions.IdleTimeoutSeconds (works with both v1 and v2 autoscaler)
 	if spec.AutoscalerOptions != nil && spec.AutoscalerOptions.IdleTimeoutSeconds != nil {
-		if err := validateIdleTimeoutSeconds(*spec.AutoscalerOptions.IdleTimeoutSeconds, "autoscalerOptions.idleTimeoutSeconds", spec); err != nil {
-			return err
+		if *spec.AutoscalerOptions.IdleTimeoutSeconds < 0 {
+			return fmt.Errorf("autoscalerOptions.idleTimeoutSeconds must be non-negative, got %d", *spec.AutoscalerOptions.IdleTimeoutSeconds)
 		}
 	}
 
@@ -609,14 +607,18 @@ func validateLegacyDeletionPolicies(rayJob *rayv1.RayJob) error {
 	return nil
 }
 
-// validateIdleTimeoutSeconds validates an idleTimeoutSeconds field value
-// fieldPath should be the spec path (e.g., "worker group X: idleTimeoutSeconds" or "autoscalerOptions.idleTimeoutSeconds")
-func validateIdleTimeoutSeconds(value int32, fieldPath string, spec *rayv1.RayClusterSpec) error {
-	if value < 0 {
-		return fmt.Errorf("%s must be non-negative, got %d", fieldPath, value)
+// validateWorkerGroupIdleTimeout validates the idleTimeoutSeconds field in a worker group spec
+func validateWorkerGroupIdleTimeout(workerGroup rayv1.WorkerGroupSpec, spec *rayv1.RayClusterSpec) error {
+	idleTimeoutSeconds := workerGroup.IdleTimeoutSeconds
+	if idleTimeoutSeconds == nil {
+		return nil
 	}
 
-	// idleTimeoutSeconds only allowed on autoscaler v2
+	if *idleTimeoutSeconds < 0 {
+		return fmt.Errorf("worker group %s: idleTimeoutSeconds must be non-negative, got %d", workerGroup.GroupName, *idleTimeoutSeconds)
+	}
+
+	// WorkerGroupSpec.idleTimeoutSeconds only allowed on autoscaler v2
 	if IsAutoscalingV2Enabled(spec) {
 		return nil
 	}
@@ -626,5 +628,5 @@ func validateIdleTimeoutSeconds(value int32, fieldPath string, spec *rayv1.RayCl
 		return nil
 	}
 
-	return fmt.Errorf("%s is set, but autoscaler v2 is not enabled. Please set .spec.autoscalerOptions.version to 'v2' (or set %s environment variable to 'true' in the head pod if using KubeRay < 1.4.0)", fieldPath, RAY_ENABLE_AUTOSCALER_V2)
+	return fmt.Errorf("worker group %s: idleTimeoutSeconds is set, but autoscaler v2 is not enabled. Please set .spec.autoscalerOptions.version to 'v2' (or set %s environment variable to 'true' in the head pod if using KubeRay < 1.4.0)", workerGroup.GroupName, RAY_ENABLE_AUTOSCALER_V2)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/kuberay/pull/4162#discussion_r2603740120

<!-- Please give a short summary of the change and the problem this solves. -->
Since IdleTimeoutSeconds validation for Autoscaler V2 was added for workergroupspec, we also need IdleTimeoutSeconds validation for Autoscaler.options.
## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/kuberay/issues/2561
## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
