### PR TITLE
Disable RayMultiHostIndexing feature for TestReconcile_Multihost_Replicas

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2965,6 +2965,8 @@ func TestReconcile_Replicas_Optional(t *testing.T) {
 func TestReconcile_Multihost_Replicas(t *testing.T) {
 	setupTest(t)
 
+	features.SetFeatureGateDuringTest(t, features.RayMultiHostIndexing, false)
+
 	// This test makes some assumptions about the testRayCluster object.
 	// (1) 1 workerGroup (2) disable autoscaling
 	assert.Len(t, testRayCluster.Spec.WorkerGroupSpecs, 1, "This test assumes only one worker group.")


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
