### PR TITLE
[Docs] Clarify per-cluster serve service behavior

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1985,10 +1985,10 @@ func (r *RayServiceReconciler) reconcilePerClusterServeService(ctx context.Conte
 
 	logger := ctrl.LoggerFrom(ctx).WithValues("RayCluster", rayClusterInstance.Name)
 
-	logger.Info("Building per-cluster RayService")
+	logger.Info("Building per-cluster serve service")
 
 	// Create a serve service for the RayCluster associated with this RayService. During an incremental
-	// upgrade, this will be called for the pending RayCluster instance.
+	// upgrade, this will be called for both the active and pending RayCluster instances.
 	desiredSvc, err := common.BuildServeService(ctx, *rayServiceInstance, *rayClusterInstance, true)
 	if err != nil {
 		logger.Error(err, "Failed to build per-cluster serve service spec")


### PR DESCRIPTION
## Why are these changes needed?

This PR corrects the log message and comment to align with per-cluster serve service reconcile logic.

There is no functional change.

## Related issue number

N/A

## Reference

`reconcilePerClusterServeService` is called for both the active and pending clusters in incremental upgrade:

https://github.com/ray-project/kuberay/blob/b5a07e8b9b8d471e2420817b2e57845e986a7bf4/ray-operator/controllers/ray/rayservice_controller.go#L220-L227

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
