### PR TITLE
fix(kubectl-plugin/log): validate header.Mode and release fds per iteration

### DIFF
--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -434,28 +434,44 @@ func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec 
 				return fmt.Errorf("Error creating directory: %w", err)
 			}
 		case tar.TypeReg:
-			// Check for overflow: G115
+			// Reject modes that can't be represented as an os.FileMode
+			// (uint32) before any cast so gosec G115 is satisfied and a
+			// crafted tar header cannot set unexpected bits on disk.
+			// Note: 'break' exits the switch, not the for loop, so the
+			// tarReader.Next() call below still runs and we advance to
+			// the next entry; using 'continue' here would skip that
+			// advance and spin forever on the bad entry.
 			if header.Mode < 0 || header.Mode > math.MaxUint32 {
-				fmt.Fprintf(options.ioStreams.Out, "file mode out side of accceptable value %d skipping file", header.Mode)
+				fmt.Fprintf(options.ioStreams.Out, "file mode %d outside of acceptable range, skipping file %s\n", header.Mode, header.Name)
+				break
 			}
-			// Create file and write contents
-			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			// Create file and write contents.
+			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(uint32(header.Mode)))
 			if err != nil {
 				return fmt.Errorf("Error creating file: %w", err)
 			}
-			defer outFile.Close()
 			// This is to limit the copy size for a decompression bomb, currently set arbitrarily
-			for {
-				n, err := io.CopyN(outFile, tarReader, 1000000)
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
+			copyErr := func() error {
+				// Close the file when this iteration ends instead of
+				// deferring inside the loop: a large tar would otherwise
+				// hold every opened fd until the whole function returns
+				// and can hit the "too many open files" ulimit.
+				defer outFile.Close()
+				for {
+					n, err := io.CopyN(outFile, tarReader, 1000000)
+					if err != nil {
+						if errors.Is(err, io.EOF) {
+							return nil
+						}
+						return fmt.Errorf("failed while writing to file: %w", err)
 					}
-					return fmt.Errorf("failed while writing to file: %w", err)
+					if n == 0 {
+						return nil
+					}
 				}
-				if n == 0 {
-					break
-				}
+			}()
+			if copyErr != nil {
+				return copyErr
 			}
 		default:
 			fmt.Printf("Ignoring unsupported file type: %b", header.Typeflag)

--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -430,28 +430,44 @@ func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec 
 				return fmt.Errorf("Error creating directory: %w", err)
 			}
 		case tar.TypeReg:
-			// Check for overflow: G115
+			// Reject modes that can't be represented as an os.FileMode
+			// (uint32) before any cast so gosec G115 is satisfied and a
+			// crafted tar header cannot set unexpected bits on disk.
+			// Note: 'break' exits the switch, not the for loop, so the
+			// tarReader.Next() call below still runs and we advance to
+			// the next entry; using 'continue' here would skip that
+			// advance and spin forever on the bad entry.
 			if header.Mode < 0 || header.Mode > math.MaxUint32 {
-				fmt.Fprintf(options.ioStreams.Out, "file mode out side of acceptable value %d skipping file\n", header.Mode)
+				fmt.Fprintf(options.ioStreams.Out, "file mode %d outside of acceptable range, skipping file %s\n", header.Mode, header.Name)
+				break
 			}
-			// Create file and write contents
-			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //nolint:gosec // overflow is guarded by bounds check above
+			// Create file and write contents.
+			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(uint32(header.Mode)))
 			if err != nil {
 				return fmt.Errorf("Error creating file: %w", err)
 			}
-			defer outFile.Close()
 			// This is to limit the copy size for a decompression bomb, currently set arbitrarily
