### PR TITLE
fix: include metadata in RayJob submit command when using clusterSelector

### DIFF
--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -60,20 +60,24 @@ func getRuntimeEnvJson(rayJobInstance *rayv1.RayJob) (string, error) {
 	return "", nil
 }
 
-// GetMetadataJson returns the JSON string of the metadata for the Ray job.
-func GetMetadataJson(metadata map[string]string, rayVersion string) (string, error) {
-	// Check that the Ray version is at least 2.6.0.
-	// If it is, we can use the --metadata-json flag.
-	// Otherwise, we need to raise an error.
-	constraint, _ := semver.NewConstraint(">= 2.6.0")
-	v, err := semver.NewVersion(rayVersion)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse Ray version: %v: %w", rayVersion, err)
+// getMetadataJSONForSubmitCommand serializes job metadata for `ray job submit --metadata-json`.
+// Ray added --metadata-json in 2.6.0, so the only rejected case is when
+// RayJob.Spec.RayClusterSpec.RayVersion is explicitly set below 2.6.0. If RayClusterSpec is
+// absent (clusterSelector) or RayVersion is unset, we assume the cluster is >= 2.6.0.
+func getMetadataJSONForSubmitCommand(rayJobInstance *rayv1.RayJob, metadata map[string]string) (string, error) {
+	if rayJobInstance.Spec.RayClusterSpec != nil {
+		rv := rayJobInstance.Spec.RayClusterSpec.RayVersion
+		if len(rv) > 0 {
+			constraint, _ := semver.NewConstraint(">= 2.6.0")
+			v, err := semver.NewVersion(rv)
+			if err != nil {
+				return "", fmt.Errorf("failed to parse Ray version: %v: %w", rv, err)
+			}
+			if !constraint.Check(v) {
+				return "", fmt.Errorf("the Ray version must be at least 2.6.0 to use the metadata field")
+			}
+		}
 	}
-	if !constraint.Check(v) {
-		return "", fmt.Errorf("the Ray version must be at least 2.6.0 to use the metadata field")
-	}
-	// Convert the metadata map to a JSON string.
 	metadataBytes, err := json.Marshal(metadata)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal metadata: %v: %w", metadata, err)
@@ -163,8 +167,8 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 		cmd = append(cmd, "--runtime-env-json", strconv.Quote(runtimeEnvJson))
 	}
 
-	if len(metadata) > 0 && rayJobInstance.Spec.RayClusterSpec != nil {
-		metadataJson, err := GetMetadataJson(metadata, rayJobInstance.Spec.RayClusterSpec.RayVersion)
+	if len(metadata) > 0 {
+		metadataJson, err := getMetadataJSONForSubmitCommand(rayJobInstance, metadata)
 		if err != nil {
 			return nil, err
 		}

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -68,14 +68,6 @@ pip: ["python-multipart==0.0.6"]
 	assert.Equal(t, expectedMap, actualMap)
 }
 
-func TestGetMetadataJson(t *testing.T) {
-	testRayJob := rayJobTemplate()
-	expected := `{"testKey":"testValue"}`
-	metadataJson, err := GetMetadataJson(testRayJob.Spec.Metadata, testRayJob.Spec.RayClusterSpec.RayVersion)
-	require.NoError(t, err)
-	assert.JSONEq(t, expected, metadataJson)
-}
-
 func TestBuildJobSubmitCommandWithK8sJobMode(t *testing.T) {
 	testRayJob := rayJobTemplate()
 	expected := []string{
@@ -173,7 +165,6 @@ func TestBuildJobSubmitCommandWithSidecarModeVersionSwitch(t *testing.T) {
 					},
 				},
 			}
-
 			command, err := BuildJobSubmitCommand(testRayJob, rayv1.SidecarMode)
 			require.NoError(t, err)
 			require.GreaterOrEqual(t, len(command), 2)
@@ -198,7 +189,6 @@ func TestBuildJobSubmitCommandWithSidecarModeCustomDashboardPort(t *testing.T) {
 			},
 		},
 	}
