### PR TITLE
do not put finalizer if the head pod container hasn't reached running state.

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -195,7 +195,10 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 
 	if enableGCSFTRedisCleanup && utils.IsGCSFaultToleranceEnabled(&instance.Spec, instance.Annotations) {
 		if instance.DeletionTimestamp.IsZero() {
-			if !controllerutil.ContainsFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer) {
+			if afterWaitingState, err := r.isHeadPodAfterWaiting(ctx, instance); err != nil {
+				logger.Error(err, "failed to get head pod for getting container state")
+				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+			} else if !controllerutil.ContainsFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer) && afterWaitingState {
 				logger.Info(
 					"GCS fault tolerance has been enabled. Implementing a finalizer to ensure that Redis is properly cleaned up once the RayCluster custom resource (CR) is deleted.",
 					"finalizer", utils.GCSFaultToleranceRedisCleanupFinalizer)
@@ -213,6 +216,11 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 				"redisCleanupFinalizer", utils.GCSFaultToleranceRedisCleanupFinalizer,
 				"deletionTimestamp", instance.ObjectMeta.DeletionTimestamp,
 			)
+
+			if !controllerutil.ContainsFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer) {
+				logger.Info("The RayCluster has no finalizer on it, skip Redis cleanup job")
+				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
+			}
 
 			// Delete the head Pod if it exists.
 			headPods, err := r.deleteAllPods(ctx, common.RayClusterHeadPodsAssociationOptions(instance))
@@ -1245,6 +1253,37 @@ func getRayContainerStateTerminated(pod corev1.Pod) *corev1.ContainerStateTermin
 	// typically arises during testing (`raycluster_controller_test.go`) as `envtest` lacks
 	// a Pod controller, preventing automatic Pod status updates.
 	return nil
