### PR TITLE
Support Multi-Arch Image in CI

### DIFF
--- a/ray-operator/test/support/environment.go
+++ b/ray-operator/test/support/environment.go
@@ -1,10 +1,7 @@
 package support
 
 import (
-	"fmt"
 	"os"
-	"runtime"
-	"strings"
 )
 
 const (
@@ -17,8 +14,6 @@ const (
 	// KuberayTestRayImage is the Ray image to use for testing.
 	KuberayTestRayImage = "KUBERAY_TEST_RAY_IMAGE"
 
-	KuberayTestArch = "KUBERAY_TEST_ARCH"
-
 	KuberayTestUpgradeImage = "KUBERAY_TEST_UPGRADE_IMAGE"
 )
 
@@ -27,19 +22,7 @@ func GetRayVersion() string {
 }
 
 func GetRayImage() string {
-	rayImage := lookupEnvOrDefault(KuberayTestRayImage, RayImage)
-	// detect if we are running on arm64 machine, most likely apple silicon
-	// the os name is not checked as it also possible that it might be linux
-	// also check if the image does not have the `-aarch64` suffix
-	arch := runtime.GOARCH
-	if archFromEnv := lookupEnvOrDefault(KuberayTestArch, ""); archFromEnv != "" {
-		arch = archFromEnv
-	}
-	if arch == "arm64" && !strings.HasSuffix(rayImage, "-aarch64") {
-		rayImage = rayImage + "-aarch64"
-		fmt.Printf("Modified Ray Image to: %s for ARM chips\n", rayImage)
-	}
-	return rayImage
+	return lookupEnvOrDefault(KuberayTestRayImage, RayImage)
 }
 
 func GetKubeRayUpgradeVersion() string {


### PR DESCRIPTION
… tests

This commit introduces a new environment variable KuberayTestArch that allows overriding the detected architecture in test environments. Previously, the system only relied on runtime.GOARCH to determine if ARM64 architecture was being used, but this change enables explicit architecture specification through the environment variable. This is particularly useful for testing scenarios where you want to force a specific architecture regardless of the actual runtime environment, improving test flexibility and consistency across different platforms.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

to #4346 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
