### PR TITLE
Fix file matching in Aliyun OSS GetContent

### DIFF
--- a/historyserver/go.mod
+++ b/historyserver/go.mod
@@ -11,10 +11,10 @@ require (
 	github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible
 	github.com/aliyun/credentials-go v1.4.7
 	github.com/aws/aws-sdk-go v1.55.8
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/emicklei/go-restful/v3 v3.13.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/fsouza/fake-gcs-server v1.53.1
-	github.com/google/martian/v3 v3.3.3
 	github.com/onsi/gomega v1.38.2
 	github.com/ray-project/kuberay/ray-operator v1.5.1
 	github.com/sirupsen/logrus v1.9.3
@@ -105,7 +105,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.35.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect

--- a/historyserver/pkg/storage/aliyunoss/ray/ray.go
+++ b/historyserver/pkg/storage/aliyunoss/ray/ray.go
@@ -193,13 +193,15 @@ func (r *RayLogsHandler) GetContent(clusterId string, fileName string) io.Reader
 		allFiles := r._listFiles(clusterId+"/"+path.Dir(fileName), "", false)
 		found := false
 		for _, f := range allFiles {
-			if path.Base(f) == fileName {
+			if path.Base(f) == path.Base(fileName) {
 				logrus.Infof("Get object %s info success", f)
 				body, err = r.OssBucket.GetObject(f, options...)
 				if err != nil {
 					logrus.Errorf("Failed to get object %s: %v", f, err)
 					return nil
 				}
+				found = true
+				break
 			}
 		}
 		if !found {

--- a/historyserver/pkg/storage/aliyunoss/ray/ray_test.go
+++ b/historyserver/pkg/storage/aliyunoss/ray/ray_test.go
@@ -30,6 +30,21 @@ func TestTrim(t *testing.T) {
 	t.Logf("test_path_join [%s]", test_path_join)
 }
 
+func TestGetContentPathComparison(t *testing.T) {
+	// fileName is a full path like the caller passes
+	fileName := "session_2026-04-09_06-41-42_754637_1/logs/abc123/events/event_RAYLET.log"
+	// f is a full key returned by _listFiles (onlyBase=false)
+	f := "session_2026-04-09_06-41-42_754637_1/logs/abc123/events/event_RAYLET.log"
+
+	if path.Base(f) != path.Base(fileName) {
+		t.Errorf("expected path.Base(%q) == path.Base(%q)", f, fileName)
+	}
+	// Verify old buggy comparison would fail
+	if path.Base(f) == fileName {
+		t.Errorf("old comparison should not match: path.Base(%q) == %q", f, fileName)
+	}
+}
+
 func TestWalk(t *testing.T) {
 	watchPath := "/tmp/ray/test/LLogs/"
 	filepath.Walk(watchPath, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
## Why are these changes needed?

The issue was in the file matching logic. GetContent was comparing path.Base(f) against the full fileName path, so it would never match. Fixed by comparing basenames on both sides. Also added the found flag and break to exit early once we find the right file.

## Related issue number

Fixes #4690

## Checks
- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(