### PR TITLE
[Fix] Increase resource limits for wait-gcs-ready init container

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -402,8 +402,8 @@ func DefaultWorkerPodTemplate(ctx context.Context, instance rayv1.RayCluster, wo
 				// The init container's resource consumption remains constant, as it solely sends requests to check the GCS status at a fixed frequency.
 				// Therefore, hard-coding the resources is acceptable.
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("200m"),
-					corev1.ResourceMemory: resource.MustParse("256Mi"),
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
 				},
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("200m"),


### PR DESCRIPTION
## Summary

- Increase resource limits for the `wait-gcs-ready` init container to prevent OOMKilled errors

## Problem

The `wait-gcs-ready` init container was being OOMKilled due to insufficient memory limit (256Mi). The `ray health-check` command consumes approximately 180-190MB of RSS, which with system overhead exceeds the 256Mi limit.

This caused Ray workers to fail to start, especially in CI environments (kind clusters) and developer machines.

## Solution

Increase the init container's resource limits:
- CPU: `200m` → `1`
- Memory: `256Mi` → `1Gi`

The Requests remain unchanged (`200m` CPU, `256Mi` memory) to ensure efficient resource allocation.

## Test Plan

- [ ] Verify the init container no longer gets OOMKilled in CI environments
- [ ] Verify workers can successfully start and connect to the head node

Fixes #2735