### PR TITLE
[golangci-lint] Enable deprecated API warnings linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,7 @@ linters:
     - revive
   settings:
     staticcheck:
-      checks: ["all", "-SA1019", "-ST1001", "-ST1003", "-ST1005", "-QF1008"]
+      checks: ["all", "-ST1001", "-ST1003", "-ST1005", "-QF1008"]
     ginkgolinter:
       forbid-focus-container: true
     gocyclo:
@@ -87,6 +87,24 @@ linters:
       disable:
         - omitzero
   exclusions:
+    # Suppress SA1019 for the project's own deprecated API fields that are
+    # intentionally maintained for backward compatibility. External deprecated
+    # API usage (e.g., from third-party libraries) will still be caught.
+    rules:
+      - linters: [staticcheck]
+        text: "SA1019:.*\\.State is deprecated: the State field"
+      - linters: [staticcheck]
+        text: "SA1019:.*\\.ServiceStatus is deprecated"
+      - linters: [staticcheck]
+        text: "SA1019:.*ServiceUnhealthySecondThreshold is deprecated"
+      - linters: [staticcheck]
+        text: "SA1019:.*DeploymentUnhealthySecondThreshold is deprecated"
+      # NewSimpleClientset is deprecated in favor of NewClientset, but
+      # NewClientset requires complete structured-merge-diff type schemas
+      # for field management which breaks Update-based tests.
+      # TODO(#4627): migrate once SMD schemas are properly generated.
+      - linters: [staticcheck]
+        text: "SA1019:.*NewSimpleClientset"
     generated: strict
     presets:
       - comments

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -84,8 +84,6 @@ fumpt: gofumpt ## Run gofmtumpt against code.
 imports: goimports ## Run goimports against code.
 	$(GOIMPORTS) -l -w .
 
-# Exclude the SA1019 check which checks the usage of deprecated fields
-# via the linters.settings.staticcheck.checks configuration in .golangci.yaml.
 .PHONY: lint
 lint: golangci-lint fmt vet fumpt imports ## Run the linter.
 	test -s $(GOLANGCI_LINT) || ($(GOLANGCI_LINT) run --timeout=3m --allow-parallel-runners)

--- a/apiserversdk/Makefile
+++ b/apiserversdk/Makefile
@@ -24,8 +24,6 @@ vet: ## Run go vet against code.
 golangci-lint: ## Download golangci_lint locally if necessary.
 	test -s $(GOLANGCI_LINT) || (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(REPO_ROOT_BIN)/ $(GOLANGCI_LINT_VERSION))
 
-# Exclude the SA1019 check which checks the usage of deprecated fields
-# via the linters.settings.staticcheck.checks configuration in .golangci.yaml.
 .PHONY: lint
 lint: golangci-lint fmt vet ## Run the linter.
 	test -s $(GOLANGCI_LINT) || ($(GOLANGCI_LINT) run --timeout=3m --allow-parallel-runners)

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -577,7 +577,7 @@ func TestEmitRayJobExecutionDuration(t *testing.T) {
 			name: "non-terminal to retrying state should emit metrics",
 			originalRayJobStatus: rayv1.RayJobStatus{
 				JobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
-				Failed:              pointer.Int32(2),
+				Failed:              ptr.To(int32(2)),
 			},
 			rayJobStatus: rayv1.RayJobStatus{
 				JobDeploymentStatus: rayv1.JobDeploymentStatusRetrying,
@@ -637,7 +637,7 @@ func TestGetSubmitterTemplate_WithEnableK8sTokenAuth(t *testing.T) {
 		Spec: rayv1.RayClusterSpec{
 			AuthOptions: &rayv1.AuthOptions{
 				Mode:               rayv1.AuthModeToken,
-				EnableK8sTokenAuth: pointer.Bool(true),
+				EnableK8sTokenAuth: ptr.To(true),
 			},
 			HeadGroupSpec: rayv1.HeadGroupSpec{
 				Template: corev1.PodTemplateSpec{

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -1650,7 +1650,7 @@ func TestCreateHTTPRoute(t *testing.T) {
 			newScheme := runtime.NewScheme()
 			_ = rayv1.AddToScheme(newScheme)
 			_ = corev1.AddToScheme(newScheme)
-			_ = gwv1.AddToScheme(newScheme)
+			_ = gwv1.Install(newScheme)
 			fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(tt.runtimeObjects...).Build()
 
 			reconciler := RayServiceReconciler{
@@ -1693,7 +1693,7 @@ func TestReconcileHTTPRoute(t *testing.T) {
 	newScheme := runtime.NewScheme()
 	_ = rayv1.AddToScheme(newScheme)
 	_ = corev1.AddToScheme(newScheme)
-	_ = gwv1.AddToScheme(newScheme)
+	_ = gwv1.Install(newScheme)
 
 	ctx := context.TODO()
 	namespace := "test-ns"
@@ -1843,7 +1843,7 @@ func TestReconcileGateway(t *testing.T) {
 	newScheme := runtime.NewScheme()
 	_ = rayv1.AddToScheme(newScheme)
 	_ = corev1.AddToScheme(newScheme)
-	_ = gwv1.AddToScheme(newScheme)
+	_ = gwv1.Install(newScheme)
 
 	ctx := context.TODO()
 	namespace := "test-ns"
@@ -2146,7 +2146,7 @@ func TestCheckIfNeedTargetCapacityUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			newScheme := runtime.NewScheme()
 			_ = corev1.AddToScheme(newScheme)
-			_ = gwv1.AddToScheme(newScheme)
+			_ = gwv1.Install(newScheme)
 			fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(tt.runtimeObjects...).Build()
 			// Initialize RayService reconciler.
 			ctx := context.TODO()

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -193,7 +193,7 @@ func main() {
 	features.LogFeatureGates(setupLog)
 
 	if features.Enabled(features.RayServiceIncrementalUpgrade) {
-		utilruntime.Must(gwv1.AddToScheme(scheme))
+		utilruntime.Must(gwv1.Install(scheme))
 	}
 
 	// Manager options

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -6,8 +6,6 @@ dirs_to_lint="ray-operator kubectl-plugin apiserver apiserversdk"
 
 for dir in $dirs_to_lint; do
   pushd "$dir"
-  # Exclude the SA1019 check which checks the usage of deprecated fields
-  # via the linters.settings.staticcheck.checks configuration in .golangci.yaml.
   golangci-lint run --fix --timeout 10m0s
   popd
 done


### PR DESCRIPTION
## Why are these changes needed?

kuberay has had [SA1019](https://staticcheck.dev/docs/checks/#SA1019) disabled in the golangci-lint config, which led to some deprecated API calls remaining. This enables the linter in general, but carves out exceptions for kuberay's own deprecated fields.

## Related issue number

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
