### PR TITLE
[Docs][History Server] update instructions for live cluster section

### DIFF
--- a/historyserver/docs/set_up_historyserver.md
+++ b/historyserver/docs/set_up_historyserver.md
@@ -126,7 +126,7 @@ SESSION="live"
 curl -c ~/cookies.txt "http://localhost:8080/enter_cluster/default/raycluster-historyserver/$SESSION"
 ```
 
-If the command returns a "RayCluster not found" error, you need to deploy the cluster before connecting:
+If the command returns a "RayCluster not found" error, you need to deploy a new, live cluster before connecting:
 
 ```bash
 kubectl apply -f historyserver/config/raycluster.yaml


### PR DESCRIPTION
## Why are these changes needed?

Add instructions in live cluster session to create RayCluster and RayJob if deleted in previous step

## Related issue number


## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
