### PR TITLE
[Fix] [RayJob]: Prevent ClusterSelector jobs from deleting external RayClusters

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -756,6 +756,12 @@ func (r *RayJobReconciler) deleteSubmitterJob(ctx context.Context, rayJobInstanc
 // deleteClusterResources deletes the RayCluster associated with the RayJob to release the compute resources.
 func (r *RayJobReconciler) deleteClusterResources(ctx context.Context, rayJobInstance *rayv1.RayJob) (bool, error) {
 	logger := ctrl.LoggerFrom(ctx)
+
+	if len(rayJobInstance.Spec.ClusterSelector) > 0 {
+		logger.Info("RayJob is using an existing RayCluster via clusterSelector; skipping resource deletion.", "RayClusterSelector", rayJobInstance.Spec.ClusterSelector)
+		return true, nil
+	}
+
 	clusterIdentifier := common.RayJobRayClusterNamespacedName(rayJobInstance)
 
 	var isClusterDeleted bool

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -305,6 +305,9 @@ func ValidateRayJobSpec(rayJob *rayv1.RayJob) error {
 		if rayJob.Spec.SubmissionMode == rayv1.SidecarMode {
 			return fmt.Errorf("ClusterSelector is not supported in SidecarMode")
 		}
+		if rayJob.Spec.BackoffLimit != nil && *rayJob.Spec.BackoffLimit > 0 {
+			return fmt.Errorf("The RayJob spec is invalid: BackoffLimit is incompatible with ClusterSelector mode")
+		}
 	}
 
 	// InteractiveMode does not support backoffLimit > 1.

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -1165,6 +1165,14 @@ func TestValidateRayJobSpec(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "BackoffLimit > 0 is incompatible with ClusterSelector mode",
+			spec: rayv1.RayJobSpec{
+				ClusterSelector: map[string]string{"ray.io/cluster": "ray-cluster"},
+				BackoffLimit:    ptr.To[int32](1),
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR addresses a critical issue where a `RayJob` configured with `clusterSelector` (to attach to an existing RayCluster) and `backoffLimit > 0` would incorrectly attempt to delete the external RayCluster upon job failure and retry.

The following changes were made:

Validation Logic: Updated `ValidateRayJobSpec` to reject `RayJob` specifications that combine `clusterSelector` with `backoffLimit > 0`. This configuration is fundamentally incompatible because the retry mechanism relies on tearing down and recreating the cluster, which should never happen for an externally managed cluster.
Controller Safeguard: Updated `deleteClusterResources` in the RayJob controller to explicitly check if `clusterSelector` is being used. If present, the function now logs an info message and returns immediately, ensuring the external cluster is never deleted by the controller.

## Related issue number
Closes #4516
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
Unit test screenshot:
<img width="1325" height="445" alt="Screenshot 2026-02-20 at 5 41 58 PM" src="https://github.com/user-attachments/assets/01b250b0-23e8-4a5d-aa35-a16c9a9c979a" />
Manual test screenshot (reproducing the issue with validation shown):
<img width="1300" height="192" alt="Screenshot 2026-02-20 at 6 21 29 PM" src="https://github.com/user-attachments/assets/2bc6ec4f-9603-41b8-be58-1243f03d5876" />
