### PR TITLE
RayService incremental upgrade reliability improvements

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -168,9 +168,14 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	if utils.IsIncrementalUpgradeEnabled(&rayServiceInstance.Spec) {
 		// If an upgrade is in progress, check if rollback is necessary.
 		isUpgradeInProgress := meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.UpgradeInProgress))
-		if isUpgradeInProgress && activeRayClusterInstance != nil && pendingRayClusterInstance != nil {
-			if err := r.reconcileRollbackState(ctx, rayServiceInstance, activeRayClusterInstance, pendingRayClusterInstance); err != nil {
-				return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
+		if isUpgradeInProgress {
+			if activeRayClusterInstance == nil {
+				logger.Info("Cannot initiate rollback: active cluster not found")
+				r.Recorder.Eventf(rayServiceInstance, corev1.EventTypeWarning, string(utils.RollbackImpossible), "Active cluster not found, rollback cannot be initiated")
+			} else if pendingRayClusterInstance != nil {
+				if err := r.reconcileRollbackState(ctx, rayServiceInstance, activeRayClusterInstance, pendingRayClusterInstance); err != nil {
+					return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
+				}
 			}
 		}
 	}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1413,8 +1413,8 @@ func (r *RayServiceReconciler) checkIfNeedTargetCapacityUpdate(ctx context.Conte
 	} else if pendingTargetCapacity < 100 || pendingTrafficRoutedPercent < 100 {
 		return true, "Pending RayCluster has not finished scaling up."
 	}
-	return true, "Active RayCluster TargetCapacity has not finished scaling down."
-	// During rollback, the goal is active pendingTarget Capacity → 100, pending pendingTarget Capacity → 0.
+
+	// During rollback, the goal is activeTargetCapacity → 100, pendingTargetCapacity → 0.
 	if meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.RollbackInProgress)) {
 		if activeTargetCapacity == 100 && pendingTargetCapacity == 0 {
 			return false, "Rollback complete: all traffic has been restored to the active cluster."
@@ -1429,7 +1429,6 @@ func (r *RayServiceReconciler) checkIfNeedTargetCapacityUpdate(ctx context.Conte
 	}
 	return true, "Active RayCluster TargetCapacity has not finished scaling down."
 }
-
 
 // applyServeTargetCapacity updates the target_capacity for a given RayCluster's Serve applications.
 func (r *RayServiceReconciler) applyServeTargetCapacity(ctx context.Context, rayServiceInstance *rayv1.RayService, rayClusterInstance *rayv1.RayCluster, rayDashboardClient dashboardclient.RayDashboardClientInterface, goalTargetCapacity int32) error {
@@ -2089,17 +2088,14 @@ func (r *RayServiceReconciler) reconcileRollbackState(ctx context.Context, raySe
 	}
 
 	// Case 2: The goal spec diverges from the pending cluster.
-	// This happens if the user reverted to the original spec, or if they submitted a 3rd entirely new spec mid-upgrade.
-	// In all divergence cases, we must first safely route all traffic back to the original cluster before allowing
-// Case 2: The goal spec diverges from the pending cluster.
-// This covers two sub-cases:
-//   2.1: The user reverted to the original spec (targetHash == originalHash).
-//        The pending cluster is no longer needed, so we roll back to the active cluster.
-//   2.2: The user submitted a 3rd entirely new spec mid-upgrade (targetHash != originalHash && targetHash != pendingHash).
-//        The pending cluster doesn't match the new goal either, so we must first roll back
-//        to the active cluster, clean up the pending cluster, and then start a fresh upgrade.
-// In both sub-cases, we must safely route all traffic back to the original cluster before
-// allowing a new cluster to be spun up.
+	// This covers two sub-cases:
+	//   2.1: The user reverted to the original spec (targetHash == originalHash).
+	//        The pending cluster is no longer needed, so we roll back to the active cluster.
+	//   2.2: The user submitted a 3rd entirely new spec mid-upgrade (targetHash != originalHash && targetHash != pendingHash).
+	//        The pending cluster doesn't match the new goal either, so we must first roll back
+	//        to the active cluster, clean up the pending cluster, and then start a fresh upgrade.
+	// In both sub-cases, we must safely route all traffic back to the original cluster before
+	// allowing a new cluster to be spun up.
 	if !isRollbackInProgress {
 		logger.Info("Goal state has changed during upgrade. Initiating safe rollback to the original cluster.", "targetHash", targetHash, "originalHash", originalHash, "pendingHash", pendingHash)
 		setCondition(rayServiceInstance, rayv1.RollbackInProgress, metav1.ConditionTrue, rayv1.TargetClusterChanged, "Goal state changed mid-upgrade, rolling back to original cluster.")

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1408,12 +1408,6 @@ func (r *RayServiceReconciler) checkIfNeedTargetCapacityUpdate(ctx context.Conte
 	pendingTargetCapacity := int(*pendingRayServiceStatus.TargetCapacity)
 	pendingTrafficRoutedPercent := int(*pendingRayServiceStatus.TrafficRoutedPercent)
 
-	if activeTargetCapacity == 0 && pendingTargetCapacity == 100 {
-		return false, "All traffic has migrated to the upgraded cluster and NewClusterWithIncrementalUpgrade is complete."
-	} else if pendingTargetCapacity < 100 || pendingTrafficRoutedPercent < 100 {
-		return true, "Pending RayCluster has not finished scaling up."
-	}
-
 	// During rollback, the goal is activeTargetCapacity → 100, pendingTargetCapacity → 0.
 	if meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.RollbackInProgress)) {
 		if activeTargetCapacity == 100 && pendingTargetCapacity == 0 {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -350,7 +350,13 @@ func reconcilePromotionAndServingStatus(ctx context.Context, headSvc, serveSvc *
 		// An incremental upgrade is complete when the active cluster has 0% capacity and the pending cluster has
 		// 100% of the traffic. We can't promote the pending cluster until traffic has been fully migrated.
 		if meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.UpgradeInProgress)) {
-			if utils.IsIncrementalUpgradeComplete(rayServiceInstance, pendingCluster) {
+			isRollbackInProgress := meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.RollbackInProgress))
+
+			// Do not promote the pending cluster during a rollback. Traffic is being
+			// shifted back to the active cluster, so the pending cluster must not
+			// become the new active even if its TargetCapacity and TrafficRoutedPercent
+			// reach the promotion thresholds.
+			if !isRollbackInProgress && utils.IsIncrementalUpgradeComplete(rayServiceInstance, pendingCluster) {
 				shouldPromote = true
 				logger.Info("Incremental upgrade completed, triggering promotion.", "rayService", rayServiceInstance.Name)
 			}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -476,7 +476,7 @@ func (r *RayServiceReconciler) calculateStatus(
 				if rayServiceInstance.Status.ActiveServiceStatus.TargetCapacity == nil {
 					rayServiceInstance.Status.PendingServiceStatus.TargetCapacity = ptr.To(int32(100))
 				}
-			} else if meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.UpgradeInProgress)) {
+			} else {
 				// Pending RayCluster during an upgrade should start with 0% TargetCapacity, since
 				// traffic will be gradually migrated to the new cluster.
 				if rayServiceInstance.Status.PendingServiceStatus.TargetCapacity == nil {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -441,7 +441,10 @@ func (r *RayServiceReconciler) calculateStatus(
 		pendingStatus := &rayServiceInstance.Status.PendingServiceStatus
 
 		// A rollback is complete when the active cluster is back at 100% TargetCapacity and TrafficRoutedPercent,
-		// and the pending cluster is at 0% TargetCapacity and TrafficRoutedPercent.
+		// A rollback is complete when the active cluster is back at 100% TargetCapacity
+		// and TrafficRoutedPercent, and either:
+		// - The pending cluster has been fully scaled down (TargetCapacity and TrafficRoutedPercent are both 0), or
+		// - The pending cluster is unhealthy (head Pod not ready)
 		if ptr.Deref(activeStatus.TargetCapacity, -1) == 100 &&
 			ptr.Deref(activeStatus.TrafficRoutedPercent, -1) == 100 &&
 			ptr.Deref(pendingStatus.TargetCapacity, -1) == 0 &&

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -7,7 +7,6 @@ import (
 	"maps"
 	"math"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -705,7 +704,7 @@ func (r *RayServiceReconciler) reconcileGateway(ctx context.Context, rayServiceI
 	}
 
 	// If Gateway already exists, check if update is needed to reach desired state
-	if !reflect.DeepEqual(existingGateway.Spec, desiredGateway.Spec) {
+	if !utils.IsGatewayEqual(existingGateway, desiredGateway) {
 		logger.Info("Updating existing Gateway", "name", existingGateway.Name)
 		existingGateway.Spec = desiredGateway.Spec
 		if err := r.Update(ctx, existingGateway); err != nil {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1414,7 +1414,22 @@ func (r *RayServiceReconciler) checkIfNeedTargetCapacityUpdate(ctx context.Conte
 		return true, "Pending RayCluster has not finished scaling up."
 	}
 	return true, "Active RayCluster TargetCapacity has not finished scaling down."
+	// During rollback, the goal is active pendingTarget Capacity → 100, pending pendingTarget Capacity → 0.
+	if meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.RollbackInProgress)) {
+		if activeTargetCapacity == 100 && pendingTargetCapacity == 0 {
+			return false, "Rollback complete: all traffic has been restored to the active cluster."
+		}
+		return true, "Rollback in progress: traffic is being restored to the active cluster."
+	}
+
+	if activeTargetCapacity == 0 && pendingTargetCapacity == 100 {
+		return false, "All traffic has migrated to the upgraded cluster and NewClusterWithIncrementalUpgrade is complete."
+	} else if pendingTargetCapacity < 100 || pendingTrafficRoutedPercent < 100 {
+		return true, "Pending RayCluster has not finished scaling up."
+	}
+	return true, "Active RayCluster TargetCapacity has not finished scaling down."
 }
+
 
 // applyServeTargetCapacity updates the target_capacity for a given RayCluster's Serve applications.
 func (r *RayServiceReconciler) applyServeTargetCapacity(ctx context.Context, rayServiceInstance *rayv1.RayService, rayClusterInstance *rayv1.RayCluster, rayDashboardClient dashboardclient.RayDashboardClientInterface, goalTargetCapacity int32) error {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1750,7 +1750,7 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 	isRollbackInProgress := utils.IsIncrementalUpgradeEnabled(&rayServiceInstance.Spec) &&
 		meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.RollbackInProgress))
 
-	if isActiveCluster && isIncrementalUpgradeInProgress {
+	if isActiveCluster && isIncrementalUpgradeInProgress && !isRollbackInProgress {
 		// Skip updating the Serve config for the Active cluster during NewClusterWithIncrementalUpgrade. The updated
 		// Serve config is applied to the pending RayService's RayCluster.
 		skipConfigUpdate = true

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -2076,7 +2076,15 @@ func (r *RayServiceReconciler) reconcileRollbackState(ctx context.Context, raySe
 	// Case 2: The goal spec diverges from the pending cluster.
 	// This happens if the user reverted to the original spec, or if they submitted a 3rd entirely new spec mid-upgrade.
 	// In all divergence cases, we must first safely route all traffic back to the original cluster before allowing
-	// a new cluster to be spun up.
+// Case 2: The goal spec diverges from the pending cluster.
+// This covers two sub-cases:
+//   2.1: The user reverted to the original spec (targetHash == originalHash).
+//        The pending cluster is no longer needed, so we roll back to the active cluster.
+//   2.2: The user submitted a 3rd entirely new spec mid-upgrade (targetHash != originalHash && targetHash != pendingHash).
+//        The pending cluster doesn't match the new goal either, so we must first roll back
+//        to the active cluster, clean up the pending cluster, and then start a fresh upgrade.
+// In both sub-cases, we must safely route all traffic back to the original cluster before
+// allowing a new cluster to be spun up.
 	if !isRollbackInProgress {
 		logger.Info("Goal state has changed during upgrade. Initiating safe rollback to the original cluster.", "targetHash", targetHash, "originalHash", originalHash, "pendingHash", pendingHash)
 		setCondition(rayServiceInstance, rayv1.RollbackInProgress, metav1.ConditionTrue, rayv1.TargetClusterChanged, "Goal state changed mid-upgrade, rolling back to original cluster.")

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1747,12 +1747,20 @@ func (r *RayServiceReconciler) reconcileServe(ctx context.Context, rayServiceIns
 	isActiveCluster := rayClusterInstance.Name == rayServiceInstance.Status.ActiveServiceStatus.RayClusterName
 	isIncrementalUpgradeInProgress := utils.IsIncrementalUpgradeEnabled(&rayServiceInstance.Spec) &&
 		meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.UpgradeInProgress))
+	isRollbackInProgress := utils.IsIncrementalUpgradeEnabled(&rayServiceInstance.Spec) &&
+		meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.RollbackInProgress))
 
 	if isActiveCluster && isIncrementalUpgradeInProgress {
 		// Skip updating the Serve config for the Active cluster during NewClusterWithIncrementalUpgrade. The updated
 		// Serve config is applied to the pending RayService's RayCluster.
 		skipConfigUpdate = true
 		logger.Info("Blocking new Serve config submission for Active cluster during upgrade.", "clusterName", rayClusterInstance.Name)
+	} else if !isActiveCluster && isRollbackInProgress {
+		// During rollback, the pending cluster is being scaled down and phased out.
+		// We skip updating its Serve config to prevent unnecessary disruptive redeployments,
+		// since its only goal is to drain traffic while the active cluster takes over.
+		skipConfigUpdate = true
+		logger.Info("Blocking new Serve config submission for Pending cluster during rollback.", "clusterName", rayClusterInstance.Name)
 	}
 
 	cachedServeConfigV2 := r.getServeConfigFromCache(rayServiceInstance, rayClusterInstance.Name)

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -446,16 +446,7 @@ func (r *RayServiceReconciler) calculateStatus(
 		activeStatus := &rayServiceInstance.Status.ActiveServiceStatus
 		pendingStatus := &rayServiceInstance.Status.PendingServiceStatus
 
-		// A rollback is complete when the active cluster is back at 100% TargetCapacity and TrafficRoutedPercent,
-		// A rollback is complete when the active cluster is back at 100% TargetCapacity
-		// and TrafficRoutedPercent, and either:
-		// - The pending cluster has been fully scaled down (TargetCapacity and TrafficRoutedPercent are both 0), or
-		// - The pending cluster is unhealthy (head Pod not ready)
-		if ptr.Deref(activeStatus.TargetCapacity, -1) == 100 &&
-			ptr.Deref(activeStatus.TrafficRoutedPercent, -1) == 100 &&
-			ptr.Deref(pendingStatus.TargetCapacity, -1) == 0 &&
-			ptr.Deref(pendingStatus.TrafficRoutedPercent, -1) == 0 {
-
+		if shouldCompleteIncrementalRollback(activeStatus, pendingStatus, pendingCluster) {
 			logger.Info("Rollback to original cluster is complete. Cleaning up pending cluster from prior upgrade.")
 
 			// Clear the RayService pending service status to clean up the pending cluster.
@@ -2023,6 +2014,28 @@ func (r *RayServiceReconciler) reconcilePerClusterServeService(ctx context.Conte
 	}
 
 	return err
+}
+
+func shouldCompleteIncrementalRollback(
+	activeStatus *rayv1.RayServiceStatus,
+	pendingStatus *rayv1.RayServiceStatus,
+	pendingCluster *rayv1.RayCluster,
+) bool {
+	// Check if the pending cluster is healthy enough to receive scale-down API calls.
+	// If the pending cluster is unhealthy and the active cluster has 100% of traffic
+	// routed to it, we should complete the rollback.
+	pendingClusterHealthy := pendingCluster != nil &&
+		meta.IsStatusConditionTrue(pendingCluster.Status.Conditions, string(rayv1.HeadPodReady))
+
+	// A rollback is complete when the active cluster is back at 100% TargetCapacity and TrafficRoutedPercent,
+	// A rollback is complete when the active cluster is back at 100% TargetCapacity
+	// and TrafficRoutedPercent, and either:
+	// - The pending cluster has been fully scaled down (TargetCapacity and TrafficRoutedPercent are both 0), or
+	// - The pending cluster is unhealthy (head Pod not ready)
+	return ptr.Deref(activeStatus.TargetCapacity, -1) == 100 &&
+		ptr.Deref(activeStatus.TrafficRoutedPercent, -1) == 100 &&
+		(!pendingClusterHealthy || (ptr.Deref(pendingStatus.TargetCapacity, -1) == 0 &&
+			ptr.Deref(pendingStatus.TrafficRoutedPercent, -1) == 0))
 }
 
 // reconcileRollbackState determines whether to initiate a rollback by setting the RollbackInProgress condition.

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -2028,8 +2028,7 @@ func shouldCompleteIncrementalRollback(
 		meta.IsStatusConditionTrue(pendingCluster.Status.Conditions, string(rayv1.HeadPodReady))
 
 	// A rollback is complete when the active cluster is back at 100% TargetCapacity and TrafficRoutedPercent,
-	// A rollback is complete when the active cluster is back at 100% TargetCapacity
-	// and TrafficRoutedPercent, and either:
+	// and either:
 	// - The pending cluster has been fully scaled down (TargetCapacity and TrafficRoutedPercent are both 0), or
 	// - The pending cluster is unhealthy (head Pod not ready)
 	return ptr.Deref(activeStatus.TargetCapacity, -1) == 100 &&

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2917,3 +2917,138 @@ func TestShouldCompleteIncrementalRollback(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcileServe_SkipConfigUpdateDuringRollback(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+	features.SetFeatureGateDuringTest(t, features.RayServiceIncrementalUpgrade, true)
+	ctx := context.TODO()
+	namespace := "test-ns"
+
+	activeCluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "active-cluster", Namespace: namespace},
+		Status: rayv1.RayClusterStatus{
+			Conditions: []metav1.Condition{
+				{Type: string(rayv1.HeadPodReady), Status: metav1.ConditionTrue},
+			},
+		},
+	}
+	
+	pendingCluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "pending-cluster", Namespace: namespace},
+		Status: rayv1.RayClusterStatus{
+			Conditions: []metav1.Condition{
+				{Type: string(rayv1.HeadPodReady), Status: metav1.ConditionTrue},
+			},
+		},
+	}
+
+	activeServiceName, _ := utils.GenerateHeadServiceName(utils.RayClusterCRD, rayv1.RayClusterSpec{}, "active-cluster")
+	activeService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: activeServiceName, Namespace: namespace},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Name: utils.DashboardPortName, Port: 8265}},
+		},
+	}
+	
+	pendingServiceName, _ := utils.GenerateHeadServiceName(utils.RayClusterCRD, rayv1.RayClusterSpec{}, "pending-cluster")
+	pendingService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: pendingServiceName, Namespace: namespace},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Name: utils.DashboardPortName, Port: 8265}},
+		},
+	}
+
+	tests := []struct {
+		name                  string
+		clusterInstance       *rayv1.RayCluster
+		isRollback            bool
+		isActiveCluster       bool
+		expectUpdate          bool
+	}{
+		{
+			name:            "Active cluster during rollback -> should update",
+			clusterInstance: activeCluster,
+			isRollback:      true,
+			isActiveCluster: true,
+			expectUpdate:    true,
+		},
+		{
+			name:            "Pending cluster during rollback -> should skip update",
+			clusterInstance: pendingCluster,
+			isRollback:      true,
+			isActiveCluster: false,
+			expectUpdate:    false,
+		},
+		{
+			name:            "Pending cluster during upgrade (no rollback) -> should update",
+			clusterInstance: pendingCluster,
+			isRollback:      false,
+			isActiveCluster: false,
+			expectUpdate:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newScheme := runtime.NewScheme()
+			_ = rayv1.AddToScheme(newScheme)
+			_ = corev1.AddToScheme(newScheme)
+
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(newScheme).
+				WithRuntimeObjects(activeCluster, pendingCluster, activeService, pendingService).
+				Build()
+
+			fakeDashboardClient := &utils.FakeRayDashboardClient{}
+			fakeDashboardClient.SetMultiApplicationStatuses(map[string]*utiltypes.ServeApplicationStatus{
+				"app1": {Status: rayv1.ApplicationStatusEnum.RUNNING},
+			})
+
+			reconciler := &RayServiceReconciler{
+				Client:   fakeClient,
+				Recorder: &record.FakeRecorder{},
+				dashboardClientFunc: func(rayCluster *rayv1.RayCluster, clientURL string) (dashboardclient.RayDashboardClientInterface, error) {
+					return fakeDashboardClient, nil
+				},
+				ServeConfigs: lru.New(10),
+			}
+
+			rayService := &rayv1.RayService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-rayservice", Namespace: namespace},
+				Spec: rayv1.RayServiceSpec{
+					UpgradeStrategy: &rayv1.RayServiceUpgradeStrategy{
+						Type: ptr.To(rayv1.RayServiceNewClusterWithIncrementalUpgrade),
+					},
+					ServeConfigV2: `{"key": "new-config"}`, 
+				},
+				Status: rayv1.RayServiceStatuses{
+					ActiveServiceStatus: rayv1.RayServiceStatus{
+						RayClusterName: "active-cluster",
+					},
+					PendingServiceStatus: rayv1.RayServiceStatus{
+						RayClusterName: "pending-cluster",
+					},
+				},
+			}
+
+			if tt.isRollback {
+				setCondition(rayService, rayv1.RollbackInProgress, metav1.ConditionTrue, rayv1.TargetClusterChanged, "rolling back")
+				setCondition(rayService, rayv1.UpgradeInProgress, metav1.ConditionFalse, rayv1.TargetClusterChanged, "rollback in progress")
+			} else {
+				setCondition(rayService, rayv1.UpgradeInProgress, metav1.ConditionTrue, rayv1.TargetClusterChanged, "upgrading")
+			}
+
+			// Run reconcileServe
+			_, _, err := reconciler.reconcileServe(ctx, rayService, tt.clusterInstance)
+			require.NoError(t, err)
+
+			// Check if UpdateDeployments was called
+			if tt.expectUpdate {
+				assert.NotNil(t, fakeDashboardClient.LastUpdatedConfig)
+				assert.Contains(t, string(fakeDashboardClient.LastUpdatedConfig), "new-config")
+			} else {
+				assert.Nil(t, fakeDashboardClient.LastUpdatedConfig)
+			}
+		})
+	}
+}

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2832,3 +2832,88 @@ func TestShouldUpdateCluster_SuspendFlip(t *testing.T) {
 		})
 	}
 }
