### PR TITLE
Update kind configs and docs to v1.29.0

### DIFF
--- a/.github/workflows/actions/kind/action.yml
+++ b/.github/workflows/actions/kind/action.yml
@@ -35,10 +35,10 @@ runs:
         EOF'
 
     - name: Setup KinD cluster
-      uses: helm/kind-action@v1.8.0
+      uses: helm/kind-action@v1.12.0
       with:
         cluster_name: cluster
-        version: v0.17.0
+        version: v0.24.0
         config: ${{ env.KIND_CONFIG_FILE }}
 
     - name: Print cluster info

--- a/.github/workflows/actions/kind/kind.yaml
+++ b/.github/workflows/actions/kind/kind.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+    image: kindest/node:v1.29.0
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -27,7 +27,7 @@ Create a local Kubernetes cluster using [Kind](https://kind.sigs.k8s.io/). If yo
 have a Kubernetes cluster, you can skip this step.
 
 ```sh
-kind create cluster --image=kindest/node:v1.26.0
+kind create cluster --image=kindest/node:v1.29.0
 ```
 
 #### Install KubeRay Operator
@@ -106,7 +106,7 @@ The following steps allow you to validate the integration of the KubeRay APIServ
     apiVersion: kind.x-k8s.io/v1alpha4
     nodes:
     - role: control-plane
-      image: kindest/node:v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
+      image: kindest/node:v1.29.0
       kubeadmConfigPatches:
         - |
           kind: InitConfiguration
@@ -132,9 +132,9 @@ The following steps allow you to validate the integration of the KubeRay APIServ
         hostPort: 31887
         listenAddress: "0.0.0.0"
     - role: worker
-      image: kindest/node:v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
+      image: kindest/node:v1.29.0
     - role: worker
-      image: kindest/node:v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb
+      image: kindest/node:v1.29.0
     EOF
     ```
 

--- a/apiserver/hack/kind-cluster-config.yaml
+++ b/apiserver/hack/kind-cluster-config.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.25.0@sha256:428aaa17ec82ccde0131cb2d1ca6547d13cf5fdabcc0bbecf749baa935387cbf
+  image: kindest/node:v1.29.0
   kubeadmConfigPatches:
     - |
       kind: InitConfiguration

--- a/apiserversdk/docs/installation.md
+++ b/apiserversdk/docs/installation.md
@@ -6,7 +6,7 @@ This step creates a local Kubernetes cluster using [Kind](https://kind.sigs.k8s.
 cluster, you can skip this step.
 
 ```sh
-kind create cluster --image=kindest/node:v1.26.0
+kind create cluster --image=kindest/node:v1.29.0
 ```
 
 ## Step 2: Deploy a KubeRay operator

--- a/apiserversdk/docs/raycluster-quickstart.md
+++ b/apiserversdk/docs/raycluster-quickstart.md
@@ -9,7 +9,7 @@ This step creates a local Kubernetes cluster using [Kind](https://kind.sigs.k8s.
 If you already have a Kubernetes cluster, you can skip this step.
 
 ```sh
-kind create cluster --image=kindest/node:v1.26.0
+kind create cluster --image=kindest/node:v1.29.0
 ```
 
 ## Step 2: Install KubeRay operator and APIServer

--- a/apiserversdk/docs/rayjob-quickstart.md
+++ b/apiserversdk/docs/rayjob-quickstart.md
@@ -9,7 +9,7 @@ This step creates a local Kubernetes cluster using [Kind](https://kind.sigs.k8s.
 cluster, you can skip this step.
 
 ```sh
-kind create cluster --image=kindest/node:v1.26.0
+kind create cluster --image=kindest/node:v1.29.0
 ```
 
 ## Step 2: Install KubeRay operator and APIServer

--- a/apiserversdk/docs/rayservice-quickstart.md
+++ b/apiserversdk/docs/rayservice-quickstart.md
@@ -9,7 +9,7 @@ This step creates a local Kubernetes cluster using [Kind](https://kind.sigs.k8s.
 cluster, you can skip this step.
 
 ```sh
-kind create cluster --image=kindest/node:v1.26.0
+kind create cluster --image=kindest/node:v1.29.0
 ```
 
 ## Step 2: Install KubeRay operator and APIServer

--- a/benchmark/perf-tests/README.md
+++ b/benchmark/perf-tests/README.md
@@ -47,7 +47,7 @@ You can test clusterloader2 configs using Kind.
 First create a kind cluster:
 
 ```sh
-kind create cluster --image=kindest/node:v1.27.3
+kind create cluster --image=kindest/node:v1.29.0
 ```
 
 Install KubeRay;

--- a/ci/kind-config-buildkite.yml
+++ b/ci/kind-config-buildkite.yml
@@ -9,7 +9,7 @@ networking:
 # https://blog.scottlowe.org/2019/07/30/adding-a-name-to-kubernetes-api-server-certificate/
 nodes:
 - role: control-plane
-  image: kindest/node:v1.25.0@sha256:428aaa17ec82ccde0131cb2d1ca6547d13cf5fdabcc0bbecf749baa935387cbf
+  image: kindest/node:v1.29.0
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration

--- a/historyserver/docs/set_up_collector.md
+++ b/historyserver/docs/set_up_collector.md
@@ -50,7 +50,7 @@ git clone https://github.com/ray-project/kuberay.git
 cd kuberay
 
 # Spin up a kind cluster.
-kind create cluster --image=kindest/node:v1.26.0
+kind create cluster --image=kindest/node:v1.29.0
 
 # Build the KubeRay operator image.
 IMG=kuberay/operator:latest make -C ray-operator docker-build

--- a/historyserver/docs/set_up_historyserver.md
+++ b/historyserver/docs/set_up_historyserver.md
@@ -12,7 +12,7 @@
 ### 1. Create Kind Cluster
 
 ```bash
-kind create cluster --image=kindest/node:v1.27.0
+kind create cluster --image=kindest/node:v1.29.0
 ```
 
 ### 2. Build and Run Ray Operator

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -62,7 +62,7 @@ make clean
 
 ```bash
 # Step 1: Create a Kind cluster
-kind create cluster --image=kindest/node:v1.26.0
+kind create cluster --image=kindest/node:v1.29.0
 
 # Step 2: Modify KubeRay source code
 # For example, add a log by adding setupLog.Info("Hello KubeRay") in the function `main` in `main.go`.
@@ -106,7 +106,7 @@ There are configuable variables in the script, the defaults are shown below:
 ```bash
 IMAGE_TAG="kuberay-dev"
 KIND_CLUSTER_NAME="kuberay-dev"
-KIND_NODE_IMAGE="kindest/node:v1.26.0"
+KIND_NODE_IMAGE="kindest/node:v1.29.0"
 ```
 
 Additionally, you can run the script with a `-l` or `--logs` to stream the logs of the ray operator to the terminal after installation.
@@ -124,7 +124,7 @@ cd ..
 
 ```bash
 # Step 1: Create a Kind cluster
-kind create cluster --image=kindest/node:v1.26.0
+kind create cluster --image=kindest/node:v1.29.0
 
 # Step 2: Install CRDs
 make -C ray-operator install

--- a/ray-operator/hack/local_deploy.sh
+++ b/ray-operator/hack/local_deploy.sh
@@ -9,7 +9,7 @@ RAY_OPERATOR_PATH="${PROJECT_ROOT}/ray-operator"
 # --- Configuration Variables ---
 IMAGE_TAG="${IMAGE_TAG:=kuberay-dev}"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:=kuberay-dev}"
-KIND_NODE_IMAGE="${KIND_NODE_IMAGE:=kindest/node:v1.24.0}"
+KIND_NODE_IMAGE="${KIND_NODE_IMAGE:=kindest/node:v1.29.0}"
 
 delete_kind_cluster() {
   echo "--- Deleting Kind Cluster ---"


### PR DESCRIPTION
## Why are these changes needed?

Several kind cluster configs reference various Kubernetes versions that are well past end-of-life. This syncs all the configs and docs to v1.29.0, the latest version already referenced.

v1.29.0 is also old, so perhaps we should consider moving that forward as well, but I wanted to ensure this didn't break things first.

## Related issue number

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
