### PR TITLE
[release-1.6] cherry-pick RayService e2e test fixes

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -94,7 +94,7 @@
     - set -o pipefail
     - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
     - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
-    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2eincrementalupgrade 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
+    - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=10m KUBERAY_TEST_TIMEOUT_LONG=20m go test -timeout 60m -v ./test/e2eincrementalupgrade 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayService Incremental Upgrade E2E (nightly operator) tests finished"
 
 - label: 'Test Autoscaler E2E Part 1 (nightly operator)'

--- a/ray-operator/test/e2eincrementalupgrade/constant.go
+++ b/ray-operator/test/e2eincrementalupgrade/constant.go
@@ -1,0 +1,121 @@
+package e2eincrementalupgrade
+
+import "k8s.io/utils/ptr"
+
+// These parameters control capacity scaling and gradual traffic migration during the upgrade.
+type incrementalUpgradeParams struct {
+	Name     string
+	StepSize int32
+	Interval int32
+	MaxSurge int32
+}
+
+// incrementalUpgradeCombinations defines diverse (stepSize, interval, maxSurge) combinations
+// to exercise different upgrade behaviors. Each combination targets a distinct scenario.
+var incrementalUpgradeCombinations = []incrementalUpgradeParams{
+	{
+		// Scenario: Instant cutover.
+		// All capacity and traffic shift in one step, which behaves like a blue/green deployment.
+		StepSize: 100,
+		Interval: 1,
+		MaxSurge: 100,
+		Name:     "BlueGreen",
+	},
+	{
+		// Scenario: Aggressive gradual upgrade.
+		// Larger traffic migration steps with shorter intervals.
+		StepSize: 25,
+		Interval: 5,
+		MaxSurge: 50,
+		Name:     "AggressiveGradual",
+	},
+	{
+		// Scenario: Conservative gradual upgrade.
+		// Smaller traffic migration steps with longer intervals.
+		StepSize: 5,
+		Interval: 10,
+		MaxSurge: 25,
+		Name:     "ConservativeGradual",
+	},
+}
+
+// ptrs returns (*stepSize, *interval, *maxSurge) for use with the RayService bootstrap helper.
+func (p incrementalUpgradeParams) ptrs() (*int32, *int32, *int32) {
+	return ptr.To(p.StepSize), ptr.To(p.Interval), ptr.To(p.MaxSurge)
+}
+
+// The following defines the Serve configurations for different types of incremental upgrade tests, including:
+//   - Functional test
+//   - High-RPS Locust load test
+//
+// NOTE: working_dir is coupled with the external GitHub repos, which might lead to CI flakiness considering the
+// availability and stability of these repos and specific commit hashes.
+
+type serveConfigV2 string
+
+// defaultIncrementalUpgradeServeConfigV2 configures a Serve app for functional tests.
+const defaultIncrementalUpgradeServeConfigV2 serveConfigV2 = `applications:
+  - name: fruit_app
+    import_path: fruit.deployment_graph
+    route_prefix: /fruit
+    runtime_env:
+      working_dir: "https://github.com/ray-project/test_dag/archive/78b4a5da38796123d9f9ffff59bab2792a043e95.zip"
+    deployments:
+      - name: MangoStand
+        num_replicas: 1
+        user_config:
+          price: 3
+        ray_actor_options:
+          num_cpus: 0.1
+      - name: OrangeStand
+        num_replicas: 1
+        user_config:
+          price: 2
+        ray_actor_options:
+          num_cpus: 0.1
+      - name: FruitMarket
+        num_replicas: 1
+        ray_actor_options:
+          num_cpus: 0.1
+  - name: math_app
+    import_path: conditional_dag.serve_dag
+    route_prefix: /calc
+    runtime_env:
+      working_dir: "https://github.com/ray-project/test_dag/archive/78b4a5da38796123d9f9ffff59bab2792a043e95.zip"
+    deployments:
+      - name: Adder
+        num_replicas: 1
+        user_config:
+          increment: 3
+        ray_actor_options:
+          num_cpus: 0.1
+      - name: Multiplier
+        num_replicas: 1
+        user_config:
+          factor: 5
+        ray_actor_options:
+          num_cpus: 0.1
+      - name: Router
+        num_replicas: 1
+        ray_actor_options:
+          num_cpus: 0.1
+`
+
+// highRPSServeConfigV2 configures a minimal high-RPS Serve app (SimpleDeployment) for Locust load tests.
+const highRPSServeConfigV2 serveConfigV2 = `applications:
+  - name: simple_app
+    import_path: locust_test.simple_serve:app
+    route_prefix: /test
+    runtime_env:
+      working_dir: "https://github.com/ray-project/serve_config_examples/archive/530e247ca195530b71b92d7e708048a1bdc02583.zip"
+    deployments:
+      - name: SimpleDeployment
+        autoscaling_config:
+          min_replicas: 1
+          max_replicas: 2
+          target_ongoing_requests: 2
+          max_ongoing_requests: 6
+          upscale_delay_s: 0.5
+        ray_actor_options:
+          num_cpus: 2
+`

