### PR TITLE
[Feature][history server] Add associated RayJob/RayService for RayCluster

### DIFF
--- a/historyserver/config/raycluster.yaml
+++ b/historyserver/config/raycluster.yaml
@@ -110,6 +110,10 @@ spec:
             value: "test"
           - name: S3FORCE_PATH_STYLE
             value: "true"
+          - name: RAYCLUSTER_NAME_ENV_VAR
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['ray.io/cluster']
           command:
           - collector
           - --role=Head

--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
@@ -30,6 +30,7 @@ type RayLogHandler struct {
 	LogDir                 string
 	RayNodeName            string
 	RayClusterID           string
+	OwnerResource          string
 	RootDir                string
 	SessionDir             string
 	prevLogsDir            string
@@ -37,7 +38,7 @@ type RayLogHandler struct {
 	PushInterval           time.Duration
 	LogBatching            int
 	filePathMu             sync.Mutex
-	IsHead             bool
+	IsHead                 bool
 	DashboardAddress       string
 	AdditionalEndpoints    []string
 	EndpointPollInterval   time.Duration
@@ -56,6 +57,21 @@ func (r *RayLogHandler) Run(stop <-chan struct{}) error {
 		logrus.Fatalf("Create fsnotify NewWatcher error %v", err)
 	}
 	defer watcher.Close()
+
+	// Retrieve associated resource, we want to run before any log watching
+	if r.IsHead {
+		kind, ownerName, err := utils.GetRayClusterOwnerInfo(r.RayClusterID)
+		if err != nil {
+			logrus.Warnf("Failed to retrieve associated owner reference for %s with error: %v, leaving empty", r.RayClusterName, err)
+			r.OwnerResource = ""
+		} else if kind == "" || ownerName == "" {
+			logrus.Warnf("No associated owner reference found %s, leaving empty", r.RayClusterName)
+			r.OwnerResource = ""
+		} else {
+			r.OwnerResource = utils.AppendRayClusterNameID(kind, ownerName)
+			logrus.Infof("The associated owner resource is: %s", r.OwnerResource)
+		}
+	}
 
 	// WatchPrevLogsLoops performs an initial scan of the prev-logs directory on startup
 	// to process leftover log files in prev-logs/{sessionID}/{nodeID}/logs/ directories.
@@ -107,7 +123,8 @@ func (r *RayLogHandler) processSessionLatestLogs() {
 			logrus.Errorf("CreateObjectIfNotExist %s error %v", metadir, err)
 			return
 		}
-		if err := r.Writer.WriteFile(metafile, strings.NewReader("")); err != nil {
+
+		if err := r.Writer.WriteFile(metafile, strings.NewReader(r.OwnerResource)); err != nil {
 			logrus.Errorf("CreateObjectIfNotExist %s error %v", metafile, err)
 			return
 		}
@@ -753,7 +770,7 @@ func (r *RayLogHandler) WatchSessionLatestLoops() {
 					logrus.Errorf("CreateObjectIfNotExist %s error %v", metadir, err)
 					return
 				}
-				if err := r.Writer.WriteFile(metafile, strings.NewReader("")); err != nil {
+				if err := r.Writer.WriteFile(metafile, strings.NewReader(r.OwnerResource)); err != nil {
 					logrus.Errorf("CreateObjectIfNotExist %s error %v", metafile, err)
 					return
 				}

--- a/historyserver/pkg/storage/gcs/gcs_handler.go
+++ b/historyserver/pkg/storage/gcs/gcs_handler.go
@@ -181,12 +181,41 @@ func (h *RayLogsHandler) List() []utils.ClusterInfo {
 		cluster.CreateTimeStamp = datetime.Unix()
 		cluster.CreateTime = datetime.UTC().Format(("2006-01-02T15:04:05Z"))
 
+		// Read the file for associated owner object
+		ownerObjectID, err := h.ReadFileFromFullPath(fullObjectPath)
+		if err != nil {
+			logrus.Errorf("Failed to retrieve associated owner resource: %v", err)
+		} else {
+			ownerObjectInfo := strings.Split(ownerObjectID, "_")
+			if len(ownerObjectInfo) == 2 {
+				cluster.OwnerKind = ownerObjectInfo[0]
+				cluster.OwnerName = ownerObjectInfo[1]
+			}
+		}
+
 		logrus.Infof("Parsed cluster %s for session %s to list", cluster.Name, cluster.SessionName)
 		clusterList = append(clusterList, *cluster)
 	}
 
 	sort.Sort(clusterList)
 	return clusterList
+}
+
+func (h *RayLogsHandler) ReadFileFromFullPath(objectPath string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	objReader, err := h.StorageClient.Bucket(h.GCSBucket).Object(objectPath).NewReader(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer objReader.Close()
+
+	content, err := io.ReadAll(objReader)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
 }
 
 func (h *RayLogsHandler) GetContent(clusterId string, fileName string) io.Reader {

--- a/historyserver/pkg/storage/gcs/gcs_handler_test.go
+++ b/historyserver/pkg/storage/gcs/gcs_handler_test.go
@@ -225,7 +225,7 @@ func TestList(t *testing.T) {
 				BucketName: "test-bucket",
 				Name:       "ray_historyserver/metadir/mycluster1_default/" + sessionID,
 			},
-			Content: []byte(""),
+			Content: []byte("rayjob_some-name"),
 		},
 		{
 			ObjectAttrs: fakestorage.ObjectAttrs{
@@ -234,13 +234,37 @@ func TestList(t *testing.T) {
 			},
 			Content: []byte(""),
 		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: "test-bucket",
+				Name:       "ray_historyserver/metadir/mycluster3_testns/" + sessionID,
+			},
+			Content: []byte("rayservice_service-name"),
+		},
 	}
 	_, client, bucketName := setupFakeGCS(t, initialObjects...)
 	handler := createRayLogsHandler(client, bucketName)
 
 	expected := []utils.ClusterInfo{
-		{Name: "mycluster1", Namespace: "default", SessionName: sessionID, CreateTimeStamp: ts.Unix(), CreateTime: ts.UTC().Format("2006-01-02T15:04:05Z")},
+		{
+			Name:            "mycluster1",
+			Namespace:       "default",
+			SessionName:     sessionID,
+			CreateTimeStamp: ts.Unix(),
+			CreateTime:      ts.UTC().Format("2006-01-02T15:04:05Z"),
+			OwnerKind:       "rayjob",
+			OwnerName:       "some-name",
+		},
 		{Name: "mycluster2", Namespace: "testns", SessionName: sessionID, CreateTimeStamp: ts.Unix(), CreateTime: ts.UTC().Format("2006-01-02T15:04:05Z")},
+		{
+			Name:            "mycluster3",
+			Namespace:       "testns",
+			SessionName:     sessionID,
+			CreateTimeStamp: ts.Unix(),
+			CreateTime:      ts.UTC().Format("2006-01-02T15:04:05Z"),
+			OwnerKind:       "rayservice",
+			OwnerName:       "service-name",
+		},
 	}
 
 	result := handler.List()

--- a/historyserver/pkg/storage/s3/s3.go
+++ b/historyserver/pkg/storage/s3/s3.go
@@ -190,6 +190,19 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 					}
 					c.CreateTimeStamp = createTime.Unix()
 					c.CreateTime = createTime.UTC().Format(("2006-01-02T15:04:05Z"))
+
+					// Read file to retrieve associated owner object
+					ownerObjectID, err := r.ReadFileFromFullPath(path.Join(r.S3RootDir, "metadir", metas[0], c.SessionName))
+					if err != nil {
+						logrus.Errorf("Failed to retrieve associated owner resource: %v", err)
+					} else {
+						ownerObjectInfo := strings.Split(ownerObjectID, "_")
+						if len(ownerObjectInfo) == 2 {
+							c.OwnerKind = ownerObjectInfo[0]
+							c.OwnerName = ownerObjectInfo[1]
+						}
+					}
+
 					clusters = append(clusters, *c)
 				}
 				return true
@@ -203,6 +216,26 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 	getClusters()
 	sort.Sort(clusters)
 	return clusters
+}
+
+// ReadFileFromFullPath will return the contents of the file input
+func (r *RayLogsHandler) ReadFileFromFullPath(objectPath string) (string, error) {
+	result, err := r.S3Client.GetObject(
+		&s3.GetObjectInput{
+			Bucket: aws.String(r.S3Bucket),
+			Key:    aws.String(objectPath),
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	defer result.Body.Close()
+
+	content, err := io.ReadAll(result.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
 }
 
 func (r *RayLogsHandler) GetContent(clusterId string, fileName string) io.Reader {

--- a/historyserver/pkg/storage/s3/s3_test.go
+++ b/historyserver/pkg/storage/s3/s3_test.go
@@ -17,12 +17,18 @@ limitations under the License.
 package s3
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/sirupsen/logrus"
 )
 
@@ -59,4 +65,44 @@ func TestWalk(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+func TestReadFileFromFullPath(t *testing.T) {
+	expectedContent := "RayJob_my-job"
+	objectKey := "path/to/my/object"
+	bucketName := "test-bucket"
+
+	// Start a local HTTP server to mock S3
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request is correct
+		if r.URL.Path != "/"+bucketName+"/"+objectKey {
+			t.Errorf("expected path /%s/%s, got %s", bucketName, objectKey, r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(expectedContent))
+	}))
+	defer server.Close()
+
+	// Configure a real S3 client to use the mock server as its endpoint
+	sess, _ := session.NewSession(&aws.Config{
+		Endpoint:         aws.String(server.URL),
+		Region:           aws.String("us-east-1"),
+		S3ForcePathStyle: aws.Bool(true), // Need is needed for local testing
+		Credentials:      credentials.NewStaticCredentials("mock_id", "mock_secret", ""),
+	})
+
+	handler := &RayLogsHandler{
+		S3Client: s3.New(sess),
+		S3Bucket: bucketName,
+	}
+
+	content, err := handler.ReadFileFromFullPath(objectKey)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != expectedContent {
+		t.Errorf("expected content %q, got %q", expectedContent, content)
+	}
 }

--- a/historyserver/pkg/utils/types.go
+++ b/historyserver/pkg/utils/types.go
@@ -6,6 +6,8 @@ type ClusterInfo struct {
 	SessionName     string `json:"sessionName"`
 	CreateTime      string `json:"createTime"`
 	CreateTimeStamp int64  `json:"createTimeStamp"`
+	OwnerKind       string `json:"ownerKind,omitempty"`
+	OwnerName       string `json:"ownerName,omitempty"`
 }
 
 type ClusterInfoList []ClusterInfo

--- a/historyserver/pkg/utils/utils.go
+++ b/historyserver/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -12,15 +13,24 @@ import (
 	"time"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	RAY_SESSIONDIR_LOGDIR_NAME            = "logs"
 	RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME = "fetched_endpoints"
-	DATETIME_LAYOUT            = "2006-01-02_15-04-05.000000"
+	DATETIME_LAYOUT                       = "2006-01-02_15-04-05.000000"
 	// The following regex shouldn't be changed unless the ray session ID changes.
-	SESSION_ID_REGEX = `session_(\d{4}-\d{2}-\d{2})_(\d{2}-\d{2}-\d{2})_(\d{6})`
+	SESSION_ID_REGEX        = `session_(\d{4}-\d{2}-\d{2})_(\d{2}-\d{2}-\d{2})_(\d{6})`
+	RAYCLUSTER_NAME_ENV_VAR = "RAYCLUSTER_NAME_ENV_VAR"
+
+	timeout = 30 * time.Second
 )
 
 // EndpointPathToStorageKey converts a Ray Dashboard API endpoint path to a
@@ -189,4 +199,56 @@ func GetDateTimeFromSessionID(sessionID string) (time.Time, error) {
 	}
 
 	return t, nil
+}
+
+// GetRayClusterOwnerInfo retrieves the OwnerReference for a RayCluster.
+func GetRayClusterOwnerInfo(namespace string) (kind string, ownerName string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get in-cluster config: %w", err)
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(rayv1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	kubeClient, err := client.New(config, client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	return getRayClusterOwnerInfoFromClient(ctx, kubeClient, namespace)
+}
+
+// getRayClusterOwnerInfoFromClient will retrieve the OwnerReference for a RayCluster
+func getRayClusterOwnerInfoFromClient(ctx context.Context, kubeClient client.Client, namespace string) (kind string, ownerName string, err error) {
+	// Find the owner reference of the current pod to get the actual name
+	rayClusterName := os.Getenv(RAYCLUSTER_NAME_ENV_VAR)
+	if rayClusterName == "" {
+		return "", "", fmt.Errorf("no RayCluster name found. This could be caused by missing env var %s", RAYCLUSTER_NAME_ENV_VAR)
+	}
+
+	rayCluster := &rayv1.RayCluster{}
+	if err := kubeClient.Get(ctx, client.ObjectKey{Name: rayClusterName, Namespace: namespace}, rayCluster); err != nil {
+		return "", "", fmt.Errorf("failed to get RayCluster %s/%s: %w", namespace, rayClusterName, err)
+	}
+
+	if len(rayCluster.OwnerReferences) == 0 {
+		return "", "", fmt.Errorf("RayCluster %s/%s has no owner references", namespace, rayClusterName)
+	}
+
+	// Try to find the one with Controller = true
+	for _, ref := range rayCluster.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller {
+			return ref.Kind, ref.Name, nil
+		}
+	}
+
+	// Use first OwnerReference if there isn't one with Controller = true
+	return rayCluster.OwnerReferences[0].Kind, rayCluster.OwnerReferences[0].Name, nil
 }

--- a/historyserver/pkg/utils/utils_test.go
+++ b/historyserver/pkg/utils/utils_test.go
@@ -1,9 +1,17 @@
 package utils
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestSlice(t *testing.T) {
@@ -101,6 +109,91 @@ func TestGetDateTimeFromSessionID(t *testing.T) {
 				if !gotTime.Equal(tc.expectedTime) {
 					t.Errorf("GetDateTimeFromSessionID(%q) = %v, want %v", tc.sessionID, gotTime, tc.expectedTime)
 				}
+			}
+		})
+	}
+}
+
+func TestGetRayClusterOwnerInfoFromClient(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(rayv1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+
+	clusterName := "test-cluster"
+	namespace := "test-ns"
+	trueVal := true
+
+	t.Setenv(RAYCLUSTER_NAME_ENV_VAR, clusterName)
+
+	tests := []struct {
+		name          string
+		rayCluster    *rayv1.RayCluster
+		expectedKind  string
+		expectedName  string
+		expectedError bool
+	}{
+		{
+			name: "with controller owner reference",
+			rayCluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "RayJob",
+							Name:       "my-job",
+							Controller: &trueVal,
+						},
+					},
+				},
+			},
+			expectedKind: "RayJob",
+			expectedName: "my-job",
+		},
+		{
+			name: "with multiple owner references, fallback to first",
+			rayCluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "RayService", Name: "my-service"},
+						{Kind: "RandomReference", Name: "random-reference"},
+					},
+				},
+			},
+			expectedKind: "RayService",
+			expectedName: "my-service",
+		},
+		{
+			name: "no owner references",
+			rayCluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: namespace,
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.rayCluster).Build()
+			kind, name, err := getRayClusterOwnerInfoFromClient(context.Background(), fakeClient, namespace)
+
+			if tc.expectedError {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if kind != tc.expectedKind || name != tc.expectedName {
+				t.Errorf("got (%s, %s), want (%s, %s)", kind, name, tc.expectedKind, tc.expectedName)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR adds the association between the RayJob/RayService by writing to the metadir/<cluster_name>/<session_name> file. It will write to file in the format of `kind_name`

<img width="815" height="466" alt="Screenshot 2026-03-10 at 4 16 10 PM" src="https://github.com/user-attachments/assets/77f80d4a-c7ec-4c69-b232-fa1045889e99" />

## Related issue number
N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