+
+// headReadyCluster is a quick test helper to construct a RayCluster with a specific HeadPodReady condition.
+func headReadyCluster(ready bool) *rayv1.RayCluster {
+	status := metav1.ConditionFalse
+	if ready {
+		status = metav1.ConditionTrue
+	}
+	return &rayv1.RayCluster{
+		Status: rayv1.RayClusterStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(rayv1.HeadPodReady),
+					Status: status,
+				},
+			},
+		},
+	}
+}
+
+func TestShouldCompleteIncrementalRollback(t *testing.T) {
+	tests := []struct {
+		name           string
+		activeTC       int32
+		activeTRP      int32
+		pendingTC      int32
+		pendingTRP     int32
+		pendingCluster *rayv1.RayCluster
+		want           bool
+	}{
+		{
+			name:           "healthy pending at zero capacity and traffic — complete",
+			activeTC:       100,
+			activeTRP:      100,
+			pendingTC:      0,
+			pendingTRP:     0,
+			pendingCluster: headReadyCluster(true),
+			want:           true,
+		},
+		{
+			name:           "unhealthy pending with leftover capacity — bypass complete",
+			activeTC:       100,
+			activeTRP:      100,
+			pendingTC:      30,
+			pendingTRP:     0,
+			pendingCluster: headReadyCluster(false),
+			want:           true,
+		},
+		{
+			name:           "no pending RayCluster — complete when active is full",
+			activeTC:       100,
+			activeTRP:      100,
+			pendingTC:      0,
+			pendingTRP:     0,
+			pendingCluster: nil,
+			want:           true,
+		},
+		{
+			name:           "healthy pending still holding target capacity — not complete",
+			activeTC:       100,
+			activeTRP:      100,
+			pendingTC:      50,
+			pendingTRP:     0,
+			pendingCluster: headReadyCluster(true),
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			activeStatus := &rayv1.RayServiceStatus{
+				TargetCapacity:       ptr.To(tt.activeTC),
+				TrafficRoutedPercent: ptr.To(tt.activeTRP),
+			}
+			pendingStatus := &rayv1.RayServiceStatus{
+				TargetCapacity:       ptr.To(tt.pendingTC),
+				TrafficRoutedPercent: ptr.To(tt.pendingTRP),
+			}
+
+			got := shouldCompleteIncrementalRollback(activeStatus, pendingStatus, tt.pendingCluster)
+			if got != tt.want {
+				t.Errorf("shouldCompleteIncrementalRollback() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2932,7 +2932,7 @@ func TestReconcileServe_SkipConfigUpdateDuringRollback(t *testing.T) {
 			},
 		},
 	}
-	
+
 	pendingCluster := &rayv1.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "pending-cluster", Namespace: namespace},
 		Status: rayv1.RayClusterStatus{
@@ -2949,7 +2949,7 @@ func TestReconcileServe_SkipConfigUpdateDuringRollback(t *testing.T) {
 			Ports: []corev1.ServicePort{{Name: utils.DashboardPortName, Port: 8265}},
 		},
 	}
-	
+
 	pendingServiceName, _ := utils.GenerateHeadServiceName(utils.RayClusterCRD, rayv1.RayClusterSpec{}, "pending-cluster")
 	pendingService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: pendingServiceName, Namespace: namespace},
