### PR TITLE
[CI] Add a buildkite job to test ray nightly releases in KubeRay CI

### DIFF
--- a/.buildkite/ray-ci-integration.md
+++ b/.buildkite/ray-ci-integration.md
@@ -1,10 +1,10 @@
 
 # Ray CI Integration
 
-| Version                | Latest Ray Release            |  Ray Nightly                         |
-| -----------            | :-------------------          | :--------------                      |
-| Latest KubeRay Release | During Ray & KubeRay Releases | Nightly from Ray Release Automation  |
-| KubeRay Nightly        | In KubeRay CI                 | Not tested                           |
+| Version                | Latest Ray Release            |  Ray Nightly                                    |
+| -----------            | :-------------------          | :--------------                                 |
+| Latest KubeRay Release | During Ray & KubeRay Releases | Nightly from Ray Release Automation             |
+| KubeRay Nightly        | In KubeRay CI                 | **test-e2e-ray-nightly.yml** (nightly schedule) |
 
 This table lays out the state of testing between Ray and KubeRay nightlies and releases.
 The goal is to have all 4 of these being consistently tested eventually.
@@ -12,6 +12,25 @@ All tests run in KubeRay CI pipeline, the difference is just where the pipeline 
 "KubeRay Nightly" just refers to running on master right now, And "Latest KubeRay Release" refers to running
 on the latest release branch. The "Latest Ray Release" will be pulled from DockerHub and same with "Ray Nightly".
 
-In the future, if we have a test needs the ray nightly to run, add a step to .buildkite/test-e2e.yaml that
-follows the other steps but sets KUBERAY_TEST_RAY_IMAGE env variable to "rayproject/ray:nightly".
-When ray releases a new version, you can change the step to just use the latest ray release.
+## Testing KubeRay with Ray Nightly
+
+The `.buildkite/test-e2e-ray-nightly.yml` pipeline runs e2e tests against `rayproject/ray:nightly`.
+It should be configured to run on a nightly schedule to catch compatibility issues early.
+
+**How it works:**
+
+- Sets `KUBERAY_TEST_RAY_IMAGE=rayproject/ray:nightly` for ray-operator tests
+- Sets `E2E_API_SERVER_RAY_IMAGE=rayproject/ray:nightly-py310` for apiserver tests
+- Tests that use static YAML files are transformed at runtime using kustomize to override the Ray image
+
+**To run tests locally with nightly Ray:**
+
+```bash
+# Ray-operator tests
+cd ray-operator
+KUBERAY_TEST_RAY_IMAGE=rayproject/ray:nightly go test -v ./test/e2e/...
+
+# Apiserver tests (requires apiserver deployed with curl sidecar)
+cd apiserver
+E2E_API_SERVER_RAY_IMAGE=rayproject/ray:nightly-py310 go test -v ./test/e2e/...
+```

--- a/.buildkite/run-e2e-nightly-test.sh
+++ b/.buildkite/run-e2e-nightly-test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Shared script to run nightly E2E tests with consistent logging, output capture,
+# and artifact collection. Expects to be run from the ray-operator/ directory.
+#
+# Usage: bash ../.buildkite/run-e2e-nightly-test.sh <test-name> <go-test-timeout> <test-dir> <artifact-tar>
+#
+# Arguments:
+#   test-name       Human-readable test name for log labels
+#   go-test-timeout Timeout for "go test -timeout" (e.g., 30m, 60m)
+#   test-dir        Test directory or files to pass to "go test -v" (e.g., ./test/e2e)
+#   artifact-tar    Tar file name placed in /artifact-mount/ on failure
+
+set -o pipefail
+
+TEST_NAME="$1"
+GO_TEST_TIMEOUT="$2"
+TEST_DIR="$3"
+ARTIFACT_TAR="$4"
+
+echo "--- START:Running ${TEST_NAME} tests"
+echo "Using Ray Image ${KUBERAY_TEST_RAY_IMAGE}"
+
+mkdir -p "$(pwd)/tmp"
+export KUBERAY_TEST_OUTPUT_DIR="$(pwd)/tmp"
+echo "KUBERAY_TEST_OUTPUT_DIR=${KUBERAY_TEST_OUTPUT_DIR}"
+
+KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m \
+  go test -timeout "${GO_TEST_TIMEOUT}" -v ${TEST_DIR} 2>&1 \
+  | awk -f ../.buildkite/format.awk \
+  | tee "${KUBERAY_TEST_OUTPUT_DIR}/gotest.log" \
+  || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay \
+      | tee "${KUBERAY_TEST_OUTPUT_DIR}/kuberay-operator.log" \
+    && cd "${KUBERAY_TEST_OUTPUT_DIR}" \
+    && find . -name "*.log" | tar -cf "/artifact-mount/${ARTIFACT_TAR}" -T - \
+    && exit 1)
+
+echo "--- END:${TEST_NAME} tests finished"

