### PR TITLE
Fix issue in helm charts where ingress backend name might not match route/service name

### DIFF
--- a/helm-chart/kuberay-apiserver/templates/ingress.yaml
+++ b/helm-chart/kuberay-apiserver/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kuberay-apiserver.fullname" . -}}
+{{- $svcName := printf "%s-service" $fullName -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
@@ -50,11 +51,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $fullName }}
+                name: {{ $svcName }}
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ $fullName }}
+              serviceName: {{ $svcName }}
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}

--- a/helm-chart/kuberay-apiserver/templates/route.yaml
+++ b/helm-chart/kuberay-apiserver/templates/route.yaml
@@ -14,7 +14,7 @@ spec:
   subdomain: api-server-kuberay
   to:
     kind: Service
-    name: {{ .Values.name }}-service
+    name: {{ include "kuberay-apiserver.fullname" . }}-service
     weight: 100
   port:
     targetPort: http

--- a/helm-chart/kuberay-apiserver/templates/service.yaml
+++ b/helm-chart/kuberay-apiserver/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}-service
+  name: {{ include "kuberay-apiserver.fullname" . }}-service
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: kuberay-apiserver

--- a/helm-chart/kuberay-apiserver/tests/ingress_test.yaml
+++ b/helm-chart/kuberay-apiserver/tests/ingress_test.yaml
@@ -57,3 +57,93 @@ tests:
           kind: Ingress
           name: kuberay-apiserver
           namespace: kuberay-system
+
+  - it: Should have ingress backend service name matching the service name
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: example.com
+            paths:
+              - path: /
+                pathType: Prefix
+      service:
+        port: 8888
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: kuberay-apiserver-service
+
+  - it: Should have ingress backend service name matching the service name when fullnameOverride is set
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      fullnameOverride: test-name
+      ingress:
+        enabled: true
+        hosts:
+          - host: example.com
+            paths:
+              - path: /
+                pathType: Prefix
+      service:
+        port: 8888
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: test-name-service
+
+  - it: Should have ingress backend service name matching the service name when nameOverride is set
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      nameOverride: custom-api
+      ingress:
+        enabled: true
+        hosts:
+          - host: example.com
+            paths:
+              - path: /
+                pathType: Prefix
+      service:
+        port: 8888
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: kuberay-apiserver-custom-api-service
+
+  - it: Should have correct service name in all backend references with multiple hosts and paths
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: example.com
+            paths:
+              - path: /api
+                pathType: Prefix
+              - path: /health
+                pathType: Exact
+          - host: api.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+      service:
+        port: 8888
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: kuberay-apiserver-service
+      - equal:
+          path: spec.rules[0].http.paths[1].backend.service.name
+          value: kuberay-apiserver-service
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.name
+          value: kuberay-apiserver-service

--- a/helm-chart/kuberay-apiserver/tests/route_test.yaml
+++ b/helm-chart/kuberay-apiserver/tests/route_test.yaml
@@ -41,3 +41,32 @@ tests:
       - equal:
           path: metadata.annotations.key2
           value: value2
+
+  - it: Should have route backend service name matching the service name
+    set:
+      route:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.to.name
+          value: kuberay-apiserver-service
+
+  - it: Should have route backend service name matching the service name when fullnameOverride is set
+    set:
+      fullnameOverride: test-name
+      route:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.to.name
+          value: test-name-service
+
+  - it: Should have route backend service name matching the service name when nameOverride is set
+    set:
+      nameOverride: custom-api
+      route:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.to.name
+          value: kuberay-apiserver-custom-api-service

--- a/helm-chart/kuberay-apiserver/tests/service_test.yaml
+++ b/helm-chart/kuberay-apiserver/tests/service_test.yaml
@@ -24,3 +24,23 @@ tests:
       - equal:
           path: spec.type
           value: NodePort
+
+  - it: Should have service name matching fullnameOverride when set
+    set:
+      fullnameOverride: test-name
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Service
+          name: test-name-service
+          namespace: kuberay-system
+
+  - it: Should have service name matching nameOverride when set
+    set:
+      nameOverride: custom-api
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Service
+          name: kuberay-apiserver-custom-api-service
+          namespace: kuberay-system


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Service name is computed different in different files in the helm chart. 
This changes makes them consistent to ensure there are no mis-matches if non-default values are used

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/kuberay/issues/4518


## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
