### PR TITLE
[historyserver] Ensure at least one worker in sample RayCluster

### DIFF
--- a/historyserver/config/raycluster.yaml
+++ b/historyserver/config/raycluster.yaml
@@ -108,7 +108,7 @@ spec:
     minReplicas: 1
     numOfHosts: 1
     rayStartParams: {}
-    replicas: 0
+    replicas: 1
     template:
       metadata:
         labels:


### PR DESCRIPTION
## Why are these changes needed?
We should test the history server with both a head node and at least one worker node; this makes it easier to find bugs.

How I test it?

1. create a raycluster
2. submit a rayjob using cluster selector
3. delete head pod and worker pod manually, trigger collectors push logs

This directory contains two subdirectories: one for the head node and the other for the worker node.  

<img width="960" height="370" alt="image" src="https://github.com/user-attachments/assets/268d7177-b223-44c5-bd3d-de368b07df33" />
<img width="1838" height="112" alt="image" src="https://github.com/user-attachments/assets/ed10a816-638d-4169-81df-b28c515190c9" />
<img width="1864" height="95" alt="image" src="https://github.com/user-attachments/assets/786ac3e5-3843-467a-840d-8961236a9786" />

E2E test passed
<img width="1234" height="132" alt="image" src="https://github.com/user-attachments/assets/63b77340-2e2d-4f4f-91e0-8d1202ab73ad" />


## Related issue number
https://github.com/ray-project/kuberay/issues/4274


## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