+}
+
+// isRayContainerAfterWaiting checks whether the Ray container in the given pod has moved past
+// the Waiting state. It returns true if the container is in a Running or Terminated state,
+// and false if the container is still Waiting or if no container status has been reported yet.
+// Similar to getRayContainerStateTerminated, this function finds the Ray container's status
+// by name because ContainerStatuses order is not guaranteed.
+func isRayContainerAfterWaiting(pod corev1.Pod) bool {
+	rayContainerName := pod.Spec.Containers[utils.RayContainerIndex].Name
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.Name == rayContainerName {
+			return containerStatus.State.Running != nil || containerStatus.State.Terminated != nil
+		}
+	}
+	// If the Ray container status isn't found, it hasn't started yet.
+	return false
+}
+
+// isHeadPodAfterWaiting retrieves the head pod for the given RayCluster and checks whether
+// its Ray container has moved past the Waiting state. It returns true if the head pod
+// exists and its Ray container is running or terminated, false if the head pod is not found
+// or is still waiting, and an error if listing head pods fails.
+func (r *RayClusterReconciler) isHeadPodAfterWaiting(ctx context.Context, instance *rayv1.RayCluster) (bool, error) {
+	headPods := corev1.PodList{}
+	if err := r.List(ctx, &headPods, common.RayClusterHeadPodsAssociationOptions(instance).ToListOptions()...); err != nil {
+		return false, err
+	}
+	if len(headPods.Items) == 0 {
+		return false, nil
+	}
+	return isRayContainerAfterWaiting(headPods.Items[0]), nil
 }
 
 func (r *RayClusterReconciler) createHeadIngress(ctx context.Context, ingress *networkingv1.Ingress, instance *rayv1.RayCluster) error {

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -221,7 +221,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 
 			if !controllerutil.ContainsFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer) {
 				logger.Info("The RayCluster has no finalizer on it, skip Redis cleanup job")
-				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
+				return ctrl.Result{}, nil
 			}
 
 			// Delete the head Pod if it exists.

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -195,20 +195,22 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 
 	if enableGCSFTRedisCleanup && utils.IsGCSFaultToleranceEnabled(&instance.Spec, instance.Annotations) {
 		if instance.DeletionTimestamp.IsZero() {
-			if afterWaitingState, err := r.isHeadPodPastWaiting(ctx, instance); err != nil {
-				logger.Error(err, "failed to get head pod for getting container state")
-				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
-			} else if !controllerutil.ContainsFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer) && afterWaitingState {
-				logger.Info(
-					"GCS fault tolerance has been enabled. Implementing a finalizer to ensure that Redis is properly cleaned up once the RayCluster custom resource (CR) is deleted.",
-					"finalizer", utils.GCSFaultToleranceRedisCleanupFinalizer)
-				controllerutil.AddFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer)
-				if err := r.Update(ctx, instance); err != nil {
-					err = fmt.Errorf("failed to add the finalizer %s to the RayCluster: %w", utils.GCSFaultToleranceRedisCleanupFinalizer, err)
+			if !controllerutil.ContainsFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer) {
+				if afterWaitingState, err := r.isHeadPodPastWaiting(ctx, instance); err != nil {
+					logger.Error(err, "failed to get head pod for getting container state")
 					return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+				} else if afterWaitingState {
+					logger.Info(
+						"GCS fault tolerance has been enabled. Implementing a finalizer to ensure that Redis is properly cleaned up once the RayCluster custom resource (CR) is deleted.",
+						"finalizer", utils.GCSFaultToleranceRedisCleanupFinalizer)
+					controllerutil.AddFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer)
+					if err := r.Update(ctx, instance); err != nil {
+						err = fmt.Errorf("failed to add the finalizer %s to the RayCluster: %w", utils.GCSFaultToleranceRedisCleanupFinalizer, err)
+						return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+					}
+					// Only start the RayCluster reconciliation after the finalizer is added.
+					return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
 				}
-				// Only start the RayCluster reconciliation after the finalizer is added.
-				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
 			}
 		} else {
 			logger.Info(

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1266,7 +1266,8 @@ func isRayContainerPastWaiting(pod corev1.Pod) bool {
 	rayContainerName := pod.Spec.Containers[utils.RayContainerIndex].Name
 	for _, containerStatus := range pod.Status.ContainerStatuses {
 		if containerStatus.Name == rayContainerName {
-			return containerStatus.State.Running != nil || containerStatus.State.Terminated != nil
+			return containerStatus.State.Running != nil || containerStatus.State.Terminated != nil ||
+				(containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == "CrashLoopBackOff")
 		}
 	}
 	// If the Ray container status isn't found, it hasn't started yet.

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -195,7 +195,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 
 	if enableGCSFTRedisCleanup && utils.IsGCSFaultToleranceEnabled(&instance.Spec, instance.Annotations) {
 		if instance.DeletionTimestamp.IsZero() {
-			if afterWaitingState, err := r.isHeadPodAfterWaiting(ctx, instance); err != nil {
+			if afterWaitingState, err := r.isHeadPodPastWaiting(ctx, instance); err != nil {
 				logger.Error(err, "failed to get head pod for getting container state")
 				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 			} else if !controllerutil.ContainsFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer) && afterWaitingState {
@@ -1255,12 +1255,12 @@ func getRayContainerStateTerminated(pod corev1.Pod) *corev1.ContainerStateTermin
 	return nil
 }
 
-// isRayContainerAfterWaiting checks whether the Ray container in the given pod has moved past
+// isRayContainerPastWaiting checks whether the Ray container in the given pod has moved past
 // the Waiting state. It returns true if the container is in a Running or Terminated state,
 // and false if the container is still Waiting or if no container status has been reported yet.
 // Similar to getRayContainerStateTerminated, this function finds the Ray container's status
 // by name because ContainerStatuses order is not guaranteed.
-func isRayContainerAfterWaiting(pod corev1.Pod) bool {
+func isRayContainerPastWaiting(pod corev1.Pod) bool {
 	rayContainerName := pod.Spec.Containers[utils.RayContainerIndex].Name
 	for _, containerStatus := range pod.Status.ContainerStatuses {
 		if containerStatus.Name == rayContainerName {
@@ -1271,11 +1271,11 @@ func isRayContainerAfterWaiting(pod corev1.Pod) bool {
 	return false
 }
 
-// isHeadPodAfterWaiting retrieves the head pod for the given RayCluster and checks whether
+// isHeadPodPastWaiting retrieves the head pod for the given RayCluster and checks whether
 // its Ray container has moved past the Waiting state. It returns true if the head pod
 // exists and its Ray container is running or terminated, false if the head pod is not found
 // or is still waiting, and an error if listing head pods fails.
-func (r *RayClusterReconciler) isHeadPodAfterWaiting(ctx context.Context, instance *rayv1.RayCluster) (bool, error) {
+func (r *RayClusterReconciler) isHeadPodPastWaiting(ctx context.Context, instance *rayv1.RayCluster) (bool, error) {
 	headPods := corev1.PodList{}
 	if err := r.List(ctx, &headPods, common.RayClusterHeadPodsAssociationOptions(instance).ToListOptions()...); err != nil {
 		return false, err
@@ -1283,7 +1283,7 @@ func (r *RayClusterReconciler) isHeadPodAfterWaiting(ctx context.Context, instan
 	if len(headPods.Items) == 0 {
 		return false, nil
 	}
-	return isRayContainerAfterWaiting(headPods.Items[0]), nil
+	return isRayContainerPastWaiting(headPods.Items[0]), nil
 }
 
 func (r *RayClusterReconciler) createHeadIngress(ctx context.Context, ingress *networkingv1.Ingress, instance *rayv1.RayCluster) error {

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1279,14 +1279,14 @@ func isRayContainerPastWaiting(pod corev1.Pod) bool {
 // exists and its Ray container is running or terminated, false if the head pod is not found
 // or is still waiting, and an error if listing head pods fails.
 func (r *RayClusterReconciler) isHeadPodPastWaiting(ctx context.Context, instance *rayv1.RayCluster) (bool, error) {
-	headPods := corev1.PodList{}
-	if err := r.List(ctx, &headPods, common.RayClusterHeadPodsAssociationOptions(instance).ToListOptions()...); err != nil {
+	headPod, err := common.GetRayClusterHeadPod(ctx, r.Client, instance)
+	if err != nil {
 		return false, err
 	}
-	if len(headPods.Items) == 0 {
+	if headPod == nil {
 		return false, nil
 	}
-	return isRayContainerPastWaiting(headPods.Items[0]), nil
+	return isRayContainerPastWaiting(*headPod), nil
 }
 
 func (r *RayClusterReconciler) createHeadIngress(ctx context.Context, ingress *networkingv1.Ingress, instance *rayv1.RayCluster) error {

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1267,7 +1267,7 @@ func isRayContainerPastWaiting(pod corev1.Pod) bool {
 	for _, containerStatus := range pod.Status.ContainerStatuses {
 		if containerStatus.Name == rayContainerName {
 			return containerStatus.State.Running != nil || containerStatus.State.Terminated != nil ||
-				(containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == "CrashLoopBackOff")
+				containerStatus.LastTerminationState.Terminated != nil
 		}
 	}
 	// If the Ray container status isn't found, it hasn't started yet.

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2840,6 +2840,116 @@ func Test_RedisCleanupFeatureFlag(t *testing.T) {
 	}
 }
 
+func Test_RedisCleanupFeatureFlag_HeadPodCrashLoopBackOffAddsFinalizer(t *testing.T) {
+	setupTest(t)
+	defer os.Unsetenv(utils.ENABLE_GCS_FT_REDIS_CLEANUP)
+	os.Setenv(utils.ENABLE_GCS_FT_REDIS_CLEANUP, "true")
+
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	cluster := testRayCluster.DeepCopy()
+	if cluster.Annotations == nil {
+		cluster.Annotations = map[string]string{}
+	}
+	cluster.Annotations[utils.RayFTEnabledAnnotationKey] = "true"
+	cluster.Spec.EnableInTreeAutoscaling = nil
+
+	ctx := context.Background()
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(newScheme).
+		WithObjects(cluster).
+		WithStatusSubresource(cluster).
+		Build()
+
+	reconciler := &RayClusterReconciler{
+		Client:                     fakeClient,
+		Recorder:                   &record.FakeRecorder{},
+		Scheme:                     newScheme,
+		rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
+	}
+
+	// First reconcile creates Pods before head container status is available.
+	_, err := reconciler.rayClusterReconcile(ctx, cluster)
+	require.NoError(t, err)
+
+	headPods := corev1.PodList{}
+	err = fakeClient.List(ctx, &headPods,
+		client.InNamespace(namespaceStr),
+		client.MatchingLabels{
+			utils.RayClusterLabelKey:  cluster.Name,
+			utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, headPods.Items, 1)
+
+	// head pod container is in running.
+	headPod := headPods.Items[0]
+	headPod.Status.Phase = corev1.PodRunning
+	headPod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: headPod.Spec.Containers[utils.RayContainerIndex].Name,
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{
+			StartedAt: metav1.Now(),
+		}},
+	}}
+	err = fakeClient.Status().Update(ctx, &headPod)
+	require.NoError(t, err)
+
+	latestCluster := &rayv1.RayCluster{}
+	err = fakeClient.Get(ctx, client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}, latestCluster)
+	require.NoError(t, err)
+
+	_, err = reconciler.rayClusterReconcile(ctx, latestCluster)
+	require.NoError(t, err)
+
+	// the finalizer should be added
+	rayClusterList := rayv1.RayClusterList{}
+	err = fakeClient.List(ctx, &rayClusterList, client.InNamespace(namespaceStr))
+	require.NoError(t, err)
+	require.Len(t, rayClusterList.Items, 1)
+	assert.True(t, controllerutil.ContainsFinalizer(&rayClusterList.Items[0], utils.GCSFaultToleranceRedisCleanupFinalizer))
+
+	// get update-to-date head pod for setting crashing state
+	headPods = corev1.PodList{}
+	err = fakeClient.List(ctx, &headPods,
+		client.InNamespace(namespaceStr),
+		client.MatchingLabels{
+			utils.RayClusterLabelKey:  cluster.Name,
+			utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, headPods.Items, 1)
+
+	headPod = headPods.Items[0]
+	headPod.Status.Phase = corev1.PodPending
+	headPod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:         headPod.Spec.Containers[utils.RayContainerIndex].Name,
+		RestartCount: 1,
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+			Reason: "CrashLoopBackOff",
+		}},
+	}}
+	err = fakeClient.Status().Update(ctx, &headPod)
+	require.NoError(t, err)
+
+	latestCluster = &rayv1.RayCluster{}
+	err = fakeClient.Get(ctx, client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}, latestCluster)
+	require.NoError(t, err)
+
+	_, err = reconciler.rayClusterReconcile(ctx, latestCluster)
+	require.NoError(t, err)
+
+	// finalizer should still exist.
+	rayClusterList = rayv1.RayClusterList{}
+	err = fakeClient.List(ctx, &rayClusterList, client.InNamespace(namespaceStr))
+	require.NoError(t, err)
+	require.Len(t, rayClusterList.Items, 1)
+	assert.True(t, controllerutil.ContainsFinalizer(&rayClusterList.Items[0], utils.GCSFaultToleranceRedisCleanupFinalizer))
+}
+
 func TestEvents_RedisCleanup(t *testing.T) {
 	setupTest(t)
 	newScheme := runtime.NewScheme()

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2502,7 +2502,7 @@ func Test_ShouldDeletePod(t *testing.T) {
 	}
 }
 
-func Test_IsRayContainerAfterWaiting(t *testing.T) {
+func Test_IsRayContainerPastWaiting(t *testing.T) {
 	tests := []struct {
 		name     string
 		pod      corev1.Pod
@@ -2615,7 +2615,7 @@ func Test_IsRayContainerAfterWaiting(t *testing.T) {
 	}
 }
 
-func Test_IsHeadPodAfterWaiting(t *testing.T) {
+func Test_IsHeadPodPastWaiting(t *testing.T) {
 	setupTest(t)
 	ctx := context.Background()
 

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2535,6 +2535,23 @@ func Test_IsRayContainerAfterWaiting(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "ray container is waiting after a non-zero exit code previously",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "ray-head"}},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "ray-head",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+						},
+					}},
+				},
+			},
+			expected: true,
+		},
+		{
 			name: "ray container is running",
 			pod: corev1.Pod{
 				Spec: corev1.PodSpec{

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2502,6 +2502,208 @@ func Test_ShouldDeletePod(t *testing.T) {
 	}
 }
 
+func Test_IsRayContainerAfterWaiting(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      corev1.Pod
+		expected bool
+	}{
+		{
+			name: "no container statuses reported yet",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "ray-head"}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "ray container is still waiting",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "ray-head"}},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "ray-head",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"},
+						},
+					}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "ray container is running",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "ray-head"}},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "ray-head",
+						State: corev1.ContainerState{
+							Running: &corev1.ContainerStateRunning{},
+						},
+					}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "ray container is terminated",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "ray-head"}},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "ray-head",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{},
+						},
+					}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "status order differs and helper still finds ray container by name",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "ray-head"}, {Name: "sidecar"}},
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "sidecar",
+							State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+						{
+							Name:  "ray-head",
+							State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isRayContainerAfterWaiting(tc.pod))
+		})
+	}
+}
+
+func Test_IsHeadPodAfterWaiting(t *testing.T) {
+	setupTest(t)
+	ctx := context.Background()
+
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	createHeadPod := func(name string, state corev1.ContainerState) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespaceStr,
+				Labels: map[string]string{
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
+					utils.RayNodeGroupLabelKey: headGroupNameStr,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "ray-head"}},
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name:  "ray-head",
+					State: state,
+				}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		runtimeObjects []runtime.Object
+		expected       bool
+	}{
+		{
+			name:           "head pod does not exist yet",
+			runtimeObjects: []runtime.Object{testRayCluster.DeepCopy()},
+			expected:       false,
+		},
+		{
+			name: "head pod is still waiting",
+			runtimeObjects: []runtime.Object{
+				testRayCluster.DeepCopy(),
+				createHeadPod("head-waiting", corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}}),
+			},
+			expected: false,
+		},
+		{
+			name: "head pod is running",
+			runtimeObjects: []runtime.Object{
+				testRayCluster.DeepCopy(),
+				createHeadPod("head-running", corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}),
+			},
+			expected: true,
+		},
+		{
+			name: "head pod is terminated",
+			runtimeObjects: []runtime.Object{
+				testRayCluster.DeepCopy(),
+				createHeadPod("head-terminated", corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}}),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(newScheme).
+				WithRuntimeObjects(tc.runtimeObjects...).
+				Build()
+
+			reconciler := &RayClusterReconciler{Client: fakeClient, Scheme: newScheme}
+			result, err := reconciler.isHeadPodAfterWaiting(ctx, testRayCluster.DeepCopy())
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func Test_IsHeadPodAfterWaiting_ListError(t *testing.T) {
+	setupTest(t)
+	ctx := context.Background()
+	expectedErr := errors.New("list failed")
+
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(newScheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return expectedErr
+			},
+		}).
+		Build()
+
+	reconciler := &RayClusterReconciler{Client: fakeClient, Scheme: newScheme}
+	result, err := reconciler.isHeadPodAfterWaiting(ctx, testRayCluster.DeepCopy())
+	require.ErrorIs(t, err, expectedErr)
+	assert.False(t, result)
+}
+
 func Test_RedisCleanupFeatureFlag(t *testing.T) {
 	setupTest(t)
 
@@ -2574,15 +2776,52 @@ func Test_RedisCleanupFeatureFlag(t *testing.T) {
 			assert.Len(t, rayClusterList.Items, 1)
 			assert.Empty(t, rayClusterList.Items[0].Finalizers)
 
+			podList := corev1.PodList{}
+			err = fakeClient.List(ctx, &podList, client.InNamespace(namespaceStr))
+			require.NoError(t, err, "Fail to get Pod list")
+			assert.Empty(t, podList.Items)
+
 			_, err = testRayClusterReconciler.rayClusterReconcile(ctx, cluster)
-			if tc.enableGCSFTRedisCleanup == "false" {
-				require.NoError(t, err)
-				podList := corev1.PodList{}
-				err = fakeClient.List(ctx, &podList, client.InNamespace(namespaceStr))
-				require.NoError(t, err)
-				assert.NotEmpty(t, podList.Items)
-			} else {
-				// Add the GCS FT Redis cleanup finalizer to the RayCluster.
+			require.NoError(t, err)
+
+			// On first reconcile, the head Pod is not after Waiting yet, so Pods are created first.
+			podList = corev1.PodList{}
+			err = fakeClient.List(ctx, &podList, client.InNamespace(namespaceStr))
+			require.NoError(t, err, "Fail to get Pod list")
+			assert.NotEmpty(t, podList.Items)
+
+			rayClusterList = rayv1.RayClusterList{}
+			err = fakeClient.List(ctx, &rayClusterList, client.InNamespace(namespaceStr))
+			require.NoError(t, err, "Fail to get RayCluster list")
+			assert.Len(t, rayClusterList.Items, 1)
+			assert.Empty(t, rayClusterList.Items[0].Finalizers)
+
+			if tc.expectedNumFinalizers > 0 {
+				headPods := corev1.PodList{}
+				err = fakeClient.List(ctx, &headPods,
+					client.InNamespace(namespaceStr),
+					client.MatchingLabels{
+						utils.RayClusterLabelKey:  cluster.Name,
+						utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
+					},
+				)
+				require.NoError(t, err, "Fail to get head Pod list")
+				require.Len(t, headPods.Items, 1)
+
+				headPod := headPods.Items[0]
+				headPod.Status.Phase = corev1.PodRunning
+				headPod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+					Name:  headPod.Spec.Containers[utils.RayContainerIndex].Name,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				}}
+				err = fakeClient.Status().Update(ctx, &headPod)
+				require.NoError(t, err, "Fail to update head Pod status")
+
+				latestCluster := &rayv1.RayCluster{}
+				err = fakeClient.Get(ctx, client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}, latestCluster)
+				require.NoError(t, err, "Fail to get latest RayCluster")
+
+				_, err = testRayClusterReconciler.rayClusterReconcile(ctx, latestCluster)
 				require.NoError(t, err)
 			}
 
