### PR TITLE
fix: include metadata in RayJob submit command when using clusterSelector

### DIFF
--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -82,7 +82,11 @@ func GetMetadataJson(metadata map[string]string, rayVersion string) (string, err
 }
 
 // BuildJobSubmitCommand builds the `ray job submit` command based on submission mode.
-func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.JobSubmissionMode) ([]string, error) {
+// rayVersion is the Ray version of the cluster being targeted. It is used to determine
+// whether the --metadata-json flag is supported. When RayJob uses clusterSelector to target
+// an existing RayCluster, RayClusterSpec is nil, so the caller must pass the version from
+// the selected cluster's spec.
+func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.JobSubmissionMode, rayVersion string) ([]string, error) {
 	var address string
 	port := utils.DefaultDashboardPort
 
@@ -163,8 +167,8 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 		cmd = append(cmd, "--runtime-env-json", strconv.Quote(runtimeEnvJson))
 	}
 
-	if len(metadata) > 0 && rayJobInstance.Spec.RayClusterSpec != nil {
-		metadataJson, err := GetMetadataJson(metadata, rayJobInstance.Spec.RayClusterSpec.RayVersion)
+	if len(metadata) > 0 && len(rayVersion) > 0 {
+		metadataJson, err := GetMetadataJson(metadata, rayVersion)
 		if err != nil {
 			return nil, err
 		}

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -94,7 +94,7 @@ func TestBuildJobSubmitCommandWithK8sJobMode(t *testing.T) {
 		";", "fi", ";",
 		"ray", "job", "logs", "--address", "http://127.0.0.1:8265", "--follow", "testJobId",
 	}
-	command, err := BuildJobSubmitCommand(testRayJob, rayv1.K8sJobMode)
+	command, err := BuildJobSubmitCommand(testRayJob, rayv1.K8sJobMode, testRayJob.Spec.RayClusterSpec.RayVersion)
 	require.NoError(t, err)
 	assert.Equal(t, expected, command)
 }
@@ -133,7 +133,7 @@ func TestBuildJobSubmitCommandWithSidecarMode(t *testing.T) {
 		"echo no quote 'single quote' \"double quote\"",
 		";",
 	}
-	command, err := BuildJobSubmitCommand(testRayJob, rayv1.SidecarMode)
+	command, err := BuildJobSubmitCommand(testRayJob, rayv1.SidecarMode, testRayJob.Spec.RayClusterSpec.RayVersion)
 	require.NoError(t, err)
 	assert.Equal(t, expected, command)
 }
@@ -174,7 +174,7 @@ func TestBuildJobSubmitCommandWithSidecarModeVersionSwitch(t *testing.T) {
 				},
 			}
 
-			command, err := BuildJobSubmitCommand(testRayJob, rayv1.SidecarMode)
+			command, err := BuildJobSubmitCommand(testRayJob, rayv1.SidecarMode, testRayJob.Spec.RayClusterSpec.RayVersion)
 			require.NoError(t, err)
 			require.GreaterOrEqual(t, len(command), 2)
 			assert.Equal(t, "until", command[0])
@@ -199,7 +199,7 @@ func TestBuildJobSubmitCommandWithSidecarModeCustomDashboardPort(t *testing.T) {
 		},
 	}
 
-	command, err := BuildJobSubmitCommand(testRayJob, rayv1.SidecarMode)
+	command, err := BuildJobSubmitCommand(testRayJob, rayv1.SidecarMode, testRayJob.Spec.RayClusterSpec.RayVersion)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(command), 2)
 	assert.Equal(t, "until", command[0])
