### PR TITLE
[Refactor] [Test] Add helpers and use auto cleanup for testing the RayJob deletion strategy

### DIFF
--- a/ray-operator/test/e2erayjob/rayjob_deletion_strategy_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_deletion_strategy_test.go
@@ -727,5 +727,9 @@ func applyRayJobAndWaitForJobDeploymentStatusFailed(test Test, g *WithT, namespa
 			WithTransform(RayJobReason, Equal(rayv1.DeadlineExceeded)),
 		))
 
+	LogWithTimestamp(test.T(), "Verifying JobStatus is Running...")
+	g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		Should(WithTransform(RayJobStatus, Equal(rayv1.JobStatusRunning)))
+
 	return rayJob
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The current e2e test `TestDeletionStrategy` runs all sub-test cases in a single shared namespace, which makes it difficult to take advantage of the per-namespace auto-cleanup logic:

https://github.com/ray-project/kuberay/blob/79b5c304b3742e9b7cbc4c660344126f731d117e/ray-operator/test/support/test.go#L116

In addition, several code snippets are duplicated, which reduces readability and reusability.

### Key Changes
- Create a dedicated test namespace for each test case and remove manual cleanup
- Introduce three helper functions to streamline applying and validating resources:
  - `applyJobScriptConfigMap`
  - `applyRayJobAndWaitForCompletion`
  - `applyRayJobAndWaitForJobDeploymentStatusFailed`

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/kuberay/issues/4294.

## Test Results

<img width="1022" height="209" alt="Screenshot 2026-01-12 at 9 15 31 PM" src="https://github.com/user-attachments/assets/f5232a7a-0cf2-4a85-9e13-de61eac0196d" />


## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
