### PR TITLE
[fix] Fix flaky RayJob e2e test by cleaning up resources after fail subtest

### DIFF
--- a/ray-operator/test/e2erayjob/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_lightweight_test.go
@@ -106,6 +106,21 @@ env_vars:
 
 		// In the lightweight submission mode, the submitter Kubernetes Job should not be created.
 		g.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
+
+		// Refresh the RayJob status
+		rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Delete the RayJob
+		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		// Assert the RayCluster has been cascade deleted
+		g.Eventually(func() error {
+			_, err := GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
+			return err
+		}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
 	})
 
 	test.T().Run("Should transition to 'Complete' if the Ray job has stopped.", func(_ *testing.T) {

--- a/ray-operator/test/e2erayjob/rayjob_sidecar_mode_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_sidecar_mode_test.go
@@ -126,6 +126,17 @@ env_vars:
 			containerNames[container.Name] = true
 		}
 		g.Expect(containerNames[utils.SubmitterContainerName]).To(BeTrue(), "submitter container should be present")
+
+		// Delete the RayJob
+		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		// Assert the RayCluster has been cascade deleted
+		g.Eventually(func() error {
+			_, err := GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
+			return err
+		}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
 	})
 
 	test.T().Run("Should transition to 'Complete' if the Ray job has stopped.", func(_ *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
### Problem
The `TestRayJobLightWeightMode/Successful_RayJob_in_HTTP_mode_with_auth_token` e2e test is currently flaky: the `counter.py` Ray job intermittently reports `FAILED` instead of `SUCCEEDED`.

### Potential Root Cause
The flakiness might be caused by state leakage from a preceding subtest (`Failing RayJob without cluster shutdown after finished`). 

In `rayjob_lightweight_test.go` and `rayjob_sidecar_mode_test.go`, this subtest sets `ShutdownAfterJobFinishes=false` but never deletes the RayJob or its RayCluster after the assertions complete. This leaves a head pod and a worker pod lingering on the kind node for the remainder of the test function.

When the subsequent auth token subtest creates its own cluster, these lingering pods cause **resource contention** on the kind node, which can make the Ray job fail intermittently. 

*(Note: The equivalent subtest in `rayjob_test.go` already includes explicit cleanup logic that deletes the RayJob and waits for the RayCluster to be cascade-deleted before proceeding, and its auth token test does not flake.)*

### Solution
This PR applies the established cleanup pattern from `rayjob_test.go` to both `rayjob_lightweight_test.go` and `rayjob_sidecar_mode_test.go`. 

The subtests now explicitly delete the RayJob and wait for the RayCluster to be cascade-deleted after all assertions pass. This eliminates the resource contention without altering what the subtests verify.

## Related issue number
Reference for test failure: https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/14015/steps/canvas?jid=019cd7b3-5471-44fb-89c5-61c8be1b4e31

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