--- a/ray-operator/test/e2eincrementalupgrade/rayservice_incremental_upgrade_test.go
+++ b/ray-operator/test/e2eincrementalupgrade/rayservice_incremental_upgrade_test.go
@@ -1,11 +1,15 @@
 package e2eincrementalupgrade
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -14,209 +18,321 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
-	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
-// helper function to get RayCluster head service external IP to use to poll the RayService
-func GetHeadServiceExternalIP(t *testing.T, clusterName, namespace string) (string, error) {
-	test := With(t)
-
-	svc, err := test.Client().Core().CoreV1().Services(namespace).Get(test.Ctx(), clusterName+"-head-svc", metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	if len(svc.Status.LoadBalancer.Ingress) == 0 {
-		return "", fmt.Errorf("no ingress for service %s", svc.Name)
-	}
-	return svc.Status.LoadBalancer.Ingress[0].IP, nil
-}
-
+// TestRayServiceIncrementalUpgrade is the functional test for the basic incremental upgrade flow of the RayService,
+// focusing on the behaviors of the RayService during the upgrade process.
+//
+// It iterates over incrementalUpgradeCombinations to cover diverse upgrade scenarios:
+//   - BlueGreen
+//   - AggressiveGradual
+//   - ConservativeGradual
+//
+// The test case follows these steps:
+// 1. Enable the RayServiceIncrementalUpgrade feature gate
+// 2. Create a RayService with IncrementalUpgrade enabled
+// 3. Wait for the RayService to be ready
+// 4. Wait for the Gateway object to be ready (Accepted and Programmed conditions are True)
+// 5. Wait for the corresponding HTTPRoute object to be ready (Accepted and ResolvedRefs conditions are True)
+// 6. Create a Curl pod to test traffic routing through Gateway to RayService and wait for it to be ready
+// 7. Validate RayService is serving traffic by sending requests through Gateway external IP
+// 8. Modify the RayCluster spec to trigger upgrade and change the RayService serve config to update the serve deployment
+//   - NOTE: Incremental upgrade is triggered by RayCluster spec changes, not serve config changes
+//
+// 9. Wait for the RayService to be upgrading
+// 10. Validate the active and pending cluster serve services have been created
+// 11. Validate the pending cluster head pod is ready
+// 12. Validate the HTTPRoute backends have two backends (active and pending cluster serve services)
+// 13. Perform behavioral checks, covering:
+//   - Current state value matches the expected value or the RayService finished upgrading
+//   - Both old and new versions served traffic during the upgrade and no requests are dropped
+//   - Traffic is migrated with respect to the interval seconds
+//   - Active TargetCapacity is monotonically decreasing, and Pending TargetCapacity is monotonically increasing
+//   - Active TrafficRoutedPercent is monotonically decreasing, and Pending TrafficRoutedPercent is monotonically increasing
+//
+// 14. Wait for incremental upgrade to complete
+// 15. Validate the RayService uses updated ServeConfig after upgrade completes
 func TestRayServiceIncrementalUpgrade(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.RayServiceIncrementalUpgrade, true)
 
-	test := With(t)
-	g := NewWithT(t)
+	for _, params := range incrementalUpgradeCombinations {
+		t.Run(params.Name, func(t *testing.T) {
+			test := With(t)
+			g := NewWithT(t)
 
-	namespace := test.NewTestNamespace()
-	rayServiceName := "incremental-rayservice"
+			namespace := test.NewTestNamespace()
+			rayServiceName := "incremental-rayservice"
 
-	// Create a RayService with IncrementalUpgrade enabled
-	stepSize := ptr.To(int32(25))
-	interval := ptr.To(int32(5))
-	maxSurge := ptr.To(int32(50))
+			stepSize, interval, maxSurge := params.ptrs()
+			serveConfigV2 := defaultIncrementalUpgradeServeConfigV2
 
-	rayServiceAC := rayv1ac.RayService(rayServiceName, namespace.Name).
-		WithSpec(IncrementalUpgradeRayServiceApplyConfiguration(stepSize, interval, maxSurge))
-	rayService, err := test.Client().Ray().RayV1().RayServices(namespace.Name).Apply(test.Ctx(), rayServiceAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(rayService).NotTo(BeNil())
+			// Create RayService with IncrementalUpgrade enabled and wait for key components to be ready
+			rayService, httpRoute, gatewayIP := bootstrapIncrementalRayService(test, g, namespace.Name, rayServiceName, stepSize, interval, maxSurge, serveConfigV2)
 
-	LogWithTimestamp(test.T(), "Waiting for RayService %s/%s to be ready", rayService.Namespace, rayService.Name)
-	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).
-		Should(WithTransform(IsRayServiceReady, BeTrue()))
-
-	rayService, err = GetRayService(test, namespace.Name, rayServiceName)
-	g.Expect(err).NotTo(HaveOccurred())
-
-	// Validate Gateway and HTTPRoute objects have been created for incremental upgrade.
-	gatewayName := fmt.Sprintf("%s-%s", rayServiceName, "gateway")
-	LogWithTimestamp(test.T(), "Waiting for Gateway %s/%s to be ready", rayService.Namespace, gatewayName)
-	g.Eventually(Gateway(test, rayService.Namespace, gatewayName), TestTimeoutMedium).
-		Should(WithTransform(utils.IsGatewayReady, BeTrue()))
-
-	// Get the Gateway endpoint to send requests to
-	gateway, err := GetGateway(test, namespace.Name, fmt.Sprintf("%s-%s", rayServiceName, "gateway"))
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(gateway).NotTo(BeNil())
-
-	httpRouteName := fmt.Sprintf("%s-%s", rayServiceName, "httproute")
-	LogWithTimestamp(test.T(), "Waiting for HTTPRoute %s/%s to be ready", rayService.Namespace, httpRouteName)
-	g.Eventually(HTTPRoute(test, rayService.Namespace, httpRouteName), TestTimeoutMedium).
-		Should(Not(BeNil()))
-
-	httpRoute, err := GetHTTPRoute(test, namespace.Name, httpRouteName)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(utils.IsHTTPRouteReady(gateway, httpRoute)).To(BeTrue())
-
-	// Create curl pod to test traffic routing through Gateway to RayService
-	curlPodName := "curl-pod"
-	curlContainerName := "curl-container"
-	curlPod, err := CreateCurlPod(g, test, curlPodName, curlContainerName, namespace.Name)
-	g.Expect(err).NotTo(HaveOccurred())
-
-	LogWithTimestamp(test.T(), "Waiting for Curl Pod %s to be ready", curlPodName)
-	g.Eventually(func(g Gomega) *corev1.Pod {
-		updatedPod, err := test.Client().Core().CoreV1().Pods(curlPod.Namespace).Get(test.Ctx(), curlPod.Name, metav1.GetOptions{})
-		g.Expect(err).NotTo(HaveOccurred())
-		return updatedPod
-	}, TestTimeoutShort).Should(WithTransform(IsPodRunningAndReady, BeTrue()))
-
-	gatewayIP := GetGatewayIP(gateway)
-	g.Expect(gatewayIP).NotTo(BeEmpty())
-
-	LogWithTimestamp(test.T(), "Verifying RayService is serving traffic")
-	stdout, _ := CurlRayServiceGateway(test, gatewayIP, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)
-	g.Expect(stdout.String()).To(Equal("6"))
-	stdout, _ = CurlRayServiceGateway(test, gatewayIP, curlPod, curlContainerName, "/calc", `["MUL", 3]`)
-	g.Expect(stdout.String()).To(Equal("15 pizzas please!"))
-
-	// Attempt to trigger NewClusterWithIncrementalUpgrade by updating RayService serve config and RayCluster spec
-	g.Eventually(func() error {
-		latestRayService, err := GetRayService(test, namespace.Name, rayServiceName)
-		if err != nil {
-			return err
-		}
-		latestRayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("500m")
-		serveConfig := latestRayService.Spec.ServeConfigV2
-		serveConfig = strings.ReplaceAll(serveConfig, "price: 3", "price: 4")
-		serveConfig = strings.ReplaceAll(serveConfig, "factor: 5", "factor: 3")
-		latestRayService.Spec.ServeConfigV2 = serveConfig
-
-		_, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(
-			test.Ctx(),
-			latestRayService,
-			metav1.UpdateOptions{},
-		)
-		return err
-	}, TestTimeoutShort).Should(Succeed(), "Failed to update RayService to trigger upgrade")
-
-	LogWithTimestamp(test.T(), "Waiting for RayService %s/%s UpgradeInProgress condition to be true", rayService.Namespace, rayService.Name)
-	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutShort).Should(WithTransform(IsRayServiceUpgrading, BeTrue()))
-
-	LogWithTimestamp(test.T(), "Verifying temporary service creation and HTTPRoute backends")
-	upgradingRaySvc, err := GetRayService(test, namespace.Name, rayServiceName)
-	g.Expect(err).NotTo(HaveOccurred())
-	activeClusterName := upgradingRaySvc.Status.ActiveServiceStatus.RayClusterName
-	g.Expect(activeClusterName).NotTo(BeEmpty(), "The active cluster should be set when a RayService is ready.")
-	pendingClusterName := upgradingRaySvc.Status.PendingServiceStatus.RayClusterName
-	g.Expect(pendingClusterName).NotTo(BeEmpty(), "The controller should have created a pending cluster.")
-
-	// Validate serve service for the active cluster exists.
-	activeServeSvcName := utils.GenerateServeServiceName(activeClusterName)
-	_, err = test.Client().Core().CoreV1().Services(namespace.Name).Get(test.Ctx(), activeServeSvcName, metav1.GetOptions{})
-	g.Expect(err).NotTo(HaveOccurred(), "The serve service for the active cluster should be created.")
-
-	// Validate serve service for the pending cluster has been created for the upgrade.
-	pendingServeSvcName := utils.GenerateServeServiceName(pendingClusterName)
-	g.Eventually(func(g Gomega) {
-		_, err = test.Client().Core().CoreV1().Services(namespace.Name).Get(test.Ctx(), pendingServeSvcName, metav1.GetOptions{})
-		g.Expect(err).NotTo(HaveOccurred(), "The serve service for the pending cluster should be created.")
-	}, TestTimeoutShort).Should(Succeed())
-
-	LogWithTimestamp(test.T(), "Waiting for pending RayCluster %s to have a ready head pod", pendingClusterName)
-	g.Eventually(RayCluster(test, namespace.Name, pendingClusterName), TestTimeoutMedium).
-		Should(WithTransform(StatusCondition(rayv1.HeadPodReady), MatchCondition(metav1.ConditionTrue, rayv1.HeadPodRunningAndReady)))
-
-	// Wait for the HTTPRoute to reflect the two backends.
-	LogWithTimestamp(test.T(), "Waiting for HTTPRoute to have two backends")
-	g.Eventually(func(g Gomega) {
-		route, err := GetHTTPRoute(test, namespace.Name, httpRouteName)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(route.Spec.Rules).To(HaveLen(1))
-		g.Expect(route.Spec.Rules[0].BackendRefs).To(HaveLen(2))
-		g.Expect(string(route.Spec.Rules[0].BackendRefs[1].Name)).To(Equal(pendingServeSvcName))
-	}, TestTimeoutShort).Should(Succeed())
-
-	LogWithTimestamp(test.T(), "Validating stepwise traffic and capacity migration")
-	intervalSeconds := *interval
-	var lastMigratedTime *metav1.Time
-	oldVersionServed := false
-	newVersionServed := false
-
-	// Validate expected behavior during an IncrementalUpgrade. The following checks ensures
-	// that no requests are dropped throughout the upgrade process.
-	upgradeSteps := generateUpgradeSteps(*stepSize, *maxSurge)
-	for _, step := range upgradeSteps {
-		LogWithTimestamp(test.T(), "%s", step.name)
-		g.Eventually(func(g Gomega) int32 {
-			// Fetch updated RayService.
-			svc, err := GetRayService(test, namespace.Name, rayServiceName)
-			g.Expect(err).NotTo(HaveOccurred())
-			return step.getValue(svc)
-		}, TestTimeoutShort).Should(Equal(step.expectedValue))
-
-		// Send a request to the RayService to validate no requests are dropped. Check that
-		// both endpoints are serving requests.
-		stdout, _ := CurlRayServiceGateway(test, gatewayIP, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)
-		response := stdout.String()
-		g.Expect(response).To(Or(Equal("6"), Equal("8")), "Response should be from the old or new app version during the upgrade")
-		if response == "6" {
-			oldVersionServed = true
-		}
-		if response == "8" {
-			newVersionServed = true
-		}
-
-		if strings.Contains(step.name, "pending traffic to shift") {
-			svc, err := GetRayService(test, namespace.Name, rayServiceName)
+			// Create curl pod to test traffic routing through Gateway to RayService
+			curlPod, err := CreateCurlPod(g, test, CurlPodName, CurlContainerName, namespace.Name)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			currentMigratedTime := svc.Status.PendingServiceStatus.LastTrafficMigratedTime
-			g.Expect(currentMigratedTime).NotTo(BeNil())
+			LogWithTimestamp(test.T(), "Verifying RayService is serving traffic")
+			stdout, _ := CurlRayServiceGateway(test, gatewayIP, curlPod, CurlContainerName, http.MethodPost, "/fruit", `["MANGO", 2]`)
+			g.Expect(stdout.String()).To(Equal("6"))
+			stdout, _ = CurlRayServiceGateway(test, gatewayIP, curlPod, CurlContainerName, http.MethodPost, "/calc", `["MUL", 3]`)
+			g.Expect(stdout.String()).To(Equal("15 pizzas please!"))
 
-			// Verify IntervalSeconds have passed since last TrafficRoutedPercent update.
-			if lastMigratedTime != nil {
-				duration := currentMigratedTime.Sub(lastMigratedTime.Time)
-				g.Expect(duration).To(BeNumerically(">=", intervalSeconds),
-					"Time between traffic steps should be >= IntervalSeconds")
+			LogWithTimestamp(test.T(), "Triggering incremental upgrade by modifying RayCluster spec and updating serve deployment by changing RayService serve config")
+			g.Eventually(incrementalUpgrade(test, namespace.Name, rayServiceName), TestTimeoutShort).Should(Succeed(), "Failed to update RayService to trigger upgrade")
+			LogWithTimestamp(test.T(), "Waiting for RayService %s/%s UpgradeInProgress condition to be true", rayService.Namespace, rayService.Name)
+			g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutShort).Should(WithTransform(IsRayServiceUpgrading, BeTrue()))
+
+			LogWithTimestamp(test.T(), "Verifying active and pending cluster serve services and HTTPRoute backends")
+			upgradingRaySvc, err := GetRayService(test, namespace.Name, rayServiceName)
+			g.Expect(err).NotTo(HaveOccurred())
+			activeClusterName := upgradingRaySvc.Status.ActiveServiceStatus.RayClusterName
+			g.Expect(activeClusterName).NotTo(BeEmpty(), "The active cluster should be set when a RayService is ready.")
+			pendingClusterName := upgradingRaySvc.Status.PendingServiceStatus.RayClusterName
+			g.Expect(pendingClusterName).NotTo(BeEmpty(), "The controller should have created a pending cluster.")
+
+			// Validate serve service for the active cluster exists.
+			activeServeSvcName := utils.GenerateServeServiceName(activeClusterName)
+			_, err = test.Client().Core().CoreV1().Services(namespace.Name).Get(test.Ctx(), activeServeSvcName, metav1.GetOptions{})
+			g.Expect(err).NotTo(HaveOccurred(), "The serve service for the active cluster should be created.")
+
+			// Validate serve service for the pending cluster has been created for the upgrade.
+			pendingServeSvcName := utils.GenerateServeServiceName(pendingClusterName)
+			g.Eventually(func(gg Gomega) {
+				_, err = test.Client().Core().CoreV1().Services(namespace.Name).Get(test.Ctx(), pendingServeSvcName, metav1.GetOptions{})
+				gg.Expect(err).NotTo(HaveOccurred(), "The serve service for the pending cluster should be created.")
+			}, TestTimeoutShort).Should(Succeed())
+
+			LogWithTimestamp(test.T(), "Waiting for pending RayCluster %s to have a ready head pod", pendingClusterName)
+			g.Eventually(RayCluster(test, namespace.Name, pendingClusterName), TestTimeoutMedium).
+				Should(WithTransform(StatusCondition(rayv1.HeadPodReady), MatchCondition(metav1.ConditionTrue, rayv1.HeadPodRunningAndReady)))
+
+			// Wait for the HTTPRoute to reflect the two backends.
+			LogWithTimestamp(test.T(), "Waiting for HTTPRoute to have two backends")
+			g.Eventually(func(gg Gomega) {
+				route, err := GetHTTPRoute(test, namespace.Name, httpRoute.Name)
+				gg.Expect(err).NotTo(HaveOccurred())
+				gg.Expect(route.Spec.Rules).To(HaveLen(1))
+				gg.Expect(route.Spec.Rules[0].BackendRefs).To(HaveLen(2))
+				gg.Expect(string(route.Spec.Rules[0].BackendRefs[1].Name)).To(Equal(pendingServeSvcName))
+			}, TestTimeoutShort).Should(Succeed())
+
+			// Validate expected behavior during an IncrementalUpgrade. The following checks ensure
+			// that no requests are dropped throughout the upgrade process.
+			LogWithTimestamp(test.T(), "Performing behavioral checks, validating stepwise traffic and capacity migration")
+
+			oldVersionServed := false
+			newVersionServed := false
+
+			intervalSeconds := *interval
+			var lastMigratedTime *metav1.Time
+
+			prevActiveCapacity := int32(100)
+			prevPendingCapacity := int32(0)
+			prevActiveTraffic := int32(100)
+			prevPendingTraffic := int32(0)
+
+			upgradeSteps := generateUpgradeSteps(*stepSize, *maxSurge)
+			for _, step := range upgradeSteps {
+				// Behavior 1: Current state value matches the expected value or the RayService finished upgrading
+				LogWithTimestamp(test.T(), "%s", step.name)
+				g.Eventually(func(gg Gomega) {
+					svc, err := GetRayService(test, namespace.Name, rayServiceName)
+					gg.Expect(err).NotTo(HaveOccurred())
+					gg.Expect(step.getValue(svc) == step.expectedValue || !IsRayServiceUpgrading(svc)).
+						To(BeTrue())
+				}, TestTimeoutMedium).Should(Succeed())
+
+				// Behavior 2: Both old and new versions served traffic during the upgrade and no requests are dropped
+				stdout, _ := CurlRayServiceGateway(test, gatewayIP, curlPod, CurlContainerName, http.MethodPost, "/fruit", `["MANGO", 2]`)
+				response := stdout.String()
+				g.Expect(response).To(Or(Equal("6"), Equal("8")), "Response should be from the old or new app version during the upgrade")
+				if response == "6" {
+					oldVersionServed = true
+				}
+				if response == "8" {
+					newVersionServed = true
+				}
+
+				svc, err := GetRayService(test, namespace.Name, rayServiceName)
+				g.Expect(err).NotTo(HaveOccurred())
+				if !IsRayServiceUpgrading(svc) {
+					break
+				}
+
+				// Behavior 3: Traffic is migrated with respect to the interval seconds
+				if strings.Contains(step.name, "pending traffic to shift") {
+					currentMigratedTime := GetLastTrafficMigratedTime(svc)
+					g.Expect(currentMigratedTime).NotTo(BeNil())
+
+					// Verify IntervalSeconds have passed since last TrafficRoutedPercent update.
+					if lastMigratedTime != nil {
+						duration := currentMigratedTime.Sub(lastMigratedTime.Time)
+						intervalDuration := time.Duration(intervalSeconds) * time.Second
+						g.Expect(duration).To(BeNumerically(">=", intervalDuration),
+							"Time between traffic steps should be >= IntervalSeconds")
+					}
+					lastMigratedTime = currentMigratedTime
+				}
+
+				// Behavior 4: Active TargetCapacity is monotonically decreasing, and Pending TargetCapacity is monotonically increasing
+				currentActiveCapacity := GetActiveCapacity(svc)
+				currentPendingCapacity := GetPendingCapacity(svc)
+				g.Expect(currentActiveCapacity).To(BeNumerically("<=", prevActiveCapacity),
+					"TargetCapacity in active cluster must be monotonically decreasing: prev %d, curr %d", prevActiveCapacity, currentActiveCapacity)
+				g.Expect(currentPendingCapacity).To(BeNumerically(">=", prevPendingCapacity),
+					"TargetCapacity in pending cluster must be monotonically increasing: prev %d, curr %d", prevPendingCapacity, currentPendingCapacity)
+				prevActiveCapacity = currentActiveCapacity
+				prevPendingCapacity = currentPendingCapacity
+
+				// Behavior 5: Active TrafficRoutedPercent is monotonically decreasing, and Pending TrafficRoutedPercent is monotonically increasing
+				currentActiveTraffic := GetActiveTraffic(svc)
+				currentPendingTraffic := GetPendingTraffic(svc)
+				g.Expect(currentActiveTraffic).To(BeNumerically("<=", prevActiveTraffic),
+					"TrafficRoutedPercent in active cluster must be monotonically decreasing: prev %d, curr %d", prevActiveTraffic, currentActiveTraffic)
+				g.Expect(currentPendingTraffic).To(BeNumerically(">=", prevPendingTraffic),
+					"TrafficRoutedPercent in pending cluster must be monotonically increasing: prev %d, curr %d", prevPendingTraffic, currentPendingTraffic)
+				prevActiveTraffic = currentActiveTraffic
+				prevPendingTraffic = currentPendingTraffic
 			}
-			lastMigratedTime = currentMigratedTime
-		}
+
+			LogWithTimestamp(test.T(), "Verifying both old and new versions served traffic during the upgrade")
+			g.Expect(oldVersionServed).To(BeTrue(), "The old version of the service should have served traffic during the upgrade.")
+			g.Expect(newVersionServed).To(BeTrue(), "The new version of the service should have served traffic during the upgrade.")
+
+			// Check that RayService completed upgrade
+			LogWithTimestamp(test.T(), "Waiting for RayService %s/%s UpgradeInProgress condition to be false", rayService.Namespace, rayService.Name)
+			g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutShort).Should(WithTransform(IsRayServiceUpgrading, BeFalse()))
+
+			LogWithTimestamp(test.T(), "Verifying RayService uses updated ServeConfig after upgrade completes")
+			stdout, _ = CurlRayServiceGateway(test, gatewayIP, curlPod, CurlContainerName, http.MethodPost, "/fruit", `["MANGO", 2]`)
+			g.Expect(stdout.String()).To(Equal("8"))
+		})
 	}
