### PR TITLE
Ray Serve readiness checks only proxy

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -510,24 +510,13 @@ func initLivenessAndReadinessProbe(rayContainer *corev1.Container, rayNodeType r
 		// See https://github.com/ray-project/kuberay/pull/1808 for reasons.
 		if creatorCRDType == utils.RayServiceCRD && rayNodeType == rayv1.WorkerNode {
 			rayContainer.ReadinessProbe.FailureThreshold = utils.ServeReadinessProbeFailureThreshold
-			if httpHealthCheck {
-				rayContainer.ReadinessProbe.Exec = nil
-				rayContainer.ReadinessProbe.HTTPGet = &corev1.HTTPGetAction{
-					Path: utils.RayServeProxyHealthPath,
-					Port: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: utils.FindContainerPort(rayContainer, utils.ServingPortName, utils.DefaultServingPort),
-					},
-				}
-			} else {
-				rayServeProxyHealthCommand := fmt.Sprintf(
-					utils.BaseWgetHealthCommand,
-					utils.DefaultReadinessProbeInitialDelaySeconds,
-					utils.FindContainerPort(rayContainer, utils.ServingPortName, utils.DefaultServingPort),
-					utils.RayServeProxyHealthPath,
-				)
-				rayContainer.ReadinessProbe.HTTPGet = nil
-				rayContainer.ReadinessProbe.Exec = &corev1.ExecAction{Command: []string{"bash", "-c", rayServeProxyHealthCommand}}
+			rayContainer.ReadinessProbe.Exec = nil
+			rayContainer.ReadinessProbe.HTTPGet = &corev1.HTTPGetAction{
+				Path: utils.RayServeProxyHealthPath,
+				Port: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: utils.FindContainerPort(rayContainer, utils.ServingPortName, utils.DefaultServingPort),
+				},
 			}
 		}
 	}

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -504,20 +504,31 @@ func initLivenessAndReadinessProbe(rayContainer *corev1.Container, rayNodeType r
 			rayContainer.ReadinessProbe.Exec = &corev1.ExecAction{Command: []string{"bash", "-c", strings.Join(commands, " && ")}}
 		}
 
-		// For worker Pods serving traffic, we need to add an additional HTTP proxy health check for the readiness probe.
+		// For worker Pods serving traffic, the readiness probe checks the proxy
+		// instead of the raylet.
 		// Note: head Pod checks the HTTP proxy's health at every rayservice controller reconcile instaed of using readiness probe.
 		// See https://github.com/ray-project/kuberay/pull/1808 for reasons.
 		if creatorCRDType == utils.RayServiceCRD && rayNodeType == rayv1.WorkerNode {
 			rayContainer.ReadinessProbe.FailureThreshold = utils.ServeReadinessProbeFailureThreshold
-			rayServeProxyHealthCommand := fmt.Sprintf(
-				utils.BaseWgetHealthCommand,
-				utils.DefaultReadinessProbeInitialDelaySeconds,
-				utils.FindContainerPort(rayContainer, utils.ServingPortName, utils.DefaultServingPort),
-				utils.RayServeProxyHealthPath,
-			)
-			commands = append(commands, rayServeProxyHealthCommand)
-			rayContainer.ReadinessProbe.HTTPGet = nil
-			rayContainer.ReadinessProbe.Exec = &corev1.ExecAction{Command: []string{"bash", "-c", strings.Join(commands, " && ")}}
+			if httpHealthCheck {
+				rayContainer.ReadinessProbe.Exec = nil
+				rayContainer.ReadinessProbe.HTTPGet = &corev1.HTTPGetAction{
+					Path: utils.RayServeProxyHealthPath,
+					Port: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: utils.FindContainerPort(rayContainer, utils.ServingPortName, utils.DefaultServingPort),
+					},
+				}
+			} else {
+				rayServeProxyHealthCommand := fmt.Sprintf(
+					utils.BaseWgetHealthCommand,
+					utils.DefaultReadinessProbeInitialDelaySeconds,
+					utils.FindContainerPort(rayContainer, utils.ServingPortName, utils.DefaultServingPort),
+					utils.RayServeProxyHealthPath,
+				)
+				rayContainer.ReadinessProbe.HTTPGet = nil
+				rayContainer.ReadinessProbe.Exec = &corev1.ExecAction{Command: []string{"bash", "-c", rayServeProxyHealthCommand}}
+			}
 		}
 	}
 }

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1702,9 +1702,9 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 	rayContainer.ReadinessProbe = nil
 	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayServiceCRD, rayStartParams, "")
 	assert.NotNil(t, rayContainer.LivenessProbe.Exec)
-	assert.NotNil(t, rayContainer.ReadinessProbe.Exec)
+	assert.NotNil(t, rayContainer.ReadinessProbe.HTTPGet)
 	assert.NotContains(t, strings.Join(rayContainer.LivenessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath)
-	assert.Contains(t, strings.Join(rayContainer.ReadinessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath)
+	assert.Equal(t, int32(utils.DefaultServingPort), rayContainer.ReadinessProbe.HTTPGet.Port.IntVal)
 	assert.Equal(t, int32(2), rayContainer.LivenessProbe.TimeoutSeconds)
 	assert.Equal(t, int32(2), rayContainer.ReadinessProbe.TimeoutSeconds)
 
@@ -1772,10 +1772,9 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 		"dashboard-agent-listen-port": "8500",
 	}
 	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayServiceCRD, rayServiceWorkerParams, "")
-	rayServiceReadinessCommand := strings.Join(rayContainer.ReadinessProbe.Exec.Command, " ")
 	rayServiceLivenessCommand := strings.Join(rayContainer.LivenessProbe.Exec.Command, " ")
 	assert.Contains(t, rayServiceLivenessCommand, ":8500", "RayService worker should use custom dashboard-agent-listen-port")
-	assert.Contains(t, rayServiceReadinessCommand, utils.RayServeProxyHealthPath, "RayService worker should include serve proxy health check")
+	assert.Equal(t, int32(utils.DefaultServingPort), rayContainer.ReadinessProbe.HTTPGet.Port.IntVal)
 	assert.Equal(t, int32(utils.ServeReadinessProbeFailureThreshold), rayContainer.ReadinessProbe.FailureThreshold, "RayService worker should have correct failure threshold")
 
 	// Test 8: Test invalid port values (should fall back to defaults)

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1823,6 +1823,7 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 	assert.Nil(t, rayContainer.ReadinessProbe.Exec)
 	assert.NotNil(t, rayContainer.ReadinessProbe.HTTPGet)
 	assert.Equal(t, int32(utils.DefaultServingPort), rayContainer.ReadinessProbe.HTTPGet.Port.IntVal)
+	assert.Equal(t, utils.RayServeProxyHealthPath, rayContainer.ReadinessProbe.HTTPGet.Path)
 
 	// Versions parsed below 2.53 must use exec probes.
 	rayContainer.LivenessProbe = nil


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The RayService readiness check uses wget to fetch both the raylet health and the proxy actor status. It's unclear if both are needed. If we can check only the raylet for liveness, and only the proxy for readiness, then we can completely remove dependencies on wget on 2.53 and later.

## Related issue number

Follow up to #4448.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>96d27be</u></sup><!-- /BUGBOT_STATUS -->