### PR TITLE
[Github Action] Skip krew-index update for pre-release tags

### DIFF
--- a/.github/workflows/kubectl-plugin-release.yaml
+++ b/.github/workflows/kubectl-plugin-release.yaml
@@ -15,6 +15,15 @@ jobs:
         if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
         with:
           script: core.setFailed('This action can only be run on tags')
+      - name: Check if stable release
+        id: check_stable
+        run: |
+          if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_stable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_stable=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -29,5 +38,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update new version in krew-index
-        if: ${{ !contains(github.ref_name, '-') }}
+        if: ${{ steps.check_stable.outputs.is_stable == 'true' }}
         uses: rajatjindal/krew-release-bot@v0.0.46


### PR DESCRIPTION
## Summary
- Skip the krew-index update step in the kubectl plugin release workflow for pre-release tags (e.g., `v1.6.0-rc.0`), since krew-index only auto-approves stable versions.
- GoReleaser still runs for all tags so pre-release binaries are published.

## Context
Pre-release tags (containing `-`, e.g., `-rc.0`, `-alpha.1`) triggered the krew-release-bot, which opened PRs to krew-index that require manual review and won't be auto-approved.

See: https://github.com/kubernetes-sigs/krew-index/pull/5411
