### PR TITLE
Add Helm values for ResourceClaims to RayCluster

### DIFF
--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -91,6 +91,7 @@ helm uninstall raycluster
 | head.resources.limits.memory | string | `"2G"` |  |
 | head.resources.requests.cpu | string | `"1"` |  |
 | head.resources.requests.memory | string | `"2G"` |  |
+| head.resourceClaims | list | `[]` | ResourceClaims to allocate with the head pod |
 | head.annotations | object | `{}` | Extra annotations for head pod |
 | head.nodeSelector | object | `{}` | Node labels for head pod assignment |
 | head.tolerations | list | `[]` | Node tolerations for head pod scheduling to nodes with taints |
@@ -122,6 +123,7 @@ helm uninstall raycluster
 | worker.resources.limits.memory | string | `"1G"` |  |
 | worker.resources.requests.cpu | string | `"1"` |  |
 | worker.resources.requests.memory | string | `"1G"` |  |
+| worker.resourceClaims | list | `[]` | ResourceClaims to allocate with the worker pod |
 | worker.annotations | object | `{}` | Extra annotations for worker pod |
 | worker.nodeSelector | object | `{}` | Node labels for worker pod assignment |
 | worker.tolerations | list | `[]` | Node tolerations for worker pod scheduling to nodes with taints |
@@ -151,6 +153,7 @@ helm uninstall raycluster
 | additionalWorkerGroups.smallGroup.resources.limits.memory | string | `"1G"` |  |
 | additionalWorkerGroups.smallGroup.resources.requests.cpu | int | `1` |  |
 | additionalWorkerGroups.smallGroup.resources.requests.memory | string | `"1G"` |  |
+| additionalWorkerGroups.smallGroup.resourceClaims | list | `[]` | ResourceClaims to allocate with the additional worker pod |
 | additionalWorkerGroups.smallGroup.annotations | object | `{}` | Extra annotations for additional worker pod |
 | additionalWorkerGroups.smallGroup.nodeSelector | object | `{}` | Node labels for additional worker pod assignment |
 | additionalWorkerGroups.smallGroup.tolerations | list | `[]` | Node tolerations for additional worker pod scheduling to nodes with taints |

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -165,6 +165,10 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.head.resourceClaims }}
+        resourceClaims:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
   workerGroupSpecs:
   {{- if not .Values.worker.disabled }}
   - groupName: {{ .Values.worker.groupName }}
@@ -292,6 +296,10 @@ spec:
         {{- end }}
         {{- with .Values.worker.podSecurityContext }}
         securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.worker.resourceClaims }}
+        resourceClaims:
           {{- toYaml . | nindent 10 }}
         {{- end }}
   {{- end }}
@@ -422,6 +430,10 @@ spec:
         {{- end }}
         {{- with $values.podSecurityContext }}
         securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $values.resourceClaims }}
+        resourceClaims:
           {{- toYaml . | nindent 10 }}
         {{- end }}
   {{- end }}

--- a/helm-chart/ray-cluster/tests/raycluster_test.yaml
+++ b/helm-chart/ray-cluster/tests/raycluster_test.yaml
@@ -799,6 +799,19 @@ tests:
           path: spec.headGroupSpec.template.spec.securityContext.fsGroup
           value: 3000
 
+  - it: Should add resource claims if `head.resourceClaims` is set
+    set:
+      head:
+        resourceClaims:
+          - name: gpu
+            resourceClaimName: gpu-claim
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.resourceClaims
+          value:
+            - name: gpu
+              resourceClaimName: gpu-claim
+
   # ===========================================================================
   # Test Default Worker Group
   # ===========================================================================
@@ -1445,6 +1458,19 @@ tests:
       - equal:
           path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.securityContext.fsGroup
           value: 3000
+
+  - it: Should add resource claims if `worker.resourceClaims` is set
+    set:
+      worker:
+        resourceClaims:
+          - name: gpu
+            resourceClaimName: gpu-claim
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.resourceClaims
+          value:
+            - name: gpu
+              resourceClaimName: gpu-claim
 
   # ===========================================================================
   # Test Additional Worker Groups
@@ -2153,6 +2179,21 @@ tests:
       - equal:
           path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.securityContext.fsGroup
           value: 3000
+
+  - it: Should add resource claims if `additionalWorkerGroups.smallGroup.resourceClaims` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          resourceClaims:
+            - name: gpu
+              resourceClaimName: gpu-claim
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.resourceClaims
+          value:
+            - name: gpu
+              resourceClaimName: gpu-claim
 
   - it: Should set head runtimeClassName when `head.runtimeClassName` is set
     set:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -133,6 +133,9 @@ head:
       cpu: "1"
       memory: "2G"
 
+  # -- ResourceClaims to allocate with the head pod
+  resourceClaims: []
+
   # -- Extra annotations for head pod
   annotations: {}
 
@@ -251,6 +254,9 @@ worker:
       cpu: "1"
       memory: "1G"
 
+  # -- ResourceClaims to allocate with the worker pod
+  resourceClaims: []
+
   # -- Extra annotations for worker pod
   annotations: {}
 
@@ -358,6 +364,9 @@ additionalWorkerGroups:
       requests:
         cpu: 1
         memory: "1G"
+
+    # -- ResourceClaims to allocate with the additional worker pod
+    resourceClaims: []
 
     # -- Extra annotations for additional worker pod
     annotations: {}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR allows users to define [DRA](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) resources for the head and worker pods in a RayCluster.

## Related issue number

None

## Checks

- [X] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [X] Manual tests (`helm template` produces the expected results)
  - [ ] This PR is not tested :(
