### PR TITLE
[history server][collector] Remove unused function processAllLogs

### DIFF
--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
@@ -71,12 +71,10 @@ func (r *RayLogHandler) Run(stop <-chan struct{}) error {
 	case <-sigChan:
 		logrus.Info("Received SIGTERM, processing all logs...")
 		r.processSessionLatestLogs()
-		// r.processPrevLogsOnShutdown()
 		close(r.ShutdownChan)
 	case <-stop:
 		logrus.Info("Received stop signal, processing all logs...")
 		r.processSessionLatestLogs()
-		// r.processPrevLogsOnShutdown()
 		close(r.ShutdownChan)
 	}
 	logrus.Warnf("Receive stop single, so stop ray collector ")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

delete the function `processAllLogs` and `processLogFile`(only used by `processAllLogs`)
in historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
Which is unused everywhere right now.

## Related issue number

Closes #4279

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
