### PR TITLE
Clean up unused label for volcano scheduler

### DIFF
--- a/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
+++ b/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
@@ -13,7 +13,6 @@ kind: RayCluster
 metadata:
   name: test-cluster-0
   labels:
-    ray.io/scheduler-name: volcano
     volcano.sh/queue-name: kuberay-test-queue
 spec:
   rayVersion: '2.52.0'

--- a/ray-operator/config/samples/ray-cluster.volcano-scheduler.yaml
+++ b/ray-operator/config/samples/ray-cluster.volcano-scheduler.yaml
@@ -2,8 +2,6 @@ apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
   name: test-cluster-0
-  labels:
-    ray.io/scheduler-name: volcano
 spec:
   rayVersion: '2.52.0'
   headGroupSpec:

--- a/ray-operator/config/samples/ray-job.volcano-scheduler-queue.yaml
+++ b/ray-operator/config/samples/ray-job.volcano-scheduler-queue.yaml
@@ -13,7 +13,6 @@ kind: RayJob
 metadata:
   name: rayjob-sample-0
   labels:
-    ray.io/scheduler-name: volcano
     volcano.sh/queue-name: kuberay-test-queue
 spec:
   entrypoint: python /home/ray/samples/sample_code.py

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -48,7 +48,6 @@ const (
 
 	// Batch scheduling labels
 	// TODO(tgaddair): consider making these part of the CRD
-	RaySchedulerName         = "ray.io/scheduler-name"
 	RayPriorityClassName     = "ray.io/priority-class-name"
 	RayGangSchedulingEnabled = "ray.io/gang-scheduling-enabled"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Previously, the `ray.io/scheduler-name` label was used to [determine the scheduler](https://github.com/ray-project/kuberay/blob/release-0.6/ray-operator/controllers/ray/batchscheduler/schedulermanager.go#L57-L64) for KubeRay CRDs. However, with the adoption of the new scheduler framework, the scheduler name is now configured via the **controller configuration**.
Since the `ray.io/scheduler-name` label is no longer in use, I removed it to avoid ambiguity.

The Ray documentation will be updated to reflect this change as well.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
None

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
