### PR TITLE
[Helm] remove ingress template support for k8s < 1.19

### DIFF
--- a/helm-chart/kuberay-apiserver/templates/ingress.yaml
+++ b/helm-chart/kuberay-apiserver/templates/ingress.yaml
@@ -2,18 +2,7 @@
 {{- $fullName := include "kuberay-apiserver.fullname" . -}}
 {{- $svcName := printf "%s-service" $fullName -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -25,7 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
@@ -45,19 +34,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $svcName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $svcName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/helm-chart/kuberay-apiserver/tests/ingress_test.yaml
+++ b/helm-chart/kuberay-apiserver/tests/ingress_test.yaml
@@ -30,34 +30,6 @@ tests:
           name: kuberay-apiserver
           namespace: kuberay-system
 
-  - it: Should create Ingress if `ingress.enabled` is `true`
-    capabilities:
-      majorVersion: 1
-      minorVersion: 14
-    set:
-      ingress:
-        enabled: true
-    asserts:
-      - containsDocument:
-          apiVersion: networking.k8s.io/v1beta1
-          kind: Ingress
-          name: kuberay-apiserver
-          namespace: kuberay-system
-
-  - it: Should create Ingress if `ingress.enabled` is `true`
-    capabilities:
-      majorVersion: 1
-      minorVersion: 12
-    set:
-      ingress:
-        enabled: true
-    asserts:
-      - containsDocument:
-          apiVersion: extensions/v1beta1
-          kind: Ingress
-          name: kuberay-apiserver
-          namespace: kuberay-system
-
   - it: Should have ingress backend service name matching the service name
     capabilities:
       majorVersion: 1


### PR DESCRIPTION
## Why are these changes needed?

Simplifies the Helm chart ingress template by removing support for Kubernetes 1.18 and earlier, which went out of support in June 2021 (almost five years ago).

## Related issue number


## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
