### PR TITLE
[Refactor] [history server] Fully encapsulate mutex of state entity map

### DIFF
--- a/historyserver/pkg/eventserver/eventserver.go
+++ b/historyserver/pkg/eventserver/eventserver.go
@@ -45,18 +45,10 @@ func isValidEventFile(fileName string) bool {
 func NewEventHandler(reader storage.StorageReader) *EventHandler {
 	return &EventHandler{
 		reader: reader,
-		ClusterTaskMap: &types.ClusterTaskMap{
-			ClusterTaskMap: make(map[string]*types.TaskMap),
-		},
-		ClusterActorMap: &types.ClusterActorMap{
-			ClusterActorMap: make(map[string]*types.ActorMap),
-		},
-		ClusterJobMap: &types.ClusterJobMap{
-			ClusterJobMap: make(map[string]*types.JobMap),
-		},
-		ClusterNodeMap: &types.ClusterNodeMap{
-			ClusterNodeMap: make(map[string]*types.NodeMap),
-		},
+		ClusterTaskMap: types.NewClusterTaskMap(),
+		ClusterActorMap: types.NewClusterActorMap(),
+		ClusterJobMap: types.NewClusterJobMap(),
+		ClusterNodeMap: types.NewClusterNodeMap(),
 		ClusterLogEventMap: types.NewClusterLogEventMap(),
 	}
 }
@@ -662,178 +654,53 @@ func (h *EventHandler) getAllNodeEventFiles(clusterInfo utils.ClusterInfo) []str
 // GetTasks returns a slice of thread-safe deep copies of all task attempts for a given cluster session.
 // Deep copy ensures the returned data is safe to use after the lock is released.
 func (h *EventHandler) GetTasks(clusterSessionKey string) []types.Task {
-	h.ClusterTaskMap.RLock()
-	defer h.ClusterTaskMap.RUnlock()
-
-	taskMap, ok := h.ClusterTaskMap.ClusterTaskMap[clusterSessionKey]
-	if !ok {
+	taskMap, found := h.ClusterTaskMap.GetTaskMap(clusterSessionKey)
+	if !found {
 		// TODO(jwj): Add error handling.
 		logrus.Errorf("Task map not found for cluster session: %s", clusterSessionKey)
 		return []types.Task{}
 	}
 
-	taskMap.Lock()
-	defer taskMap.Unlock()
-
-	// Flatten all task attempts into a single slice with deep copy.
-	allTasks := make([]types.Task, 0)
-	for _, taskAttempts := range taskMap.TaskMap {
-		for _, taskAttempt := range taskAttempts {
-			allTasks = append(allTasks, taskAttempt.DeepCopy())
-		}
+	tasks := make([]types.Task, 0)
+	for _, attempts := range taskMap {
+		tasks = append(tasks, attempts...)
 	}
 
-	return allTasks
+	return tasks
 }
 
 // GetTaskByID returns all attempts for a specific task ID in a given cluster.
 // Returns a slice of tasks representing all attempts, sorted by attempt number is not guaranteed.
 func (h *EventHandler) GetTaskByID(clusterName, taskID string) ([]types.Task, bool) {
-	h.ClusterTaskMap.RLock()
-	defer h.ClusterTaskMap.RUnlock()
-
-	taskMap, ok := h.ClusterTaskMap.ClusterTaskMap[clusterName]
-	if !ok {
-		return nil, false
-	}
-
-	taskMap.Lock()
-	defer taskMap.Unlock()
-
-	attempts, ok := taskMap.TaskMap[taskID]
-	if !ok || len(attempts) == 0 {
-		return nil, false
-	}
-	// Return a deep copy to avoid data race
-	result := make([]types.Task, len(attempts))
-	for i, task := range attempts {
-		result[i] = task.DeepCopy()
-	}
-	return result, true
+	return h.ClusterTaskMap.GetTaskByID(clusterName, taskID)
 }
 
 // GetTasksByJobID returns all tasks (including all attempts) for a given job ID in a cluster.
 func (h *EventHandler) GetTasksByJobID(clusterName, jobID string) []types.Task {
-	h.ClusterTaskMap.RLock()
-	defer h.ClusterTaskMap.RUnlock()
-
-	taskMap, ok := h.ClusterTaskMap.ClusterTaskMap[clusterName]
-	if !ok {
-		return []types.Task{}
-	}
-
-	taskMap.Lock()
-	defer taskMap.Unlock()
-
-	var tasks []types.Task
-	for _, attempts := range taskMap.TaskMap {
-		for _, task := range attempts {
-			if task.JobID == jobID {
-				tasks = append(tasks, task.DeepCopy())
-			}
-		}
-	}
-	return tasks
+	return h.ClusterTaskMap.GetTasksByJobID(clusterName, jobID)
 }
 
 // GetActors returns a thread-safe deep copy of all actors for a given cluster
 func (h *EventHandler) GetActors(clusterName string) []types.Actor {
-	h.ClusterActorMap.RLock()
-	defer h.ClusterActorMap.RUnlock()
-
-	actorMap, ok := h.ClusterActorMap.ClusterActorMap[clusterName]
-	if !ok {
-		return []types.Actor{}
-	}
-
-	actorMap.Lock()
-	defer actorMap.Unlock()
-
-	actors := make([]types.Actor, 0, len(actorMap.ActorMap))
-	for _, actor := range actorMap.ActorMap {
-		actors = append(actors, actor.DeepCopy())
-	}
-	return actors
+	return h.ClusterActorMap.GetActors(clusterName)
 }
 
 // GetActorByID returns a specific actor by ID for a given cluster
 func (h *EventHandler) GetActorByID(clusterName, actorID string) (types.Actor, bool) {
-	h.ClusterActorMap.RLock()
-	defer h.ClusterActorMap.RUnlock()
-
-	actorMap, ok := h.ClusterActorMap.ClusterActorMap[clusterName]
-	if !ok {
-		return types.Actor{}, false
-	}
-
-	actorMap.Lock()
-	defer actorMap.Unlock()
-
-	// Actor IDs are normalized to hex at ingestion time (normalizeActorIDsToHex),
-	// so direct lookup by hex ID always succeeds.
-	actor, ok := actorMap.ActorMap[actorID]
-	if !ok {
-		return types.Actor{}, false
-	}
-	return actor.DeepCopy(), true
+	return h.ClusterActorMap.GetActorByID(clusterName, actorID)
 }
 
 // GetActorsMap returns a thread-safe deep copy of all actors as a map for a given cluster
 func (h *EventHandler) GetActorsMap(clusterName string) map[string]types.Actor {
-	h.ClusterActorMap.RLock()
-	defer h.ClusterActorMap.RUnlock()
-
-	actorMap, ok := h.ClusterActorMap.ClusterActorMap[clusterName]
-	if !ok {
-		return map[string]types.Actor{}
-	}
-
-	actorMap.Lock()
-	defer actorMap.Unlock()
-
-	actors := make(map[string]types.Actor, len(actorMap.ActorMap))
-	for id, actor := range actorMap.ActorMap {
-		actors[id] = actor.DeepCopy()
-	}
-	return actors
+	return h.ClusterActorMap.GetActorsMap(clusterName)
 }
 
 func (h *EventHandler) GetJobsMap(clusterName string) map[string]types.Job {
-	h.ClusterJobMap.RLock()
-	defer h.ClusterJobMap.RUnlock()
-
-	jobMap, ok := h.ClusterJobMap.ClusterJobMap[clusterName]
-	if !ok {
-		return map[string]types.Job{}
-	}
-
-	jobMap.Lock()
-	defer jobMap.Unlock()
-
-	jobs := make(map[string]types.Job, len(jobMap.JobMap))
-	for id, job := range jobMap.JobMap {
-		jobs[id] = job.DeepCopy()
-	}
-	return jobs
+	return h.ClusterJobMap.GetJobsMap(clusterName)
 }
 
 func (h *EventHandler) GetJobByJobID(clusterName, jobID string) (types.Job, bool) {
-	h.ClusterJobMap.RLock()
-	defer h.ClusterJobMap.RUnlock()
-
-	jobMap, ok := h.ClusterJobMap.ClusterJobMap[clusterName]
-	if !ok {
-		return types.Job{}, false
-	}
-
-	jobMap.Lock()
-	defer jobMap.Unlock()
-
-	job, ok := jobMap.JobMap[jobID]
-	if !ok {
-		return types.Job{}, false
-	}
-	return job.DeepCopy(), true
+	return h.ClusterJobMap.GetJobByJobID(clusterName, jobID)
 }
 
 // handleTaskDefinitionEvent processes TASK_DEFINITION_EVENT or ACTOR_TASK_DEFINITION_EVENT and preserves the task attempt ordering.
@@ -1257,42 +1124,12 @@ func normalizeActorIDsToHex(actor *types.Actor) {
 
 // GetNodeMap returns a thread-safe deep copy of all nodes for a given cluster session.
 func (h *EventHandler) GetNodeMap(clusterSessionID string) map[string]types.Node {
-	h.ClusterNodeMap.RLock()
-	defer h.ClusterNodeMap.RUnlock()
-
-	nodeMap, ok := h.ClusterNodeMap.ClusterNodeMap[clusterSessionID]
-	if !ok {
-		return map[string]types.Node{}
-	}
-
-	nodeMap.Lock()
-	defer nodeMap.Unlock()
-
-	nodes := make(map[string]types.Node, len(nodeMap.NodeMap))
-	for id, node := range nodeMap.NodeMap {
-		nodes[id] = node.DeepCopy()
-	}
-	return nodes
+	return h.ClusterNodeMap.GetNodeMap(clusterSessionID)
 }
 
 // GetNodeByNodeID returns a node by node ID for a given cluster session.
 func (h *EventHandler) GetNodeByNodeID(clusterSessionID, nodeID string) (types.Node, bool) {
-	h.ClusterNodeMap.RLock()
-	defer h.ClusterNodeMap.RUnlock()
-
-	nodeMap, ok := h.ClusterNodeMap.ClusterNodeMap[clusterSessionID]
-	if !ok {
-		return types.Node{}, false
-	}
-
-	nodeMap.Lock()
-	defer nodeMap.Unlock()
-
-	node, ok := nodeMap.NodeMap[nodeID]
-	if !ok {
-		return types.Node{}, false
-	}
-	return node.DeepCopy(), true
+	return h.ClusterNodeMap.GetNodeByNodeID(clusterSessionID, nodeID)
 }
 
 // GetTasksTimeline returns timeline data in Chrome Tracing Format

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -25,6 +25,11 @@ func makeTaskEventMap(taskName, nodeId, taskID, cluster string, attempt int) map
 }
 
 func TestEventProcessor(t *testing.T) {
+	taskID12345 := normalizeIDToHex("ID_12345")
+	taskID54321 := normalizeIDToHex("ID_54321")
+	nodeID12345 := normalizeIDToHex("Nodeid_12345")
+	nodeID54321 := normalizeIDToHex("Nodeid_54321")
+
 	tests := []struct {
 		name string
 		// Setup
@@ -63,19 +68,19 @@ func TestEventProcessor(t *testing.T) {
 			},
 			closeChan: true,
 			wantStoredEvents: map[string][]types.Task{
-				"ID_12345": {
+				taskID12345: {
 					{
-						TaskID:      "ID_12345",
+						TaskID:      taskID12345,
 						TaskName:    "Name_12345",
-						NodeID:      "Nodeid_12345",
+						NodeID:      nodeID12345,
 						TaskAttempt: 2,
 					},
 				},
-				"ID_54321": {
+				taskID54321: {
 					{
-						TaskID:      "ID_54321",
+						TaskID:      taskID54321,
 						TaskName:    "Name_54321",
-						NodeID:      "Nodeid_54321",
+						NodeID:      nodeID54321,
 						TaskAttempt: 1,
 					},
 				},
@@ -105,11 +110,11 @@ func TestEventProcessor(t *testing.T) {
 			expectedErrType: context.Canceled,
 			// Event might be processed before cancellation is detected
 			wantStoredEvents: map[string][]types.Task{
-				"ID_12345": {
+				taskID12345: {
 					{
-						TaskID:      "ID_12345",
+						TaskID:      taskID12345,
 						TaskName:    "Name_12345",
-						NodeID:      "Nodeid_12345",
+						NodeID:      nodeID12345,
 						TaskAttempt: 2,
 					},
 				},
@@ -170,7 +175,11 @@ func TestEventProcessor(t *testing.T) {
 
 			// Check stored events
 			if tt.wantStoredEvents != nil {
-				if diff := cmp.Diff(tt.wantStoredEvents, h.ClusterTaskMap.ClusterTaskMap["cluster1"].TaskMap); diff != "" {
+				gotTaskMap, found := h.ClusterTaskMap.GetTaskMap("cluster1")
+				if !found {
+					t.Fatalf("cluster1 task map not found")
+				}
+				if diff := cmp.Diff(tt.wantStoredEvents, gotTaskMap); diff != "" {
 					t.Errorf("storeEventCalls diff (-want +got):\n%s", diff)
 				}
 			}
@@ -179,10 +188,15 @@ func TestEventProcessor(t *testing.T) {
 }
 
 func TestStoreEvent(t *testing.T) {
+	taskID1 := normalizeIDToHex("taskid1")
+	taskID2 := normalizeIDToHex("taskid2")
+	nodeID123 := normalizeIDToHex("nodeid123")
+	nodeID1234 := normalizeIDToHex("nodeid1234")
+
 	initialTask := types.Task{
-		TaskID:      "taskid1",
+		TaskID:      taskID1,
 		TaskName:    "taskName123",
-		NodeID:      "nodeid123",
+		NodeID:      nodeID123,
 		TaskAttempt: 0,
 	}
 	tests := []struct {
@@ -197,9 +211,7 @@ func TestStoreEvent(t *testing.T) {
 	}{
 		{
 			name: "unsupported event type",
-			initialState: &types.ClusterTaskMap{
-				ClusterTaskMap: make(map[string]*types.TaskMap),
-			},
+			initialState: types.NewClusterTaskMap(),
 			eventMap: map[string]any{
 				"eventType":   "UNKNOWN_TYPE",
 				"clusterName": "c1",
@@ -209,81 +221,76 @@ func TestStoreEvent(t *testing.T) {
 		},
 		{
 			name: "task event - new cluster and new task",
-			initialState: &types.ClusterTaskMap{
-				ClusterTaskMap: make(map[string]*types.TaskMap),
-			},
+			initialState: types.NewClusterTaskMap(),
 			eventMap:          makeTaskEventMap("taskName123", "nodeid1234", "taskid1", "cluster1", 0),
 			wantErr:           false,
 			wantClusterCount:  1,
 			wantTaskInCluster: "cluster1",
-			wantTaskID:        "taskid1",
+			wantTaskID:        taskID1,
 			wantTasks: []types.Task{
 				{
-					TaskID:      "taskid1",
+					TaskID:      taskID1,
 					TaskName:    "taskName123",
-					NodeID:      "nodeid1234",
+					NodeID:      nodeID1234,
 					TaskAttempt: 0,
 				},
 			},
 		},
 		{
 			name: "task event - existing cluster, new task",
-			initialState: &types.ClusterTaskMap{
-				ClusterTaskMap: map[string]*types.TaskMap{
-					"cluster1": types.NewTaskMap(),
-				},
-			},
+			initialState: func() *types.ClusterTaskMap {
+				m := types.NewClusterTaskMap()
+				m.GetOrCreateTaskMap("cluster1")
+				return m
+			}(),
 			eventMap:          makeTaskEventMap("taskName123", "nodeid1234", "taskid2", "cluster1", 1),
 			wantErr:           false,
 			wantClusterCount:  1,
 			wantTaskInCluster: "cluster1",
-			wantTaskID:        "taskid2",
+			wantTaskID:        taskID2,
 			wantTasks: []types.Task{
 				{
-					TaskID:      "taskid2",
+					TaskID:      taskID2,
 					TaskName:    "taskName123",
-					NodeID:      "nodeid1234",
+					NodeID:      nodeID1234,
 					TaskAttempt: 1,
 				},
 			},
 		},
 		{
 			name: "task event - existing cluster and existing task with new attempt",
-			initialState: &types.ClusterTaskMap{
-				ClusterTaskMap: map[string]*types.TaskMap{
-					"cluster1": {
-						TaskMap: map[string][]types.Task{
-							"taskid1": {initialTask},
-						},
-					},
-				},
-			},
+			initialState: func() *types.ClusterTaskMap {
+				m := types.NewClusterTaskMap()
+				taskMap := m.GetOrCreateTaskMap("cluster1")
+				taskMap.CreateOrMergeAttempt(taskID1, initialTask.TaskAttempt, func(task *types.Task) {
+					*task = initialTask
+				})
+				return m
+			}(),
 			eventMap:          makeTaskEventMap("taskName123", "nodeid123", "taskid1", "cluster1", 2),
 			wantErr:           false,
 			wantClusterCount:  1,
 			wantTaskInCluster: "cluster1",
-			wantTaskID:        "taskid1",
+			wantTaskID:        taskID1,
 			// Now expects BOTH attempts to be stored
 			wantTasks: []types.Task{
 				{
-					TaskID:      "taskid1",
+					TaskID:      taskID1,
 					TaskName:    "taskName123",
-					NodeID:      "nodeid123",
+					NodeID:      nodeID123,
 					TaskAttempt: 0,
 				},
 				{
-					TaskID:      "taskid1",
+					TaskID:      taskID1,
 					TaskName:    "taskName123",
-					NodeID:      "nodeid123",
+					NodeID:      nodeID123,
 					TaskAttempt: 2,
 				},
 			},
 		},
 		{
 			name: "task event - missing taskDefinitionEvent",
-			initialState: &types.ClusterTaskMap{
-				ClusterTaskMap: make(map[string]*types.TaskMap),
-			},
+			initialState: types.NewClusterTaskMap(),
 			eventMap: map[string]any{
 				"eventType":   string(types.TASK_DEFINITION_EVENT),
 				"clusterName": "c1",
@@ -292,9 +299,7 @@ func TestStoreEvent(t *testing.T) {
 		},
 		{
 			name: "task event - taskDefinitionEvent wrong type",
-			initialState: &types.ClusterTaskMap{
-				ClusterTaskMap: make(map[string]*types.TaskMap),
-			},
+			initialState: types.NewClusterTaskMap(),
 			eventMap: map[string]any{
 				"eventType":           string(types.TASK_DEFINITION_EVENT),
 				"clusterName":         "c1",
@@ -304,9 +309,7 @@ func TestStoreEvent(t *testing.T) {
 		},
 		{
 			name: "task event - invalid task structure",
-			initialState: &types.ClusterTaskMap{
-				ClusterTaskMap: make(map[string]*types.TaskMap),
-			},
+			initialState: types.NewClusterTaskMap(),
 			eventMap: map[string]any{
 				"eventType":   string(types.TASK_DEFINITION_EVENT),
 				"clusterName": "c1",
@@ -325,9 +328,7 @@ func TestStoreEvent(t *testing.T) {
 				ClusterTaskMap: tt.initialState,
 			}
 			if h.ClusterTaskMap == nil {
-				h.ClusterTaskMap = &types.ClusterTaskMap{
-					ClusterTaskMap: make(map[string]*types.TaskMap),
-				}
+				h.ClusterTaskMap = types.NewClusterTaskMap()
 			}
 
 			err := h.storeEvent(tt.eventMap)
@@ -339,22 +340,14 @@ func TestStoreEvent(t *testing.T) {
 				return
 			}
 
-			gotClusterCount := len(h.ClusterTaskMap.ClusterTaskMap)
+			gotClusterCount := h.ClusterTaskMap.GetClusterCount()
 
 			if gotClusterCount != tt.wantClusterCount {
 				t.Errorf("storeEvent() resulted in %d clusters, want %d", gotClusterCount, tt.wantClusterCount)
 			}
 
 			if tt.wantTasks != nil {
-				clusterObj, clusterExists := h.ClusterTaskMap.ClusterTaskMap[tt.wantTaskInCluster]
-
-				if !clusterExists {
-					t.Fatalf("storeEvent() cluster %s not found", tt.wantTaskInCluster)
-				}
-
-				clusterObj.Lock()
-				defer clusterObj.Unlock()
-				gotTasks, taskExists := clusterObj.TaskMap[tt.wantTaskID]
+				gotTasks, taskExists := h.GetTaskByID(tt.wantTaskInCluster, tt.wantTaskID)
 				if !taskExists {
 					t.Fatalf("storeEvent() task %s not found in cluster %s", tt.wantTaskID, tt.wantTaskInCluster)
 				}
@@ -370,6 +363,8 @@ func TestStoreEvent(t *testing.T) {
 // TestTaskLifecycleEventDeduplication verifies that duplicate events are correctly filtered
 // and out-of-order events are properly sorted
 func TestTaskLifecycleEventDeduplication(t *testing.T) {
+	taskID := normalizeIDToHex("ta-1")
+
 	// Helper to create a StateEvent
 	makeStateEvent := func(state types.TaskStatus, timestampNano int64) types.TaskStateTransition {
 		return types.TaskStateTransition{
@@ -532,8 +527,8 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			// Pre-populate existing events if any
 			if len(tt.existingEvents) > 0 {
 				taskMap := h.ClusterTaskMap.GetOrCreateTaskMap("test-cluster")
-				taskMap.CreateOrMergeAttempt("task-1", 0, func(task *types.Task) {
-					task.TaskID = "task-1"
+				taskMap.CreateOrMergeAttempt(taskID, 0, func(task *types.Task) {
+					task.TaskID = taskID
 					task.StateTransitions = tt.existingEvents
 					if len(tt.existingEvents) > 0 {
 						task.State = tt.existingEvents[len(tt.existingEvents)-1].State
@@ -542,18 +537,14 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Process the lifecycle event
-			eventMap := makeLifecycleEvent("task-1", 0, tt.newTransitions)
+			eventMap := makeLifecycleEvent("ta-1", 0, tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
 			// Get the task and verify
-			taskMap := h.ClusterTaskMap.GetOrCreateTaskMap("test-cluster")
-			taskMap.Lock()
-			defer taskMap.Unlock()
-
-			tasks, exists := taskMap.TaskMap["task-1"]
+			tasks, exists := h.GetTaskByID("test-cluster", taskID)
 			if !exists || len(tasks) == 0 {
 				t.Fatal("Task not found after processing")
 			}
@@ -580,6 +571,8 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 
 // TestActorLifecycleEventDeduplication verifies that duplicate actor events are correctly filtered
 func TestActorLifecycleEventDeduplication(t *testing.T) {
+	actorID := normalizeIDToHex("actor-1")
+
 	// Helper to create an ActorStateEvent
 	makeActorStateEvent := func(state types.StateType, timestampNano int64) types.ActorStateEvent {
 		return types.ActorStateEvent{
@@ -690,8 +683,8 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 			// Pre-populate existing events
 			if len(tt.existingEvents) > 0 {
 				actorMap := h.ClusterActorMap.GetOrCreateActorMap("test-cluster")
-				actorMap.CreateOrMergeActor("actor-1", func(a *types.Actor) {
-					a.ActorID = "actor-1"
+				actorMap.CreateOrMergeActor(actorID, func(a *types.Actor) {
+					a.ActorID = actorID
 					a.Events = tt.existingEvents
 					if len(tt.existingEvents) > 0 {
 						a.State = tt.existingEvents[len(tt.existingEvents)-1].State
@@ -707,7 +700,7 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Get the actor and verify
-			actor, found := h.GetActorByID("test-cluster", "actor-1")
+			actor, found := h.GetActorByID("test-cluster", actorID)
 			if !found {
 				t.Fatal("Actor not found after processing")
 			}
@@ -728,6 +721,8 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 // TestDriverJobLifeCycleEventDuplication tests that duplicate events are properly filtered and sorted
 // TODO(chiayi): Update once more fields are added to driver job event
 func TestDriverJobLifecycleEventDuplication(t *testing.T) {
+	jobID := normalizeIDToHex("job-1")
+
 	makeDriverJobStateTransitionEvent := func(state types.JobState, timestampNano int64) types.JobStateTransition {
 		return types.JobStateTransition{
 			State:     state,
@@ -854,8 +849,8 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 
 			if len(tt.existingTransitions) > 0 {
 				jobMap := h.ClusterJobMap.GetOrCreateJobMap("test-cluster")
-				jobMap.CreateOrMergeJob("job-1", func(job *types.Job) {
-					job.JobID = "job-1"
+				jobMap.CreateOrMergeJob(jobID, func(job *types.Job) {
+					job.JobID = jobID
 					job.StateTransitions = tt.existingTransitions
 					if len(tt.existingTransitions) > 0 {
 						job.State = tt.existingTransitions[len(tt.existingTransitions)-1].State
@@ -869,7 +864,7 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
-			job, exists := h.GetJobByJobID("test-cluster", "job-1")
+			job, exists := h.GetJobByJobID("test-cluster", jobID)
 			if !exists {
 				t.Fatal("Job not found after processing")
 			}
@@ -888,6 +883,7 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 // TestMultipleReprocessingCycles simulates hourly reprocessing and verifies no memory growth
 func TestMultipleReprocessingCycles(t *testing.T) {
 	h := NewEventHandler(nil)
+	taskID := normalizeIDToHex("task-1")
 
 	// The same events that would be in an event file
 	// Use []any to match what storeEvent expects from JSON parsing
@@ -917,11 +913,11 @@ func TestMultipleReprocessingCycles(t *testing.T) {
 		}
 
 		// Check event count after each cycle
-		taskMap := h.ClusterTaskMap.GetOrCreateTaskMap("test-cluster")
-		taskMap.Lock()
-		tasks := taskMap.TaskMap["task-1"]
+		tasks, found := h.GetTaskByID("test-cluster", taskID)
+		if !found || len(tasks) == 0 {
+			t.Fatalf("Cycle %d: task not found after processing", cycle)
+		}
 		eventCount := len(tasks[0].StateTransitions)
-		taskMap.Unlock()
 
 		// Should always be exactly 3 events, never growing
 		if eventCount != 3 {

--- a/historyserver/pkg/eventserver/types/actor.go
+++ b/historyserver/pkg/eventserver/types/actor.go
@@ -92,58 +92,76 @@ type Actor struct {
 
 // ActorMap is a struct that uses ActorID as key and the Actor struct as value
 type ActorMap struct {
-	ActorMap map[string]Actor
-	Mu       sync.Mutex
-}
-
-func (a *ActorMap) Lock() {
-	a.Mu.Lock()
-}
-
-func (a *ActorMap) Unlock() {
-	a.Mu.Unlock()
+	actorMap map[string]Actor
+	mu       sync.Mutex
 }
 
 func NewActorMap() *ActorMap {
 	return &ActorMap{
-		ActorMap: make(map[string]Actor),
+		actorMap: make(map[string]Actor),
 	}
 }
 
 // ClusterActorMap uses the cluster name as the key
 type ClusterActorMap struct {
-	ClusterActorMap map[string]*ActorMap
-	Mu              sync.RWMutex
+	clusterActorMap map[string]*ActorMap
+	mu              sync.RWMutex
 }
 
-func (c *ClusterActorMap) RLock() {
-	c.Mu.RLock()
-}
-
-func (c *ClusterActorMap) RUnlock() {
-	c.Mu.RUnlock()
-}
-
-func (c *ClusterActorMap) Lock() {
-	c.Mu.Lock()
-}
-
-func (c *ClusterActorMap) Unlock() {
-	c.Mu.Unlock()
+func NewClusterActorMap() *ClusterActorMap {
+	return &ClusterActorMap{
+		clusterActorMap: make(map[string]*ActorMap),
+	}
 }
 
 // GetOrCreateActorMap returns the ActorMap for the given cluster, creating it if it doesn't exist.
 // This is the actor equivalent of ClusterTaskMap.GetOrCreateTaskMap
 func (c *ClusterActorMap) GetOrCreateActorMap(clusterName string) *ActorMap {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	actorMap, exists := c.ClusterActorMap[clusterName]
+	actorMap, exists := c.clusterActorMap[clusterName]
 	if !exists {
 		actorMap = NewActorMap()
-		c.ClusterActorMap[clusterName] = actorMap
+		c.clusterActorMap[clusterName] = actorMap
 	}
 	return actorMap
+}
+
+// GetActors returns all actors in a cluster session as deep copies.
+func (c *ClusterActorMap) GetActors(clusterName string) []Actor {
+	c.mu.RLock()
+	actorMap, ok := c.clusterActorMap[clusterName]
+	c.mu.RUnlock()
+	if !ok {
+		return []Actor{}
+	}
+
+	return actorMap.GetActors()
+}
+
+// GetActorByID returns an actor by ID in a cluster session as a deep copy.
+func (c *ClusterActorMap) GetActorByID(clusterName, actorID string) (Actor, bool) {
+	c.mu.RLock()
+	actorMap, ok := c.clusterActorMap[clusterName]
+	c.mu.RUnlock()
+	if !ok {
+		return Actor{}, false
+	}
+
+	return actorMap.GetActorByID(actorID)
+}
+
+// GetActorsMap returns all actors in a cluster session as deep copies keyed by actor ID.
+func (c *ClusterActorMap) GetActorsMap(clusterName string) map[string]Actor {
+	c.mu.RLock()
+	actorMap, ok := c.clusterActorMap[clusterName]
+	c.mu.RUnlock()
+	if !ok {
+		return map[string]Actor{}
+	}
+
+	return actorMap.GetActorsMap()
 }
 
 // CreateOrMergeActor finds or creates an actor and applies the merge function.
@@ -151,22 +169,61 @@ func (c *ClusterActorMap) GetOrCreateActorMap(clusterName string) *ActorMap {
 // Actor uses simple map lookup since ActorID is unique.
 // This handles the case where LIFECYCLE events arrive before DEFINITION events.
 func (a *ActorMap) CreateOrMergeActor(actorId string, mergeFn func(*Actor)) {
-	a.Lock()
-	defer a.Unlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
 
-	actor, exists := a.ActorMap[actorId]
+	actor, exists := a.actorMap[actorId]
 	if !exists {
 		// Actor doesn't exist, create new with ActorID initialized
 		newActor := Actor{ActorID: actorId}
 		mergeFn(&newActor)
-		a.ActorMap[actorId] = newActor
+		a.actorMap[actorId] = newActor
 		return
 	}
 
 	// Actor exists: apply merge function and write back to map
 	// NOTE: Must write back because Go map returns a copy, not a reference
 	mergeFn(&actor)
-	a.ActorMap[actorId] = actor
+	a.actorMap[actorId] = actor
+}
+
+// GetActors returns all actors as deep copies.
+func (a *ActorMap) GetActors() []Actor {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	actors := make([]Actor, 0, len(a.actorMap))
+	for _, actor := range a.actorMap {
+		actors = append(actors, actor.DeepCopy())
+	}
+
+	return actors
+}
+
+// GetActorByID returns an actor by ID as a deep copy.
+func (a *ActorMap) GetActorByID(actorID string) (Actor, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	actor, ok := a.actorMap[actorID]
+	if !ok {
+		return Actor{}, false
+	}
+
+	return actor.DeepCopy(), true
+}
+
+// GetActorsMap returns all actors as deep copies keyed by actor ID.
+func (a *ActorMap) GetActorsMap() map[string]Actor {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	actors := make(map[string]Actor, len(a.actorMap))
+	for id, actor := range a.actorMap {
+		actors[id] = actor.DeepCopy()
+	}
+
+	return actors
 }
 
 // DeepCopy returns a deep copy of the Actor, including slices and maps.

--- a/historyserver/pkg/eventserver/types/job.go
+++ b/historyserver/pkg/eventserver/types/job.go
@@ -71,56 +71,62 @@ type Job struct {
 }
 
 type JobMap struct {
-	JobMap map[string]Job
-	Mu     sync.Mutex
-}
-
-func (j *JobMap) Lock() {
-	j.Mu.Lock()
-}
-
-func (j *JobMap) Unlock() {
-	j.Mu.Unlock()
+	jobMap map[string]Job
+	mu     sync.Mutex
 }
 
 func NewJobMap() *JobMap {
 	return &JobMap{
-		JobMap: make(map[string]Job),
+		jobMap: make(map[string]Job),
 	}
 }
 
 type ClusterJobMap struct {
-	ClusterJobMap map[string]*JobMap
-	Mu            sync.RWMutex
+	clusterJobMap map[string]*JobMap
+	mu            sync.RWMutex
 }
 
-func (c *ClusterJobMap) RLock() {
-	c.Mu.RLock()
-}
-
-func (c *ClusterJobMap) RUnlock() {
-	c.Mu.RUnlock()
-}
-
-func (c *ClusterJobMap) Lock() {
-	c.Mu.Lock()
-}
-
-func (c *ClusterJobMap) Unlock() {
-	c.Mu.Unlock()
+func NewClusterJobMap() *ClusterJobMap {
+	return &ClusterJobMap{
+		clusterJobMap: make(map[string]*JobMap),
+	}
 }
 
 func (c *ClusterJobMap) GetOrCreateJobMap(clusterName string) *JobMap {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	jobMap, exists := c.ClusterJobMap[clusterName]
+	jobMap, exists := c.clusterJobMap[clusterName]
 	if !exists {
 		jobMap = NewJobMap()
-		c.ClusterJobMap[clusterName] = jobMap
+		c.clusterJobMap[clusterName] = jobMap
 	}
 
 	return jobMap
+}
+
+// GetJobsMap returns a deep copy of all jobs for a cluster session.
+func (c *ClusterJobMap) GetJobsMap(clusterName string) map[string]Job {
+	c.mu.RLock()
+	jobMap, ok := c.clusterJobMap[clusterName]
+	c.mu.RUnlock()
+	if !ok {
+		return map[string]Job{}
+	}
+
+	return jobMap.GetJobsMap()
+}
+
+// GetJobByJobID returns a deep copy of a job by ID in a cluster session.
+func (c *ClusterJobMap) GetJobByJobID(clusterName, jobID string) (Job, bool) {
+	c.mu.RLock()
+	jobMap, ok := c.clusterJobMap[clusterName]
+	c.mu.RUnlock()
+	if !ok {
+		return Job{}, false
+	}
+
+	return jobMap.GetJobByJobID(jobID)
 }
 
 // CreateOrMergeJob will find or create the job and runs the merge function.
@@ -128,20 +134,46 @@ func (c *ClusterJobMap) GetOrCreateJobMap(clusterName string) *JobMap {
 // The State and Status, one representing the driver lifecycle and another
 // represents the status of the progress of the job.
 func (j *JobMap) CreateOrMergeJob(jobId string, mergeFn func(*Job)) {
-	j.Lock()
-	defer j.Unlock()
+	j.mu.Lock()
+	defer j.mu.Unlock()
 
-	job, exist := j.JobMap[jobId]
+	job, exist := j.jobMap[jobId]
 	if !exist {
 		// Job does not exist, creating new with JobID
 		newJob := Job{JobID: jobId}
 		mergeFn(&newJob)
-		j.JobMap[jobId] = newJob
+		j.jobMap[jobId] = newJob
 		return
 	}
 
 	mergeFn(&job)
-	j.JobMap[jobId] = job
+	j.jobMap[jobId] = job
+}
+
+// GetJobsMap returns a deep copy of all jobs.
+func (j *JobMap) GetJobsMap() map[string]Job {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	jobs := make(map[string]Job, len(j.jobMap))
+	for id, job := range j.jobMap {
+		jobs[id] = job.DeepCopy()
+	}
+
+	return jobs
+}
+
+// GetJobByJobID returns a deep copy of a job by ID.
+func (j *JobMap) GetJobByJobID(jobID string) (Job, bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	job, ok := j.jobMap[jobID]
+	if !ok {
+		return Job{}, false
+	}
+
+	return job.DeepCopy(), true
 }
 
 // DeepCopy will return a deep copy of the Job

--- a/historyserver/pkg/eventserver/types/node.go
+++ b/historyserver/pkg/eventserver/types/node.go
@@ -78,71 +78,103 @@ type Node struct {
 }
 
 type NodeMap struct {
-	NodeMap map[string]Node
-	Mu      sync.Mutex
-}
-
-func (n *NodeMap) Lock() {
-	n.Mu.Lock()
-}
-
-func (n *NodeMap) Unlock() {
-	n.Mu.Unlock()
+	nodeMap map[string]Node
+	mu      sync.Mutex
 }
 
 func NewNodeMap() *NodeMap {
 	return &NodeMap{
-		NodeMap: make(map[string]Node),
+		nodeMap: make(map[string]Node),
 	}
 }
 
 type ClusterNodeMap struct {
 	// ClusterNodeMap is a map of cluster session ID to NodeMap.
-	ClusterNodeMap map[string]*NodeMap
-	Mu             sync.RWMutex
+	clusterNodeMap map[string]*NodeMap
+	mu             sync.RWMutex
 }
 
-func (c *ClusterNodeMap) RLock() {
-	c.Mu.RLock()
-}
-
-func (c *ClusterNodeMap) RUnlock() {
-	c.Mu.RUnlock()
-}
-
-func (c *ClusterNodeMap) Lock() {
-	c.Mu.Lock()
-}
-
-func (c *ClusterNodeMap) Unlock() {
-	c.Mu.Unlock()
+func NewClusterNodeMap() *ClusterNodeMap {
+	return &ClusterNodeMap{
+		clusterNodeMap: make(map[string]*NodeMap),
+	}
 }
 
 // GetOrCreateNodeMap retrieves the NodeMap for the given cluster session, creating it if it doesn't exist.
 func (c *ClusterNodeMap) GetOrCreateNodeMap(clusterSessionID string) *NodeMap {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	nodeMap, exists := c.ClusterNodeMap[clusterSessionID]
+	nodeMap, exists := c.clusterNodeMap[clusterSessionID]
 	if !exists {
 		nodeMap = NewNodeMap()
-		c.ClusterNodeMap[clusterSessionID] = nodeMap
+		c.clusterNodeMap[clusterSessionID] = nodeMap
 	}
 	return nodeMap
 }
 
+// GetNodeMap returns all nodes for a cluster session as deep copies.
+func (c *ClusterNodeMap) GetNodeMap(clusterSessionID string) map[string]Node {
+	c.mu.RLock()
+	nodeMap, ok := c.clusterNodeMap[clusterSessionID]
+	c.mu.RUnlock()
+	if !ok {
+		return map[string]Node{}
+	}
+
+	return nodeMap.GetNodeMap()
+}
+
+// GetNodeByNodeID returns a node by ID in a cluster session as a deep copy.
+func (c *ClusterNodeMap) GetNodeByNodeID(clusterSessionID, nodeID string) (Node, bool) {
+	c.mu.RLock()
+	nodeMap, ok := c.clusterNodeMap[clusterSessionID]
+	c.mu.RUnlock()
+	if !ok {
+		return Node{}, false
+	}
+
+	return nodeMap.GetNodeByNodeID(nodeID)
+}
+
 // CreateOrMergeNode retrieves or creates a Node and applies the merge function.
 func (n *NodeMap) CreateOrMergeNode(nodeId string, mergeFn func(*Node)) {
-	n.Lock()
-	defer n.Unlock()
+	n.mu.Lock()
+	defer n.mu.Unlock()
 
-	node, exists := n.NodeMap[nodeId]
+	node, exists := n.nodeMap[nodeId]
 	if !exists {
 		node = Node{NodeID: nodeId}
 	}
 
 	mergeFn(&node)
-	n.NodeMap[nodeId] = node
+	n.nodeMap[nodeId] = node
+}
+
+// GetNodeMap returns all nodes as deep copies keyed by node ID.
+func (n *NodeMap) GetNodeMap() map[string]Node {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	nodes := make(map[string]Node, len(n.nodeMap))
+	for id, node := range n.nodeMap {
+		nodes[id] = node.DeepCopy()
+	}
+
+	return nodes
+}
+
+// GetNodeByNodeID returns a node by ID as a deep copy.
+func (n *NodeMap) GetNodeByNodeID(nodeID string) (Node, bool) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	node, ok := n.nodeMap[nodeID]
+	if !ok {
+		return Node{}, false
+	}
+
+	return node.DeepCopy(), true
 }
 
 // DeepCopy returns a deep copy of the Node, which prevents race conditions.

--- a/historyserver/pkg/eventserver/types/task.go
+++ b/historyserver/pkg/eventserver/types/task.go
@@ -208,57 +208,95 @@ type ProfileEventRaw struct {
 // TaskMap is a struct that uses TaskID as key and stores a list of Task attempts.
 // Each TaskID maps to a slice of Tasks, where each element represents a different attempt.
 type TaskMap struct {
-	TaskMap map[string][]Task
-	Mu      sync.Mutex
-}
-
-func (t *TaskMap) Lock() {
-	t.Mu.Lock()
-}
-
-func (t *TaskMap) Unlock() {
-	t.Mu.Unlock()
+	taskMap map[string][]Task
+	mu      sync.Mutex
 }
 
 func NewTaskMap() *TaskMap {
 	return &TaskMap{
-		TaskMap: make(map[string][]Task),
+		taskMap: make(map[string][]Task),
 	}
 }
 
 type ClusterTaskMap struct {
 	// ClusterTaskMap is a map of cluster session ID to TaskMap.
-	ClusterTaskMap map[string]*TaskMap
-	Mu             sync.RWMutex
+	clusterTaskMap map[string]*TaskMap
+	mu             sync.RWMutex
 }
 
-func (c *ClusterTaskMap) RLock() {
-	c.Mu.RLock()
-}
-
-func (c *ClusterTaskMap) RUnlock() {
-	c.Mu.RUnlock()
-}
-
-func (c *ClusterTaskMap) Lock() {
-	c.Mu.Lock()
-}
-
-func (c *ClusterTaskMap) Unlock() {
-	c.Mu.Unlock()
+func NewClusterTaskMap() *ClusterTaskMap {
+	return &ClusterTaskMap{
+		clusterTaskMap: make(map[string]*TaskMap),
+	}
 }
 
 // GetOrCreateTaskMap retrieves the TaskMap for the given cluster session, creating it if it doesn't exist.
 func (c *ClusterTaskMap) GetOrCreateTaskMap(clusterSessionKey string) *TaskMap {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	taskMap, exists := c.ClusterTaskMap[clusterSessionKey]
+	taskMap, exists := c.clusterTaskMap[clusterSessionKey]
 	if !exists {
 		taskMap = NewTaskMap()
-		c.ClusterTaskMap[clusterSessionKey] = taskMap
+		c.clusterTaskMap[clusterSessionKey] = taskMap
 	}
 	return taskMap
+}
+
+// GetClusterCount returns the number of cluster sessions currently tracked.
+func (c *ClusterTaskMap) GetClusterCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return len(c.clusterTaskMap)
+}
+
+// GetTaskMap returns a deep copy of all task attempts for a cluster session.
+func (c *ClusterTaskMap) GetTaskMap(clusterSessionKey string) (map[string][]Task, bool) {
+	c.mu.RLock()
+	taskMap, ok := c.clusterTaskMap[clusterSessionKey]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+
+	return taskMap.GetTaskMap(), true
+}
+
+// GetTasks returns all task attempts for a cluster session.
+func (c *ClusterTaskMap) GetTasks(clusterSessionKey string) []Task {
+	c.mu.RLock()
+	taskMap, ok := c.clusterTaskMap[clusterSessionKey]
+	c.mu.RUnlock()
+	if !ok {
+		return []Task{}
+	}
+
+	return taskMap.GetTasks()
+}
+
+// GetTaskByID returns all attempts for a task ID in a cluster session.
+func (c *ClusterTaskMap) GetTaskByID(clusterSessionKey, taskID string) ([]Task, bool) {
+	c.mu.RLock()
+	taskMap, ok := c.clusterTaskMap[clusterSessionKey]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+
+	return taskMap.GetTaskByID(taskID)
+}
+
+// GetTasksByJobID returns all task attempts associated with a job ID in a cluster session.
+func (c *ClusterTaskMap) GetTasksByJobID(clusterSessionKey, jobID string) []Task {
+	c.mu.RLock()
+	taskMap, ok := c.clusterTaskMap[clusterSessionKey]
+	c.mu.RUnlock()
+	if !ok {
+		return []Task{}
+	}
+
+	return taskMap.GetTasksByJobID(jobID)
 }
 
 // CreateOrMergeTaskAttempt creates a new slice of Task attempts or insert the current attempt at the correct position for the given taskId.
@@ -267,16 +305,16 @@ func (c *ClusterTaskMap) GetOrCreateTaskMap(clusterSessionKey string) *TaskMap {
 //   - If the attempt doesn't exist, creates a new one at the correct position
 //   - If the attempt exists, applies mergeFn to merge new data into existing
 func (t *TaskMap) CreateOrMergeAttempt(taskId string, taskAttempt int, mergeFn func(*Task)) {
-	t.Lock()
-	defer t.Unlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
 	// Case 1: tasks doesn't exist.
 	// Create a new slice of Task attempts with the current attempt.
-	tasks, exists := t.TaskMap[taskId]
+	tasks, exists := t.taskMap[taskId]
 	if !exists {
 		newTask := Task{TaskID: taskId, TaskAttempt: taskAttempt}
 		mergeFn(&newTask)
-		t.TaskMap[taskId] = []Task{newTask}
+		t.taskMap[taskId] = []Task{newTask}
 		return
 	}
 
@@ -301,7 +339,74 @@ func (t *TaskMap) CreateOrMergeAttempt(taskId string, taskAttempt int, mergeFn f
 	tasks = append(tasks, Task{})    // Extend slice by 1
 	copy(tasks[idx+1:], tasks[idx:]) // Shift elements right
 	tasks[idx] = newTask             // Insert at correct position
-	t.TaskMap[taskId] = tasks
+	t.taskMap[taskId] = tasks
+}
+
+// GetTaskMap returns a deep copy of the task attempts map.
+func (t *TaskMap) GetTaskMap() map[string][]Task {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	result := make(map[string][]Task, len(t.taskMap))
+	for taskID, attempts := range t.taskMap {
+		attemptCopies := make([]Task, len(attempts))
+		for i, attempt := range attempts {
+			attemptCopies[i] = attempt.DeepCopy()
+		}
+		result[taskID] = attemptCopies
+	}
+
+	return result
+}
+
+// GetTasks returns all task attempts in the map as deep copies.
+func (t *TaskMap) GetTasks() []Task {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	allTasks := make([]Task, 0)
+	for _, attempts := range t.taskMap {
+		for _, attempt := range attempts {
+			allTasks = append(allTasks, attempt.DeepCopy())
+		}
+	}
+
+	return allTasks
+}
+
+// GetTaskByID returns all attempts for a task ID as deep copies.
+func (t *TaskMap) GetTaskByID(taskID string) ([]Task, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	attempts, ok := t.taskMap[taskID]
+	if !ok || len(attempts) == 0 {
+		return nil, false
+	}
+
+	result := make([]Task, len(attempts))
+	for i, task := range attempts {
+		result[i] = task.DeepCopy()
+	}
+
+	return result, true
+}
+
+// GetTasksByJobID returns all task attempts for a given job ID as deep copies.
+func (t *TaskMap) GetTasksByJobID(jobID string) []Task {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	tasks := make([]Task, 0)
+	for _, attempts := range t.taskMap {
+		for _, task := range attempts {
+			if task.JobID == jobID {
+				tasks = append(tasks, task.DeepCopy())
+			}
+		}
+	}
+
+	return tasks
 }
 
 // GetTaskName returns the task name of the task.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently `Entity level map` and `Cluster level map` expose internal synchronization and storage directly like `TaskMap.TaskMap and TaskMap.Mu` and `ClusterTaskMap.ClusterTaskMap and ClusterTaskMap.Mu`. This PR encapsulates this by making these maps and locks private and introducing exported helper functions in order to interact with them. It follows the same pattern as in #4479.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #4490 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
