### PR TITLE
[release-1.5] cherry-pick bug for v1.5.2

### DIFF
--- a/apiserversdk/Makefile
+++ b/apiserversdk/Makefile
@@ -38,7 +38,7 @@ test: envtest ## Run tests.
 ENVTEST = $(LOCALBIN)/setup-envtest
 $(ENVTEST): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest locally if necessary.
-	test -s $(ENVTEST) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240201105228-4000e996a202
+	test -s $(ENVTEST) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
 
 .PHONY: clean
 clean:

--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -200,7 +200,7 @@ kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 ENVTEST = $(LOCALBIN)/setup-envtest
 $(ENVTEST): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest locally if necessary.
-	test -s $(ENVTEST) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240201105228-4000e996a202
+	test -s $(ENVTEST) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
 
 GOFUMPT = $(LOCALBIN)/gofumpt
 $(GOFUMPT): $(LOCALBIN)

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1025,6 +1025,14 @@ func shouldUpdateCluster(rayServiceInstance *rayv1.RayService, cluster *rayv1.Ra
 		}
 	}
 
+	if ptr.Deref(rayServiceInstance.Spec.RayClusterSpec.Suspend, false) != ptr.Deref(cluster.Spec.Suspend, false) {
+		// Suspend toggles (e.g. from Kueue admitting or preempting the workload) must be
+		// applied in-place to the existing RayCluster. Otherwise the hash comparison below
+		// selects neither the update nor the new-cluster path, and the cluster stays
+		// suspended with no head pod (ray-project/kuberay#4686).
+		return true
+	}
+
 	if isClusterSpecHashEqual(rayServiceInstance, cluster, false) {
 		// The RayCluster spec matches the cluster spec in the RayService. No need to update the cluster.
 		return false

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1047,7 +1047,7 @@ func isClusterSpecHashEqual(rayServiceInstance *rayv1.RayService, cluster *rayv1
 	clusterHash := cluster.ObjectMeta.Annotations[utils.HashWithoutReplicasAndWorkersToDeleteKey]
 	goalClusterHash := ""
 	if !partial {
-		goalClusterHash, _ = generateHashWithoutReplicasAndWorkersToDelete(rayServiceInstance.Spec.RayClusterSpec)
+		goalClusterHash, _ = utils.GenerateHashWithoutReplicasAndWorkersToDelete(rayServiceInstance.Spec.RayClusterSpec)
 	} else {
 		// If everything is identical except for the Replicas and WorkersToDelete of
 		// the existing workergroups, and one or more new workergroups are added at the end, then update the cluster.
@@ -1063,7 +1063,7 @@ func isClusterSpecHashEqual(rayServiceInstance *rayv1.RayService, cluster *rayv1
 			goalClusterSpec.WorkerGroupSpecs = goalClusterSpec.WorkerGroupSpecs[:clusterNumWorkerGroups]
 
 			// Generate the hash of the old worker group specs.
-			goalClusterHash, err = generateHashWithoutReplicasAndWorkersToDelete(*goalClusterSpec)
+			goalClusterHash, err = utils.GenerateHashWithoutReplicasAndWorkersToDelete(*goalClusterSpec)
 			if err != nil {
 				return true
 			}
@@ -1154,7 +1154,7 @@ func constructRayClusterForRayService(rayService *rayv1.RayService, rayClusterNa
 	for k, v := range rayService.Annotations {
 		rayClusterAnnotations[k] = v
 	}
-	rayClusterAnnotations[utils.HashWithoutReplicasAndWorkersToDeleteKey], err = generateHashWithoutReplicasAndWorkersToDelete(rayService.Spec.RayClusterSpec)
+	rayClusterAnnotations[utils.HashWithoutReplicasAndWorkersToDeleteKey], err = utils.GenerateHashWithoutReplicasAndWorkersToDelete(rayService.Spec.RayClusterSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -1717,21 +1717,6 @@ func (r *RayServiceReconciler) updateHeadPodServeLabel(ctx context.Context, rayS
 	}
 
 	return nil
-}
-
-func generateHashWithoutReplicasAndWorkersToDelete(rayClusterSpec rayv1.RayClusterSpec) (string, error) {
-	// Mute certain fields that will not trigger new RayCluster preparation. For example,
-	// Autoscaler will update `Replicas` and `WorkersToDelete` when scaling up/down.
-	updatedRayClusterSpec := rayClusterSpec.DeepCopy()
-	for i := 0; i < len(updatedRayClusterSpec.WorkerGroupSpecs); i++ {
-		updatedRayClusterSpec.WorkerGroupSpecs[i].Replicas = nil
-		updatedRayClusterSpec.WorkerGroupSpecs[i].MaxReplicas = nil
-		updatedRayClusterSpec.WorkerGroupSpecs[i].MinReplicas = nil
-		updatedRayClusterSpec.WorkerGroupSpecs[i].ScaleStrategy.WorkersToDelete = nil
-	}
-
-	// Generate a hash for the RayClusterSpec.
-	return utils.GenerateJsonHash(updatedRayClusterSpec)
 }
 
 // isHeadPodRunningAndReady checks if the head pod of the RayCluster is running and ready.

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -67,6 +67,31 @@ func TestGenerateHashWithoutReplicasAndWorkersToDelete(t *testing.T) {
 	hash3, err := generateHashWithoutReplicasAndWorkersToDelete(cluster.Spec)
 	require.NoError(t, err)
 	assert.NotEqual(t, hash1, hash3)
+
+	// Tolerations injected by external controllers (e.g., Kueue) should not change the hash.
+	cluster.Spec.RayVersion = support.GetRayVersion()
+	cluster.Spec.HeadGroupSpec.Template.Spec.Tolerations = []corev1.Toleration{
+		{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+	}
+	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Tolerations = []corev1.Toleration{
+		{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+	}
+	hash4, err := utils.GenerateHashWithoutReplicasAndWorkersToDelete(cluster.Spec)
+	require.NoError(t, err)
+	assert.Equal(t, hash1, hash4)
+
+	// SchedulingGates injected by external controllers (e.g., Kueue) should not change the hash.
+	cluster.Spec.HeadGroupSpec.Template.Spec.Tolerations = nil
+	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.Tolerations = nil
+	cluster.Spec.HeadGroupSpec.Template.Spec.SchedulingGates = []corev1.PodSchedulingGate{
+		{Name: "kueue.x-k8s.io/admission"},
+	}
+	cluster.Spec.WorkerGroupSpecs[0].Template.Spec.SchedulingGates = []corev1.PodSchedulingGate{
+		{Name: "kueue.x-k8s.io/admission"},
+	}
+	hash5, err := utils.GenerateHashWithoutReplicasAndWorkersToDelete(cluster.Spec)
+	require.NoError(t, err)
+	assert.Equal(t, hash1, hash5)
 }
 
 func TestIsHeadPodRunningAndReady(t *testing.T) {

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2566,3 +2566,75 @@ func TestMarkFailedIfInitializingTimedOut(t *testing.T) {
 		})
 	}
 }
+
+// TestShouldUpdateCluster_SuspendFlip covers ray-project/kuberay#4686: when Kueue
+// toggles RayService.Spec.RayClusterSpec.Suspend, the existing RayCluster must be
+// updated in-place. Previously shouldUpdateCluster returned false because the
+// cluster hash annotation encodes the old Suspend value, leaving the cluster
+// stuck suspended with no head pod.
+func TestShouldUpdateCluster_SuspendFlip(t *testing.T) {
+	namespace := "test-namespace"
+
+	newRayService := func(suspend *bool) *rayv1.RayService {
+		return &rayv1.RayService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-service",
+				Namespace: namespace,
+			},
+			Spec: rayv1.RayServiceSpec{
+				RayClusterSpec: rayv1.RayClusterSpec{
+					RayVersion: "2.9.0",
+					Suspend:    suspend,
+				},
+			},
+		}
+	}
+
+	// newClusterFrom mirrors the annotation layout produced by
+	// constructRayClusterForRayService so the hash reflects the cluster's
+	// actual spec (including its Suspend value).
+	newClusterFrom := func(t *testing.T, service *rayv1.RayService, suspend *bool) *rayv1.RayCluster {
+		t.Helper()
+		clusterSpec := service.Spec.RayClusterSpec.DeepCopy()
+		clusterSpec.Suspend = suspend
+		hash, err := utils.GenerateHashWithoutReplicasAndWorkersToDelete(*clusterSpec)
+		require.NoError(t, err)
+		return &rayv1.RayCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					utils.HashWithoutReplicasAndWorkersToDeleteKey: hash,
+					utils.NumWorkerGroupsKey:                       strconv.Itoa(len(clusterSpec.WorkerGroupSpecs)),
+					utils.KubeRayVersion:                           utils.KUBERAY_VERSION,
+				},
+			},
+			Spec: *clusterSpec,
+		}
+	}
+
+	tests := []struct {
+		serviceSuspend  *bool
+		clusterSuspend  *bool
+		name            string
+		isActiveCluster bool
+		expect          bool
+	}{
+		{name: "pending unsuspended by Kueue: true -> false", serviceSuspend: ptr.To(false), clusterSuspend: ptr.To(true), isActiveCluster: false, expect: true},
+		{name: "pending suspended by Kueue: false -> true", serviceSuspend: ptr.To(true), clusterSuspend: ptr.To(false), isActiveCluster: false, expect: true},
+		{name: "active unsuspended by Kueue: true -> false", serviceSuspend: ptr.To(false), clusterSuspend: ptr.To(true), isActiveCluster: true, expect: true},
+		{name: "active suspended by Kueue: false -> true", serviceSuspend: ptr.To(true), clusterSuspend: ptr.To(false), isActiveCluster: true, expect: true},
+		{name: "no change, both nil", serviceSuspend: nil, clusterSuspend: nil, isActiveCluster: false, expect: false},
+		{name: "no change, both false", serviceSuspend: ptr.To(false), clusterSuspend: ptr.To(false), isActiveCluster: false, expect: false},
+		{name: "no change, both true", serviceSuspend: ptr.To(true), clusterSuspend: ptr.To(true), isActiveCluster: false, expect: false},
+		{name: "nil vs false treated equal", serviceSuspend: nil, clusterSuspend: ptr.To(false), isActiveCluster: false, expect: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := newRayService(tt.serviceSuspend)
+			cluster := newClusterFrom(t, service, tt.clusterSuspend)
+			assert.Equal(t, tt.expect, shouldUpdateCluster(service, cluster, tt.isActiveCluster))
+		})
+	}
+}

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -54,17 +54,17 @@ func TestGenerateHashWithoutReplicasAndWorkersToDelete(t *testing.T) {
 		},
 	}
 
