### PR TITLE
[Chore] Bump up KuberayUpgradeVersion default version for e2e test

### DIFF
--- a/ray-operator/test/support/defaults.go
+++ b/ray-operator/test/support/defaults.go
@@ -3,5 +3,5 @@ package support
 const (
 	RayVersion            = "2.52.0"
 	RayImage              = "rayproject/ray:2.52.0"
-	KuberayUpgradeVersion = "v1.4.0"
+	KuberayUpgradeVersion = "v1.5.1"
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR updates `KuberayUpgradeVersion` from `v1.4.0` to `v1.5.1`, ensuring the e2e upgrade tests (`TestZeroDowntimeUpgradeAfterOperatorUpgrade`) validate operator upgrades to the latest stable version.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