--- a/.buildkite/setup-env.sh
+++ b/.buildkite/setup-env.sh
@@ -30,6 +30,11 @@ mv linux-amd64/helm /usr/local/bin/helm
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 
+# Install kustomize
+curl -Lo kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.3.0/kustomize_v5.3.0_linux_amd64.tar.gz
+tar -zxvf kustomize.tar.gz
+mv kustomize /usr/local/bin/kustomize
+
 # Install python 3.11 and pip
 apt-get update
 apt-get install -y python3.11 python3-pip python3-venv python3-dev build-essential

--- a/.buildkite/setup-nightly-test.sh
+++ b/.buildkite/setup-nightly-test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Common setup for nightly Ray image E2E tests.
+# Sources setup-env.sh, creates a kind cluster, builds and starts the KubeRay operator.
+# After sourcing, the working directory will be in ray-operator/.
+#
+# Usage: source .buildkite/setup-nightly-test.sh
+
+source .buildkite/setup-env.sh
+kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+kubectl config set clusters.kind-kind.server https://docker:6443
+
+# Build nightly KubeRay operator image
+pushd ray-operator
+source ../.buildkite/build-start-operator.sh
+kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator

--- a/.buildkite/test-e2e-ray-nightly.yml
+++ b/.buildkite/test-e2e-ray-nightly.yml
@@ -1,0 +1,133 @@
+# Nightly Ray Image E2E Tests
+#
+# This pipeline tests KubeRay (main branch) against the nightly Ray image.
+# It should runs on a schedule to catch compatibility issues early before
+# Ray releases.
+#
+# Environment variables:
+#   KUBERAY_TEST_RAY_IMAGE: rayproject/ray:nightly
+
+- label: 'Test RayCluster and GCS E2E (nightly Ray image)'
+  instance_size: large
+  image: golang:1.25-bookworm
+  commands:
+    - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
+    - source .buildkite/setup-nightly-test.sh
+    # Run e2e tests and print KubeRay operator logs if tests fail
+    - echo "--- START:Running RayCluster and GCS E2E (nightly Ray image) tests"
+    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2e 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-log.tar -T - && exit 1)
+    - echo "--- END:RayCluster and GCS E2E (nightly Ray image) tests finished"
+
+- label: 'Test RayJob E2E (nightly Ray image)'
+  instance_size: large
+  image: golang:1.25-bookworm
+  commands:
+    - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
+    - source .buildkite/setup-nightly-test.sh
+    # Run e2e tests and print KubeRay operator logs if tests fail
+    - echo "--- START:Running RayJob E2E (nightly Ray image) tests"
+    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2erayjob 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-log.tar -T - && exit 1)
+    - echo "--- END:RayJob E2E (nightly Ray image) tests finished"
+
+- label: 'Test RayService E2E (nightly Ray image)'
+  instance_size: large
+  image: golang:1.25-bookworm
+  commands:
+    - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
+    - source .buildkite/setup-nightly-test.sh
+    # Run e2e tests and print KubeRay operator logs if tests fail
+    - echo "--- START:Running RayService E2E (nightly Ray image) tests"
+    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2erayservice 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-rayservice-log.tar -T - && exit 1)
+    - echo "--- END:RayService E2E (nightly Ray image) tests finished"
+
+- label: 'Test Autoscaler E2E Part 1 (nightly Ray image)'
+  instance_size: large
+  image: golang:1.25-bookworm
+  commands:
+    - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
+    - source .buildkite/setup-nightly-test.sh
+    # Run e2e tests and print KubeRay operator logs if tests fail
+    - echo "--- START:Running Autoscaler E2E Part 1 (nightly Ray image) tests"
+    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2eautoscaler/raycluster_autoscaler_test.go ./test/e2eautoscaler/support.go 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-autoscaler-log.tar -T - && exit 1)
+    - echo "--- END:Autoscaler E2E Part 1 (nightly Ray image) tests finished"
+
+- label: 'Test Autoscaler E2E Part 2 (nightly Ray image)'
+  instance_size: large
+  image: golang:1.25-bookworm
+  commands:
+    - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
+    - source .buildkite/setup-nightly-test.sh
+    # Run e2e tests and print KubeRay operator logs if tests fail
+    - echo "--- START:Running Autoscaler E2E Part 2 (nightly Ray image) tests"
+    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2eautoscaler/raycluster_autoscaler_part2_test.go ./test/e2eautoscaler/support.go 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-autoscaler-log.tar -T - && exit 1)
+    - echo "--- END:Autoscaler E2E Part 2 (nightly Ray image) tests finished"
+
+- label: 'Test RayJob Light Weight Submitter E2E (nightly Ray image)'
+  instance_size: large
+  image: golang:1.25-bookworm
+  commands:
+    - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
+    - source .buildkite/setup-nightly-test.sh
+    - bash ../.buildkite/build-load-light-weight-submitter.sh
+    # Run e2e tests and print KubeRay operator logs if tests fail
+    - echo "--- START:Running RayJob Light Weight Submitter E2E (nightly Ray image) tests"
+    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2erayjobsubmitter 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-log.tar -T - && exit 1)
+    - echo "--- END:RayJob Light Weight Submitter E2E (nightly Ray image) tests finished"
+
+- label: 'Test RayCronJob E2E (nightly Ray image)'
+  instance_size: large
+  image: golang:1.25-bookworm
+  commands:
+    - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
+    - source .buildkite/setup-nightly-test.sh
+    # Run e2e tests and print KubeRay operator logs if tests fail
+    - echo "--- START:Running RayCronJob E2E (nightly Ray image) tests"
+    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 40m -v ./test/e2eraycronjob 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-cronjob-log.tar -T - && exit 1)
+    - echo "--- END:RayCronJob E2E (nightly Ray image) tests finished"
+
+- label: 'Test Apiserver E2E (nightly Ray image)'
+  instance_size: large
+  image: golang:1.25-bookworm
+  commands:
+    - export E2E_API_SERVER_RAY_IMAGE="rayproject/ray:nightly-py310"
+    - source .buildkite/setup-nightly-test.sh
+    # Build and start apiserver
+    - pushd ../apiserver
+    - KIND_CLUSTER_NAME=kind KIND=kind make install-apiserver-e2e
+    - kubectl wait --namespace ray-system --for=condition=Available --timeout=90s deployment/kuberay-apiserver -n ray-system
+    # Run e2e tests and print KubeRay api server logs if tests fail
+    - echo "--- START:Running Apiserver E2E (nightly Ray image) tests"
+    - echo "Using Ray Image $${E2E_API_SERVER_RAY_IMAGE}"
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - E2E_API_SERVER_URL="http://localhost:8888" go test -parallel 4 -timeout 60m -v ./test/e2e/... 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs -l app.kubernetes.io/component=kuberay-apiserver --namespace ray-system | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-apiserver.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-apiserver-log.tar -T - && exit 1)
+    - echo "--- END:Apiserver E2E (nightly Ray image) tests finished"

