### PR TITLE
Bump kind config to use v1.35.0 for supported k8s clusters

### DIFF
--- a/.buildkite/setup-env.sh
+++ b/.buildkite/setup-env.sh
@@ -18,8 +18,8 @@ bash scripts/install-docker.sh
 kind delete clusters --all
 
 # Install kubectl.
-curl -LO https://dl.k8s.io/release/v1.27.3/bin/linux/amd64/kubectl
-curl -LO "https://dl.k8s.io/release/v1.27.3/bin/linux/amd64/kubectl.sha256"
+curl -LO https://dl.k8s.io/release/v1.35.0/bin/linux/amd64/kubectl
+curl -LO "https://dl.k8s.io/release/v1.35.0/bin/linux/amd64/kubectl.sha256"
 echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
 install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 

--- a/.github/workflows/actions/kind/action.yml
+++ b/.github/workflows/actions/kind/action.yml
@@ -35,11 +35,22 @@ runs:
         EOF'
 
     - name: Setup KinD cluster
-      uses: helm/kind-action@v1.12.0
+      uses: helm/kind-action@v1.14.0
       with:
         cluster_name: cluster
-        version: v0.24.0
+        version: v0.31.0
         config: ${{ env.KIND_CONFIG_FILE }}
+
+    - name: Configure registry on kind nodes
+      shell: bash
+      run: |
+        for node in $(kind get nodes --name cluster); do
+          docker exec "${node}" mkdir -p "/etc/containerd/certs.d/${REGISTRY_ADDRESS}"
+          docker exec -i "${node}" sh -c "cat > /etc/containerd/certs.d/${REGISTRY_ADDRESS}/hosts.toml" <<EOF
+        [host."http://${REGISTRY_ADDRESS}"]
+          capabilities = ["pull", "resolve", "push"]
+        EOF
+        done
 
     - name: Print cluster info
       shell: bash

--- a/.github/workflows/actions/kind/kind.yaml
+++ b/.github/workflows/actions/kind/kind.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.29.0
+    image: kindest/node:v1.35.0
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration
@@ -11,5 +11,5 @@ nodes:
             node-labels: "ingress-ready=true"
 containerdConfigPatches:
   - |-
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."${REGISTRY_ADDRESS}"]
-      endpoint = ["http://${REGISTRY_ADDRESS}"]
+    [plugins."io.containerd.cri.v1.images".registry]
+      config_path = "/etc/containerd/certs.d"

