### PR TITLE
Include serve-x prefixed ports in ray serve service for grpc support

### DIFF
--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -222,9 +222,6 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 			ports = append(ports, svcPort)
 		}
 	}
-	sort.SliceStable(ports, func(i, j int) bool {
-		return ports[i].Name < ports[j].Name
-	})
 
 	if isRayService {
 		// We are invoked from RayService
@@ -265,17 +262,6 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 					}
 				}
 				serveService.Spec.Ports = mergedPorts
-			} else {
-				filteredPorts := make([]corev1.ServicePort, 0)
-				for _, port := range serveService.Spec.Ports {
-					if isServingPort(port.Name) {
-						filteredPorts = append(filteredPorts, port)
-					}
-				}
-				sort.SliceStable(filteredPorts, func(i, j int) bool {
-					return filteredPorts[i].Name < filteredPorts[j].Name
-				})
-				serveService.Spec.Ports = filteredPorts
 			}
 
 			setLabelsforUserProvidedService(serveService, labels)

--- a/ray-operator/controllers/ray/common/service_test.go
+++ b/ray-operator/controllers/ray/common/service_test.go
@@ -812,12 +812,14 @@ func TestUserSpecifiedServeServiceFallbackPreservesAppProtocol(t *testing.T) {
 	svc, err := BuildServeServiceForRayService(context.Background(), *testRayService, cluster)
 	require.NoError(t, err)
 
-	// Only serve-* ports are kept, non-serve ports are filtered out
-	assert.Len(t, svc.Spec.Ports, 1)
+	// All user-provided ports are kept as-is when no ports are auto-detected
+	assert.Len(t, svc.Spec.Ports, 2)
 	assert.Equal(t, "serve-grpc", svc.Spec.Ports[0].Name)
 	assert.Equal(t, int32(9000), svc.Spec.Ports[0].Port)
 	require.NotNil(t, svc.Spec.Ports[0].AppProtocol)
 	assert.Equal(t, "kubernetes.io/h2c", *svc.Spec.Ports[0].AppProtocol)
+	assert.Equal(t, "not-a-serve-port", svc.Spec.Ports[1].Name)
+	assert.Equal(t, int32(1234), svc.Spec.Ports[1].Port)
 }
 
 func TestIsServingPort(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The serve service previously only included the port named exactly \"serve\", which meant additional serving ports (e.g., gRPC on a port named \"serve-grpc\") were silently dropped from the Kubernetes service. This caused gRPC traffic to be unreachable via the serve service when using proxy_location=EveryNode,even though the pods were correctly listening on the gRPC port.

This change expands the port filter to include any port matching \"serve\" or the \"serve-\" prefix (e.g., \"serve-grpc\", \"serve-http\"), allowing multiple serving protocols to be exposed through the serve service."

<!-- Please give a short summary of the change and the problem this solves. -->

Now

`
ports:
    containerPort: 8000
    name: serve-http 
    containerPort: 9000
    name: serve-grpc   
`

will work.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
