### PR TITLE
fix: Make Redis cleanup job resources configurable via RayCluster annotations

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -231,8 +231,8 @@ GcsFaultToleranceOptions contains configs for GCS FT.
 
 The Redis cleanup Job created on RayCluster deletion defaults to 200m CPU and 256Mi memory.
 To override these defaults (e.g. on GKE Autopilot), set the following annotations on the RayCluster:
-  - ray.io/gcs-ft-redis-cleanup-job-cpu-requests: CPU request/limit (e.g. "500m")
-  - ray.io/gcs-ft-redis-cleanup-job-memory-requests: memory request/limit (e.g. "512Mi")
+  - ray.io/gcs-ft-redis-cleanup-job-cpu-resource: CPU request/limit (e.g. "500m")
+  - ray.io/gcs-ft-redis-cleanup-job-memory-resource: memory request/limit (e.g. "512Mi")
 
 
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -227,7 +227,12 @@ _Appears in:_
 
 
 
-GcsFaultToleranceOptions contains configs for GCS FT
+GcsFaultToleranceOptions contains configs for GCS FT.
+
+The Redis cleanup Job created on RayCluster deletion defaults to 200m CPU and 256Mi memory.
+To override these defaults (e.g. on GKE Autopilot), set the following annotations on the RayCluster:
+  - ray.io/gcs-ft-redis-cleanup-job-cpu-requests: CPU request/limit (e.g. "500m")
+  - ray.io/gcs-ft-redis-cleanup-job-memory-requests: memory request/limit (e.g. "512Mi")
 
 
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -234,6 +234,8 @@ To override these defaults (e.g. on GKE Autopilot), set the following annotation
   - ray.io/gcs-ft-redis-cleanup-job-cpu-resource: CPU request/limit (e.g. "500m")
   - ray.io/gcs-ft-redis-cleanup-job-memory-resource: memory request/limit (e.g. "512Mi")
 
+See https://github.com/ray-project/kuberay/issues/4721 for more details.
+
 
 
 _Appears in:_

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -110,8 +110,8 @@ type AuthOptions struct {
 //
 // The Redis cleanup Job created on RayCluster deletion defaults to 200m CPU and 256Mi memory.
 // To override these defaults (e.g. on GKE Autopilot), set the following annotations on the RayCluster:
-//   - ray.io/gcs-ft-redis-cleanup-job-cpu-requests: CPU request/limit (e.g. "500m")
-//   - ray.io/gcs-ft-redis-cleanup-job-memory-requests: memory request/limit (e.g. "512Mi")
+//   - ray.io/gcs-ft-redis-cleanup-job-cpu-resource: CPU request/limit (e.g. "500m")
+//   - ray.io/gcs-ft-redis-cleanup-job-memory-resource: memory request/limit (e.g. "512Mi")
 type GcsFaultToleranceOptions struct {
 	// +optional
 	RedisUsername *RedisCredential `json:"redisUsername,omitempty"`

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -112,6 +112,8 @@ type AuthOptions struct {
 // To override these defaults (e.g. on GKE Autopilot), set the following annotations on the RayCluster:
 //   - ray.io/gcs-ft-redis-cleanup-job-cpu-resource: CPU request/limit (e.g. "500m")
 //   - ray.io/gcs-ft-redis-cleanup-job-memory-resource: memory request/limit (e.g. "512Mi")
+//
+// See https://github.com/ray-project/kuberay/issues/4721 for more details.
 type GcsFaultToleranceOptions struct {
 	// +optional
 	RedisUsername *RedisCredential `json:"redisUsername,omitempty"`

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -106,7 +106,12 @@ type AuthOptions struct {
 	Mode AuthMode `json:"mode,omitempty"`
 }
 
-// GcsFaultToleranceOptions contains configs for GCS FT
+// GcsFaultToleranceOptions contains configs for GCS FT.
+//
+// The Redis cleanup Job created on RayCluster deletion defaults to 200m CPU and 256Mi memory.
+// To override these defaults (e.g. on GKE Autopilot), set the following annotations on the RayCluster:
+//   - ray.io/gcs-ft-redis-cleanup-job-cpu-requests: CPU request/limit (e.g. "500m")
+//   - ray.io/gcs-ft-redis-cleanup-job-memory-requests: memory request/limit (e.g. "512Mi")
 type GcsFaultToleranceOptions struct {
 	// +optional
 	RedisUsername *RedisCredential `json:"redisUsername,omitempty"`

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1477,16 +1477,25 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instanc
 		Value: "500",
 	})
 
-	// The container's resource consumption remains constant. Hard-coding the resources is acceptable.
-	// Avoid using the GPU for the Redis cleanup Job.
+	// Avoid using the GPU for the Redis cleanup Job. Allow overriding the default
+	// resources via operator env vars for platforms with higher minimum requirements
+	// (e.g. GKE Autopilot).
+	cpuStr := os.Getenv(utils.REDIS_CLEANUP_JOB_CPU)
+	if cpuStr == "" {
+		cpuStr = "200m"
+	}
+	memStr := os.Getenv(utils.REDIS_CLEANUP_JOB_MEMORY)
+	if memStr == "" {
+		memStr = "256Mi"
+	}
 	pod.Spec.Containers[utils.RayContainerIndex].Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("200m"),
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceCPU:    resource.MustParse(cpuStr),
+			corev1.ResourceMemory: resource.MustParse(memStr),
 		},
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("200m"),
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceCPU:    resource.MustParse(cpuStr),
+			corev1.ResourceMemory: resource.MustParse(memStr),
 		},
 	}
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1477,16 +1477,38 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instanc
 		Value: "500",
 	})
 
