### PR TITLE
fix: upgrade Ray image in ray-cluster.auth.yaml to 2.53.0 to resolve dashboard 'Failed to load' error

### DIFF
--- a/ray-operator/config/samples/ray-cluster.auth.yaml
+++ b/ray-operator/config/samples/ray-cluster.auth.yaml
@@ -6,14 +6,14 @@ spec:
   enableInTreeAutoscaling: true
   authOptions:
     mode: token
-  rayVersion: '2.52.0'
+  rayVersion: '2.53.0'
   headGroupSpec:
     rayStartParams: {}
     template:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.52.0
+          image: rayproject/ray:2.53.0
           resources:
             limits:
               memory: 8G
@@ -37,7 +37,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.52.0
+          image: rayproject/ray:2.53.0
           resources:
             limits:
               memory: 8G


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In Ray versions 2.52.0, when running in auth token mode, the Logs section consistently shows the error “Failed to load.”
This issue does not occur starting from Ray 2.53.0.


Ray 2.52.0:
<img width="1264" height="927" alt="image" src="https://github.com/user-attachments/assets/7f90b200-e1f9-404b-96a1-67b040295c3e" />


Ray 2.53.0:
<img width="1653" height="1221" alt="image" src="https://github.com/user-attachments/assets/9da0b0a2-e3f8-4ec6-b56f-4083f06a8235" />


Reproduction script
```
$ k apply -f config/samples/ray-cluster.auth.yaml
$ export RAY_AUTH_MODE=token
$ export RAY_AUTH_TOKEN=$(kubectl get secrets ray-cluster-with-auth --template={{.data.auth_token}} | base64 -d)
$ ray job submit --address http://localhost:8265  -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
```




<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/59614

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
