### PR TITLE
[Helm] use service.ports list for apiserver ingress backend port

### DIFF
--- a/helm-chart/kuberay-apiserver/templates/ingress.yaml
+++ b/helm-chart/kuberay-apiserver/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kuberay-apiserver.fullname" . -}}
 {{- $svcName := printf "%s-service" $fullName -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := (index .Values.service.ports 0).port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/helm-chart/kuberay-apiserver/tests/ingress_test.yaml
+++ b/helm-chart/kuberay-apiserver/tests/ingress_test.yaml
@@ -42,8 +42,6 @@ tests:
             paths:
               - path: /
                 pathType: Prefix
-      service:
-        port: 8888
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
@@ -62,8 +60,6 @@ tests:
             paths:
               - path: /
                 pathType: Prefix
-      service:
-        port: 8888
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
@@ -82,8 +78,6 @@ tests:
             paths:
               - path: /
                 pathType: Prefix
-      service:
-        port: 8888
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
@@ -107,8 +101,6 @@ tests:
             paths:
               - path: /
                 pathType: Prefix
-      service:
-        port: 8888
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
@@ -119,3 +111,42 @@ tests:
       - equal:
           path: spec.rules[1].http.paths[0].backend.service.name
           value: kuberay-apiserver-service
+
+  - it: Should use port from the first entry in service.ports
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8888
+
+  - it: Should use custom port when service.ports is overridden
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: example.com
+            paths:
+              - path: /
+                pathType: Prefix
+      service:
+        ports:
+          - name: http
+            port: 9999
+            targetPort: 9999
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9999


### PR DESCRIPTION
## Why are these changes needed?

The kuberay-apiserver ingress template referenced `.Values.service.port`, but values.yaml defines `service.ports` as a list. So the ingress backend port rendered as empty when ingress was enabled: seems like a bug. The unit tests inadvertently worked around this by setting the non-existent scalar `service.port` in each test case.

This changes the template to use the first entry from `service.ports`, and updates the ingress tests to use the real list structure instead of overriding.

## Related issue number

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
