### PR TITLE
[Chore] Use RayCluster name as ServiceAccount name for RBAC authentication

### DIFF
--- a/ray-operator/config/samples/ray-cluster.kubernetes.auth-manual.yaml
+++ b/ray-operator/config/samples/ray-cluster.kubernetes.auth-manual.yaml
@@ -8,7 +8,7 @@ spec:
     rayStartParams: {}
     template:
       spec:
-        serviceAccountName: raylet
+        serviceAccountName: ray-cluster-with-k8s-auth
         containers:
         - name: ray-head
           imagePullPolicy: Always
@@ -50,7 +50,7 @@ spec:
     rayStartParams: {}
     template:
       spec:
-        serviceAccountName: raylet
+        serviceAccountName: ray-cluster-with-k8s-auth
         containers:
         - name: ray-worker
           imagePullPolicy: Always
@@ -81,7 +81,7 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: raylet
+  name: ray-cluster-with-k8s-auth
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -117,18 +117,18 @@ roleRef:
   name: ray-authenticator
 subjects:
 - kind: ServiceAccount
-  name: raylet
+  name: ray-cluster-with-k8s-auth
   namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: raylet
+  name: ray-cluster-with-k8s-auth
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: ray-writer
 subjects:
 - kind: ServiceAccount
-  name: raylet
+  name: ray-cluster-with-k8s-auth
   namespace: default

--- a/ray-operator/config/samples/ray-cluster.kubernetes.auth.yaml
+++ b/ray-operator/config/samples/ray-cluster.kubernetes.auth.yaml
@@ -11,7 +11,7 @@ spec:
     rayStartParams: {}
     template:
       spec:
-        serviceAccountName: raylet
+        serviceAccountName: ray-cluster-with-k8s-auth
         containers:
         - name: ray-head
           imagePullPolicy: Always
@@ -39,7 +39,7 @@ spec:
     rayStartParams: {}
     template:
       spec:
-        serviceAccountName: raylet
+        serviceAccountName: ray-cluster-with-k8s-auth
         containers:
         - name: ray-worker
           imagePullPolicy: Always
@@ -56,7 +56,7 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: raylet
+  name: ray-cluster-with-k8s-auth
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -92,18 +92,18 @@ roleRef:
   name: ray-authenticator
 subjects:
 - kind: ServiceAccount
-  name: raylet
+  name: ray-cluster-with-k8s-auth
   namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: raylet
+  name: ray-cluster-with-k8s-auth
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: ray-writer
 subjects:
 - kind: ServiceAccount
-  name: raylet
+  name: ray-cluster-with-k8s-auth
   namespace: default


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In this PR, we change all SA names in the manifest to the cluster name `ray-cluster-with-k8s-auth` for consistency.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/kuberay/issues/4594

## Test Results

|  `ray-cluster.kubernetes.auth.yaml`   | `ray-cluster.kubernetes.auth-manual.yaml`  |
|  ----  | ----  |
| <img width="1070" height="1041" alt="Screenshot 2026-03-17 at 11 50 36 AM" src="https://github.com/user-attachments/assets/e99042c0-ab62-4ccc-95e7-5c5f2fc4d293" /> | <img width="1070" height="1041" alt="Screenshot 2026-03-17 at 11 49 23 AM" src="https://github.com/user-attachments/assets/22659a52-ac2c-4585-91a4-d3c48e68977c" /> |

## Ray Doc Link

https://anyscale-ray--61785.com.readthedocs.build/en/61785/cluster/kubernetes/user-guides/kuberay-auth-rbac.html#deploy-a-ray-cluster-with-kubernetes-rbac-enabled

<img width="1297" height="310" alt="Screenshot 2026-03-17 at 12 09 44 PM" src="https://github.com/user-attachments/assets/ba452d13-9810-4f71-93fb-4282ecbe2e86" />

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
