### PR TITLE
[history server] Support jobs endpoint for retrieving logs

### DIFF
--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -115,6 +115,11 @@ func routerAPI(s *ServerHandler) {
 		Param(ws.PathParameter("job_id", "job_id")).
 		Writes("")) // Placeholder for specific return type
 
+	ws.Route(ws.GET("/jobs/{job_id}/logs").To(s.getJobLog).Filter(s.CookieHandle).
+		Doc("get log for job").
+		Param(ws.PathParameter("job_id", "job_id")).
+		Writes("")) // Placeholder for specific return type
+
 	ws.Route(ws.GET("/data/datasets/{job_id}").To(s.getDatasets).Filter(s.CookieHandle).
 		Doc("get datasets").
 		Param(ws.PathParameter("job_id", "job_id")).
@@ -584,15 +589,13 @@ func (s *ServerHandler) getJobs(req *restful.Request, resp *restful.Response) {
 		jobs = append(jobs, job)
 	}
 
-	// Formate response to match Ray Dashboard API format
+	// Format response to match Ray Dashboard API format
 	formattedJobs := make([]interface{}, 0)
 	for _, job := range jobs {
 		formattedJobs = append(formattedJobs, formatJobForResponse(job))
 	}
 
-	response := formattedJobs
-
-	respData, err := json.Marshal(response)
+	respData, err := json.Marshal(formattedJobs)
 	if err != nil {
 		logrus.Errorf("Failed to marshal jobs response: %v", err)
 		resp.WriteErrorString(http.StatusInternalServerError, err.Error())
@@ -651,10 +654,8 @@ func (s *ServerHandler) getJob(req *restful.Request, resp *restful.Response) {
 	}
 
 	jobID := req.PathParameter("job_id")
-
 	clusterSessionKey := utils.BuildClusterSessionKey(clusterName, clusterNamespace, sessionName)
 	job, found := s.eventHandler.GetJobByJobID(clusterSessionKey, jobID)
-
 	if !found {
 		responseString := fmt.Sprintf("Job %s does not exist", jobID)
 		resp.Write([]byte(responseString))
@@ -669,6 +670,46 @@ func (s *ServerHandler) getJob(req *restful.Request, resp *restful.Response) {
 	}
 	resp.Write(respData)
 
+}
+
+func (s *ServerHandler) getJobLog(req *restful.Request, resp *restful.Response) {
+	clusterName := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
+	clusterNamespace := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
+	sessionName := req.Attribute(COOKIE_SESSION_NAME_KEY).(string)
+	if sessionName == "live" {
+		s.redirectRequest(req, resp)
+		return
+	}
+
+	jobID := req.PathParameter("job_id")
+	clusterSessionKey := utils.BuildClusterSessionKey(clusterName, clusterNamespace, sessionName)
+
+	reader, err := s.eventHandler.GetJobLogByJobID(clusterSessionKey, clusterName, clusterNamespace, jobID)
+	if err != nil {
+		responseString := fmt.Sprintf("Failed to get log for Job %s, error: %v", jobID, err)
+		resp.Write([]byte(responseString))
+		return
+	}
+
+	logContent, err := io.ReadAll(reader)
+	if err != nil {
+		responseString := fmt.Sprintf("Failed to read file content for Job %s, error: %q", jobID, err)
+		resp.Write([]byte(responseString))
+		return
+	}
+
+	response := map[string]interface{}{
+		"logs": string(logContent),
+	}
+
+	respData, err := json.Marshal(response)
+	if err != nil {
+		logrus.Errorf("Failed to marshal jobs response: %v", err)
+		resp.WriteErrorString(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	resp.Write(respData)
 }
 
 func (s *ServerHandler) getDatasets(req *restful.Request, resp *restful.Response) {

--- a/historyserver/pkg/utils/utils_test.go
+++ b/historyserver/pkg/utils/utils_test.go
@@ -21,7 +21,6 @@ func TestSlice(t *testing.T) {
 }
 
 func TestConvertBase64ToHex(t *testing.T) {
-	//TODO(chiayi): use real base64 strings from job ids as tests ex: AgAAAA==
 	tests := []struct {
 		scenario       string
 		base64Str      string


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR add support for the `/jobs/{job_id}/logs` endpoint. The endpoint will retrieve the logs for the given job_id
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Part of #4375 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
