### PR TITLE
[CI] Fix apiserversdk test failures by updating setup-envtest

### DIFF
--- a/apiserversdk/Makefile
+++ b/apiserversdk/Makefile
@@ -31,7 +31,7 @@ lint: golangci-lint fmt vet ## Run the linter.
 	test -s $(GOLANGCI_LINT) || ($(GOLANGCI_LINT) run --timeout=3m --allow-parallel-runners)
 
 test: WHAT ?= $(shell go list ./... | grep -v /test/)
-test: ENVTEST_K8S_VERSION ?= 1.24.2
+test: ENVTEST_K8S_VERSION ?= 1.34.1
 test: envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v $(WHAT) -coverprofile cover.out
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
see: https://github.com/ray-project/kuberay/actions/runs/21890331311/job/63194592612?pr=4437
CI tests are failing in both `apiserversdk` with the following error:
```
unable to fetch metadata for kubebuilder-tools-1.24.2-linux-amd64.tar.gz 
-- got status "403 Forbidden" from GCS
```
Since the kubebuilder project recently migrated away from their GCS bucket (`storage.googleapis.com/kubebuilder-tools`) to GitHub releases, the old bucket is no longer publicly accessible.
See: https://github.com/kubernetes-sigs/kubebuilder/discussions/4082

Therefore, this PR updates `setup-envtest` to `release-0.23` (matching `ray-operator/Makefile` for consistency) which downloads from the new GitHub releases location.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
