### PR TITLE
[historyserver][collector] EventServer use filepath functions to handle file path

### DIFF
--- a/historyserver/pkg/collector/eventserver/eventserver.go
+++ b/historyserver/pkg/collector/eventserver/eventserver.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -107,7 +108,7 @@ func (es *EventServer) InitServer(stop <-chan struct{}, port int) {
 
 // watchNodeIDFile watches raylet_node_id for content changes.
 func (es *EventServer) watchNodeIDFile() {
-	rayTmpDir := filepath.Join(os.TempDir(), "ray")
+	rayTmpDir := filepath.Join("/tmp", "ray")
 	nodeIDFilePath := filepath.Join(rayTmpDir, "raylet_node_id")
 
 	// Create new watcher
@@ -452,7 +453,7 @@ func (es *EventServer) flushNodeEventsForHour(hourKey string, events []Event) er
 	}
 
 	// Build node event storage path using event's nodeID
-	basePath := filepath.Join(
+	basePath := path.Join(
 		es.root,
 		fmt.Sprintf("%s_%s", es.clusterName, es.clusterID),
 		sessionNameToUse,
@@ -460,7 +461,7 @@ func (es *EventServer) flushNodeEventsForHour(hourKey string, events []Event) er
 		fmt.Sprintf("%s-%s", nodeIDToUse, hourKey))
 
 	// Ensure storage directory exists
-	dir := filepath.Dir(basePath)
+	dir := path.Dir(basePath)
 	if err := es.storageWriter.CreateDirectory(dir); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
@@ -502,7 +503,7 @@ func (es *EventServer) flushJobEventsForHour(jobID, hourKey string, events []Eve
 	}
 
 	// Build job event storage path using event's nodeID
-	basePath := filepath.Join(
+	basePath := path.Join(
 		es.root,
 		fmt.Sprintf("%s_%s", es.clusterName, es.clusterID),
 		sessionNameToUse,
@@ -511,7 +512,7 @@ func (es *EventServer) flushJobEventsForHour(jobID, hourKey string, events []Eve
 		fmt.Sprintf("%s-%s", nodeIDToUse, hourKey))
 
 	// Ensure storage directory exists
-	dir := filepath.Dir(basePath)
+	dir := path.Dir(basePath)
 	if err := es.storageWriter.CreateDirectory(dir); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}


### PR DESCRIPTION
## Why are these changes needed?

There are some hardcode path in `pkg/collector/eventserver/eventserver.go`. We can use filepath to provide cross-platform capabilities for those filename paths.

## What changed

- Introduced a single tmp root (`rayTmpDir := filepath.Join("/tmp", "ray")`) and derived:
  - node ID file path via `filepath.Join(rayTmpDir, "raylet_node_id")`
  - watcher directory via `rayTmpDir`
- Normalized fsnotify event matching by comparing `filepath.Clean(event.Name)` with the target file path before checking ops.
- Updated comments to avoid duplicating hardcoded paths.

## Related issue number

Closes #4439
Related to #4417 

## Checks

- [x] I've made sure the tests are passing.

### Testing Strategy

- [ ] Unit tests
- [x] Manual tests
- [ ] This PR is not tested :(
