### PR TITLE
Add Pod informer cache selector to reduce memory usage

### DIFF
--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -17,6 +17,7 @@ COPY pkg/features pkg/features
 COPY pkg/utils pkg/utils
 COPY pkg/webhooks pkg/webhooks
 COPY rayjob-submitter/ rayjob-submitter/
+COPY internal/ internal/
 
 # Build
 USER root

--- a/ray-operator/controllers/ray/cache_selectors.go
+++ b/ray-operator/controllers/ray/cache_selectors.go
@@ -1,0 +1,37 @@
+package ray
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+)
+
+// CacheSelectors returns ByObject options that restrict which Job and Pod objects
+// the manager's informers watch and store in the local cache.
+func CacheSelectors() (map[client.Object]cache.ByObject, error) {
+	createByLabel, err := labels.NewRequirement(utils.KubernetesCreatedByLabelKey, selection.Equals, []string{utils.ComponentName})
+	if err != nil {
+		return nil, err
+	}
+	rayNodeTypeLabel, err := labels.NewRequirement(
+		utils.RayNodeTypeLabelKey,
+		selection.In,
+		[]string{string(rayv1.HeadNode), string(rayv1.WorkerNode), string(rayv1.RedisCleanupNode)},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	jobSelector := labels.NewSelector().Add(*createByLabel)
+	podSelector := labels.NewSelector().Add(*rayNodeTypeLabel)
+	return map[client.Object]cache.ByObject{
+		&batchv1.Job{}: {Label: jobSelector},
+		&corev1.Pod{}:  {Label: podSelector},
+	}, nil
+}

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -1691,7 +1691,7 @@ var _ = Context("Inside the default namespace", func() {
 		})
 
 		It("The manager cache should only include Ray node Pods (ray.io/node-type in head|worker|redis-cleanup), not the unrelated Pod", func() {
-			cacheClient := k8sManager.GetClient()
+			cacheClient := mgr.GetClient()
 			clusterListOpts := []client.ListOption{
 				client.InNamespace(namespace),
 				client.MatchingLabels{utils.RayClusterLabelKey: rayClusterName},

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1616,6 +1617,101 @@ var _ = Context("Inside the default namespace", func() {
 			Eventually(
 				getClusterState(ctx, namespace, rayCluster.Name),
 				time.Second*3, time.Millisecond*500).Should(Equal(rayv1.Ready))
+		})
+	})
+
+	Describe("Manager cache Pod label selectors", Ordered, func() {
+		ctx := context.Background()
+		namespace := "ray-mgr-cache-test"
+		rayClusterName := "raycluster-cache-label-selectors"
+		unrelatedPodName := "unrelated-pod-for-cache-test"
+
+		rayCluster := rayClusterTemplate(rayClusterName, namespace)
+		rayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](1)
+		rayCluster.Spec.WorkerGroupSpecs[0].MaxReplicas = ptr.To[int32](1)
+		rayCluster.Spec.WorkerGroupSpecs[0].MinReplicas = ptr.To[int32](0)
+
+		unrelatedPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      unrelatedPodName,
+				Namespace: namespace,
+				Labels:    map[string]string{"app": "unrelated-to-ray"},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "pause",
+						Image: support.GetRayImage(),
+					},
+				},
+			},
+		}
+
+		headPods := corev1.PodList{}
+		workerPods := corev1.PodList{}
+		workerFilters := common.RayClusterGroupPodsAssociationOptions(rayCluster, rayCluster.Spec.WorkerGroupSpecs[0].GroupName).ToListOptions()
+		headFilters := common.RayClusterHeadPodsAssociationOptions(rayCluster).ToListOptions()
+
+		BeforeAll(func() {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			err := k8sClient.Create(ctx, ns)
+			if !apierrors.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred(), "create test namespace for cache selector test")
+			}
+		})
+
+		It("Create RayCluster and unrelated Pod", func() {
+			err := k8sClient.Create(ctx, rayCluster)
+			Expect(err).NotTo(HaveOccurred(), "create RayCluster")
+			Eventually(
+				getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
+				time.Second*10, time.Millisecond*200).Should(Succeed())
+
+			err = k8sClient.Create(ctx, unrelatedPod)
+			Expect(err).NotTo(HaveOccurred(), "create unrelated pod")
+
+			Eventually(
+				listResourceFunc(ctx, &headPods, headFilters...),
+				time.Second*10, time.Millisecond*200).Should(Equal(1))
+			Eventually(
+				listResourceFunc(ctx, &workerPods, workerFilters...),
+				time.Second*10, time.Millisecond*200).Should(Equal(1))
+
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: unrelatedPodName}, unrelatedPod)).Should(Succeed())
+		})
+
+		It("The direct API client should list head, worker, and unrelated Pod", func() {
+			Eventually(
+				listResourceFunc(ctx, &headPods, headFilters...),
+				time.Second*3, time.Millisecond*200).Should(Equal(1))
+			Eventually(
+				listResourceFunc(ctx, &workerPods, workerFilters...),
+				time.Second*3, time.Millisecond*200).Should(Equal(1))
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: unrelatedPodName}, unrelatedPod)).Should(Succeed(), "unrelated pod visible to API")
+		})
+
+		It("The manager cache should only include Ray node Pods (ray.io/node-type in head|worker|redis-cleanup), not the unrelated Pod", func() {
+			cacheClient := k8sManager.GetClient()
+			clusterListOpts := []client.ListOption{
+				client.InNamespace(namespace),
+				client.MatchingLabels{utils.RayClusterLabelKey: rayClusterName},
+			}
+			Eventually(func(g Gomega) {
+				var cachedRayPods corev1.PodList
+				g.Expect(cacheClient.List(ctx, &cachedRayPods, clusterListOpts...)).To(Succeed())
+				var names []string
+				for _, p := range cachedRayPods.Items {
+					names = append(names, p.Name)
+					g.Expect(p.Labels[utils.RayNodeTypeLabelKey]).To(Or(
+						Equal(string(rayv1.HeadNode)),
+						Equal(string(rayv1.WorkerNode)),
+						Equal(string(rayv1.RedisCleanupNode)),
+					), "informer only watches Pods with a Ray node type; pod %q has labels %v", p.Name, p.Labels)
+				}
+				g.Expect(names).To(ContainElements(headPods.Items[0].Name, workerPods.Items[0].Name), "cache should list this cluster's Ray head and worker: got %v", names)
+				g.Expect(names).NotTo(ContainElement(unrelatedPodName), "unrelated pod must not appear in the manager's Pod store; got: %v", names)
+				g.Expect(cachedRayPods.Items).To(HaveLen(2), "this RayCluster has one head and one worker Pod in cache")
+			}, time.Second*10, time.Millisecond*300).Should(Succeed(), "wait for the manager informer to sync listed Pods")
 		})
 	})
 })

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -102,7 +102,7 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	// TODO: We probably should not shorten RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV here just to make tests pass.
 	// Instead, we should fix the reconciliation if any unexpected happened.
 	os.Setenv(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV, "10")
