### PR TITLE
[Chore] Add historyserver option to bug report component dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -34,6 +34,7 @@ body:
         - "kubectl-plugin"
         - "dashboard"
         - "ci"
+        - "historyserver"
         - "Others"
     validations:
       required: true


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

As the history server is actively developed, adding `historyserver` option to the component dropdown can facilitate bug categorization.

## Related issue number

<!-- For example: "Closes #1234" -->

N/A

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