--- a/.buildkite/test-e2e-ray-nightly.yml
+++ b/.buildkite/test-e2e-ray-nightly.yml
@@ -13,14 +13,7 @@
   commands:
     - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
     - source .buildkite/setup-nightly-test.sh
-    # Run e2e tests and print KubeRay operator logs if tests fail
-    - echo "--- START:Running RayCluster and GCS E2E (nightly Ray image) tests"
-    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
-    - set -o pipefail
-    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
-    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2e 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-log.tar -T - && exit 1)
-    - echo "--- END:RayCluster and GCS E2E (nightly Ray image) tests finished"
+    - bash ../.buildkite/run-e2e-nightly-test.sh "RayCluster and GCS E2E (nightly Ray image)" 30m "./test/e2e" e2e-nightly-raycluster-log.tar
 
 - label: 'Test RayJob E2E (nightly Ray image)'
   instance_size: large
@@ -28,14 +21,7 @@
   commands:
     - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
     - source .buildkite/setup-nightly-test.sh
-    # Run e2e tests and print KubeRay operator logs if tests fail
-    - echo "--- START:Running RayJob E2E (nightly Ray image) tests"
-    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
-    - set -o pipefail
-    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
-    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2erayjob 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-log.tar -T - && exit 1)
-    - echo "--- END:RayJob E2E (nightly Ray image) tests finished"
+    - bash ../.buildkite/run-e2e-nightly-test.sh "RayJob E2E (nightly Ray image)" 60m "./test/e2erayjob" e2e-nightly-rayjob-log.tar
 
 - label: 'Test RayService E2E (nightly Ray image)'
   instance_size: large
@@ -43,14 +29,7 @@
   commands:
     - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
     - source .buildkite/setup-nightly-test.sh