@@ -2959,11 +2959,11 @@ func TestReconcileServe_SkipConfigUpdateDuringRollback(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                  string
-		clusterInstance       *rayv1.RayCluster
-		isRollback            bool
-		isActiveCluster       bool
-		expectUpdate          bool
+		name            string
+		clusterInstance *rayv1.RayCluster
+		isRollback      bool
+		isActiveCluster bool
+		expectUpdate    bool
 	}{
 		{
 			name:            "Active cluster during rollback -> should update",
@@ -3007,7 +3007,7 @@ func TestReconcileServe_SkipConfigUpdateDuringRollback(t *testing.T) {
 			reconciler := &RayServiceReconciler{
 				Client:   fakeClient,
 				Recorder: &record.FakeRecorder{},
-				dashboardClientFunc: func(rayCluster *rayv1.RayCluster, clientURL string) (dashboardclient.RayDashboardClientInterface, error) {
+				dashboardClientFunc: func(_ *rayv1.RayCluster, _ string) (dashboardclient.RayDashboardClientInterface, error) {
 					return fakeDashboardClient, nil
 				},
 				ServeConfigs: lru.New(10),
@@ -3019,7 +3019,7 @@ func TestReconcileServe_SkipConfigUpdateDuringRollback(t *testing.T) {
 					UpgradeStrategy: &rayv1.RayServiceUpgradeStrategy{
 						Type: ptr.To(rayv1.RayServiceNewClusterWithIncrementalUpgrade),
 					},
-					ServeConfigV2: `{"key": "new-config"}`, 
+					ServeConfigV2: `{"key": "new-config"}`,
 				},
 				Status: rayv1.RayServiceStatuses{
 					ActiveServiceStatus: rayv1.RayServiceStatus{

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2833,7 +2833,7 @@ func TestShouldUpdateCluster_SuspendFlip(t *testing.T) {
 	}
 }
 
-// headReadyCluster is a quick test helper to construct a RayCluster with a specific HeadPodReady condition.
+// headReadyCluster is a helper to construct a RayCluster with a specific HeadPodReady condition.
 func headReadyCluster(ready bool) *rayv1.RayCluster {
 	status := metav1.ConditionFalse
 	if ready {
@@ -3033,7 +3033,7 @@ func TestReconcileServe_SkipConfigUpdateDuringRollback(t *testing.T) {
 
 			if tt.isRollback {
 				setCondition(rayService, rayv1.RollbackInProgress, metav1.ConditionTrue, rayv1.TargetClusterChanged, "rolling back")
-				setCondition(rayService, rayv1.UpgradeInProgress, metav1.ConditionFalse, rayv1.TargetClusterChanged, "rollback in progress")
+				setCondition(rayService, rayv1.UpgradeInProgress, metav1.ConditionTrue, rayv1.TargetClusterChanged, "upgrade still in progress during rollback")
 			} else {
 				setCondition(rayService, rayv1.UpgradeInProgress, metav1.ConditionTrue, rayv1.TargetClusterChanged, "upgrading")
 			}

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -390,6 +390,7 @@ const (
 	InvalidRayServiceSpec           K8sEventType = "InvalidRayServiceSpec"
 	InvalidRayServiceMetadata       K8sEventType = "InvalidRayServiceMetadata"
 	RayServiceInitializingTimeout   K8sEventType = "RayServiceInitializingTimeout"
+	RollbackImpossible              K8sEventType = "RollbackImpossible"
 	UpdatedHeadPodServeLabel        K8sEventType = "UpdatedHeadPodServeLabel"
 	UpdatedGateway                  K8sEventType = "UpdatedGateway"
 	UpdatedHTTPRoute                K8sEventType = "UpdatedHTTPRoute"

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -1035,7 +1035,24 @@ func IsHTTPRouteEqual(existing, desired *gwv1.HTTPRoute) bool {
 	}
 
 	for i := range desired.Spec.Rules {
-		if len(existing.Spec.Rules[i].BackendRefs) != len(desired.Spec.Rules[i].BackendRefs) {
+		eRule := existing.Spec.Rules[i]
+		dRule := desired.Spec.Rules[i]
+
+		// Compare Matches
+		if !reflect.DeepEqual(eRule.Matches, dRule.Matches) {
+			return false
+		}
+
+		// Compare Filters. Treat nil and empty slice as equivalent to avoid false positives
+		// caused by renormalization from the API server or the Gateway implementation.
+		if len(eRule.Filters) != len(dRule.Filters) {
+			return false
+		}
+		if len(eRule.Filters) > 0 && !reflect.DeepEqual(eRule.Filters, dRule.Filters) {
+			return false
+		}
+
+		if len(eRule.BackendRefs) != len(dRule.BackendRefs) {
 			return false
 		}
 

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -1102,6 +1102,8 @@ func IsHTTPRouteEqual(existing, desired *gwv1.HTTPRoute) bool {
 
 // IsGatewayEqual checks if the existing Gateway matches the desired Gateway.
 // This check only compares the fields explicitly managed by the RayService controller.
+// If the controller starts managing additional Gateway fields in the future,
+// this function must be updated accordingly.
 func IsGatewayEqual(existing, desired *gwv1.Gateway) bool {
 	if existing == nil || desired == nil {
 		return existing == desired

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -1028,6 +1028,7 @@ func HasSubmitter(rayJobInstance *rayv1.RayJob) bool {
 }
 
 // IsHTTPRouteEqual checks if the existing HTTPRoute matches the desired HTTPRoute.
+// This check only compares the fields explicitly managed by the RayService controller.
 func IsHTTPRouteEqual(existing, desired *gwv1.HTTPRoute) bool {
 	if len(existing.Spec.Rules) != len(desired.Spec.Rules) {
 		return false

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -1030,6 +1030,34 @@ func HasSubmitter(rayJobInstance *rayv1.RayJob) bool {
 // IsHTTPRouteEqual checks if the existing HTTPRoute matches the desired HTTPRoute.
 // This check only compares the fields explicitly managed by the RayService controller.
 func IsHTTPRouteEqual(existing, desired *gwv1.HTTPRoute) bool {
+	if existing == nil || desired == nil {
+		return existing == desired
+	}
+
+	// Compare Hostnames. Treat nil and empty slice as equivalent to avoid false positives
+	// caused by renormalization from the API server or the Gateway implementation.
+	if len(existing.Spec.Hostnames) != len(desired.Spec.Hostnames) {
+		return false
+	}
+	if len(existing.Spec.Hostnames) > 0 && !reflect.DeepEqual(existing.Spec.Hostnames, desired.Spec.Hostnames) {
+		return false
+	}
+
+	// Compare ParentRefs
+	if len(existing.Spec.ParentRefs) != len(desired.Spec.ParentRefs) {
+		return false
+	}
+	for i := range desired.Spec.ParentRefs {
+		eRef := existing.Spec.ParentRefs[i]
+		dRef := desired.Spec.ParentRefs[i]
+
+		if string(eRef.Name) != string(dRef.Name) ||
+			string(ptr.Deref(eRef.Namespace, "")) != string(ptr.Deref(dRef.Namespace, "")) {
+			return false
+		}
+	}
+
+	// Compare Rules
 	if len(existing.Spec.Rules) != len(desired.Spec.Rules) {
 		return false
 	}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -1098,3 +1098,32 @@ func IsHTTPRouteEqual(existing, desired *gwv1.HTTPRoute) bool {
 	}
 	return true
 }
+
+// IsGatewayEqual checks if the existing Gateway matches the desired Gateway.
+// This check only compares the fields explicitly managed by the RayService controller to
+// avoid infinite update loops caused by defaults injected by the Gateway implementation.
+func IsGatewayEqual(existing, desired *gwv1.Gateway) bool {
+	if existing == nil || desired == nil {
+		return existing == desired
+	}
+
+	if string(existing.Spec.GatewayClassName) != string(desired.Spec.GatewayClassName) {
+		return false
+	}
+
+	// Compare Listeners. RayService controller sets Name, Protocol, and Port on each Listener.
+	if len(existing.Spec.Listeners) != len(desired.Spec.Listeners) {
+		return false
+	}
+	for i := range desired.Spec.Listeners {
+		eL := existing.Spec.Listeners[i]
+		dL := desired.Spec.Listeners[i]
+
+		if string(eL.Name) != string(dL.Name) ||
+			eL.Protocol != dL.Protocol ||
+			eL.Port != dL.Port {
+			return false
+		}
+	}
+	return true
+}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -1090,6 +1090,7 @@ func IsHTTPRouteEqual(existing, desired *gwv1.HTTPRoute) bool {
 
 			// Only compare the fields the controller updates.
 			if string(existingRef.Name) != string(desiredRef.Name) ||
+				string(ptr.Deref(existingRef.Namespace, "")) != string(ptr.Deref(desiredRef.Namespace, "")) ||
 				ptr.Deref(existingRef.Weight, 1) != ptr.Deref(desiredRef.Weight, 1) ||
 				ptr.Deref(existingRef.Port, 0) != ptr.Deref(desiredRef.Port, 0) {
 				return false
@@ -1100,8 +1101,7 @@ func IsHTTPRouteEqual(existing, desired *gwv1.HTTPRoute) bool {
 }
 
 // IsGatewayEqual checks if the existing Gateway matches the desired Gateway.
-// This check only compares the fields explicitly managed by the RayService controller to
-// avoid infinite update loops caused by defaults injected by the Gateway implementation.
+// This check only compares the fields explicitly managed by the RayService controller.
 func IsGatewayEqual(existing, desired *gwv1.Gateway) bool {
 	if existing == nil || desired == nil {
 		return existing == desired

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -2107,3 +2107,172 @@ func TestIsHTTPRouteEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestIsGatewayEqual(t *testing.T) {
+	tests := []struct {
+		existing *gwv1.Gateway
+		desired  *gwv1.Gateway
+		name     string
+		expected bool
+	}{
+		{
+			name:     "Both nil",
+			existing: nil,
+			desired:  nil,
+			expected: true,
+		},
+		{
+			name:     "Existing nil",
+			desired:  &gwv1.Gateway{},
+			expected: false,
+		},
+		{
+			name:     "Desired nil",
+			existing: &gwv1.Gateway{},
+			expected: false,
+		},
+		{
+			name: "Exactly equal Gateways",
+			existing: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					GatewayClassName: "test-class",
+					Listeners: []gwv1.Listener{
+						{Name: "http", Protocol: gwv1.HTTPProtocolType, Port: 80},
+					},
+				},
+			},
+			desired: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					GatewayClassName: "test-class",
+					Listeners: []gwv1.Listener{
+						{Name: "http", Protocol: gwv1.HTTPProtocolType, Port: 80},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Different GatewayClassName",
+			existing: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					GatewayClassName: "test-class-old",
+				},
+			},
+			desired: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					GatewayClassName: "test-class-new",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Different number of Listeners",
+			existing: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{Name: "http", Protocol: gwv1.HTTPProtocolType, Port: 80},
+					},
+				},
+			},
+			desired: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{Name: "http", Protocol: gwv1.HTTPProtocolType, Port: 80},
+						{Name: "https", Protocol: gwv1.HTTPSProtocolType, Port: 443},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Different Listener Name",
+			existing: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{Name: "http-old", Protocol: gwv1.HTTPProtocolType, Port: 80},
+					},
+				},
+			},
+			desired: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{Name: "http-new", Protocol: gwv1.HTTPProtocolType, Port: 80},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Different Listener Protocol",
+			existing: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{Name: "http", Protocol: gwv1.HTTPProtocolType, Port: 80},
+					},
+				},
+			},
+			desired: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{Name: "http", Protocol: gwv1.HTTPSProtocolType, Port: 80},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Different Listener Port",
+			existing: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{Name: "http", Protocol: gwv1.HTTPProtocolType, Port: 80},
+					},
+				},
+			},
+			desired: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{Name: "http", Protocol: gwv1.HTTPProtocolType, Port: 8080},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Equal Gateways ignoring defaulted AllowedRoutes",
+			existing: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					GatewayClassName: "test-class",
+					Listeners: []gwv1.Listener{
+						{
+							Name:     "http",
+							Protocol: gwv1.HTTPProtocolType,
+							Port:     80,
+							AllowedRoutes: &gwv1.AllowedRoutes{
+								Namespaces: &gwv1.RouteNamespaces{
+									From: ptr.To(gwv1.NamespacesFromSame),
+								},
+							},
+						},
+					},
+				},
+			},
+			desired: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					GatewayClassName: "test-class",
+					Listeners: []gwv1.Listener{
+						{Name: "http", Protocol: gwv1.HTTPProtocolType, Port: 80},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsGatewayEqual(tt.existing, tt.desired)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -1917,6 +1917,171 @@ func TestIsHTTPRouteEqual(t *testing.T) {
 			},
 			expected: false,
 		},
+
+		{
+			name: "Different ParentRefs",
+			existing: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{
+						ParentRefs: []gwv1.ParentReference{
+							{Name: "gateway-old"},
+						},
+					},
+				},
+			},
+			desired: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{
+						ParentRefs: []gwv1.ParentReference{
+							{Name: "gateway-new"},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Different Hostnames",
+			existing: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					Hostnames: []gwv1.Hostname{"example.com"},
+				},
+			},
+			desired: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					Hostnames: []gwv1.Hostname{"different.com"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Different Matches",
+			existing: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					Rules: []gwv1.HTTPRouteRule{
+						{
+							Matches: []gwv1.HTTPRouteMatch{
+								{Path: &gwv1.HTTPPathMatch{Value: ptr.To("/api")}},
+							},
+						},
+					},
+				},
+			},
+			desired: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					Rules: []gwv1.HTTPRouteRule{
+						{
+							Matches: []gwv1.HTTPRouteMatch{
+								{Path: &gwv1.HTTPPathMatch{Value: ptr.To("/v2")}},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Different Filters",
+			existing: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					Rules: []gwv1.HTTPRouteRule{
+						{
+							Filters: []gwv1.HTTPRouteFilter{
+								{Type: gwv1.HTTPRouteFilterRequestHeaderModifier},
+							},
+						},
+					},
+				},
+			},
+			desired: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					Rules: []gwv1.HTTPRouteRule{
+						{
+							Filters: []gwv1.HTTPRouteFilter{
+								{Type: gwv1.HTTPRouteFilterRequestRedirect},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Filters nil vs empty slice, should be equal for our check.",
+			existing: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					Rules: []gwv1.HTTPRouteRule{
+						{
+							// Nil slice
+							Filters: nil,
+						},
+					},
+				},
+			},
+			desired: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					Rules: []gwv1.HTTPRouteRule{
+						{
+							Filters: []gwv1.HTTPRouteFilter{},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Different Backend Namespace",
+			existing: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					Rules: []gwv1.HTTPRouteRule{
+						{
+							BackendRefs: []gwv1.HTTPBackendRef{
+								{BackendRef: gwv1.BackendRef{BackendObjectReference: gwv1.BackendObjectReference{Name: "svc-a", Namespace: ptr.To(gwv1.Namespace("default"))}}},
+							},
+						},
+					},
+				},
+			},
+			desired: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					Rules: []gwv1.HTTPRouteRule{
+						{
+							BackendRefs: []gwv1.HTTPBackendRef{
+								{BackendRef: gwv1.BackendRef{BackendObjectReference: gwv1.BackendObjectReference{Name: "svc-a", Namespace: ptr.To(gwv1.Namespace("other-ns"))}}},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Different Backend Port",
+			existing: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					Rules: []gwv1.HTTPRouteRule{
+						{
+							BackendRefs: []gwv1.HTTPBackendRef{
+								{BackendRef: gwv1.BackendRef{BackendObjectReference: gwv1.BackendObjectReference{Name: "svc-a", Port: ptr.To(gwv1.PortNumber(8000))}}},
+							},
+						},
+					},
+				},
+			},
+			desired: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					Rules: []gwv1.HTTPRouteRule{
+						{
+							BackendRefs: []gwv1.HTTPBackendRef{
+								{BackendRef: gwv1.BackendRef{BackendObjectReference: gwv1.BackendObjectReference{Name: "svc-a", Port: ptr.To(gwv1.PortNumber(9000))}}},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+
 	}
 
 	for _, tt := range tests {

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -1820,6 +1820,22 @@ func TestIsHTTPRouteEqual(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "Hostnames nil vs empty slice - equal",
+			existing: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					// Empty slice
+					Hostnames: []gwv1.Hostname{},
+				},
+			},
+			desired: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{
+					// Nil slice
+					Hostnames: nil,
+				},
+			},
+			expected: true,
+		},
+		{
 			name: "Different number of rules",
 			existing: &gwv1.HTTPRoute{
 				Spec: gwv1.HTTPRouteSpec{

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -2097,7 +2097,6 @@ func TestIsHTTPRouteEqual(t *testing.T) {
 			},
 			expected: false,
 		},
-
 	}
 
 	for _, tt := range tests {

--- a/ray-operator/test/e2eincrementalupgrade/support.go
+++ b/ray-operator/test/e2eincrementalupgrade/support.go
@@ -127,6 +127,7 @@ func incrementalUpgradeRayServiceApplyConfiguration(
 	serveConfigV2 serveConfigV2,
 ) *rayv1ac.RayServiceSpecApplyConfiguration {
 	return rayv1ac.RayServiceSpec().
+		WithRayClusterDeletionDelaySeconds(0). // Delete the dangling cluster immediately to prevent CI test timeouts
 		WithUpgradeStrategy(rayv1ac.RayServiceUpgradeStrategy().
 			WithType(rayv1.RayServiceNewClusterWithIncrementalUpgrade).
 			WithClusterUpgradeOptions(


### PR DESCRIPTION
## Why are these changes needed?

This PR resolves issues in https://github.com/ray-project/kuberay/pull/4600 with incremental upgrade reliability and rollbacks. The specific changes are:

- Fixed a capacity scaling deadlock by making the target capacity update logic explicitly aware of rollback states.

- Fixed a rollback completion deadlock by allowing the system to clean up and delete the pending cluster even if its head pod crashes and is unresponsive.

- Gated rollback traffic migration on active cluster readiness to safely prevent routing user traffic back to an unhealthy original cluster.

- Added Kubernetes event emissions to immediately warn users if a rollback is impossible because the active cluster was deleted.

- Clarified rollback condition messages to distinguish between reverting to the original spec versus submitting a third, entirely new spec mid-upgrade.

- Fixed a nil-pointer panic that occurred when the upgrade strategy type was missing from the service spec.

- Improved HTTPRoute reconciliation with graceful fallbacks for missing upgrade options and robust equality checks to stop infinite update loops.

- Added comprehensive unit tests for rollback capacity and traffic math, plus a new E2E test to explicitly verify the third-spec rollback scenario.

- Default traffic routed percent to the active (old) cluster to TargetCapacity to avoid a potential deadlock

Additionally, I rebased this PR on https://github.com/ray-project/kuberay/pull/4541 (didn't make any changes to the locust tests though) to verify the tests pass.

## Related issue number

https://github.com/ray-project/kuberay/issues/3209

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
