### PR TITLE
[Refactor] [history server] Align `tasks/timeline` generation with Ray Dashboard

### DIFF
--- a/historyserver/pkg/eventserver/eventserver.go
+++ b/historyserver/pkg/eventserver/eventserver.go
@@ -1105,14 +1105,14 @@ func (h *EventHandler) handleTaskProfileEvent(eventMap map[string]any, clusterSe
 		return err
 	}
 
-	if profileData.TaskID == "" || len(profileData.ProfileEvents.ProfileEventEntry) == 0 {
+	if profileData.TaskID == "" || len(profileData.ProfileEvents.Events) == 0 {
 		logrus.Debugf("TASK_PROFILE_EVENT has no taskId or events, skipping")
 		return nil
 	}
 
 	// Convert events to ProfileEventRaw format
-	var rawEvents = make([]types.ProfileEventRaw, 0, len(profileData.ProfileEvents.ProfileEventEntry))
-	for _, e := range profileData.ProfileEvents.ProfileEventEntry {
+	var rawEvents = make([]types.ProfileEventRaw, 0, len(profileData.ProfileEvents.Events))
+	for _, e := range profileData.ProfileEvents.Events {
 		startTime, err := strconv.ParseInt(e.StartTime, 10, 64)
 		if err != nil {
 			logrus.Warnf("Failed to parse StartTime '%s': %v", e.StartTime, err)

--- a/historyserver/pkg/eventserver/types/task.go
+++ b/historyserver/pkg/eventserver/types/task.go
@@ -175,10 +175,10 @@ type TaskProfileEvents struct {
 
 // ProfileEvents contains component and event information
 type ProfileEvents struct {
-	ComponentID       string              `json:"componentId"`
-	ComponentType     string              `json:"componentType"`
-	NodeIPAddress     string              `json:"nodeIpAddress"`
-	ProfileEventEntry []ProfileEventEntry `json:"events"`
+	ComponentID   string              `json:"componentId"`
+	ComponentType string              `json:"componentType"`
+	NodeIPAddress string              `json:"nodeIpAddress"`
+	Events        []ProfileEventEntry `json:"events"`
 }
 
 // ProfileEventEntry represents a single profile event within Spans


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As mentioned in #4488 , the timeline generation and event model logic had several maintainability and consistency issues:

- The `"task::"` prefix was hard-coded in multiple places, increasing the risk of inconsistent usage or future drift.
- `PID/TID` assignment behavior slightly diverged from Ray Dashboard’s implementation, which could lead to inconsistencies in timeline visualization.
- Identical filtering logic was duplicated across multiple timeline passes, creating maintenance risk if future updates modified one path but not the other.
- Several structs included a `DTO` suffix despite directly representing Ray Event Export API JSON payloads rather than cross-layer transfer objects, making naming less accurate.

This refactor improves consistency with Ray Dashboard, reduces duplication, clarifies naming semantics, and lowers long-term maintenance risk without changing external behavior.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #4488 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
