### PR TITLE
[Fix][History Server] add an empty manifestPath in ApplyHistoryServer 

### DIFF
--- a/historyserver/test/e2e/historyserver_test.go
+++ b/historyserver/test/e2e/historyserver_test.go
@@ -121,7 +121,7 @@ func testLiveGrafanaHealth(test Test, g *WithT, namespace *corev1.Namespace, s3C
 func testLivePrometheusHealth(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnvWithPrometheusAndGrafana(test, g, namespace, s3Client)
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
-	ApplyHistoryServer(test, g, namespace)
+	ApplyHistoryServer(test, g, namespace, "")
 	historyServerURL := GetHistoryServerURL(test, g, namespace)
 
 	clusterInfo := getClusterFromList(test, g, historyServerURL, rayCluster.Name, namespace.Name)


### PR DESCRIPTION
## Why are these changes needed?

ApplyHistoryServer now expects a manifestPath argument. In [historyserver/test/e2e/historyserver_test.go](https://github.com/ray-project/kuberay/blob/master/historyserver/test/e2e/historyserver_test.go#L124 ) the call at line 124 was missing it. Added an empty manifestPath, aligning with the other tests and fixing the CI failure.

## Related issue number

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
