### PR TITLE
[RayCluster] Add example YAML for manually enabling Ray k8s auth

### DIFF
--- a/ray-operator/config/samples/ray-cluster.kubernetes.auth-manual.yaml
+++ b/ray-operator/config/samples/ray-cluster.kubernetes.auth-manual.yaml
@@ -1,0 +1,134 @@
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: ray-cluster-with-k8s-auth
+spec:
+  rayVersion: '2.55.0'
+  headGroupSpec:
+    rayStartParams: {}
+    template:
+      spec:
+        serviceAccountName: raylet
+        containers:
+        - name: ray-head
+          imagePullPolicy: Always
+          # TODO: update to rayproject/ray:2.55.0 once released
+          image: rayproject/ray:nightly
+          env:
+          - name: RAY_AUTH_MODE
+            value: "token"
+          - name: RAY_ENABLE_K8S_TOKEN_AUTH
+            value: "true"
+          resources:
+            limits:
+              cpu: "4"
+              memory: "8Gi"
+            requests:
+              cpu: "4"
+              memory: "8Gi"
+          ports:
+          - containerPort: 6379
+            name: gcs-server
+          - containerPort: 8265
+            name: dashboard
+          - containerPort: 10001
+            name: client
+          volumeMounts:
+          - mountPath: /var/run/secrets/ray.io/serviceaccount
+            name: ray-token
+        volumes:
+        - name: ray-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+  workerGroupSpecs:
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 5
+    groupName: workergroup
+    rayStartParams: {}
+    template:
+      spec:
+        serviceAccountName: raylet
+        containers:
+        - name: ray-worker
+          imagePullPolicy: Always
+          # TODO: update to rayproject/ray:2.55.0 once released
+          image: rayproject/ray:nightly
+          env:
+          - name: RAY_AUTH_MODE
+            value: "token"
+          - name: RAY_ENABLE_K8S_TOKEN_AUTH
+            value: "true"
+          resources:
+            limits:
+              cpu: "4"
+              memory: "8Gi"
+            requests:
+              cpu: "4"
+              memory: "8Gi"
+          volumeMounts:
+          - mountPath: /var/run/secrets/ray.io/serviceaccount
+            name: ray-token
+        volumes:
+        - name: ray-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: raylet
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ray-authenticator
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - 'tokenreviews'
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - 'subjectaccessreviews'
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ray-writer
+rules:
+- apiGroups: ["ray.io"]
+  resources:
+  - 'rayclusters'
+  verbs: ["ray:write"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ray-authenticator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ray-authenticator
+subjects:
+- kind: ServiceAccount
+  name: raylet
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: raylet
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ray-writer
+subjects:
+- kind: ServiceAccount
+  name: raylet
+  namespace: default


### PR DESCRIPTION
## Why are these changes needed?

Example YAML for manually configuring k8s token auth for users using older KubeRay versions

[added by future-outlier]
this is for kuberay version < 1.6

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