--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -27,7 +27,7 @@ Create a local Kubernetes cluster using [Kind](https://kind.sigs.k8s.io/). If yo
 have a Kubernetes cluster, you can skip this step.
 
 ```sh
-kind create cluster --image=kindest/node:v1.29.0
+kind create cluster --image=kindest/node:v1.35.0
 ```
 
 #### Install KubeRay Operator
@@ -106,7 +106,7 @@ The following steps allow you to validate the integration of the KubeRay APIServ
     apiVersion: kind.x-k8s.io/v1alpha4
     nodes:
     - role: control-plane
-      image: kindest/node:v1.29.0
+      image: kindest/node:v1.35.0
       kubeadmConfigPatches:
         - |
           kind: InitConfiguration
@@ -132,9 +132,9 @@ The following steps allow you to validate the integration of the KubeRay APIServ
         hostPort: 31887
         listenAddress: "0.0.0.0"
     - role: worker
-      image: kindest/node:v1.29.0
+      image: kindest/node:v1.35.0
     - role: worker
-      image: kindest/node:v1.29.0
+      image: kindest/node:v1.35.0
     EOF
     ```
 

--- a/apiserver/hack/kind-cluster-config.yaml
+++ b/apiserver/hack/kind-cluster-config.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.29.0
+  image: kindest/node:v1.35.0
   kubeadmConfigPatches:
     - |
       kind: InitConfiguration

--- a/apiserversdk/docs/installation.md
+++ b/apiserversdk/docs/installation.md
@@ -6,7 +6,7 @@ This step creates a local Kubernetes cluster using [Kind](https://kind.sigs.k8s.
 cluster, you can skip this step.
 
 ```sh
-kind create cluster --image=kindest/node:v1.29.0
+kind create cluster --image=kindest/node:v1.35.0
 ```
 
 ## Step 2: Deploy a KubeRay operator

--- a/apiserversdk/docs/raycluster-quickstart.md
+++ b/apiserversdk/docs/raycluster-quickstart.md
@@ -9,7 +9,7 @@ This step creates a local Kubernetes cluster using [Kind](https://kind.sigs.k8s.
 If you already have a Kubernetes cluster, you can skip this step.
 
 ```sh
-kind create cluster --image=kindest/node:v1.29.0
+kind create cluster --image=kindest/node:v1.35.0
 ```
 
 ## Step 2: Install KubeRay operator and APIServer

--- a/apiserversdk/docs/rayjob-quickstart.md
+++ b/apiserversdk/docs/rayjob-quickstart.md
@@ -9,7 +9,7 @@ This step creates a local Kubernetes cluster using [Kind](https://kind.sigs.k8s.
 cluster, you can skip this step.
 
 ```sh
-kind create cluster --image=kindest/node:v1.29.0
+kind create cluster --image=kindest/node:v1.35.0
 ```
 
 ## Step 2: Install KubeRay operator and APIServer

--- a/apiserversdk/docs/rayservice-quickstart.md
+++ b/apiserversdk/docs/rayservice-quickstart.md
@@ -9,7 +9,7 @@ This step creates a local Kubernetes cluster using [Kind](https://kind.sigs.k8s.
 cluster, you can skip this step.
 
 ```sh
-kind create cluster --image=kindest/node:v1.29.0
+kind create cluster --image=kindest/node:v1.35.0
 ```
 
 ## Step 2: Install KubeRay operator and APIServer

--- a/benchmark/perf-tests/README.md
+++ b/benchmark/perf-tests/README.md
@@ -47,7 +47,7 @@ You can test clusterloader2 configs using Kind.
 First create a kind cluster:
 
 ```sh
-kind create cluster --image=kindest/node:v1.29.0
+kind create cluster --image=kindest/node:v1.35.0
 ```
 
 Install KubeRay;

--- a/historyserver/docs/set_up_collector.md
+++ b/historyserver/docs/set_up_collector.md
@@ -50,7 +50,8 @@ git clone https://github.com/ray-project/kuberay.git
 cd kuberay
 
 # Spin up a kind cluster.
-kind create cluster --image=kindest/node:v1.29.0
+kind create cluster --image=kindest/node:v1.35.0
+
 
 # Build the KubeRay operator image.
 IMG=kuberay/operator:latest make -C ray-operator docker-build

--- a/historyserver/docs/set_up_historyserver.md
+++ b/historyserver/docs/set_up_historyserver.md
@@ -12,7 +12,7 @@
 ### 1. Create Kind Cluster
 
 ```bash
-kind create cluster --image=kindest/node:v1.29.0
+kind create cluster --image=kindest/node:v1.35.0
 ```
 
 ### 2. Build and Run Ray Operator

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -62,7 +62,7 @@ make clean
 
 ```bash
 # Step 1: Create a Kind cluster
-kind create cluster --image=kindest/node:v1.29.0
+kind create cluster --image=kindest/node:v1.35.0
 
 # Step 2: Modify KubeRay source code
 # For example, add a log by adding setupLog.Info("Hello KubeRay") in the function `main` in `main.go`.
@@ -106,7 +106,7 @@ There are configuable variables in the script, the defaults are shown below:
 ```bash
 IMAGE_TAG="kuberay-dev"
 KIND_CLUSTER_NAME="kuberay-dev"
-KIND_NODE_IMAGE="kindest/node:v1.29.0"
+KIND_NODE_IMAGE="kindest/node:v1.35.0"
 ```
 
 Additionally, you can run the script with a `-l` or `--logs` to stream the logs of the ray operator to the terminal after installation.
@@ -124,7 +124,8 @@ cd ..
 
 ```bash
 # Step 1: Create a Kind cluster
-kind create cluster --image=kindest/node:v1.29.0
+kind create cluster --image=kindest/node:v1.35.0
+
 
 # Step 2: Install CRDs
 make -C ray-operator install

--- a/ray-operator/hack/local_deploy.sh
+++ b/ray-operator/hack/local_deploy.sh
@@ -9,7 +9,7 @@ RAY_OPERATOR_PATH="${PROJECT_ROOT}/ray-operator"
 # --- Configuration Variables ---
 IMAGE_TAG="${IMAGE_TAG:=kuberay-dev}"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:=kuberay-dev}"
-KIND_NODE_IMAGE="${KIND_NODE_IMAGE:=kindest/node:v1.29.0}"
+KIND_NODE_IMAGE="${KIND_NODE_IMAGE:=kindest/node:v1.35.0}"
 
 delete_kind_cluster() {
   echo "--- Deleting Kind Cluster ---"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
~~Currently we are using kubernetes clusters that are no longer supported at v1.29.0~~ .  
There have been changes made to use in ci with kind clusters at v1.35.0.

This is to ensure we can stay compatible with future versions of kubernetes where this may be ran. 

<!-- Please give a short summary of the change and the problem this solves. -->
- [x] Updated kind configs and documents to use v1.35.0 instead of v1.29.0
- [x] Updated ci and github actions to use newer helm/kind-action and version v0.31.0 of kind (which defaults to v1.35.0) 

## Related issue number
Closes #4606 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