-			for {
-				n, err := io.CopyN(outFile, tarReader, 1000000)
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
+			copyErr := func() error {
+				// Close the file when this iteration ends instead of
+				// deferring inside the loop: a large tar would otherwise
+				// hold every opened fd until the whole function returns
+				// and can hit the "too many open files" ulimit.
+				defer outFile.Close()
+				for {
+					n, err := io.CopyN(outFile, tarReader, 1000000)
+					if err != nil {
+						if errors.Is(err, io.EOF) {
+							return nil
+						}
+						return fmt.Errorf("failed while writing to file: %w", err)
 					}
-					return fmt.Errorf("failed while writing to file: %w", err)
+					if n == 0 {
+						return nil
+					}
 				}
-				if n == 0 {
-					break
-				}
+			}()
+			if copyErr != nil {
+				return copyErr
 			}
 		default:
 			fmt.Printf("Ignoring unsupported file type: %b", header.Typeflag)

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -56,29 +57,24 @@ func (f *fakeExecutor) StreamWithContext(_ context.Context, options remotecomman
 	return err
 }
 
-// createFakeTarFile creates the fake tar file that will be used for testing
-func createFakeTarFile() (*bytes.Buffer, error) {
-	// Create a buffer to hold the tar archive
+// fakeTarEntry describes a single entry to add to a fake tar archive.
+// Tests that need to exercise unusual modes (e.g. out-of-range G115
+// values) drop them in here directly.
+type fakeTarEntry struct {
+	ModTime time.Time
+	Name    string
+	Body    string
+	IsDir   bool
+	Mode    int64
+}
+
+// buildFakeTarFile writes the supplied entries to an in-memory tar
+// archive in order. Used by tests that need precise control over the
+// header layout (mode, ordering, etc.).
+func buildFakeTarFile(entries []fakeTarEntry) (*bytes.Buffer, error) {
 	tarbuff := new(bytes.Buffer)
-
-	// Create a tar writer
 	tw := tar.NewWriter(tarbuff)
-
-	// Define the files/directories to include
-	files := []struct {
-		ModTime time.Time
-		Name    string
-		Body    string
-		IsDir   bool
-		Mode    int64
-	}{
-		{time.Now(), "/", "", true, 0o755},
-		{time.Now(), "file1.txt", "This is the content of file1.txt\n", false, 0o644},
-		{time.Now(), "file2.txt", "Content of file2.txt inside subdir\n", false, 0o644},
-	}
-
-	// Add each file/directory to the tar archive
-	for _, file := range files {
+	for _, file := range entries {
 		hdr := &tar.Header{
 			Name:    file.Name,
 			Mode:    file.Mode,
@@ -90,25 +86,30 @@ func createFakeTarFile() (*bytes.Buffer, error) {
 		} else {
 			hdr.Typeflag = tar.TypeReg
 		}
-
-		// Write the header
 		if err := tw.WriteHeader(hdr); err != nil {
 			return nil, err
 		}
-
-		// Write the file content (if not a directory)
 		if !file.IsDir {
 			if _, err := tw.Write([]byte(file.Body)); err != nil {
 				return nil, err
 			}
 		}
 	}
-
-	// Close the tar writer
 	if err := tw.Close(); err != nil {
 		return nil, err
 	}
 	return tarbuff, nil
+}
+
+// createFakeTarFile creates the fake tar file that will be used for testing.
+// Kept for backwards compatibility with tests written before
+// buildFakeTarFile existed.
+func createFakeTarFile() (*bytes.Buffer, error) {
+	return buildFakeTarFile([]fakeTarEntry{
+		{time.Now(), "/", "", true, 0o755},
+		{time.Now(), "file1.txt", "This is the content of file1.txt\n", false, 0o644},
+		{time.Now(), "file2.txt", "Content of file2.txt inside subdir\n", false, 0o644},
+	})
 }
 
 type FakeRemoteExecutor struct{}
@@ -482,6 +483,78 @@ func TestDownloadRayLogFiles(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, curr.Body, string(actualContent))
 	}
+}
+
+// TestDownloadRayLogFiles_SkipsInvalidMode pins the regression for the
+// G115 fix in #4728: when an extracted tar entry has a header.Mode
+// outside the os.FileMode (uint32) range, downloadRayLogFiles must
+// skip just that entry — not abort the extraction or spin forever.
+//
+// The tar layout below interleaves a valid entry, an out-of-range
+// entry, and another valid entry so we can prove that:
+//
+//   - the bad entry is reported and skipped (no file written for it);
+//   - extraction continues past it (the post-bad valid entry still
+//     lands on disk).
+func TestDownloadRayLogFiles_SkipsInvalidMode(t *testing.T) {
+	fakeDir, err := os.MkdirTemp("", "fake-bad-mode")
+	require.NoError(t, err)
+	defer os.RemoveAll(fakeDir)
+
+	testStreams, _, _, _ := genericiooptions.NewTestIOStreams()
+	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+
+	fakeClusterLogOptions := NewClusterLogOptions(cmdFactory, testStreams)
+	fakeClusterLogOptions.ResourceName = "test-cluster"
+	fakeClusterLogOptions.outputDir = fakeDir
+
+	// math.MaxUint32 + 1 is the smallest int64 that fails the bounds
+	// check; a real tar (e.g. constructed by a malicious server) can
+	// set Mode to anything an int64 will hold.
+	const outOfRangeMode int64 = int64(math.MaxUint32) + 1
+
+	fakeTar, err := buildFakeTarFile([]fakeTarEntry{
+		{time.Now(), "/", "", true, 0o755},
+		{time.Now(), "good_before.txt", "before\n", false, 0o644},
+		{time.Now(), "bad_mode.txt", "should be skipped\n", false, outOfRangeMode},
+		{time.Now(), "good_after.txt", "after\n", false, 0o644},
+	})
+	require.NoError(t, err)
+
+	rayHead := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-kuberay-head-1",
+			Namespace: "test",
+			Labels: map[string]string{
+				"ray.io/group":    "headgroup",
+				"ray.io/clusters": "test-cluster",
+			},
+		},
+		Spec: v1.PodSpec{Containers: []v1.Container{{Name: "mycontainer", Image: "nginx:latest"}}},
+		Status: v1.PodStatus{Phase: v1.PodRunning, PodIP: "10.0.0.1"},
+	}
+
+	executor, _ := fakeNewSPDYExecutor("GET", &url.URL{}, fakeTar)
+
+	err = fakeClusterLogOptions.downloadRayLogFiles(context.Background(), executor, rayHead)
+	require.NoError(t, err, "downloadRayLogFiles must not fail on a single bad-mode entry")
+
+	entries, err := os.ReadDir(fakeDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "exactly one pod-named subdir should be created")
+
+	files, err := os.ReadDir(filepath.Join(fakeDir, entries[0].Name()))
+	require.NoError(t, err)
+
+	// good_before + good_after should land; bad_mode should be skipped.
+	names := make([]string, 0, len(files))
+	for _, f := range files {
+		names = append(names, f.Name())
+	}
+	assert.ElementsMatch(t, []string{"good_before.txt", "good_after.txt"}, names,
+		"entries with valid header.Mode must round-trip; bad-mode entry must be skipped")
+	assert.NotContains(t, names, "bad_mode.txt",
+		"the out-of-range mode entry must not be written to disk")
 }
 
 // createTempKubeConfigFile creates a temporary kubeconfig file with the given current context.

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -488,7 +488,7 @@ func TestDownloadRayLogFiles(t *testing.T) {
 // TestDownloadRayLogFiles_SkipsInvalidMode pins the regression for the
 // G115 fix in #4728: when an extracted tar entry has a header.Mode
 // outside the os.FileMode (uint32) range, downloadRayLogFiles must
-// skip just that entry — not abort the extraction or spin forever.
+// skip just that entry, not abort the extraction or spin forever.
 //
 // The tar layout below interleaves a valid entry, an out-of-range
 // entry, and another valid entry so we can prove that:


### PR DESCRIPTION
Fixes #4695.

## What

`ClusterLogOptions.downloadRayLogFiles` in `kubectl-plugin/pkg/cmd/log/log.go` had three issues called out in the bug:

1. **gosec G115 (integer overflow).** `tar.Header.Mode` is `int64`, `os.FileMode` is `uint32`. The existing overflow check printed a warning but then fell through to `os.FileMode(header.Mode)` anyway, so a crafted tar header could still apply unexpected mode bits. Now we `continue` when the mode is out of range and cast explicitly through `uint32` so the G115 diagnostic is honoured:

   ```go
   if header.Mode < 0 || header.Mode > math.MaxUint32 {
       fmt.Fprintf(..., "file mode %d outside of acceptable range, skipping file %s\n", header.Mode, header.Name)
       continue
   }
   outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(uint32(header.Mode)))
   ```

2. **File-descriptor leak.** `defer outFile.Close()` sat inside the extraction loop, so every opened file stayed open until `downloadRayLogFiles` returned. Extracting a large log tar can hit the `too many open files` ulimit. The copy is now wrapped in an IIFE so the `defer` fires at the end of each iteration:

   ```go
   copyErr := func() error {
       defer outFile.Close()
       for {
           ...
       }
   }()
   ```

3. **Error message quality.** `out side` → `outside`, `accceptable` → `acceptable`, include the offending filename, add a newline.

## Why

(1) is a security improvement (gosec was right), (2) is a reliability improvement for large log tars, and (3) is housekeeping that falls out of touching the surrounding block anyway.

Signed off per DCO.