-	LogWithTimestamp(test.T(), "Verifying both old and new versions served traffic during the upgrade")
-	g.Expect(oldVersionServed).To(BeTrue(), "The old version of the service should have served traffic during the upgrade.")
-	g.Expect(newVersionServed).To(BeTrue(), "The new version of the service should have served traffic during the upgrade.")
+}
 
-	// Check that RayService completed upgrade
-	LogWithTimestamp(test.T(), "Waiting for RayService %s/%s UpgradeInProgress condition to be false", rayService.Namespace, rayService.Name)
-	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutShort).Should(WithTransform(IsRayServiceUpgrading, BeFalse()))
+// TestRayServiceIncrementalUpgradeWithLocust tests the incremental upgrade flow of the RayService
+// by running a Locust load test throughout the entire upgrade lifecycle:
+//   - Initial serving on the old cluster
+//   - During the upgrade phase
+//   - Final serving on the new cluster
+//
+// It iterates over incrementalUpgradeCombinations to cover diverse upgrade scenarios under load:
+//   - BlueGreen
+//   - AggressiveGradual
+//   - ConservativeGradual
+//
+// The ultimate goal is to ensure that there are no request drops during the upgrade.
+//
+// The test case follows these steps:
+// 1. Enable the RayServiceIncrementalUpgrade feature gate
+// 2. Create a RayService with IncrementalUpgrade enabled
+// 3. Wait for the RayService to be ready
+// 4. Wait for the Gateway object to be ready (Accepted and Programmed conditions are True)
+// 5. Wait for the corresponding HTTPRoute object to be ready (Accepted and ResolvedRefs conditions are True)
+// 6. Create a ConfigMap with Locust runner script
+// 7. Deploy a head-only Locust RayCluster and install Locust in the head Pod
+// 8. Start Locust in a background goroutine targeting Gateway IP
+// 9. Wait for Locust to ramp up and enter the steady state
+// 10. Modify the RayCluster spec to trigger upgrade and change the RayService serve config to update the serve deployment
+//   - NOTE: Incremental upgrade is triggered by RayCluster spec changes, not serve config changes
+//
+// 11. Wait for incremental upgrade to complete
+// 12. Ensure all remaining traffic is routed to the new cluster after upgrade completes
+//
+// NOTE: locust_runner.py validates whether the Locust load test completed with zero failures.
+// So we don't need to validate this here.
+func TestRayServiceIncrementalUpgradeWithLocust(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.RayServiceIncrementalUpgrade, true)
 
