### PR TITLE
Ray-operator updates for user supplied sidecar container for job submission

### DIFF
--- a/ray-operator/config/samples/ray-job.sidecar-mode-custom-submitter.yaml
+++ b/ray-operator/config/samples/ray-job.sidecar-mode-custom-submitter.yaml
@@ -1,0 +1,139 @@
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sidecar-mode-custom-submitter
+spec:
+  # In SidecarMode, the KubeRay operator injects a submitter container into the Ray head Pod.
+  # By default, the operator creates the submitter container automatically.
+  #
+  # However, you can provide your own submitter container by adding a container named
+  # "ray-job-submitter" to the head pod spec. This lets you customize the submitter's
+  # image, volume mounts, environment variables, resource limits, and more.
+  #
+  # The controller will detect the container by its well-known name and inject the
+  # required state (command, args, dashboard address, job ID, auth env vars) into it.
+  #
+  # What the controller always injects (cannot be overridden):
+  #   - Command and Args (the `ray job submit` command with GCS health wait loop)
+  #   - PYTHONUNBUFFERED env var
+  #   - RAY_DASHBOARD_ADDRESS env var
+  #   - RAY_JOB_SUBMISSION_ID env var
+  #   - Auth-related env vars and volume mounts (when auth is enabled)
+  #
+  # What you can customize:
+  #   - Container image (defaults to Ray head image if left empty)
+  #   - Resource requests/limits (defaults to 500m/200Mi requests, 1/1Gi limits if unset)
+  #   - Volume mounts (e.g., mount ConfigMaps, Secrets, PVCs for job scripts)
+  #   - Additional environment variables (preserved alongside injected vars)
+  #   - Image pull policy
+  #   - Security context
+  #
+  # What you cannot change:
+  #   - Container name (must be "ray-job-submitter")
+  #   - Command/Args (always overwritten by the controller in SidecarMode)
+  submissionMode: "SidecarMode"
+  entrypoint: python /scripts/sample_code.py
+  runtimeEnvYAML: |
+    env_vars:
+      counter_name: "test_counter"
+
+  rayClusterSpec:
+    rayVersion: '2.52.0'
+    headGroupSpec:
+      rayStartParams: {}
+      template:
+        spec:
+          # Define volumes at the pod level — both the Ray head and the custom
+          # submitter container can mount them.
+          volumes:
+          - name: job-scripts
+            configMap:
+              name: ray-job-scripts
+          containers:
+          - name: ray-head
+            image: rayproject/ray:2.52.0
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            resources:
+              limits:
+                cpu: "1"
+                memory: "5Gi"
+              requests:
+                cpu: "1"
+                memory: "2Gi"
+
+          # User-provided sidecar submitter container.
+          # The controller detects this container by its well-known name
+          # "ray-job-submitter" and configures it in place.
+          - name: ray-job-submitter
+            image: rayproject/ray:2.52.0
+            volumeMounts:
+            - name: job-scripts
+              mountPath: /scripts
+              readOnly: true
+            env:
+            - name: MY_CUSTOM_VAR
+              value: "hello"
+            resources:
+              requests:
+                cpu: "200m"
+                memory: "256Mi"
+              limits:
+                cpu: "500m"
+                memory: "512Mi"
+
+    workerGroupSpecs:
+    - replicas: 1
+      minReplicas: 1
+      maxReplicas: 5
+      groupName: small-group
+      rayStartParams: {}
+      template:
+        spec:
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.52.0
+            resources:
+              limits:
+                cpu: "1"
+                memory: "1Gi"
+              requests:
+                cpu: "1"
+                memory: "1Gi"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ray-job-scripts
+data:
+  sample_code.py: |
+    import ray
+    import os
+
+    ray.init()
+
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.name = os.getenv("counter_name")
+            assert self.name == "test_counter"
+            self.counter = 0
+
+        def inc(self):
+            self.counter += 1
+
+        def get_counter(self):
+            return "{} got {}".format(self.name, self.counter)
+
+    counter = Counter.remote()
+
+    for _ in range(5):
+        ray.get(counter.inc.remote())
+
+    print(ray.get(counter.get_counter.remote()))

--- a/ray-operator/config/samples/ray-job.sidecar-mode.yaml
+++ b/ray-operator/config/samples/ray-job.sidecar-mode.yaml
@@ -6,6 +6,9 @@ spec:
   # In SidecarMode, the KubeRay operator injects a container into the Ray head Pod to submit the Ray job and tail logs.
   # This will avoid inter-Pod communication, which may cause network issues. For example, some users face WebSocket hangs.
   # For more details, see https://github.com/ray-project/kuberay/issues/3928#issuecomment-3187164736.
