### PR TITLE
feat(kuberay-operator)!: rename service monitor field for additional labels

### DIFF
--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -183,8 +183,8 @@ spec:
 | metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
 | metrics.serviceMonitor.honorLabels | bool | `true` | When true, honorLabels preserves the metric’s labels when they collide with the target’s labels. |
-| metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
-| metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
+| metrics.serviceMonitor.additionalLabels | object | `{}` | Prometheus ServiceMonitor selector |
+| metrics.serviceMonitor.namespace | string | `nil` | Prometheus ServiceMonitor namespace |
 | operatorCommand | string | `"/manager"` | Path to the operator binary |
 | leaderElectionEnabled | bool | `true` | If leaderElectionEnabled is set to true, the KubeRay operator will use leader election for high availability. |
 | reconcileConcurrency | int | `1` | The maximum number of reconcile operations that can be performed simultaneously. This setting controls the concurrency of the controller reconciliation loops. Higher values can improve throughput in clusters with many resources, but may increase resource consumption. |

--- a/helm-chart/kuberay-operator/templates/servicemonitor.yaml
+++ b/helm-chart/kuberay-operator/templates/servicemonitor.yaml
@@ -4,10 +4,11 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "kuberay-operator.fullname" . }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
-  {{- with .Values.metrics.serviceMonitor.additionalLabels }}
   labels:
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   endpoints:
     - path: /metrics

--- a/helm-chart/kuberay-operator/templates/servicemonitor.yaml
+++ b/helm-chart/kuberay-operator/templates/servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "kuberay-operator.fullname" . }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
-  {{- with .Values.metrics.serviceMonitor.selector }}
+  {{- with .Values.metrics.serviceMonitor.additionalLabels }}
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm-chart/kuberay-operator/templates/servicemonitor.yaml
+++ b/helm-chart/kuberay-operator/templates/servicemonitor.yaml
@@ -4,10 +4,10 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "kuberay-operator.fullname" . }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
+  {{- with .Values.metrics.serviceMonitor.selector }}
   labels:
-    {{- with .Values.metrics.serviceMonitor.selector }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   endpoints:
     - path: /metrics

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -153,7 +153,7 @@ metrics:
     # -- When true, honorLabels preserves the metric’s labels when they collide with the target’s labels.
     honorLabels: true
     # -- Prometheus ServiceMonitor selector
-    selector: {}
+    additionalLabels: {}
       #  release: prometheus
     # -- Prometheus ServiceMonitor namespace
     namespace: ""  # "monitoring"

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -156,7 +156,7 @@ metrics:
     additionalLabels: {}
       #  release: prometheus
     # -- Prometheus ServiceMonitor namespace
-    namespace: ""  # "monitoring"
+    namespace: null  # "monitoring"
 
 # -- Path to the operator binary
 operatorCommand: /manager


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

When rendering the `ServiceMonitor` template in the Kuberay Operator Helm chart without setting labels (`.Values.metrics.serviceMonitor.selector`), the output manifest contains an empty `labels` key:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: kuberay-operator
  namespace: default
  labels:   # <--- EMPTY
spec:
  endpoints:
    - path: /metrics
      targetPort: http
      interval: 30s
      honorLabels: true
  namespaceSelector:
    matchNames:
      - default
  selector:
    matchLabels:
      app.kubernetes.io/name: kuberay-operator
```

## Why are these changes needed?

An empty `labels` key is problematic for CD tools like ArgoCD. The rendered manifest omits the `labels` key, but ArgoCD expects `labels: null`, causing a perpetual diff that prevents the resource from appearing as synced.

## Related issue number

_None_
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