-	selectorsByObject, err := managercache.CacheByObject()
+	selectorsByObject, err := managercache.K8sControllerRuntimeCacheSelectors()
 	Expect(err).NotTo(HaveOccurred(), "failed to build manager cache ByObject")
 	mgr, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -38,6 +38,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils/dashboardclient"
+	"github.com/ray-project/kuberay/ray-operator/internal/managercache"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -101,8 +102,8 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	// TODO: We probably should not shorten RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV here just to make tests pass.
 	// Instead, we should fix the reconciliation if any unexpected happened.
 	os.Setenv(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV, "10")
-	selectorsByObject, err := CacheSelectors()
-	Expect(err).NotTo(HaveOccurred(), "failed to create cache selectors")
+	selectorsByObject, err := managercache.CacheByObject()
+	Expect(err).NotTo(HaveOccurred(), "failed to build manager cache ByObject")
 	mgr, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 		Metrics: metricsserver.Options{

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -24,9 +24,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -43,9 +44,10 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg       *rest.Config
-	k8sClient client.Client
-	testEnv   *envtest.Environment
+	cfg        *rest.Config
+	k8sClient  client.Client
+	k8sManager ctrl.Manager
+	testEnv    *envtest.Environment
 
 	fakeRayDashboardClient *utils.FakeRayDashboardClient
 	fakeRayHttpProxyClient *utils.FakeRayHttpProxyClient
@@ -85,12 +87,12 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = rayv1.AddToScheme(scheme.Scheme)
+	err = rayv1.AddToScheme(clientgoscheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	k8sClient, err = client.New(cfg, client.Options{Scheme: clientgoscheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
@@ -99,10 +101,15 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	// TODO: We probably should not shorten RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV here just to make tests pass.
 	// Instead, we should fix the reconciliation if any unexpected happened.
 	os.Setenv(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV, "10")
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
+	selectorsByObject, err := CacheSelectors()
+	Expect(err).NotTo(HaveOccurred(), "failed to create cache selectors")
+	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: clientgoscheme.Scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
+		},
+		Cache: cache.Options{
+			ByObject: selectorsByObject,
 		},
 	})
 	Expect(err).NotTo(HaveOccurred(), "failed to create manager")
@@ -118,19 +125,19 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 			},
 		},
 	}
