### PR TITLE
[History Server] Typo and minor fix for image guide readme 

### DIFF
--- a/historyserver/docs/image-build-push-guide.md
+++ b/historyserver/docs/image-build-push-guide.md
@@ -74,9 +74,9 @@ export REPO_NAME=<repository-name>
 ### (Optional) Create Artifact Registry Repository
 
 ```sh
-gcloud artifacts repositories create ${REPO_NAME} \\
-    --repository-format=docker \\
-    --location=${REGION} \\
+gcloud artifacts repositories create ${REPO_NAME} \
+    --repository-format=docker \
+    --location=${REGION} \
     --description="History Server images"
 ```
 
@@ -90,7 +90,7 @@ gcloud auth configure-docker ${REGION}-docker.pkg.dev
 
 ## Tagging Artifact Registry Images
 
-The image have to follows a specific naming convention for Google Artifact Registry
+The image has to follow a specific naming convention for Google Artifact Registry
 
 Format:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why are these changes needed?
This PR fixes some minor typos and errors to the image build guide readme.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