@@ -2594,20 +2833,8 @@ func Test_RedisCleanupFeatureFlag(t *testing.T) {
 			assert.Len(t, rayClusterList.Items[0].Finalizers, tc.expectedNumFinalizers)
 			if tc.expectedNumFinalizers > 0 {
 				assert.True(t, controllerutil.ContainsFinalizer(&rayClusterList.Items[0], utils.GCSFaultToleranceRedisCleanupFinalizer))
-
-				// No Pod should be created before adding the GCS FT Redis cleanup finalizer.
-				podList := corev1.PodList{}
-				err = fakeClient.List(ctx, &podList, client.InNamespace(namespaceStr))
-				require.NoError(t, err, "Fail to get Pod list")
-				assert.Empty(t, podList.Items)
-
-				// Reconcile the RayCluster again. The controller should create Pods.
-				_, err = testRayClusterReconciler.rayClusterReconcile(ctx, cluster)
-				require.NoError(t, err)
-
-				err = fakeClient.List(ctx, &podList, client.InNamespace(namespaceStr))
-				require.NoError(t, err, "Fail to get Pod list")
-				assert.NotEmpty(t, podList.Items)
+			} else {
+				assert.False(t, controllerutil.ContainsFinalizer(&rayClusterList.Items[0], utils.GCSFaultToleranceRedisCleanupFinalizer))
 			}
 		})
 	}

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2593,7 +2593,7 @@ func Test_IsRayContainerAfterWaiting(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, isRayContainerAfterWaiting(tc.pod))
+			assert.Equal(t, tc.expected, isRayContainerPastWaiting(tc.pod))
 		})
 	}
 }
