### PR TITLE
[RayJob][volcano] consistent naming on the return of calculatePodGroupParams

### DIFF
--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -312,9 +312,9 @@ func (v *VolcanoBatchScheduler) CleanupOnCompletion(ctx context.Context, object 
 		// RayCluster exists. Recalculate based on live spec (suspended workers are automatically excluded).
 		// If the RayJob is SidecarMode, the submitter is included. Even if the submitter container has terminated, it still takes into account
 		// If it is K8sJobMode, the submitter pod is not taken into account. The completed pod doesn't have resources allocated.
-		clusterMinMember, clusterMinResource := v.calculatePodGroupParams(&cluster.Spec)
-		minMember = clusterMinMember
-		totalResourceList = append(totalResourceList, clusterMinResource)
+		clusterMinMembers, clusterMinResources := v.calculatePodGroupParams(&cluster.Spec)
+		minMember = clusterMinMembers
+		totalResourceList = append(totalResourceList, clusterMinResources)
 	}
 
 	didUpdate, err := v.syncPodGroup(ctx, rayJob, minMember, utils.SumResourceList(totalResourceList))

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -292,7 +292,7 @@ func (v *VolcanoBatchScheduler) CleanupOnCompletion(ctx context.Context, object 
 		return false, nil
 	}
 
-	var minMember int32
+	var minMembers int32
 	var totalResourceList []corev1.ResourceList
 
 	if len(rayJob.Status.RayClusterName) == 0 {
@@ -313,11 +313,11 @@ func (v *VolcanoBatchScheduler) CleanupOnCompletion(ctx context.Context, object 
 		// If the RayJob is SidecarMode, the submitter is included. Even if the submitter container has terminated, it still takes into account
 		// If it is K8sJobMode, the submitter pod is not taken into account. The completed pod doesn't have resources allocated.
 		clusterMinMembers, clusterMinResources := v.calculatePodGroupParams(&cluster.Spec)
-		minMember = clusterMinMembers
+		minMembers = clusterMinMembers
 		totalResourceList = append(totalResourceList, clusterMinResources)
 	}
 
-	didUpdate, err := v.syncPodGroup(ctx, rayJob, minMember, utils.SumResourceList(totalResourceList))
+	didUpdate, err := v.syncPodGroup(ctx, rayJob, minMembers, utils.SumResourceList(totalResourceList))
 	if err != nil {
 		return false, err
 	}

--- a/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
+++ b/ray-operator/controllers/ray/batchscheduler/volcano/volcano_scheduler.go
@@ -312,9 +312,9 @@ func (v *VolcanoBatchScheduler) CleanupOnCompletion(ctx context.Context, object 
 		// RayCluster exists. Recalculate based on live spec (suspended workers are automatically excluded).
 		// If the RayJob is SidecarMode, the submitter is included. Even if the submitter container has terminated, it still takes into account
 		// If it is K8sJobMode, the submitter pod is not taken into account. The completed pod doesn't have resources allocated.
-		clusterMinMember, clusterResource := v.calculatePodGroupParams(&cluster.Spec)
+		clusterMinMember, clusterMinResource := v.calculatePodGroupParams(&cluster.Spec)
 		minMember = clusterMinMember
-		totalResourceList = append(totalResourceList, clusterResource)
+		totalResourceList = append(totalResourceList, clusterMinResource)
 	}
 
 	didUpdate, err := v.syncPodGroup(ctx, rayJob, minMember, utils.SumResourceList(totalResourceList))


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
A nit comment to make the naming consistency on the return of calculatePodGroupParams.

https://github.com/ray-project/kuberay/pull/4669#discussion_r3101963384
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