-	LogWithTimestamp(test.T(), "Verifying RayService uses updated ServeConfig after upgrade completes")
-	stdout, _ = CurlRayServiceGateway(test, gatewayIP, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)
-	g.Expect(stdout.String()).To(Equal("8"))
+	for _, params := range incrementalUpgradeCombinations {
+		t.Run(params.Name, func(t *testing.T) {
+			test := With(t)
+			g := NewWithT(t)
+
+			namespace := test.NewTestNamespace()
+			rayServiceName := "incremental-rayservice"
+			stepSize, interval, maxSurge := params.ptrs()
+			serveConfigV2 := highRPSServeConfigV2
+
+			// Phase 1: Create RayService with incremental upgrade and wait for key components to be ready
+			_, _, gatewayIP := bootstrapIncrementalRayService(test, g, namespace.Name, rayServiceName, stepSize, interval, maxSurge, serveConfigV2)
+
+			// Phase 2: Deploy Locust RayCluster and install Locust
+			// TODO(jwj): Extract a helper for cross-module reusability (rayservice_ha_test.go) if needed.
+			locustYamlFile := "testdata/locust-cluster.incremental-upgrade.yaml"
+
+			configMapAC := newLocustRunnerConfigMapAC(namespace.Name, Files(test, "locust_runner.py"))
+			configMap, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), configMapAC, TestApplyOptions)
+			g.Expect(err).NotTo(HaveOccurred())
+			LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", configMap.Namespace, configMap.Name)
+
+			KubectlApplyYAML(test, locustYamlFile, namespace.Name)
+			locustCluster, err := GetRayCluster(test, namespace.Name, "locust-cluster")
+			g.Expect(err).NotTo(HaveOccurred())
+			LogWithTimestamp(test.T(), "Created Locust RayCluster %s/%s successfully", locustCluster.Namespace, locustCluster.Name)
+
+			g.Eventually(RayCluster(test, locustCluster.Namespace, locustCluster.Name), TestTimeoutMedium).
+				Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
+			g.Expect(GetRayCluster(test, locustCluster.Namespace, locustCluster.Name)).
+				To(WithTransform(RayClusterDesiredWorkerReplicas, Equal(int32(0))))
+
+			locustHeadPod, err := GetHeadPod(test, locustCluster)
+			g.Expect(err).NotTo(HaveOccurred())
+			LogWithTimestamp(test.T(), "Found Locust head pod %s/%s", locustHeadPod.Namespace, locustHeadPod.Name)
+
+			ExecPodCmd(test, locustHeadPod, common.RayHeadContainer, []string{"pip", "install", "locust==2.32.10"})
+
+			// Phase 3: Start Locust in a background goroutine targeting Gateway IP
+			locustHost := fmt.Sprintf("http://%s", gatewayIP)
+
+			eg, _ := errgroup.WithContext(test.Ctx())
+			eg.Go(func() error {
+				LogWithTimestamp(test.T(), "Starting Locust load test against %s", locustHost)
+				_, _, err := ExecPodCmdWithError(test, locustHeadPod, common.RayHeadContainer, []string{
+					"python", "/locust-runner/locust_runner.py",
+					"-f", "/locustfile/locustfile.py",
+					"--host", locustHost,
+				})
+				return err
+			})
+
+			// Allow Locust to ramp up and send traffic to the old cluster before triggering upgrade.
+			err = warmupLocust(test, locustHeadPod, locustWarmupRPSThreshold, locustWarmupStableWindowSeconds, locustWarmupTimeout)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// Phase 4: Trigger incremental upgrade
+			LogWithTimestamp(test.T(), "Triggering incremental upgrade by updating RayCluster spec")
+			g.Eventually(incrementalUpgrade(test, namespace.Name, rayServiceName), TestTimeoutShort).Should(Succeed(), "Failed to update RayService to trigger upgrade")
+			LogWithTimestamp(test.T(), "Waiting for RayService %s/%s UpgradeInProgress condition to be true", namespace.Name, rayServiceName)
+			g.Eventually(RayService(test, namespace.Name, rayServiceName), TestTimeoutShort).Should(WithTransform(IsRayServiceUpgrading, BeTrue()))
+
+			// Phase 5: Wait for upgrade to complete and validate remaining traffic is routed to the new cluster
+			// Since no additional validation is needed during the upgrade, we use a longer timeout.
+			LogWithTimestamp(test.T(), "Waiting for RayService %s/%s UpgradeInProgress condition to be false", namespace.Name, rayServiceName)
+			g.Eventually(RayService(test, namespace.Name, rayServiceName), TestTimeoutMedium).Should(WithTransform(IsRayServiceUpgrading, BeFalse()))
+
+			LogWithTimestamp(test.T(), "Waiting for Locust load test goroutine to finish")
+			g.Expect(eg.Wait()).NotTo(HaveOccurred(), "Locust load test failed")
+
+			LogWithTimestamp(test.T(), "Validating remaining traffic is routed to the new cluster after upgrade completes")
+			curlPod, err := CreateCurlPod(g, test, CurlPodName, CurlContainerName, namespace.Name)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			stdout, _ := CurlRayServiceGateway(test, gatewayIP, curlPod, CurlContainerName, http.MethodGet, "/test", "")
+			var resp struct {
+				Status string `json:"status"`
+			}
+			err = json.Unmarshal(stdout.Bytes(), &resp)
+			g.Expect(err).NotTo(HaveOccurred(), "GET /test response should be valid JSON, got: %s", stdout.String())
+			g.Expect(resp.Status).To(Equal("ok"), "GET /test status field should be ok, got: %s", resp.Status)
+		})
+	}
 }
 
 func TestRayServiceIncrementalUpgradeRollback(t *testing.T) {
@@ -232,39 +348,14 @@ func TestRayServiceIncrementalUpgradeRollback(t *testing.T) {
 	stepSize := ptr.To(int32(25))
 	interval := ptr.To(int32(10))
 	maxSurge := ptr.To(int32(50))
+	serveConfigV2 := defaultIncrementalUpgradeServeConfigV2
 
-	rayServiceAC := rayv1ac.RayService(rayServiceName, namespace.Name).
-		WithSpec(IncrementalUpgradeRayServiceApplyConfiguration(stepSize, interval, maxSurge))
-	rayService, err := test.Client().Ray().RayV1().RayServices(namespace.Name).Apply(test.Ctx(), rayServiceAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(rayService).NotTo(BeNil())
-
-	LogWithTimestamp(test.T(), "Waiting for RayService %s/%s to be ready", rayService.Namespace, rayService.Name)
-	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).
-		Should(WithTransform(IsRayServiceReady, BeTrue()))
+	_, httpRoute, _ := bootstrapIncrementalRayService(test, g, namespace.Name, rayServiceName, stepSize, interval, maxSurge, serveConfigV2)
 
 	// Copy original spec to use to trigger a rollback later.
-	rayService, err = GetRayService(test, namespace.Name, rayServiceName)
+	rayService, err := GetRayService(test, namespace.Name, rayServiceName)
 	g.Expect(err).NotTo(HaveOccurred())
 	originalSpec := rayService.Spec.DeepCopy()
-
-	// Verify Gateway and HTTPRoute are ready.
-	gatewayName := fmt.Sprintf("%s-%s", rayServiceName, "gateway")
-	g.Eventually(Gateway(test, rayService.Namespace, gatewayName), TestTimeoutMedium).
-		Should(WithTransform(utils.IsGatewayReady, BeTrue()))
-
-	gateway, err := GetGateway(test, namespace.Name, fmt.Sprintf("%s-%s", rayServiceName, "gateway"))
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(gateway).NotTo(BeNil())
-
-	httpRouteName := fmt.Sprintf("%s-%s", rayServiceName, "httproute")
-	LogWithTimestamp(test.T(), "Waiting for HTTPRoute %s/%s to be ready", rayService.Namespace, httpRouteName)
-	g.Eventually(HTTPRoute(test, rayService.Namespace, httpRouteName), TestTimeoutMedium).
-		Should(Not(BeNil()))
-
-	httpRoute, err := GetHTTPRoute(test, namespace.Name, httpRouteName)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(utils.IsHTTPRouteReady(gateway, httpRoute)).To(BeTrue())
 
 	// Trigger an incremental upgrade through a change to the RayCluster spec.
 	LogWithTimestamp(test.T(), "Triggering an upgrade for RayService %s/%s", rayService.Namespace, rayService.Name)
@@ -333,7 +424,7 @@ func TestRayServiceIncrementalUpgradeRollback(t *testing.T) {
 	}, TestTimeoutMedium).Should(WithTransform(errors.IsNotFound, BeTrue()))
 
 	// The HTTPRoute should now only have one backend after the rollback completes.
-	g.Eventually(HTTPRoute(test, namespace.Name, httpRouteName), TestTimeoutShort).
+	g.Eventually(HTTPRoute(test, namespace.Name, httpRoute.Name), TestTimeoutShort).
 		Should(WithTransform(func(route *gwv1.HTTPRoute) int {
 			if route == nil || len(route.Spec.Rules) == 0 {
 				return 0

--- a/ray-operator/test/e2eincrementalupgrade/support.go
+++ b/ray-operator/test/e2eincrementalupgrade/support.go
@@ -70,9 +70,10 @@ func bootstrapIncrementalRayService(
 	g.Eventually(HTTPRoute(test, rayService.Namespace, httpRouteName), TestTimeoutMedium).
 		Should(Not(BeNil()))
 
-	httpRoute, err = GetHTTPRoute(test, rayService.Namespace, httpRouteName)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(utils.IsHTTPRouteReady(gateway, httpRoute)).To(BeTrue())
+	g.Eventually(func() (bool, error) {
+		httpRoute, err = GetHTTPRoute(test, rayService.Namespace, httpRouteName)
+		return utils.IsHTTPRouteReady(gateway, httpRoute), err
+	}, TestTimeoutMedium).Should(BeTrue())
 
 	gatewayIP = GetGatewayIP(gateway)
 	g.Expect(gatewayIP).NotTo(BeEmpty())

--- a/ray-operator/test/e2eincrementalupgrade/support.go
+++ b/ray-operator/test/e2eincrementalupgrade/support.go
@@ -3,7 +3,12 @@ package e2eincrementalupgrade
 import (
 	"bytes"
 	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
 
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,34 +17,113 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
+// bootstrapIncrementalRayService creates a RayService with incremental upgrade enabled
+// and waits for all required components to be ready, including:
+//   - RayService
+//   - Gateway
+//   - HTTPRoute
+//
+// Parameters:
+//   - stepSize: The percentage of traffic to shift from the old to the new cluster during each interval.
+//   - interval: The time in seconds to wait between shifting traffic by stepSize.
+//   - maxSurge: The percentage of capacity (Serve replicas) to add to the new cluster in each scaling step.
+//   - serveConfigV2: The Serve config V2 to use for the RayService.
+//
+// Returns the RayService, HTTPRoute, and Gateway IP.
+func bootstrapIncrementalRayService(
+	test Test,
+	g *WithT,
+	namespace string,
+	rayServiceName string,
+	stepSize, interval, maxSurge *int32,
+	serveConfigV2 serveConfigV2,
+) (rayService *rayv1.RayService, httpRoute *gwv1.HTTPRoute, gatewayIP string) {
+	var err error
+	rayServiceAC := rayv1ac.RayService(rayServiceName, namespace).
+		WithSpec(incrementalUpgradeRayServiceApplyConfiguration(stepSize, interval, maxSurge, serveConfigV2))
+	rayService, err = test.Client().Ray().RayV1().RayServices(namespace).Apply(test.Ctx(), rayServiceAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(rayService).NotTo(BeNil())
+
+	LogWithTimestamp(test.T(), "Waiting for RayService %s/%s to be ready", rayService.Namespace, rayService.Name)
+	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).
+		Should(WithTransform(IsRayServiceReady, BeTrue()))
+
+	gatewayName := fmt.Sprintf("%s-gateway", rayServiceName)
+	LogWithTimestamp(test.T(), "Waiting for Gateway %s/%s to be ready", rayService.Namespace, gatewayName)
+	g.Eventually(Gateway(test, rayService.Namespace, gatewayName), TestTimeoutMedium).
+		Should(WithTransform(utils.IsGatewayReady, BeTrue()))
+
+	var gateway *gwv1.Gateway
+	gateway, err = GetGateway(test, rayService.Namespace, gatewayName)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(gateway).NotTo(BeNil())
+
+	httpRouteName := fmt.Sprintf("%s-httproute", rayServiceName)
+	LogWithTimestamp(test.T(), "Waiting for HTTPRoute %s/%s to be ready", rayService.Namespace, httpRouteName)
+	g.Eventually(HTTPRoute(test, rayService.Namespace, httpRouteName), TestTimeoutMedium).
+		Should(Not(BeNil()))
+
+	httpRoute, err = GetHTTPRoute(test, rayService.Namespace, httpRouteName)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(utils.IsHTTPRouteReady(gateway, httpRoute)).To(BeTrue())
+
+	gatewayIP = GetGatewayIP(gateway)
+	g.Expect(gatewayIP).NotTo(BeEmpty())
+
+	return
+}
+
+// newLocustRunnerConfigMapAC creates a ConfigMap apply configuration for the Locust runner script.
+func newLocustRunnerConfigMapAC(namespace string, options ...SupportOption[corev1ac.ConfigMapApplyConfiguration]) *corev1ac.ConfigMapApplyConfiguration {
+	cmAC := corev1ac.ConfigMap("locust-runner-script", namespace).
+		WithBinaryData(map[string][]byte{}).
+		WithImmutable(true)
+
+	return ConfigMapWith(cmAC, options...)
+}
+
+// CurlPodName and CurlContainerName are the default names used when creating a curl pod for gateway tests.
+const (
+	CurlPodName       = "curl-pod"
+	CurlContainerName = "curl-container"
+)
+
+// CurlRayServiceGateway sends a request to the RayService Gateway using a Curl pod.
+// This method currently supports POST and GET methods.
 func CurlRayServiceGateway(
 	t Test,
 	gatewayIP string,
 	curlPod *corev1.Pod,
 	curlPodContainerName,
+	method,
 	rayServicePath,
 	body string,
 ) (bytes.Buffer, bytes.Buffer) {
 	cmd := []string{
 		"curl",
 		"--max-time", "10",
-		"-X", "POST",
+		"-X", method,
 		"-H", "Connection: close", // avoid re-using the same connection for test
 		"-H", "Content-Type: application/json",
 		fmt.Sprintf("http://%s%s", gatewayIP, rayServicePath),
-		"-d", body,
+	}
+	if body != "" {
+		cmd = append(cmd, "-d", body)
 	}
 
 	return ExecPodCmd(t, curlPod, curlPodContainerName, cmd)
 }
 
-func IncrementalUpgradeRayServiceApplyConfiguration(
+func incrementalUpgradeRayServiceApplyConfiguration(
 	stepSizePercent, intervalSeconds, maxSurgePercent *int32,
+	serveConfigV2 serveConfigV2,
 ) *rayv1ac.RayServiceSpecApplyConfiguration {
 	return rayv1ac.RayServiceSpec().
 		WithUpgradeStrategy(rayv1ac.RayServiceUpgradeStrategy().
@@ -51,56 +135,13 @@ func IncrementalUpgradeRayServiceApplyConfiguration(
 					WithIntervalSeconds(*intervalSeconds).
 					WithMaxSurgePercent(*maxSurgePercent),
 			)).
-		WithServeConfigV2(`applications:
-  - name: fruit_app
-    import_path: fruit.deployment_graph
-    route_prefix: /fruit
-    runtime_env:
-      working_dir: "https://github.com/ray-project/test_dag/archive/78b4a5da38796123d9f9ffff59bab2792a043e95.zip"
-    deployments:
-      - name: MangoStand
-        num_replicas: 1
-        user_config:
-          price: 3
-        ray_actor_options:
-          num_cpus: 0.1
-      - name: OrangeStand
-        num_replicas: 1
-        user_config:
-          price: 2
-        ray_actor_options:
-          num_cpus: 0.1
-      - name: FruitMarket
-        num_replicas: 1
-        ray_actor_options:
-          num_cpus: 0.1
-  - name: math_app
-    import_path: conditional_dag.serve_dag
-    route_prefix: /calc
-    runtime_env:
-      working_dir: "https://github.com/ray-project/test_dag/archive/78b4a5da38796123d9f9ffff59bab2792a043e95.zip"
-    deployments:
-      - name: Adder
-        num_replicas: 1
-        user_config:
-          increment: 3
-        ray_actor_options:
-          num_cpus: 0.1
-      - name: Multiplier
-        num_replicas: 1
-        user_config:
-          factor: 5
-        ray_actor_options:
-          num_cpus: 0.1
-      - name: Router
-        ray_actor_options:
-          num_cpus: 0.1
-        num_replicas: 1`).
+		WithServeConfigV2(string(serveConfigV2)).
 		WithRayClusterSpec(rayv1ac.RayClusterSpec().
 			WithRayVersion(GetRayVersion()).
 			WithEnableInTreeAutoscaling(true).
 			WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
-				WithRayStartParams(map[string]string{"dashboard-host": "0.0.0.0"}).
+				// Prevent actors from being scheduled on the Ray head node.
+				WithRayStartParams(map[string]string{"dashboard-host": "0.0.0.0", "num-cpus": "0"}).
 				WithTemplate(corev1ac.PodTemplateSpec().
 					WithSpec(corev1ac.PodSpec().
 						WithRestartPolicy(corev1.RestartPolicyNever).
@@ -113,21 +154,11 @@ func IncrementalUpgradeRayServiceApplyConfiguration(
 								corev1ac.ContainerPort().WithName(utils.ServingPortName).WithContainerPort(utils.DefaultServingPort),
 								corev1ac.ContainerPort().WithName(utils.DashboardPortName).WithContainerPort(utils.DefaultDashboardPort),
 								corev1ac.ContainerPort().WithName(utils.ClientPortName).WithContainerPort(utils.DefaultClientPort),
-							).
-							WithResources(corev1ac.ResourceRequirements().
-								WithRequests(corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("2"),
-									corev1.ResourceMemory: resource.MustParse("3Gi"),
-								}).
-								WithLimits(corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("2"),
-									corev1.ResourceMemory: resource.MustParse("3Gi"),
-								})))))).
+							))))).
 			WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
 				WithReplicas(1).
 				WithMinReplicas(1).
-				WithMaxReplicas(4).
-				WithRayStartParams(map[string]string{"num-cpus": "1"}).
+				WithMaxReplicas(2).
 				WithGroupName("small-group").
 				WithTemplate(corev1ac.PodTemplateSpec().
 					WithSpec(corev1ac.PodSpec().
@@ -137,12 +168,12 @@ func IncrementalUpgradeRayServiceApplyConfiguration(
 							WithImage(GetRayImage()).
 							WithResources(corev1ac.ResourceRequirements().
 								WithRequests(corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("300m"),
-									corev1.ResourceMemory: resource.MustParse("1G"),
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
 								}).
 								WithLimits(corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("500m"),
-									corev1.ResourceMemory: resource.MustParse("1G"),
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
 								})))))),
 		)
 }