-	// The container's resource consumption remains constant. Hard-coding the resources is acceptable.
-	// Avoid using the GPU for the Redis cleanup Job.
+	// Avoid using the GPU for the Redis cleanup Job. Allow overriding the default
+	// resources via per-cluster annotations for platforms with higher minimum requirements
+	// (e.g. GKE Autopilot).
+	defaultCPU := resource.MustParse("200m")
+	defaultMemory := resource.MustParse("256Mi")
+
+	cpuQuantity := defaultCPU
+	if cpuStr, ok := instance.Annotations[utils.RayGCSFTRedisCleanupJobCPURequestAnnotationKey]; ok {
+		if parsed, err := resource.ParseQuantity(cpuStr); err != nil {
+			logger.Error(err, "Invalid annotation value, using default", "annotation", utils.RayGCSFTRedisCleanupJobCPURequestAnnotationKey, "value", cpuStr, "default", defaultCPU.String())
+		} else {
+			cpuQuantity = parsed
+		}
+	}
+
+	memQuantity := defaultMemory
+	if memStr, ok := instance.Annotations[utils.RayGCSFTRedisCleanupJobMemoryRequestAnnotationKey]; ok {
+		if parsed, err := resource.ParseQuantity(memStr); err != nil {
+			logger.Error(err, "Invalid annotation value, using default", "annotation", utils.RayGCSFTRedisCleanupJobMemoryRequestAnnotationKey, "value", memStr, "default", defaultMemory.String())
+		} else {
+			memQuantity = parsed
+		}
+	}
+
 	pod.Spec.Containers[utils.RayContainerIndex].Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("200m"),
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceCPU:    cpuQuantity,
+			corev1.ResourceMemory: memQuantity,
 		},
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("200m"),
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceCPU:    cpuQuantity,
+			corev1.ResourceMemory: memQuantity,
 		},
 	}
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1477,25 +1477,16 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instanc
 		Value: "500",
 	})
 
-	// Avoid using the GPU for the Redis cleanup Job. Allow overriding the default
-	// resources via operator env vars for platforms with higher minimum requirements
-	// (e.g. GKE Autopilot).
-	cpuStr := os.Getenv(utils.REDIS_CLEANUP_JOB_CPU)
-	if cpuStr == "" {
-		cpuStr = "200m"
-	}
-	memStr := os.Getenv(utils.REDIS_CLEANUP_JOB_MEMORY)
-	if memStr == "" {
-		memStr = "256Mi"
-	}
+	// The container's resource consumption remains constant. Hard-coding the resources is acceptable.
+	// Avoid using the GPU for the Redis cleanup Job.
 	pod.Spec.Containers[utils.RayContainerIndex].Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(cpuStr),
-			corev1.ResourceMemory: resource.MustParse(memStr),
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		},
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(cpuStr),
-			corev1.ResourceMemory: resource.MustParse(memStr),
+			corev1.ResourceCPU:    resource.MustParse("200m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		},
 	}
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1484,18 +1484,18 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instanc
 	defaultMemory := resource.MustParse("256Mi")
 
 	cpuQuantity := defaultCPU