+  #
+  # To customize the submitter container (e.g., mount volumes, set env vars, use a custom image),
+  # see the ray-job.sidecar-mode-custom-submitter.yaml sample.
   submissionMode: "SidecarMode"
   entrypoint: python /home/ray/samples/sample_code.py
   runtimeEnvYAML: |

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -92,6 +92,16 @@ func getSubmitterResource(rayJob *rayv1.RayJob) corev1.ResourceList {
 		submitterTemplate := common.GetSubmitterTemplate(&rayJob.Spec, rayJob.Spec.RayClusterSpec)
 		return utils.CalculatePodResource(submitterTemplate.Spec)
 	case rayv1.SidecarMode:
+		// If the user provided a submitter container named "ray-job-submitter" in the head pod spec,
+		// its resources are already included in the head pod resource calculation from
+		// calculatePodGroupParams. Return an empty list to avoid double-counting.
+		for _, c := range rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers {
+			if c.Name == utils.SubmitterContainerName {
+				return corev1.ResourceList{}
+			}
+		}
+		// No user-provided container — use default sidecar resources to account for
+		// the container that will be injected at cluster creation time.
 		submitterContainer := common.GetDefaultSubmitterContainer(rayJob.Spec.RayClusterSpec)
 		containerResource := submitterContainer.Resources.Requests
 		for name, quantity := range submitterContainer.Resources.Limits {

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler_test.go
@@ -353,6 +353,44 @@ func TestCreatePodGroupForRayJob(t *testing.T) {
 		a.Len(pg.OwnerReferences, 1)
 		a.Equal("RayJob", pg.OwnerReferences[0].Kind)
 	})
+
+	t.Run("SidecarMode with user-provided submitter container does not double-count resources", func(_ *testing.T) {
+		rayJob := createTestRayJob(1)
+		rayJob.Spec.SubmissionMode = rayv1.SidecarMode
+		// Add a user-provided submitter container to the head pod spec.
+		rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers = append(
+			rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers,
+			corev1.Container{
+				Name:  utils.SubmitterContainerName,
+				Image: "my-custom-image:latest",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("400m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			},
+		)
+
+		err := scheduler.handleRayJob(ctx, &rayJob)
+		require.NoError(t, err)
+
+		var pg volcanoschedulingv1beta1.PodGroup
+		err = fakeCli.Get(ctx, client.ObjectKey{Namespace: rayJob.Namespace, Name: getAppPodGroupName(&rayJob)}, &pg)
+		require.NoError(t, err)
+
+		a.Equal(int32(3), pg.Spec.MinMember)
+		// The user-provided submitter container resources (200m) are already included in the head pod calculation:
+		// head (256m) + user-provided submitter (200m) + 2 workers (256m each) = 968m
+		// No additional submitter resources should be added.
+		a.Equal("968m", pg.Spec.MinResources.Cpu().String())
+		// head (256Mi) + user-provided submitter (128Mi) + 2 workers (256Mi each) = 896Mi
+		a.Equal("896Mi", pg.Spec.MinResources.Memory().String())
+	})
 }
 
 func TestCreatePodGroupForRayJob_NumOfHosts2(t *testing.T) {

--- a/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_scheduler_test.go
+++ b/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_scheduler_test.go
@@ -298,6 +298,84 @@ func TestPropagateTaskGroupsAnnotationToPod(t *testing.T) {
 	assert.Equal(t, resource.MustParse("1"), workerGroup.MinResource["nvidia.com/gpu"])
 }
 
+func TestPropagateTaskGroupsAnnotation_SidecarMode_UserProvidedSubmitter(t *testing.T) {
+	appID := "job-1-01234"
+	queue := "root.default"
+
+	rayCluster := createRayClusterWithLabels(
+		"ray-job-user-submitter",
+		"test-namespace",
+		map[string]string{},
+	)
+
+	addHeadPodSpec(rayCluster, corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("5"),
+		corev1.ResourceMemory: resource.MustParse("5Gi"),
+	})
+
+	// Add a user-provided submitter container to the head pod spec.
+	rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers = append(
+		rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers,
+		corev1.Container{
+			Name:  utils.SubmitterContainerName,
+			Image: "my-custom-submitter:latest",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	)
+
+	addWorkerPodSpec(rayCluster, "worker-group-1", 2, 2, 2, corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("2"),
+		corev1.ResourceMemory: resource.MustParse("10Gi"),
+	})
+
+	rayJobWithUserSubmitter := createRayJobWithLabels(
+		"ray-job-user-submitter",
+		"test-namespace",
+		rayCluster.Spec.DeepCopy(),
+		map[string]string{
+			RayApplicationIDLabelName:      appID,
+			RayApplicationQueueLabelName:   queue,
+			utils.RayGangSchedulingEnabled: "true",
+		},
+	)
+	rayJobWithUserSubmitter.Spec.SubmissionMode = rayv1.SidecarMode
+
+	rayPod := createPod("ray-pod", "default")
+	err := propagateTaskGroupsAnnotation(rayJobWithUserSubmitter, rayPod)
+	require.NoError(t, err)
+
+	taskGroupsSpec := rayPod.Annotations[YuniKornTaskGroupsAnnotationName]
+	assert.NotEmpty(t, taskGroupsSpec)
+	taskGroups := newTaskGroups()
+	err = taskGroups.unmarshalFrom(taskGroupsSpec)
+	require.NoError(t, err)
+
+	// Should only have 2 task groups (head + worker), NO separate submitter task group.
+	// The user-provided submitter container resources are already included in the head task group.
+	assert.Len(t, taskGroups.Groups, 2)
+
+	headGroup := taskGroups.getTaskGroup(utils.RayNodeHeadGroupLabelValue)
+	assert.NotNil(t, headGroup)
+	assert.Equal(t, int32(1), headGroup.MinMember)
+	// Head resources include both the ray-head container (5 CPU) and the user-provided submitter container (1 CPU) = 6 CPU
+	assert.Equal(t, resource.MustParse("6"), headGroup.MinResource[corev1.ResourceCPU.String()])
+	// Head memory: 5Gi + 1Gi = 6Gi
+	assert.Equal(t, resource.MustParse("6Gi"), headGroup.MinResource[corev1.ResourceMemory.String()])
+
+	workerGroup := taskGroups.getTaskGroup("worker-group-1")
+	assert.NotNil(t, workerGroup)
+	assert.Equal(t, int32(2), workerGroup.MinMember)
+
+	// Verify no submitter task group was created
+	submitterGroup := taskGroups.getTaskGroup(utils.RayNodeSubmitterGroupLabelValue)
+	assert.Equal(t, TaskGroup{}, submitterGroup)
+}
+
 func TestPropagateTaskGroupsAnnotationToRayClusterAndSubmitterPodTemplate(t *testing.T) {
 	appID := "job-1-01234"
 	queue := "root.default"

--- a/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_task_groups.go
+++ b/ray-operator/controllers/ray/batchscheduler/yunikorn/yunikorn_task_groups.go
@@ -73,6 +73,18 @@ func newTaskGroupsFromRayClusterSpec(rayClusterSpec *v1.RayClusterSpec) *TaskGro
 func newTaskGroupsFromRayJobSpec(rayJobSpec *v1.RayJobSpec) *TaskGroups {
 	taskGroups := newTaskGroupsFromRayClusterSpec(rayJobSpec.RayClusterSpec)
 
+	// In SidecarMode, check if the user provided a container named "ray-job-submitter"
+	// in the head pod spec. If so, its resources are already counted in the head task group
+	// from newTaskGroupsFromRayClusterSpec — skip creating a separate submitter task group
+	// to avoid double-counting.
+	if rayJobSpec.SubmissionMode == v1.SidecarMode {
+		for _, c := range rayJobSpec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers {
+			if c.Name == utils.SubmitterContainerName {
+				return taskGroups
+			}
+		}
+	}
+
 	submitterGroupSpec := common.GetSubmitterTemplate(rayJobSpec, rayJobSpec.RayClusterSpec).Spec
 
 	submitterPodMinResource := utils.CalculatePodResource(submitterGroupSpec)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -601,8 +601,23 @@ func getSubmitterContainer(rayJobInstance *rayv1.RayJob, rayClusterInstance *ray
 	return submitterContainer, nil
 }
 
-// pass the RayCluster instance for cluster selector case
+// configureSubmitterContainer injects the required state into a submitter container.
+// This function works for both the default submitter and user-provided submitter containers.
+// It handles: image defaulting, resource defaulting, command/args generation,
+// and env var injection (PYTHONUNBUFFERED, RAY_DASHBOARD_ADDRESS, RAY_JOB_SUBMISSION_ID, auth).
+// In SidecarMode, Command/Args are always overwritten. User-defined env vars and volume mounts are preserved.
 func configureSubmitterContainer(container *corev1.Container, rayJobInstance *rayv1.RayJob, rayClusterInstance *rayv1.RayCluster, submissionMode rayv1.JobSubmissionMode) error {
+	// In SidecarMode, default the image to the Ray head image if not specified.
+	if submissionMode == rayv1.SidecarMode && container.Image == "" && rayClusterInstance != nil {
+		container.Image = rayClusterInstance.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Image
+	}
+
+	// In SidecarMode, default resource requests/limits if not specified.
+	if submissionMode == rayv1.SidecarMode && container.Resources.Limits == nil && container.Resources.Requests == nil {
+		defaultContainer := common.GetDefaultSubmitterContainer(&rayClusterInstance.Spec)
+		container.Resources = defaultContainer.Resources
+	}
+
 	// If the command in the submitter container manifest isn't set, use the default command.
 	jobCmd, err := common.BuildJobSubmitCommand(rayJobInstance, submissionMode)
 	if err != nil {
@@ -617,14 +632,16 @@ func configureSubmitterContainer(container *corev1.Container, rayJobInstance *ra
 		container.Args = []string{strings.Join(jobCmd, " ")}
 	}
 
-	// Set PYTHONUNBUFFERED=1 for real-time logging
-	container.Env = append(container.Env, corev1.EnvVar{Name: PythonUnbufferedEnvVarName, Value: "1"})
+	// Set PYTHONUNBUFFERED=1 for real-time logging.
+	// Use SetOrReplaceEnvVar to avoid duplicates when users pre-define these env vars
+	// in a user-provided submitter container.
+	utils.SetOrReplaceEnvVar(container, PythonUnbufferedEnvVarName, "1")
 
 	// Users can use `RAY_DASHBOARD_ADDRESS` to specify the dashboard address and `RAY_JOB_SUBMISSION_ID` to specify the job id to avoid
 	// double submission in the `ray job submit` command. For example:
 	// ray job submit --address=http://$RAY_DASHBOARD_ADDRESS --submission-id=$RAY_JOB_SUBMISSION_ID ...
-	container.Env = append(container.Env, corev1.EnvVar{Name: utils.RAY_DASHBOARD_ADDRESS, Value: rayJobInstance.Status.DashboardURL})
-	container.Env = append(container.Env, corev1.EnvVar{Name: utils.RAY_JOB_SUBMISSION_ID, Value: rayJobInstance.Status.JobId})
+	utils.SetOrReplaceEnvVar(container, utils.RAY_DASHBOARD_ADDRESS, rayJobInstance.Status.DashboardURL)
+	utils.SetOrReplaceEnvVar(container, utils.RAY_JOB_SUBMISSION_ID, rayJobInstance.Status.JobId)
 	if rayClusterInstance != nil && utils.IsAuthEnabled(&rayClusterInstance.Spec) {
 		common.SetContainerTokenAuthEnvVars(rayClusterInstance.Name, container, rayClusterInstance.Spec.AuthOptions)
 	}
@@ -992,14 +1009,31 @@ func (r *RayJobReconciler) constructRayClusterForRayJob(rayJobInstance *rayv1.Ra
 		return nil, err
 	}
 
-	// Inject a submitter container into the head Pod in SidecarMode.
+	// Inject or configure a submitter container in the head Pod in SidecarMode.
 	if rayJobInstance.Spec.SubmissionMode == rayv1.SidecarMode {
-		sidecar, err := getSubmitterContainer(rayJobInstance, rayCluster)
-		if err != nil {
-			return nil, err
+		// Check if the user already provided a container named "ray-job-submitter" in the head pod spec.
+		userContainerIdx := -1
+		for i, c := range rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers {
+			if c.Name == utils.SubmitterContainerName {
+				userContainerIdx = i
+				break
+			}
 		}
-		rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers = append(
-			rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers, sidecar)
+
+		if userContainerIdx >= 0 {
+			// User provided their own sidecar submitter container — configure it in place.
+			if err := configureSubmitterContainer(&rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[userContainerIdx], rayJobInstance, rayCluster, rayv1.SidecarMode); err != nil {
+				return nil, err
+			}
+		} else {
+			// No user-provided container — create the default sidecar and append it.
+			sidecar, err := getSubmitterContainer(rayJobInstance, rayCluster)
+			if err != nil {
+				return nil, err
+			}
+			rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers = append(
+				rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers, sidecar)
+		}
 		// In K8sJobMode, the submitter Job relies on the K8s Job backoffLimit API to restart if it fails.
 		// This mainly handles WebSocket connection failures caused by transient network issues.
 		// In SidecarMode, however, the submitter container shares the same network namespace as the Ray dashboard,

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/mock/gomock"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -676,4 +677,457 @@ func TestGetSubmitterTemplate_WithEnableK8sTokenAuth(t *testing.T) {
 		}
 	}
 	assert.True(t, foundVolumeMount, "Submitter container should have the ray-token volume mount")
+}
+
+// newSidecarModeRayJob creates a base RayJob configured for SidecarMode testing.
+// If submitter is non-nil, it's added as a user-provided submitter container in the head pod.
+func newSidecarModeRayJob(submitter *corev1.Container) *rayv1.RayJob {
+	containers := []corev1.Container{
+		{Name: "ray-head", Image: "rayproject/ray:2.9.0"},
+	}
+	if submitter != nil {
+		containers = append(containers, *submitter)
+	}
+	return &rayv1.RayJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-rayjob", Namespace: "default"},
+		Spec: rayv1.RayJobSpec{
+			SubmissionMode: rayv1.SidecarMode,
+			Entrypoint:     "python test.py",
+			RayClusterSpec: &rayv1.RayClusterSpec{
+				HeadGroupSpec: rayv1.HeadGroupSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{Containers: containers},
+					},
+				},
+			},
+		},
+		Status: rayv1.RayJobStatus{
+			DashboardURL: "test-url",
+			JobId:        "test-job-id",
+		},
+	}
+}
+
+// constructSidecarModeCluster runs the reconciler on a SidecarMode RayJob and returns the resulting RayCluster.
+func constructSidecarModeCluster(t *testing.T, rayJob *rayv1.RayJob) *rayv1.RayCluster {
+	t.Helper()
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	reconciler := &RayJobReconciler{Scheme: newScheme}
+	rayCluster, err := reconciler.constructRayClusterForRayJob(rayJob, "test-raycluster")
+	require.NoError(t, err)
+	return rayCluster
+}
+
+func TestConstructRayClusterForRayJob_SidecarMode_DefaultContainer(t *testing.T) {
+	// When no user-provided ray-job-submitter container exists, the controller
+	// should create a default sidecar and append it to the head pod containers.
+	rayJob := newSidecarModeRayJob(nil)
+	rayCluster := constructSidecarModeCluster(t, rayJob)
+
+	// Should have 2 containers: ray-head + ray-job-submitter
+	require.Len(t, rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers, 2)
+	assert.Equal(t, "ray-head", rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Name)
+	assert.Equal(t, utils.SubmitterContainerName, rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1].Name)
+
+	// Default sidecar should use the ray head image
+	assert.Equal(t, "rayproject/ray:2.9.0", rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1].Image)
+
+	// RestartPolicy should be set to Never
+	assert.Equal(t, corev1.RestartPolicyNever, rayCluster.Spec.HeadGroupSpec.Template.Spec.RestartPolicy)
+
+	// Annotation should be set
+	assert.Equal(t, "true", rayCluster.Annotations[utils.DisableProvisionedHeadRestartAnnotationKey])
+
+	// Env vars should be injected
+	submitter := rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1]
+	envVar, found := utils.EnvVarByName(PythonUnbufferedEnvVarName, submitter.Env)
+	assert.True(t, found)
+	assert.Equal(t, "1", envVar.Value)
+
+	envVar, found = utils.EnvVarByName(utils.RAY_DASHBOARD_ADDRESS, submitter.Env)
+	assert.True(t, found)
+	assert.Equal(t, "test-url", envVar.Value)
+
+	envVar, found = utils.EnvVarByName(utils.RAY_JOB_SUBMISSION_ID, submitter.Env)
+	assert.True(t, found)
+	assert.Equal(t, "test-job-id", envVar.Value)
+}
+
+func TestConstructRayClusterForRayJob_SidecarMode_UserProvidedContainer(t *testing.T) {
+	// When the user provides a container named "ray-job-submitter" in the head pod spec,
+	// the controller should configure it in place rather than appending a new one.
+	rayJob := newSidecarModeRayJob(&corev1.Container{
+		Name:  utils.SubmitterContainerName,
+		Image: "my-custom-image:latest",
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "job-scripts", MountPath: "/scripts"},
+		},
+		Env: []corev1.EnvVar{
+			{Name: "MY_CUSTOM_VAR", Value: "hello"},
+		},
+	})
+	rayJob.Spec.Entrypoint = "python /scripts/my_job.py"
+	rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Volumes = []corev1.Volume{
+		{
+			Name: "job-scripts",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "my-job-scripts"},
+				},
+			},
+		},
+	}
+
+	rayCluster := constructSidecarModeCluster(t, rayJob)
+
+	// Should still have exactly 2 containers — no duplicate appended
+	require.Len(t, rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers, 2)
+	assert.Equal(t, "ray-head", rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[0].Name)
+	assert.Equal(t, utils.SubmitterContainerName, rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1].Name)
+
+	submitter := rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1]
+
+	// User's custom image should be preserved
+	assert.Equal(t, "my-custom-image:latest", submitter.Image)
+
+	// User's volume mounts should be preserved
+	require.Len(t, submitter.VolumeMounts, 1)
+	assert.Equal(t, "job-scripts", submitter.VolumeMounts[0].Name)
+	assert.Equal(t, "/scripts", submitter.VolumeMounts[0].MountPath)
+
+	// User's env vars should be preserved, with controller env vars appended
+	envVar, found := utils.EnvVarByName("MY_CUSTOM_VAR", submitter.Env)
+	assert.True(t, found)
+	assert.Equal(t, "hello", envVar.Value)
+
+	envVar, found = utils.EnvVarByName(PythonUnbufferedEnvVarName, submitter.Env)
+	assert.True(t, found)
+	assert.Equal(t, "1", envVar.Value)
+
+	envVar, found = utils.EnvVarByName(utils.RAY_DASHBOARD_ADDRESS, submitter.Env)
+	assert.True(t, found)
+	assert.Equal(t, "test-url", envVar.Value)
+
+	envVar, found = utils.EnvVarByName(utils.RAY_JOB_SUBMISSION_ID, submitter.Env)
+	assert.True(t, found)
+	assert.Equal(t, "test-job-id", envVar.Value)
+
+	// Command should be overwritten by the controller
+	assert.Equal(t, []string{"/bin/bash", "-ce", "--"}, submitter.Command)
+	assert.Len(t, submitter.Args, 1)
+
+	// RestartPolicy should be set to Never
+	assert.Equal(t, corev1.RestartPolicyNever, rayCluster.Spec.HeadGroupSpec.Template.Spec.RestartPolicy)
+}
+
+func TestConstructRayClusterForRayJob_SidecarMode_UserProvidedContainer_ImageDefaulting(t *testing.T) {
+	// When the user provides a ray-job-submitter container without an image,
+	// the controller should default to the Ray head image.
+	rayJob := newSidecarModeRayJob(&corev1.Container{
+		Name: utils.SubmitterContainerName,
+		// No image specified — should default to ray head image
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "job-scripts", MountPath: "/scripts"},
+		},
+	})
+
+	rayCluster := constructSidecarModeCluster(t, rayJob)
+	submitter := rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1]
+
+	// Image should default to the ray head image
+	assert.Equal(t, "rayproject/ray:2.9.0", submitter.Image)
+
+	// Volume mounts should be preserved
+	require.Len(t, submitter.VolumeMounts, 1)
+	assert.Equal(t, "job-scripts", submitter.VolumeMounts[0].Name)
+}
+
+func TestConstructRayClusterForRayJob_SidecarMode_UserProvidedContainer_ResourceDefaulting(t *testing.T) {
+	// When the user provides a ray-job-submitter container without resources,
+	// the controller should apply default resource limits.
+	rayJob := newSidecarModeRayJob(&corev1.Container{
+		Name:  utils.SubmitterContainerName,
+		Image: "my-custom-image:latest",
+		// No resources specified — should get defaults
+	})
+
+	rayCluster := constructSidecarModeCluster(t, rayJob)
+	submitter := rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1]
+
+	// Default resources should be applied
+	assert.NotNil(t, submitter.Resources.Limits)
+	assert.NotNil(t, submitter.Resources.Requests)
+}
+
+func TestConstructRayClusterForRayJob_SidecarMode_UserProvidedContainer_CustomResources(t *testing.T) {
+	// When the user specifies custom resources, they should be preserved.
+	rayJob := newSidecarModeRayJob(&corev1.Container{
+		Name:  utils.SubmitterContainerName,
+		Image: "my-custom-image:latest",
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+	})
+
+	rayCluster := constructSidecarModeCluster(t, rayJob)
+	submitter := rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1]
+
+	// User-specified resources should be preserved
+	assert.True(t, submitter.Resources.Requests.Cpu().Equal(resource.MustParse("200m")))
+	assert.True(t, submitter.Resources.Requests.Memory().Equal(resource.MustParse("256Mi")))
+	assert.True(t, submitter.Resources.Limits.Cpu().Equal(resource.MustParse("500m")))
+	assert.True(t, submitter.Resources.Limits.Memory().Equal(resource.MustParse("512Mi")))
+}
+
+func TestConstructRayClusterForRayJob_SidecarMode_UserProvidedContainer_PartialResources_OnlyRequests(t *testing.T) {
+	// When the user specifies only Requests (no Limits), defaults are NOT applied.
+	// The user's partial resource spec is preserved as-is.
+	rayJob := newSidecarModeRayJob(&corev1.Container{
+		Name:  utils.SubmitterContainerName,
+		Image: "my-custom-image:latest",
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
+	})
+
+	rayCluster := constructSidecarModeCluster(t, rayJob)
+	submitter := rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1]
+
+	// User's Requests should be preserved
+	assert.True(t, submitter.Resources.Requests.Cpu().Equal(resource.MustParse("100m")))
+	assert.True(t, submitter.Resources.Requests.Memory().Equal(resource.MustParse("128Mi")))
+
+	// Limits should remain nil (no defaults applied for partial spec)
+	assert.Nil(t, submitter.Resources.Limits)
+}
+
+func TestConstructRayClusterForRayJob_SidecarMode_UserProvidedContainer_PartialResources_OnlyLimits(t *testing.T) {
+	// When the user specifies only Limits (no Requests), defaults are NOT applied.
+	// The user's partial resource spec is preserved as-is.
+	rayJob := newSidecarModeRayJob(&corev1.Container{
+		Name:  utils.SubmitterContainerName,
+		Image: "my-custom-image:latest",
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+	})
+
+	rayCluster := constructSidecarModeCluster(t, rayJob)
+	submitter := rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1]
+
+	// Requests should remain nil (no defaults applied for partial spec)
+	assert.Nil(t, submitter.Resources.Requests)
+
+	// User's Limits should be preserved
+	assert.True(t, submitter.Resources.Limits.Cpu().Equal(resource.MustParse("500m")))
+	assert.True(t, submitter.Resources.Limits.Memory().Equal(resource.MustParse("512Mi")))
+}
+
+func TestConstructRayClusterForRayJob_SidecarMode_UserEnvVarsPreserved(t *testing.T) {
+	// Verify that user-defined env vars on the user-provided submitter container are preserved
+	// and controller-injected env vars are appended (not replacing user vars).
+	rayJob := newSidecarModeRayJob(&corev1.Container{
+		Name:  utils.SubmitterContainerName,
+		Image: "my-custom-image:latest",
+		Env: []corev1.EnvVar{
+			{Name: "USER_VAR_1", Value: "value1"},
+			{Name: "USER_VAR_2", Value: "value2"},
+			{Name: "API_KEY", Value: "secret-key"},
+		},
+	})
+
+	rayCluster := constructSidecarModeCluster(t, rayJob)
+	submitter := rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1]
+
+	// All user-defined env vars should be preserved
+	envVar, found := utils.EnvVarByName("USER_VAR_1", submitter.Env)
+	assert.True(t, found, "USER_VAR_1 should be preserved")
+	assert.Equal(t, "value1", envVar.Value)
+
+	envVar, found = utils.EnvVarByName("USER_VAR_2", submitter.Env)
+	assert.True(t, found, "USER_VAR_2 should be preserved")
+	assert.Equal(t, "value2", envVar.Value)
+
+	envVar, found = utils.EnvVarByName("API_KEY", submitter.Env)
+	assert.True(t, found, "API_KEY should be preserved")
+	assert.Equal(t, "secret-key", envVar.Value)
+
+	// Controller-injected env vars should also be present
+	_, found = utils.EnvVarByName(utils.RAY_DASHBOARD_ADDRESS, submitter.Env)
+	assert.True(t, found, "RAY_DASHBOARD_ADDRESS should be injected")
+	_, found = utils.EnvVarByName(utils.RAY_JOB_SUBMISSION_ID, submitter.Env)
+	assert.True(t, found, "RAY_JOB_SUBMISSION_ID should be injected")
+	_, found = utils.EnvVarByName(PythonUnbufferedEnvVarName, submitter.Env)
+	assert.True(t, found, "PYTHONUNBUFFERED should be injected")
+
+	// Total env count: 3 user + 3 controller-injected
+	assert.Len(t, submitter.Env, 6)
+}
+
+func TestConstructRayClusterForRayJob_SidecarMode_ControllerEnvVarsOverrideUserValues(t *testing.T) {
+	// Verify that when a user pre-defines controller-managed env vars (RAY_DASHBOARD_ADDRESS,
+	// RAY_JOB_SUBMISSION_ID, PYTHONUNBUFFERED) on the user-provided submitter container,
+	// the controller replaces them with the correct runtime values instead of creating duplicates.
+	rayJob := newSidecarModeRayJob(&corev1.Container{
+		Name:  utils.SubmitterContainerName,
+		Image: "my-custom-image:latest",
+		Env: []corev1.EnvVar{
+			{Name: "USER_VAR", Value: "keep-me"},
+			{Name: utils.RAY_DASHBOARD_ADDRESS, Value: "user-should-be-overridden"},
+			{Name: utils.RAY_JOB_SUBMISSION_ID, Value: "user-should-be-overridden"},
+			{Name: PythonUnbufferedEnvVarName, Value: "0"},
+		},
+	})
+	rayJob.Status.DashboardURL = "correct-dashboard-url"
+	rayJob.Status.JobId = "correct-job-id"
+
+	rayCluster := constructSidecarModeCluster(t, rayJob)
+	submitter := rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1]
+
+	// Controller-managed env vars should have the controller's values, not the user's
+	envVar, found := utils.EnvVarByName(utils.RAY_DASHBOARD_ADDRESS, submitter.Env)
+	assert.True(t, found)
+	assert.Equal(t, "correct-dashboard-url", envVar.Value, "RAY_DASHBOARD_ADDRESS should be overridden with controller value")
+
+	envVar, found = utils.EnvVarByName(utils.RAY_JOB_SUBMISSION_ID, submitter.Env)
+	assert.True(t, found)
+	assert.Equal(t, "correct-job-id", envVar.Value, "RAY_JOB_SUBMISSION_ID should be overridden with controller value")
+
+	envVar, found = utils.EnvVarByName(PythonUnbufferedEnvVarName, submitter.Env)
+	assert.True(t, found)
+	assert.Equal(t, "1", envVar.Value, "PYTHONUNBUFFERED should be overridden with controller value")
+
+	// User-defined env var should still be preserved
+	envVar, found = utils.EnvVarByName("USER_VAR", submitter.Env)
+	assert.True(t, found)
+	assert.Equal(t, "keep-me", envVar.Value)
+
+	// No duplicates — should be exactly 4 env vars (1 user + 3 controller-managed, replaced in place)
+	assert.Len(t, submitter.Env, 4)
+}
+
+func TestConstructRayClusterForRayJob_SidecarMode_CommandAlwaysOverwritten(t *testing.T) {
+	// Verify that even if the user sets Command and Args on the user-provided submitter container,
+	// the controller overwrites them in SidecarMode.
+	rayJob := newSidecarModeRayJob(&corev1.Container{
+		Name:    utils.SubmitterContainerName,
+		Image:   "my-custom-image:latest",
+		Command: []string{"/bin/sh", "-c"},
+		Args:    []string{"echo user-command"},
+	})
+
+	rayCluster := constructSidecarModeCluster(t, rayJob)
+	submitter := rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1]
+
+	// Command should be overwritten to the controller's default, not the user's
+	assert.Equal(t, []string{"/bin/bash", "-ce", "--"}, submitter.Command)
+	assert.NotContains(t, submitter.Args[0], "echo user-command", "user args should be overwritten")
+	assert.Contains(t, submitter.Args[0], "ray job submit", "controller should inject ray job submit command")
+}
+
+func TestConstructRayClusterForRayJob_SidecarMode_UserVolumeMountsPreserved(t *testing.T) {
+	// Verify that user-defined volume mounts on the user-provided submitter container are preserved
+	// since configureSubmitterContainer never touches VolumeMounts.
+	rayJob := newSidecarModeRayJob(&corev1.Container{
+		Name:  utils.SubmitterContainerName,
+		Image: "my-custom-image:latest",
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "scripts", MountPath: "/opt/scripts", ReadOnly: true},
+			{Name: "creds", MountPath: "/etc/creds", ReadOnly: true},
+		},
+	})
+	rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Volumes = []corev1.Volume{
+		{
+			Name: "scripts",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "my-scripts"},
+				},
+			},
+		},
+		{
+			Name: "creds",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: "my-creds"},
+			},
+		},
+	}
+
+	rayCluster := constructSidecarModeCluster(t, rayJob)
+	submitter := rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1]
+
+	// Both user-defined volume mounts should be preserved
+	require.Len(t, submitter.VolumeMounts, 2)
+
+	assert.Equal(t, "scripts", submitter.VolumeMounts[0].Name)
+	assert.Equal(t, "/opt/scripts", submitter.VolumeMounts[0].MountPath)
+	assert.True(t, submitter.VolumeMounts[0].ReadOnly)
+
+	assert.Equal(t, "creds", submitter.VolumeMounts[1].Name)
+	assert.Equal(t, "/etc/creds", submitter.VolumeMounts[1].MountPath)
+	assert.True(t, submitter.VolumeMounts[1].ReadOnly)
+}
+
+func TestConstructRayClusterForRayJob_SidecarMode_UserProvidedContainer_WithAuthToken(t *testing.T) {
+	// Verify that when auth is enabled, the controller injects auth env vars into
+	// a user-provided submitter container without conflicting with user-defined
+	// env vars or volume mounts.
+	rayJob := newSidecarModeRayJob(&corev1.Container{
+		Name:  utils.SubmitterContainerName,
+		Image: "my-custom-image:latest",
+		Env: []corev1.EnvVar{
+			{Name: "USER_VAR", Value: "keep-me"},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "user-mount", MountPath: "/data"},
+		},
+	})
+	rayJob.Spec.RayClusterSpec.AuthOptions = &rayv1.AuthOptions{
+		Mode: rayv1.AuthModeToken,
+	}
+
+	rayCluster := constructSidecarModeCluster(t, rayJob)
+	submitter := rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[1]
+
+	// User env var preserved
+	envVar, found := utils.EnvVarByName("USER_VAR", submitter.Env)
+	assert.True(t, found)
+	assert.Equal(t, "keep-me", envVar.Value)
+
+	// Controller-injected env vars present
+	_, found = utils.EnvVarByName(utils.RAY_DASHBOARD_ADDRESS, submitter.Env)
+	assert.True(t, found, "RAY_DASHBOARD_ADDRESS should be injected")
+	_, found = utils.EnvVarByName(utils.RAY_JOB_SUBMISSION_ID, submitter.Env)
+	assert.True(t, found, "RAY_JOB_SUBMISSION_ID should be injected")
+	_, found = utils.EnvVarByName(PythonUnbufferedEnvVarName, submitter.Env)
+	assert.True(t, found, "PYTHONUNBUFFERED should be injected")
+
+	// Auth env vars should be injected
+	envVar, found = utils.EnvVarByName(utils.RAY_AUTH_MODE_ENV_VAR, submitter.Env)
+	assert.True(t, found, "RAY_AUTH_MODE should be injected")
+	assert.Equal(t, string(rayv1.AuthModeToken), envVar.Value)
+
+	envVar, found = utils.EnvVarByName(utils.RAY_AUTH_TOKEN_ENV_VAR, submitter.Env)
+	assert.True(t, found, "RAY_AUTH_TOKEN should be injected")
+	assert.NotNil(t, envVar.ValueFrom, "RAY_AUTH_TOKEN should reference a secret")
+	assert.NotNil(t, envVar.ValueFrom.SecretKeyRef)
+	assert.Equal(t, utils.RAY_AUTH_TOKEN_SECRET_KEY, envVar.ValueFrom.SecretKeyRef.Key)
+
+	// User volume mount preserved
+	assert.Equal(t, "user-mount", submitter.VolumeMounts[0].Name)
+	assert.Equal(t, "/data", submitter.VolumeMounts[0].MountPath)
 }

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -698,6 +698,19 @@ func EnvVarExists(envName string, envVars []corev1.EnvVar) bool {
 	return false
 }
 