-	hash1, err := generateHashWithoutReplicasAndWorkersToDelete(cluster.Spec)
+	hash1, err := utils.GenerateHashWithoutReplicasAndWorkersToDelete(cluster.Spec)
 	require.NoError(t, err)
 
 	*cluster.Spec.WorkerGroupSpecs[0].Replicas++
-	hash2, err := generateHashWithoutReplicasAndWorkersToDelete(cluster.Spec)
+	hash2, err := utils.GenerateHashWithoutReplicasAndWorkersToDelete(cluster.Spec)
 	require.NoError(t, err)
 	assert.Equal(t, hash1, hash2)
 
 	// RayVersion will not be muted, so `hash3` should not be equal to `hash1`.
 	cluster.Spec.RayVersion = "2.100.0"
-	hash3, err := generateHashWithoutReplicasAndWorkersToDelete(cluster.Spec)
+	hash3, err := utils.GenerateHashWithoutReplicasAndWorkersToDelete(cluster.Spec)
 	require.NoError(t, err)
 	assert.NotEqual(t, hash1, hash3)
 
@@ -497,7 +497,7 @@ func TestReconcileRayCluster_UpdateActiveCluster(t *testing.T) {
 		},
 	}
 
-	hash, err := generateHashWithoutReplicasAndWorkersToDelete(rayServiceTemplate.Spec.RayClusterSpec)
+	hash, err := utils.GenerateHashWithoutReplicasAndWorkersToDelete(rayServiceTemplate.Spec.RayClusterSpec)
 	require.NoError(t, err)
 	activeClusterTemplate := rayv1.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -581,7 +581,7 @@ func TestReconcileRayCluster_UpdatePendingCluster(t *testing.T) {
 		},
 	}
 