@@ -210,7 +210,7 @@ func TestBuildJobSubmitCommandWithSidecarModeCustomDashboardPort(t *testing.T) {
 
 func TestBuildJobSubmitCommandWithK8sJobModeNoSidecarHealthWaitLoop(t *testing.T) {
 	testRayJob := rayJobTemplate()
-	command, err := BuildJobSubmitCommand(testRayJob, rayv1.K8sJobMode)
+	command, err := BuildJobSubmitCommand(testRayJob, rayv1.K8sJobMode, testRayJob.Spec.RayClusterSpec.RayVersion)
 	require.NoError(t, err)
 	assert.NotContains(t, command, "until")
 	for _, token := range command {
@@ -253,7 +253,7 @@ pip: ["python-multipart==0.0.6"]
 		";", "fi", ";",
 		"ray", "job", "logs", "--address", "http://127.0.0.1:8265", "--follow", "testJobId",
 	}
-	command, err := BuildJobSubmitCommand(rayJobWithYAML, rayv1.K8sJobMode)
+	command, err := BuildJobSubmitCommand(rayJobWithYAML, rayv1.K8sJobMode, rayJobWithYAML.Spec.RayClusterSpec.RayVersion)
 	require.NoError(t, err)
 
 	// Ensure the slices are the same length.
@@ -298,6 +298,50 @@ func TestMetadataRaisesErrorBeforeRay26(t *testing.T) {
 	}
 	_, err := GetMetadataJson(rayJob.Spec.Metadata, rayJob.Spec.RayClusterSpec.RayVersion)
 	require.Error(t, err)
+}
+
+// TestBuildJobSubmitCommandWithClusterSelectorIncludesMetadata verifies that metadata
+// is correctly included in the job submit command when using clusterSelector (i.e.,
+// RayClusterSpec on the RayJob is nil). This tests the fix for:
+// https://github.com/ray-project/kuberay/issues/4589
+func TestBuildJobSubmitCommandWithClusterSelectorIncludesMetadata(t *testing.T) {
+	// Simulate a RayJob that uses clusterSelector: RayClusterSpec is nil.
+	rayJobWithClusterSelector := &rayv1.RayJob{
+		Spec: rayv1.RayJobSpec{
+			ClusterSelector: map[string]string{
+				"ray.io/cluster-name": "existing-cluster",
+			},
+			// RayClusterSpec is intentionally nil — this is the clusterSelector case.
+			RayClusterSpec: nil,
+			Metadata: map[string]string{
+				"tenant": "tenant1",
+				"team":   "ml-platform",
+			},
+			Entrypoint: "python /app/batch_inference.py",
+		},
+		Status: rayv1.RayJobStatus{
+			DashboardURL: "http://ray-dashboard.svc:8265",
+			JobId:        "test-job-001",
+		},
+	}
+	// The rayVersion is passed from the selected RayCluster's spec (>= 2.6.0 supports --metadata-json).
+	const clusterRayVersion = "2.35.0"
+	command, err := BuildJobSubmitCommand(rayJobWithClusterSelector, rayv1.K8sJobMode, clusterRayVersion)
+	require.NoError(t, err)
+	// The command must contain --metadata-json to populate metadata in Ray UI/jobs API.
+	assert.Contains(t, command, "--metadata-json")
+	metadataIdx := -1
+	for i, token := range command {
+		if token == "--metadata-json" {
+			metadataIdx = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, metadataIdx, "--metadata-json flag must be present in the command")
+	require.Less(t, metadataIdx+1, len(command), "--metadata-json must be followed by a value")
+	unquoted, err := strconv.Unquote(command[metadataIdx+1])
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"tenant":"tenant1","team":"ml-platform"}`, unquoted)
 }
 
 func TestGetSubmitterTemplate(t *testing.T) {

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -626,7 +626,15 @@ func getSubmitterContainer(rayJobInstance *rayv1.RayJob, rayClusterInstance *ray
 // pass the RayCluster instance for cluster selector case
 func configureSubmitterContainer(container *corev1.Container, rayJobInstance *rayv1.RayJob, rayClusterInstance *rayv1.RayCluster, submissionMode rayv1.JobSubmissionMode) error {
 	// If the command in the submitter container manifest isn't set, use the default command.
-	jobCmd, err := common.BuildJobSubmitCommand(rayJobInstance, submissionMode)
+	// Pass the RayVersion from the actual cluster (works for both inline RayClusterSpec and
+	// clusterSelector cases where RayClusterSpec on the RayJob is nil).
+	rayVersion := ""
+	if rayClusterInstance != nil {
+		rayVersion = rayClusterInstance.Spec.RayVersion
+	} else if rayJobInstance.Spec.RayClusterSpec != nil {
+		rayVersion = rayJobInstance.Spec.RayClusterSpec.RayVersion
+	}
+	jobCmd, err := common.BuildJobSubmitCommand(rayJobInstance, submissionMode, rayVersion)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

When a `RayJob` uses `clusterSelector` to target an existing `RayCluster`, the `RayClusterSpec` field on the `RayJob` is `nil`. The previous code guarded the `--metadata-json` flag with:

```go
if len(metadata) > 0 && rayJobInstance.Spec.RayClusterSpec != nil {
    metadataJson, err := GetMetadataJson(metadata, rayJobInstance.Spec.RayClusterSpec.RayVersion)
```

This silently dropped all metadata whenever `clusterSelector` was used, because `RayClusterSpec` is always `nil` in that path.

## Changes

- **`common/job.go`**: Changed `BuildJobSubmitCommand` signature to accept an explicit `rayVersion string` parameter instead of reading it from `RayClusterSpec`. Updated the metadata guard condition to `if len(metadata) > 0 && len(rayVersion) > 0`.

- **`rayjob_controller.go`**: In `configureSubmitterContainer`, derive `rayVersion` from the actual `rayClusterInstance.Spec.RayVersion`. This works for both paths:
  - **Managed cluster** (inline `RayClusterSpec`): `rayClusterInstance` is created from the spec, its version matches.
  - **clusterSelector**: `rayClusterInstance` is the selected existing cluster, its version is used correctly.

- **`job_test.go`**: Updated all existing call sites to pass `rayVersion`. Added `TestBuildJobSubmitCommandWithClusterSelectorIncludesMetadata` to reproduce the bug and verify the fix.

## Testing

```
go test ./controllers/ray/common/... -run "TestBuildJobSubmitCommand|TestMetadata" -v
```

All existing tests pass. The new test `TestBuildJobSubmitCommandWithClusterSelectorIncludesMetadata` confirms that `--metadata-json` is now correctly included in the submit command when `RayClusterSpec` is `nil` (clusterSelector mode).

Fixes #4589