### PR TITLE
[history server][bug] use sessionName in task, actor, and job endpoints

### DIFF
--- a/historyserver/pkg/eventserver/eventserver.go
+++ b/historyserver/pkg/eventserver/eventserver.go
@@ -119,6 +119,7 @@ func (h *EventHandler) Run(stop chan struct{}, numOfEventProcessors int) error {
 			clusterList := h.reader.List()
 			for _, clusterInfo := range clusterList {
 				clusterNameNamespace := clusterInfo.Name + "_" + clusterInfo.Namespace
+				clusterSessionKey := utils.BuildClusterSessionKey(clusterInfo.Name, clusterInfo.Namespace, clusterInfo.SessionName)
 				eventFileList := append(h.getAllJobEventFiles(clusterInfo), h.getAllNodeEventFiles(clusterInfo)...)
 
 				logrus.Infof("current eventFileList for cluster %s is: %v", clusterInfo.Name, eventFileList)
@@ -149,7 +150,7 @@ func (h *EventHandler) Run(stop chan struct{}, numOfEventProcessors int) error {
 						if curr == nil {
 							continue
 						}
-						curr["clusterName"] = clusterInfo.Name + "_" + clusterInfo.Namespace
+						curr["clusterName"] = clusterSessionKey
 						eventProcessorChannels[i%numOfEventProcessors] <- curr
 					}
 				}

--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -343,7 +343,6 @@ func (s *ServerHandler) getPrometheusHealth(req *restful.Request, resp *restful.
 func (s *ServerHandler) getJobs(req *restful.Request, resp *restful.Response) {
 	clusterName := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
 	clusterNamespace := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
-	clusterNameID := clusterName + "_" + clusterNamespace
 	sessionName := req.Attribute(COOKIE_SESSION_NAME_KEY).(string)
 
 	if sessionName == "live" {
@@ -351,7 +350,8 @@ func (s *ServerHandler) getJobs(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	jobsMap := s.eventHandler.GetJobsMap(clusterNameID)
+	clusterSessionKey := utils.BuildClusterSessionKey(clusterName, clusterNamespace, sessionName)
+	jobsMap := s.eventHandler.GetJobsMap(clusterSessionKey)
 
 	jobs := make([]eventtypes.Job, 0, len(jobsMap))
 	for _, job := range jobsMap {
@@ -428,7 +428,6 @@ func (s *ServerHandler) getNode(req *restful.Request, resp *restful.Response) {
 func (s *ServerHandler) getJob(req *restful.Request, resp *restful.Response) {
 	clusterName := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
 	clusterNamespace := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
-	clusterNameID := clusterName + "_" + clusterNamespace
 	sessionName := req.Attribute(COOKIE_SESSION_NAME_KEY).(string)
 	if sessionName == "live" {
 		s.redirectRequest(req, resp)
@@ -437,7 +436,8 @@ func (s *ServerHandler) getJob(req *restful.Request, resp *restful.Response) {
 
 	jobID := req.PathParameter("job_id")
 
-	job, found := s.eventHandler.GetJobByJobID(clusterNameID, jobID)
+	clusterSessionKey := utils.BuildClusterSessionKey(clusterName, clusterNamespace, sessionName)
+	job, found := s.eventHandler.GetJobByJobID(clusterSessionKey, jobID)
 
 	if !found {
 		responseString := fmt.Sprintf("Job %s does not exist", jobID)
@@ -527,7 +527,6 @@ func (s *ServerHandler) getNodeLogs(req *restful.Request, resp *restful.Response
 func (s *ServerHandler) getLogicalActors(req *restful.Request, resp *restful.Response) {
 	clusterName := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
 	clusterNamespace := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
-	clusterNameID := clusterName + "_" + clusterNamespace
 	sessionName := req.Attribute(COOKIE_SESSION_NAME_KEY).(string)
 
 	if sessionName == "live" {
@@ -540,7 +539,8 @@ func (s *ServerHandler) getLogicalActors(req *restful.Request, resp *restful.Res
 	filterPredicate := req.QueryParameter("filter_predicates")
 
 	// Get actors from EventHandler's in-memory map
-	actorsMap := s.eventHandler.GetActorsMap(clusterNameID)
+	clusterSessionKey := utils.BuildClusterSessionKey(clusterName, clusterNamespace, sessionName)
+	actorsMap := s.eventHandler.GetActorsMap(clusterSessionKey)
 
 	// Convert map to slice for filtering
 	actors := make([]eventtypes.Actor, 0, len(actorsMap))
@@ -617,7 +617,6 @@ func formatActorForResponse(actor eventtypes.Actor) map[string]interface{} {
 func (s *ServerHandler) getLogicalActor(req *restful.Request, resp *restful.Response) {
 	clusterName := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
 	clusterNamespace := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
-	clusterNameID := clusterName + "_" + clusterNamespace
 	sessionName := req.Attribute(COOKIE_SESSION_NAME_KEY).(string)
 	if sessionName == "live" {
 		s.redirectRequest(req, resp)
@@ -627,7 +626,8 @@ func (s *ServerHandler) getLogicalActor(req *restful.Request, resp *restful.Resp
 	actorID := req.PathParameter("single_actor")
 
 	// Get actor from EventHandler's in-memory map
-	actor, found := s.eventHandler.GetActorByID(clusterNameID, actorID)
+	clusterSessionKey := utils.BuildClusterSessionKey(clusterName, clusterNamespace, sessionName)
+	actor, found := s.eventHandler.GetActorByID(clusterSessionKey, actorID)
 
 	replyActorInfo := ReplyActorInfo{
 		Data: ActorInfoData{},
@@ -712,7 +712,6 @@ func (s *ServerHandler) getNodeLogFile(req *restful.Request, resp *restful.Respo
 func (s *ServerHandler) getTaskSummarize(req *restful.Request, resp *restful.Response) {
 	clusterName := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
 	clusterNamespace := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
-	clusterNameID := clusterName + "_" + clusterNamespace
 	sessionName := req.Attribute(COOKIE_SESSION_NAME_KEY).(string)
 
 	if sessionName == "live" {
@@ -727,7 +726,8 @@ func (s *ServerHandler) getTaskSummarize(req *restful.Request, resp *restful.Res
 	summaryBy := req.QueryParameter("summary_by")
 
 	// Get all tasks
-	tasks := s.eventHandler.GetTasks(clusterNameID)
+	clusterSessionKey := utils.BuildClusterSessionKey(clusterName, clusterNamespace, sessionName)
+	tasks := s.eventHandler.GetTasks(clusterSessionKey)
 
 	// Apply generic filtering using utils.ApplyFilter
 	tasks = utils.ApplyFilter(tasks, filterKey, filterPredicate, filterValue,
@@ -822,9 +822,6 @@ func (s *ServerHandler) getTaskDetail(req *restful.Request, resp *restful.Respon
 	clusterNamespace := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
 	sessionName := req.Attribute(COOKIE_SESSION_NAME_KEY).(string)
 
-	// Combine into internal key format
-	clusterNameID := clusterName + "_" + clusterNamespace
-
 	if sessionName == "live" {
 		s.redirectRequest(req, resp)
 		return
@@ -834,7 +831,8 @@ func (s *ServerHandler) getTaskDetail(req *restful.Request, resp *restful.Respon
 	filterValue := req.QueryParameter("filter_values")
 	filterPredicate := req.QueryParameter("filter_predicates")
 
-	tasks := s.eventHandler.GetTasks(clusterNameID)
+	clusterSessionKey := utils.BuildClusterSessionKey(clusterName, clusterNamespace, sessionName)
+	tasks := s.eventHandler.GetTasks(clusterSessionKey)
 	tasks = utils.ApplyFilter(tasks, filterKey, filterPredicate, filterValue,
 		func(t eventtypes.Task, key string) string {
 			return eventtypes.GetTaskFieldValue(t, key)

--- a/historyserver/pkg/utils/utils.go
+++ b/historyserver/pkg/utils/utils.go
@@ -253,3 +253,10 @@ func ConvertBase64ToHex(input string) (string, error) {
 
 	return hexStr, nil
 }
+
+// BuildClusterSessionKey constructs the key used to identify a specific cluster session.
+// Format: "{clusterName}_{namespace}_{sessionName}"
+// Example: "raycluster-historyserver_default_session_2026-01-11_19-38-40"
+func BuildClusterSessionKey(clusterName, namespace, sessionName string) string {
+	return clusterName + connector + namespace + connector + sessionName
+}


### PR DESCRIPTION
## Why
1. We should include the session name so that the same RayCluster (name and namespace) can display data from different sessions.
2. 

## Change
1. EventHandler (`eventserver/eventserver.go`)
	•	Updated to use `clusterSessionKey` instead of `clusterName_namespace`
2. Router (`historyserver/router.go`)
Updated 6 endpoints to use new key format:
	•	`GET /api/jobs/` → `GetJobsMap()`
	•	`GET /api/jobs/{job_id}` → `GetJobByJobID()`
	•	`GET /logical/actors` → `GetActorsMap()`
	•	`GET /logical/actors/{id}` → `GetActorByID()`
	•	`GET /api/v0/tasks` → `GetTasks()`
	•	`GET /api/v0/tasks/summarize` → `GetTasks()`
3. 


## Others
1. Unchanged Endpoints (Already Session-Aware)
	•	`GET /nodes`, `GET /api/v0/logs`, `GET /api/v0/logs/file`

## Test proof

### Test Environment
```
Host: localhost:8080 (port-forward to historyserver)
Cluster: raycluster-historyserver
Namespace: default
```

### Available Sessions
| Session Name | Type | Create Time |
|-------------|------|-------------|
| `session_2026-01-30_04-51-30_516777_1` | Dead | 2026-01-30 04:51:30 UTC |
| `session_2026-01-30_04-49-54_219082_1` | Dead | 2026-01-30 04:49:54 UTC |

---

### Test Results Summary

| Endpoint | Session 1 Result | Session 2 Result | Isolation? |
|----------|------------------|------------------|------------|
| `GET /api/jobs/` | `rayjob-lxk78` | `rayjob-24jnd` | ✅ **PASS** |
| `GET /api/jobs/{job_id}` | driver_node_id: `1d5becc0...` | driver_node_id: `dfc6342c...` | ✅ **PASS** |
| `GET /logical/actors` | actor IDs: `4xzpsR6M...`, `NGVuwAm3...` | actor IDs: `P4WAVh/u...`, `yuPjClPl...` | ✅ **PASS** |
| `GET /logical/actors/{id}` | `NGVuwAm3...` → Found | `NGVuwAm3...` → **Not Found** | ✅ **PASS** |
| `GET /api/v0/tasks` | 6 tasks, different task_ids | 6 tasks, different task_ids | ✅ **PASS** |
| `GET /api/v0/tasks/summarize` | 6 total, 5 FINISHED, 1 RUNNING | 6 total, 5 FINISHED, 1 RUNNING | ✅ **PASS** |

---

### Detailed Evidence

#### 1. GET /api/jobs/ - Different Jobs Per Session

**Session 1 (`session_2026-01-30_04-51-30_516777_1`):**
```json
{
  "job_id": "02000000",
  "submission_id": "rayjob-lxk78",
  "driver_node_id": "1d5becc08c51bfa6011930407843f74a14f8c9fb8da7d2665323a0d2",
  "start_time": 1769777510931,
  "end_time": 1769777516996
}
```

**Session 2 (`session_2026-01-30_04-49-54_219082_1`):**
```json
{
  "job_id": "02000000",
  "submission_id": "rayjob-24jnd",
  "driver_node_id": "dfc6342ca531cdc6c694af521ebfc8e3f443201f3b1f5db00452047a",
  "start_time": 1769777420224,
  "end_time": 1769777426318
}
```

---

#### 2. GET /logical/actors - Different Actors Per Session

**Session 1 Actors:**
- `4xzpsR6MuoFg6SeGAQAAAA==` (JobSupervisor) - IP: `10.244.0.14`
- `NGVuwAm3Qa+9su4WAgAAAA==` (Counter) - IP: `10.244.0.15`

**Session 2 Actors:**
- `yuPjClPl7rQKUUhgAQAAAA==` (JobSupervisor) - IP: `10.244.0.11`
- `P4WAVh/uX0O4FhezAgAAAA==` (Counter) - IP: `10.244.0.12`

---

#### 3. Cross-Session Actor Lookup - Isolation Verified

```bash
# Session 1's actor queried in Session 1: FOUND ✓
curl -b session1_cookies "http://localhost:8080/logical/actors/NGVuwAm3Qa+9su4WAgAAAA=="
# Result: {"result": true, "msg": "Actor fetched.", ...}

# Session 1's actor queried in Session 2: NOT FOUND ✓
curl -b session2_cookies "http://localhost:8080/logical/actors/NGVuwAm3Qa+9su4WAgAAAA=="
# Result: {"result": false, "msg": "Actor not found."}
```

---

#### 4. GET /api/v0/tasks - Different Tasks Per Session

**Session 1 (`session_2026-01-30_04-51-30_516777_1`):**

| Task Name | Task ID | Node ID | Start Time | End Time | State |
|-----------|---------|---------|------------|----------|-------|
| `Counter.__init__` | `...0ZW7ACbdBr72y7hYCAAAA` | - | 1769777511376 | 1769777511379 | FINISHED |
| (lifecycle) | `5cvZC38ft3Y0ZW7ACbdBr72y7hYCAAAA` | `B4eMubdblreAfh868C/fb0CkdFCnqtFiYa2WZQ==` | 1769777511380 | 1769777511466 | FINISHED |
| (lifecycle) | `OQiL43NuWQo0ZW7ACbdBr72y7hYCAAAA` | `B4eMubdblreAfh868C/fb0CkdFCnqtFiYa2WZQ==` | 1769777511467 | 1769777511467 | FINISHED |
| (driver) | `//////////////////////////8CAAAA` | - | 1769777510930 | 1769777516995 | FINISHED |
| (driver) | `//////////////////////////8BAAAA` | - | 1769777510064 | - | RUNNING |
| `my_task` | `Z6Loz6WgbbP...CAAAA` | `B4eMubdblreAfh868C/fb0CkdFCnqtFiYa2WZQ==` | 1769777511288 | 1769777511370 | FINISHED |

**Worker ID:** `aB9i02iq1owakA5BDinFNCY0q8Mg7l6LAFW5cg==`

---

**Session 2 (`session_2026-01-30_04-49-54_219082_1`):**

| Task Name | Task ID | Node ID | Start Time | End Time | State |
|-----------|---------|---------|------------|----------|-------|
| `Counter.__init__` | `.../hYBWH+5fQ7gWF7MCAAAA` | - | - | - | FINISHED |
| (lifecycle) | `5cvZC38ft3Y/hYBWH+5fQ7gWF7MCAAAA` | `Vncyl9HlVeUzPRITieyl+cV+FPzA4bQQjDmrTg==` | 1769777420693 | 1769777420789 | FINISHED |
| (lifecycle) | `OQiL43NuWQo/hYBWH+5fQ7gWF7MCAAAA` | `Vncyl9HlVeUzPRITieyl+cV+FPzA4bQQjDmrTg==` | 1769777420789 | 1769777420790 | FINISHED |
| (driver) | `//////////////////////////8CAAAA` | - | 1769777420224 | 1769777426315 | FINISHED |
| (driver) | `//////////////////////////8BAAAA` | - | 1769777419298 | - | RUNNING |
| `my_task` | `Z6Loz6WgbbP...CAAAA` | - | - | - | FINISHED |

**Worker ID:** `QlSuzT5YItnB4lDo5pjHQtU3x/KZEuPcMznLFA==`

---

**Key Differences:**

| Field | Session 1 | Session 2 |
|-------|-----------|-----------|
| `Counter.__init__` task_id | `...0ZW7ACbdBr72y7hY...` | `.../hYBWH+5fQ7gWF7M...` |
| Node ID | `B4eMubdblreAfh868C/fb0CkdFCnqtFiYa2WZQ==` | `Vncyl9HlVeUzPRITieyl+cV+FPzA4bQQjDmrTg==` |
| Worker ID | `aB9i02iq...` | `QlSuzT5Y...` |
| Start Time Range | `1769777510064` - `1769777511467` | `1769777419298` - `1769777420789` |

---

#### 5. GET /api/v0/tasks/summarize - Task Summary Per Session

**Session 1:**
```json
{
    "data": {
        "result": {
            "summary": { "unknown": { "FINISHED": 5, "RUNNING": 1 } },
            "total": 6
        }
    },
    "msg": "Tasks summarized.",
    "result": true
}
```

**Session 2:**
```json
{
    "data": {
        "result": {
            "summary": { "unknown": { "FINISHED": 5, "RUNNING": 1 } },
            "total": 6
        }
    },
    "msg": "Tasks summarized.",
    "result": true
}
```

### Conclusion

All 6 endpoints correctly return **session-isolated data**:

| # | Endpoint | Evidence of Isolation |
|---|----------|----------------------|
| 1 | `GET /api/jobs/` | Different `submission_id`: `rayjob-lxk78` vs `rayjob-24jnd` |
| 2 | `GET /api/jobs/{job_id}` | Different `driver_node_id`: `1d5becc0...` vs `dfc6342c...` |
| 3 | `GET /logical/actors` | Different actor IDs and IP addresses |
| 4 | `GET /logical/actors/{id}` | Cross-session lookup returns "not found" |
| 5 | `GET /api/v0/tasks` | Different `node_id`, `worker_id`, `task_id`, timestamps |
| 6 | `GET /api/v0/tasks/summarize` | Uses isolated task data from `GetTasks()` |
## Related issue number
https://github.com/ray-project/kuberay/issues/4465
