### PR TITLE
[Chore] Enable modernize linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,21 +3,22 @@ linters:
   default: none
   enable:
     - asciicheck
+    - errcheck
     - ginkgolinter
+    - gosec
+    - govet
     - ineffassign
     - makezero
     - misspell
+    - modernize
     - nilerr
     - nolintlint
     - predeclared
+    - testifylint
     - unconvert
     - unparam
     - unused
     - wastedassign
-    - gosec
-    - govet
-    - errcheck
-    - testifylint
     # TODO: The following linters are disabled for now to unblock the golangci-lint v2 migration.
     # We will fix the lint errors and re-enable these linters in follow-up PRs.
     # - noctx
@@ -81,6 +82,9 @@ linters:
             - '**/ray-operator/apis/config/v1alpha1/*.go'
             - '**/ray-operator/apis/ray/v1alpha1/*.go'
             - '**/ray-operator/apis/ray/v1/*.go'
+    modernize:
+      disable:
+        - omitzero
   exclusions:
     generated: strict
     presets:

--- a/apiserver/pkg/interceptor/interceptor.go
+++ b/apiserver/pkg/interceptor/interceptor.go
@@ -11,7 +11,7 @@ import (
 // APIServerInterceptor implements UnaryServerInterceptor that provides the common wrapping logic
 // to be executed before and after all API handler calls, e.g. Logging, error handling.
 // For more details, see https://github.com/grpc/grpc-go/blob/master/interceptor.go
-func APIServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+func APIServerInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 	klog.Infof("%v handler starting", info.FullMethod)
 	resp, err = handler(ctx, req)
 	if err != nil {
@@ -25,10 +25,10 @@ func APIServerInterceptor(ctx context.Context, req interface{}, info *grpc.Unary
 func TimeoutInterceptor(timeout time.Duration) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
-		req interface{},
+		req any,
 		_ *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
-	) (interface{}, error) {
+	) (any, error) {
 		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		return handler(ctx, req)

--- a/apiserver/pkg/interceptor/interceptor_test.go
+++ b/apiserver/pkg/interceptor/interceptor_test.go
@@ -27,7 +27,7 @@ type mockHandler struct {
 // If the delay completes before the context expires, it returns "test_response" along with predefined error.
 // If the context is canceled or the deadline is exceeded before the delay completes,
 // it returns a corresponding gRPC status error instead.
-func (h *mockHandler) Handle(ctx context.Context, _ interface{}, delay time.Duration) (interface{}, error) {
+func (h *mockHandler) Handle(ctx context.Context, _ any, delay time.Duration) (any, error) {
 	h.called = true
 
 	select {
@@ -49,7 +49,7 @@ func (h *mockHandler) Handle(ctx context.Context, _ interface{}, delay time.Dura
 
 func TestAPIServerInterceptor(t *testing.T) {
 	tests := []struct {
-		expectedResp  interface{}
+		expectedResp  any
 		expectedError error
 		handler       *mockHandler
 		name          string
@@ -82,7 +82,7 @@ func TestAPIServerInterceptor(t *testing.T) {
 				ctx,
 				req,
 				info,
-				func(ctx context.Context, req interface{}) (interface{}, error) {
+				func(ctx context.Context, req any) (any, error) {
 					return tt.handler.Handle(ctx, req, 0 /*delay*/)
 				},
 			)
@@ -115,7 +115,7 @@ func TestAPIServerInterceptorContextPassing(t *testing.T) {
 		ctx,
 		"test_request",
 		info,
-		func(receivedCtx context.Context, req interface{}) (interface{}, error) {
+		func(receivedCtx context.Context, req any) (any, error) {
 			// Verify context value is passed through
 			assert.Equal(t, "test_value", receivedCtx.Value(testContextKey("test_key")))
 			return handler.Handle(receivedCtx, req, 0 /*delay*/)
@@ -174,7 +174,7 @@ func TestAPIServerInterceptorLogging(t *testing.T) {
 				ctx,
 				"test_request",
 				info,
-				func(receivedCtx context.Context, req interface{}) (interface{}, error) {
+				func(receivedCtx context.Context, req any) (any, error) {
 					return handler.Handle(receivedCtx, req, 0 /*delay*/)
 				},
 			)
@@ -254,7 +254,7 @@ func TestTimeoutInterceptor(t *testing.T) {
 				ctx,
 				req,
 				&grpc.UnaryServerInfo{FullMethod: "TestTimeoutMethod"},
-				func(ctx context.Context, req interface{}) (interface{}, error) {
+				func(ctx context.Context, req any) (any, error) {
 					return handler.Handle(ctx, req, tt.handlerDelay)
 				},
 			)

--- a/apiserver/pkg/manager/resource_manager.go
+++ b/apiserver/pkg/manager/resource_manager.go
@@ -131,7 +131,7 @@ func (r *ResourceManager) ListClusters(ctx context.Context, namespace string, co
 
 	var result []*rayv1api.RayCluster
 	length := len(rayClusterList.Items)
-	for i := 0; i < length; i++ {
+	for i := range length {
 		result = append(result, &rayClusterList.Items[i])
 	}
 
@@ -202,7 +202,7 @@ func (r *ResourceManager) ListJobs(ctx context.Context, namespace string, contin
 
 	var result []*rayv1api.RayJob
 	length := len(rayJobList.Items)
-	for i := 0; i < length; i++ {
+	for i := range length {
 		result = append(result, &rayJobList.Items[i])
 	}
 
@@ -346,7 +346,7 @@ func (r *ResourceManager) ListComputeTemplates(ctx context.Context, namespace st
 
 	var result []*corev1.ConfigMap
 	length := len(configMapList.Items)
-	for i := 0; i < length; i++ {
+	for i := range length {
 		result = append(result, &configMapList.Items[i])
 	}
 
@@ -368,7 +368,7 @@ func (r *ResourceManager) ListAllComputeTemplates(ctx context.Context) ([]*corev
 		}
 
 		length := len(configMapList.Items)
-		for i := 0; i < length; i++ {
+		for i := range length {
 			result = append(result, &configMapList.Items[i])
 		}
 	}

--- a/apiserver/pkg/model/converter.go
+++ b/apiserver/pkg/model/converter.go
@@ -3,6 +3,8 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 	"strconv"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -79,12 +81,7 @@ func getWorkNodeEnv() []string {
 
 // Check if an array contains string
 func contains(s []string, str string) bool {
-	for _, v := range s {
-		if v == str {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s, str)
 }
 
 func FromCrdToAPIClusters(clusters []*rayv1api.RayCluster, clusterEventsMap map[string][]corev1.Event) []*api.Cluster {
@@ -132,9 +129,7 @@ func FromCrdToAPICluster(cluster *rayv1api.RayCluster, events []corev1.Event) *a
 	}
 
 	pbCluster.ServiceEndpoint = map[string]string{}
-	for name, port := range cluster.Status.Endpoints {
-		pbCluster.ServiceEndpoint[name] = port
-	}
+	maps.Copy(pbCluster.ServiceEndpoint, cluster.Status.Endpoints)
 	return pbCluster
 }
 
@@ -591,9 +586,7 @@ func PoplulateRayServiceStatus(
 		ServeApplicationStatus: PopulateServeApplicationStatus(serviceStatus.ActiveServiceStatus.Applications),
 	}
 	status.ServiceEndpoint = map[string]string{}
-	for name, port := range serviceStatus.ActiveServiceStatus.RayClusterStatus.Endpoints {
-		status.ServiceEndpoint[name] = port
-	}
+	maps.Copy(status.ServiceEndpoint, serviceStatus.ActiveServiceStatus.RayClusterStatus.Endpoints)
 	return status
 }
 

--- a/apiserver/pkg/server/ray_job_submission_service_server.go
+++ b/apiserver/pkg/server/ray_job_submission_service_server.go
@@ -68,7 +68,7 @@ func (s *RayJobSubmissionServiceServer) SubmitRayJob(ctx context.Context, req *a
 		if err != nil {
 			return nil, err
 		}
-		re := make(map[string]interface{})
+		re := make(map[string]any)
 		err = json.Unmarshal(jsonData, &re)
 		if err != nil {
 			return nil, err

--- a/apiserver/pkg/util/cluster.go
+++ b/apiserver/pkg/util/cluster.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"strconv"
 	"strings"
@@ -287,16 +288,12 @@ func buildHeadPodTemplate(imageVersion string, envs *api.EnvironmentVariables, s
 
 	// Add specific annotations
 	if spec.Annotations != nil {
-		for k, v := range spec.Annotations {
-			podTemplateSpec.ObjectMeta.Annotations[k] = v
-		}
+		maps.Copy(podTemplateSpec.ObjectMeta.Annotations, spec.Annotations)
 	}
 
 	// Add specific labels
 	if spec.Labels != nil {
-		for k, v := range spec.Labels {
-			podTemplateSpec.ObjectMeta.Labels[k] = v
-		}
+		maps.Copy(podTemplateSpec.ObjectMeta.Labels, spec.Labels)
 	}
 
 	// Add specific tollerations
@@ -582,16 +579,12 @@ func buildWorkerPodTemplate(imageVersion string, envs *api.EnvironmentVariables,
 
 	// Add specific annotations
 	if spec.Annotations != nil {
-		for k, v := range spec.Annotations {
-			podTemplateSpec.ObjectMeta.Annotations[k] = v
-		}
+		maps.Copy(podTemplateSpec.ObjectMeta.Annotations, spec.Annotations)
 	}
 
 	// Add specific labels
 	if spec.Labels != nil {
-		for k, v := range spec.Labels {
-			podTemplateSpec.ObjectMeta.Labels[k] = v
-		}
+		maps.Copy(podTemplateSpec.ObjectMeta.Labels, spec.Labels)
 	}
 
 	// Add specific tollerations

--- a/apiserver/pkg/util/error.go
+++ b/apiserver/pkg/util/error.go
@@ -43,7 +43,7 @@ func ExtractErrorForCLI(err error, isDebugMode bool) error {
 }
 
 func NewInternalServerError(err error, internalMessageFormat string,
-	a ...interface{},
+	a ...any,
 ) *UserError {
 	internalMessage := fmt.Sprintf(internalMessageFormat, a...)
 	return newUserError(
@@ -53,7 +53,7 @@ func NewInternalServerError(err error, internalMessageFormat string,
 }
 
 func NewNotFoundError(err error, externalMessageFormat string,
-	a ...interface{},
+	a ...any,
 ) *UserError {
 	externalMessage := fmt.Sprintf(externalMessageFormat, a...)
 	return newUserError(
@@ -70,7 +70,7 @@ func NewResourceNotFoundError(resourceType string, resourceName string) *UserErr
 		codes.NotFound)
 }
 
-func NewResourcesNotFoundError(resourceTypesFormat string, resourceNames ...interface{}) *UserError {
+func NewResourcesNotFoundError(resourceTypesFormat string, resourceNames ...any) *UserError {
 	externalMessage := fmt.Sprintf("%s not found.", fmt.Sprintf(resourceTypesFormat, resourceNames...))
 	return newUserError(
 		fmt.Errorf("ResourceNotFoundError: %v", externalMessage),
@@ -78,7 +78,7 @@ func NewResourcesNotFoundError(resourceTypesFormat string, resourceNames ...inte
 		codes.NotFound)
 }
 
-func NewInvalidInputError(messageFormat string, a ...interface{}) *UserError {
+func NewInvalidInputError(messageFormat string, a ...any) *UserError {
 	message := fmt.Sprintf(messageFormat, a...)
 	return newUserError(errors.Errorf("Invalid input error: %v", message), message, codes.InvalidArgument)
 }
@@ -90,12 +90,12 @@ func NewInvalidInputErrorWithDetails(err error, externalMessage string) *UserErr
 		codes.InvalidArgument)
 }
 
-func NewAlreadyExistError(messageFormat string, a ...interface{}) *UserError {
+func NewAlreadyExistError(messageFormat string, a ...any) *UserError {
 	message := fmt.Sprintf(messageFormat, a...)
 	return newUserError(errors.Errorf("Already exist error: %v", message), message, codes.AlreadyExists)
 }
 
-func NewBadRequestError(err error, externalFormat string, a ...interface{}) *UserError {
+func NewBadRequestError(err error, externalFormat string, a ...any) *UserError {
 	externalMessage := fmt.Sprintf(externalFormat, a...)
 	return newUserError(
 		errors.Wrapf(err, "BadRequestError: %v", externalMessage),
@@ -103,7 +103,7 @@ func NewBadRequestError(err error, externalFormat string, a ...interface{}) *Use
 		codes.Aborted)
 }
 
-func NewUnauthenticatedError(err error, externalFormat string, a ...interface{}) *UserError {
+func NewUnauthenticatedError(err error, externalFormat string, a ...any) *UserError {
 	externalMessage := fmt.Sprintf(externalFormat, a...)
 	return newUserError(
 		errors.Wrapf(err, "Unauthenticated: %v", externalMessage),
@@ -111,7 +111,7 @@ func NewUnauthenticatedError(err error, externalFormat string, a ...interface{})
 		codes.Unauthenticated)
 }
 
-func NewPermissionDeniedError(err error, externalFormat string, a ...interface{}) *UserError {
+func NewPermissionDeniedError(err error, externalFormat string, a ...any) *UserError {
 	externalMessage := fmt.Sprintf(externalFormat, a...)
 	return newUserError(
 		errors.Wrapf(err, "PermissionDenied: %v", externalMessage),
@@ -151,7 +151,7 @@ func (e *UserError) GRPCStatus() *status.Status {
 	return status.New(e.externalStatusCode, e.ErrorStringWithoutStackTrace())
 }
 
-func (e *UserError) wrapf(format string, args ...interface{}) *UserError {
+func (e *UserError) wrapf(format string, args ...any) *UserError {
 	return newUserError(errors.Wrapf(e.internalError, format, args...),
 		e.externalMessage, e.externalStatusCode)
 }
@@ -170,7 +170,7 @@ func (e *UserError) Log() {
 	}
 }
 
-func Wrapf(err error, format string, args ...interface{}) error {
+func Wrapf(err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}

--- a/apiserver/test/e2e/cluster_server_e2e_test.go
+++ b/apiserver/test/e2e/cluster_server_e2e_test.go
@@ -535,7 +535,7 @@ func TestDeleteCluster(t *testing.T) {
 
 func createOneClusterInEachNamespaces(t *testing.T, numberOfNamespaces int, expectedConditions []rayv1api.RayClusterConditionType) []*End2EndTestingContext {
 	tCtxs := make([]*End2EndTestingContext, numberOfNamespaces)
-	for i := 0; i < numberOfNamespaces; i++ {
+	for i := range numberOfNamespaces {
 		tCtx, err := NewEnd2EndTestingContext(t)
 		require.NoError(t, err, "No error expected when creating testing context")
 
@@ -574,14 +574,14 @@ func TestGetAllClusters(t *testing.T) {
 	require.Len(t, response.Clusters, numberOfNamespaces, "Number of clusters returned is not as expected")
 	gotClusters := make([]bool, numberOfNamespaces)
 	for _, cluster := range response.Clusters {
-		for i := 0; i < numberOfNamespaces; i++ {
+		for i := range numberOfNamespaces {
 			if isMatchingCluster(tCtxs[i], cluster) {
 				gotClusters[i] = true
 				break
 			}
 		}
 	}
-	for i := 0; i < numberOfNamespaces; i++ {
+	for i := range numberOfNamespaces {
 		if !gotClusters[i] {
 			t.Errorf("ListAllClusters did not return expected clusters %s", tCtxs[i].GetRayClusterName())
 		}
@@ -595,7 +595,7 @@ func TestGetAllClustersByPagination(t *testing.T) {
 	tCtx := tCtxs[0]
 	gotClusters := make([]bool, numberOfNamespaces)
 	continueToken := ""
-	for i := 0; i < numberOfNamespaces; i++ {
+	for i := range numberOfNamespaces {
 		limit := 1
 		response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllClusters(&api.ListAllClustersRequest{
 			Limit:    int64(limit),
@@ -612,7 +612,7 @@ func TestGetAllClustersByPagination(t *testing.T) {
 		require.NotEmpty(t, response.Clusters, "A list of clusters is required")
 		require.Len(t, response.Clusters, limit, "Number of clusters returned is not as expected")
 		for _, cluster := range response.Clusters {
-			for i := 0; i < numberOfNamespaces; i++ {
+			for i := range numberOfNamespaces {
 				if isMatchingCluster(tCtxs[i], cluster) {
 					gotClusters[i] = true
 					break
@@ -621,7 +621,7 @@ func TestGetAllClustersByPagination(t *testing.T) {
 		}
 		continueToken = response.Continue
 	}
-	for i := 0; i < numberOfNamespaces; i++ {
+	for i := range numberOfNamespaces {
 		if !gotClusters[i] {
 			t.Errorf("ListAllClusters did not return expected clusters %s", tCtxs[i].GetRayClusterName())
 		}
@@ -644,14 +644,14 @@ func TestGetAllClustersByPaginationWithAllResults(t *testing.T) {
 	require.Len(t, response.Clusters, numberOfNamespaces, "Number of clusters returned is not as expected")
 	gotClusters := make([]bool, numberOfNamespaces)
 	for _, cluster := range response.Clusters {
-		for i := 0; i < numberOfNamespaces; i++ {
+		for i := range numberOfNamespaces {
 			if isMatchingCluster(tCtxs[i], cluster) {
 				gotClusters[i] = true
 				break
 			}
 		}
 	}
-	for i := 0; i < numberOfNamespaces; i++ {
+	for i := range numberOfNamespaces {
 		if !gotClusters[i] {
 			t.Errorf("ListAllClusters did not return expected clusters %s", tCtxs[i].GetRayClusterName())
 		}

--- a/apiserver/test/e2e/job_server_e2e_test.go
+++ b/apiserver/test/e2e/job_server_e2e_test.go
@@ -314,7 +314,7 @@ func TestGetAllJobsWithPagination(t *testing.T) {
 	const numberOfNamespaces = 3
 	testContexts := make([]*End2EndTestingContext, 0, numberOfNamespaces)
 
-	for idx := 0; idx < numberOfNamespaces; idx++ {
+	for range numberOfNamespaces {
 		tCtx, err := NewEnd2EndTestingContext(t)
 		require.NoError(t, err, "No error expected when creating testing context")
 
@@ -332,7 +332,7 @@ func TestGetAllJobsWithPagination(t *testing.T) {
 		gotJob := []bool{false, false, false}
 
 		continueToken := ""
-		for i := 0; i < numberOfNamespaces; i++ {
+		for i := range numberOfNamespaces {
 			response, actualRPCStatus, err := testContexts[i].GetRayAPIServerClient().ListAllRayJobs(&api.ListAllRayJobsRequest{
 				Limit:    int64(1),
 				Continue: continueToken,
@@ -348,7 +348,7 @@ func TestGetAllJobsWithPagination(t *testing.T) {
 			require.NotEmpty(t, response.Jobs, "A list of jobs is required")
 			require.Len(t, response.Jobs, 1, "Number of jobs returned is not as expected")
 			for _, curJob := range response.Jobs {
-				for j := 0; j < numberOfNamespaces; j++ {
+				for j := range numberOfNamespaces {
 					if testContexts[j].GetCurrentName() == curJob.Name && testContexts[j].GetNamespaceName() == curJob.Namespace {
 						gotJob[j] = true
 						break
@@ -357,7 +357,7 @@ func TestGetAllJobsWithPagination(t *testing.T) {
 			}
 			continueToken = response.Continue
 		}
-		for i := 0; i < numberOfNamespaces; i++ {
+		for i := range numberOfNamespaces {
 			if !gotJob[i] {
 				t.Errorf("ListAllJobs did not return expected jobs %s", testContexts[i].GetCurrentName())
 			}
@@ -381,7 +381,7 @@ func TestGetAllJobsWithPagination(t *testing.T) {
 		require.NotEmpty(t, response.Jobs, "A list of jobs is required")
 		require.Len(t, response.Jobs, numberOfNamespaces, "Number of jobs returned is not as expected")
 		for _, curJob := range response.Jobs {
-			for j := 0; j < numberOfNamespaces; j++ {
+			for j := range numberOfNamespaces {
 				if testContexts[j].GetCurrentName() == curJob.Name && testContexts[j].GetNamespaceName() == curJob.Namespace {
 					gotJob[j] = true
 					break
@@ -389,7 +389,7 @@ func TestGetAllJobsWithPagination(t *testing.T) {
 			}
 		}
 
-		for i := 0; i < numberOfNamespaces; i++ {
+		for i := range numberOfNamespaces {
 			if !gotJob[i] {
 				t.Errorf("ListAllJobs did not return expected jobs %s", testContexts[i].GetCurrentName())
 			}
@@ -437,14 +437,14 @@ func TestGetJobByPaginationInNamespace(t *testing.T) {
 	})
 	testJobNum := 10
 	testJobs := make([]*api.CreateRayJobRequest, 0, testJobNum)
-	for i := 0; i < testJobNum; i++ {
+	for i := range testJobNum {
 		tCtx.currentName = fmt.Sprintf("job%d", i)
 		tCtx.configMapName = fmt.Sprintf("job%d-cm", i)
 		testJobs = append(testJobs, createTestJob(t, tCtx, []rayv1api.JobStatus{rayv1api.JobStatusNew, rayv1api.JobStatusPending, rayv1api.JobStatusRunning, rayv1api.JobStatusSucceeded}))
 	}
 
 	t.Cleanup(func() {
-		for i := 0; i < testJobNum; i++ {
+		for i := range testJobNum {
 			tCtx.DeleteRayJobByName(t, testJobs[i].Job.Name)
 		}
 	})
@@ -452,7 +452,7 @@ func TestGetJobByPaginationInNamespace(t *testing.T) {
 	// Test pagination with limit 1
 	t.Run("Test pagination return part of the result jobs", func(t *testing.T) {
 		continueToken := ""
-		for i := 0; i < testJobNum; i++ {
+		for i := range testJobNum {
 			response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListRayJobs(&api.ListRayJobsRequest{
 				Namespace: tCtx.GetNamespaceName(),
 				Limit:     1,

--- a/apiserver/test/e2e/service_server_e2e_test.go
+++ b/apiserver/test/e2e/service_server_e2e_test.go
@@ -238,7 +238,7 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 	expectedServices := make([]targetService, 0, totalServices)
 
 	// Create services for each namespace
-	for i := 0; i < numberOfNamespaces; i++ {
+	for range numberOfNamespaces {
 		tCtx, err := NewEnd2EndTestingContext(t)
 		require.NoError(t, err, "No error expected when creating testing context")
 
@@ -247,7 +247,7 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 			tCtx.DeleteComputeTemplate(t)
 		})
 
-		for j := 0; j < numberOfService; j++ {
+		for range numberOfService {
 			testServiceRequest := createTestServiceV2(t, tCtx)
 			t.Cleanup(func() {
 				tCtx.DeleteRayService(t, testServiceRequest.Service.Name)
@@ -272,7 +272,7 @@ func TestGetAllServicesWithPagination(t *testing.T) {
 			gotServices[expectedService] = false
 		}
 
-		for i := 0; i < totalServices; i++ {
+		for i := range totalServices {
 			response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListAllRayServices(&api.ListAllRayServicesRequest{
 				PageToken: pageToken,
 				PageSize:  int32(1),
@@ -398,7 +398,7 @@ func TestGetServicesInNamespaceWithPagination(t *testing.T) {
 		tCtx.DeleteComputeTemplate(t)
 	})
 
-	for ii := 0; ii < serviceCount; ii++ {
+	for range serviceCount {
 		testServiceRequest := createTestServiceV2(t, tCtx)
 		t.Cleanup(func() {
 			tCtx.DeleteRayService(t, testServiceRequest.Service.Name)
@@ -412,7 +412,7 @@ func TestGetServicesInNamespaceWithPagination(t *testing.T) {
 		gotServices := []bool{false, false}
 
 		pageToken := ""
-		for ii := 0; ii < serviceCount; ii++ {
+		for ii := range serviceCount {
 			response, actualRPCStatus, err := tCtx.GetRayAPIServerClient().ListRayServices(&api.ListRayServicesRequest{
 				Namespace: tCtx.GetNamespaceName(),
 				PageToken: pageToken,
@@ -426,7 +426,7 @@ func TestGetServicesInNamespaceWithPagination(t *testing.T) {
 			require.Len(t, response.Services, 1)
 
 			for _, curService := range response.Services {
-				for jj := 0; jj < serviceCount; jj++ {
+				for jj := range serviceCount {
 					if expectedServiceNames[jj] == curService.Name {
 						gotServices[jj] = true
 						break
@@ -444,7 +444,7 @@ func TestGetServicesInNamespaceWithPagination(t *testing.T) {
 		}
 
 		// Check all services created have been returned.
-		for idx := 0; idx < serviceCount; idx++ {
+		for idx := range serviceCount {
 			require.True(t, gotServices[idx],
 				"ListServices did not return expected services %s",
 				expectedServiceNames[idx])
@@ -470,7 +470,7 @@ func TestGetServicesInNamespaceWithPagination(t *testing.T) {
 		require.Len(t, response.Services, serviceCount)
 		require.Empty(t, pageToken, "Page token should be empty")
 		for _, curService := range response.Services {
-			for jj := 0; jj < serviceCount; jj++ {
+			for jj := range serviceCount {
 				if expectedServiceNames[jj] == curService.Name {
 					gotServices[jj] = true
 					break
@@ -479,7 +479,7 @@ func TestGetServicesInNamespaceWithPagination(t *testing.T) {
 		}
 
 		// Check all services created have been returned.
-		for idx := 0; idx < serviceCount; idx++ {
+		for idx := range serviceCount {
 			require.True(t, gotServices[idx],
 				"ListServices did not return expected services %s",
 				expectedServiceNames[idx])

--- a/experimental/pkg/grpcproxy/handler.go
+++ b/experimental/pkg/grpcproxy/handler.go
@@ -24,7 +24,7 @@ func RegisterService(server *grpc.Server, director StreamDirector, serviceName s
 	streamer := &handler{director: director, securityheader: nil}
 	fakeDesc := &grpc.ServiceDesc{
 		ServiceName: serviceName,
-		HandlerType: (*interface{})(nil),
+		HandlerType: (*any)(nil),
 	}
 	for _, m := range methodNames {
 		streamDesc := grpc.StreamDesc{
@@ -60,7 +60,7 @@ func (s *handler) AddSecurityHeaderToHandler(securityheader map[string]string) {
 // handler is where the real magic of proxying happens.
 // It is invoked like any gRPC server stream and uses the emptypb.Empty type server
 // to proxy calls between the input and output streams.
-func (s *handler) handler(srv interface{}, serverStream grpc.ServerStream) error {
+func (s *handler) handler(srv any, serverStream grpc.ServerStream) error {
 	// little bit of gRPC internals never hurt anyone
 	fullMethodName, ok := grpc.MethodFromServerStream(serverStream)
 	if !ok {
@@ -104,7 +104,7 @@ func (s *handler) handler(srv interface{}, serverStream grpc.ServerStream) error
 	s2cErrChan := s.forwardServerToClient(serverStream, clientStream)
 	c2sErrChan := s.forwardClientToServer(clientStream, serverStream)
 	// We don't know which side is going to stop sending first, so we need a select between the two.
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case s2cErr := <-s2cErrChan:
 			if s2cErr == io.EOF {

--- a/kubectl-plugin/pkg/cmd/delete/delete.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete.go
@@ -134,17 +134,17 @@ func (options *DeleteOptions) Run(ctx context.Context, factory cmdutil.Factory) 
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	resources := ""
+	var resources strings.Builder
 	for resourceType, resourceNames := range options.resources {
 		for _, resourceName := range resourceNames {
-			resources += fmt.Sprintf("\n- %s/%s", resourceType, resourceName)
+			resources.WriteString(fmt.Sprintf("\n- %s/%s", resourceType, resourceName))
 		}
 	}
 
 	if !options.yes {
 		// Ask user for confirmation
 		reader := bufio.NewReader(os.Stdin)
-		fmt.Printf("Are you sure you want to delete the following resources?%s\n(y/yes/n/no)", resources)
+		fmt.Printf("Are you sure you want to delete the following resources?%s\n(y/yes/n/no)", resources.String())
 		confirmation, err := reader.ReadString('\n')
 		if err != nil {
 			return fmt.Errorf("Failed to read user input: %w", err)

--- a/kubectl-plugin/pkg/cmd/get/get_cluster.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster.go
@@ -153,7 +153,7 @@ func printClusters(rayclusterList *rayv1.RayClusterList, output io.Writer) error
 			relevantConditionType = relevantCondition.Type
 		}
 		resTable.Rows = append(resTable.Rows, v1.TableRow{
-			Cells: []interface{}{
+			Cells: []any{
 				raycluster.GetName(),
 				raycluster.GetNamespace(),
 				raycluster.Status.DesiredWorkerReplicas,

--- a/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
@@ -183,7 +183,7 @@ func TestRayClusterGetRun(t *testing.T) {
 			}
 
 			testResTable.Rows = append(testResTable.Rows, v1.TableRow{
-				Cells: []interface{}{
+				Cells: []any{
 					"raycluster-kuberay",
 					"test",
 					"2",
@@ -411,7 +411,7 @@ func TestPrintClusters(t *testing.T) {
 
 	testResTable.Rows = append(testResTable.Rows,
 		v1.TableRow{
-			Cells: []interface{}{
+			Cells: []any{
 				"barista",
 				"cafe",
 				"2",
@@ -426,7 +426,7 @@ func TestPrintClusters(t *testing.T) {
 			},
 		},
 		v1.TableRow{
-			Cells: []interface{}{
+			Cells: []any{
 				"bartender",
 				"speakeasy",
 				"3",

--- a/kubectl-plugin/pkg/cmd/get/get_nodes.go
+++ b/kubectl-plugin/pkg/cmd/get/get_nodes.go
@@ -231,7 +231,7 @@ func printNodes(nodes []node, allNamespaces bool, output io.Writer) error {
 		if allNamespaces {
 			row.Cells = append(row.Cells, node.namespace)
 		}
-		row.Cells = append(row.Cells, []interface{}{
+		row.Cells = append(row.Cells, []any{
 			node.name,
 			node.cpus.String(),
 			node.gpus.String(),

--- a/kubectl-plugin/pkg/cmd/get/get_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/get/get_workergroup.go
@@ -306,7 +306,7 @@ func printWorkerGroups(workerGroups []workerGroup, allNamespaces bool, output io
 		minStr := fmt.Sprintf("%d", wg.minReplicas)
 		maxStr := fmt.Sprintf("%d", wg.maxReplicas)
 
-		row.Cells = append(row.Cells, []interface{}{
+		row.Cells = append(row.Cells, []any{
 			wg.name,
 			minStr,
 			maxStr,

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -696,7 +696,7 @@ func runtimeEnvHasWorkingDir(runtimePath string) (string, error) {
 		return "", err
 	}
 
-	var runtimeEnvYaml map[string]interface{}
+	var runtimeEnvYaml map[string]any
 	err = yaml.Unmarshal(runtimeEnvFileContent, &runtimeEnvYaml)
 	if err != nil {
 		return "", err

--- a/kubectl-plugin/pkg/cmd/session/session.go
+++ b/kubectl-plugin/pkg/cmd/session/session.go
@@ -194,9 +194,7 @@ func (options *SessionOptions) Run(ctx context.Context, factory cmdutil.Factory)
 	fmt.Println()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			portforwardCmd := exec.Command("kubectl", kubectlArgs...)
 			portforwardCmd.Stdout = options.ioStreams.Out
@@ -212,7 +210,7 @@ func (options *SessionOptions) Run(ctx context.Context, factory cmdutil.Factory)
 			fmt.Printf("failed to port-forward: %v. Retrying in %v ...\n\n", err, reconnectDelay)
 			time.Sleep(reconnectDelay)
 		}
-	}()
+	})
 
 	wg.Wait()
 	return nil

--- a/kubectl-plugin/test/e2e/kubectl_ray_cluster_get_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_cluster_get_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Calling ray plugin `get` command", func() {
 		}
 
 		expectedTestResultTable.Rows = append(expectedTestResultTable.Rows, v1.TableRow{
-			Cells: []interface{}{
+			Cells: []any{
 				"raycluster-kuberay",
 				namespace,
 				"1",

--- a/kubectl-plugin/test/e2e/kubectl_ray_cluster_get_workergroup_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_cluster_get_workergroup_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Calling ray plugin `get workergroups` command to list worker g
 		}
 
 		expectedTestResultTable.Rows = append(expectedTestResultTable.Rows, v1.TableRow{
-			Cells: []interface{}{
+			Cells: []any{
 				"workergroup",
 				"1",
 				"5",

--- a/kubectl-plugin/test/e2e/kubectl_ray_log_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_log_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"maps"
 	"os"
 	"os/exec"
 	"path"
@@ -56,9 +57,7 @@ var _ = Describe("Calling ray plugin `log` command on Ray Cluster", func() {
 
 			currentRequiredFileList := make(map[string]string)
 
-			for key, value := range requiredFileSet {
-				currentRequiredFileList[key] = value
-			}
+			maps.Copy(currentRequiredFileList, requiredFileSet)
 
 			for _, logFile := range logList {
 				if checkContent := currentRequiredFileList[logFile.Name()]; checkContent != "" {
@@ -109,9 +108,7 @@ var _ = Describe("Calling ray plugin `log` command on Ray Cluster", func() {
 
 			currentRequiredFileList := make(map[string]string)
 
-			for key, value := range requiredFileSet {
-				currentRequiredFileList[key] = value
-			}
+			maps.Copy(currentRequiredFileList, requiredFileSet)
 
 			for _, logFile := range logList {
 				if checkContent := currentRequiredFileList[logFile.Name()]; checkContent != "" {
@@ -163,9 +160,7 @@ var _ = Describe("Calling ray plugin `log` command on Ray Cluster", func() {
 
 			currentRequiredFileList := make(map[string]string)
 
-			for key, value := range requiredFileSet {
-				currentRequiredFileList[key] = value
-			}
+			maps.Copy(currentRequiredFileList, requiredFileSet)
 
 			for _, logFile := range logList {
 				if checkContent := currentRequiredFileList[logFile.Name()]; checkContent != "" {

--- a/ray-operator/apis/config/v1alpha1/defaults.go
+++ b/ray-operator/apis/config/v1alpha1/defaults.go
@@ -15,7 +15,7 @@ const (
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	scheme.AddTypeDefaultingFunc(&Configuration{}, func(obj interface{}) {
+	scheme.AddTypeDefaultingFunc(&Configuration{}, func(obj any) {
 		SetDefaults_Configuration(obj.(*Configuration))
 	})
 	return nil

--- a/ray-operator/controllers/ray/batchscheduler/schedulermanager_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/schedulermanager_test.go
@@ -14,11 +14,6 @@ import (
 )
 
 func TestGetSchedulerFactory(t *testing.T) {
-	DefaultFactory := &schedulerinterface.DefaultBatchSchedulerFactory{}
-	VolcanoFactory := &volcano.VolcanoBatchSchedulerFactory{}
-	YuniKornFactory := &yunikorn.YuniKornSchedulerFactory{}
-	KaiFactory := &kaischeduler.KaiSchedulerFactory{}
-
 	type args struct {
 		rayConfigs v1alpha1.Configuration
 	}
@@ -36,7 +31,7 @@ func TestGetSchedulerFactory(t *testing.T) {
 					BatchScheduler:       "",
 				},
 			},
-			want: reflect.TypeOf(DefaultFactory),
+			want: reflect.TypeFor[*schedulerinterface.DefaultBatchSchedulerFactory](),
 		},
 		{
 			name: "enableBatchScheduler=false, batchScheduler not set",
@@ -45,7 +40,7 @@ func TestGetSchedulerFactory(t *testing.T) {
 					EnableBatchScheduler: false,
 				},
 			},
-			want: reflect.TypeOf(DefaultFactory),
+			want: reflect.TypeFor[*schedulerinterface.DefaultBatchSchedulerFactory](),
 		},
 		{
 			name: "enableBatchScheduler=false, batchScheduler set to yunikorn",
@@ -55,7 +50,7 @@ func TestGetSchedulerFactory(t *testing.T) {
 					BatchScheduler:       yunikorn.GetPluginName(),
 				},
 			},
-			want: reflect.TypeOf(YuniKornFactory),
+			want: reflect.TypeFor[*yunikorn.YuniKornSchedulerFactory](),
 		},
 		{
 			name: "enableBatchScheduler=false, batchScheduler set to volcano",
@@ -65,7 +60,7 @@ func TestGetSchedulerFactory(t *testing.T) {
 					BatchScheduler:       volcano.GetPluginName(),
 				},
 			},
-			want: reflect.TypeOf(VolcanoFactory),
+			want: reflect.TypeFor[*volcano.VolcanoBatchSchedulerFactory](),
 		},
 		{
 			name: "enableBatchScheduler=false, batchScheduler set to kai-scheduler",
@@ -75,7 +70,7 @@ func TestGetSchedulerFactory(t *testing.T) {
 					BatchScheduler:       kaischeduler.GetPluginName(),
 				},
 			},
-			want: reflect.TypeOf(KaiFactory),
+			want: reflect.TypeFor[*kaischeduler.KaiSchedulerFactory](),
 		},
 		{
 			name: "enableBatchScheduler not set, batchScheduler set to yunikorn",
@@ -84,7 +79,7 @@ func TestGetSchedulerFactory(t *testing.T) {
 					BatchScheduler: yunikorn.GetPluginName(),
 				},
 			},
-			want: reflect.TypeOf(YuniKornFactory),
+			want: reflect.TypeFor[*yunikorn.YuniKornSchedulerFactory](),
 		},
 		{
 			name: "enableBatchScheduler not set, batchScheduler set to volcano",
@@ -93,7 +88,7 @@ func TestGetSchedulerFactory(t *testing.T) {
 					BatchScheduler: volcano.GetPluginName(),
 				},
 			},
-			want: reflect.TypeOf(VolcanoFactory),
+			want: reflect.TypeFor[*volcano.VolcanoBatchSchedulerFactory](),
 		},
 		{
 			name: "enableBatchScheduler not set, batchScheduler set to kai-scheduler",
@@ -102,7 +97,7 @@ func TestGetSchedulerFactory(t *testing.T) {
 					BatchScheduler: kaischeduler.GetPluginName(),
 				},
 			},
-			want: reflect.TypeOf(KaiFactory),
+			want: reflect.TypeFor[*kaischeduler.KaiSchedulerFactory](),
 		},
 		{
 			name: "enableBatchScheduler not set, batchScheduler set to unknown value",
@@ -122,7 +117,7 @@ func TestGetSchedulerFactory(t *testing.T) {
 					BatchScheduler:       yunikorn.GetPluginName(),
 				},
 			},
-			want: reflect.TypeOf(VolcanoFactory),
+			want: reflect.TypeFor[*volcano.VolcanoBatchSchedulerFactory](),
 		},
 		{
 			// for backwards compatibility, if enableBatchScheduler=true, always use volcano
@@ -133,7 +128,7 @@ func TestGetSchedulerFactory(t *testing.T) {
 					BatchScheduler:       volcano.GetPluginName(),
 				},
 			},
-			want: reflect.TypeOf(VolcanoFactory),
+			want: reflect.TypeFor[*volcano.VolcanoBatchSchedulerFactory](),
 		},
 		{
 			// for backwards compatibility, if enableBatchScheduler=true, always use volcano
@@ -144,7 +139,7 @@ func TestGetSchedulerFactory(t *testing.T) {
 					BatchScheduler:       "",
 				},
 			},
-			want: reflect.TypeOf(VolcanoFactory),
+			want: reflect.TypeFor[*volcano.VolcanoBatchSchedulerFactory](),
 		},
 	}
 

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
@@ -2,6 +2,7 @@ package volcano
 
 import (
 	"context"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -213,9 +214,7 @@ func createTestRayClusterWithLabels(labels map[string]string) rayv1.RayCluster {
 	if cluster.ObjectMeta.Labels == nil {
 		cluster.ObjectMeta.Labels = make(map[string]string)
 	}
-	for k, v := range labels {
-		cluster.ObjectMeta.Labels[k] = v
-	}
+	maps.Copy(cluster.ObjectMeta.Labels, labels)
 	return cluster
 }
 

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -57,8 +57,8 @@ pip: ["python-multipart==0.0.6"]
 	jsonOutput, err := getRuntimeEnvJson(rayJobWithYAML)
 	require.NoError(t, err)
 
-	var expectedMap map[string]interface{}
-	var actualMap map[string]interface{}
+	var expectedMap map[string]any
+	var actualMap map[string]any
 
 	// Convert the JSON strings into map types to avoid errors due to ordering
 	require.NoError(t, json.Unmarshal([]byte(expectedJSON), &expectedMap))
@@ -182,7 +182,7 @@ pip: ["python-multipart==0.0.6"]
 		assert.Equal(t, expected[i], command[i])
 		if expected[i] == "--runtime-env-json" {
 			// Decode the JSON string from the next element.
-			var expectedMap, actualMap map[string]interface{}
+			var expectedMap, actualMap map[string]any
 			unquoteExpected, err1 := strconv.Unquote(expected[i+1])
 			require.NoError(t, err1)
 			unquotedCommand, err2 := strconv.Unquote(command[i+1])

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"sort"
 	"strconv"
@@ -1168,11 +1169,7 @@ func updateRayStartParamsResources(ctx context.Context, rayStartParams map[strin
 // with the top-level labels field taking precedence.
 func mergeLabels(templateLabels map[string]string, groupLabels map[string]string) map[string]string {
 	merged := make(map[string]string)
-	for k, v := range templateLabels {
-		merged[k] = v
-	}
-	for k, v := range groupLabels {
-		merged[k] = v
-	}
+	maps.Copy(merged, templateLabels)
+	maps.Copy(merged, groupLabels)
 	return merged
 }

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
 	"sort"
@@ -2009,9 +2010,7 @@ func TestUpdateRayStartParamsLabels(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// copy of rayStartParams for test
 			rayStartParams := make(map[string]string)
-			for k, v := range tc.initialRayStartParams {
-				rayStartParams[k] = v
-			}
+			maps.Copy(rayStartParams, tc.initialRayStartParams)
 
 			updateRayStartParamsLabels(rayStartParams, tc.groupLabels)
 
@@ -2088,9 +2087,7 @@ func TestUpdateRayStartParamsResources(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			rayStartParams := make(map[string]string)
-			for k, v := range tc.initialRayStartParams {
-				rayStartParams[k] = v
-			}
+			maps.Copy(rayStartParams, tc.initialRayStartParams)
 
 			updateRayStartParamsResources(ctx, rayStartParams, tc.groupResources)
 

--- a/ray-operator/controllers/ray/common/route.go
+++ b/ray-operator/controllers/ray/common/route.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"maps"
+
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -22,9 +24,7 @@ func BuildRouteForHeadService(cluster rayv1.RayCluster) (*routev1.Route, error) 
 	// Copy other configurations from cluster annotations to provide a generic way
 	// for user to customize their route settings.
 	annotation := map[string]string{}
-	for key, value := range cluster.Annotations {
-		annotation[key] = value
-	}
+	maps.Copy(annotation, cluster.Annotations)
 
 	servicePorts := getServicePorts(cluster)
 	dashboardPort := utils.DefaultDashboardPort

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"sort"
 	"strings"
@@ -54,9 +55,7 @@ func BuildServiceForHeadPod(ctx context.Context, cluster rayv1.RayCluster, label
 
 	// Deep copy the selector to avoid modifying the original object
 	labelsForService := make(map[string]string)
-	for k, v := range selector {
-		labelsForService[k] = v
-	}
+	maps.Copy(labelsForService, selector)
 
 	if annotations == nil {
 		annotations = make(map[string]string)
@@ -390,9 +389,7 @@ func setLabelsforUserProvidedService(service *corev1.Service, labels map[string]
 	if service.ObjectMeta.Labels == nil {
 		service.ObjectMeta.Labels = make(map[string]string)
 	}
-	for k, v := range labels {
-		service.ObjectMeta.Labels[k] = v
-	}
+	maps.Copy(service.ObjectMeta.Labels, labels)
 }
 
 // getServicePorts will either user passing ports or default ports to create service.

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -460,7 +460,7 @@ func TestBuildServiceForHeadPodPortsOrder(t *testing.T) {
 
 	// length should be same
 	assert.Len(t, ports2, len(ports1))
-	for i := 0; i < len(ports1); i++ {
+	for i := range ports1 {
 		// name should be same
 		assert.Equal(t, ports1[i].Name, ports2[i].Name)
 	}

--- a/ray-operator/controllers/ray/common/test_utils.go
+++ b/ray-operator/controllers/ray/common/test_utils.go
@@ -12,7 +12,7 @@ import (
 // Generate a string of length 200.
 func longString(t *testing.T) string {
 	var b bytes.Buffer
-	for i := 0; i < 200; i++ {
+	for range 200 {
 		b.WriteString("a")
 	}
 	result := b.String()

--- a/ray-operator/controllers/ray/expectations/scale_expectations.go
+++ b/ray-operator/controllers/ray/expectations/scale_expectations.go
@@ -149,17 +149,17 @@ func (p *rayPod) ClusterKey() string {
 }
 
 // rayPodKey is used only for getting rayPod.Key(). The type of obj must be rayPod.
-func rayPodKey(obj interface{}) (string, error) {
+func rayPodKey(obj any) (string, error) {
 	return obj.(*rayPod).Key(), nil
 }
 
 // groupIndexFunc is used only for getting rayPod.GroupKey(). The type of obj must be rayPod.
-func groupIndexFunc(obj interface{}) ([]string, error) {
+func groupIndexFunc(obj any) ([]string, error) {
 	return []string{obj.(*rayPod).GroupKey()}, nil
 }
 
 // rayClusterIndexFunc is used only for getting rayPod.ClusterKey(). The type of obj must be rayPod.
-func rayClusterIndexFunc(obj interface{}) ([]string, error) {
+func rayClusterIndexFunc(obj any) ([]string, error) {
 	return []string{obj.(*rayPod).ClusterKey()}, nil
 }
 

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -3,6 +3,7 @@ package ray
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"strconv"
 	"strings"
@@ -935,9 +936,7 @@ func (r *RayJobReconciler) getOrCreateRayClusterInstance(ctx context.Context, ra
 
 func (r *RayJobReconciler) constructRayClusterForRayJob(rayJobInstance *rayv1.RayJob, rayClusterName string) (*rayv1.RayCluster, error) {
 	labels := make(map[string]string, len(rayJobInstance.Labels))
-	for key, value := range rayJobInstance.Labels {
-		labels[key] = value
-	}
+	maps.Copy(labels, rayJobInstance.Labels)
 	labels[utils.RayOriginatedFromCRNameLabelKey] = rayJobInstance.Name
 	labels[utils.RayOriginatedFromCRDLabelKey] = utils.RayOriginatedFromCRDLabelValue(utils.RayJobCRD)
 	rayCluster := &rayv1.RayCluster{

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	errstd "errors"
 	"fmt"
+	"maps"
 	"math"
 	"os"
 	"reflect"
@@ -1156,16 +1157,12 @@ func (r *RayServiceReconciler) createRayClusterInstance(ctx context.Context, ray
 func constructRayClusterForRayService(rayService *rayv1.RayService, rayClusterName string, scheme *runtime.Scheme) (*rayv1.RayCluster, error) {
 	var err error
 	rayClusterLabel := make(map[string]string)
-	for k, v := range rayService.Labels {
-		rayClusterLabel[k] = v
-	}
+	maps.Copy(rayClusterLabel, rayService.Labels)
 	rayClusterLabel[utils.RayOriginatedFromCRNameLabelKey] = rayService.Name
 	rayClusterLabel[utils.RayOriginatedFromCRDLabelKey] = utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD)
 
 	rayClusterAnnotations := make(map[string]string)
-	for k, v := range rayService.Annotations {
-		rayClusterAnnotations[k] = v
-	}
+	maps.Copy(rayClusterAnnotations, rayService.Annotations)
 	rayClusterAnnotations[utils.HashWithoutReplicasAndWorkersToDeleteKey], err = generateHashWithoutReplicasAndWorkersToDelete(rayService.Spec.RayClusterSpec)
 	if err != nil {
 		return nil, err
@@ -1229,7 +1226,7 @@ func (r *RayServiceReconciler) updateServeDeployment(ctx context.Context, raySer
 	logger := ctrl.LoggerFrom(ctx)
 	logger.Info("updateServeDeployment", "V2 config", rayServiceInstance.Spec.ServeConfigV2)
 
-	serveConfig := make(map[string]interface{})
+	serveConfig := make(map[string]any)
 	if err := yaml.Unmarshal([]byte(rayServiceInstance.Spec.ServeConfigV2), &serveConfig); err != nil {
 		return err
 	}
@@ -1351,7 +1348,7 @@ func (r *RayServiceReconciler) applyServeTargetCapacity(ctx context.Context, ray
 		cachedConfig = rayServiceInstance.Spec.ServeConfigV2
 	}
 
-	serveConfig := make(map[string]interface{})
+	serveConfig := make(map[string]any)
 	if err := yaml.Unmarshal([]byte(cachedConfig), &serveConfig); err != nil {
 		return err
 	}

--- a/ray-operator/controllers/ray/utils/types/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/types/dashboard_httpclient.go
@@ -4,7 +4,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
-type RuntimeEnvType map[string]interface{}
+type RuntimeEnvType map[string]any
 
 // RayJobInfo is the response of "ray job status" api.
 // Reference to https://docs.ray.io/en/latest/cluster/running-applications/job-submission/rest.html#ray-job-rest-api-spec

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -567,12 +568,7 @@ func SumResourceList(list []corev1.ResourceList) corev1.ResourceList {
 }
 
 func Contains(elems []string, searchTerm string) bool {
-	for _, s := range elems {
-		if searchTerm == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(elems, searchTerm)
 }
 
 // GetHeadGroupServiceAccountName returns the head group service account if it exists.
@@ -608,7 +604,7 @@ func CheckAllPodsRunning(ctx context.Context, runningPods corev1.PodList) bool {
 }
 
 // CompareJsonStruct This is a way to better compare if two objects are the same when they are json/yaml structs. reflect.DeepEqual will fail in some cases.
-func CompareJsonStruct(objA interface{}, objB interface{}) bool {
+func CompareJsonStruct(objA any, objB any) bool {
 	a, err := json.Marshal(objA)
 	if err != nil {
 		return false
@@ -617,7 +613,7 @@ func CompareJsonStruct(objA interface{}, objB interface{}) bool {
 	if err != nil {
 		return false
 	}
-	var v1, v2 interface{}
+	var v1, v2 any
 	err = json.Unmarshal(a, &v1)
 	if err != nil {
 		return false
@@ -630,7 +626,7 @@ func CompareJsonStruct(objA interface{}, objB interface{}) bool {
 }
 
 // Json-serializes obj and returns its hash string
-func GenerateJsonHash(obj interface{}) (string, error) {
+func GenerateJsonHash(obj any) (string, error) {
 	serialObj, err := json.Marshal(obj)
 	if err != nil {
 		return "", err

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -320,7 +320,7 @@ func cacheSelectors() (map[client.Object]cache.ByObject, error) {
 	}, nil
 }
 
-func exitOnError(err error, msg string, keysAndValues ...interface{}) {
+func exitOnError(err error, msg string, keysAndValues ...any) {
 	if err != nil {
 		setupLog.Error(err, msg, keysAndValues...)
 		os.Exit(1)

--- a/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
+++ b/ray-operator/test/e2eautoscaler/raycluster_autoscaler_test.go
@@ -321,7 +321,7 @@ func TestRayClusterAutoscalerMinReplicasUpdate(t *testing.T) {
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 			LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
 
-			for i := 0; i < 3; i++ {
+			for i := range 3 {
 				ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "/home/ray/test_scripts/create_detached_actor.py", fmt.Sprintf("actor%d", i)})
 			}
 

--- a/ray-operator/test/e2eautoscaler/support.go
+++ b/ray-operator/test/e2eautoscaler/support.go
@@ -57,7 +57,7 @@ func files(t Test, fileNames ...string) option[corev1ac.ConfigMapApplyConfigurat
 
 func mountConfigMap[T rayv1ac.RayClusterSpecApplyConfiguration | corev1ac.PodTemplateSpecApplyConfiguration](configMap *corev1.ConfigMap, mountPath string) option[T] {
 	return func(t *T) *T {
-		switch obj := (interface{})(t).(type) {
+		switch obj := (any)(t).(type) {
 		case *rayv1ac.RayClusterSpecApplyConfiguration:
 			obj.HeadGroupSpec.Template.Spec.Containers[0].WithVolumeMounts(corev1ac.VolumeMount().
 				WithName(configMap.Name).

--- a/ray-operator/test/e2erayservice/rayservice_ha_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_ha_test.go
@@ -160,11 +160,8 @@ func TestRayServiceZeroDowntimeUpgrade(t *testing.T) {
 
 	// Start a goroutine to perform zero-downtime upgrade
 	var wg sync.WaitGroup
-	wg.Add(1)
 
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		LogWithTimestamp(test.T(), "Waiting several seconds before updating RayService")
 		time.Sleep(30 * time.Second)
 
@@ -179,7 +176,7 @@ func TestRayServiceZeroDowntimeUpgrade(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 
 		waitingForRayClusterSwitch(g, test, newRayService, rayClusterName)
-	}()
+	})
 
 	// Run Locust test
 	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{

--- a/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
@@ -78,8 +78,8 @@ func TestOldHeadPodFailDuringUpgrade(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	LogWithTimestamp(test.T(), "Using iptables to make the ProxyActor(8000 port) fail to receive requests on the old head Pod")
-	headPodPatch := map[string]interface{}{
-		"spec": map[string]interface{}{
+	headPodPatch := map[string]any{
+		"spec": map[string]any{
 			"ephemeralContainers": []corev1.EphemeralContainer{
 				{
 					EphemeralContainerCommon: corev1.EphemeralContainerCommon{

--- a/ray-operator/test/sampleyaml/support.go
+++ b/ray-operator/test/sampleyaml/support.go
@@ -2,6 +2,7 @@ package sampleyaml
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -43,9 +44,7 @@ func SubmitJobsToAllPods(t Test, rayCluster *rayv1.RayCluster) func(Gomega) {
 
 func getApps(rayService *rayv1.RayService) map[string]rayv1.AppStatus {
 	apps := make(map[string]rayv1.AppStatus)
-	for k, v := range rayService.Status.ActiveServiceStatus.Applications {
-		apps[k] = v
-	}
+	maps.Copy(apps, rayService.Status.ActiveServiceStatus.Applications)
 	return apps
 }
 

--- a/ray-operator/test/support/events.go
+++ b/ray-operator/test/support/events.go
@@ -3,6 +3,7 @@ package support
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -122,9 +123,9 @@ func renderEventContent(keys []string, dataMaps []map[string]string) ([]byte, er
 }
 
 func getWhitespaceStr(size int) string {
-	whiteSpaceStr := ""
-	for i := 0; i < size; i++ {
-		whiteSpaceStr += " "
+	var whiteSpaceStr strings.Builder
+	for range size {
+		whiteSpaceStr.WriteString(" ")
 	}
-	return whiteSpaceStr
+	return whiteSpaceStr.String()
 }

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -92,7 +92,7 @@ type ConditionMatcher struct {
 	expected metav1.Condition
 }
 
-func (c *ConditionMatcher) Match(actual interface{}) (success bool, err error) {
+func (c *ConditionMatcher) Match(actual any) (success bool, err error) {
 	if actual == nil {
 		return false, errors.New("<actual> should be a metav1.Condition but it is nil")
 	}
@@ -107,12 +107,12 @@ func (c *ConditionMatcher) Match(actual interface{}) (success bool, err error) {
 	return a.Reason == c.expected.Reason && a.Status == c.expected.Status && messageMatch, nil
 }
 
-func (c *ConditionMatcher) FailureMessage(actual interface{}) (message string) {
+func (c *ConditionMatcher) FailureMessage(actual any) (message string) {
 	a := actual.(metav1.Condition)
 	return format.Message(a, "to equal", c.expected)
 }
 
-func (c *ConditionMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (c *ConditionMatcher) NegatedFailureMessage(actual any) (message string) {
 	a := actual.(metav1.Condition)
 	return format.Message(a, "not to equal", c.expected)
 }

--- a/ray-operator/test/support/resource_logger.go
+++ b/ray-operator/test/support/resource_logger.go
@@ -44,7 +44,7 @@ func (l *RayResourceLogger) Helper() {
 	l.t.T().Helper()
 }
 
-func (l *RayResourceLogger) Fatalf(format string, args ...interface{}) {
+func (l *RayResourceLogger) Fatalf(format string, args ...any) {
 	l.Helper()
 	loggers := l.GetLoggers()
 	var sb strings.Builder

--- a/ray-operator/test/support/support.go
+++ b/ray-operator/test/support/support.go
@@ -92,7 +92,7 @@ func RayClusterSpecWith(spec *rayv1ac.RayClusterSpecApplyConfiguration, options 
 
 func MountConfigMap[T rayv1ac.RayClusterSpecApplyConfiguration | corev1ac.PodTemplateSpecApplyConfiguration](configMap *corev1.ConfigMap, mountPath string) SupportOption[T] {
 	return func(t *T) *T {
-		switch obj := (interface{})(t).(type) {
+		switch obj := (any)(t).(type) {
 		case *rayv1ac.RayClusterSpecApplyConfiguration:
 			obj.HeadGroupSpec.Template.Spec.Containers[0].WithVolumeMounts(corev1ac.VolumeMount().
 				WithName(configMap.Name).

--- a/ray-operator/test/support/test.go
+++ b/ray-operator/test/support/test.go
@@ -118,7 +118,7 @@ func (t *T) NewTestNamespace(options ...Option[*corev1.Namespace]) *corev1.Names
 	return namespace
 }
 
-func LogWithTimestamp(t *testing.T, format string, args ...interface{}) {
+func LogWithTimestamp(t *testing.T, format string, args ...any) {
 	t.Helper()
 	t.Logf("[%s] %s", time.Now().Format(time.RFC3339), fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
I propose enabling the `modernize` analyzer in` golangci-lint` for KubeRay.
The `modernize` linter suggests more modern, idiomatic Go patterns based on newer language and standard library features, helping keep the codebase consistently up-to-date and easier to read and maintain.
For a long-lived, multi-contributor project like KubeRay, this reduces maintenance cost by preventing a mix of legacy and modern styles from accumulating over time, and it shifts code review discussions away from “style/idioms” toward behavior, correctness, and design.
Additionally, enabling modernize follows a broader trend across large Go / cloud-native projects that are adopting it in their `golangci-lint` pipelines, for example, [Prometheus](https://github.com/prometheus/prometheus/blob/main/.golangci.yml#L34), [Cert-Manager](https://github.com/cert-manager/cert-manager/blob/master/.golangci.yaml#L72), and [controller-tools](https://github.com/kubernetes-sigs/controller-tools/blob/main/.golangci.yml#L36). 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Part of #4008
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
