### PR TITLE
Skip ServeConfigV2 for active cluster on cache miss during upgrade

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1350,6 +1350,15 @@ func (r *RayServiceReconciler) applyServeTargetCapacity(ctx context.Context, ray
 	// Retrieve cached ServeConfig from last reconciliation for cluster to update
 	cachedConfig := r.getServeConfigFromCache(rayServiceInstance, rayClusterInstance.Name)
 	if cachedConfig == "" {
+		isActiveCluster := rayClusterInstance.Name == rayServiceInstance.Status.ActiveServiceStatus.RayClusterName
+		isIncrementalUpgradeInProgress := utils.IsIncrementalUpgradeEnabled(&rayServiceInstance.Spec) &&
+			meta.IsStatusConditionTrue(rayServiceInstance.Status.Conditions, string(rayv1.UpgradeInProgress))
+		if isActiveCluster && isIncrementalUpgradeInProgress {
+			// On cache miss, skip applying the new ServeConfigV2 to the active cluster
+			// to prevent a 3rd spec from being applied during rollback.
+			logger.Info("Cache miss for active cluster during upgrade, skipping target_capacity update", "clusterName", rayClusterInstance.Name)
+			return nil
+		}
 		cachedConfig = rayServiceInstance.Spec.ServeConfigV2
 	}
 

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2003,6 +2003,62 @@ func TestReconcileServeTargetCapacity(t *testing.T) {
 	}
 }
 
+func TestApplyServeTargetCapacityCacheMiss(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.RayServiceIncrementalUpgrade, true)
+
+	ctx := context.TODO()
+	makeService := func(upgradeInProgress bool) *rayv1.RayService {
+		rs := &rayv1.RayService{
+			Spec: rayv1.RayServiceSpec{
+				UpgradeStrategy: &rayv1.RayServiceUpgradeStrategy{
+					Type: ptr.To(rayv1.RayServiceNewClusterWithIncrementalUpgrade),
+					ClusterUpgradeOptions: &rayv1.ClusterUpgradeOptions{
+						MaxSurgePercent: ptr.To(int32(20)),
+					},
+				},
+				ServeConfigV2: `{"target_capacity": 0}`,
+			},
+			Status: rayv1.RayServiceStatuses{
+				ActiveServiceStatus: rayv1.RayServiceStatus{
+					RayClusterName: "active",
+					TargetCapacity: ptr.To(int32(80)),
+				},
+				PendingServiceStatus: rayv1.RayServiceStatus{
+					RayClusterName: "pending",
+					TargetCapacity: ptr.To(int32(30)),
+				},
+			},
+		}
+		if upgradeInProgress {
+			meta.SetStatusCondition(&rs.Status.Conditions, metav1.Condition{
+				Type:   string(rayv1.UpgradeInProgress),
+				Status: metav1.ConditionTrue,
+				Reason: string(rayv1.BothActivePendingClustersExist),
+			})
+		}
+		return rs
+	}
+
+	t.Run("cache miss on active cluster during upgrade skips update", func(t *testing.T) {
+		rs := makeService(true)
+		fakeDashboard := &utils.FakeRayDashboardClient{}
+		reconciler := &RayServiceReconciler{ServeConfigs: lru.New(10)}
+		// No cache seeded — cache miss
+		err := reconciler.applyServeTargetCapacity(ctx, rs, &rayv1.RayCluster{ObjectMeta: metav1.ObjectMeta{Name: "active"}}, fakeDashboard, int32(60))
+		require.NoError(t, err)
+		assert.Empty(t, fakeDashboard.LastUpdatedConfig, "dashboard should not be called on active cluster cache miss during upgrade")
+	})
+
+	t.Run("cache miss on active cluster without upgrade applies update", func(t *testing.T) {
+		rs := makeService(false)
+		fakeDashboard := &utils.FakeRayDashboardClient{}
+		reconciler := &RayServiceReconciler{ServeConfigs: lru.New(10)}
+		err := reconciler.applyServeTargetCapacity(ctx, rs, &rayv1.RayCluster{ObjectMeta: metav1.ObjectMeta{Name: "active"}}, fakeDashboard, int32(60))
+		require.NoError(t, err)
+		assert.NotEmpty(t, fakeDashboard.LastUpdatedConfig)
+	})
+}
+
 // MakeGateway is a helper function to return an Gateway object
 func makeGateway(name, namespace string, isReady bool) *gwv1.Gateway {
 	status := metav1.ConditionFalse


### PR DESCRIPTION
## Why are these changes needed?

During incremental upgrade, a cache miss on the active cluster was applying the new ServeConfigV2, which caused a 3rd spec to be applied during rollback. Added a check to skip applying the config when we're on the active cluster during an upgrade. Covered with unit tests.

## Related issue number

Closes #4717

## Checks
- [x] I've made sure the tests are passing.
- Testing strategy:
  - [x] Unit tests