### PR TITLE
[Draft] Add multi-cluster setup scripts and manifests for local development of FederatedRayCluster

### DIFF
--- a/federated/README.md
+++ b/federated/README.md
@@ -7,7 +7,7 @@ for cross-cluster head-to-worker and worker-to-worker communication.
 
 ## Architecture
 
-```
+```text
 Host machine (Docker network: kind)
 ├─ frc-primary   (podSubnet: 10.10.0.0/16, Cilium id=1)  ← Ray head, federation controller
 ├─ frc-member-a  (podSubnet: 10.20.0.0/16, Cilium id=2)  ← remote workers
@@ -27,11 +27,22 @@ handling all of Ray's dynamic port requirements without per-port configuration.
 
 ## Prerequisites
 
-- Docker Desktop (or Docker Engine on Linux) with at least **16 GB memory** allocated
+- Docker Desktop (or Docker Engine on Linux) configured with:
+  - **Memory ≥ 12 GB** (16 GB recommended). The default 8 GB is not enough — Cilium
+    pods will OOM-kill in a restart loop and the API server will become unresponsive.
+    Docker Desktop → Settings → Resources → Memory.
+  - **"Use containerd for pulling and storing images" DISABLED** on Docker Desktop.
+    When enabled, `kind load docker-image` fails with
+    `ctr: content digest sha256:... not found`. Docker Desktop → Settings → General.
+    See [Troubleshooting](#kind-load-docker-image-fails-with-ctr-content-digest--not-found)
+    for details.
 - [`kind`](https://kind.sigs.k8s.io/) (v0.20.0+)
 - `kubectl`
 - `helm`
-- [`cilium` CLI](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#install-the-cilium-cli) (v0.19.2+ -- the scripts pin Cilium image versions to match this CLI version)
+- [`cilium` CLI][cilium-cli] (v0.19.2+ -- the scripts pin Cilium image versions
+  to match this CLI version). On macOS: `brew install cilium-cli`.
+
+[cilium-cli]: https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#install-the-cilium-cli
 
 ## Quick Start
 
@@ -68,7 +79,7 @@ After deploying the Ray cluster, port-forward to access the dashboard:
 kubectl --context kind-frc-primary port-forward ray-head 8265:8265
 ```
 
-Open http://localhost:8265 in your browser. The **Cluster** tab shows all 3 nodes
+Open <http://localhost:8265> in your browser. The **Cluster** tab shows all 3 nodes
 from 3 different subnets, confirming the cross-cluster Ray cluster is working.
 
 ## Cleanup
@@ -124,7 +135,7 @@ If you upgrade the `cilium` CLI, update the `CILIUM_IMAGES` array in
 
 ## Directory Structure
 
-```
+```text
 federated/
 ├── README.md
 ├── docs/
@@ -148,6 +159,111 @@ federated/
 ```
 
 ## Troubleshooting
+
+The three issues below are the ones we actually hit during initial setup. If the
+bootstrap or smoke test fails, check these first.
+
+### Docker Desktop is memory-starved → Cilium OOMs and API server times out
+
+**Symptoms:**
+
+- `cilium status --wait` hangs forever on "Cilium control plane not ready".
+- `kubectl` calls eventually fail with `net/http: TLS handshake timeout`.
+- `kubectl -n kube-system get pods` shows Cilium pods restarting repeatedly
+  (`OOMKilled` in `kubectl describe pod`).
+- `docker info | grep "Total Memory"` reports something like `7.652GiB`.
+
+**Cause:** Running 3 kind clusters + Cilium + ClusterMesh API servers in parallel
+needs more memory than Docker Desktop's default allocation (8 GB).
+
+**Fix:**
+
+1. Tear down any half-started clusters:
+
+   ```bash
+   ./hack/cleanup-federated-ray-lab.sh
+   docker image prune -af
+   ```
+
+2. Docker Desktop → Settings → Resources:
+   - Memory: **12 GB minimum**
+   - Swap: 2 GB
+   - Virtual disk limit: 80 GB
+3. Apply & Restart Docker Desktop.
+4. Verify with `docker info | grep -E "CPUs|Total Memory"` — you should see
+   `Total Memory: 1[2-9]GiB` or higher.
+5. Re-run `./hack/bootstrap-federated-ray-lab.sh`.
+
+### `kind load docker-image` fails with `ctr: content digest ... not found`
+
+**Symptoms:**
+
+- Bootstrap script prints `WARNING: failed to load quay.io/cilium/cilium:v1.19.1 into frc-primary`.
+- Running the load manually shows:
+  `ctr: content digest sha256:... not found`
+- `docker info | grep "Storage Driver"` reports `Storage Driver: overlayfs`.
+
+**Cause:** Known compatibility bug between `kind` and Docker Desktop's
+**containerd-backed image store**. The image exists in Docker's containerd store
+but `kind load` can't read it.
+
+**Fix:**
+
+1. Docker Desktop → Settings → General → **Uncheck "Use containerd for pulling
+   and storing images"**.
+2. Apply & Restart. After restart, `docker info | grep "Storage Driver"` should
+   read `Storage Driver: overlay2`.
+3. Re-pull any images (they need to be re-downloaded into the legacy store):
+
+   ```bash
+   for img in quay.io/cilium/cilium:v1.19.1 \
+              quay.io/cilium/operator-generic:v1.19.1 \
+              quay.io/cilium/clustermesh-apiserver:v1.19.1 \
+              quay.io/cilium/cilium-envoy:v1.35.9 \
+              quay.io/cilium/certgen:v0.3.2 \
+              rayproject/ray:2.52.0; do
+     docker pull "$img"
+   done
+   ```
+
+4. Re-run `./hack/bootstrap-federated-ray-lab.sh`.
+
+### Cilium install / clustermesh timeouts because images are too large
+
+**Symptoms:**
+
+- `cilium status --wait` inside the bootstrap prints
+  `timeout: Cilium is not ready` after ~5 minutes.
+- `kubectl -n kube-system get pods` shows Cilium pods still in
+  `ContainerCreating` or `Init:0/N` — the image pull hasn't finished yet.
+- Your network is slow and `quay.io/cilium/cilium` (~500 MB) and
+  `clustermesh-apiserver` take a long time to pull.
+
+**Cause:** Cilium images are large and the default `--wait-duration` on
+`cilium status` and `cilium clustermesh status` was too short for slow networks.
+
+**Workarounds (in order of preference):**
+
+1. **Pre-load images into kind** — this is what the bootstrap script already does
+   for the `CILIUM_IMAGES` array. Images are pulled *once* to the host and then
+   `kind load`ed into all 3 clusters. If you hit this, make sure the pre-load
+   step actually succeeded (see the `ctr: content digest not found` issue above —
+   silent load failures look identical to this symptom).
+
+2. **Bump the wait duration** in `hack/bootstrap-federated-ray-lab.sh` if your
+   network is genuinely slow:
+
+   ```bash
+   cilium status --context "${PRIMARY_CONTEXT}"  --wait --wait-duration 60m
+   cilium status --context "${MEMBER_A_CONTEXT}" --wait --wait-duration 60m
+   cilium status --context "${MEMBER_B_CONTEXT}" --wait --wait-duration 60m
+   ```
+
+   60m is a deliberately large defensive bound; it only blocks until Cilium is
+   actually ready, it doesn't force you to wait the full hour.
+
+3. **Pre-pull images on a fast network** then move to the slow one. The script
+   skips `docker pull` for images already in the local cache.
 
 ### Cilium pods stuck in `Init` or `ImagePullBackOff`
 

--- a/federated/README.md
+++ b/federated/README.md
@@ -1,0 +1,171 @@
+# Federated RayCluster Local Development Environment
+
+Local environment using kind + Cilium ClusterMesh for developing and testing
+Federated RayCluster. Creates 3 interconnected Kubernetes clusters where Pods can
+communicate across cluster boundaries -- the same connectivity model that Ray requires
+for cross-cluster head-to-worker and worker-to-worker communication.
+
+## Architecture
+
+```
+Host machine (Docker network: kind)
+├─ frc-primary   (podSubnet: 10.10.0.0/16, Cilium id=1)  ← Ray head, federation controller
+├─ frc-member-a  (podSubnet: 10.20.0.0/16, Cilium id=2)  ← remote workers
+├─ frc-member-b  (podSubnet: 10.30.0.0/16, Cilium id=3)  ← remote workers
+└─ Cilium ClusterMesh: full mesh, cross-cluster Pod-to-Pod connectivity
+```
+
+## Why Cilium ClusterMesh
+
+Ray requires **full bidirectional Pod-to-Pod IP connectivity** between all nodes.
+Workers register their Pod IP with the head's GCS server, and the head connects
+back to workers for task scheduling. Workers also communicate directly with each
+other for object transfer (`ray.get()`).
+
+Cilium ClusterMesh provides transparent Pod IP routing across kind clusters,
+handling all of Ray's dynamic port requirements without per-port configuration.
+
+## Prerequisites
+
+- Docker Desktop (or Docker Engine on Linux) with at least **16 GB memory** allocated
+- [`kind`](https://kind.sigs.k8s.io/) (v0.20.0+)
+- `kubectl`
+- `helm`
+- [`cilium` CLI](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#install-the-cilium-cli) (v0.19.2+ -- the scripts pin Cilium image versions to match this CLI version)
+
+## Quick Start
+
+```bash
+cd federated/
+
+# Create 3 clusters with Cilium ClusterMesh.
+# First run pulls ~1.2 GB of Cilium images; subsequent runs use cached images.
+./hack/bootstrap-federated-ray-lab.sh
+
+# Verify cross-cluster Pod-to-Pod connectivity (6 bidirectional checks)
+./hack/smoke-test.sh
+```
+
+## Deploy a Cross-Cluster Ray Cluster
+
+After the clusters are running, deploy a Ray head on frc-primary and one worker
+on each member cluster:
+
+```bash
+# Deploy Ray head + 2 cross-cluster workers (pulls rayproject/ray:2.52.0 if not cached)
+./hack/deploy-ray-cluster.sh
+```
+
+This proves that workers in remote clusters can join the head's Ray cluster via
+ClusterMesh Pod IPs. The script outputs the node IPs and verifies they come from
+3 different subnets (10.10.x.x, 10.20.x.x, 10.30.x.x).
+
+## Ray Dashboard
+
+After deploying the Ray cluster, port-forward to access the dashboard:
+
+```bash
+kubectl --context kind-frc-primary port-forward ray-head 8265:8265
+```
+
+Open http://localhost:8265 in your browser. The **Cluster** tab shows all 3 nodes
+from 3 different subnets, confirming the cross-cluster Ray cluster is working.
+
+## Cleanup
+
+```bash
+# Remove only the Ray pods (keep the 3 clusters running)
+./hack/deploy-ray-cluster.sh --cleanup
+
+# Tear down everything (all clusters and pods)
+./hack/cleanup-federated-ray-lab.sh
+```
+
+## Building and Loading Your Own Images
+
+Build and load images directly into kind clusters:
+
+```bash
+docker build -t my-operator:dev .
+for c in frc-primary frc-member-a frc-member-b; do
+  kind load docker-image my-operator:dev --name=$c
+done
+```
+
+When using `kind load`, set `imagePullPolicy: IfNotPresent` in your manifests.
+
+## Contexts
+
+After setup, use these kubectl contexts:
+
+| Context              | Cluster       | Role                                              |
+|----------------------|---------------|----------------------------------------------------|
+| `kind-frc-primary`   | frc-primary   | KubeRay operator, federation controller, Ray head  |
+| `kind-frc-member-a`  | frc-member-a  | KubeRay operator, remote Ray workers               |
+| `kind-frc-member-b`  | frc-member-b  | KubeRay operator, remote Ray workers               |
+
+## Version Pinning
+
+The bootstrap script pre-pulls and loads specific image versions into kind clusters.
+These versions are pinned to match what `cilium` CLI v0.19.2 deploys:
+
+| Component | Version | Used by |
+|-----------|---------|---------|
+| Cilium | v1.19.1 | bootstrap |
+| Cilium Envoy | v1.35.9 | bootstrap |
+| Cilium Operator | v1.19.1 | bootstrap |
+| ClusterMesh API Server | v1.19.1 | bootstrap |
+| Certgen | v0.3.2 | bootstrap |
+| Ray | 2.52.0 | deploy-ray-cluster |
+
+If you upgrade the `cilium` CLI, update the `CILIUM_IMAGES` array in
+`hack/bootstrap-federated-ray-lab.sh` to match the new default versions
+(check with `cilium install --dry-run-helm-values`).
+
+## Directory Structure
+
+```
+federated/
+├── README.md
+├── docs/
+│   ├── cross-cluster-ray-validation.md  # Cross-cluster Ray validation results
+├── hack/
+│   ├── bootstrap-federated-ray-lab.sh   # Create 3 clusters with Cilium ClusterMesh
+│   ├── cleanup-federated-ray-lab.sh     # Tear down all clusters
+│   ├── deploy-ray-cluster.sh            # Deploy Ray head + cross-cluster workers
+│   └── smoke-test.sh                    # Cross-cluster Pod connectivity test
+└── infra/
+    ├── kind/
+    │   ├── frc-primary.yaml             # Primary cluster config (10.10.0.0/16)
+    │   ├── frc-member-a.yaml            # Member A cluster config (10.20.0.0/16)
+    │   └── frc-member-b.yaml            # Member B cluster config (10.30.0.0/16)
+    └── manifests/
+        ├── ray-head.yaml                # Ray head pod manifest
+        ├── ray-worker.yaml              # Ray worker pod manifest (template)
+        ├── smoke-primary.yaml           # Echo pod for connectivity test
+        ├── smoke-member-a.yaml          # Echo pod for connectivity test
+        └── smoke-member-b.yaml          # Echo pod for connectivity test
+```
+
+## Troubleshooting
+
+### Cilium pods stuck in `Init` or `ImagePullBackOff`
+
+The bootstrap script pre-pulls Cilium images to the host and loads them into kind
+clusters to avoid slow in-cluster pulls. If your network blocks `quay.io` entirely,
+pull the images from another network first, then re-run the bootstrap (it skips
+already-cached images).
+
+### ClusterMesh connect fails with "CA certificates do not match"
+
+Each cluster generates its own Cilium CA by default. The bootstrap script already
+handles this with `--allow-mismatching-ca`. If you run the commands manually,
+add that flag, or share a common CA across clusters by passing
+`--set tls.ca.cert=... --set tls.ca.key=...` during `cilium install`.
+
+### Smoke test fails intermittently
+
+Cross-cluster routes may take a few seconds to propagate after ClusterMesh connects.
+The smoke test retries each check up to 3 times. If failures persist, run
+`cilium clustermesh status --context kind-frc-primary` to verify all connections
+are established.

--- a/federated/docs/cross-cluster-ray-validation.md
+++ b/federated/docs/cross-cluster-ray-validation.md
@@ -1,0 +1,142 @@
+# Cross-Cluster Ray Cluster Validation
+
+This document describes how to deploy a Ray cluster spanning 3 Kubernetes clusters
+and validates that the networking setup works for Federated RayCluster development.
+
+## What This Validates
+
+1. A Ray head in the **primary** cluster can accept workers from **member** clusters
+2. Workers register with their Pod IP and the head can connect back to them
+3. All 3 nodes form a single, unified Ray cluster via Cilium ClusterMesh Pod-to-Pod routing
+
+## Prerequisites
+
+- 3 kind clusters running with Cilium ClusterMesh (run `./hack/bootstrap-federated-ray-lab.sh`)
+- `rayproject/ray:2.52.0` image available
+
+## Quick Start
+
+```bash
+cd federated/
+
+# Deploy head on primary, workers on member-a and member-b
+./hack/deploy-ray-cluster.sh
+
+# Clean up Ray pods (keeps clusters running)
+./hack/deploy-ray-cluster.sh --cleanup
+```
+
+## What the Script Does
+
+### Step 1: Deploy Ray Head on frc-primary
+
+```yaml
+# ray-head.yaml
+command: ray start --head --port=6379 --dashboard-host=0.0.0.0 --node-ip-address=$POD_IP --block
+ports: [6379 (GCS), 8265 (dashboard), 10001 (client)]
+```
+
+The head starts GCS on port 6379 and advertises its Pod IP (`10.10.x.x`) via `--node-ip-address`.
+
+### Step 2: Get Head Pod IP
+
+```bash
+HEAD_IP=$(kubectl --context kind-frc-primary get pod ray-head -o jsonpath='{.status.podIP}')
+# Example: 10.10.2.231
+```
+
+### Step 3: Deploy Workers on Member Clusters
+
+Workers are deployed with `RAY_HEAD_ADDRESS` set to the head's Pod IP:
+
+```yaml
+# ray-worker.yaml
+command: ray start --address=$RAY_HEAD_ADDRESS --node-ip-address=$POD_IP --block
+env:
+  RAY_HEAD_ADDRESS: "10.10.2.231:6379"   # Injected by deploy script
+  POD_IP: <from downward API>             # Worker's own Pod IP
+```
+
+The `--node-ip-address=$POD_IP` is critical: it tells Ray to advertise the worker's
+Pod IP (e.g., `10.20.x.x`) so the head can connect back to it via ClusterMesh.
+
+### Step 4: Verify
+
+```bash
+kubectl --context kind-frc-primary exec ray-head -- ray status
+```
+
+Expected output:
+```
+Node status
+---------------------------------------------------------------
+Active:
+ 1 node_<hash1>    ← head  (10.10.x.x)
+ 1 node_<hash2>    ← worker (10.20.x.x)
+ 1 node_<hash3>    ← worker (10.30.x.x)
+```
+
+3 active nodes, 3 unique subnets = workers from 2 different Kubernetes clusters
+successfully joined the head's Ray cluster.
+
+## Validated Results
+
+| Component | Cluster | Pod IP Subnet | Status |
+|-----------|---------|---------------|--------|
+| Ray Head  | frc-primary  | 10.10.x.x | Active |
+| Worker A  | frc-member-a | 10.20.x.x | Active, joined head |
+| Worker B  | frc-member-b | 10.30.x.x | Active, joined head |
+
+Total resources visible to Ray: 6 CPU, ~3 GiB memory (2 CPU per node).
+
+## What This Proves for Federated RayCluster
+
+1. **GCS bootstrap works cross-cluster**: Workers in member clusters connect to the
+   head's GCS port via ClusterMesh Pod IP routing.
+
+2. **Bidirectional connectivity works**: The head can reach workers back at their Pod IPs
+   for task scheduling (NodeManager RPCs). If this didn't work, workers would register
+   but `ray status` would show them as dead.
+
+3. **Pod IP advertisement works**: `--node-ip-address=$POD_IP` correctly advertises
+   each node's ClusterMesh-routable Pod IP. The head uses these IPs for reverse
+   connections.
+
+4. **No special networking configuration needed**: Beyond Cilium ClusterMesh setup,
+   no additional ports, services, or routing rules were needed. Ray's dynamic port
+   allocation works transparently over ClusterMesh.
+
+## What's NOT Validated Yet
+
+- **Object transfer across clusters**: Running `ray.get()` on a remote object would
+  exercise the ObjectManager path (Pod-to-Pod on random ports). This requires
+  submitting a Ray job, which needs a driver process with sufficient resources.
+
+- **KubeRay operator integration**: This test uses plain pods. The FederatedRayCluster
+  controller would use KubeRay to manage these pods.
+
+- **Autoscaling**: Ray autoscaler is not configured in this manual test.
+
+- **Head restart / reconnection**: What happens when the head pod restarts and gets
+  a new IP.
+
+## Useful Commands
+
+```bash
+# Check Ray cluster status
+kubectl --context kind-frc-primary exec ray-head -- ray status
+
+# Access Ray dashboard
+kubectl --context kind-frc-primary port-forward ray-head 8265:8265
+# Then open http://localhost:8265
+
+# Check worker logs
+kubectl --context kind-frc-member-a logs ray-worker
+kubectl --context kind-frc-member-b logs ray-worker
+
+# Clean up Ray pods only (keep clusters running)
+./hack/deploy-ray-cluster.sh --cleanup
+
+# Tear down everything
+./hack/cleanup-federated-ray-lab.sh
+```

--- a/federated/hack/bootstrap-federated-ray-lab.sh
+++ b/federated/hack/bootstrap-federated-ray-lab.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Bootstrap script for the Federated RayCluster local development environment.
+#
+# Creates 3 kind clusters with Cilium CNI and ClusterMesh for cross-cluster
+# Pod-to-Pod connectivity.
+set -euo pipefail
+
+# ── Configuration ────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="${SCRIPT_DIR}/../infra"
+
+PRIMARY_CLUSTER="frc-primary"
+MEMBER_A_CLUSTER="frc-member-a"
+MEMBER_B_CLUSTER="frc-member-b"
+ALL_CLUSTERS=("${PRIMARY_CLUSTER}" "${MEMBER_A_CLUSTER}" "${MEMBER_B_CLUSTER}")
+
+PRIMARY_CONTEXT="kind-${PRIMARY_CLUSTER}"
+MEMBER_A_CONTEXT="kind-${MEMBER_A_CLUSTER}"
+MEMBER_B_CONTEXT="kind-${MEMBER_B_CLUSTER}"
+
+CLUSTERMESH_SERVICE_TYPE="${CLUSTERMESH_SERVICE_TYPE:-NodePort}"
+
+# Cilium images to pre-pull and load into kind clusters.
+# Pre-loading avoids 27 parallel pulls from quay.io (9 nodes x 3 images)
+# and makes the setup work reliably regardless of network speed.
+CILIUM_IMAGES=(
+  "quay.io/cilium/cilium:v1.19.1"
+  "quay.io/cilium/cilium-envoy:v1.35.9-1770979049-232ed4a26881e4ab4f766f251f258ed424fff663"
+  "quay.io/cilium/operator-generic:v1.19.1"
+  "quay.io/cilium/clustermesh-apiserver:v1.19.1"
+  "quay.io/cilium/certgen:v0.3.2"
+)
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "ERROR: missing required command: $1" >&2
+    exit 1
+  }
+}
+
+# ── Step 1: Check dependencies ───────────────────────────────────────────────
+echo "[1/8] Checking dependencies..."
+need_cmd docker
+need_cmd kubectl
+need_cmd helm
+need_cmd kind
+need_cmd cilium
+
+# ── Step 2: Pull Cilium images to host ───────────────────────────────────────
+echo "[2/8] Pulling Cilium images to host (if not already cached)..."
+for image in "${CILIUM_IMAGES[@]}"; do
+  if docker image inspect "${image}" >/dev/null 2>&1; then
+    echo "  Already cached: ${image}"
+  else
+    echo "  Pulling: ${image}..."
+    docker pull "${image}"
+  fi
+done
+
+# ── Step 3: Create kind clusters ─────────────────────────────────────────────
+echo "[3/8] Creating kind clusters..."
+for cluster in "${ALL_CLUSTERS[@]}"; do
+  kind delete cluster --name "${cluster}" 2>/dev/null || true
+done
+
+kind create cluster --config "${INFRA_DIR}/kind/frc-primary.yaml"
+kind create cluster --config "${INFRA_DIR}/kind/frc-member-a.yaml"
+kind create cluster --config "${INFRA_DIR}/kind/frc-member-b.yaml"
+
+# ── Step 4: Load Cilium images into kind clusters ────────────────────────────
+echo "[4/8] Loading Cilium images into kind clusters..."
+for cluster in "${ALL_CLUSTERS[@]}"; do
+  echo "  ${cluster}: loading ${#CILIUM_IMAGES[@]} images..."
+  for image in "${CILIUM_IMAGES[@]}"; do
+    if ! kind load docker-image "${image}" --name="${cluster}" >/dev/null 2>&1; then
+      echo "    WARNING: failed to load ${image} into ${cluster}"
+    fi
+  done
+done
+
+# ── Step 5: Install Cilium ───────────────────────────────────────────────────
+echo "[5/8] Installing Cilium on all clusters..."
+
+install_cilium() {
+  local ctx="$1" name="$2" id="$3"
+  echo "  Installing Cilium on ${name} (id=${id})..."
+  cilium install \
+    --context "${ctx}" \
+    --set cluster.name="${name}" \
+    --set cluster.id="${id}" \
+    --set ipam.mode=kubernetes \
+    --set image.useDigest=false \
+    --set operator.image.useDigest=false \
+    --set envoy.image.useDigest=false \
+    --set clustermesh.apiserver.image.useDigest=false \
+    --set certgen.image.useDigest=false
+}
+
+install_cilium "${PRIMARY_CONTEXT}"  "${PRIMARY_CLUSTER}"  1
+install_cilium "${MEMBER_A_CONTEXT}" "${MEMBER_A_CLUSTER}" 2
+install_cilium "${MEMBER_B_CONTEXT}" "${MEMBER_B_CLUSTER}" 3
+
+echo "  Waiting for Cilium to be ready (timeout: 15m per cluster)..."
+cilium status --context "${PRIMARY_CONTEXT}" --wait --wait-duration 15m
+cilium status --context "${MEMBER_A_CONTEXT}" --wait --wait-duration 15m
+cilium status --context "${MEMBER_B_CONTEXT}" --wait --wait-duration 15m
+
+# ── Step 6: Enable ClusterMesh ───────────────────────────────────────────────
+echo "[6/8] Enabling ClusterMesh (${CLUSTERMESH_SERVICE_TYPE} mode)..."
+cilium clustermesh enable --context "${PRIMARY_CONTEXT}" --service-type "${CLUSTERMESH_SERVICE_TYPE}"
+cilium clustermesh enable --context "${MEMBER_A_CONTEXT}" --service-type "${CLUSTERMESH_SERVICE_TYPE}"
+cilium clustermesh enable --context "${MEMBER_B_CONTEXT}" --service-type "${CLUSTERMESH_SERVICE_TYPE}"
+
+echo "  Waiting for ClusterMesh to be ready (timeout: 15m per cluster)..."
+cilium clustermesh status --context "${PRIMARY_CONTEXT}" --wait --wait-duration 15m
+cilium clustermesh status --context "${MEMBER_A_CONTEXT}" --wait --wait-duration 15m
+cilium clustermesh status --context "${MEMBER_B_CONTEXT}" --wait --wait-duration 15m
+
+# ── Step 7: Connect clusters ────────────────────────────────────────────────
+echo "[7/8] Connecting clusters into mesh..."
+# Each cluster has its own Cilium CA; --allow-mismatching-ca bundles remote CAs
+# into the trust chain so mutual TLS works across independently-installed clusters.
+cilium clustermesh connect --context "${PRIMARY_CONTEXT}" --destination-context "${MEMBER_A_CONTEXT}" --allow-mismatching-ca
+cilium clustermesh connect --context "${PRIMARY_CONTEXT}" --destination-context "${MEMBER_B_CONTEXT}" --allow-mismatching-ca
+cilium clustermesh connect --context "${MEMBER_A_CONTEXT}" --destination-context "${MEMBER_B_CONTEXT}" --allow-mismatching-ca
+
+echo "  Waiting for mesh connections to stabilize (timeout: 15m per cluster)..."
+cilium clustermesh status --context "${PRIMARY_CONTEXT}" --wait --wait-duration 15m
+cilium clustermesh status --context "${MEMBER_A_CONTEXT}" --wait --wait-duration 15m
+cilium clustermesh status --context "${MEMBER_B_CONTEXT}" --wait --wait-duration 15m
+
+# ── Step 8: Verify ──────────────────────────────────────────────────────────
+echo "[8/8] Verifying cluster connectivity..."
+kubectl --context "${PRIMARY_CONTEXT}" get nodes
+kubectl --context "${MEMBER_A_CONTEXT}" get nodes
+kubectl --context "${MEMBER_B_CONTEXT}" get nodes
+
+echo ""
+echo "Done!"
+echo
+echo "Contexts:"
+echo "  ${PRIMARY_CONTEXT}"
+echo "  ${MEMBER_A_CONTEXT}"
+echo "  ${MEMBER_B_CONTEXT}"
+echo
+echo "Next steps:"
+echo "  # Run cross-cluster connectivity test:"
+echo "  ./hack/smoke-test.sh"
+echo
+echo "  # Deploy a cross-cluster Ray cluster:"
+echo "  ./hack/deploy-ray-cluster.sh"

--- a/federated/hack/cleanup-federated-ray-lab.sh
+++ b/federated/hack/cleanup-federated-ray-lab.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Tear down the Federated RayCluster local development environment.
+set -euo pipefail
+
+echo "Deleting kind clusters..."
+kind delete cluster --name frc-primary  || true
+kind delete cluster --name frc-member-a || true
+kind delete cluster --name frc-member-b || true
+
+echo "Done."

--- a/federated/hack/deploy-ray-cluster.sh
+++ b/federated/hack/deploy-ray-cluster.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Deploy a cross-cluster Ray cluster: head on frc-primary, one worker on each member cluster.
+#
+# Prerequisites:
+#   - 3 kind clusters running with Cilium ClusterMesh (run bootstrap-federated-ray-lab.sh first)
+#   - rayproject/ray:2.52.0 image available (pulled automatically if not cached)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFESTS_DIR="${SCRIPT_DIR}/../infra/manifests"
+
+PRIMARY_CONTEXT="kind-frc-primary"
+MEMBER_A_CONTEXT="kind-frc-member-a"
+MEMBER_B_CONTEXT="kind-frc-member-b"
+
+RAY_IMAGE="rayproject/ray:2.52.0"
+
+cleanup_ray() {
+  echo ""
+  echo "=== Cleaning up Ray pods ==="
+  kubectl --context "${PRIMARY_CONTEXT}"  delete pod ray-head   --ignore-not-found 2>/dev/null || true
+  kubectl --context "${MEMBER_A_CONTEXT}" delete pod ray-worker --ignore-not-found 2>/dev/null || true
+  kubectl --context "${MEMBER_B_CONTEXT}" delete pod ray-worker --ignore-not-found 2>/dev/null || true
+}
+
+# Handle --cleanup flag
+if [ "${1:-}" = "--cleanup" ]; then
+  cleanup_ray
+  exit 0
+fi
+
+# ── Step 1: Pull and load Ray image ─────────────────────────────────────────
+echo "[1/4] Preparing Ray image..."
+if docker image inspect "${RAY_IMAGE}" >/dev/null 2>&1; then
+  echo "  Already cached: ${RAY_IMAGE}"
+else
+  echo "  Pulling: ${RAY_IMAGE} (~1.5 GB, may take a few minutes)..."
+  docker pull "${RAY_IMAGE}"
+fi
+
+for cluster in frc-primary frc-member-a frc-member-b; do
+  echo "  Loading into ${cluster}..."
+  if ! kind load docker-image "${RAY_IMAGE}" --name="${cluster}" >/dev/null 2>&1; then
+    echo "    WARNING: failed to load ${RAY_IMAGE} into ${cluster}"
+  fi
+done
+
+# ── Step 2: Deploy Ray head on primary cluster ──────────────────────────────
+echo "[2/4] Deploying Ray head on frc-primary..."
+kubectl --context "${PRIMARY_CONTEXT}" delete pod ray-head --ignore-not-found 2>/dev/null || true
+kubectl --context "${PRIMARY_CONTEXT}" apply -f "${MANIFESTS_DIR}/ray-head.yaml"
+
+echo "  Waiting for head pod to be ready..."
+kubectl --context "${PRIMARY_CONTEXT}" wait --for=condition=Ready pod/ray-head --timeout=300s
+
+echo "  Waiting for GCS to accept connections..."
+HEAD_IP=$(kubectl --context "${PRIMARY_CONTEXT}" get pod ray-head -o jsonpath='{.status.podIP}')
+for i in $(seq 1 30); do
+  if kubectl --context "${PRIMARY_CONTEXT}" exec ray-head -- ray health-check --address "${HEAD_IP}:6379" >/dev/null 2>&1; then
+    echo "  GCS is ready."
+    break
+  fi
+  sleep 2
+done
+
+# ── Step 3: Get head Pod IP and deploy workers ──────────────────────────────
+echo "[3/4] Head Pod IP: ${HEAD_IP}"
+echo "  Deploying workers with RAY_HEAD_ADDRESS=${HEAD_IP}:6379..."
+
+# Deploy worker on member-a
+kubectl --context "${MEMBER_A_CONTEXT}" delete pod ray-worker --ignore-not-found 2>/dev/null || true
+sed "s|PLACEHOLDER:6379|${HEAD_IP}:6379|g" "${MANIFESTS_DIR}/ray-worker.yaml" \
+  | kubectl --context "${MEMBER_A_CONTEXT}" apply -f -
+
+# Deploy worker on member-b
+kubectl --context "${MEMBER_B_CONTEXT}" delete pod ray-worker --ignore-not-found 2>/dev/null || true
+sed "s|PLACEHOLDER:6379|${HEAD_IP}:6379|g" "${MANIFESTS_DIR}/ray-worker.yaml" \
+  | kubectl --context "${MEMBER_B_CONTEXT}" apply -f -
+
+echo "  Waiting for workers to be ready..."
+kubectl --context "${MEMBER_A_CONTEXT}" wait --for=condition=Ready pod/ray-worker --timeout=300s
+kubectl --context "${MEMBER_B_CONTEXT}" wait --for=condition=Ready pod/ray-worker --timeout=300s
+
+# ── Step 4: Verify Ray cluster formed ───────────────────────────────────────
+echo "[4/4] Verifying Ray cluster..."
+sleep 10
+
+echo ""
+HEAD_IP=$(kubectl --context "${PRIMARY_CONTEXT}" get pod ray-head -o jsonpath='{.status.podIP}')
+echo "=== Ray cluster status ==="
+kubectl --context "${PRIMARY_CONTEXT}" exec ray-head -- ray status --address "${HEAD_IP}:6379"
+echo ""
+
+echo "=== Node IPs (via dashboard API) ==="
+kubectl --context "${PRIMARY_CONTEXT}" exec ray-head -- python3 -c "
+import urllib.request, json
+data = json.loads(urllib.request.urlopen('http://localhost:8265/nodes?view=summary').read())
+nodes = data.get('data', {}).get('summary', [])
+for n in sorted(nodes, key=lambda x: x.get('ip', '')):
+    ip = n.get('ip', '?')
+    hostname = n.get('hostname', '?')
+    print(f'  {ip}  hostname={hostname}')
+print()
+ips = [n['ip'] for n in nodes if 'ip' in n]
+subnets = set(ip.rsplit('.', 2)[0] for ip in ips)
+print(f'Nodes: {len(nodes)}, Unique subnets: {len(subnets)} (expect 3 for cross-cluster)')
+"
+echo ""
+
+echo "Done! Ray cluster is running across 3 Kubernetes clusters."
+echo ""
+echo "Useful commands:"
+echo "  kubectl --context ${PRIMARY_CONTEXT} exec ray-head -- ray status --address ${HEAD_IP}:6379"
+echo "  kubectl --context ${PRIMARY_CONTEXT} port-forward ray-head 8265:8265  # Ray Dashboard at http://localhost:8265"
+echo "  ./hack/deploy-ray-cluster.sh --cleanup  # Tear down Ray pods"

--- a/federated/hack/smoke-test.sh
+++ b/federated/hack/smoke-test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Smoke test: verify cross-cluster Pod-to-Pod connectivity via Cilium ClusterMesh.
+#
+# Deploys echo pods in each cluster, then curls across clusters to verify
+# that Pods can reach each other directly by Pod IP.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFESTS_DIR="${SCRIPT_DIR}/../infra/manifests"
+
+PRIMARY_CONTEXT="kind-frc-primary"
+MEMBER_A_CONTEXT="kind-frc-member-a"
+MEMBER_B_CONTEXT="kind-frc-member-b"
+
+cleanup() {
+  echo ""
+  echo "=== Cleaning up echo pods ==="
+  kubectl --context "${PRIMARY_CONTEXT}"  delete pod echo-primary  --ignore-not-found 2>/dev/null || true
+  kubectl --context "${MEMBER_A_CONTEXT}" delete pod echo-member-a --ignore-not-found 2>/dev/null || true
+  kubectl --context "${MEMBER_B_CONTEXT}" delete pod echo-member-b --ignore-not-found 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== Deploying echo pods ==="
+kubectl --context "${PRIMARY_CONTEXT}"  apply -f "${MANIFESTS_DIR}/smoke-primary.yaml"
+kubectl --context "${MEMBER_A_CONTEXT}" apply -f "${MANIFESTS_DIR}/smoke-member-a.yaml"
+kubectl --context "${MEMBER_B_CONTEXT}" apply -f "${MANIFESTS_DIR}/smoke-member-b.yaml"
+
+echo "=== Waiting for pods to be ready ==="
+kubectl --context "${PRIMARY_CONTEXT}"  wait --for=condition=Ready pod/echo-primary  --timeout=120s
+kubectl --context "${MEMBER_A_CONTEXT}" wait --for=condition=Ready pod/echo-member-a --timeout=120s
+kubectl --context "${MEMBER_B_CONTEXT}" wait --for=condition=Ready pod/echo-member-b --timeout=120s
+
+echo "=== Getting Pod IPs ==="
+PRIMARY_IP=$(kubectl --context "${PRIMARY_CONTEXT}"  get pod echo-primary  -o jsonpath='{.status.podIP}')
+MEMBER_A_IP=$(kubectl --context "${MEMBER_A_CONTEXT}" get pod echo-member-a -o jsonpath='{.status.podIP}')
+MEMBER_B_IP=$(kubectl --context "${MEMBER_B_CONTEXT}" get pod echo-member-b -o jsonpath='{.status.podIP}')
+
+echo "  echo-primary  (frc-primary):  ${PRIMARY_IP}"
+echo "  echo-member-a (frc-member-a): ${MEMBER_A_IP}"
+echo "  echo-member-b (frc-member-b): ${MEMBER_B_IP}"
+
+PASS=0
+FAIL=0
+TEST_NUM=0
+
+cross_curl() {
+  local from_ctx="$1" from_name="$2" target_ip="$3" target_name="$4"
+  TEST_NUM=$((TEST_NUM + 1))
+  local pod_name="curl-test-${$}-${TEST_NUM}"
+  echo -n "  ${from_name} -> ${target_name} (${target_ip}:5678): "
+
+  local attempt result
+  for attempt in 1 2 3; do
+    kubectl --context "${from_ctx}" delete pod "${pod_name}" --ignore-not-found 2>/dev/null || true
+
+    result=$(kubectl --context "${from_ctx}" run "${pod_name}" \
+      --rm -i --restart=Never --image=curlimages/curl \
+      -- curl -s --connect-timeout 10 "http://${target_ip}:5678" 2>/dev/null \
+      | tr -d '\r' | grep "hello-from-") || result=""
+
+    if [ -n "${result}" ]; then
+      echo "OK (${result})"
+      PASS=$((PASS + 1))
+      return
+    fi
+
+    if [ "${attempt}" -lt 3 ]; then
+      sleep 2
+    fi
+  done
+
+  echo "FAILED (after ${attempt} attempts)"
+  FAIL=$((FAIL + 1))
+}
+
+echo ""
+echo "=== Testing cross-cluster Pod-to-Pod connectivity ==="
+
+# primary -> members
+cross_curl "${PRIMARY_CONTEXT}" "frc-primary" "${MEMBER_A_IP}" "frc-member-a"
+cross_curl "${PRIMARY_CONTEXT}" "frc-primary" "${MEMBER_B_IP}" "frc-member-b"
+
+# member-a -> primary and member-b
+cross_curl "${MEMBER_A_CONTEXT}" "frc-member-a" "${PRIMARY_IP}" "frc-primary"
+cross_curl "${MEMBER_A_CONTEXT}" "frc-member-a" "${MEMBER_B_IP}" "frc-member-b"
+
+# member-b -> primary and member-a
+cross_curl "${MEMBER_B_CONTEXT}" "frc-member-b" "${PRIMARY_IP}" "frc-primary"
+cross_curl "${MEMBER_B_CONTEXT}" "frc-member-b" "${MEMBER_A_IP}" "frc-member-a"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+# Cleanup is handled by the EXIT trap above.
+
+if [ "${FAIL}" -gt 0 ]; then
+  echo ""
+  echo "SMOKE TEST FAILED: ${FAIL} connectivity check(s) failed."
+  exit 1
+fi
+
+echo ""
+echo "SMOKE TEST PASSED: All cross-cluster connectivity checks succeeded."

--- a/federated/infra/kind/frc-member-a.yaml
+++ b/federated/infra/kind/frc-member-a.yaml
@@ -1,0 +1,13 @@
+# Member cluster A: remote Ray workers.
+# CIDRs must not overlap with other clusters or Docker's kind network (172.18.0.0/16).
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: frc-member-a
+networking:
+  disableDefaultCNI: true   # Cilium will replace the default CNI
+  podSubnet: "10.20.0.0/16"
+  serviceSubnet: "10.21.0.0/16"
+nodes:
+- role: control-plane
+- role: worker
+- role: worker

--- a/federated/infra/kind/frc-member-b.yaml
+++ b/federated/infra/kind/frc-member-b.yaml
@@ -1,0 +1,13 @@
+# Member cluster B: remote Ray workers.
+# CIDRs must not overlap with other clusters or Docker's kind network (172.18.0.0/16).
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: frc-member-b
+networking:
+  disableDefaultCNI: true   # Cilium will replace the default CNI
+  podSubnet: "10.30.0.0/16"
+  serviceSubnet: "10.31.0.0/16"
+nodes:
+- role: control-plane
+- role: worker
+- role: worker

--- a/federated/infra/kind/frc-primary.yaml
+++ b/federated/infra/kind/frc-primary.yaml
@@ -1,0 +1,14 @@
+# Primary cluster: Ray head + federation controller.
+# CIDRs must not overlap with other clusters or Docker's kind network (172.18.0.0/16).
+# Spacing: primary=10.1x, member-a=10.2x, member-b=10.3x.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: frc-primary
+networking:
+  disableDefaultCNI: true   # Cilium will replace the default CNI
+  podSubnet: "10.10.0.0/16"
+  serviceSubnet: "10.11.0.0/16"
+nodes:
+- role: control-plane
+- role: worker
+- role: worker

--- a/federated/infra/manifests/ray-head.yaml
+++ b/federated/infra/manifests/ray-head.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ray-head
+  labels:
+    app: ray
+    component: head
+spec:
+  containers:
+  - name: ray-head
+    image: rayproject/ray:2.52.0
+    command: ["/bin/bash", "-lc"]
+    args:
+    - |
+      ulimit -n 65536; \
+      ray start --head \
+        --port=6379 \
+        --dashboard-host=0.0.0.0 \
+        --dashboard-agent-listen-port=52365 \
+        --node-ip-address=$POD_IP \
+        --num-cpus=1 \
+        --block
+    env:
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    ports:
+    - containerPort: 6379
+      name: gcs-server
+    - containerPort: 8265
+      name: dashboard
+    - containerPort: 10001
+      name: client
+    resources:
+      requests:
+        cpu: "1"
+        memory: "5Gi"
+      limits:
+        cpu: "1"
+        memory: "5Gi"
+    volumeMounts:
+    - name: dshm
+      mountPath: /dev/shm
+  volumes:
+  - name: dshm
+    emptyDir:
+      medium: Memory
+      sizeLimit: 5Gi

--- a/federated/infra/manifests/ray-worker.yaml
+++ b/federated/infra/manifests/ray-worker.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ray-worker
+  labels:
+    app: ray
+    component: worker
+spec:
+  # Wait for GCS to be ready before starting the worker.
+  # This is the same pattern KubeRay uses (wait-gcs-ready init container).
+  initContainers:
+  - name: wait-gcs-ready
+    image: rayproject/ray:2.52.0
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      SECONDS=0
+      while true; do
+        if ray health-check --address $RAY_HEAD_ADDRESS > /dev/null 2>&1; then
+          echo "GCS is ready."
+          break
+        fi
+        echo "$SECONDS seconds elapsed: Waiting for GCS to be ready."
+        sleep 5
+      done
+    env:
+    - name: RAY_HEAD_ADDRESS
+      value: "PLACEHOLDER:6379"
+  containers:
+  - name: ray-worker
+    image: rayproject/ray:2.52.0
+    command: ["/bin/bash", "-lc"]
+    args:
+    - |
+      ulimit -n 65536; \
+      ray start \
+        --address=$RAY_HEAD_ADDRESS \
+        --dashboard-agent-listen-port=52365 \
+        --node-ip-address=$POD_IP \
+        --num-cpus=1 \
+        --block
+    env:
+    - name: RAY_HEAD_ADDRESS
+      value: "PLACEHOLDER:6379"
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    resources:
+      requests:
+        cpu: "1"
+        memory: "2Gi"
+      limits:
+        cpu: "1"
+        memory: "2Gi"
+    volumeMounts:
+    - name: dshm
+      mountPath: /dev/shm
+  volumes:
+  - name: dshm
+    emptyDir:
+      medium: Memory
+      sizeLimit: 2Gi

--- a/federated/infra/manifests/smoke-member-a.yaml
+++ b/federated/infra/manifests/smoke-member-a.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: echo-member-a
+  labels:
+    app: echo
+    cluster: frc-member-a
+spec:
+  containers:
+  - name: echo
+    image: hashicorp/http-echo
+    args: ["-text=hello-from-member-a"]
+    ports:
+    - containerPort: 5678

--- a/federated/infra/manifests/smoke-member-b.yaml
+++ b/federated/infra/manifests/smoke-member-b.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: echo-member-b
+  labels:
+    app: echo
+    cluster: frc-member-b
+spec:
+  containers:
+  - name: echo
+    image: hashicorp/http-echo
+    args: ["-text=hello-from-member-b"]
+    ports:
+    - containerPort: 5678

--- a/federated/infra/manifests/smoke-primary.yaml
+++ b/federated/infra/manifests/smoke-primary.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: echo-primary
+  labels:
+    app: echo
+    cluster: frc-primary
+spec:
+  containers:
+  - name: echo
+    image: hashicorp/http-echo
+    args: ["-text=hello-from-primary"]
+    ports:
+    - containerPort: 5678


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR adds a local development environment for the upcoming Federated RayCluster feature. It creates 3 interconnected kind clusters using `Cilium` ClusterMesh, providing the full bidirectional Pod-to-Pod IP connectivity that Ray requires for cross-cluster head-to-worker and worker-to-worker communication.

Ray's networking model demands more than just exposing the head's GCS port -- the head must connect back to workers (for task scheduling, placement groups, node draining), and workers must communicate directly with each other (for object transfer via ray.get(), actor calls). Cilium ClusterMesh provides this transparently across kind clusters, handling Ray's dynamic port requirements without per-port configuration.

What's included:
- `hack/bootstrap-federated-ray-lab.sh` -- one-command setup: creates 3 kind clusters, installs Cilium, enables. ClusterMesh, connects all clusters into a full mesh
- `hack/smoke-test.sh` -- verifies all 6 bidirectional cross-cluster Pod-to-Pod connectivity paths
- `hack/cleanup-federated-ray-lab.sh` -- tears down everything

This environment can be used for developing and testing the `FederatedRayCluster` CRD, federation controller, and `spec.workerOnly` support described in the design proposal.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