-    # Run e2e tests and print KubeRay operator logs if tests fail
-    - echo "--- START:Running RayService E2E (nightly Ray image) tests"
-    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
-    - set -o pipefail
-    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
-    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2erayservice 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-rayservice-log.tar -T - && exit 1)
-    - echo "--- END:RayService E2E (nightly Ray image) tests finished"
+    - bash ../.buildkite/run-e2e-nightly-test.sh "RayService E2E (nightly Ray image)" 30m "./test/e2erayservice" e2e-nightly-ray-rayservice-log.tar
 
 - label: 'Test Autoscaler E2E Part 1 (nightly Ray image)'
   instance_size: large
@@ -58,14 +37,7 @@
   commands:
     - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
     - source .buildkite/setup-nightly-test.sh
-    # Run e2e tests and print KubeRay operator logs if tests fail
-    - echo "--- START:Running Autoscaler E2E Part 1 (nightly Ray image) tests"
-    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
-    - set -o pipefail
-    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
-    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2eautoscaler/raycluster_autoscaler_test.go ./test/e2eautoscaler/support.go 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-autoscaler-log.tar -T - && exit 1)
-    - echo "--- END:Autoscaler E2E Part 1 (nightly Ray image) tests finished"
+    - bash ../.buildkite/run-e2e-nightly-test.sh "Autoscaler E2E Part 1 (nightly Ray image)" 60m "./test/e2eautoscaler/raycluster_autoscaler_test.go ./test/e2eautoscaler/support.go" e2e-nightly-ray-autoscaler-part1-log.tar
 
 - label: 'Test Autoscaler E2E Part 2 (nightly Ray image)'
   instance_size: large
@@ -73,14 +45,7 @@
   commands:
     - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
     - source .buildkite/setup-nightly-test.sh
-    # Run e2e tests and print KubeRay operator logs if tests fail
-    - echo "--- START:Running Autoscaler E2E Part 2 (nightly Ray image) tests"
-    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
-    - set -o pipefail
-    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
-    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 60m -v ./test/e2eautoscaler/raycluster_autoscaler_part2_test.go ./test/e2eautoscaler/support.go 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-autoscaler-log.tar -T - && exit 1)
-    - echo "--- END:Autoscaler E2E Part 2 (nightly Ray image) tests finished"
+    - bash ../.buildkite/run-e2e-nightly-test.sh "Autoscaler E2E Part 2 (nightly Ray image)" 60m "./test/e2eautoscaler/raycluster_autoscaler_part2_test.go ./test/e2eautoscaler/support.go" e2e-nightly-ray-autoscaler-part2-log.tar
 
 - label: 'Test RayJob Light Weight Submitter E2E (nightly Ray image)'
   instance_size: large
@@ -89,14 +54,7 @@
     - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
     - source .buildkite/setup-nightly-test.sh
     - bash ../.buildkite/build-load-light-weight-submitter.sh
-    # Run e2e tests and print KubeRay operator logs if tests fail
-    - echo "--- START:Running RayJob Light Weight Submitter E2E (nightly Ray image) tests"
-    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
-    - set -o pipefail
-    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
-    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2erayjobsubmitter 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-log.tar -T - && exit 1)
-    - echo "--- END:RayJob Light Weight Submitter E2E (nightly Ray image) tests finished"
+    - bash ../.buildkite/run-e2e-nightly-test.sh "RayJob Light Weight Submitter E2E (nightly Ray image)" 30m "./test/e2erayjobsubmitter" e2e-nightly-rayjob-submitter-log.tar
 
 - label: 'Test RayCronJob E2E (nightly Ray image)'
   instance_size: large
@@ -104,14 +62,7 @@
   commands:
     - export KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly"
     - source .buildkite/setup-nightly-test.sh
-    # Run e2e tests and print KubeRay operator logs if tests fail
-    - echo "--- START:Running RayCronJob E2E (nightly Ray image) tests"
-    - echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"
-    - set -o pipefail
-    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
-    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 40m -v ./test/e2eraycronjob 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-nightly-ray-cronjob-log.tar -T - && exit 1)
-    - echo "--- END:RayCronJob E2E (nightly Ray image) tests finished"
+    - bash ../.buildkite/run-e2e-nightly-test.sh "RayCronJob E2E (nightly Ray image)" 40m "./test/e2eraycronjob" e2e-nightly-ray-cronjob-log.tar
 
 - label: 'Test Apiserver E2E (nightly Ray image)'
   instance_size: large

