### PR TITLE
Revert "[Test][Autoscaler] deflaky unexpected dead actors in tests by setting max_restarts=-1 (#3700)"

### DIFF
--- a/ray-operator/test/support/create_detached_actor.py
+++ b/ray-operator/test/support/create_detached_actor.py
@@ -9,9 +9,7 @@ parser.add_argument('--num-gpus', type=float, default=0)
 parser.add_argument('--num-custom-resources', type=float, default=0)
 args = parser.parse_args()
 
-# set max_restarts=-1 as a workaround to restart unexpected death in tests.
-# TODO (rueian): Remove the max_restarts workaround when https://github.com/ray-project/ray/issues/40864 is fixed.
-@ray.remote(max_restarts=-1, num_cpus=args.num_cpus, num_gpus=args.num_gpus, resources={"CustomResource": args.num_custom_resources})
+@ray.remote(num_cpus=args.num_cpus, num_gpus=args.num_gpus, resources={"CustomResource": args.num_custom_resources})
 class Actor:
     pass
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Revert https://github.com/ray-project/kuberay/pull/3700 because https://github.com/ray-project/ray/pull/53562 is already included in Ray [2.48.0](https://github.com/ray-project/ray/releases/tag/ray-2.48.0).
We are using Ray 2.52.0 for e2e testing.

https://github.com/ray-project/kuberay/blob/bd0d46b673ce5dab0fca51dacbb6a9b03ace73c8/ray-operator/test/support/defaults.go#L1-L7




<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #3752 #3748

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
