### PR TITLE
[Helm] update ray-cluster chart to apiVersion: v2

### DIFF
--- a/helm-chart/ray-cluster/Chart.yaml
+++ b/helm-chart/ray-cluster/Chart.yaml
@@ -1,6 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 
 name: ray-cluster
+
+type: application
 
 description: A Helm chart for deploying the RayCluster with the kuberay operator.
 

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -1,6 +1,6 @@
 # RayCluster
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying the RayCluster with the kuberay operator.
 


### PR DESCRIPTION
## Why are these changes needed?

Updates helm-chart/ray-cluster/Chart.yaml to use `apiVersion: v2` and adds `type: application` to match the kuberay-operator and kuberay-apiserver charts.

Helm v2 is end-of-life — chart API v2 is required for Helm 3 features like type and dependencies.

## Related issue number


## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
