### PR TITLE
Change Ray/Kuberay Google Calendar link

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Join [Ray's Slack workspace](https://docs.google.com/forms/d/e/1FAIpQLSfAcoiLCHO
 
 KubeRay contributors are welcome to join the bi-weekly KubeRay community meetings.
 
-* Add the [Ray/KubeRay Google calendar](https://calendar.google.com/calendar/u/1?cid=Y19iZWIwYTUxZDQyZTczMTFmZWFmYTY5YjZiOTY1NjAxMTQ3ZTEzOTAxZWE0ZGU5YzA1NjFlZWQ5OTljY2FiOWM4QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) to your calendar.
+* Add the [Ray/KubeRay Google calendar](https://calendar.google.com/calendar/u/0?cid=Y184NmVlNzE0NjM2YzVjZTA5YzJjOGYzOGMzYTYyYzY5YjRmMDY0MDRlMWU2MjNlZGYxN2FiM2JlMDg5MDY4ZTdkQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) to your calendar.
 
 ## Security
 

--- a/docs/community/community.md
+++ b/docs/community/community.md
@@ -19,7 +19,7 @@ to get started. You can also read [ray-project/kuberay#1059](https://github.com/
 for tips on getting involved in the KubeRay community.
 
 In addition, you can add the
-[Ray / KubeRay OSS community Google calendar](https://calendar.google.com/calendar/u/0?cid=Y19iZWIwYTUxZDQyZTczMTFmZWFmYTY5YjZiOTY1NjAxMTQ3ZTEzOTAxZWE0ZGU5YzA1NjFlZWQ5OTljY2FiOWM4QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
+[Ray / KubeRay OSS community Google calendar](https://calendar.google.com/calendar/u/0?cid=Y184NmVlNzE0NjM2YzVjZTA5YzJjOGYzOGMzYTYyYzY5YjRmMDY0MDRlMWU2MjNlZGYxN2FiM2JlMDg5MDY4ZTdkQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
 to your calendar and join the bi-weekly KubeRay community meetings.
 
 ### Becoming a Triager


### PR DESCRIPTION
Since the kuberay community's google calendar and google meet links were created by a deactivated account, we need to change the link to enable Gemini take notes and recording features in google meet.