-	hash, err := generateHashWithoutReplicasAndWorkersToDelete(rayServiceTemplate.Spec.RayClusterSpec)
+	hash, err := utils.GenerateHashWithoutReplicasAndWorkersToDelete(rayServiceTemplate.Spec.RayClusterSpec)
 	require.NoError(t, err)
 	cluster := rayv1.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1115,7 +1115,7 @@ func TestIsClusterSpecHashEqual(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			service := rayService.DeepCopy()
-			hash, err := generateHashWithoutReplicasAndWorkersToDelete(service.Spec.RayClusterSpec)
+			hash, err := utils.GenerateHashWithoutReplicasAndWorkersToDelete(service.Spec.RayClusterSpec)
 			require.NoError(t, err)
 			cluster := rayv1.RayCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1178,7 +1178,7 @@ func TestShouldPrepareNewCluster_ZeroDowntimeUpgrade(t *testing.T) {
 		},
 	}
 
-	hash, err := generateHashWithoutReplicasAndWorkersToDelete(rayService.Spec.RayClusterSpec)
+	hash, err := utils.GenerateHashWithoutReplicasAndWorkersToDelete(rayService.Spec.RayClusterSpec)
 	require.NoError(t, err)
 	activeCluster := &rayv1.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1216,7 +1216,7 @@ func TestShouldPrepareNewCluster_PendingCluster(t *testing.T) {
 		},
 	}
 