@@ -2673,7 +2673,7 @@ func Test_IsHeadPodAfterWaiting(t *testing.T) {
 				Build()
 
 			reconciler := &RayClusterReconciler{Client: fakeClient, Scheme: newScheme}
-			result, err := reconciler.isHeadPodAfterWaiting(ctx, testRayCluster.DeepCopy())
+			result, err := reconciler.isHeadPodPastWaiting(ctx, testRayCluster.DeepCopy())
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
 		})
@@ -2699,7 +2699,7 @@ func Test_IsHeadPodAfterWaiting_ListError(t *testing.T) {
 		Build()
 
 	reconciler := &RayClusterReconciler{Client: fakeClient, Scheme: newScheme}
-	result, err := reconciler.isHeadPodAfterWaiting(ctx, testRayCluster.DeepCopy())
+	result, err := reconciler.isHeadPodPastWaiting(ctx, testRayCluster.DeepCopy())
 	require.ErrorIs(t, err, expectedErr)
 	assert.False(t, result)
 }

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2535,7 +2535,7 @@ func Test_IsRayContainerPastWaiting(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "ray container is waiting after a non-zero exit code previously",
+			name: "ray container with last state is not nil",
 			pod: corev1.Pod{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{Name: "ray-head"}},
@@ -2545,6 +2545,11 @@ func Test_IsRayContainerPastWaiting(t *testing.T) {
 						Name: "ray-head",
 						State: corev1.ContainerState{
 							Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+						},
+						LastTerminationState: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 127,
+							},
 						},
 					}},
 				},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The deletion of the RayCluster could be blocked for a long time while GCS cleanup is enabled and this RayCluster has a issue at getting up. 

It might be the GCS cleanup job shares some setting with the head pod. If the head pod has the issue to getting up, the GCS cleanup job might have the issue to getting up, too.

In this PR, it postpones the finalizer added and takes the existence of the finalizer to determine whether it should execute the cleanup job or not during the deletion of the Raycluster. If the container has not reached running state, the command is not executed yet. Thus, there is no need to clean up Redis.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes https://github.com/ray-project/kuberay/issues/4678

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
