### PR TITLE
Quick fix for kubectl ray logs --link=gke 

### DIFF
--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -513,7 +513,7 @@ func (options *ClusterLogOptions) gcpLink(ctx context.Context, clientSet client.
 		// GKE context names are usually in the format: gke_PROJECT_LOCATION_NAME.
 		_, rest, _ := strings.Cut(config.CurrentContext, "_")
 		project, _, _ := strings.Cut(rest, "_")
-		gcpURL += fmt.Sprintf(";project=%s", url.QueryEscape(project))
+		gcpURL += fmt.Sprintf("?project=%s", url.QueryEscape(project))
 	} else {
 		fmt.Fprintln(options.ioStreams.ErrOut, "Warning: The current kubectl context does not appear to be a GKE cluster. The generated link may not work.")
 	}

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -542,7 +542,7 @@ func TestGCPLogLink(t *testing.T) {
 					},
 				},
 			},
-			expectedGCPURL:  "https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.%22k8s-pod%2Fray_io%2Fcluster%22%3D%22test-cluster%22%0Alabels.%22k8s-pod%2Fray_io%2Fis-ray-node%22%3D%22yes%22;project=my-project",
+			expectedGCPURL:  "https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.%22k8s-pod%2Fray_io%2Fcluster%22%3D%22test-cluster%22%0Alabels.%22k8s-pod%2Fray_io%2Fis-ray-node%22%3D%22yes%22?project=my-project",
 			expectedWarning: "",
 		},
 		{
@@ -566,7 +566,7 @@ func TestGCPLogLink(t *testing.T) {
 					},
 				},
 			},
-			expectedGCPURL:  "https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.%22k8s-pod%2Fray_io%2Fcluster%22%3D%22test-cluster%22%0Alabels.%22k8s-pod%2Fray_io%2Fis-ray-node%22%3D%22yes%22;project=my-project",
+			expectedGCPURL:  "https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.%22k8s-pod%2Fray_io%2Fcluster%22%3D%22test-cluster%22%0Alabels.%22k8s-pod%2Fray_io%2Fis-ray-node%22%3D%22yes%22?project=my-project",
 			expectedWarning: "Warning: The head pod does not have a 'fluentbit' container. Logs might not be exported to Google Cloud Logging.",
 		},
 		{


### PR DESCRIPTION
The project URL parameter needs to be set after `?`, not `;`.

Follow on to #4683