-	if cpuStr, ok := instance.Annotations[utils.RayGCSFTRedisCleanupJobCPURequestAnnotationKey]; ok {
+	if cpuStr, ok := instance.Annotations[utils.RayGCSFTRedisCleanupJobCPUAnnotationKey]; ok {
 		if parsed, err := resource.ParseQuantity(cpuStr); err != nil {
-			logger.Error(err, "Invalid annotation value, using default", "annotation", utils.RayGCSFTRedisCleanupJobCPURequestAnnotationKey, "value", cpuStr, "default", defaultCPU.String())
+			logger.Error(err, "Invalid annotation value, using default", "annotation", utils.RayGCSFTRedisCleanupJobCPUAnnotationKey, "value", cpuStr, "default", defaultCPU.String())
 		} else {
 			cpuQuantity = parsed
 		}
 	}
 
 	memQuantity := defaultMemory
-	if memStr, ok := instance.Annotations[utils.RayGCSFTRedisCleanupJobMemoryRequestAnnotationKey]; ok {
+	if memStr, ok := instance.Annotations[utils.RayGCSFTRedisCleanupJobMemoryAnnotationKey]; ok {
 		if parsed, err := resource.ParseQuantity(memStr); err != nil {
-			logger.Error(err, "Invalid annotation value, using default", "annotation", utils.RayGCSFTRedisCleanupJobMemoryRequestAnnotationKey, "value", memStr, "default", defaultMemory.String())
+			logger.Error(err, "Invalid annotation value, using default", "annotation", utils.RayGCSFTRedisCleanupJobMemoryAnnotationKey, "value", memStr, "default", defaultMemory.String())
 		} else {
 			memQuantity = parsed
 		}

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1480,22 +1480,35 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instanc
 	// Avoid using the GPU for the Redis cleanup Job. Allow overriding the default
 	// resources via operator env vars for platforms with higher minimum requirements
 	// (e.g. GKE Autopilot).
-	cpuStr := os.Getenv(utils.REDIS_CLEANUP_JOB_CPU)
-	if cpuStr == "" {
-		cpuStr = "200m"
+	defaultCPU := resource.MustParse("200m")
+	defaultMemory := resource.MustParse("256Mi")
+
+	cpuQuantity := defaultCPU
+	if cpuStr := os.Getenv(utils.REDIS_CLEANUP_JOB_CPU); cpuStr != "" {
+		if parsed, err := resource.ParseQuantity(cpuStr); err != nil {
+			logger.Error(err, "Invalid value for env var, using default", "envVar", utils.REDIS_CLEANUP_JOB_CPU, "value", cpuStr, "default", defaultCPU.String())
+		} else {
+			cpuQuantity = parsed
+		}
 	}
-	memStr := os.Getenv(utils.REDIS_CLEANUP_JOB_MEMORY)
-	if memStr == "" {
-		memStr = "256Mi"
+
+	memQuantity := defaultMemory
+	if memStr := os.Getenv(utils.REDIS_CLEANUP_JOB_MEMORY); memStr != "" {
+		if parsed, err := resource.ParseQuantity(memStr); err != nil {
+			logger.Error(err, "Invalid value for env var, using default", "envVar", utils.REDIS_CLEANUP_JOB_MEMORY, "value", memStr, "default", defaultMemory.String())
+		} else {
+			memQuantity = parsed
+		}
 	}
+
 	pod.Spec.Containers[utils.RayContainerIndex].Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(cpuStr),
-			corev1.ResourceMemory: resource.MustParse(memStr),
+			corev1.ResourceCPU:    cpuQuantity,
+			corev1.ResourceMemory: memQuantity,
 		},
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(cpuStr),
-			corev1.ResourceMemory: resource.MustParse(memStr),
+			corev1.ResourceCPU:    cpuQuantity,
+			corev1.ResourceMemory: memQuantity,
 		},
 	}
 

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1480,35 +1480,22 @@ func (r *RayClusterReconciler) buildRedisCleanupJob(ctx context.Context, instanc
 	// Avoid using the GPU for the Redis cleanup Job. Allow overriding the default
 	// resources via operator env vars for platforms with higher minimum requirements
 	// (e.g. GKE Autopilot).
-	defaultCPU := resource.MustParse("200m")
-	defaultMemory := resource.MustParse("256Mi")
-
-	cpuQuantity := defaultCPU
-	if cpuStr := os.Getenv(utils.REDIS_CLEANUP_JOB_CPU); cpuStr != "" {
-		if parsed, err := resource.ParseQuantity(cpuStr); err != nil {
-			logger.Error(err, "Invalid value for env var, using default", "envVar", utils.REDIS_CLEANUP_JOB_CPU, "value", cpuStr, "default", defaultCPU.String())
-		} else {
-			cpuQuantity = parsed
-		}
+	cpuStr := os.Getenv(utils.REDIS_CLEANUP_JOB_CPU)
+	if cpuStr == "" {
+		cpuStr = "200m"
 	}
-
-	memQuantity := defaultMemory
-	if memStr := os.Getenv(utils.REDIS_CLEANUP_JOB_MEMORY); memStr != "" {
-		if parsed, err := resource.ParseQuantity(memStr); err != nil {
-			logger.Error(err, "Invalid value for env var, using default", "envVar", utils.REDIS_CLEANUP_JOB_MEMORY, "value", memStr, "default", defaultMemory.String())
-		} else {
-			memQuantity = parsed
-		}
+	memStr := os.Getenv(utils.REDIS_CLEANUP_JOB_MEMORY)
+	if memStr == "" {
+		memStr = "256Mi"
 	}
-
 	pod.Spec.Containers[utils.RayContainerIndex].Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    cpuQuantity,
-			corev1.ResourceMemory: memQuantity,
+			corev1.ResourceCPU:    resource.MustParse(cpuStr),
+			corev1.ResourceMemory: resource.MustParse(memStr),
 		},
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    cpuQuantity,
-			corev1.ResourceMemory: memQuantity,
+			corev1.ResourceCPU:    resource.MustParse(cpuStr),
+			corev1.ResourceMemory: resource.MustParse(memStr),
 		},
 	}
 

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2891,8 +2891,6 @@ func Test_RedisCleanupCustomResources(t *testing.T) {
 		name          string
 		cpuAnnotation string
 		memAnnotation string
-		setCPU        bool
-		setMem        bool
 		expectedCPU   string
 		expectedMem   string
 	}{
@@ -2900,8 +2898,6 @@ func Test_RedisCleanupCustomResources(t *testing.T) {
 			name:          "Valid custom resources are used",
 			cpuAnnotation: "500m",
 			memAnnotation: "512Mi",
-			setCPU:        true,
-			setMem:        true,
 			expectedCPU:   "500m",
 			expectedMem:   "512Mi",
 		},
@@ -2909,8 +2905,6 @@ func Test_RedisCleanupCustomResources(t *testing.T) {
 			name:          "Invalid CPU falls back to default",
 			cpuAnnotation: "invalid",
 			memAnnotation: "512Mi",
-			setCPU:        true,
-			setMem:        true,
 			expectedCPU:   "200m",
 			expectedMem:   "512Mi",
 		},
@@ -2918,15 +2912,11 @@ func Test_RedisCleanupCustomResources(t *testing.T) {
 			name:          "Invalid memory falls back to default",
 			cpuAnnotation: "500m",
 			memAnnotation: "invalid",
-			setCPU:        true,
-			setMem:        true,
 			expectedCPU:   "500m",
 			expectedMem:   "256Mi",
 		},
 		{
 			name:        "No annotations uses defaults",
-			setCPU:      false,
-			setMem:      false,
 			expectedCPU: "200m",
 			expectedMem: "256Mi",
 		},
@@ -2935,10 +2925,10 @@ func Test_RedisCleanupCustomResources(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cluster := gcsFTEnabledCluster.DeepCopy()
-			if tc.setCPU {
+			if tc.cpuAnnotation != "" {
 				cluster.Annotations[utils.RayGCSFTRedisCleanupJobCPUAnnotationKey] = tc.cpuAnnotation
 			}
-			if tc.setMem {
+			if tc.memAnnotation != "" {
 				cluster.Annotations[utils.RayGCSFTRedisCleanupJobMemoryAnnotationKey] = tc.memAnnotation
 			}
 

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2887,35 +2887,69 @@ func Test_RedisCleanupCustomResources(t *testing.T) {
 	now := metav1.Now()
 	gcsFTEnabledCluster.DeletionTimestamp = &now
 
-	t.Setenv(utils.REDIS_CLEANUP_JOB_CPU, "500m")
-	t.Setenv(utils.REDIS_CLEANUP_JOB_MEMORY, "512Mi")
-
-	ctx := context.Background()
-	fakeClient := clientFake.NewClientBuilder().
-		WithScheme(newScheme).
-		WithRuntimeObjects(gcsFTEnabledCluster.DeepCopy()).
-		WithStatusSubresource(gcsFTEnabledCluster).
-		Build()
-
-	testRayClusterReconciler := &RayClusterReconciler{
-		Client:   fakeClient,
-		Recorder: &record.FakeRecorder{},
-		Scheme:   newScheme,
+	tests := []struct {
+		name        string
+		cpuEnv      string
+		memEnv      string
+		expectedCPU string
+		expectedMem string
+	}{
+		{
+			name:        "Valid custom resources are used",
+			cpuEnv:      "500m",
+			memEnv:      "512Mi",
+			expectedCPU: "500m",
+			expectedMem: "512Mi",
+		},
+		{
+			name:        "Invalid CPU falls back to default",
+			cpuEnv:      "invalid",
+			memEnv:      "512Mi",
+			expectedCPU: "200m",
+			expectedMem: "512Mi",
+		},
+		{
+			name:        "Invalid memory falls back to default",
+			cpuEnv:      "500m",
+			memEnv:      "invalid",
+			expectedCPU: "500m",
+			expectedMem: "256Mi",
+		},
 	}
 
-	_, err := testRayClusterReconciler.rayClusterReconcile(ctx, gcsFTEnabledCluster)
-	require.NoError(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(utils.REDIS_CLEANUP_JOB_CPU, tc.cpuEnv)
+			t.Setenv(utils.REDIS_CLEANUP_JOB_MEMORY, tc.memEnv)
 
-	jobList := batchv1.JobList{}
-	err = fakeClient.List(ctx, &jobList, client.InNamespace(namespaceStr))
-	require.NoError(t, err)
-	require.Len(t, jobList.Items, 1)
+			ctx := context.Background()
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(newScheme).
+				WithRuntimeObjects(gcsFTEnabledCluster.DeepCopy()).
+				WithStatusSubresource(gcsFTEnabledCluster).
+				Build()
 
-	container := jobList.Items[0].Spec.Template.Spec.Containers[utils.RayContainerIndex]
-	assert.Equal(t, resource.MustParse("500m"), container.Resources.Requests[corev1.ResourceCPU])
-	assert.Equal(t, resource.MustParse("512Mi"), container.Resources.Requests[corev1.ResourceMemory])
-	assert.Equal(t, resource.MustParse("500m"), container.Resources.Limits[corev1.ResourceCPU])
-	assert.Equal(t, resource.MustParse("512Mi"), container.Resources.Limits[corev1.ResourceMemory])
+			testRayClusterReconciler := &RayClusterReconciler{
+				Client:   fakeClient,
+				Recorder: &record.FakeRecorder{},
+				Scheme:   newScheme,
+			}
+
+			_, err := testRayClusterReconciler.rayClusterReconcile(ctx, gcsFTEnabledCluster)
+			require.NoError(t, err)
+
+			jobList := batchv1.JobList{}
+			err = fakeClient.List(ctx, &jobList, client.InNamespace(namespaceStr))
+			require.NoError(t, err)
+			require.Len(t, jobList.Items, 1)
+
+			container := jobList.Items[0].Spec.Template.Spec.Containers[utils.RayContainerIndex]
+			assert.Equal(t, resource.MustParse(tc.expectedCPU), container.Resources.Requests[corev1.ResourceCPU])
+			assert.Equal(t, resource.MustParse(tc.expectedMem), container.Resources.Requests[corev1.ResourceMemory])
+			assert.Equal(t, resource.MustParse(tc.expectedCPU), container.Resources.Limits[corev1.ResourceCPU])
+			assert.Equal(t, resource.MustParse(tc.expectedMem), container.Resources.Limits[corev1.ResourceMemory])
+		})
+	}
 }
 
 func TestReconcile_Replicas_Optional(t *testing.T) {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2870,54 +2870,6 @@ func Test_RedisCleanup(t *testing.T) {
 	}
 }
 
-func Test_RedisCleanupCustomResources(t *testing.T) {
-	setupTest(t)
-	newScheme := runtime.NewScheme()
-	_ = rayv1.AddToScheme(newScheme)
-	_ = corev1.AddToScheme(newScheme)
-	_ = batchv1.AddToScheme(newScheme)
-
-	gcsFTEnabledCluster := testRayCluster.DeepCopy()
-	if gcsFTEnabledCluster.Annotations == nil {
-		gcsFTEnabledCluster.Annotations = make(map[string]string)
-	}
-	gcsFTEnabledCluster.Annotations[utils.RayFTEnabledAnnotationKey] = "true"
-	gcsFTEnabledCluster.Spec.EnableInTreeAutoscaling = nil
-	controllerutil.AddFinalizer(gcsFTEnabledCluster, utils.GCSFaultToleranceRedisCleanupFinalizer)
-	now := metav1.Now()
-	gcsFTEnabledCluster.DeletionTimestamp = &now
-
-	t.Setenv(utils.REDIS_CLEANUP_JOB_CPU, "500m")
-	t.Setenv(utils.REDIS_CLEANUP_JOB_MEMORY, "512Mi")
-
-	ctx := context.Background()
-	fakeClient := clientFake.NewClientBuilder().
-		WithScheme(newScheme).
-		WithRuntimeObjects(gcsFTEnabledCluster.DeepCopy()).
-		WithStatusSubresource(gcsFTEnabledCluster).
-		Build()
-
-	testRayClusterReconciler := &RayClusterReconciler{
-		Client:   fakeClient,
-		Recorder: &record.FakeRecorder{},
-		Scheme:   newScheme,
-	}
-
-	_, err := testRayClusterReconciler.rayClusterReconcile(ctx, gcsFTEnabledCluster)
-	require.NoError(t, err)
-
-	jobList := batchv1.JobList{}
-	err = fakeClient.List(ctx, &jobList, client.InNamespace(namespaceStr))
-	require.NoError(t, err)
-	require.Len(t, jobList.Items, 1)
-
-	container := jobList.Items[0].Spec.Template.Spec.Containers[utils.RayContainerIndex]
-	assert.Equal(t, resource.MustParse("500m"), container.Resources.Requests[corev1.ResourceCPU])
-	assert.Equal(t, resource.MustParse("512Mi"), container.Resources.Requests[corev1.ResourceMemory])
-	assert.Equal(t, resource.MustParse("500m"), container.Resources.Limits[corev1.ResourceCPU])
-	assert.Equal(t, resource.MustParse("512Mi"), container.Resources.Limits[corev1.ResourceMemory])
-}
-
 func TestReconcile_Replicas_Optional(t *testing.T) {
 	setupTest(t)
 

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2870,6 +2870,54 @@ func Test_RedisCleanup(t *testing.T) {
 	}
 }
 
+func Test_RedisCleanupCustomResources(t *testing.T) {
+	setupTest(t)
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+	_ = batchv1.AddToScheme(newScheme)
+
+	gcsFTEnabledCluster := testRayCluster.DeepCopy()
+	if gcsFTEnabledCluster.Annotations == nil {
+		gcsFTEnabledCluster.Annotations = make(map[string]string)
+	}
+	gcsFTEnabledCluster.Annotations[utils.RayFTEnabledAnnotationKey] = "true"
+	gcsFTEnabledCluster.Spec.EnableInTreeAutoscaling = nil
+	controllerutil.AddFinalizer(gcsFTEnabledCluster, utils.GCSFaultToleranceRedisCleanupFinalizer)
+	now := metav1.Now()
+	gcsFTEnabledCluster.DeletionTimestamp = &now
+
+	t.Setenv(utils.REDIS_CLEANUP_JOB_CPU, "500m")
+	t.Setenv(utils.REDIS_CLEANUP_JOB_MEMORY, "512Mi")
+
+	ctx := context.Background()
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(newScheme).
+		WithRuntimeObjects(gcsFTEnabledCluster.DeepCopy()).
+		WithStatusSubresource(gcsFTEnabledCluster).
+		Build()
+
+	testRayClusterReconciler := &RayClusterReconciler{
+		Client:   fakeClient,
+		Recorder: &record.FakeRecorder{},
+		Scheme:   newScheme,
+	}
+
+	_, err := testRayClusterReconciler.rayClusterReconcile(ctx, gcsFTEnabledCluster)
+	require.NoError(t, err)
+
+	jobList := batchv1.JobList{}
+	err = fakeClient.List(ctx, &jobList, client.InNamespace(namespaceStr))
+	require.NoError(t, err)
+	require.Len(t, jobList.Items, 1)
+
+	container := jobList.Items[0].Spec.Template.Spec.Containers[utils.RayContainerIndex]
+	assert.Equal(t, resource.MustParse("500m"), container.Resources.Requests[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("512Mi"), container.Resources.Requests[corev1.ResourceMemory])
+	assert.Equal(t, resource.MustParse("500m"), container.Resources.Limits[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("512Mi"), container.Resources.Limits[corev1.ResourceMemory])
+}
+
 func TestReconcile_Replicas_Optional(t *testing.T) {
 	setupTest(t)
 

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2887,69 +2887,35 @@ func Test_RedisCleanupCustomResources(t *testing.T) {
 	now := metav1.Now()
 	gcsFTEnabledCluster.DeletionTimestamp = &now
 
-	tests := []struct {
-		name        string
-		cpuEnv      string
-		memEnv      string
-		expectedCPU string
-		expectedMem string
-	}{
-		{
-			name:        "Valid custom resources are used",
-			cpuEnv:      "500m",
-			memEnv:      "512Mi",
-			expectedCPU: "500m",
-			expectedMem: "512Mi",
-		},
-		{
-			name:        "Invalid CPU falls back to default",
-			cpuEnv:      "invalid",
-			memEnv:      "512Mi",
-			expectedCPU: "200m",
-			expectedMem: "512Mi",
-		},
-		{
-			name:        "Invalid memory falls back to default",
-			cpuEnv:      "500m",
-			memEnv:      "invalid",
-			expectedCPU: "500m",
-			expectedMem: "256Mi",
-		},
+	t.Setenv(utils.REDIS_CLEANUP_JOB_CPU, "500m")
+	t.Setenv(utils.REDIS_CLEANUP_JOB_MEMORY, "512Mi")
+
+	ctx := context.Background()
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(newScheme).
+		WithRuntimeObjects(gcsFTEnabledCluster.DeepCopy()).
+		WithStatusSubresource(gcsFTEnabledCluster).
+		Build()
+
+	testRayClusterReconciler := &RayClusterReconciler{
+		Client:   fakeClient,
+		Recorder: &record.FakeRecorder{},
+		Scheme:   newScheme,
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv(utils.REDIS_CLEANUP_JOB_CPU, tc.cpuEnv)
-			t.Setenv(utils.REDIS_CLEANUP_JOB_MEMORY, tc.memEnv)
+	_, err := testRayClusterReconciler.rayClusterReconcile(ctx, gcsFTEnabledCluster)
+	require.NoError(t, err)
 
-			ctx := context.Background()
-			fakeClient := clientFake.NewClientBuilder().
-				WithScheme(newScheme).
-				WithRuntimeObjects(gcsFTEnabledCluster.DeepCopy()).
-				WithStatusSubresource(gcsFTEnabledCluster).
-				Build()
+	jobList := batchv1.JobList{}
+	err = fakeClient.List(ctx, &jobList, client.InNamespace(namespaceStr))
+	require.NoError(t, err)
+	require.Len(t, jobList.Items, 1)
 
-			testRayClusterReconciler := &RayClusterReconciler{
-				Client:   fakeClient,
-				Recorder: &record.FakeRecorder{},
-				Scheme:   newScheme,
-			}
-
-			_, err := testRayClusterReconciler.rayClusterReconcile(ctx, gcsFTEnabledCluster)
-			require.NoError(t, err)
-
-			jobList := batchv1.JobList{}
-			err = fakeClient.List(ctx, &jobList, client.InNamespace(namespaceStr))
-			require.NoError(t, err)
-			require.Len(t, jobList.Items, 1)
-
-			container := jobList.Items[0].Spec.Template.Spec.Containers[utils.RayContainerIndex]
-			assert.Equal(t, resource.MustParse(tc.expectedCPU), container.Resources.Requests[corev1.ResourceCPU])
-			assert.Equal(t, resource.MustParse(tc.expectedMem), container.Resources.Requests[corev1.ResourceMemory])
-			assert.Equal(t, resource.MustParse(tc.expectedCPU), container.Resources.Limits[corev1.ResourceCPU])
-			assert.Equal(t, resource.MustParse(tc.expectedMem), container.Resources.Limits[corev1.ResourceMemory])
-		})
-	}
+	container := jobList.Items[0].Spec.Template.Spec.Containers[utils.RayContainerIndex]
+	assert.Equal(t, resource.MustParse("500m"), container.Resources.Requests[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("512Mi"), container.Resources.Requests[corev1.ResourceMemory])
+	assert.Equal(t, resource.MustParse("500m"), container.Resources.Limits[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("512Mi"), container.Resources.Limits[corev1.ResourceMemory])
 }
 
 func TestReconcile_Replicas_Optional(t *testing.T) {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2936,10 +2936,10 @@ func Test_RedisCleanupCustomResources(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cluster := gcsFTEnabledCluster.DeepCopy()
 			if tc.setCPU {
-				cluster.Annotations[utils.RayGCSFTRedisCleanupJobCPURequestAnnotationKey] = tc.cpuAnnotation
+				cluster.Annotations[utils.RayGCSFTRedisCleanupJobCPUAnnotationKey] = tc.cpuAnnotation
 			}
 			if tc.setMem {
-				cluster.Annotations[utils.RayGCSFTRedisCleanupJobMemoryRequestAnnotationKey] = tc.memAnnotation
+				cluster.Annotations[utils.RayGCSFTRedisCleanupJobMemoryAnnotationKey] = tc.memAnnotation
 			}
 
 			ctx := context.Background()

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -2870,6 +2870,108 @@ func Test_RedisCleanup(t *testing.T) {
 	}
 }
 
+func Test_RedisCleanupCustomResources(t *testing.T) {
+	setupTest(t)
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+	_ = batchv1.AddToScheme(newScheme)
+
+	gcsFTEnabledCluster := testRayCluster.DeepCopy()
+	if gcsFTEnabledCluster.Annotations == nil {
+		gcsFTEnabledCluster.Annotations = make(map[string]string)
+	}
+	gcsFTEnabledCluster.Annotations[utils.RayFTEnabledAnnotationKey] = "true"
+	gcsFTEnabledCluster.Spec.EnableInTreeAutoscaling = nil
+	controllerutil.AddFinalizer(gcsFTEnabledCluster, utils.GCSFaultToleranceRedisCleanupFinalizer)
+	now := metav1.Now()
+	gcsFTEnabledCluster.DeletionTimestamp = &now
+
+	tests := []struct {
+		name          string
+		cpuAnnotation string
+		memAnnotation string
+		setCPU        bool
+		setMem        bool
+		expectedCPU   string
+		expectedMem   string
+	}{
+		{
+			name:          "Valid custom resources are used",
+			cpuAnnotation: "500m",
+			memAnnotation: "512Mi",
+			setCPU:        true,
+			setMem:        true,
+			expectedCPU:   "500m",
+			expectedMem:   "512Mi",
+		},
+		{
+			name:          "Invalid CPU falls back to default",
+			cpuAnnotation: "invalid",
+			memAnnotation: "512Mi",
+			setCPU:        true,
+			setMem:        true,
+			expectedCPU:   "200m",
+			expectedMem:   "512Mi",
+		},
+		{
+			name:          "Invalid memory falls back to default",
+			cpuAnnotation: "500m",
+			memAnnotation: "invalid",
+			setCPU:        true,
+			setMem:        true,
+			expectedCPU:   "500m",
+			expectedMem:   "256Mi",
+		},
+		{
+			name:        "No annotations uses defaults",
+			setCPU:      false,
+			setMem:      false,
+			expectedCPU: "200m",
+			expectedMem: "256Mi",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := gcsFTEnabledCluster.DeepCopy()
+			if tc.setCPU {
+				cluster.Annotations[utils.RayGCSFTRedisCleanupJobCPURequestAnnotationKey] = tc.cpuAnnotation
+			}
+			if tc.setMem {
+				cluster.Annotations[utils.RayGCSFTRedisCleanupJobMemoryRequestAnnotationKey] = tc.memAnnotation
+			}
+
+			ctx := context.Background()
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(newScheme).
+				WithRuntimeObjects(cluster.DeepCopy()).
+				WithStatusSubresource(cluster).
+				Build()
+
+			testRayClusterReconciler := &RayClusterReconciler{
+				Client:   fakeClient,
+				Recorder: &record.FakeRecorder{},
+				Scheme:   newScheme,
+			}
+
+			_, err := testRayClusterReconciler.rayClusterReconcile(ctx, cluster)
+			require.NoError(t, err)
+
+			jobList := batchv1.JobList{}
+			err = fakeClient.List(ctx, &jobList, client.InNamespace(namespaceStr))
+			require.NoError(t, err)
+			require.Len(t, jobList.Items, 1)
+
+			container := jobList.Items[0].Spec.Template.Spec.Containers[utils.RayContainerIndex]
+			assert.Equal(t, resource.MustParse(tc.expectedCPU), container.Resources.Requests[corev1.ResourceCPU])
+			assert.Equal(t, resource.MustParse(tc.expectedMem), container.Resources.Requests[corev1.ResourceMemory])
+			assert.Equal(t, resource.MustParse(tc.expectedCPU), container.Resources.Limits[corev1.ResourceCPU])
+			assert.Equal(t, resource.MustParse(tc.expectedMem), container.Resources.Limits[corev1.ResourceMemory])
+		})
+	}
+}
+
 func TestReconcile_Replicas_Optional(t *testing.T) {
 	setupTest(t)
 

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -185,13 +185,6 @@ const (
 	// cleanup Job should be enabled. This is a feature flag for v1.0.0.
 	ENABLE_GCS_FT_REDIS_CLEANUP = "ENABLE_GCS_FT_REDIS_CLEANUP"
 
-	// These KubeRay operator environment variables allow overriding the default
-	// resource requests/limits for the Redis cleanup Job. This is useful on
-	// platforms like GKE Autopilot where minimum resource requirements may be
-	// higher than the defaults.
-	REDIS_CLEANUP_JOB_CPU    = "REDIS_CLEANUP_JOB_CPU"
-	REDIS_CLEANUP_JOB_MEMORY = "REDIS_CLEANUP_JOB_MEMORY"
-
 	// This environment variable for the KubeRay operator is used to determine whether to enable
 	// the injection of readiness and liveness probes into Ray head and worker containers.
 	// Enabling this feature contributes to the robustness of Ray clusters. It is currently a feature

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -185,6 +185,13 @@ const (
 	// cleanup Job should be enabled. This is a feature flag for v1.0.0.
 	ENABLE_GCS_FT_REDIS_CLEANUP = "ENABLE_GCS_FT_REDIS_CLEANUP"
 
+	// These KubeRay operator environment variables allow overriding the default
+	// resource requests/limits for the Redis cleanup Job. This is useful on
+	// platforms like GKE Autopilot where minimum resource requirements may be
+	// higher than the defaults.
+	REDIS_CLEANUP_JOB_CPU    = "REDIS_CLEANUP_JOB_CPU"
+	REDIS_CLEANUP_JOB_MEMORY = "REDIS_CLEANUP_JOB_MEMORY"
+
 	// This environment variable for the KubeRay operator is used to determine whether to enable
 	// the injection of readiness and liveness probes into Ray head and worker containers.
 	// Enabling this feature contributes to the robustness of Ray clusters. It is currently a feature

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -83,6 +83,15 @@ const (
 	// Finalizers for GCS fault tolerance
 	GCSFaultToleranceRedisCleanupFinalizer = "ray.io/gcs-ft-redis-cleanup-finalizer"
 
+	// RayGCSFTRedisCleanupJobCPURequestAnnotationKey allows overriding the CPU request/limit
+	// for the Redis cleanup Job on a per-cluster basis. Accepts any valid Kubernetes quantity
+	// (e.g. "500m", "1"). Defaults to "200m" if unset or invalid.
+	RayGCSFTRedisCleanupJobCPURequestAnnotationKey = "ray.io/gcs-ft-redis-cleanup-job-cpu-requests"
+	// RayGCSFTRedisCleanupJobMemoryRequestAnnotationKey allows overriding the memory request/limit
+	// for the Redis cleanup Job on a per-cluster basis. Accepts any valid Kubernetes quantity
+	// (e.g. "512Mi", "1Gi"). Defaults to "256Mi" if unset or invalid.
+	RayGCSFTRedisCleanupJobMemoryRequestAnnotationKey = "ray.io/gcs-ft-redis-cleanup-job-memory-requests"
+
 	// EnableServeServiceKey is exclusively utilized to indicate if a RayCluster is directly used for serving.
 	// See https://github.com/ray-project/kuberay/pull/1672 for more details.
 	EnableServeServiceKey  = "ray.io/enable-serve-service"

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -83,14 +83,14 @@ const (
 	// Finalizers for GCS fault tolerance
 	GCSFaultToleranceRedisCleanupFinalizer = "ray.io/gcs-ft-redis-cleanup-finalizer"
 
-	// RayGCSFTRedisCleanupJobCPURequestAnnotationKey allows overriding the CPU request/limit
+	// RayGCSFTRedisCleanupJobCPUAnnotationKey allows overriding the CPU request/limit
 	// for the Redis cleanup Job on a per-cluster basis. Accepts any valid Kubernetes quantity
 	// (e.g. "500m", "1"). Defaults to "200m" if unset or invalid.
-	RayGCSFTRedisCleanupJobCPURequestAnnotationKey = "ray.io/gcs-ft-redis-cleanup-job-cpu-requests"
-	// RayGCSFTRedisCleanupJobMemoryRequestAnnotationKey allows overriding the memory request/limit
+	RayGCSFTRedisCleanupJobCPUAnnotationKey = "ray.io/gcs-ft-redis-cleanup-job-cpu-resource"
+	// RayGCSFTRedisCleanupJobMemoryAnnotationKey allows overriding the memory request/limit
 	// for the Redis cleanup Job on a per-cluster basis. Accepts any valid Kubernetes quantity
 	// (e.g. "512Mi", "1Gi"). Defaults to "256Mi" if unset or invalid.
-	RayGCSFTRedisCleanupJobMemoryRequestAnnotationKey = "ray.io/gcs-ft-redis-cleanup-job-memory-requests"
+	RayGCSFTRedisCleanupJobMemoryAnnotationKey = "ray.io/gcs-ft-redis-cleanup-job-memory-resource"
 
 	// EnableServeServiceKey is exclusively utilized to indicate if a RayCluster is directly used for serving.
 	// See https://github.com/ray-project/kuberay/pull/1672 for more details.

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/gcsfaulttoleranceoptions.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/gcsfaulttoleranceoptions.go
@@ -5,7 +5,12 @@ package v1
 // GcsFaultToleranceOptionsApplyConfiguration represents a declarative configuration of the GcsFaultToleranceOptions type for use
 // with apply.
 //
-// GcsFaultToleranceOptions contains configs for GCS FT
+// GcsFaultToleranceOptions contains configs for GCS FT.
+//
+// The Redis cleanup Job created on RayCluster deletion defaults to 200m CPU and 256Mi memory.
+// To override these defaults (e.g. on GKE Autopilot), set the following annotations on the RayCluster:
+// - ray.io/gcs-ft-redis-cleanup-job-cpu-requests: CPU request/limit (e.g. "500m")
+// - ray.io/gcs-ft-redis-cleanup-job-memory-requests: memory request/limit (e.g. "512Mi")
 type GcsFaultToleranceOptionsApplyConfiguration struct {
 	RedisUsername            *RedisCredentialApplyConfiguration `json:"redisUsername,omitempty"`
 	RedisPassword            *RedisCredentialApplyConfiguration `json:"redisPassword,omitempty"`

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/gcsfaulttoleranceoptions.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/gcsfaulttoleranceoptions.go
@@ -9,8 +9,8 @@ package v1
 //
 // The Redis cleanup Job created on RayCluster deletion defaults to 200m CPU and 256Mi memory.
 // To override these defaults (e.g. on GKE Autopilot), set the following annotations on the RayCluster:
-// - ray.io/gcs-ft-redis-cleanup-job-cpu-requests: CPU request/limit (e.g. "500m")
-// - ray.io/gcs-ft-redis-cleanup-job-memory-requests: memory request/limit (e.g. "512Mi")
+// - ray.io/gcs-ft-redis-cleanup-job-cpu-resource: CPU request/limit (e.g. "500m")
+// - ray.io/gcs-ft-redis-cleanup-job-memory-resource: memory request/limit (e.g. "512Mi")
 type GcsFaultToleranceOptionsApplyConfiguration struct {
 	RedisUsername            *RedisCredentialApplyConfiguration `json:"redisUsername,omitempty"`
 	RedisPassword            *RedisCredentialApplyConfiguration `json:"redisPassword,omitempty"`

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/gcsfaulttoleranceoptions.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/gcsfaulttoleranceoptions.go
@@ -11,6 +11,8 @@ package v1
 // To override these defaults (e.g. on GKE Autopilot), set the following annotations on the RayCluster:
 // - ray.io/gcs-ft-redis-cleanup-job-cpu-resource: CPU request/limit (e.g. "500m")
 // - ray.io/gcs-ft-redis-cleanup-job-memory-resource: memory request/limit (e.g. "512Mi")
+//
+// See https://github.com/ray-project/kuberay/issues/4721 for more details.
 type GcsFaultToleranceOptionsApplyConfiguration struct {
 	RedisUsername            *RedisCredentialApplyConfiguration `json:"redisUsername,omitempty"`
 	RedisPassword            *RedisCredentialApplyConfiguration `json:"redisPassword,omitempty"`

--- a/ray-operator/test/e2e/raycluster_gcs_ft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcs_ft_test.go
@@ -6,7 +6,9 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 
@@ -357,6 +359,100 @@ func TestGcsFaultToleranceAnnotations(t *testing.T) {
 
 			err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Delete(test.Ctx(), rayCluster.Name, metav1.DeleteOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
+		})
+	}
+}
+
+func TestRedisCleanupJobCustomResources(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expectedCPU string
+		expectedMem string
+	}{
+		{
+			name:        "Default resources when no annotations set",
+			annotations: map[string]string{},
+			expectedCPU: "200m",
+			expectedMem: "256Mi",
+		},
+		{
+			name: "Custom resources via annotations",
+			annotations: map[string]string{
+				utils.RayGCSFTRedisCleanupJobCPURequestAnnotationKey:    "500m",
+				utils.RayGCSFTRedisCleanupJobMemoryRequestAnnotationKey: "512Mi",
+			},
+			expectedCPU: "500m",
+			expectedMem: "512Mi",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			test := With(t)
+			g := NewWithT(t)
+			namespace := test.NewTestNamespace()
+
+			DeployRedis(test, namespace.Name, "")
+
+			// Build annotations map: always include ft-enabled, merge test-specific annotations
+			annotations := map[string]string{
+				utils.RayFTEnabledAnnotationKey: "true",
+			}
+			for k, v := range tc.annotations {
+				annotations[k] = v
+			}
+
+			rayClusterAC := rayv1ac.RayCluster("raycluster-cleanup-res", namespace.Name).
+				WithAnnotations(annotations).
+				WithSpec(
+					RayClusterSpecWith(
+						rayv1ac.RayClusterSpec().
+							WithRayVersion(GetRayVersion()).
+							WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+								WithRayStartParams(map[string]string{"dashboard-host": "0.0.0.0"}).
+								WithTemplate(HeadPodTemplateApplyConfiguration())),
+					),
+				)
+
+			rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+			g.Expect(err).NotTo(HaveOccurred())
+			LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+			// Wait for the cluster to become ready
+			LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+			g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+				Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionTrue, rayv1.AllPodRunningAndReadyFirstTime)))
+
+			// Delete the RayCluster to trigger the Redis cleanup Job
+			LogWithTimestamp(test.T(), "Deleting RayCluster to trigger Redis cleanup Job")
+			err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Delete(test.Ctx(), rayCluster.Name, metav1.DeleteOptions{})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// Wait for the Redis cleanup Job to appear
+			LogWithTimestamp(test.T(), "Waiting for Redis cleanup Job to be created")
+			var cleanupJob *batchv1.Job
+			g.Eventually(func() (bool, error) {
+				jobs, err := test.Client().Core().BatchV1().Jobs(namespace.Name).List(test.Ctx(), metav1.ListOptions{})
+				if err != nil {
+					return false, err
+				}
+				for i := range jobs.Items {
+					if jobs.Items[i].Name == rayCluster.Name+"-redis-cleanup" {
+						cleanupJob = &jobs.Items[i]
+						return true, nil
+					}
+				}
+				return false, nil
+			}, TestTimeoutMedium).Should(BeTrue(), "Redis cleanup Job should be created")
+
+			// Verify the cleanup Job container resources
+			container := cleanupJob.Spec.Template.Spec.Containers[utils.RayContainerIndex]
+			LogWithTimestamp(test.T(), "Verifying Redis cleanup Job resources: expecting CPU=%s, Memory=%s", tc.expectedCPU, tc.expectedMem)
+			g.Expect(container.Resources.Requests[corev1.ResourceCPU]).To(Equal(resource.MustParse(tc.expectedCPU)))
+			g.Expect(container.Resources.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse(tc.expectedMem)))
+			g.Expect(container.Resources.Limits[corev1.ResourceCPU]).To(Equal(resource.MustParse(tc.expectedCPU)))
+			g.Expect(container.Resources.Limits[corev1.ResourceMemory]).To(Equal(resource.MustParse(tc.expectedMem)))
 		})
 	}
 }

--- a/ray-operator/test/e2e/raycluster_gcs_ft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcs_ft_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"maps"
 	"testing"
 	"time"
 
@@ -399,9 +400,7 @@ func TestRedisCleanupJobCustomResources(t *testing.T) {
 			annotations := map[string]string{
 				utils.RayFTEnabledAnnotationKey: "true",
 			}
-			for k, v := range tc.annotations {
-				annotations[k] = v
-			}
+			maps.Copy(annotations, tc.annotations)
 
 			rayClusterAC := rayv1ac.RayCluster("raycluster-cleanup-res", namespace.Name).
 				WithAnnotations(annotations).

--- a/ray-operator/test/e2e/raycluster_gcs_ft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcs_ft_test.go
@@ -380,8 +380,8 @@ func TestRedisCleanupJobCustomResources(t *testing.T) {
 		{
 			name: "Custom resources via annotations",
 			annotations: map[string]string{
-				utils.RayGCSFTRedisCleanupJobCPURequestAnnotationKey:    "500m",
-				utils.RayGCSFTRedisCleanupJobMemoryRequestAnnotationKey: "512Mi",
+				utils.RayGCSFTRedisCleanupJobCPUAnnotationKey:    "500m",
+				utils.RayGCSFTRedisCleanupJobMemoryAnnotationKey: "512Mi",
 			},
 			expectedCPU: "500m",
 			expectedMem: "512Mi",


### PR DESCRIPTION
## Why are these changes needed?

Fixes #4721

On GKE Autopilot, the Redis cleanup job is rejected because its hardcoded CPU request (`200m`) is below the platform minimum (`500m` with anti-affinity). This blocks RayCluster deletion indefinitely since the finalizer is never removed.


## Related issue

https://github.com/ray-project/kuberay/issues/4721