### PR TITLE
Fix Issue #4686 (rayservice): update RayCluster when Suspend toggles

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1154,15 +1154,7 @@ func isClusterSpecHashEqual(rayServiceInstance *rayv1.RayService, cluster *rayv1
 }
 
 func suspendValueSame(value1 *bool, value2 *bool) bool {
-	boolValue1 := false
-	if value1 != nil {
-		boolValue1 = *value1
-	}
-	boolValue2 := false
-	if value2 != nil {
-		boolValue2 = *value2
-	}
-	return boolValue1 == boolValue2
+	return ptr.Deref(value1, false) == ptr.Deref(value2, false)
 }
 
 func shouldPrepareNewCluster(ctx context.Context, rayServiceInstance *rayv1.RayService, activeRayCluster, pendingRayCluster *rayv1.RayCluster, isPendingClusterServing bool) bool {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1106,6 +1106,14 @@ func shouldUpdateCluster(rayServiceInstance *rayv1.RayService, cluster *rayv1.Ra
 		}
 	}
 
+	if !suspendValueSame(rayServiceInstance.Spec.RayClusterSpec.Suspend, cluster.Spec.Suspend) {
+		// Suspend toggles (e.g. from Kueue admitting or preempting the workload) must be
+		// applied in-place to the existing RayCluster. Otherwise the hash comparison below
+		// selects neither the update nor the new-cluster path, and the cluster stays
+		// suspended with no head pod (ray-project/kuberay#4686).
+		return true
+	}
+
 	if isClusterSpecHashEqual(rayServiceInstance, cluster, false) {
 		// The RayCluster spec matches the cluster spec in the RayService. No need to update the cluster.
 		return false
@@ -1143,6 +1151,18 @@ func isClusterSpecHashEqual(rayServiceInstance *rayv1.RayService, cluster *rayv1
 		}
 	}
 	return clusterHash == goalClusterHash
+}
+
+func suspendValueSame(value1 *bool, value2 *bool) bool {
+	boolValue1 := false
+	if value1 != nil {
+		boolValue1 = *value1
+	}
+	boolValue2 := false
+	if value2 != nil {
+		boolValue2 = *value2
+	}
+	return boolValue1 == boolValue2
 }
 
 func shouldPrepareNewCluster(ctx context.Context, rayServiceInstance *rayv1.RayService, activeRayCluster, pendingRayCluster *rayv1.RayCluster, isPendingClusterServing bool) bool {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1106,7 +1106,7 @@ func shouldUpdateCluster(rayServiceInstance *rayv1.RayService, cluster *rayv1.Ra
 		}
 	}
 
-	if !suspendValueSame(rayServiceInstance.Spec.RayClusterSpec.Suspend, cluster.Spec.Suspend) {
+	if ptr.Deref(rayServiceInstance.Spec.RayClusterSpec.Suspend, false) != ptr.Deref(cluster.Spec.Suspend, false) {
 		// Suspend toggles (e.g. from Kueue admitting or preempting the workload) must be
 		// applied in-place to the existing RayCluster. Otherwise the hash comparison below
 		// selects neither the update nor the new-cluster path, and the cluster stays
@@ -1151,10 +1151,6 @@ func isClusterSpecHashEqual(rayServiceInstance *rayv1.RayService, cluster *rayv1
 		}
 	}
 	return clusterHash == goalClusterHash
-}
-
-func suspendValueSame(value1 *bool, value2 *bool) bool {
-	return ptr.Deref(value1, false) == ptr.Deref(value2, false)
 }
 
 func shouldPrepareNewCluster(ctx context.Context, rayServiceInstance *rayv1.RayService, activeRayCluster, pendingRayCluster *rayv1.RayCluster, isPendingClusterServing bool) bool {

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2761,31 +2761,6 @@ func TestReconcileRollbackState(t *testing.T) {
 	}
 }
 
-func TestSuspendValueSame(t *testing.T) {
-	tests := []struct {
-		name   string
-		value1 *bool
-		value2 *bool
-		expect bool
-	}{
-		{"both nil", nil, nil, true},
-		{"nil and false", nil, ptr.To(false), true},
-		{"false and nil", ptr.To(false), nil, true},
-		{"both false", ptr.To(false), ptr.To(false), true},
-		{"both true", ptr.To(true), ptr.To(true), true},
-		{"nil and true", nil, ptr.To(true), false},
-		{"true and nil", ptr.To(true), nil, false},
-		{"true and false", ptr.To(true), ptr.To(false), false},
-		{"false and true", ptr.To(false), ptr.To(true), false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expect, suspendValueSame(tt.value1, tt.value2))
-		})
-	}
-}
-
 // TestShouldUpdateCluster_SuspendFlip covers ray-project/kuberay#4686: when Kueue
 // toggles RayService.Spec.RayClusterSpec.Suspend, the existing RayCluster must be
 // updated in-place. Previously shouldUpdateCluster returned false because the

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2760,3 +2760,100 @@ func TestReconcileRollbackState(t *testing.T) {
 		})
 	}
 }