-	hash, err := generateHashWithoutReplicasAndWorkersToDelete(rayService.Spec.RayClusterSpec)
+	hash, err := utils.GenerateHashWithoutReplicasAndWorkersToDelete(rayService.Spec.RayClusterSpec)
 	require.NoError(t, err)
 	pendingCluster := &rayv1.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -644,6 +644,29 @@ func GenerateJsonHash(obj interface{}) (string, error) {
 	return hashStr, nil
 }
 
+func GenerateHashWithoutReplicasAndWorkersToDelete(rayClusterSpec rayv1.RayClusterSpec) (string, error) {
+	// Mute certain fields that will not trigger new RayCluster preparation. For example,
+	// Autoscaler will update `Replicas` and `WorkersToDelete` when scaling up/down.
+	updatedRayClusterSpec := rayClusterSpec.DeepCopy()
+
+	// Mute tolerations and scheduling gates for all pod templates.
+	// External controllers like Kueue may inject these fields into the RayCluster
+	// after creation, which should not trigger a new RayCluster preparation.
+	updatedRayClusterSpec.HeadGroupSpec.Template.Spec.Tolerations = nil
+	updatedRayClusterSpec.HeadGroupSpec.Template.Spec.SchedulingGates = nil
+	for i := 0; i < len(updatedRayClusterSpec.WorkerGroupSpecs); i++ {
+		updatedRayClusterSpec.WorkerGroupSpecs[i].Replicas = nil
+		updatedRayClusterSpec.WorkerGroupSpecs[i].MaxReplicas = nil
+		updatedRayClusterSpec.WorkerGroupSpecs[i].MinReplicas = nil
+		updatedRayClusterSpec.WorkerGroupSpecs[i].ScaleStrategy.WorkersToDelete = nil
+		updatedRayClusterSpec.WorkerGroupSpecs[i].Template.Spec.Tolerations = nil
+		updatedRayClusterSpec.WorkerGroupSpecs[i].Template.Spec.SchedulingGates = nil
+	}
+
+	// Generate a hash for the RayClusterSpec.
+	return GenerateJsonHash(updatedRayClusterSpec)
+}
+
 // FindContainerPort searches for a specific port $portName in the container.
 // If the port is found in the container, the corresponding port is returned.
 // If the port is not found, the $defaultPort is returned instead.

