### PR TITLE
[History Server] Add Google Cloud storage history server deployment example

### DIFF
--- a/historyserver/config/historyserver-gcs.yaml
+++ b/historyserver/config/historyserver-gcs.yaml
@@ -1,0 +1,50 @@
+# Ensure that the env var GCS_BUCKET is set before applying
+apiVersion: v1
+kind: Service
+metadata:
+  name: historyserver
+  labels:
+    app: historyserver
+spec:
+  selector:
+    app: historyserver
+  ports:
+  - protocol: TCP
+    name: http
+    port: 30080
+    targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: historyserver-demo
+  labels:
+    app: historyserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: historyserver
+  template:
+    metadata:
+      labels:
+        app: historyserver
+    spec:
+      serviceAccountName: historyserver
+      containers:
+      - name: historyserver
+        env:
+          - name: GCS_BUCKET
+            value: "${GCS_BUCKET}"
+        image: historyserver:v0.1.0
+        imagePullPolicy: IfNotPresent
+        command:
+        - historyserver
+        - --runtime-class-name=gcs
+        - --ray-root-dir=log
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: "500m"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Why are these changes needed?
Add a history server deployment manifest example for Google Cloud Storage.

## Related issue number
N/A

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
