### PR TITLE
[Fix] [Flaky] Insert firewall rules to the correct table

### DIFF
--- a/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
@@ -117,10 +117,10 @@ func TestOldHeadPodFailDuringUpgrade(t *testing.T) {
 	curlCmd := []string{
 		"curl", "-sS", "-f", "--connect-timeout", "3", "--max-time", "5", "-X", "GET", healthURL,
 	}
-	g.Eventually(func(gg Gomega) {
+	g.Eventually(func() error {
 		_, _, curlErr := ExecPodCmdWithError(test, curlPod, curlContainerName, curlCmd)
-		gg.Expect(curlErr).To(HaveOccurred(), "iptables should block TCP :8000 like CheckProxyActorHealth would fail")
-	}, TestTimeoutShort, 2*time.Second).Should(Succeed())
+		return curlErr
+	}, TestTimeoutShort, 2*time.Second).Should(HaveOccurred(), "iptables should block TCP :8000 like CheckProxyActorHealth would fail")
 
 	LogWithTimestamp(test.T(), "Checking that the old Head Pod's label `ray.io/serve` is `false` because it is not healthy")
 	g.Eventually(func(g Gomega) string {


### PR DESCRIPTION
## Why are these changes needed?

In the Buildkite agent, the `iptables` userspace tool may target a different backend (nft vs legacy) than the one used by the kernel datapath, causing rules inserted via `iptables` to have no effect. As a short-term fix, this PR inserts rules into both `x_tables` and `nftables` to ensure they are applied regardless of the active backend (kernel subsystem).

## Related issue number

https://github.com/ray-project/kuberay/issues/4660

This issue will remain open until a more robust solution is identified.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
