### PR TITLE
[CI] fixing covdata errors when running go tests via make targets

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -107,6 +107,11 @@ generate: mockgen # Generate code using command after //go:generate in each file
 
 ##@ Testing
 
+# TODO: Remove this once a fix for https://github.com/golang/go/issues/75031 is released.
+# This is a workaround for an issue where `go test -cover` reports errors for packages with no test files.
+GOVERSION := $(shell go env GOVERSION)
+export GOTOOLCHAIN := $(GOVERSION)+auto
+
 .PHONY: test
 test: fmt vet fumpt imports generate ## Run all unit tests.
 	go test ./pkg/... $(GO_TEST_FLAGS) -race -coverprofile ray-kube-api-server-coverage.out -parallel 4

--- a/apiserversdk/Makefile
+++ b/apiserversdk/Makefile
@@ -30,6 +30,11 @@ golangci-lint: ## Download golangci_lint locally if necessary.
 lint: golangci-lint fmt vet ## Run the linter.
 	test -s $(GOLANGCI_LINT) || ($(GOLANGCI_LINT) run --timeout=3m --allow-parallel-runners)
 
+# TODO: Remove this once a fix for https://github.com/golang/go/issues/75031 is released.
+# This is a workaround for an issue where `go test -cover` reports errors for packages with no test files.
+GOVERSION := $(shell go env GOVERSION)
+export GOTOOLCHAIN := $(GOVERSION)+auto
+
 test: WHAT ?= $(shell go list ./... | grep -v /test/)
 test: ENVTEST_K8S_VERSION ?= 1.34.1
 test: envtest ## Run tests.

--- a/historyserver/Makefile
+++ b/historyserver/Makefile
@@ -112,6 +112,11 @@ ifeq ($(ENGINE),docker)
 	${ENGINE} buildx use $(DOCKERBUILDER_INSTANCE)
 endif
 
+# TODO: Remove this once a fix for https://github.com/golang/go/issues/75031 is released.
+# This is a workaround for an issue where `go test -cover` reports errors for packages with no test files.
+GOVERSION := $(shell go env GOVERSION)
+export GOTOOLCHAIN := $(GOVERSION)+auto
+
 # Run tests
 .PHONY: test
 test:

--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -62,6 +62,11 @@ vet: ## Run go vet against code.
 fumpt: gofumpt
 	$(GOFUMPT) -l -w ../
 
+# TODO: Remove this once a fix for https://github.com/golang/go/issues/75031 is released.
+# This is a workaround for an issue where `go test -cover` reports errors for packages with no test files.
+GOVERSION := $(shell go env GOVERSION)
+export GOTOOLCHAIN := $(GOVERSION)+auto
+
 test: WHAT ?= $(shell go list ./... | grep -v /test/)
 test: ENVTEST_K8S_VERSION ?= 1.34.1
 test: manifests fmt vet envtest ## Run tests.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Starting with go v1.25 `go test -cover` reports errors when run against packages that do contain test files when using the default / **auto** toolchain.
This implements a work-around discussed in the golang/go issue which sets the go toolcahin to $GOVERSION-auto

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Related to https://github.com/golang/go/issues/75031 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
