### PR TITLE
[RayService][e2e] fix flaky test in getting HTTPRoute

### DIFF
--- a/ray-operator/test/e2eincrementalupgrade/support.go
+++ b/ray-operator/test/e2eincrementalupgrade/support.go
@@ -70,9 +70,10 @@ func bootstrapIncrementalRayService(
 	g.Eventually(HTTPRoute(test, rayService.Namespace, httpRouteName), TestTimeoutMedium).
 		Should(Not(BeNil()))
 
-	httpRoute, err = GetHTTPRoute(test, rayService.Namespace, httpRouteName)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(utils.IsHTTPRouteReady(gateway, httpRoute)).To(BeTrue())
+	g.Eventually(func() (bool, error) {
+		httpRoute, err = GetHTTPRoute(test, rayService.Namespace, httpRouteName)
+		return utils.IsHTTPRouteReady(gateway, httpRoute), err
+	}, TestTimeoutMedium).Should(BeTrue())
 
 	gatewayIP = GetGatewayIP(gateway)
 	g.Expect(gatewayIP).NotTo(BeEmpty())


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There is [a flaky test](https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/14465/steps/canvas?jid=019d8081-a717-42e7-9a81-a6d8305d7005&tab=output#019d8081-a717-42e7-9a81-a6d8305d7005) in incremental upgrade e2e test. The pr turns the verification of the readiness of HTTPRoute to Eventually to wait for the status. It might not that easy to reproduce the original test failure, I ran 3x times of test to encounter an test failure.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
