### PR TITLE
Enable newexpr linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - errorlint
     - staticcheck
     - noctx
+    - newexpr
     - revive
   settings:
     staticcheck:


### PR DESCRIPTION
Good day,

This PR enables the newexpr linter in the golangci-lint configuration.

The newexpr linter suggests using explicit dereference expressions which is available since Go 1.21 and can improve code readability.

This change resolves issue #4694 by re-enabling the linter that was temporarily disabled during the Go upgrade.

Thank you for your work on this project. I hope this small fix is helpful.
Please let me know if there's anything to adjust.

Warmly,
RoomWithOutRoof