### PR TITLE
[history server][e2e] Fix missing manifestPath argument in ApplyHistoryServer call

### DIFF
--- a/historyserver/test/e2e/historyserver_test.go
+++ b/historyserver/test/e2e/historyserver_test.go
@@ -121,7 +121,7 @@ func testLiveGrafanaHealth(test Test, g *WithT, namespace *corev1.Namespace, s3C
 func testLivePrometheusHealth(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnvWithPrometheusAndGrafana(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace)
+	ApplyHistoryServer(test, g, namespace, "")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fix ci error in `testLivePrometheusHealth` caused by missing `manifestPath` argument

https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/13393#019c4881-34f7-4787-abad-ef993fa7fb31
```
# github.com/ray-project/kuberay/historyserver/test/e2e [github.com/ray-project/kuberay/historyserver/test/e2e.test]
test/e2e/historyserver_test.go:124:30: not enough arguments in call to ApplyHistoryServer
	have ("github.com/ray-project/kuberay/ray-operator/test/support".Test, *gomega.WithT, *"k8s.io/api/core/v1".Namespace)
	want ("github.com/ray-project/kuberay/ray-operator/test/support".Test, *gomega.WithT, *"k8s.io/api/core/v1".Namespace, string)
FAIL	github.com/ray-project/kuberay/historyserver/test/e2e [build failed]
FAIL
```
Ref: https://github.com/ray-project/kuberay/pull/4460

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
