### PR TITLE
[Enhancement] Support enabling RAY_ENABLE_K8S_TOKEN_AUTH

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -575,7 +575,7 @@ func getSubmitterTemplate(rayJobInstance *rayv1.RayJob, rayClusterInstance *rayv
 		return corev1.PodTemplateSpec{}, err
 	}
 
-	if rayClusterInstance != nil && rayClusterInstance.Spec.AuthOptions != nil && ptr.Deref(rayClusterInstance.Spec.AuthOptions.EnableK8sTokenAuth, false) {
+	if rayClusterInstance != nil && utils.IsK8sAuthEnabled(rayClusterInstance.Spec.AuthOptions) {
 		common.AddRayTokenVolume(&submitterTemplate.Spec)
 	}
 

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -752,8 +752,8 @@ func IsAuthEnabled(spec *rayv1.RayClusterSpec) bool {
 	return spec.AuthOptions != nil && spec.AuthOptions.Mode == rayv1.AuthModeToken
 }
 
-func IsK8sAuthEnabled(spec *rayv1.RayClusterSpec) bool {
-	return spec.AuthOptions != nil && spec.AuthOptions.EnableK8sTokenAuth != nil && *spec.AuthOptions.EnableK8sTokenAuth
+func IsK8sAuthEnabled(authOptions *rayv1.AuthOptions) bool {
+	return authOptions != nil && authOptions.EnableK8sTokenAuth != nil && *authOptions.EnableK8sTokenAuth
 }
 
 // GetRayClusterNameFromService returns the name of the RayCluster that the service points to

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -251,14 +251,14 @@ func ValidateRayClusterSpec(spec *rayv1.RayClusterSpec, annotations map[string]s
 			return fmt.Errorf("authOptions.mode is 'token' but minimum Ray version is 2.52.0, got %s", spec.RayVersion)
 		}
 
-		if IsK8sAuthEnabled(spec) {
+		if IsK8sAuthEnabled(spec.AuthOptions) {
 			minVersion := version.MustParseGeneric("2.55.0")
 			if rayVersion.LessThan(minVersion) {
 				return fmt.Errorf("authOptions.enableK8sTokenAuth is enabled but minimum Ray version is 2.55.0, got %s", spec.RayVersion)
 			}
 		}
 	} else {
-		if IsK8sAuthEnabled(spec) {
+		if IsK8sAuthEnabled(spec.AuthOptions) {
 			return fmt.Errorf("authOptions.enableK8sTokenAuth is enabled but authOptions.mode not set to 'token'")
 		}
 	}


### PR DESCRIPTION
https://github.com/ray-project/kuberay/issues/4542
## Summary
- Refactor `IsK8sAuthEnabled` to accept `*AuthOptions` instead of `*RayClusterSpec`, making it reusable in contexts where only `AuthOptions` is available (e.g., `rayjob_controller.go` submitter template).
- Replace duplicated nil-check + dereference logic with the centralized `IsK8sAuthEnabled()` helper across `pod.go`, `rayjob_controller.go`, and `validation.go`.
- Remove unused `k8s.io/utils/ptr` import from `pod.go`.
- Add TODO for future support of audiences (e.g., `["ray.io"]`) in service account token projection.