--- a/ray-operator/test/e2erayservice/rayservice_ha_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_ha_test.go
@@ -48,7 +48,7 @@ func TestStaticRayService(t *testing.T) {
 	LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
 
 	// Install Locust in the head Pod
-	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10"})
+	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10", "gevent<26"})
 
 	// Run Locust test
 	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
@@ -105,7 +105,7 @@ func TestAutoscalingRayService(t *testing.T) {
 	LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
 
 	// Install Locust in the head Pod
-	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10"})
+	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10", "gevent<26"})
 
 	// Run Locust test
 	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{
@@ -156,7 +156,7 @@ func TestRayServiceZeroDowntimeUpgrade(t *testing.T) {
 	LogWithTimestamp(test.T(), "Found head pod %s/%s", headPod.Namespace, headPod.Name)
 
 	// Install Locust in the head Pod
-	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10"})
+	ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10", "gevent<26"})
 
 	// Start a goroutine to perform zero-downtime upgrade
 	var wg sync.WaitGroup
@@ -233,7 +233,7 @@ func TestRayServiceGCSFaultTolerance(t *testing.T) {
 	LogWithTimestamp(test.T(), "Found head pod %s/%s", locustHeadPod.Namespace, locustHeadPod.Name)
 
 	// Install Locust in the Locust head Pod
-	ExecPodCmd(test, locustHeadPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10"})
+	ExecPodCmd(test, locustHeadPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10", "gevent<26"})
 
 	// Get current head pod
 	oldHeadPod, err := GetHeadPod(test, rayServiceUnderlyingRayCluster)

--- a/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
@@ -2,7 +2,9 @@ package e2erayservice
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -77,32 +79,48 @@ func TestOldHeadPodFailDuringUpgrade(t *testing.T) {
 	rayService, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rayService, metav1.UpdateOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
 
-	LogWithTimestamp(test.T(), "Using iptables to make the ProxyActor(8000 port) fail to receive requests on the old head Pod")
-	headPodPatch := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"ephemeralContainers": []corev1.EphemeralContainer{
-				{
-					EphemeralContainerCommon: corev1.EphemeralContainerCommon{
-						Name:    "proxy-actor-drop",
-						Image:   "istio/iptables",
-						Command: []string{"iptables"},
-						Args:    []string{"-A", "INPUT", "-p", "tcp", "--dport", "8000", "-j", "DROP"},
-						SecurityContext: &corev1.SecurityContext{
-							Privileged: ptr.To(true),
-							RunAsUser:  ptr.To(int64(0)),
+	for _, iptables := range []string{"iptables-legacy", "iptables-nft"} {
+		LogWithTimestamp(test.T(), "Using %s to make the ProxyActor(8000 port) fail to receive requests on the old head Pod", iptables)
+		headPodPatch := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"ephemeralContainers": []corev1.EphemeralContainer{
+					{
+						EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+							Name:    "proxy-actor-drop-" + iptables,
+							Image:   "istio/iptables:1.27-2026-02-26T19-02-11",
+							Command: []string{iptables},
+							Args:    []string{"-A", "INPUT", "-p", "tcp", "--dport", "8000", "-j", "DROP"},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+								RunAsUser:  ptr.To(int64(0)),
+							},
 						},
 					},
 				},
 			},
-		},
+		}
+		patchBytes, err := json.Marshal(headPodPatch)
+		g.Expect(err).NotTo(HaveOccurred())
+		_, err = test.Client().Core().CoreV1().Pods(namespace.Name).Patch(test.Ctx(), headPodName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "ephemeralcontainers")
+		g.Expect(err).NotTo(HaveOccurred())
 	}
-	patchBytes, err := json.Marshal(headPodPatch)
+
+	headPod, err := test.Client().Core().CoreV1().Pods(namespace.Name).Get(test.Ctx(), headPodName, metav1.GetOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
-	headPod, err := test.Client().Core().CoreV1().Pods(namespace.Name).Patch(test.Ctx(), headPodName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "ephemeralcontainers")
-	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(headPod.Status.PodIP).NotTo(BeEmpty())
 
 	LogWithTimestamp(test.T(), "Checking that the old Head Pod's label `ray.io/serve` is `true`")
 	g.Expect(headPod.Labels[utils.RayClusterServingServiceLabelKey]).To(Equal("true"))
+
+	healthURL := fmt.Sprintf("http://%s:%d/", headPod.Status.PodIP, utils.DefaultServingPort) + utils.RayServeProxyHealthPath
+	LogWithTimestamp(test.T(), "Curling head Pod %s at %s until ephemeral iptables applies DROP on :%d (expect curl to fail)", headPodName, healthURL, utils.DefaultServingPort)
+	curlCmd := []string{
+		"curl", "-sS", "-f", "--connect-timeout", "3", "--max-time", "5", "-X", "GET", healthURL,
+	}
+	g.Eventually(func() error {
+		_, _, curlErr := ExecPodCmdWithError(test, curlPod, curlContainerName, curlCmd)
+		return curlErr
+	}, TestTimeoutShort, 2*time.Second).Should(HaveOccurred(), "iptables should block TCP :8000 like CheckProxyActorHealth would fail")
 
 	LogWithTimestamp(test.T(), "Checking that the old Head Pod's label `ray.io/serve` is `false` because it is not healthy")
 	g.Eventually(func(g Gomega) string {

--- a/ray-operator/test/support/core.go
+++ b/ray-operator/test/support/core.go
@@ -68,7 +68,8 @@ func storeContainerLog(t Test, namespace *corev1.Namespace, podName, containerNa
 	WriteToOutputDir(t, containerLogFileName, Log, bytes)
 }
 
-func ExecPodCmd(t Test, pod *corev1.Pod, containerName string, cmd []string) (bytes.Buffer, bytes.Buffer) {
+// execPodCmd is the core implementation that always returns the error from the command execution in the pod.
+func execPodCmd(t Test, pod *corev1.Pod, containerName string, cmd []string) (bytes.Buffer, bytes.Buffer, error) {
 	req := t.Client().Core().CoreV1().RESTClient().
 		Post().
 		Resource("pods").
@@ -99,8 +100,26 @@ func ExecPodCmd(t Test, pod *corev1.Pod, containerName string, cmd []string) (by
 	})
 	LogWithTimestamp(t.T(), "Command stdout: %s", stdout.String())
 	LogWithTimestamp(t.T(), "Command stderr: %s", stderr.String())
-	require.NoError(t.T(), err)
+
+	return stdout, stderr, err
+}
+
+// ExecPodCmd is a wrapper that allows the caller to specify whether to allow the command to fail.
+func ExecPodCmd(t Test, pod *corev1.Pod, containerName string, cmd []string, allowError ...bool) (bytes.Buffer, bytes.Buffer) {
+	stdout, stderr, err := execPodCmd(t, pod, containerName, cmd)
+
+	shouldAllowError := len(allowError) > 0 && allowError[0]
+	if !shouldAllowError {
+		require.NoError(t.T(), err, "Command failed unexpectedly")
+	}
+
 	return stdout, stderr
+}
+
+// ExecPodCmdWithError is a wrapper that always returns the error from the command execution in the pod.
+// Since it propagates the error, it's safe to call this function from any goroutine,
+func ExecPodCmdWithError(t Test, pod *corev1.Pod, containerName string, cmd []string) (bytes.Buffer, bytes.Buffer, error) {
+	return execPodCmd(t, pod, containerName, cmd)
 }
 
 func SetupPortForward(t Test, podName, namespace string, localPort, remotePort int) (chan struct{}, error) {


### PR DESCRIPTION
## Why are these changes needed?

Cherry-pick the following bug fixes from master to `release-1.5` for the upcoming `v1.5.2` patch release:

- #4569 — Exclude `tolerations` and `scheduling gates` from the RayCluster spec hash, so Kueue-style admission does not spuriously trigger cluster rebuilds.
- #4739 — Fix RayService not updating the RayCluster in place when `Spec.RayClusterSpec.Suspend` toggles (addresses #4686). Without this, Kueue admit/preempt leaves the cluster stuck suspended with no head pod.

## Related issue number

- Closes #4686 (for the #4739 cherry-pick)
- Follows up on #4569

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests (both commits carry their original unit tests; `TestShouldUpdateCluster_SuspendFlip` covers the Suspend toggle behavior)
  - [ ] Manual tests
  - [ ] This PR is not tested :(