### PR TITLE
[Fix][RayCluster] Skip auth Secret reconciliation when K8s token auth is enabled

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -374,6 +374,12 @@ func (r *RayClusterReconciler) reconcileAuthSecret(ctx context.Context, instance
 		return nil
 	}
 
+	// When K8s token auth is enabled, authentication is delegated to the K8s API server
+	// via ServiceAccount tokens, so no Secret needs to be created.
+	if utils.IsK8sAuthEnabled(instance.Spec.AuthOptions) {
+		return nil
+	}
+
 	secret := &corev1.Secret{}
 	secretName := utils.CheckName(instance.Name)
 	err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: instance.Namespace}, secret)

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3589,6 +3589,37 @@ func TestReconcile_AuthSecret(t *testing.T) {
 	assert.Len(t, decodedBytes, 32)
 }
 
+func TestReconcile_AuthSecret_SkipWhenK8sTokenAuthEnabled(t *testing.T) {
+	setupTest(t)
+
+	testRayCluster.Spec.AuthOptions = &rayv1.AuthOptions{
+		Mode:               rayv1.AuthModeToken,
+		EnableK8sTokenAuth: ptr.To(true),
+	}
+
+	fakeClient := clientFake.NewClientBuilder().WithRuntimeObjects(testPods...).Build()
+	ctx := context.Background()
+
+	secretNamespacedName := types.NamespacedName{
+		Name:      instanceName,
+		Namespace: namespaceStr,
+	}
+
+	testRayClusterReconciler := &RayClusterReconciler{
+		Client:                     fakeClient,
+		Recorder:                   &record.FakeRecorder{},
+		Scheme:                     scheme.Scheme,
+		rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
+	}
+
+	err := testRayClusterReconciler.reconcileAuthSecret(ctx, testRayCluster)
+	require.NoError(t, err, "Fail to reconcile auth secret")
+
+	secret := corev1.Secret{}
+	err = fakeClient.Get(ctx, secretNamespacedName, &secret)
+	assert.True(t, k8serrors.IsNotFound(err), "Secret should not be created when K8s token auth is enabled")
+}
+
 func TestReconcile_PodsWithAuthToken(t *testing.T) {
 	setupTest(t)
 


### PR DESCRIPTION
## Summary
- When `enableK8sTokenAuth` is true, `reconcileAuthSecret` now skips Secret creation since authentication is delegated to the K8s API server via ServiceAccount tokens and the Secret will never be referenced.

## Test plan
unit test