-	err = NewReconciler(mgr, options).SetupWithManager(mgr, 1)
+	err = NewReconciler(k8sManager, options).SetupWithManager(k8sManager, 1)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayCluster controller")
 
 	testClientProvider := TestClientProvider{}
-	err = NewRayServiceReconciler(ctx, mgr, testClientProvider).SetupWithManager(mgr, 1)
+	err = NewRayServiceReconciler(ctx, k8sManager, testClientProvider).SetupWithManager(k8sManager, 1)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayService controller")
 
 	rayJobOptions := RayJobReconcilerOptions{}
-	err = NewRayJobReconciler(ctx, mgr, rayJobOptions, testClientProvider).SetupWithManager(mgr, 1)
+	err = NewRayJobReconciler(ctx, k8sManager, rayJobOptions, testClientProvider).SetupWithManager(k8sManager, 1)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayJob controller")
 
 	go func() {
-		err = mgr.Start(ctrl.SetupSignalHandler())
+		err = k8sManager.Start(ctrl.SetupSignalHandler())
 		Expect(err).ToNot(HaveOccurred())
 	}()
 })

--- a/ray-operator/controllers/ray/suite_test.go
+++ b/ray-operator/controllers/ray/suite_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -44,10 +44,10 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg        *rest.Config
-	k8sClient  client.Client
-	k8sManager ctrl.Manager
-	testEnv    *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
+	mgr       ctrl.Manager
+	testEnv   *envtest.Environment
 
 	fakeRayDashboardClient *utils.FakeRayDashboardClient
 	fakeRayHttpProxyClient *utils.FakeRayHttpProxyClient
@@ -87,12 +87,12 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = rayv1.AddToScheme(clientgoscheme.Scheme)
+	err = rayv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: clientgoscheme.Scheme})
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
@@ -103,8 +103,8 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	os.Setenv(utils.RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV, "10")
 	selectorsByObject, err := CacheSelectors()
 	Expect(err).NotTo(HaveOccurred(), "failed to create cache selectors")
-	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: clientgoscheme.Scheme,
+	mgr, err = ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},
@@ -125,19 +125,19 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 			},
 		},
 	}
-	err = NewReconciler(k8sManager, options).SetupWithManager(k8sManager, 1)
+	err = NewReconciler(mgr, options).SetupWithManager(mgr, 1)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayCluster controller")
 
 	testClientProvider := TestClientProvider{}
-	err = NewRayServiceReconciler(ctx, k8sManager, testClientProvider).SetupWithManager(k8sManager, 1)
+	err = NewRayServiceReconciler(ctx, mgr, testClientProvider).SetupWithManager(mgr, 1)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayService controller")
 
 	rayJobOptions := RayJobReconcilerOptions{}
-	err = NewRayJobReconciler(ctx, k8sManager, rayJobOptions, testClientProvider).SetupWithManager(k8sManager, 1)
+	err = NewRayJobReconciler(ctx, mgr, rayJobOptions, testClientProvider).SetupWithManager(mgr, 1)
 	Expect(err).NotTo(HaveOccurred(), "failed to setup RayJob controller")
 
 	go func() {
-		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		err = mgr.Start(ctrl.SetupSignalHandler())
 		Expect(err).ToNot(HaveOccurred())
 	}()
 })

--- a/ray-operator/internal/managercache/cache.go
+++ b/ray-operator/internal/managercache/cache.go
@@ -1,4 +1,4 @@
-package ray
+package managercache
 
 import (
 	batchv1 "k8s.io/api/batch/v1"
@@ -12,9 +12,8 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 )
 