@@ -159,6 +190,39 @@ func GetGatewayIP(gateway *gwv1.Gateway) string {
 	}
 
 	return ""
+}
+
+// incrementalUpgrade is a wrapper around triggerIncrementalUpgrade that returns a function that can be used with g.Eventually.
+func incrementalUpgrade(test Test, namespace, rayServiceName string) func() error {
+	return func() error {
+		return triggerIncrementalUpgrade(test, namespace, rayServiceName)
+	}
+}
+
+// triggerIncrementalUpgrade updates the RayService to trigger an incremental upgrade:
+//   - RayCluster spec: Set worker CPU request to 500m
+//   - Serve config: Update (price 3->4, factor 5->3)
+func triggerIncrementalUpgrade(test Test, namespace, rayServiceName string) error {
+	rayService, err := GetRayService(test, namespace, rayServiceName)
+	if err != nil {
+		return err
+	}
+
+	// Update the RayCluster spec.
+	rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("500m")
+
+	// Update the serve config.
+	serveConfig := rayService.Spec.ServeConfigV2
+	serveConfig = strings.ReplaceAll(serveConfig, "price: 3", "price: 4")
+	serveConfig = strings.ReplaceAll(serveConfig, "factor: 5", "factor: 3")
+	rayService.Spec.ServeConfigV2 = serveConfig
+
+	_, err = test.Client().Ray().RayV1().RayServices(namespace).Update(
+		test.Ctx(),
+		rayService,
+		metav1.UpdateOptions{},
+	)
+	return err
 }
 
 func GetPendingCapacity(rs *rayv1.RayService) int32 {
@@ -178,7 +242,7 @@ func GetActiveTraffic(rs *rayv1.RayService) int32 {
 }
 
 func GetLastTrafficMigratedTime(rs *rayv1.RayService) *metav1.Time {
-	return rs.Status.ActiveServiceStatus.LastTrafficMigratedTime
+	return rs.Status.PendingServiceStatus.LastTrafficMigratedTime
 }
 
 // testStep defines a validation condition to wait for during the upgrade.
@@ -244,4 +308,133 @@ func generateUpgradeSteps(stepSize, maxSurge int32) []testStep {
 		}
 	}
 	return steps
