### PR TITLE
[historyserver] Fix S3 client to use default credential chain when static credentials are not provided

### DIFF
--- a/historyserver/pkg/storage/s3/s3.go
+++ b/historyserver/pkg/storage/s3/s3.go
@@ -339,9 +339,16 @@ func New(c *config) (*RayLogsHandler, error) {
 		Timeout: 5 * time.Second,
 	}
 
+	// Only use static credentials when explicitly provided; otherwise let the
+	// SDK fall back to the default credential chain (IRSA, instance role, etc.).
+	var creds *credentials.Credentials
+	if c.S3ID != "" {
+		creds = credentials.NewStaticCredentials(c.S3ID, c.S3Secret, c.S3Token)
+	}
+
 	// Create AWS session
 	sess, err := session.NewSession(&aws.Config{
-		Credentials:      credentials.NewStaticCredentials(c.S3ID, c.S3Secret, c.S3Token),
+		Credentials:      creds,
 		Endpoint:         aws.String(c.S3Endpoint),
 		Region:           aws.String(c.S3Region),
 		HTTPClient:       httpClient,


### PR DESCRIPTION
## Why are these changes needed?

The `New()` function in `historyserver/pkg/storage/s3/s3.go` always creates static credentials via `credentials.NewStaticCredentials(c.S3ID, c.S3Secret, c.S3Token)`, even when `AWS_S3ID` / `AWS_S3SECRET` are not set.

When these env vars are empty strings (the normal case on EKS with IRSA), the AWS SDK treats them as explicitly-provided empty credentials rather than falling back to the default credential chain (IRSA web identity token, instance role, etc.), causing `EmptyStaticCreds: static credentials are empty`.

This affects both the historyserver and the collector sidecar since they share the same code.

## Changes

Only set static credentials when `c.S3ID` is actually provided. When `nil` is passed as `Credentials`, the SDK uses its default credential chain (IRSA, instance profile, environment variables, etc.).

Fixes #4652