### PR TITLE
Check job deletion status code

### DIFF
--- a/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient.go
@@ -354,6 +354,9 @@ func (r *RayDashboardClient) DeleteJob(ctx context.Context, jobName string) erro
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		// No need to read the body for successful responses.
+		// Intentionally ignore the stream read error here: server response code is more indicative.
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("DeleteJob fail: %s %s", resp.Status, string(body))
 	}
 	return nil

--- a/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient.go
@@ -353,6 +353,9 @@ func (r *RayDashboardClient) DeleteJob(ctx context.Context, jobName string) erro
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("DeleteJob fail: %s %s", resp.Status, string(body))
+	}
 	return nil
 }
 

--- a/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go
@@ -298,4 +298,18 @@ var _ = Describe("RayFrameworkGenerator", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
 	})
+
+	It("Test delete job returns error on 500", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		httpmock.RegisterResponder(http.MethodDelete, rayDashboardClient.dashboardURL+JobPath+"delete-job-2",
+			func(_ *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(500, "Internal Server Error"), nil
+			})
+
+		err := rayDashboardClient.DeleteJob(context.TODO(), "delete-job-2")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("DeleteJob fail"))
+		Expect(err.Error()).To(ContainSubstring("500"))
+	})
 })


### PR DESCRIPTION
## Why are these changes needed?

When we do HTTP requests there're two types of possible errors:
- Network errors, that's the error status we've already checked and returned
- Server side logic error (i.e., server internal error, permission error), which is indicated by HTTP status code

Current implementation hides the second types of errors.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [X] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