-// CacheSelectors returns ByObject options that restrict which Job and Pod objects
-// the manager's informers watch and store in the local cache.
-func CacheSelectors() (map[client.Object]cache.ByObject, error) {
+// CacheByObject returns cache.ByObject entries that scope the manager client's Job and Pod watches.
+func CacheByObject() (map[client.Object]cache.ByObject, error) {
 	createByLabel, err := labels.NewRequirement(utils.KubernetesCreatedByLabelKey, selection.Equals, []string{utils.ComponentName})
 	if err != nil {
 		return nil, err

--- a/ray-operator/internal/managercache/cache.go
+++ b/ray-operator/internal/managercache/cache.go
@@ -13,7 +13,7 @@ import (
 )
 
 // CacheByObject returns cache.ByObject entries that scope the manager client's Job and Pod watches.
-func CacheByObject() (map[client.Object]cache.ByObject, error) {
+func K8sControllerRuntimeCacheSelectors() (map[client.Object]cache.ByObject, error) {
 	createByLabel, err := labels.NewRequirement(utils.KubernetesCreatedByLabelKey, selection.Equals, []string{utils.ComponentName})
 	if err != nil {
 		return nil, err

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -12,17 +12,14 @@ import (
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	k8szap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -215,10 +212,11 @@ func main() {
 	// Set the informers label selectors to narrow the scope of the resources being watched and cached.
 	// This improves the scalability of the system, both for KubeRay itself by reducing the size of the
 	// informers cache, and for the API server / etcd, by reducing the number of watch events.
-	// For example, KubeRay is only interested in the batch Jobs it creates when reconciling RayJobs,
-	// so the controller sets the app.kubernetes.io/created-by=kuberay-operator label on any Job it creates,
-	// and that label is provided to the manager cache as a selector for Job resources.
-	selectorsByObject, err := cacheSelectors()
+	// For example, KubeRay is only interested in:
+	// - the batch Jobs it creates when reconciling RayJobs (app.kubernetes.io/created-by=kuberay-operator), and
+	// - Ray-managed Pods (ray.io/node-type in head|worker|redis-cleanup).
+	// These labels are provided to the manager cache as selectors for Job and Pod resources.
+	selectorsByObject, err := ray.CacheSelectors()
 	exitOnError(err, "unable to create cache selectors")
 	options.Cache.ByObject = selectorsByObject
 
@@ -313,18 +311,6 @@ func main() {
 
 	setupLog.Info("starting manager")
 	exitOnError(mgr.Start(ctx), "problem running manager")
-}
-
-func cacheSelectors() (map[client.Object]cache.ByObject, error) {
-	label, err := labels.NewRequirement(utils.KubernetesCreatedByLabelKey, selection.Equals, []string{utils.ComponentName})
-	if err != nil {
-		return nil, err
-	}
-	selector := labels.NewSelector().Add(*label)
-
-	return map[client.Object]cache.ByObject{
-		&batchv1.Job{}: {Label: selector},
-	}, nil
 }
 
 func exitOnError(err error, msg string, keysAndValues ...any) {

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/metrics"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	"github.com/ray-project/kuberay/ray-operator/internal/managercache"
 	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 	webhooks "github.com/ray-project/kuberay/ray-operator/pkg/webhooks/v1"
 )
@@ -216,8 +217,8 @@ func main() {
 	// - the batch Jobs it creates when reconciling RayJobs (app.kubernetes.io/created-by=kuberay-operator), and
 	// - Ray-managed Pods (ray.io/node-type in head|worker|redis-cleanup).
 	// These labels are provided to the manager cache as selectors for Job and Pod resources.
-	selectorsByObject, err := ray.CacheSelectors()
-	exitOnError(err, "unable to create cache selectors")
+	selectorsByObject, err := managercache.CacheByObject()
+	exitOnError(err, "unable to build manager cache ByObject")
 	options.Cache.ByObject = selectorsByObject
 
 	if watchNamespaces := strings.Split(config.WatchNamespace, ","); len(watchNamespaces) == 1 { // It is not possible for len(watchNamespaces) == 0 to be true. The length of `strings.Split("", ",")` is still 1.

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -217,7 +217,7 @@ func main() {
 	// - the batch Jobs it creates when reconciling RayJobs (app.kubernetes.io/created-by=kuberay-operator), and
 	// - Ray-managed Pods (ray.io/node-type in head|worker|redis-cleanup).
 	// These labels are provided to the manager cache as selectors for Job and Pod resources.
-	selectorsByObject, err := managercache.CacheByObject()
+	selectorsByObject, err := managercache.K8sControllerRuntimeCacheSelectors()
 	exitOnError(err, "unable to build manager cache ByObject")
 	options.Cache.ByObject = selectorsByObject
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In the current implementation, the KubeRay operator watches and caches all Pod resources in the cluster when watching all namespaces, while it only needs to manage Pods labeled with `ray.io/node-type`. Caching all Pod causes unnecessary memory consumption, especially in large-scale clusters with thousands of unrelated Pods.

This PR adds a Pod cache selector using the `ray.io/node-type` label, which is protected from user override in labelPod(), to filter the informer cache to only include KubeRay-managed Pods. This reduces the operator's memory footprint without affecting reconciliation behavior.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #4625 
## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