+}
+
+const (
+	// The lower bound of the RPS for the Locust to reach the steady state.
+	locustWarmupRPSThreshold = 400.0
+	// The period of time that the RPS must be greater than or equal to the threshold to be considered steady state.
+	locustWarmupStableWindowSeconds = 15
+	// The maximum duration to wait for the Locust to reach the steady state.
+	locustWarmupTimeout = 120 * time.Second
+)
+
+// warmupLocust waits for Locust to ramp up and enter the steady state before triggering upgrade.
+// Hence, all requests are sent to the old cluster during the warmup period.
+//
+// The warmup period follows these steps:
+// 1. Retrieve the index of the Requests/s column in the stats history file
+//   - Retry for cases where the stats history file is not written yet
+//
+// 2. Query the current RPS from the stats history file
+//   - Retry for cases where the query failed
+//
+// 3. Check if the last RPS is greater than or equal to the threshold for the specified duration
+//   - Determine if the Locust has reached the steady state
+func warmupLocust(
+	test Test,
+	locustHeadPod *corev1.Pod,
+	rpsThreshold float64,
+	stableWindow int,
+	timeout time.Duration,
+) error {
+	// rpsColIdxResult is the result of getting the index of the Requests/s column in the stats history file.
+	//   - index: the index of the Requests/s column (the valid index should be >= 0)
+	//   - ready: false when the file or column is not ready, a retry is needed
+	type rpsColIdxResult struct {
+		index int
+		ready bool
+	}
+
+	// getRpsColIdx gets the index of the Requests/s column in the stats history file.
+	getRpsColIdx := func() (rpsColIdxResult, error) {
+		stdout, stderr := ExecPodCmd(test, locustHeadPod, common.RayHeadContainer, []string{
+			"bash", "-lc", `
+latest=$(ls /home/ray/locust_results/test_stats_history.csv 2>/dev/null | head -n 1) || exit 1
+head -n1 "$latest"
+		`,
+		}, true)
+		if stderr.Len() != 0 || stdout.Len() == 0 {
+			return rpsColIdxResult{ready: false}, nil
+		}
+
+		header := strings.TrimSpace(stdout.String())
+		cols := strings.Split(header, ",")
+		idx := slices.Index(cols, "Requests/s")
+		if idx == -1 {
+			return rpsColIdxResult{}, fmt.Errorf("Requests/s column not found in stats history file")
+		}
+		return rpsColIdxResult{
+			index: idx,
+			ready: true,
+		}, nil
+	}
+
+	var rpsIdx int
+	var haveRpsColIdx bool
+
+	ddl := time.Now().Add(timeout)
+	stableCount := 0
+	for time.Now().Before(ddl) {
+		if !haveRpsColIdx {
+			rpsColIdxRes, err := getRpsColIdx()
+			if err != nil {
+				return err
+			}
+
+			if !rpsColIdxRes.ready {
+				test.T().Logf("failed to find header in stats history file, retrying in 2 seconds")
+				time.Sleep(2 * time.Second)
+				continue
+			}
+
+			rpsIdx = rpsColIdxRes.index
+			haveRpsColIdx = true
+			test.T().Logf("found Requests/s column at index: %d", rpsIdx)
+		}
+
+		stdout, stderr := ExecPodCmd(test, locustHeadPod, common.RayHeadContainer, []string{
+			"bash", "-lc", `
+		latest=$(ls /home/ray/locust_results/test_stats_history.csv 2>/dev/null | head -n1) || exit 1
+		tail -n1 "$latest"
+		`,
+		}, true)
+		if stderr.Len() != 0 || stdout.Len() == 0 {
+			test.T().Logf("failed to query current RPS from Locust, retrying in 2 seconds: %s", stderr.String())
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		lastStats := strings.TrimSpace(stdout.String())
+		statsSlice := strings.Split(lastStats, ",")
+		// Sometimes, we get the last stats with only 4 numbers, which leads to RPS index out of range.
+		// This is a temporary workaround. We will fix this in the future.
+		if len(statsSlice) <= rpsIdx {
+			test.T().Logf("RPS index out of range, retrying in 2 seconds")
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		rps := statsSlice[rpsIdx]
+		rpsFloat, err := strconv.ParseFloat(rps, 64)
+		if err != nil {
+			test.T().Logf("failed to parse RPS, retrying in 2 seconds: %s", err.Error())
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		if rpsFloat >= rpsThreshold {
+			stableCount++
+		} else {
+			stableCount = 0
+		}
+		if stableCount >= stableWindow {
+			test.T().Logf("Locust has reached the steady state with RPS >= %.2f for %d seconds", rpsThreshold, stableWindow)
+			return nil
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return fmt.Errorf("timeout waiting for Locust to reach the steady state with RPS >= %.2f", rpsThreshold)
 }

--- a/ray-operator/test/e2eincrementalupgrade/testdata/locust-cluster.incremental-upgrade.yaml
+++ b/ray-operator/test/e2eincrementalupgrade/testdata/locust-cluster.incremental-upgrade.yaml
@@ -1,0 +1,77 @@
+# This is a head-only RayCluster to run Locust load test for incremental upgrade.
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: locust-cluster
+spec:
+  rayVersion: '2.52.0'
+  headGroupSpec:
+    template:
+      spec:
+        containers:
+          - name: ray-head
+            image: rayproject/ray:2.52.0
+            resources:
+              requests:
+                cpu: 300m
+                memory: 1G
+              limits:
+                cpu: 500m
+                memory: 2G
+            ports:
+              - containerPort: 6379
+                name: gcs-server
+              - containerPort: 8265
+                name: dashboard
+              - containerPort: 10001
+                name: client
+            volumeMounts:
+              - mountPath: /locustfile
+                name: locustfile-volume
+              - mountPath: /locust-runner
+                name: locust-runner-volume
+        volumes:
+          # locustfile defines user behavior for Locust load test.
+          - name: locustfile-volume
+            configMap:
+              name: locustfile-config
+          # locust-runner is a script to start Locust load test.
+          - name: locust-runner-volume
+            configMap:
+              name: locust-runner-script
+---
+# This is a ConfigMap that contains the locustfile.py which defines user behavior for Locust load test.
+# Requests are sent to the /test endpoint of the serve application.
+# With wait_time = constant(0), each test_request is sent immediately after the previous one completes.
+# TODO(jwj): Consider making stages parameter configurable.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: locustfile-config
+data:
+  locustfile.py: |
+    from locust import HttpUser, constant, task, LoadTestShape
+
+    class SimpleUser(HttpUser):
+        wait_time = constant(0)
+        network_timeout = None
+        connection_timeout = None
+
+        @task
+        def test_request(self):
+            resp = self.client.get("/test")
+            if resp.status_code != 200:
+                print(f"Error: {resp.status_code} - {resp.text}")
+
+    class StagesShape(LoadTestShape):
+        stages = [
+            {"duration": 300, "users": 10, "spawn_rate": 10},
+        ]
+
+        def tick(self):
+            run_time = self.get_run_time()
+            for stage in self.stages:
+                if run_time < stage["duration"]:
+                    tick_data = (stage["users"], stage["spawn_rate"])
+                    return tick_data
+            return None

--- a/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
@@ -2,7 +2,9 @@ package e2erayservice
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -77,32 +79,48 @@ func TestOldHeadPodFailDuringUpgrade(t *testing.T) {
 	rayService, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rayService, metav1.UpdateOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
 
-	LogWithTimestamp(test.T(), "Using iptables to make the ProxyActor(8000 port) fail to receive requests on the old head Pod")
-	headPodPatch := map[string]any{
-		"spec": map[string]any{
-			"ephemeralContainers": []corev1.EphemeralContainer{
-				{
-					EphemeralContainerCommon: corev1.EphemeralContainerCommon{
-						Name:    "proxy-actor-drop",
-						Image:   "istio/iptables",
-						Command: []string{"iptables"},
-						Args:    []string{"-A", "INPUT", "-p", "tcp", "--dport", "8000", "-j", "DROP"},
-						SecurityContext: &corev1.SecurityContext{
-							Privileged: ptr.To(true),
-							RunAsUser:  ptr.To(int64(0)),
+	for _, iptables := range []string{"iptables-legacy", "iptables-nft"} {
+		LogWithTimestamp(test.T(), "Using %s to make the ProxyActor(8000 port) fail to receive requests on the old head Pod", iptables)
+		headPodPatch := map[string]any{
+			"spec": map[string]any{
+				"ephemeralContainers": []corev1.EphemeralContainer{
+					{
+						EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+							Name:    "proxy-actor-drop-" + iptables,
+							Image:   "istio/iptables:1.27-2026-02-26T19-02-11",
+							Command: []string{iptables},
+							Args:    []string{"-A", "INPUT", "-p", "tcp", "--dport", "8000", "-j", "DROP"},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+								RunAsUser:  ptr.To(int64(0)),
+							},
 						},
 					},
 				},
 			},
-		},
+		}
+		patchBytes, err := json.Marshal(headPodPatch)
+		g.Expect(err).NotTo(HaveOccurred())
+		_, err = test.Client().Core().CoreV1().Pods(namespace.Name).Patch(test.Ctx(), headPodName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "ephemeralcontainers")
+		g.Expect(err).NotTo(HaveOccurred())
 	}
-	patchBytes, err := json.Marshal(headPodPatch)
+
+	headPod, err := test.Client().Core().CoreV1().Pods(namespace.Name).Get(test.Ctx(), headPodName, metav1.GetOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
-	headPod, err := test.Client().Core().CoreV1().Pods(namespace.Name).Patch(test.Ctx(), headPodName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "ephemeralcontainers")
-	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(headPod.Status.PodIP).NotTo(BeEmpty())
 
 	LogWithTimestamp(test.T(), "Checking that the old Head Pod's label `ray.io/serve` is `true`")
 	g.Expect(headPod.Labels[utils.RayClusterServingServiceLabelKey]).To(Equal("true"))
+
+	healthURL := fmt.Sprintf("http://%s:%d/", headPod.Status.PodIP, utils.DefaultServingPort) + utils.RayServeProxyHealthPath
+	LogWithTimestamp(test.T(), "Curling head Pod %s at %s until ephemeral iptables applies DROP on :%d (expect curl to fail)", headPodName, healthURL, utils.DefaultServingPort)
+	curlCmd := []string{
+		"curl", "-sS", "-f", "--connect-timeout", "3", "--max-time", "5", "-X", "GET", healthURL,
+	}
+	g.Eventually(func() error {
+		_, _, curlErr := ExecPodCmdWithError(test, curlPod, curlContainerName, curlCmd)
+		return curlErr
+	}, TestTimeoutShort, 2*time.Second).Should(HaveOccurred(), "iptables should block TCP :8000 like CheckProxyActorHealth would fail")
 
 	LogWithTimestamp(test.T(), "Checking that the old Head Pod's label `ray.io/serve` is `false` because it is not healthy")
 	g.Eventually(func(g Gomega) string {

--- a/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_upgrade_test.go
@@ -79,6 +79,13 @@ func TestOldHeadPodFailDuringUpgrade(t *testing.T) {
 	rayService, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rayService, metav1.UpdateOptions{})
 	g.Expect(err).NotTo(HaveOccurred())
 
+	headPod, err := test.Client().Core().CoreV1().Pods(namespace.Name).Get(test.Ctx(), headPodName, metav1.GetOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(headPod.Status.PodIP).NotTo(BeEmpty())
+
+	LogWithTimestamp(test.T(), "Checking that the old Head Pod's label `ray.io/serve` is `true`")
+	g.Expect(headPod.Labels[utils.RayClusterServingServiceLabelKey]).To(Equal("true"))
+
 	for _, iptables := range []string{"iptables-legacy", "iptables-nft"} {
 		LogWithTimestamp(test.T(), "Using %s to make the ProxyActor(8000 port) fail to receive requests on the old head Pod", iptables)
 		headPodPatch := map[string]any{
@@ -104,13 +111,6 @@ func TestOldHeadPodFailDuringUpgrade(t *testing.T) {
 		_, err = test.Client().Core().CoreV1().Pods(namespace.Name).Patch(test.Ctx(), headPodName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "ephemeralcontainers")
 		g.Expect(err).NotTo(HaveOccurred())
 	}
-
-	headPod, err := test.Client().Core().CoreV1().Pods(namespace.Name).Get(test.Ctx(), headPodName, metav1.GetOptions{})
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(headPod.Status.PodIP).NotTo(BeEmpty())
-
-	LogWithTimestamp(test.T(), "Checking that the old Head Pod's label `ray.io/serve` is `true`")
-	g.Expect(headPod.Labels[utils.RayClusterServingServiceLabelKey]).To(Equal("true"))
 
 	healthURL := fmt.Sprintf("http://%s:%d/", headPod.Status.PodIP, utils.DefaultServingPort) + utils.RayServeProxyHealthPath
 	LogWithTimestamp(test.T(), "Curling head Pod %s at %s until ephemeral iptables applies DROP on :%d (expect curl to fail)", headPodName, healthURL, utils.DefaultServingPort)

--- a/ray-operator/test/e2erayservice/testdata/rayservice.autoscaling.yaml
+++ b/ray-operator/test/e2erayservice/testdata/rayservice.autoscaling.yaml
@@ -40,10 +40,10 @@ spec:
               image: rayproject/ray:2.52.0
               resources:
                 requests:
-                  cpu: 300m
+                  cpu: "1"
                   memory: 1G
                 limits:
-                  cpu: 500m
+                  cpu: "1"
                   memory: 2G
               ports:
                 - containerPort: 6379

--- a/ray-operator/test/support/core.go
+++ b/ray-operator/test/support/core.go
@@ -68,9 +68,8 @@ func storeContainerLog(t Test, namespace *corev1.Namespace, podName, containerNa
 	WriteToOutputDir(t, containerLogFileName, Log, bytes)
 }
 
-func ExecPodCmd(t Test, pod *corev1.Pod, containerName string, cmd []string, allowError ...bool) (bytes.Buffer, bytes.Buffer) {
-	shouldAllowError := len(allowError) > 0 && allowError[0]
-
+// execPodCmd is the core implementation that always returns the error from the command execution in the pod.
+func execPodCmd(t Test, pod *corev1.Pod, containerName string, cmd []string) (bytes.Buffer, bytes.Buffer, error) {
 	req := t.Client().Core().CoreV1().RESTClient().
 		Post().
 		Resource("pods").
@@ -102,11 +101,25 @@ func ExecPodCmd(t Test, pod *corev1.Pod, containerName string, cmd []string, all
 	LogWithTimestamp(t.T(), "Command stdout: %s", stdout.String())
 	LogWithTimestamp(t.T(), "Command stderr: %s", stderr.String())
 
+	return stdout, stderr, err
+}
+
+// ExecPodCmd is a wrapper that allows the caller to specify whether to allow the command to fail.
+func ExecPodCmd(t Test, pod *corev1.Pod, containerName string, cmd []string, allowError ...bool) (bytes.Buffer, bytes.Buffer) {
+	stdout, stderr, err := execPodCmd(t, pod, containerName, cmd)
+
+	shouldAllowError := len(allowError) > 0 && allowError[0]
 	if !shouldAllowError {
 		require.NoError(t.T(), err, "Command failed unexpectedly")
 	}
 
 	return stdout, stderr
+}
+
+// ExecPodCmdWithError is a wrapper that always returns the error from the command execution in the pod.
+// Since it propagates the error, it's safe to call this function from any goroutine,
+func ExecPodCmdWithError(t Test, pod *corev1.Pod, containerName string, cmd []string) (bytes.Buffer, bytes.Buffer, error) {
+	return execPodCmd(t, pod, containerName, cmd)
 }
 
 func SetupPortForward(t Test, podName, namespace string, localPort, remotePort int) (chan struct{}, error) {

--- a/ray-operator/test/support/locust_runner.py
+++ b/ray-operator/test/support/locust_runner.py
@@ -55,6 +55,7 @@ base_locust_cmd = [
     "locust",
     "--headless",
     f"--html={HTML_RESULTS_DIR}/{args.html}",
+    f"--csv={HTML_RESULTS_DIR}/test",
     *locust_args,
 ]
 


### PR DESCRIPTION
## Why are these changes needed?
Cherry-pick the following test improvements/fixes to release-1.6 to keep e2e CI stable:
- #4541 [Test] Add load tests and behavioral checks to incremental upgrade E2E (dependency for #4677/#4701, brings ExecPodCmdWithError)
- #4662 [Fix] [Flaky] Insert firewall rules to the correct table (dependency for #4677, switches to iptables-legacy+nft loop)
- #4677 [Fix] [RayService] Check serve label before iptables injection in upgrade test
- #4701 [RayService][e2e] fix flaky test in getting HTTPRoute
- #4702 [RayService][e2e] fix flaky test TestAutoscalingRayService
## Related issue number
Follow-up to #4744.
## Checks
- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests