### PR TITLE
[kubectl-plugin][Refactor] Standardize namespace resolution to respect kubeconfig context.

### DIFF
--- a/kubectl-plugin/pkg/cmd/create/create_cluster.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster.go
@@ -149,7 +149,7 @@ func NewCreateClusterCommand(cmdFactory cmdutil.Factory, streams genericclioptio
 }
 
 func (options *CreateClusterOptions) Complete(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	namespace, _, err := options.cmdFactory.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return fmt.Errorf("failed to get namespace: %w", err)
 	}
@@ -240,15 +240,17 @@ func (options *CreateClusterOptions) resolveClusterName() (string, error) {
 
 // resolveNamespace resolves the namespace from the CLI flag and the config file
 func (options *CreateClusterOptions) resolveNamespace() (string, error) {
-	namespace := "default"
-
-	if options.rayClusterConfig.Namespace != nil && *options.rayClusterConfig.Namespace != "" && options.namespace != "" && options.namespace != *options.rayClusterConfig.Namespace {
-		return "", fmt.Errorf("the namespace in the config file %q does not match the namespace %q. You must pass --namespace=%s to perform this operation", *options.rayClusterConfig.Namespace, options.namespace, *options.rayClusterConfig.Namespace)
+	namespace, cliNamespace, err := options.cmdFactory.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current namespace: %w", err)
 	}
 
-	if options.namespace != "" {
-		namespace = options.namespace
-	} else if options.rayClusterConfig.Namespace != nil && *options.rayClusterConfig.Namespace != "" {
+	if cliNamespace && options.rayClusterConfig.Namespace != nil && *options.rayClusterConfig.Namespace != "" && namespace != *options.rayClusterConfig.Namespace {
+		return "", fmt.Errorf("the namespace in the config file %q does not match the namespace %q. You must pass --namespace=%s to perform this operation", *options.rayClusterConfig.Namespace, namespace, *options.rayClusterConfig.Namespace)
+	}
+
+	if options.rayClusterConfig.Namespace != nil && *options.rayClusterConfig.Namespace != "" {
+		options.namespace = *options.rayClusterConfig.Namespace
 		namespace = *options.rayClusterConfig.Namespace
 	}
 
@@ -273,10 +275,6 @@ func (options *CreateClusterOptions) Run(ctx context.Context, k8sClient client.C
 		}
 		options.rayClusterConfig.Namespace = &namespace
 	} else {
-		if options.namespace == "" {
-			options.namespace = "default"
-		}
-
 		options.rayClusterConfig = &generation.RayClusterConfig{
 			Namespace:   &options.namespace,
 			Name:        &options.clusterName,

--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/ray-project/kuberay/kubectl-plugin/pkg/util"
@@ -22,48 +24,94 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
 
+func createTempKubeConfigFile(t *testing.T, currentNamespace string) (string, error) {
+	tmpDir := t.TempDir()
+
+	// Set up fake config for kubeconfig
+	config := &api.Config{
+		Clusters: map[string]*api.Cluster{
+			"test-cluster": {
+				Server:                "https://fake-kubernetes-cluster.example.com",
+				InsecureSkipTLSVerify: true, // For testing purposes
+			},
+		},
+		Contexts: map[string]*api.Context{
+			"test-context": {
+				Cluster:   "test-cluster",
+				AuthInfo:  "my-fake-user",
+				Namespace: currentNamespace,
+			},
+		},
+		CurrentContext: "test-context",
+		AuthInfos: map[string]*api.AuthInfo{
+			"my-fake-user": {
+				Token: "", // Empty for testing without authentication
+			},
+		},
+	}
+
+	fakeFile := filepath.Join(tmpDir, ".kubeconfig")
+
+	return fakeFile, clientcmd.WriteToFile(*config, fakeFile)
+}
+
 func TestRayCreateClusterComplete(t *testing.T) {
+	kubeConfigWithCurrentContext, err := createTempKubeConfigFile(t, "test-namespace")
+	require.NoError(t, err)
 	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
 
 	tests := map[string]struct {
-		image         string
-		rayVersion    string
-		expectedError string
-		expectedImage string
-		args          []string
+		image             string
+		namespace         string
+		rayVersion        string
+		expectedError     string
+		expectedImage     string
+		expectedNamespace string
+		args              []string
 	}{
 		"should error when there are no args": {
-			args:          []string{},
-			expectedError: "See 'cluster -h' for help and examples",
+			args:              []string{},
+			expectedError:     "See 'cluster -h' for help and examples",
+			expectedNamespace: "test-namespace",
 		},
 		"should error when too many args": {
-			args:          []string{"testRayClusterName", "extra-arg"},
-			expectedError: "See 'cluster -h' for help and examples",
+			args:              []string{"testRayClusterName", "extra-arg"},
+			expectedError:     "See 'cluster -h' for help and examples",
+			expectedNamespace: "test-namespace",
 		},
 		"should succeed with default image when no image is specified": {
-			args:          []string{"testRayClusterName"},
-			rayVersion:    util.RayVersion,
-			expectedImage: defaultImageWithTag,
+			args:              []string{"testRayClusterName"},
+			rayVersion:        util.RayVersion,
+			expectedImage:     defaultImageWithTag,
+			expectedNamespace: "test-namespace",
 		},
 		"should succeed with provided image when provided": {
-			args:          []string{"testRayClusterName"},
-			image:         "DEADBEEF",
-			expectedImage: "DEADBEEF",
+			args:              []string{"testRayClusterName"},
+			image:             "DEADBEEF",
+			expectedImage:     "DEADBEEF",
+			expectedNamespace: "test-namespace",
 		},
 		"should set the image to the same version as the ray version when the image is the default and the ray version is not the default": {
-			args:          []string{"testRayClusterName"},
-			image:         defaultImageWithTag,
-			rayVersion:    "2.52.0",
-			expectedImage: fmt.Sprintf("%s:2.52.0", defaultImage),
+			args:              []string{"testRayClusterName"},
+			image:             defaultImageWithTag,
+			namespace:         "foo",
+			rayVersion:        "2.52.0",
+			expectedImage:     fmt.Sprintf("%s:2.52.0", defaultImage),
+			expectedNamespace: "foo",
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+			configFlags := &genericclioptions.ConfigFlags{KubeConfig: &kubeConfigWithCurrentContext}
+			if tc.namespace != "" {
+				configFlags.Namespace = &tc.namespace
+			}
+
+			cmdFactory := cmdutil.NewFactory(configFlags)
 			fakeCreateClusterOptions := NewCreateClusterOptions(cmdFactory, testStreams)
 			cmd := &cobra.Command{Use: "cluster"}
-			cmd.Flags().StringVarP(&fakeCreateClusterOptions.namespace, "namespace", "n", "", "")
+			configFlags.AddFlags(cmd.Flags())
 			fakeCreateClusterOptions.rayVersion = tc.rayVersion
 
 			if tc.image != "" {
@@ -77,6 +125,7 @@ func TestRayCreateClusterComplete(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedImage, fakeCreateClusterOptions.image)
+				require.Equal(t, tc.expectedNamespace, fakeCreateClusterOptions.namespace)
 			}
 		})
 	}
@@ -306,8 +355,9 @@ func TestNewCreateClusterCommand(t *testing.T) {
 }
 
 func TestResolveNamespace(t *testing.T) {
+	kubeConfigWithCurrentContext, err := createTempKubeConfigFile(t, "")
+	require.NoError(t, err)
 	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
 
 	tests := map[string]struct {
 		cliNamespace      string  // namespace from the CLI flag
@@ -344,6 +394,12 @@ func TestResolveNamespace(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			configFlags := &genericclioptions.ConfigFlags{KubeConfig: &kubeConfigWithCurrentContext}
+			if tc.cliNamespace != "" {
+				configFlags.Namespace = &tc.cliNamespace
+			}
+
+			cmdFactory := cmdutil.NewFactory(configFlags)
 			options := NewCreateClusterOptions(cmdFactory, testStreams)
 			options.namespace = tc.cliNamespace
 			options.rayClusterConfig = &generation.RayClusterConfig{

--- a/kubectl-plugin/pkg/cmd/create/create_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/create/create_workergroup.go
@@ -108,15 +108,11 @@ func NewCreateWorkerGroupCommand(cmdFactory cmdutil.Factory, streams genericclio
 }
 
 func (options *CreateWorkerGroupOptions) Complete(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	namespace, _, err := options.cmdFactory.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return fmt.Errorf("failed to get namespace: %w", err)
 	}
 	options.namespace = namespace
-
-	if options.namespace == "" {
-		options.namespace = "default"
-	}
 
 	if options.rayStartParams == nil {
 		options.rayStartParams = map[string]string{}

--- a/kubectl-plugin/pkg/cmd/delete/delete.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete.go
@@ -78,14 +78,11 @@ func NewDeleteCommand(cmdFactory cmdutil.Factory, streams genericclioptions.IOSt
 }
 
 func (options *DeleteOptions) Complete(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	namespace, _, err := options.cmdFactory.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return fmt.Errorf("failed to get namespace: %w", err)
 	}
 	options.namespace = namespace
-	if options.namespace == "" {
-		options.namespace = "default"
-	}
 
 	if options.resources == nil {
 		options.resources = map[util.ResourceType][]string{}

--- a/kubectl-plugin/pkg/cmd/delete/delete_test.go
+++ b/kubectl-plugin/pkg/cmd/delete/delete_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestComplete(t *testing.T) {
 	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
 
 	tests := []struct {
 		name                 string
@@ -102,10 +101,16 @@ func TestComplete(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fakeDeleteOptions := NewDeleteOptions(cmdFactory, testStreams)
+			configFlags := genericclioptions.NewConfigFlags(true)
+			if tc.namespace != "" {
+				configFlags.Namespace = &tc.namespace
+			}
+			cmdFactory := cmdutil.NewFactory(configFlags)
 
+			fakeDeleteOptions := NewDeleteOptions(cmdFactory, testStreams)
 			cmd := &cobra.Command{}
-			cmd.Flags().StringVarP(&fakeDeleteOptions.namespace, "namespace", "n", tc.namespace, "")
+			flags := cmd.Flags()
+			configFlags.AddFlags(flags)
 
 			err := fakeDeleteOptions.Complete(cmd, tc.args)
 

--- a/kubectl-plugin/pkg/cmd/get/get_cluster.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster.go
@@ -46,7 +46,7 @@ func NewGetClusterCommand(cmdFactory cmdutil.Factory, streams genericclioptions.
 		ValidArgsFunction: completion.RayClusterCompletionFunc(cmdFactory),
 		Args:              cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := options.Complete(args, cmd); err != nil {
+			if err := options.Complete(args); err != nil {
 				return err
 			}
 			// running cmd.Execute or cmd.ExecuteE sets the context, which will be done by root
@@ -61,15 +61,12 @@ func NewGetClusterCommand(cmdFactory cmdutil.Factory, streams genericclioptions.
 	return cmd
 }
 
-func (options *GetClusterOptions) Complete(args []string, cmd *cobra.Command) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+func (options *GetClusterOptions) Complete(args []string) error {
+	namespace, _, err := options.cmdFactory.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return fmt.Errorf("failed to get namespace: %w", err)
 	}
 	options.namespace = namespace
-	if options.namespace == "" {
-		options.namespace = "default"
-	}
 
 	if len(args) >= 1 {
 		options.cluster = args[0]

--- a/kubectl-plugin/pkg/cmd/get/get_nodes.go
+++ b/kubectl-plugin/pkg/cmd/get/get_nodes.go
@@ -83,7 +83,7 @@ func NewGetNodesCommand(cmdFactory cmdutil.Factory, streams genericclioptions.IO
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: completion.NodeCompletionFunc(cmdFactory),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := options.Complete(args, cmd); err != nil {
+			if err := options.Complete(args); err != nil {
 				return err
 			}
 			k8sClient, err := client.NewClient(cmdFactory)
@@ -105,19 +105,15 @@ func NewGetNodesCommand(cmdFactory cmdutil.Factory, streams genericclioptions.IO
 	return cmd
 }
 
-func (options *GetNodesOptions) Complete(args []string, cmd *cobra.Command) error {
+func (options *GetNodesOptions) Complete(args []string) error {
 	if options.allNamespaces {
 		options.namespace = ""
 	} else {
-		namespace, err := cmd.Flags().GetString("namespace")
+		namespace, _, err := options.cmdFactory.ToRawKubeConfigLoader().Namespace()
 		if err != nil {
 			return fmt.Errorf("failed to get namespace: %w", err)
 		}
 		options.namespace = namespace
-
-		if options.namespace == "" {
-			options.namespace = "default"
-		}
 	}
 
 	if len(args) > 0 {

--- a/kubectl-plugin/pkg/cmd/get/get_nodes_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_nodes_test.go
@@ -25,9 +25,6 @@ import (
 
 func TestRayNodesGetComplete(t *testing.T) {
 	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
-	cmd := &cobra.Command{}
-	flags := cmd.Flags()
-	flags.String("namespace", "", "namespace flag")
 
 	tests := []struct {
 		opts              *GetNodesOptions
@@ -83,9 +80,15 @@ func TestRayNodesGetComplete(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := flags.Set("namespace", tc.namespace)
-			require.NoError(t, err)
-			err = tc.opts.Complete(tc.args, cmd)
+			configFlags := genericclioptions.NewConfigFlags(true)
+			if tc.namespace != "" {
+				configFlags.Namespace = &tc.namespace
+			}
+			tc.opts.cmdFactory = cmdutil.NewFactory(configFlags)
+			cmd := &cobra.Command{}
+			flags := cmd.Flags()
+			configFlags.AddFlags(flags)
+			err := tc.opts.Complete(tc.args)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedNamespace, tc.opts.namespace)
 			assert.Equal(t, tc.expectedNode, tc.opts.node)

--- a/kubectl-plugin/pkg/cmd/get/get_token.go
+++ b/kubectl-plugin/pkg/cmd/get/get_token.go
@@ -40,7 +40,7 @@ func NewGetTokenCommand(cmdFactory cmdutil.Factory, streams genericclioptions.IO
 		ValidArgsFunction: completion.RayClusterCompletionFunc(cmdFactory),
 		Args:              cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := options.Complete(args, cmd); err != nil {
+			if err := options.Complete(args); err != nil {
 				return err
 			}
 			// running cmd.Execute or cmd.ExecuteE sets the context, which will be done by root
@@ -54,15 +54,12 @@ func NewGetTokenCommand(cmdFactory cmdutil.Factory, streams genericclioptions.IO
 	return cmd
 }
 
-func (options *GetTokenOptions) Complete(args []string, cmd *cobra.Command) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+func (options *GetTokenOptions) Complete(args []string) error {
+	namespace, _, err := options.cmdFactory.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return fmt.Errorf("failed to get namespace: %w", err)
 	}
 	options.namespace = namespace
-	if options.namespace == "" {
-		options.namespace = "default"
-	}
 	// guarded by cobra.ExactArgs(1)
 	options.cluster = args[0]
 	return nil

--- a/kubectl-plugin/pkg/cmd/get/get_token_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_token_test.go
@@ -19,7 +19,8 @@ import (
 
 // Tests the Run() step of the command and ensure that the output is as expected.
 func TestTokenGetRun(t *testing.T) {
-	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+	configFlags := genericclioptions.NewConfigFlags(true)
+	cmdFactory := cmdutil.NewFactory(configFlags)
 
 	testStreams, _, resBuf, _ := genericclioptions.NewTestIOStreams()
 	fakeTokenGetOptions := NewGetTokenOptions(cmdFactory, testStreams)
@@ -50,9 +51,12 @@ func TestTokenGetRun(t *testing.T) {
 	rayClient := clienttesting.NewRayClientset(rayCluster)
 	k8sClients := client.NewClientForTesting(kubeClientSet, rayClient)
 
+	if secret.Namespace != "" {
+		configFlags.Namespace = &secret.Namespace
+	}
 	cmd := &cobra.Command{}
-	cmd.Flags().StringVarP(&fakeTokenGetOptions.namespace, "namespace", "n", secret.Namespace, "")
-	err := fakeTokenGetOptions.Complete([]string{rayCluster.Name}, cmd)
+	configFlags.AddFlags(cmd.Flags())
+	err := fakeTokenGetOptions.Complete([]string{rayCluster.Name})
 	require.NoError(t, err)
 	err = fakeTokenGetOptions.Run(t.Context(), k8sClients)
 	require.NoError(t, err)

--- a/kubectl-plugin/pkg/cmd/get/get_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/get/get_workergroup.go
@@ -90,7 +90,7 @@ func NewGetWorkerGroupCommand(cmdFactory cmdutil.Factory, streams genericcliopti
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: completion.WorkerGroupCompletionFunc(cmdFactory),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := options.Complete(args, cmd); err != nil {
+			if err := options.Complete(args); err != nil {
 				return err
 			}
 			k8sClient, err := client.NewClient(cmdFactory)
@@ -112,19 +112,15 @@ func NewGetWorkerGroupCommand(cmdFactory cmdutil.Factory, streams genericcliopti
 	return cmd
 }
 
-func (options *GetWorkerGroupsOptions) Complete(args []string, cmd *cobra.Command) error {
+func (options *GetWorkerGroupsOptions) Complete(args []string) error {
 	if options.allNamespaces {
 		options.namespace = ""
 	} else {
-		namespace, err := cmd.Flags().GetString("namespace")
+		namespace, _, err := options.cmdFactory.ToRawKubeConfigLoader().Namespace()
 		if err != nil {
 			return fmt.Errorf("failed to get namespace: %w", err)
 		}
 		options.namespace = namespace
-
-		if options.namespace == "" {
-			options.namespace = "default"
-		}
 	}
 
 	if len(args) > 0 {

--- a/kubectl-plugin/pkg/cmd/get/get_workergroup_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_workergroup_test.go
@@ -29,9 +29,6 @@ import (
 
 func TestRayWorkerGroupGetComplete(t *testing.T) {
 	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
-	cmd := &cobra.Command{}
-	flags := cmd.Flags()
-	flags.String("namespace", "", "namespace flag")
 
 	tests := []struct {
 		opts                *GetWorkerGroupsOptions
@@ -88,9 +85,15 @@ func TestRayWorkerGroupGetComplete(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := flags.Set("namespace", tc.namespace)
-			require.NoError(t, err)
-			err = tc.opts.Complete(tc.args, cmd)
+			configFlags := genericclioptions.NewConfigFlags(true)
+			if tc.namespace != "" {
+				configFlags.Namespace = &tc.namespace
+			}
+			tc.opts.cmdFactory = cmdutil.NewFactory(configFlags)
+			cmd := &cobra.Command{}
+			flags := cmd.Flags()
+			configFlags.AddFlags(flags)
+			err := tc.opts.Complete(tc.args)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedNamespace, tc.opts.namespace)
 			assert.Equal(t, tc.expectedWorkerGroup, tc.opts.workerGroup)

--- a/kubectl-plugin/pkg/cmd/job/job_submit.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit.go
@@ -141,7 +141,7 @@ func NewJobSubmitCommand(cmdFactory cmdutil.Factory, streams genericclioptions.I
 				return cmdutil.UsageErrorf(cmd, "%s", cmd.Use)
 			}
 			options.entryPoint = strings.Join(args[entryPointStart:], " ")
-			if err := options.Complete(cmd); err != nil {
+			if err := options.Complete(); err != nil {
 				return err
 			}
 			if err := options.Validate(cmd); err != nil {
@@ -186,15 +186,12 @@ func NewJobSubmitCommand(cmdFactory cmdutil.Factory, streams genericclioptions.I
 	return cmd
 }
 
-func (options *SubmitJobOptions) Complete(cmd *cobra.Command) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+func (options *SubmitJobOptions) Complete() error {
+	namespace, _, err := options.cmdFactory.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return fmt.Errorf("failed to get namespace: %w", err)
 	}
 	options.namespace = namespace
-	if options.namespace == "" {
-		options.namespace = "default"
-	}
 
 	if len(options.runtimeEnv) > 0 {
 		options.runtimeEnv = filepath.Clean(options.runtimeEnv)

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -18,15 +18,15 @@ import (
 
 func TestRayJobSubmitComplete(t *testing.T) {
 	testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+	configFlags := genericclioptions.NewConfigFlags(true)
+	cmdFactory := cmdutil.NewFactory(configFlags)
 	fakeSubmitJobOptions := NewJobSubmitOptions(cmdFactory, testStreams)
 	fakeSubmitJobOptions.runtimeEnv = "././fake/path/to/env/yaml"
 	fakeSubmitJobOptions.fileName = "fake/path/to/rayjob.yaml"
 
 	cmd := &cobra.Command{}
-	cmd.Flags().StringVarP(&fakeSubmitJobOptions.namespace, "namespace", "n", "", "")
-
-	err := fakeSubmitJobOptions.Complete(cmd)
+	configFlags.AddFlags(cmd.Flags())
+	err := fakeSubmitJobOptions.Complete()
 	require.NoError(t, err)
 	assert.Equal(t, "default", fakeSubmitJobOptions.namespace)
 	assert.Equal(t, "fake/path/to/env/yaml", fakeSubmitJobOptions.runtimeEnv)

--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -161,15 +161,11 @@ func NewClusterLogCommand(cmdFactory cmdutil.Factory, streams genericclioptions.
 }
 
 func (options *ClusterLogOptions) Complete(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	namespace, _, err := options.cmdFactory.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return fmt.Errorf("failed to get namespace: %w", err)
 	}
 	options.namespace = namespace
-
-	if options.namespace == "" {
-		options.namespace = "default"
-	}
 
 	typeAndName := strings.Split(args[0], "/")
 	if len(typeAndName) == 1 {

--- a/kubectl-plugin/pkg/cmd/scale/scale_cluster.go
+++ b/kubectl-plugin/pkg/cmd/scale/scale_cluster.go
@@ -69,7 +69,7 @@ func NewScaleClusterCommand(cmdFactory cmdutil.Factory, streams genericclioption
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := options.Complete(args, cmd); err != nil {
+			if err := options.Complete(args); err != nil {
 				return err
 			}
 			if err := options.Validate(); err != nil {
@@ -91,16 +91,12 @@ func NewScaleClusterCommand(cmdFactory cmdutil.Factory, streams genericclioption
 	return cmd
 }
 
-func (options *ScaleClusterOptions) Complete(args []string, cmd *cobra.Command) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+func (options *ScaleClusterOptions) Complete(args []string) error {
+	namespace, _, err := options.cmdFactory.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return fmt.Errorf("failed to get namespace: %w", err)
 	}
 	options.namespace = namespace
-	if options.namespace == "" {
-		options.namespace = "default"
-	}
-
 	options.cluster = args[0]
 
 	return nil

--- a/kubectl-plugin/pkg/cmd/scale/scale_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/scale/scale_cluster_test.go
@@ -43,14 +43,17 @@ func TestRayScaleClusterComplete(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			testStreams, _, _, _ := genericclioptions.NewTestIOStreams()
-			cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+			configFlags := genericclioptions.NewConfigFlags(true)
+			if tc.namespace != "" {
+				configFlags.Namespace = &tc.namespace
+			}
+			cmdFactory := cmdutil.NewFactory(configFlags)
 
 			fakeScaleClusterOptions := NewScaleClusterOptions(cmdFactory, testStreams)
 
 			cmd := &cobra.Command{}
-			cmd.Flags().StringVarP(&fakeScaleClusterOptions.namespace, "namespace", "n", tc.namespace, "")
-
-			err := fakeScaleClusterOptions.Complete(tc.args, cmd)
+			configFlags.AddFlags(cmd.Flags())
+			err := fakeScaleClusterOptions.Complete(tc.args)
 
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedNamespace, fakeScaleClusterOptions.namespace)

--- a/kubectl-plugin/pkg/cmd/session/session.go
+++ b/kubectl-plugin/pkg/cmd/session/session.go
@@ -108,14 +108,11 @@ func NewSessionCommand(cmdFactory cmdutil.Factory, streams genericiooptions.IOSt
 }
 
 func (options *SessionOptions) Complete(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	namespace, _, err := options.cmdFactory.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return fmt.Errorf("failed to get namespace: %w", err)
 	}
 	options.namespace = namespace
-	if options.namespace == "" {
-		options.namespace = "default"
-	}
 
 	context, err := cmd.Flags().GetString("context")
 	if err != nil || context == "" {

--- a/kubectl-plugin/pkg/util/completion/completion.go
+++ b/kubectl-plugin/pkg/util/completion/completion.go
@@ -68,13 +68,13 @@ func WorkerGroupCompletionFunc(f cmdutil.Factory) func(*cobra.Command, []string,
 			return []string{}, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return workerGroupCompletionFunc(cmd, args, toComplete, k8sClient)
+		return workerGroupCompletionFunc(cmd, args, toComplete, k8sClient, f)
 	}
 }
 
 // workerGroupCompletionFunc Returns completions of:
 // Workergroup names that match the toComplete prefix and respect flag values (--ray-cluster, --namespace, --all-namespaces)
-func workerGroupCompletionFunc(cmd *cobra.Command, args []string, toComplete string, k8sClient client.Client) ([]string, cobra.ShellCompDirective) {
+func workerGroupCompletionFunc(cmd *cobra.Command, args []string, toComplete string, k8sClient client.Client, f cmdutil.Factory) ([]string, cobra.ShellCompDirective) {
 	var comps []string
 	directive := cobra.ShellCompDirectiveNoFileComp
 
@@ -84,15 +84,14 @@ func workerGroupCompletionFunc(cmd *cobra.Command, args []string, toComplete str
 	}
 
 	cluster, _ := cmd.Flags().GetString("ray-cluster")
-	namespace, _ := cmd.Flags().GetString("namespace")
+	namespace, _, err := f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return comps, directive
+	}
 	allNamespaces, _ := cmd.Flags().GetBool("all-namespaces")
 
 	if allNamespaces {
 		return comps, directive
-	}
-
-	if namespace == "" {
-		namespace = "default"
 	}
 
 	listopts := v1.ListOptions{}
@@ -127,13 +126,13 @@ func NodeCompletionFunc(f cmdutil.Factory) func(*cobra.Command, []string, string
 			return []string{}, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return nodeCompletionFunc(cmd, args, toComplete, k8sClient)
+		return nodeCompletionFunc(cmd, args, toComplete, k8sClient, f)
 	}
 }
 
 // nodeCompletionFunc Returns completions of:
 // Node names that match the toComplete prefix and respect flag values (--ray-cluster, --namespace)
-func nodeCompletionFunc(cmd *cobra.Command, args []string, toComplete string, k8sClient client.Client) ([]string, cobra.ShellCompDirective) {
+func nodeCompletionFunc(cmd *cobra.Command, args []string, toComplete string, k8sClient client.Client, f cmdutil.Factory) ([]string, cobra.ShellCompDirective) {
 	var comps []string
 	directive := cobra.ShellCompDirectiveNoFileComp
 
@@ -143,15 +142,14 @@ func nodeCompletionFunc(cmd *cobra.Command, args []string, toComplete string, k8
 	}
 
 	cluster, _ := cmd.Flags().GetString("ray-cluster")
-	namespace, _ := cmd.Flags().GetString("namespace")
+	namespace, _, err := f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return comps, directive
+	}
 	allNamespaces, _ := cmd.Flags().GetBool("all-namespaces")
 
 	if allNamespaces {
 		return comps, directive
-	}
-
-	if namespace == "" {
-		namespace = "default"
 	}
 
 	labelSelectors := createRayNodeLabelSelectors(cluster)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently kubectl-plugin failed to respect the kubeconfig context by hardcoding the namespace value to default. 

This PR uses Factory's namespace resolution in order to use namespace configured in kubeconfig.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #4318 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