+// SetOrReplaceEnvVar sets an env var on a container. If the env var already exists, its value is replaced.
+// If it does not exist, it is appended.
+func SetOrReplaceEnvVar(container *corev1.Container, name, value string) {
+	for i := range container.Env {
+		if container.Env[i].Name == name {
+			container.Env[i].Value = value
+			container.Env[i].ValueFrom = nil
+			return
+		}
+	}
+	container.Env = append(container.Env, corev1.EnvVar{Name: name, Value: value})
+}
+
 // VolumeMountExists checks if a volume mount with the given name exists in the list of volume mounts.
 func VolumeMountExists(mountName string, volumeMounts []corev1.VolumeMount) bool {
 	for _, vm := range volumeMounts {

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -348,6 +348,32 @@ func ValidateRayJobSpec(rayJob *rayv1.RayJob) error {
 		}
 	}
 
+	// Reject a container named "ray-job-submitter" in the head pod spec when not using SidecarMode.
+	// The name is reserved for the sidecar submitter and would conflict with the controller's status monitoring.
+	if rayJob.Spec.RayClusterSpec != nil {
+		submitterCount := 0
+		for _, c := range rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers {
+			if c.Name == SubmitterContainerName {
+				submitterCount++
+			}
+		}
+		if rayJob.Spec.SubmissionMode != rayv1.SidecarMode && submitterCount > 0 {
+			return fmt.Errorf("container name %q is reserved for the sidecar submitter and can only be used with SidecarMode", SubmitterContainerName)
+		}
+		if submitterCount > 1 {
+			return fmt.Errorf("only one container named %q is allowed in the head pod spec", SubmitterContainerName)
+		}
+		// In SidecarMode, the controller always overwrites Command/Args on the submitter container.
+		// Reject user-specified Command/Args to avoid silent overwriting.
+		if rayJob.Spec.SubmissionMode == rayv1.SidecarMode {
+			for _, c := range rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers {
+				if c.Name == SubmitterContainerName && (len(c.Command) > 0 || len(c.Args) > 0) {
+					return fmt.Errorf("setting Command or Args on the %q container is not allowed in SidecarMode because the controller manages the command", SubmitterContainerName)
+				}
+			}
+		}
+	}
+
 	if rayJob.Spec.RayClusterSpec != nil {
 		if IsK8sAuthEnabled(rayJob.Spec.RayClusterSpec.AuthOptions) {
 			return fmt.Errorf("The RayJob spec is invalid: K8s token auth mode is currently not supported for RayJob")

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -1165,6 +1165,121 @@ func TestValidateRayJobSpec(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "reserved container name ray-job-submitter rejected in K8sJobMode",
+			spec: rayv1.RayJobSpec{
+				SubmissionMode: rayv1.K8sJobMode,
+				RayClusterSpec: &rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "ray-head"},
+									{Name: SubmitterContainerName},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "reserved container name ray-job-submitter allowed in SidecarMode",
+			spec: rayv1.RayJobSpec{
+				SubmissionMode: rayv1.SidecarMode,
+				RayClusterSpec: &rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "ray-head"},
+									{Name: SubmitterContainerName, Image: "rayproject/ray:2.9.0"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "SidecarMode rejects Command on ray-job-submitter container",
+			spec: rayv1.RayJobSpec{
+				SubmissionMode: rayv1.SidecarMode,
+				RayClusterSpec: &rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "ray-head"},
+									{Name: SubmitterContainerName, Image: "rayproject/ray:2.9.0", Command: []string{"/bin/sh"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "SidecarMode rejects Args on ray-job-submitter container",
+			spec: rayv1.RayJobSpec{
+				SubmissionMode: rayv1.SidecarMode,
+				RayClusterSpec: &rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "ray-head"},
+									{Name: SubmitterContainerName, Image: "rayproject/ray:2.9.0", Args: []string{"--flag"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "SidecarMode rejects Command and Args on ray-job-submitter container",
+			spec: rayv1.RayJobSpec{
+				SubmissionMode: rayv1.SidecarMode,
+				RayClusterSpec: &rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "ray-head"},
+									{Name: SubmitterContainerName, Image: "rayproject/ray:2.9.0", Command: []string{"/bin/sh"}, Args: []string{"script.sh"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "duplicate ray-job-submitter containers rejected in SidecarMode",
+			spec: rayv1.RayJobSpec{
+				SubmissionMode: rayv1.SidecarMode,
+				RayClusterSpec: &rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{Name: "ray-head"},
+									{Name: SubmitterContainerName, Image: "rayproject/ray:2.9.0"},
+									{Name: SubmitterContainerName, Image: "rayproject/ray:2.9.0"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
 			name: "failed to get cluster name in ClusterSelector map",
 			spec: rayv1.RayJobSpec{
 				ClusterSelector: map[string]string{},

--- a/ray-operator/test/e2erayjob/rayjob_sidecar_mode_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_sidecar_mode_test.go
@@ -290,4 +290,112 @@ env_vars:
 
 		LogWithTimestamp(test.T(), "RayJob %s/%s completed successfully with auth token", rayJob.Namespace, rayJob.Name)
 	})
+
+	test.T().Run("Successful RayJob with user-provided submitter container", func(_ *testing.T) {
+		// Create a separate ConfigMap to mount into the user-provided submitter to prove user volume mounts are preserved.
+		sidecarCMAC := corev1ac.ConfigMap("custom-submitter-scripts", namespace.Name).
+			WithData(map[string]string{"hello.txt": "hello from user-provided submitter"})
+		sidecarCM, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), sidecarCMAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Build the head pod template with the user-provided sidecar container already present.
+		headTemplate := PodTemplateSpecApplyConfiguration(
+			HeadPodTemplateApplyConfiguration(),
+			MountConfigMap[corev1ac.PodTemplateSpecApplyConfiguration](jobs, "/home/ray/jobs"),
+		)
+		// Append a user-provided container named "ray-job-submitter" with a custom volume mount.
+		headTemplate.Spec.WithContainers(
+			corev1ac.Container().
+				WithName(utils.SubmitterContainerName).
+				WithImage(GetRayImage()).
+				WithVolumeMounts(corev1ac.VolumeMount().
+					WithName(sidecarCM.Name).
+					WithMountPath("/custom-scripts")),
+		)
+		headTemplate.Spec.WithVolumes(corev1ac.Volume().
+			WithName(sidecarCM.Name).
+			WithConfigMap(corev1ac.ConfigMapVolumeSource().WithName(sidecarCM.Name)))
+
+		rayJobAC := rayv1ac.RayJob("custom-submitter-counter", namespace.Name).
+			WithSpec(rayv1ac.RayJobSpec().
+				WithSubmissionMode(rayv1.SidecarMode).
+				WithEntrypoint("python /home/ray/jobs/counter.py").
+				WithRuntimeEnvYAML(`
+env_vars:
+  counter_name: test_counter
+`).
+				WithShutdownAfterJobFinishes(false).
+				WithRayClusterSpec(rayv1ac.RayClusterSpec().
+					WithRayVersion(GetRayVersion()).
+					WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+						WithRayStartParams(map[string]string{"dashboard-host": "0.0.0.0"}).
+						WithTemplate(headTemplate))))
+
+		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(test.T(), "Created RayJob %s/%s with user-provided submitter container successfully", rayJob.Namespace, rayJob.Name)
+
+		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+
+		// Assert the RayJob has completed successfully
+		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)))
+
+		// And the RayJob deployment status is updated accordingly
+		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
+
+		// Refresh the RayJob status
+		rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Verify the submitter container is present on the head pod and retains the user's volume mount.
+		rayCluster, err := GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		headPod, err := GetHeadPod(test, rayCluster)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(headPod).NotTo(BeNil())
+
+		var submitterContainer *corev1.Container
+		for i := range headPod.Spec.Containers {
+			if headPod.Spec.Containers[i].Name == utils.SubmitterContainerName {
+				submitterContainer = &headPod.Spec.Containers[i]
+				break
+			}
+		}
+		g.Expect(submitterContainer).NotTo(BeNil(), "submitter container should be present in head pod")
+
+		// Verify the user's custom volume mount was preserved.
+		hasCustomMount := false
+		for _, vm := range submitterContainer.VolumeMounts {
+			if vm.MountPath == "/custom-scripts" {
+				hasCustomMount = true
+				break
+			}
+		}
+		g.Expect(hasCustomMount).To(BeTrue(), "user's custom volume mount should be preserved on the submitter container")
+
+		// Verify that the controller injected the required environment variables.
+		envMap := make(map[string]string)
+		for _, env := range submitterContainer.Env {
+			envMap[env.Name] = env.Value
+		}
+		g.Expect(envMap).To(HaveKey(utils.RAY_DASHBOARD_ADDRESS), "RAY_DASHBOARD_ADDRESS should be injected")
+		g.Expect(envMap).To(HaveKey(utils.RAY_JOB_SUBMISSION_ID), "RAY_JOB_SUBMISSION_ID should be injected")
+
+		// Verify the user's image was preserved (not overwritten).
+		g.Expect(submitterContainer.Image).To(Equal(GetRayImage()), "user-specified image should be preserved")
+
+		// Verify there is no duplicate submitter container.
+		submitterCount := 0
+		for _, c := range headPod.Spec.Containers {
+			if c.Name == utils.SubmitterContainerName {
+				submitterCount++
+			}
+		}
+		g.Expect(submitterCount).To(Equal(1), "there should be exactly one submitter container")
+	})
 }


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change allows users to specify a container in the head pod group to be used as the submitter pod when using sidecar submission mode.
This is an alternate approach to https://github.com/ray-project/kuberay/pull/4477 which does not increase the API surface area for kuberay but still allows the sidecar submitter container to specify / use volume mounts and env vars during ray job submission.

## Related issue number
Fixes #4197 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
