### PR TITLE
Mark RC releases as pre-release in GoReleaser

### DIFF
--- a/kubectl-plugin/.goreleaser.yaml
+++ b/kubectl-plugin/.goreleaser.yaml
@@ -1,5 +1,8 @@
 version: 2
 
+release:
+  prerelease: auto
+
 before:
   hooks:
     - cp ../LICENSE .


### PR DESCRIPTION
## Summary
- Add `prerelease: auto` to `.goreleaser.yaml` so that RC releases
(e.g. `v1.6.0-rc.0`) are automatically marked as pre-release on GitHub
instead of being labeled as "Latest".

## Reference
https://goreleaser.com/customization/release/#github

```
  # If set to auto, will mark the release as not ready for production
  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
  # If set to true, will mark the release as not ready for production.
  # Default: false.
  prerelease: auto
```