--- a/ray-operator/test/support/yaml.go
+++ b/ray-operator/test/support/yaml.go
@@ -1,8 +1,12 @@
 package support
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,10 +53,98 @@ func DeserializeRayServiceYAML(t Test, filename string) *rayv1.RayService {
 
 func KubectlApplyYAML(t Test, filename string, namespace string) {
 	t.T().Helper()
+
+	// Check if we should transform the YAML for a custom Ray image
+	rayImage := GetRayImage()
+	defaultImage := RayImage // from defaults.go
+
+	if rayImage != defaultImage {
+		LogWithTimestamp(t.T(), "Using kustomize to transform %s with Ray image: %s", filename, rayImage)
+		kubectlApplyYAMLWithKustomize(t, filename, namespace, rayImage)
+		return
+	}
+
 	kubectlCmd := exec.CommandContext(t.Ctx(), "kubectl", "apply", "-f", filename, "-n", namespace)
 	err := kubectlCmd.Run()
 	require.NoError(t.T(), err, "Failed to apply %s to namespace %s", filename, namespace)
 	LogWithTimestamp(t.T(), "Successfully applied %s to namespace %s", filename, namespace)
+}
+
+// kubectlApplyYAMLWithKustomize creates a temporary kustomization that transforms the Ray image
+// in the given YAML file, then applies it to the cluster.
+func kubectlApplyYAMLWithKustomize(t Test, filename string, namespace string, rayImage string) {
+	t.T().Helper()
+
+	// Get absolute path to the source file
+	absFilename, err := filepath.Abs(filename)
+	require.NoError(t.T(), err, "Failed to get absolute path for %s", filename)
+
+	// Create a temporary directory for kustomize
+	tempDir, err := os.MkdirTemp("", "kuberay-kustomize-*")
+	require.NoError(t.T(), err, "Failed to create temp directory for kustomize")
+	defer os.RemoveAll(tempDir)
+
+	// Copy the source YAML file to the temp directory
+	sourceContent, err := os.ReadFile(absFilename)
+	require.NoError(t.T(), err, "Failed to read %s", filename)
+
+	baseFilename := filepath.Base(filename)
+	destFile := filepath.Join(tempDir, baseFilename)
+	err = os.WriteFile(destFile, sourceContent, 0o600)
+	require.NoError(t.T(), err, "Failed to write %s to temp directory", baseFilename)
+
+	// Extract image name and tag from rayImage (e.g., "rayproject/ray:nightly" -> name="rayproject/ray", tag="nightly")
+	// If no tag is specified use the whole string as the image name
+	var imageName, imageTag string
+	if idx := strings.LastIndex(rayImage, ":"); idx != -1 {
+		imageName = rayImage[:idx]
+		imageTag = rayImage[idx+1:]
+	} else {
+		imageName = rayImage
+		imageTag = ""
+	}
+
+	// Generate kustomization.yaml
+	// Only include newTag if a tag was specified
+	var imagesSection string
+	if imageTag != "" {
+		imagesSection = fmt.Sprintf(`images:
+  - name: rayproject/ray
+    newName: %s
+    newTag: %s`, imageName, imageTag)
+	} else {
+		imagesSection = fmt.Sprintf(`images:
+  - name: rayproject/ray
+    newName: %s`, imageName)
+	}
+
+	kustomizationContent := fmt.Sprintf(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - %s
+
+%s
+`, baseFilename, imagesSection)
+
+	kustomizationFile := filepath.Join(tempDir, "kustomization.yaml")
+	err = os.WriteFile(kustomizationFile, []byte(kustomizationContent), 0o600)
+	require.NoError(t.T(), err, "Failed to write kustomization.yaml")
+
+	// Run kustomize build
+	kustomizeCmd := exec.CommandContext(t.Ctx(), "kustomize", "build", tempDir)
+	var stdout, stderr bytes.Buffer
+	kustomizeCmd.Stdout = &stdout
+	kustomizeCmd.Stderr = &stderr
+	err = kustomizeCmd.Run()
+	require.NoError(t.T(), err, "Kustomize build failed: %s", stderr.String())
+
+	// Apply the kustomize output
+	kubectlCmd := exec.CommandContext(t.Ctx(), "kubectl", "apply", "-n", namespace, "-f", "-")
+	kubectlCmd.Stdin = strings.NewReader(stdout.String())
+	output, err := kubectlCmd.CombinedOutput()
+	require.NoError(t.T(), err, "Failed to apply kustomize output for %s: %s", filename, string(output))
+	LogWithTimestamp(t.T(), "Successfully applied %s with kustomized Ray image %s to namespace %s", filename, rayImage, namespace)
 }
 
 func KubectlApplyQuota(t Test, namespace, quota string) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change adds a new buildkite job that will test KubeRay against nightly releases of Ray.

## Related issue number

Related to: #3158 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
