### PR TITLE
[History Server] Restructure metadir file structure to include owner kind and name

### DIFF
--- a/historyserver/cmd/collector/main.go
+++ b/historyserver/cmd/collector/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/collector"
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/eventcollector"
@@ -33,6 +34,8 @@ func main() {
 	eventsPort := 8080
 	pushInterval := time.Minute
 	runtimeClassConfigPath := "/var/collector-config/data"
+	ownerKind := ""
+	ownerName := ""
 
 	flag.StringVar(&role, "role", "Worker", "")
 	flag.StringVar(&runtimeClassName, "runtime-class-name", "", "")
@@ -43,8 +46,14 @@ func main() {
 	flag.IntVar(&eventsPort, "events-port", 8080, "")
 	flag.StringVar(&runtimeClassConfigPath, "runtime-class-config-path", "", "") //"/var/collector-config/data"
 	flag.DurationVar(&pushInterval, "push-interval", time.Minute, "")
+	flag.StringVar(&ownerKind, "owner-kind", "", "")
+	flag.StringVar(&ownerName, "owner-name", "", "")
 
 	flag.Parse()
+
+	if err := validateFlags(&rayClusterName, &rayClusterNamespace, &ownerKind, &ownerName); err != nil {
+		logrus.Fatalf("Failed to validate flags: %v", err)
+	}
 
 	var additionalEndpoints []string
 	if epStr := os.Getenv("RAY_COLLECTOR_ADDITIONAL_ENDPOINTS"); epStr != "" {
@@ -108,6 +117,8 @@ func main() {
 		PushInterval:        pushInterval,
 		LogBatching:         logBatching,
 		DashboardAddress:    os.Getenv("RAY_DASHBOARD_ADDRESS"),
+		OwnerKind:           ownerKind,
+		OwnerName:           ownerName,
 
 		AdditionalEndpoints:  additionalEndpoints,
 		EndpointPollInterval: endpointPollInterval,
@@ -151,4 +162,31 @@ func main() {
 	// Wait for both goroutines to complete
 	wg.Wait()
 	logrus.Info("Graceful shutdown complete")
+}
+
+func validateFlags(rayClusterName, rayClusterNamespace, ownerKind, ownerName *string) error {
+	*rayClusterName = strings.TrimSpace(*rayClusterName)
+	*rayClusterNamespace = strings.TrimSpace(*rayClusterNamespace)
+
+	if errs := validation.IsDNS1123Subdomain(*rayClusterName); len(errs) > 0 {
+		return fmt.Errorf("invalid ray-cluster-name %q: %s", *rayClusterName, strings.Join(errs, ", "))
+	}
+	if errs := validation.IsDNS1123Subdomain(*rayClusterNamespace); len(errs) > 0 {
+		return fmt.Errorf("invalid ray-cluster-namespace %q: %s", *rayClusterNamespace, strings.Join(errs, ", "))
+	}
+
+	*ownerKind = strings.ToLower(strings.TrimSpace(*ownerKind))
+	*ownerName = strings.TrimSpace(*ownerName)
+	if (*ownerName != "" && *ownerKind == "") || (*ownerName == "" && *ownerKind != "") {
+		return fmt.Errorf("both --owner-name and --owner-kind must be provided together, or both omitted")
+	}
+	if *ownerKind != "" && *ownerKind != utils.RAYJOB_OBJECT_DIR && *ownerKind != utils.RAYSERVICE_OBJECT_DIR {
+		return fmt.Errorf("unsupported owner-kind: %q. Supported kinds are 'rayjob' or 'rayservice'", *ownerKind)
+	}
+	if *ownerName != "" {
+		if errs := validation.IsDNS1123Subdomain(*ownerName); len(errs) > 0 {
+			return fmt.Errorf("invalid owner-name %q: %s", *ownerName, strings.Join(errs, ", "))
+		}
+	}
+	return nil
 }

--- a/historyserver/pkg/collector/eventcollector/eventcollector.go
+++ b/historyserver/pkg/collector/eventcollector/eventcollector.go
@@ -452,12 +452,9 @@ func (ec *EventCollector) flushNodeEventsForHour(hourKey string, events []Event)
 	}
 
 	// Build node event storage path using event's nodeID
-	basePath := path.Join(
-		ec.root,
-		fmt.Sprintf("%s_%s", ec.clusterName, ec.clusterNamespace),
-		sessionNameToUse,
-		"node_events",
-		fmt.Sprintf("%s-%s", nodeIDToUse, hourKey))
+	sessionPath := path.Clean(path.Join(ec.root, utils.AppendRayClusterNameNamespace(ec.clusterName, ec.clusterNamespace), sessionNameToUse))
+
+	basePath := path.Join(sessionPath, "node_events", fmt.Sprintf("%s-%s", nodeIDToUse, hourKey))
 
 	// Ensure storage directory exists
 	dir := path.Dir(basePath)
@@ -502,13 +499,9 @@ func (ec *EventCollector) flushJobEventsForHour(jobID, hourKey string, events []
 	}
 
 	// Build job event storage path using event's nodeID
-	basePath := path.Join(
-		ec.root,
-		fmt.Sprintf("%s_%s", ec.clusterName, ec.clusterNamespace),
-		sessionNameToUse,
-		"job_events",
-		jobID,
-		fmt.Sprintf("%s-%s", nodeIDToUse, hourKey))
+	sessionPath := path.Clean(path.Join(ec.root, utils.AppendRayClusterNameNamespace(ec.clusterName, ec.clusterNamespace), sessionNameToUse))
+
+	basePath := path.Join(sessionPath, "job_events", jobID, fmt.Sprintf("%s-%s", nodeIDToUse, hourKey))
 
 	// Ensure storage directory exists
 	dir := path.Dir(basePath)

--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clustermetadata"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
@@ -30,6 +31,8 @@ type RayLogHandler struct {
 	LogDir                 string
 	RayNodeName            string
 	RayClusterNamespace    string
+	OwnerKind              string
+	OwnerName              string
 	RootDir                string
 	SessionDir             string
 	prevLogsDir            string
@@ -99,17 +102,21 @@ func (r *RayLogHandler) processSessionLatestLogs() {
 	// Extract the real session ID from the resolved path
 	sessionID := filepath.Base(sessionRealDir)
 	if r.IsHead {
-		metadir := path.Join(r.RootDir, "metadir")
-		metafile := path.Clean(metadir + "/" + fmt.Sprintf("%s/%v",
-			utils.AppendRayClusterNameNamespace(r.RayClusterName, r.RayClusterNamespace),
-			path.Base(sessionID),
-		))
+		metafile := clustermetadata.EncodePath(
+			utils.ClusterInfo{
+				Name:      r.RayClusterName,
+				Namespace: r.RayClusterNamespace,
+				OwnerKind: r.OwnerKind,
+				OwnerName: r.OwnerName},
+			r.RootDir,
+			sessionID,
+		)
 		if err := r.Writer.CreateDirectory(path.Dir(metafile)); err != nil {
-			logrus.Errorf("CreateObjectIfNotExist %s error %v", metadir, err)
+			logrus.Errorf("Failed to create directory %s error %v", path.Dir(metafile), err)
 			return
 		}
 		if err := r.Writer.WriteFile(metafile, strings.NewReader("")); err != nil {
-			logrus.Errorf("CreateObjectIfNotExist %s error %v", metafile, err)
+			logrus.Errorf("Failed to write session file %s error %v", metafile, err)
 			return
 		}
 	}
@@ -448,17 +455,20 @@ func (r *RayLogHandler) processSessionPrevLogs(sessionDir string) {
 	sessionID := parts[0]
 	logrus.Infof("Processing all node logs for session: %s", sessionID)
 	if r.IsHead {
-		metadir := path.Join(r.RootDir, "metadir")
-		metafile := path.Clean(metadir + "/" + fmt.Sprintf("%s/%v",
-			utils.AppendRayClusterNameNamespace(r.RayClusterName, r.RayClusterNamespace),
-			path.Base(sessionID),
-		))
+		metafile := clustermetadata.EncodePath(
+			utils.ClusterInfo{
+				Name:      r.RayClusterName,
+				Namespace: r.RayClusterNamespace,
+				OwnerKind: r.OwnerKind,
+				OwnerName: r.OwnerName},
+			r.RootDir,
+			sessionID)
 		if err := r.Writer.CreateDirectory(path.Dir(metafile)); err != nil {
-			logrus.Errorf("CreateObjectIfNotExist %s error %v", metadir, err)
+			logrus.Errorf("Failed to create directory %s error %v", path.Dir(metafile), err)
 			return
 		}
 		if err := r.Writer.WriteFile(metafile, strings.NewReader("")); err != nil {
-			logrus.Errorf("CreateObjectIfNotExist %s error %v", metafile, err)
+			logrus.Errorf("Failed to write session file %s error %v", metafile, err)
 			return
 		}
 	}
@@ -689,14 +699,9 @@ func (r *RayLogHandler) processPrevLogFile(absoluteLogPathName, localLogDir, ses
 	return nil
 }
 
-// meta-dir only stores metadata indicating which clusters have been saved.
-// As long as worker logs are uploaded normally and head writes the metadata,
-// the cluster can be viewed.
 // Any session change triggers sessiondir updates on all head and worker nodes,
 // so we only need to update from one node.
 // for example:
-// metadir/
-//
 //	my-cluster_abc123/
 //		session_2024-12-15_10-30-45_123456    ← Empty file! The path itself is the information
 //		session_2024-12-15_14-20-10_789012
@@ -745,17 +750,21 @@ func (r *RayLogHandler) WatchSessionLatestLoops() {
 			// Handle changes to the symlink
 			if event.Op&(fsnotify.Create|fsnotify.Write) != 0 {
 				sessionID := filepath.Base(event.Name)
-				metadir := path.Join(r.RootDir, "metadir")
-				metafile := path.Clean(metadir + "/" + fmt.Sprintf("%s/%v",
-					utils.AppendRayClusterNameNamespace(r.RayClusterName, r.RayClusterNamespace),
-					path.Base(sessionID),
-				))
+				metafile := clustermetadata.EncodePath(
+					utils.ClusterInfo{
+						Name:      r.RayClusterName,
+						Namespace: r.RayClusterNamespace,
+						OwnerKind: r.OwnerKind,
+						OwnerName: r.OwnerName},
+					r.RootDir,
+					sessionID,
+				)
 				if err := r.Writer.CreateDirectory(path.Dir(metafile)); err != nil {
-					logrus.Errorf("CreateObjectIfNotExist %s error %v", metadir, err)
+					logrus.Errorf("Failed to create directory %s error %v", path.Dir(metafile), err)
 					return
 				}
 				if err := r.Writer.WriteFile(metafile, strings.NewReader("")); err != nil {
-					logrus.Errorf("CreateObjectIfNotExist %s error %v", metafile, err)
+					logrus.Errorf("Failed to write session file %s error %v", metafile, err)
 					return
 				}
 			}

--- a/historyserver/pkg/collector/logcollector/runtime/runtime.go
+++ b/historyserver/pkg/collector/logcollector/runtime/runtime.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/logcollector/runtime/logcollector"
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
@@ -42,10 +44,15 @@ func NewCollector(config *types.RayCollectorConfig, writer storage.StorageWriter
 		Writer:       writer,
 		ShutdownChan: make(chan struct{}),
 	}
+
+	handler.OwnerKind = config.OwnerKind
+	handler.OwnerName = config.OwnerName
+	if handler.OwnerKind != "" && handler.OwnerName != "" {
+		logrus.Infof("The associated owner resource is: %s/%s", handler.OwnerKind, handler.OwnerName)
+	}
+
 	logDir := strings.TrimSpace(filepath.Join(config.SessionDir, utils.RAY_SESSIONDIR_LOGDIR_NAME))
 	handler.LogDir = logDir
-	// clusterRootDir uses flat key format (name_id) for S3/OSS performance optimization.
-	// See utils.connector for the design rationale.
 	clusterRootDir := fmt.Sprintf("%s/", path.Clean(path.Join(handler.RootDir, utils.AppendRayClusterNameNamespace(handler.RayClusterName, handler.RayClusterNamespace))))
 	handler.ClusterDir = clusterRootDir
 

--- a/historyserver/pkg/collector/types/types.go
+++ b/historyserver/pkg/collector/types/types.go
@@ -18,6 +18,8 @@ type RayCollectorConfig struct {
 	Role                string
 	RayClusterName      string
 	RayClusterNamespace string
+	OwnerKind           string
+	OwnerName           string
 	LogBatching         int
 	PushInterval        time.Duration
 	DashboardAddress    string

--- a/historyserver/pkg/storage/aliyunoss/ray/ray.go
+++ b/historyserver/pkg/storage/aliyunoss/ray/ray.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage/aliyunoss/rrsa"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clustermetadata"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
@@ -147,10 +148,12 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 	clusters := make(utils.ClusterInfoList, 0, 10)
 	logrus.Debugf("Prepare to get list clusters info ...")
 
+	prefix := clustermetadata.Prefix(r.OssRootDir)
+
 	getClusters := func() {
 		p := r.OssClient.NewListObjectsV2Paginator(&oss.ListObjectsV2Request{
 			Bucket:    oss.Ptr(r.OssBucket),
-			Prefix:    oss.Ptr(path.Join(r.OssRootDir, "metadir") + "/"),
+			Prefix:    oss.Ptr(prefix),
 			Delimiter: oss.Ptr(""),
 			MaxKeys:   100,
 		})
@@ -158,34 +161,18 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 		for p.HasNext() {
 			page, err := p.NextPage(ctx)
 			if err != nil {
-				logrus.Errorf("Failed to list objects from %s: %v", path.Join(r.OssRootDir, "metadir")+"/", err)
+				logrus.Errorf("Failed to list objects from %s: %v", prefix, err)
 				return
 			}
-			logrus.Infof("[List]Returned objects in %v. length of Contents: %v, length of CommonPrefixes: %v", path.Join(r.OssRootDir, "metadir")+"/", len(page.Contents),
+			logrus.Infof("[List]Returned objects in %v. length of Contents: %v, length of CommonPrefixes: %v", prefix, len(page.Contents),
 				len(page.CommonPrefixes))
 			for _, objects := range page.Contents {
-				c := &utils.ClusterInfo{}
-				metaInfo := strings.Trim(strings.TrimPrefix(*objects.Key, path.Join(r.OssRootDir, "metadir/")), "/")
-				metas := strings.Split(metaInfo, "/")
-				if len(metas) < 2 {
-					continue
-				}
-				logrus.Infof("Process %++v", metas)
-				namespaceName := strings.Split(metas[0], "_")
-				c.Name = namespaceName[0]
-				c.Namespace = namespaceName[1]
-				c.SessionName = metas[1]
-				sessionInfo := strings.Split(metas[1], "_")
-				date := sessionInfo[1]
-				dataTime := sessionInfo[2]
-				createTime, err := time.Parse("2006-01-02_15-04-05", date+"_"+dataTime)
+				c, err := clustermetadata.DecodePath(*objects.Key, r.OssRootDir)
 				if err != nil {
-					logrus.Errorf("Failed to parse time %s: %v", date+"_"+dataTime, err)
+					logrus.Errorf("Failed to parse meta file path: %s, error: %v", *objects.Key, err)
 					continue
 				}
-				c.CreateTimeStamp = createTime.Unix()
-				c.CreateTime = createTime.UTC().Format(("2006-01-02T15:04:05Z"))
-				clusters = append(clusters, *c)
+				clusters = append(clusters, c)
 			}
 		}
 	}

--- a/historyserver/pkg/storage/azureblob/azureblob.go
+++ b/historyserver/pkg/storage/azureblob/azureblob.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clustermetadata"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
@@ -164,52 +165,30 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 	ctx, cancel := context.WithTimeout(context.Background(), listTimeout)
 	defer cancel()
 
-	metadirPrefix := path.Join(r.RootDir, "metadir") + "/"
+	prefix := clustermetadata.Prefix(r.RootDir)
 
 	pager := r.ContainerClient.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
-		Prefix:     &metadirPrefix,
+		Prefix:     &prefix,
 		MaxResults: to32(100),
 	})
 
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)
 		if err != nil {
-			logrus.Errorf("Failed to list blobs from %s: %v", metadirPrefix, err)
+			logrus.Errorf("Failed to list blobs from %s: %v", prefix, err)
 			break
 		}
 
 		logrus.Infof("[List]Returned blobs in %v. length of Segment.BlobItems: %v",
-			metadirPrefix, len(resp.Segment.BlobItems))
+			prefix, len(resp.Segment.BlobItems))
 
 		for _, blob := range resp.Segment.BlobItems {
-			c := &utils.ClusterInfo{}
-			metaInfo := strings.Trim(strings.TrimPrefix(*blob.Name, path.Join(r.RootDir, "metadir/")), "/")
-			metas := strings.Split(metaInfo, "/")
-			if len(metas) < 2 {
-				continue
-			}
-			logrus.Infof("Process %++v", metas)
-			namespaceName := strings.Split(metas[0], "_")
-			if len(namespaceName) < 2 {
-				continue
-			}
-			c.Name = namespaceName[0]
-			c.Namespace = namespaceName[1]
-			c.SessionName = metas[1]
-			sessionInfo := strings.Split(metas[1], "_")
-			if len(sessionInfo) < 3 {
-				continue
-			}
-			date := sessionInfo[1]
-			dataTime := sessionInfo[2]
-			createTime, err := time.Parse("2006-01-02_15-04-05", date+"_"+dataTime)
+			c, err := clustermetadata.DecodePath(*blob.Name, r.RootDir)
 			if err != nil {
-				logrus.Errorf("Failed to parse time %s: %v", date+"_"+dataTime, err)
+				logrus.Errorf("Failed to parse meta file path: %s, error: %v", *blob.Name, err)
 				continue
 			}
-			c.CreateTimeStamp = createTime.Unix()
-			c.CreateTime = createTime.UTC().Format("2006-01-02T15:04:05Z")
-			clusters = append(clusters, *c)
+			clusters = append(clusters, c)
 		}
 	}
 

--- a/historyserver/pkg/storage/clustermetadata/clustermetadata.go
+++ b/historyserver/pkg/storage/clustermetadata/clustermetadata.go
@@ -1,0 +1,100 @@
+package clustermetadata
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+)
+
+const (
+	ClusterMetadataDir = "cluster-metadata"
+	// Without owner: cluster-metadata/raycluster/{namespace}_{cluster_name}/{session_id}
+	metaPartsCountWithoutOwner = 2
+	// With owner:    cluster-metadata/{rayjob|rayservice}/{namespace}_{owner_name}_{cluster_name}/{session_id}
+	metaPartsCountWithOwner    = 3
+)
+
+// EncodePath builds the hierarchical path for a given session ID.
+func EncodePath(info utils.ClusterInfo, rootDir, sessionID string) string {
+	prefix := Prefix(rootDir)
+	var resourceSubDir string
+	ownerKind := strings.ToLower(info.OwnerKind)
+	if (ownerKind == utils.RAYJOB_OBJECT_DIR || ownerKind == utils.RAYSERVICE_OBJECT_DIR) && info.OwnerName != "" {
+		resourceSubDir = ownerKind
+	} else {
+		resourceSubDir = utils.RAYCLUSTER_OBJECT_DIR
+	}
+
+	var parts []string
+	parts = append(parts, info.Namespace)
+	if (ownerKind == utils.RAYJOB_OBJECT_DIR || ownerKind == utils.RAYSERVICE_OBJECT_DIR) && info.OwnerName != "" {
+		parts = append(parts, info.OwnerName)
+	}
+	parts = append(parts, info.Name)
+	p := path.Join(prefix, resourceSubDir, strings.Join(parts, utils.Connector))
+	return path.Clean(path.Join(p, path.Base(sessionID)))
+}
+
+// DecodePath parses the hierarchical path and returns the cluster info.
+func DecodePath(filePath string, rootDir string) (utils.ClusterInfo, error) {
+	prefix := Prefix(rootDir)
+	cleanFilePath := strings.Trim(filePath, "/")
+	cleanPrefix := strings.Trim(prefix, "/") + "/"
+	if !strings.HasPrefix(cleanFilePath, cleanPrefix) {
+		return utils.ClusterInfo{}, fmt.Errorf("invalid path %q: expected prefix %q", filePath, prefix)
+	}
+	relativePath := strings.Trim(strings.TrimPrefix(cleanFilePath, cleanPrefix), "/")
+
+	pathSegments := strings.Split(relativePath, "/")
+
+	if len(pathSegments) != 3 {
+		return utils.ClusterInfo{}, fmt.Errorf("invalid path segment count for cluster metadata structure: %s", filePath)
+	}
+
+	resourceSubDir := strings.ToLower(pathSegments[0])
+	if resourceSubDir != utils.RAYCLUSTER_OBJECT_DIR && resourceSubDir != utils.RAYJOB_OBJECT_DIR && resourceSubDir != utils.RAYSERVICE_OBJECT_DIR {
+		return utils.ClusterInfo{}, fmt.Errorf("unsupported cluster metadata subdirectory %q in path %q", resourceSubDir, filePath)
+	}
+
+	c := utils.ClusterInfo{
+		SessionName: pathSegments[2],
+	}
+
+	metaParts := strings.Split(pathSegments[1], utils.Connector)
+	c.Namespace = metaParts[0]
+	switch len(metaParts) {
+	case metaPartsCountWithoutOwner:
+		if resourceSubDir != utils.RAYCLUSTER_OBJECT_DIR {
+			return utils.ClusterInfo{}, fmt.Errorf("mismatched subdirectory %q for metadata structure without owner in path %q", resourceSubDir, filePath)
+		}
+		c.Name = metaParts[1]
+	case metaPartsCountWithOwner:
+		if resourceSubDir != utils.RAYJOB_OBJECT_DIR && resourceSubDir != utils.RAYSERVICE_OBJECT_DIR {
+			return utils.ClusterInfo{}, fmt.Errorf("unsupported subdirectory %q with owner metadata in path %q", resourceSubDir, filePath)
+		}
+		c.OwnerKind = resourceSubDir
+		c.OwnerName = metaParts[1]
+		c.Name = metaParts[2]
+	default:
+		return utils.ClusterInfo{}, fmt.Errorf("invalid cluster-metadata segment count %d in path %q", len(metaParts), filePath)
+	}
+
+	createTime, err := utils.GetDateTimeFromSessionID(c.SessionName)
+	if err != nil {
+		return utils.ClusterInfo{}, fmt.Errorf("parse session time from %s: %w", c.SessionName, err)
+	}
+	c.CreateTimeStamp = createTime.Unix()
+	c.CreateTime = createTime.UTC().Format("2006-01-02T15:04:05Z")
+
+	return c, nil
+}
+
+// Prefix returns the root directory prefix
+func Prefix(rootDir string) string {
+	if rootDir == "" {
+		return ClusterMetadataDir + "/"
+	}
+	return strings.TrimRight(path.Join(rootDir, ClusterMetadataDir), "/") + "/"
+}

--- a/historyserver/pkg/storage/clustermetadata/clustermetadata_test.go
+++ b/historyserver/pkg/storage/clustermetadata/clustermetadata_test.go
@@ -1,0 +1,220 @@
+package clustermetadata
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+)
+
+func TestDecodePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		filePath    string
+		rootDir     string
+		expectErr   bool
+		expected    utils.ClusterInfo
+	}{
+		{
+			name:        "valid hierarchical path job",
+			filePath:    "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
+			expectErr:   false,
+			expected: utils.ClusterInfo{
+				Namespace:       "defaultns",
+				OwnerKind:       "rayjob",
+				OwnerName:       "myrayjob",
+				Name:            "mycluster3",
+				SessionName:     "session_2024-05-15_10-30-55_123456",
+				CreateTimeStamp: time.Date(2024, time.May, 15, 10, 30, 55, 123456000, time.UTC).Unix(),
+				CreateTime:      "2024-05-15T10:30:55Z",
+			},
+		},
+		{
+			name:        "valid hierarchical path standalone",
+			filePath:    "cluster-metadata/raycluster/defaultns_mycluster1/session_2024-05-15_10-30-55_123456",
+			expectErr:   false,
+			expected: utils.ClusterInfo{
+				Namespace:       "defaultns",
+				Name:            "mycluster1",
+				SessionName:     "session_2024-05-15_10-30-55_123456",
+				CreateTimeStamp: time.Date(2024, time.May, 15, 10, 30, 55, 123456000, time.UTC).Unix(),
+				CreateTime:      "2024-05-15T10:30:55Z",
+			},
+		},
+		{
+			name:        "invalid path prefix",
+			filePath:    "wrong-prefix/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
+			expectErr:   true,
+		},
+		{
+			name:        "invalid path prefix with custom rootDir",
+			filePath:    "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
+			rootDir:     "custom-root",
+			expectErr:   true,
+		},
+		{
+			name:        "invalid path structure - missing session",
+			filePath:    "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3",
+			expectErr:   true,
+		},
+		{
+			name:        "invalid path structure - too many parts",
+			filePath:    "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session/extra",
+			expectErr:   true,
+		},
+		{
+			name:        "invalid metadir segment - only one part",
+			filePath:    "cluster-metadata/raycluster/defaultns/session_2024-05-15_10-30-55_123456",
+			expectErr:   true,
+		},
+		{
+			name:        "invalid metadir segment with owner - too few parts",
+			filePath:    "cluster-metadata/rayjob/defaultns/session_2024-05-15_10-30-55_123456",
+			expectErr:   true,
+		},
+		{
+			name:        "session id with bad timestamp pattern",
+			filePath:    "cluster-metadata/raycluster/defaultns_mycluster/session_not-a-real-timestamp",
+			expectErr:   true,
+		},
+		{
+			name:            "valid owner kind - mixed case",
+			filePath:        "cluster-metadata/rayservice/defaultns_myservice_mycluster3/session_2024-05-15_10-30-55_123456",
+			expectErr:       false,
+			expected: utils.ClusterInfo{
+				Namespace:       "defaultns",
+				OwnerKind:       "rayservice",
+				OwnerName:       "myservice",
+				Name:            "mycluster3",
+				SessionName:     "session_2024-05-15_10-30-55_123456",
+				CreateTimeStamp: time.Date(2024, time.May, 15, 10, 30, 55, 123456000, time.UTC).Unix(),
+				CreateTime:      "2024-05-15T10:30:55Z",
+			},
+		},
+		{
+			name:      "invalid decode - raycluster with 3 meta parts",
+			filePath:  "cluster-metadata/raycluster/defaultns_myservice_mycluster3/session_2024-05-15_10-30-55_123456",
+			expectErr: true,
+		},
+		{
+			name:      "unsupported owner kind",
+			filePath:  "cluster-metadata/wrongowner/defaultns_myservice_name/session_2024-05-15_10-30-55_123456",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := DecodePath(tc.filePath, tc.rootDir)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("DecodePath(%q) succeeded unexpectedly", tc.filePath)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("DecodePath(%q) failed unexpectedly: %v", tc.filePath, err)
+				}
+				if c.Namespace != tc.expected.Namespace {
+					t.Errorf("Namespace = %q, want %q", c.Namespace, tc.expected.Namespace)
+				}
+				if c.Name != tc.expected.Name {
+					t.Errorf("Name = %q, want %q", c.Name, tc.expected.Name)
+				}
+				if c.SessionName != tc.expected.SessionName {
+					t.Errorf("SessionName = %q, want %q", c.SessionName, tc.expected.SessionName)
+				}
+				if c.OwnerKind != tc.expected.OwnerKind {
+					t.Errorf("OwnerKind = %q, want %q", c.OwnerKind, tc.expected.OwnerKind)
+				}
+				if c.OwnerName != tc.expected.OwnerName {
+					t.Errorf("OwnerName = %q, want %q", c.OwnerName, tc.expected.OwnerName)
+				}
+				if c.CreateTimeStamp != tc.expected.CreateTimeStamp {
+					t.Errorf("CreateTimeStamp = %d, want %d", c.CreateTimeStamp, tc.expected.CreateTimeStamp)
+				}
+				if c.CreateTime != tc.expected.CreateTime {
+					t.Errorf("CreateTime = %q, want %q", c.CreateTime, tc.expected.CreateTime)
+				}
+			}
+		})
+	}
+}
+
+func TestMetadirPathRoundTrip(t *testing.T) {
+	const sessionID = "session_2026-05-15_10-30-55_123456"
+	sessionTime, _ := utils.GetDateTimeFromSessionID(sessionID)
+
+	cases := []utils.ClusterInfo{
+		{Namespace: "default", Name: "raycluster1"},
+		{Namespace: "testns", Name: "raycluster2"},
+		{OwnerKind: "rayjob", OwnerName: "rayjob1", Namespace: "default", Name: "raycluster3"},
+		{OwnerKind: "rayservice", OwnerName: "rayservice1", Namespace: "testns", Name: "raycluster3"},
+	}
+
+	rootDirs := []string{"", "rootdir"}
+	for _, rootDir := range rootDirs {
+		for _, in := range cases {
+			t.Run(rootDir+"/"+in.Namespace+"/"+in.Name, func(t *testing.T) {
+				fullKey := EncodePath(in, rootDir, sessionID)
+
+				got, err := DecodePath(fullKey, rootDir)
+				if err != nil {
+					t.Fatalf("DecodePath(%q) failed: %v", fullKey, err)
+				}
+
+				if got.Namespace != in.Namespace || got.Name != in.Name ||
+					got.OwnerKind != in.OwnerKind || got.OwnerName != in.OwnerName {
+					t.Errorf("Round-trip structure mismatch:\n  in : %+v\n  got: %+v", in, got)
+				}
+				if got.SessionName != sessionID {
+					t.Errorf("SessionName = %q, want %q", got.SessionName, sessionID)
+				}
+				if got.CreateTimeStamp != sessionTime.Unix() {
+					t.Errorf("CreateTimeStamp = %d, want %d", got.CreateTimeStamp, sessionTime.Unix())
+				}
+			})
+		}
+	}
+}
+
+func TestEncodePath(t *testing.T) {
+	tests := []struct {
+		name      string
+		info      utils.ClusterInfo
+		rootDir   string
+		sessionID string
+		want      string
+	}{
+		{
+			name:      "standalone without owner kind",
+			info:      utils.ClusterInfo{Namespace: "ns", Name: "cluster"},
+			rootDir:   "myroot",
+			sessionID: "session-123",
+			want:      "myroot/cluster-metadata/raycluster/ns_cluster/session-123",
+		},
+		{
+			name:      "job with owner kind details",
+			info:      utils.ClusterInfo{OwnerKind: "rayjob", OwnerName: "job1", Namespace: "ns", Name: "cluster"},
+			rootDir:   "",
+			sessionID: "session-456",
+			want:      "cluster-metadata/rayjob/ns_job1_cluster/session-456",
+		},
+		{
+			name:      "inconsistent owner details (OwnerKind set but OwnerName empty)",
+			info:      utils.ClusterInfo{OwnerKind: "rayjob", OwnerName: "", Namespace: "ns", Name: "cluster"},
+			rootDir:   "",
+			sessionID: "session-789",
+			want:      "cluster-metadata/raycluster/ns_cluster/session-789",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EncodePath(tc.info, tc.rootDir, tc.sessionID)
+			if got != tc.want {
+				t.Errorf("EncodePath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/historyserver/pkg/storage/gcs/gcs_handler.go
+++ b/historyserver/pkg/storage/gcs/gcs_handler.go
@@ -15,6 +15,7 @@ import (
 	gstorage "cloud.google.com/go/storage"
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clustermetadata"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 	"github.com/sirupsen/logrus"
 	gIterator "google.golang.org/api/iterator"
@@ -140,14 +141,14 @@ func (h *RayLogsHandler) List() []utils.ClusterInfo {
 
 	clusterList := make(utils.ClusterInfoList, 0, 20)
 	bucket := h.StorageClient.Bucket(h.GCSBucket)
-	pathPrefix := strings.TrimPrefix(path.Join(h.RootDir, "metadir"), "/") + "/"
+	prefix := clustermetadata.Prefix(h.RootDir)
+	pathPrefix := strings.TrimPrefix(prefix, "/")
 	query := &gstorage.Query{
 		// Match with only non-directory objects
 		MatchGlob: pathPrefix + "**/*[!/]",
 	}
 	objectIterator := bucket.Objects(ctx, query)
 	for {
-		cluster := &utils.ClusterInfo{}
 		objectAttr, err := objectIterator.Next()
 		if err == gIterator.Done {
 			logrus.Infof("Finished iterating through gcs objects")
@@ -158,31 +159,14 @@ func (h *RayLogsHandler) List() []utils.ClusterInfo {
 			return nil
 		}
 
-		fullObjectPath := objectAttr.Name
-		metaInfo := strings.Split(strings.TrimPrefix(fullObjectPath, pathPrefix), "/")
-		if len(metaInfo) != 2 {
-			logrus.Errorf("Unable to properly parse cluster metadir path with fullpath: %s", fullObjectPath)
-			continue
-		}
-		clusterMeta := strings.Split(metaInfo[0], "_")
-		if len(clusterMeta) != 2 {
-			logrus.Errorf("Unable to get cluster name and namespace from directory: %s", metaInfo[0])
-			continue
-		}
-		cluster.Name = clusterMeta[0]
-		cluster.Namespace = clusterMeta[1]
-
-		cluster.SessionName = metaInfo[1]
-		datetime, err := utils.GetDateTimeFromSessionID(metaInfo[1])
+		c, err := clustermetadata.DecodePath(objectAttr.Name, h.RootDir)
 		if err != nil {
-			logrus.Errorf("Failed to get date time from the given sessionID: %s, error: %v", metaInfo[1], err)
+			logrus.Errorf("Failed to parse meta file path: %s, error: %v", objectAttr.Name, err)
 			continue
 		}
-		cluster.CreateTimeStamp = datetime.Unix()
-		cluster.CreateTime = datetime.UTC().Format(("2006-01-02T15:04:05Z"))
 
-		logrus.Infof("Parsed cluster %s for session %s to list", cluster.Name, cluster.SessionName)
-		clusterList = append(clusterList, *cluster)
+		logrus.Infof("Parsed cluster %s for session %s to list", c.Name, c.SessionName)
+		clusterList = append(clusterList, c)
 	}
 
 	sort.Sort(clusterList)

--- a/historyserver/pkg/storage/gcs/gcs_handler_test.go
+++ b/historyserver/pkg/storage/gcs/gcs_handler_test.go
@@ -215,7 +215,7 @@ func TestListFiles(t *testing.T) {
 
 func TestList(t *testing.T) {
 	// RootDir is "ray_historyserver"
-	// Path format: {RootDir}/metadir/{ClusterName}_{Namespace}/{SessionName}
+	// Path format: {RootDir}/cluster-metadata/{ClusterKey}/{SessionName}
 	ts := time.Now().UTC()
 	sessionID := "session_" + ts.Format("2006-01-02_15-04-05_000000")
 
@@ -223,14 +223,28 @@ func TestList(t *testing.T) {
 		{
 			ObjectAttrs: fakestorage.ObjectAttrs{
 				BucketName: "test-bucket",
-				Name:       "ray_historyserver/metadir/mycluster1_default/" + sessionID,
+				Name:       "ray_historyserver/cluster-metadata/raycluster/defaultns_mycluster1/" + sessionID,
 			},
 			Content: []byte(""),
 		},
 		{
 			ObjectAttrs: fakestorage.ObjectAttrs{
 				BucketName: "test-bucket",
-				Name:       "ray_historyserver/metadir/mycluster2_testns/" + sessionID,
+				Name:       "ray_historyserver/cluster-metadata/raycluster/testns_mycluster2/" + sessionID,
+			},
+			Content: []byte(""),
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: "test-bucket",
+				Name:       "ray_historyserver/cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/" + sessionID,
+			},
+			Content: []byte(""),
+		},
+		{
+			ObjectAttrs: fakestorage.ObjectAttrs{
+				BucketName: "test-bucket",
+				Name:       "ray_historyserver/cluster-metadata/rayservice/defaultns_myraysvc_mycluster4/" + sessionID,
 			},
 			Content: []byte(""),
 		},
@@ -239,8 +253,10 @@ func TestList(t *testing.T) {
 	handler := createRayLogsHandler(client, bucketName)
 
 	expected := []utils.ClusterInfo{
-		{Name: "mycluster1", Namespace: "default", SessionName: sessionID, CreateTimeStamp: ts.Unix(), CreateTime: ts.UTC().Format("2006-01-02T15:04:05Z")},
+		{Name: "mycluster1", Namespace: "defaultns", SessionName: sessionID, CreateTimeStamp: ts.Unix(), CreateTime: ts.UTC().Format("2006-01-02T15:04:05Z")},
 		{Name: "mycluster2", Namespace: "testns", SessionName: sessionID, CreateTimeStamp: ts.Unix(), CreateTime: ts.UTC().Format("2006-01-02T15:04:05Z")},
+		{Name: "mycluster3", OwnerKind: "rayjob", OwnerName: "myrayjob", Namespace: "defaultns", SessionName: sessionID, CreateTimeStamp: ts.Unix(), CreateTime: ts.UTC().Format("2006-01-02T15:04:05Z")},
+		{Name: "mycluster4", OwnerKind: "rayservice", OwnerName: "myraysvc", Namespace: "defaultns", SessionName: sessionID, CreateTimeStamp: ts.Unix(), CreateTime: ts.UTC().Format("2006-01-02T15:04:05Z")},
 	}
 
 	result := handler.List()

--- a/historyserver/pkg/storage/s3/s3.go
+++ b/historyserver/pkg/storage/s3/s3.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clustermetadata"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
@@ -152,10 +153,12 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 	clusters := make(utils.ClusterInfoList, 0, 10)
 	logrus.Debugf("Prepare to get list clusters info ...")
 
+	prefix := clustermetadata.Prefix(r.S3RootDir)
+
 	getClusters := func() {
 		listInput := &s3.ListObjectsV2Input{
 			Bucket:    aws.String(r.S3Bucket),
-			Prefix:    aws.String(path.Join(r.S3RootDir, "metadir") + "/"),
+			Prefix:    aws.String(prefix),
 			MaxKeys:   aws.Int64(100),
 			Delimiter: aws.String(""),
 		}
@@ -163,39 +166,21 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 		err := r.S3Client.ListObjectsV2Pages(listInput,
 			func(page *s3.ListObjectsV2Output, lastPage bool) bool {
 				logrus.Infof("[List]Returned objects in %v. length of page.Contents: %v, length of page.CommonPrefixes: %v",
-					path.Join(r.S3RootDir, "metadir")+"/", len(page.Contents), len(page.CommonPrefixes))
+					prefix, len(page.Contents), len(page.CommonPrefixes))
 
 				for _, object := range page.Contents {
-					c := &utils.ClusterInfo{}
-					metaInfo := strings.Trim(strings.TrimPrefix(*object.Key, path.Join(r.S3RootDir, "metadir/")), "/")
-					metas := strings.Split(metaInfo, "/")
-					if len(metas) < 2 {
-						continue
-					}
-					logrus.Infof("Process %++v", metas)
-					namespaceName := strings.Split(metas[0], "_")
-					if len(namespaceName) < 2 {
-						continue
-					}
-					c.Name = namespaceName[0]
-					c.Namespace = namespaceName[1]
-					c.SessionName = metas[1]
-					sessionInfo := strings.Split(metas[1], "_")
-					date := sessionInfo[1]
-					dataTime := sessionInfo[2]
-					createTime, err := time.Parse("2006-01-02_15-04-05", date+"_"+dataTime)
+					c, err := clustermetadata.DecodePath(*object.Key, r.S3RootDir)
 					if err != nil {
-						logrus.Errorf("Failed to parse time %s: %v", date+"_"+dataTime, err)
+						logrus.Errorf("Failed to parse meta file path: %s, error: %v", *object.Key, err)
 						continue
 					}
-					c.CreateTimeStamp = createTime.Unix()
-					c.CreateTime = createTime.UTC().Format(("2006-01-02T15:04:05Z"))
-					clusters = append(clusters, *c)
+					logrus.Infof("Parsed cluster %s for session %s to list", c.Name, c.SessionName)
+					clusters = append(clusters, c)
 				}
 				return true
 			})
 		if err != nil {
-			logrus.Errorf("Failed to list objects from %s: %v", path.Join(r.S3RootDir, "metadir")+"/", err)
+			logrus.Errorf("Failed to list objects from %s: %v", prefix, err)
 			return
 		}
 	}

--- a/historyserver/pkg/utils/constant.go
+++ b/historyserver/pkg/utils/constant.go
@@ -5,7 +5,13 @@ import (
 	"path/filepath"
 )
 
-const defaultTmpRayRoot = "/tmp/ray"
+const (
+	defaultTmpRayRoot = "/tmp/ray"
+
+	RAYJOB_OBJECT_DIR = "rayjob"
+	RAYSERVICE_OBJECT_DIR = "rayservice"
+	RAYCLUSTER_OBJECT_DIR = "raycluster"
+)
 
 func GetTmpRayRoot() string {
 	if tmpRoot := os.Getenv("RAY_TMP_ROOT"); tmpRoot != "" {

--- a/historyserver/pkg/utils/types.go
+++ b/historyserver/pkg/utils/types.go
@@ -6,6 +6,8 @@ type ClusterInfo struct {
 	SessionName     string `json:"sessionName"`
 	CreateTime      string `json:"createTime"`
 	CreateTimeStamp int64  `json:"createTimeStamp"`
+	OwnerKind       string `json:"ownerKind,omitempty"`
+	OwnerName       string `json:"ownerName,omitempty"`
 }
 
 type ClusterInfoList []ClusterInfo

--- a/historyserver/pkg/utils/utils.go
+++ b/historyserver/pkg/utils/utils.go
@@ -66,11 +66,11 @@ const (
 	// - Namespace CANNOT contain "_", so we can unambiguously split from the LAST "_"
 	//
 	// DO NOT CHANGE: Would break existing stored data paths
-	connector = "_"
+	Connector = "_"
 )
 
 func AppendRayClusterNameNamespace(rayClusterName, rayClusterNamespace string) string {
-	return fmt.Sprintf("%s%s%s", rayClusterName, connector, rayClusterNamespace)
+	return fmt.Sprintf("%s%s%s", rayClusterName, Connector, rayClusterNamespace)
 }
 
 func GetSessionDir() (string, error) {
@@ -152,7 +152,7 @@ func IsHexNil(hexStr string) (bool, error) {
 // Format: "{clusterName}_{namespace}_{sessionName}"
 // Example: "raycluster-historyserver_default_session_2026-01-11_19-38-40"
 func BuildClusterSessionKey(clusterName, namespace, sessionName string) string {
-	return clusterName + connector + namespace + connector + sessionName
+	return clusterName + Connector + namespace + Connector + sessionName
 }
 
 // GetDateTimeFromSessionID will convert sessionID string i.e. `session_2026-01-27_10-52-59_373533_1` to time.Time


### PR DESCRIPTION
## Why are these changes needed?
Add associated RayJob or RayService to the RayCluster for history server

Edit:
The structure of the metadir will be as follows:
```
cluster-metadata/    <- previously "metadir"
  raycluster/
    [<namespace>_<ray_cluster_name>  ... ]
  rayjob/
    [<namespace>_<rayjob_name>_<ray_cluster_name> ... ] 
  rayservice/
    [<namespace>_<rayservice_name>_<ray_cluster_name> ... ]
```

## Related issue number
#4707 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
