### PR TITLE
[History Server] Add guide to push image to Google Artifact Registry for History Server images

### DIFF
--- a/historyserver/docs/image-build-push-guide.md
+++ b/historyserver/docs/image-build-push-guide.md
@@ -1,0 +1,103 @@
+# Guide: Pushing Docker Images to Registry
+
+This guide outlines the process for tagging,
+and pushing your Docker images to a docker repository.
+
+## Prerequisites
+
+* **Docker:** Installed and running on your local machine.
+* **KubeRay:** Minimum version v1.6
+
+## 1. Build History Server and Collector image
+
+Navigate to the `kuberay/` dir and run:
+
+```sh
+make -C historyserver localimage-build
+```
+
+This will build the following images
+
+1. historyserver:v0.1.0
+2. collector:v0.1.0
+
+## 2. Tag Image
+
+Registry tags usually follow the following format:
+`<REGISTRY_HOST>/<PATH>/<IMAGE_NAME>:<TAG>`
+
+Run the following to tag the Collector and History Server images
+
+```sh
+docker tag historyserver:v0.1.0 <REGISTRY_HOST>/<PATH>/historyserver:v0.1.0
+docker tag collector:v0.1.0 <REGISTRY_HOST>/<PATH>/collector:v0.1.0
+```
+
+## 3. Push image
+
+Once tagged, upload the image to the registry:
+
+```sh
+docker push <REGISTRY_HOST>/<PATH>/historyserver:v0.1.0
+docker push <REGISTRY_HOST>/<PATH>/collector:v0.1.0
+```
+
+---
+
+## Google Artifact Registry
+
+Additional steps specific for pushing to Google Artifact Registry
+
+### Requirements
+
+* **Cloud Project:** An active cloud project.
+* **GCloud SDK:** Installed and initialized (`gcloud init`).
+* **Permissions:** Ensure the **Artifact Registry API** is enabled and you have at
+least the `roles/artifactregistry.writer` IAM role.
+
+### Additional Configurations
+
+| Variable | Description|
+|---|---|
+| REGION | The physical location of your repository (e.g., us-east1) |
+| PROJECT_ID | Google Cloud Project ID |
+| REPO_NAME | AR Repository Name |
+
+#### Set configurable variables
+
+```sh
+export REGION=<location>
+export PROJECT_ID=<project-id>
+export REPO_NAME=<repository-name>
+```
+
+### (Optional) Create Artifact Registry Repository
+
+```sh
+gcloud artifacts repositories create ${REPO_NAME} \\
+    --repository-format=docker \\
+    --location=${REGION} \\
+    --description="History Server images"
+```
+
+### Configure `gcloud`
+
+Configure Docker CLI to authenticate with Google Artifact Registry (AR)
+
+```sh
+gcloud auth configure-docker ${REGION}-docker.pkg.dev
+```
+
+## Tagging Artifact Registry Images
+
+The image have to follows a specific naming convention for Google Artifact Registry
+
+Format:
+
+`${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/${IMAGE_NAME}:${TAG}`
+
+Perform the push on the tagged images. Example for the history server image:
+
+```sh
+docker tag historyserver:v0.1.0 ${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/historyserver:v0.1.0
+```

--- a/historyserver/go.mod
+++ b/historyserver/go.mod
@@ -11,10 +11,10 @@ require (
 	github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible
 	github.com/aliyun/credentials-go v1.4.7
 	github.com/aws/aws-sdk-go v1.55.8
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/emicklei/go-restful/v3 v3.13.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/fsouza/fake-gcs-server v1.53.1
-	github.com/google/martian/v3 v3.3.3
 	github.com/onsi/gomega v1.38.2
 	github.com/ray-project/kuberay/ray-operator v1.5.1
 	github.com/sirupsen/logrus v1.9.3
@@ -105,7 +105,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.35.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Why are these changes needed?
Users currently have to build their own history-server image. This just adds a guide to push those images to Google Artifact Registry

## Related issue number
N/A

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