+
+func TestSuspendValueSame(t *testing.T) {
+	tests := []struct {
+		name   string
+		value1 *bool
+		value2 *bool
+		expect bool
+	}{
+		{"both nil", nil, nil, true},
+		{"nil and false", nil, ptr.To(false), true},
+		{"false and nil", ptr.To(false), nil, true},
+		{"both false", ptr.To(false), ptr.To(false), true},
+		{"both true", ptr.To(true), ptr.To(true), true},
+		{"nil and true", nil, ptr.To(true), false},
+		{"true and nil", ptr.To(true), nil, false},
+		{"true and false", ptr.To(true), ptr.To(false), false},
+		{"false and true", ptr.To(false), ptr.To(true), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, suspendValueSame(tt.value1, tt.value2))
+		})
+	}
+}
+
+// TestShouldUpdateCluster_SuspendFlip covers ray-project/kuberay#4686: when Kueue
+// toggles RayService.Spec.RayClusterSpec.Suspend, the existing RayCluster must be
+// updated in-place. Previously shouldUpdateCluster returned false because the
+// cluster hash annotation encodes the old Suspend value, leaving the cluster
+// stuck suspended with no head pod.
+func TestShouldUpdateCluster_SuspendFlip(t *testing.T) {
+	namespace := "test-namespace"
+
+	newRayService := func(suspend *bool) *rayv1.RayService {
+		return &rayv1.RayService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-service",
+				Namespace: namespace,
+			},
+			Spec: rayv1.RayServiceSpec{
+				RayClusterSpec: rayv1.RayClusterSpec{
+					RayVersion: "2.9.0",
+					Suspend:    suspend,
+				},
+			},
+		}
+	}
+
+	// newClusterFrom mirrors the annotation layout produced by
+	// constructRayClusterForRayService so the hash reflects the cluster's
+	// actual spec (including its Suspend value).
+	newClusterFrom := func(t *testing.T, service *rayv1.RayService, suspend *bool) *rayv1.RayCluster {
+		t.Helper()
+		clusterSpec := service.Spec.RayClusterSpec.DeepCopy()
+		clusterSpec.Suspend = suspend
+		hash, err := utils.GenerateHashWithoutReplicasAndWorkersToDelete(*clusterSpec)
+		require.NoError(t, err)
+		return &rayv1.RayCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					utils.HashWithoutReplicasAndWorkersToDeleteKey: hash,
+					utils.NumWorkerGroupsKey:                       strconv.Itoa(len(clusterSpec.WorkerGroupSpecs)),
+					utils.KubeRayVersion:                           utils.KUBERAY_VERSION,
+				},
+			},
+			Spec: *clusterSpec,
+		}
+	}
+
+	tests := []struct {
+		name            string
+		serviceSuspend  *bool
+		clusterSuspend  *bool
+		isActiveCluster bool
+		expect          bool
+	}{
+		{"pending unsuspended by Kueue: true -> false", ptr.To(false), ptr.To(true), false, true},
+		{"pending suspended by Kueue: false -> true", ptr.To(true), ptr.To(false), false, true},
+		{"active unsuspended by Kueue: true -> false", ptr.To(false), ptr.To(true), true, true},
+		{"active suspended by Kueue: false -> true", ptr.To(true), ptr.To(false), true, true},
+		{"no change, both nil", nil, nil, false, false},
+		{"no change, both false", ptr.To(false), ptr.To(false), false, false},
+		{"no change, both true", ptr.To(true), ptr.To(true), false, false},
+		{"nil vs false treated equal", nil, ptr.To(false), false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := newRayService(tt.serviceSuspend)
+			cluster := newClusterFrom(t, service, tt.clusterSuspend)
+			assert.Equal(t, tt.expect, shouldUpdateCluster(service, cluster, tt.isActiveCluster))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

It is a fix for a bug when Kuberay works with Kueue for rayservice after syncing with @hiboyang for this issue: https://github.com/ray-project/kuberay/issues/4686

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When Kueue toggles RayService.Spec.RayClusterSpec.Suspend, the existing RayCluster was not updated because shouldUpdateCluster compares hashes that encode Suspend, and neither the full nor partial hash path returns true for a Suspend-only change. This left the RayCluster stuck with Suspend=true after Kueue admitted the workload, so no head pod was never created and reconcile entered a dead loop in updateHeadPodServeLabel. 

Short-circuit shouldUpdateCluster to return true whenever Suspend differs between the RayService spec and the existing RayCluster, so the existing cluster is updated in place.

How to verify locally:

1. Create cluster
`kind create cluster --name kuberay-test
kubectl config use-context kind-kuberay-test
`
2. Install CRDs
`cd ~/kuberay/ray-operator
make install
`
3. Start operator
`cd ~/kuberay/ray-operator
go run main.go --enable-leader-election=false
`
4. Apply a rayservice CRD:
Use a test rayservice YAML <[rayservice-suspend-repro.yaml](https://github.com/user-attachments/files/26878461/rayservice-suspend-repro.yaml)

`kubectl apply -f rayservice-suspend-repro.yaml
`

5. Verify suspended state

`kubectl get raycluster -o jsonpath='{.items[0].spec.suspend}{"\n"}'
kubectl get pods
`

Expected: true and No resources is created because of the suspending.

6. Unsuspend (simulates Kueue admission)
`kubectl patch rayservice rs-suspend-repro --type=merge -p '{"spec":{"rayClusterConfig":{"suspend":false}}}'
`
7. verify pods get created

`
kubectl get raycluster -o jsonpath='{.items[0].spec.suspend}{"\n"}'
kubectl get pods
`
Expected: false and head + worker pods Running.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