-
 	command, err := BuildJobSubmitCommand(testRayJob, rayv1.SidecarMode)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(command), 2)
@@ -213,10 +203,10 @@ func TestBuildJobSubmitCommandWithK8sJobModeNoSidecarHealthWaitLoop(t *testing.T
 	command, err := BuildJobSubmitCommand(testRayJob, rayv1.K8sJobMode)
 	require.NoError(t, err)
 	assert.NotContains(t, command, "until")
-	for _, token := range command {
-		assert.NotContains(t, token, utils.RayDashboardGCSHealthPath)
-		assert.NotContains(t, token, "python -c")
-		assert.NotContains(t, token, "wget")
+	for _, arg := range command {
+		assert.NotContains(t, arg, utils.RayDashboardGCSHealthPath)
+		assert.NotContains(t, arg, "python -c")
+		assert.NotContains(t, arg, "wget")
 	}
 }
 
@@ -285,7 +275,73 @@ pip: ["python-multipart==0.0.6"]
 	}
 }
 
-func TestMetadataRaisesErrorBeforeRay26(t *testing.T) {
+// TestBuildJobSubmitCommandWithClusterSelector verifies that metadata is included
+// when submitting a RayJob to an existing cluster via clusterSelector (no RayClusterSpec,
+// so we can't know the Ray version without looking up the RayCluster; we assume >= 2.6).
+func TestBuildJobSubmitCommandWithClusterSelector(t *testing.T) {
+	rayJobWithClusterSelector := &rayv1.RayJob{
+		Spec: rayv1.RayJobSpec{
+			ClusterSelector: map[string]string{
+				"ray.io/cluster": "existing-cluster",
+			},
+			Metadata: map[string]string{
+				"tenant": "tenant1",
+				"team":   "ml-platform",
+			},
+			Entrypoint: "python /app/batch_inference.py",
+		},
+		Status: rayv1.RayJobStatus{
+			DashboardURL: "http://existing-cluster-head-svc:8265",
+			JobId:        "cluster-selector-job-id",
+		},
+	}
+
+	command, err := BuildJobSubmitCommand(rayJobWithClusterSelector, rayv1.K8sJobMode)
+	require.NoError(t, err)
+
+	hasMetadataFlag := false
+	for i, arg := range command {
+		if arg == "--metadata-json" {
+			hasMetadataFlag = true
+			require.Greater(t, len(command), i+1)
+			unquoted, err := strconv.Unquote(command[i+1])
+			require.NoError(t, err)
+			var metadata map[string]string
+			require.NoError(t, json.Unmarshal([]byte(unquoted), &metadata))
+			assert.Equal(t, "tenant1", metadata["tenant"])
+			assert.Equal(t, "ml-platform", metadata["team"])
+			break
+		}
+	}
+	assert.True(t, hasMetadataFlag, "metadata-json flag should be present when using clusterSelector with metadata")
+}
+
+// TestBuildJobSubmitCommandWithUnparseableRayVersion verifies that metadata is
+// rejected when RayJob.Spec.RayClusterSpec.RayVersion is set to a non-semver string. A user
+// who went to the trouble of typing a version should fail fast rather than silently proceed.
+func TestBuildJobSubmitCommandWithUnparseableRayVersion(t *testing.T) {
+	rayJob := &rayv1.RayJob{
+		Spec: rayv1.RayJobSpec{
+			RayClusterSpec: &rayv1.RayClusterSpec{
+				RayVersion: "not-a-version",
+			},
+			Metadata: map[string]string{
+				"testKey": "testValue",
+			},
+			Entrypoint: "echo hello",
+		},
+		Status: rayv1.RayJobStatus{
+			DashboardURL: "http://127.0.0.1:8265",
+			JobId:        "testJobId",
+		},
+	}
+	_, err := BuildJobSubmitCommand(rayJob, rayv1.K8sJobMode)
+	require.Error(t, err)
+}
+
+// TestBuildJobSubmitCommandWithOldRayVersion verifies that metadata is
+// rejected when RayJob.Spec.RayClusterSpec.RayVersion is explicitly set below 2.6.0.
+func TestBuildJobSubmitCommandWithOldRayVersion(t *testing.T) {
 	rayJob := &rayv1.RayJob{
 		Spec: rayv1.RayJobSpec{
 			RayClusterSpec: &rayv1.RayClusterSpec{
@@ -294,10 +350,51 @@ func TestMetadataRaisesErrorBeforeRay26(t *testing.T) {
 			Metadata: map[string]string{
 				"testKey": "testValue",
 			},
+			Entrypoint: "echo hello",
+		},
+		Status: rayv1.RayJobStatus{
+			DashboardURL: "http://127.0.0.1:8265",
+			JobId:        "testJobId",
 		},
 	}
-	_, err := GetMetadataJson(rayJob.Spec.Metadata, rayJob.Spec.RayClusterSpec.RayVersion)
+	_, err := BuildJobSubmitCommand(rayJob, rayv1.K8sJobMode)
 	require.Error(t, err)
+}
+
+// TestBuildJobSubmitCommandWithUnsetRayVersion verifies that
+// metadata is still included when RayClusterSpec is present but RayVersion is empty. We assume
+// the cluster is >= 2.6.0 unless the user explicitly sets a lower version.
+func TestBuildJobSubmitCommandWithUnsetRayVersion(t *testing.T) {
+	rayJob := &rayv1.RayJob{
+		Spec: rayv1.RayJobSpec{
+			RayClusterSpec: &rayv1.RayClusterSpec{},
+			Metadata: map[string]string{
+				"testKey": "testValue",
+			},
+			Entrypoint: "echo hello",
+		},
+		Status: rayv1.RayJobStatus{
+			DashboardURL: "http://127.0.0.1:8265",
+			JobId:        "testJobId",
+		},
+	}
+	command, err := BuildJobSubmitCommand(rayJob, rayv1.K8sJobMode)
+	require.NoError(t, err)
+
+	hasMetadataFlag := false
+	for i, arg := range command {
+		if arg == "--metadata-json" {
+			hasMetadataFlag = true
+			require.Greater(t, len(command), i+1)
+			unquoted, err := strconv.Unquote(command[i+1])
+			require.NoError(t, err)
+			var metadata map[string]string
+			require.NoError(t, json.Unmarshal([]byte(unquoted), &metadata))
+			assert.Equal(t, "testValue", metadata["testKey"])
+			break
+		}
+	}
+	assert.True(t, hasMetadataFlag, "metadata-json flag should be present when RayVersion is unset")
 }
 
 func TestGetSubmitterTemplate(t *testing.T) {


### PR DESCRIPTION
## Why are these changes needed?

When submitting a RayJob to an existing RayCluster via `clusterSelector`, the user-defined `metadata` field is not included in the `ray job submit` command, even though it's specified in the RayJob YAML.

**Root cause:** The code only set `--metadata-json` when `RayClusterSpec != nil` to access `RayVersion` for version checking. However, in `clusterSelector` mode, `RayClusterSpec` is `nil` because we're pointing to an existing cluster rather than creating a new one.

**Fix:** Pass the actual `RayCluster` instance to `BuildJobSubmitCommand` and get the `RayVersion` from the cluster directly. This works for both modes:
- Creating a new cluster via `RayClusterSpec`
- Using an existing cluster via `clusterSelector`

## Related issue number

Closes #4589 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

- Ran `make test` and all tests passed
- Added a new unit test `TestBuildJobSubmitCommandWithClusterSelector` that specifically verifies metadata is included when using `clusterSelector` mode (the bug scenario from #4589 )

<img width="1119" height="243" alt="Screenshot 2026-03-18 at 8 58 38 AM" src="https://github.com/user-attachments/assets/7603d2ca-6ce7-49bf-9687-c8f54099b432" />



