### PR TITLE
[Test] Updating k8s.io/api/admission/v1beta1 usage to k8s.io/api/admission/v1

### DIFF
--- a/ray-operator/pkg/webhooks/v1/suite_test.go
+++ b/ray-operator/pkg/webhooks/v1/suite_test.go
@@ -11,7 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -66,7 +66,7 @@ var _ = BeforeSuite(func() {
 	err = rayv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = admissionv1beta1.AddToScheme(scheme)
+	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The `vbeta1` admission API was removed in v1.22.
The go code still has not been removed but we should switch to using the stable package for testing.

https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#webhook-resources

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
