### PR TITLE
fix: HistoryServer unit tests failure caused by ID normalization in ConvertBase64ToHex

### DIFF
--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -17,12 +17,6 @@ const (
 	testClusterName1 = "cluster1"
 	testTaskName1    = "Name_12345"
 	testTaskName2    = "Name_54321"
-
-	// Base64 and Hex pairs to verify normalization of base64 to hex
-	testBase64ID1 = "AgAAAA=="
-	testBase64ID2 = "AwAAAA=="
-	testHexID1    = "02000000" // hex for base64 "AgAAAA=="
-	testHexID2    = "03000000" // hex for base64 "AwAAAA=="
 )
 
 func makeTaskEventMap(taskName, nodeId, taskID, cluster string, attempt int) map[string]any {
@@ -218,7 +212,14 @@ func TestStoreEvent(t *testing.T) {
 		lowerNodeID1 = "aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb" // 28B lowercase
 		upperTaskID1 = "AAAABBBB5678AAAABBBB5678AAAABBBB5678AAAABBBB5678"         // 24B uppercase
 		lowerTaskID1 = "aaaabbbb5678aaaabbbb5678aaaabbbb5678aaaabbbb5678"         // 24B lowercase
+
+		// Base64 and Hex pairs to verify normalization of base64 to hex
+		testBase64ID1 = "AgAAAA=="
+		testBase64ID2 = "AwAAAA=="
+		testHexID1    = "02000000" // hex for base64 "AgAAAA=="
+		testHexID2    = "03000000" // hex for base64 "AwAAAA=="
 	)
+
 	initialTask := types.Task{
 		TaskID:      taskID1,
 		TaskName:    testTaskName1,

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -30,13 +30,13 @@ func TestEventProcessor(t *testing.T) {
 	// Sizes: JobID=4B, ActorID=12B unique+JobID (16B), TaskID=8B unique+ActorID (24B), NodeID/WorkerID=28B
 	const (
 		// Pure-hex IDs to verify normalizeIDToHex is identity.
-        // Use lowercase to match production hex output and avoid map-key collision.
-		testJobID       = "aaaabbbb"                                                  // 4B
-		testActorID     = "aaaabbbb1234aaaabbbb1234" + testJobID                          // 12B unique + JobID
-		testTaskID1     = "ccccdddd5678cccc" + testActorID                                // 8B unique + ActorID
-		testTaskID2     = "ccccdddd9012dddd" + testActorID                                // 8B unique + ActorID
-		testNodeID1     = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
-		testNodeID2     = "eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff"  // 28B
+		// Use lowercase to match production hex output and avoid map-key collision.
+		testJobID   = "aaaabbbb"                                                 // 4B
+		testActorID = "aaaabbbb1234aaaabbbb1234" + testJobID                     // 12B unique + JobID
+		testTaskID1 = "ccccdddd5678cccc" + testActorID                           // 8B unique + ActorID
+		testTaskID2 = "ccccdddd9012dddd" + testActorID                           // 8B unique + ActorID
+		testNodeID1 = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff" // 28B
+		testNodeID2 = "eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff" // 28B
 
 		testClusterName = "cluster1"
 		testTaskName1   = "Name_12345"
@@ -198,12 +198,12 @@ func TestEventProcessor(t *testing.T) {
 func TestStoreEvent(t *testing.T) {
 	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
 	const (
-		testJobID        = "aaaabbbb"                                                  // 4B
-		testActorID      = "aaaabbbb1234aaaabbbb1234" + testJobID                          // 12B unique + JobID
-		testTaskID1      = "ccccdddd5678cccc" + testActorID                                // 8B unique + ActorID
-		testTaskID2      = "ccccdddd9012dddd" + testActorID                                // 8B unique + ActorID
-		testNodeID1      = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
-		testNodeID2      = "eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff"  // 28B
+		testJobID        = "aaaabbbb"                                                 // 4B
+		testActorID      = "aaaabbbb1234aaaabbbb1234" + testJobID                     // 12B unique + JobID
+		testTaskID1      = "ccccdddd5678cccc" + testActorID                           // 8B unique + ActorID
+		testTaskID2      = "ccccdddd9012dddd" + testActorID                           // 8B unique + ActorID
+		testNodeID1      = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff" // 28B
+		testNodeID2      = "eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff" // 28B
 		testUpperNodeID1 = "AAAABBBB1234AAAABBBB1234AAAABBBB1234AAAABBBB1234AAAABBBB" // 28B uppercase
 		testLowerNodeID1 = "aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb" // 28B lowercase
 		testUpperTaskID1 = "AAAABBBB5678AAAABBBB5678AAAABBBB5678AAAABBBB5678"         // 24B uppercase
@@ -470,11 +470,11 @@ func TestStoreEvent(t *testing.T) {
 func TestTaskLifecycleEventDeduplication(t *testing.T) {
 	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
 	const (
-		testJobID       = "aaaabbbb"                                                  // 4B
-		testActorID     = "aaaabbbb1234aaaabbbb1234" + testJobID                          // 12B unique + JobID
-		testTaskID      = "ccccdddd5678cccc" + testActorID                                // 8B unique + ActorID
-		testNodeID      = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
-		testWorkerID    = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff"  // 28B
+		testJobID       = "aaaabbbb"                                                 // 4B
+		testActorID     = "aaaabbbb1234aaaabbbb1234" + testJobID                     // 12B unique + JobID
+		testTaskID      = "ccccdddd5678cccc" + testActorID                           // 8B unique + ActorID
+		testNodeID      = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff" // 28B
+		testWorkerID    = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff" // 28B
 		testClusterName = "cluster1"
 	)
 
@@ -690,7 +690,7 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 func TestActorLifecycleEventDeduplication(t *testing.T) {
 	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
 	const (
-		testJobID       = "aaaabbbb"                         // 4B
+		testJobID       = "aaaabbbb"                             // 4B
 		testActorID     = "aaaabbbb1234aaaabbbb1234" + testJobID // 12B unique + JobID
 		testClusterName = "cluster1"
 	)
@@ -1012,11 +1012,11 @@ func TestMultipleReprocessingCycles(t *testing.T) {
 
 	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
 	const (
-		testJobID       = "aaaabbbb"                                                  // 4B
-		testActorID     = "aaaabbbb1234aaaabbbb1234" + testJobID                          // 12B unique + JobID
-		testTaskID      = "ccccdddd5678cccc" + testActorID                                // 8B unique + ActorID
-		testNodeID      = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
-		testWorkerID    = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff"  // 28B
+		testJobID       = "aaaabbbb"                                                 // 4B
+		testActorID     = "aaaabbbb1234aaaabbbb1234" + testJobID                     // 12B unique + JobID
+		testTaskID      = "ccccdddd5678cccc" + testActorID                           // 8B unique + ActorID
+		testNodeID      = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff" // 28B
+		testWorkerID    = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff" // 28B
 		testClusterName = "cluster1"
 	)
 

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -685,6 +685,8 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 		},
 	}
 
+	const actorID = "AAaaFFff1234"
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewEventHandler(nil)
@@ -692,8 +694,8 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 			// Pre-populate existing events
 			if len(tt.existingEvents) > 0 {
 				actorMap := h.ClusterActorMap.GetOrCreateActorMap("test-cluster")
-				actorMap.CreateOrMergeActor("actor-1", func(a *types.Actor) {
-					a.ActorID = "actor-1"
+				actorMap.CreateOrMergeActor(actorID, func(a *types.Actor) {
+					a.ActorID = actorID
 					a.Events = tt.existingEvents
 					if len(tt.existingEvents) > 0 {
 						a.State = tt.existingEvents[len(tt.existingEvents)-1].State
@@ -702,14 +704,14 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Process the lifecycle event
-			eventMap := makeActorLifecycleEvent("actor-1", tt.newTransitions)
+			eventMap := makeActorLifecycleEvent(actorID, tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
 			// Get the actor and verify
-			actor, found := h.GetActorByID("test-cluster", "actor-1")
+			actor, found := h.GetActorByID("test-cluster", actorID)
 			if !found {
 				t.Fatal("Actor not found after processing")
 			}

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -22,7 +22,6 @@ const (
 	testJobID1       = "ffffaaaa4321"
 	testActorID1     = "aaaabbbb6789"
 	testClusterName1 = "cluster1"
-	testClusterName2 = "cluster2"
 	testTaskName1    = "Name_12345"
 	testTaskName2    = "Name_54321"
 	testBase64ID1    = "AgAAAA=="

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -487,7 +487,7 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 	}
 
 	// Helper to create a TASK_LIFECYCLE_EVENT map
-	makeLifecycleEvent := func(testTaskID string, attempt int, transitions []map[string]any) map[string]any {
+	makeLifecycleEvent := func(transitions []map[string]any) map[string]any {
 		// Convert []map[string]any to []any for proper type assertion in storeEvent
 		transitionsAny := make([]any, len(transitions))
 		for i, t := range transitions {
@@ -498,7 +498,7 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			"clusterName": testClusterName,
 			"taskLifecycleEvent": map[string]any{
 				"taskId":           testTaskID,
-				"taskAttempt":      float64(attempt),
+				"taskAttempt":      0,
 				"stateTransitions": transitionsAny,
 				"nodeId":           testNodeID,
 				"workerId":         testWorkerID,
@@ -650,7 +650,7 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Process the lifecycle event
-			eventMap := makeLifecycleEvent(testTaskID, 0, tt.newTransitions)
+			eventMap := makeLifecycleEvent(tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
@@ -704,7 +704,7 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 	}
 
 	// Helper to create an ACTOR_LIFECYCLE_EVENT map
-	makeActorLifecycleEvent := func(testActorID string, transitions []map[string]any) map[string]any {
+	makeActorLifecycleEvent := func(transitions []map[string]any) map[string]any {
 		// Convert []map[string]any to []any for proper type assertion in storeEvent
 		transitionsAny := make([]any, len(transitions))
 		for i, t := range transitions {
@@ -815,7 +815,7 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Process the lifecycle event
-			eventMap := makeActorLifecycleEvent(testActorID, tt.newTransitions)
+			eventMap := makeActorLifecycleEvent(tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
@@ -856,7 +856,7 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 		}
 	}
 
-	makeDriverJobLifecycleEvent := func(testJobID string, transitions []map[string]any) map[string]any {
+	makeDriverJobLifecycleEvent := func(transitions []map[string]any) map[string]any {
 		transitionsAny := make([]any, len(transitions))
 		for i, t := range transitions {
 			transitionsAny[i] = t
@@ -984,7 +984,7 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 				})
 			}
 
-			eventMap := makeDriverJobLifecycleEvent(testJobID, tt.newTransitions)
+			eventMap := makeDriverJobLifecycleEvent(tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -25,6 +25,16 @@ func makeTaskEventMap(taskName, nodeId, taskID, cluster string, attempt int) map
 }
 
 func TestEventProcessor(t *testing.T) {
+	const TaskID1 = "AAaaFFff1234"
+	const TaskID2 = "BBbbFFff5678"
+	const NodeID1 = "CCccFFff9012"
+	const NodeID2 = "DDddFFff3456"
+
+	const TaskName1 = "Name_12345"
+	const TaskName2 = "Name_54321"
+
+	const ClusterName = "cluster1"
+
 	tests := []struct {
 		name string
 		// Setup
@@ -41,41 +51,41 @@ func TestEventProcessor(t *testing.T) {
 			name: "process multiple events then close channel",
 			eventsToSend: []map[string]any{
 				{
-					"clusterName": "cluster1",
+					"clusterName": ClusterName,
 					"eventType":   "TASK_DEFINITION_EVENT",
 					"taskDefinitionEvent": map[string]any{
-						"taskId":      "ID_12345",
-						"taskName":    "Name_12345",
-						"nodeId":      "Nodeid_12345",
+						"taskId":      TaskID1,
+						"taskName":    TaskName1,
+						"nodeId":      NodeID1,
 						"taskAttempt": 2,
 					},
 				},
 				{
-					"clusterName": "cluster1",
+					"clusterName": ClusterName,
 					"eventType":   "TASK_DEFINITION_EVENT",
 					"taskDefinitionEvent": map[string]any{
-						"taskId":      "ID_54321",
-						"taskName":    "Name_54321",
-						"nodeId":      "Nodeid_54321",
+						"taskId":      TaskID2,
+						"taskName":    TaskName2,
+						"nodeId":      NodeID2,
 						"taskAttempt": 1,
 					},
 				},
 			},
 			closeChan: true,
 			wantStoredEvents: map[string][]types.Task{
-				"ID_12345": {
+				TaskID1: {
 					{
-						TaskID:      "ID_12345",
-						TaskName:    "Name_12345",
-						NodeID:      "Nodeid_12345",
+						TaskID:      TaskID1,
+						TaskName:    TaskName1,
+						NodeID:      NodeID1,
 						TaskAttempt: 2,
 					},
 				},
-				"ID_54321": {
+				TaskID2: {
 					{
-						TaskID:      "ID_54321",
-						TaskName:    "Name_54321",
-						NodeID:      "Nodeid_54321",
+						TaskID:      TaskID2,
+						TaskName:    TaskName2,
+						NodeID:      NodeID2,
 						TaskAttempt: 1,
 					},
 				},
@@ -90,12 +100,12 @@ func TestEventProcessor(t *testing.T) {
 			name: "context canceled",
 			eventsToSend: []map[string]any{
 				{
-					"clusterName": "cluster1",
+					"clusterName": ClusterName,
 					"eventType":   "TASK_DEFINITION_EVENT",
 					"taskDefinitionEvent": map[string]any{
-						"taskId":      "ID_12345",
-						"taskName":    "Name_12345",
-						"nodeId":      "Nodeid_12345",
+						"taskId":      TaskID1,
+						"taskName":    TaskName1,
+						"nodeId":      NodeID1,
 						"taskAttempt": 2,
 					},
 				},
@@ -105,11 +115,11 @@ func TestEventProcessor(t *testing.T) {
 			expectedErrType: context.Canceled,
 			// Event might be processed before cancellation is detected
 			wantStoredEvents: map[string][]types.Task{
-				"ID_12345": {
+				TaskID1: {
 					{
-						TaskID:      "ID_12345",
-						TaskName:    "Name_12345",
-						NodeID:      "Nodeid_12345",
+						TaskID:      TaskID1,
+						TaskName:    TaskName1,
+						NodeID:      NodeID1,
 						TaskAttempt: 2,
 					},
 				},
@@ -170,7 +180,7 @@ func TestEventProcessor(t *testing.T) {
 
 			// Check stored events
 			if tt.wantStoredEvents != nil {
-				if diff := cmp.Diff(tt.wantStoredEvents, h.ClusterTaskMap.ClusterTaskMap["cluster1"].TaskMap); diff != "" {
+				if diff := cmp.Diff(tt.wantStoredEvents, h.ClusterTaskMap.ClusterTaskMap[ClusterName].TaskMap); diff != "" {
 					t.Errorf("storeEventCalls diff (-want +got):\n%s", diff)
 				}
 			}
@@ -179,10 +189,17 @@ func TestEventProcessor(t *testing.T) {
 }
 
 func TestStoreEvent(t *testing.T) {
+	const TaskID1 = "AAaaFFff1234"
+	const TaskID2 = "BBbbFFff5678"
+	const NodeID  = "CCccFFff9012"
+
+	const TaskName = "taskName123"
+	const ClusterName = "cluster1"
+
 	initialTask := types.Task{
-		TaskID:      "taskid1",
-		TaskName:    "taskName123",
-		NodeID:      "nodeid123",
+		TaskID:      TaskID1,
+		TaskName:    TaskName,
+		NodeID:      NodeID,
 		TaskAttempt: 0,
 	}
 	tests := []struct {
@@ -212,16 +229,16 @@ func TestStoreEvent(t *testing.T) {
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: make(map[string]*types.TaskMap),
 			},
-			eventMap:          makeTaskEventMap("taskName123", "nodeid1234", "taskid1", "cluster1", 0),
+			eventMap:          makeTaskEventMap(TaskName, NodeID, TaskID1, ClusterName, 0),
 			wantErr:           false,
 			wantClusterCount:  1,
-			wantTaskInCluster: "cluster1",
-			wantTaskID:        "taskid1",
+			wantTaskInCluster: ClusterName,
+			wantTaskID:        TaskID1,
 			wantTasks: []types.Task{
 				{
-					TaskID:      "taskid1",
-					TaskName:    "taskName123",
-					NodeID:      "nodeid1234",
+					TaskID:      TaskID1,
+					TaskName:    TaskName,
+					NodeID:      NodeID,
 					TaskAttempt: 0,
 				},
 			},
@@ -230,19 +247,19 @@ func TestStoreEvent(t *testing.T) {
 			name: "task event - existing cluster, new task",
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: map[string]*types.TaskMap{
-					"cluster1": types.NewTaskMap(),
+					ClusterName: types.NewTaskMap(),
 				},
 			},
-			eventMap:          makeTaskEventMap("taskName123", "nodeid1234", "taskid2", "cluster1", 1),
+			eventMap:          makeTaskEventMap(TaskName, NodeID, TaskID2, ClusterName, 1),
 			wantErr:           false,
 			wantClusterCount:  1,
-			wantTaskInCluster: "cluster1",
-			wantTaskID:        "taskid2",
+			wantTaskInCluster: ClusterName,
+			wantTaskID:        TaskID2,
 			wantTasks: []types.Task{
 				{
-					TaskID:      "taskid2",
-					TaskName:    "taskName123",
-					NodeID:      "nodeid1234",
+					TaskID:      TaskID2,
+					TaskName:    TaskName,
+					NodeID:      NodeID,
 					TaskAttempt: 1,
 				},
 			},
@@ -251,30 +268,30 @@ func TestStoreEvent(t *testing.T) {
 			name: "task event - existing cluster and existing task with new attempt",
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: map[string]*types.TaskMap{
-					"cluster1": {
+					ClusterName: {
 						TaskMap: map[string][]types.Task{
-							"taskid1": {initialTask},
+							TaskID1: {initialTask},
 						},
 					},
 				},
 			},
-			eventMap:          makeTaskEventMap("taskName123", "nodeid123", "taskid1", "cluster1", 2),
+			eventMap:          makeTaskEventMap(TaskName, NodeID, TaskID1, ClusterName, 2),
 			wantErr:           false,
 			wantClusterCount:  1,
-			wantTaskInCluster: "cluster1",
-			wantTaskID:        "taskid1",
+			wantTaskInCluster: ClusterName,
+			wantTaskID:        TaskID1,
 			// Now expects BOTH attempts to be stored
 			wantTasks: []types.Task{
 				{
-					TaskID:      "taskid1",
-					TaskName:    "taskName123",
-					NodeID:      "nodeid123",
+					TaskID:      TaskID1,
+					TaskName:    TaskName,
+					NodeID:      NodeID,
 					TaskAttempt: 0,
 				},
 				{
-					TaskID:      "taskid1",
-					TaskName:    "taskName123",
-					NodeID:      "nodeid123",
+					TaskID:      TaskID1,
+					TaskName:    TaskName,
+					NodeID:      NodeID,
 					TaskAttempt: 2,
 				},
 			},

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -525,6 +525,8 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 		},
 	}
 
+	const taskID = "AAaaFFff1234"
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewEventHandler(nil)
@@ -532,8 +534,8 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			// Pre-populate existing events if any
 			if len(tt.existingEvents) > 0 {
 				taskMap := h.ClusterTaskMap.GetOrCreateTaskMap("test-cluster")
-				taskMap.CreateOrMergeAttempt("task-1", 0, func(task *types.Task) {
-					task.TaskID = "task-1"
+				taskMap.CreateOrMergeAttempt(taskID, 0, func(task *types.Task) {
+					task.TaskID = taskID
 					task.StateTransitions = tt.existingEvents
 					if len(tt.existingEvents) > 0 {
 						task.State = tt.existingEvents[len(tt.existingEvents)-1].State
@@ -542,7 +544,7 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Process the lifecycle event
-			eventMap := makeLifecycleEvent("task-1", 0, tt.newTransitions)
+			eventMap := makeLifecycleEvent(taskID, 0, tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
@@ -553,7 +555,7 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			taskMap.Lock()
 			defer taskMap.Unlock()
 
-			tasks, exists := taskMap.TaskMap["task-1"]
+			tasks, exists := taskMap.TaskMap[taskID]
 			if !exists || len(tasks) == 0 {
 				t.Fatal("Task not found after processing")
 			}
@@ -897,11 +899,14 @@ func TestMultipleReprocessingCycles(t *testing.T) {
 		map[string]any{"state": "FINISHED", "timestamp": time.Unix(0, 3000).Format(time.RFC3339Nano)},
 	}
 
+	// Use a pure hex task ID so normalizeIDToHex returns it unchanged.
+	const taskID = "AAaaFFff1234"
+
 	eventMap := map[string]any{
 		"eventType":   string(types.TASK_LIFECYCLE_EVENT),
 		"clusterName": "test-cluster",
 		"taskLifecycleEvent": map[string]any{
-			"taskId":           "task-1",
+			"taskId":           taskID,
 			"taskAttempt":      float64(0),
 			"stateTransitions": transitions,
 			"nodeId":           "node-1",
@@ -919,7 +924,7 @@ func TestMultipleReprocessingCycles(t *testing.T) {
 		// Check event count after each cycle
 		taskMap := h.ClusterTaskMap.GetOrCreateTaskMap("test-cluster")
 		taskMap.Lock()
-		tasks := taskMap.TaskMap["task-1"]
+		tasks := taskMap.TaskMap[taskID]
 		eventCount := len(tasks[0].StateTransitions)
 		taskMap.Unlock()
 

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -11,25 +11,9 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
-// ID fixtures follow Ray's ID specification
-// ref: https://github.com/ray-project/ray/blob/f229d5376eb87b09a3fa0b991323450de84df890/src/ray/design_docs/id_specification.md
+// Test fixtures: pure-hex IDs so normalizeIDToHex is identity.
+// Use lowercase to match production hex output and avoid map-key collision.
 const (
-        // Pure-hex IDs to verify normalizeIDToHex is identity.
-        // Use lowercase to match production hex output and avoid map-key collision.
-	testJobID1    = "aaaabbbb"                                                 // 4B hex
-	testActorID1  = "aaaabbbb1234aaaabbbb1234" + testJobID1                    // 12B unique hex prefix
-	testTaskID1   = "ccccdddd5678cccc" + testActorID1                          // 8B unique hex prefix
-	testTaskID2   = "ccccdddd9012dddd" + testActorID1                          // 8B unique hex prefix
-	testNodeID1   = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff" // 28B Node hex ID
-	testNodeID2   = "eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff" // 28B Node hex ID
-	testWorkerID1 = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff" // 28B Worker hex ID
-
-	// Upper and Lower case pairs to verify normalization to lowercase hex
-	testUpperNodeID1 = "AAAABBBB1234AAAABBBB1234AAAABBBB1234AAAABBBB1234AAAABBBB" // 28B Upper Node hex ID
-	testLowerNodeID1 = "aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb" // 28B Lower Node hex ID
-	testUpperTaskID1 = "AAAABBBB5678AAAABBBB5678AAAABBBB5678AAAABBBB5678"         // 24B Upper Task hex ID
-	testLowerTaskID1 = "aaaabbbb5678aaaabbbb5678aaaabbbb5678aaaabbbb5678"         // 24B Lower Task hex ID
-
 	testClusterName1 = "cluster1"
 	testTaskName1    = "Name_12345"
 	testTaskName2    = "Name_54321"
@@ -55,6 +39,19 @@ func makeTaskEventMap(taskName, nodeId, taskID, cluster string, attempt int) map
 }
 
 func TestEventProcessor(t *testing.T) {
+	// IDs follow Ray's ID specification:
+	// ref: https://github.com/ray-project/ray/blob/f229d5376eb87b09a3fa0b991323450de84df890/src/ray/design_docs/id_specification.md
+	// Sizes: JobID=4B, ActorID=12B unique+JobID (16B), TaskID=8B unique+ActorID (24B), NodeID/WorkerID=28B
+	const (
+		// Pure-hex IDs to verify normalizeIDToHex is identity.
+        // Use lowercase to match production hex output and avoid map-key collision.
+		jobID   = "aaaabbbb"                                                  // 4B
+		actorID = "aaaabbbb1234aaaabbbb1234" + jobID                          // 12B unique + JobID
+		taskID1 = "ccccdddd5678cccc" + actorID                                // 8B unique + ActorID
+		taskID2 = "ccccdddd9012dddd" + actorID                                // 8B unique + ActorID
+		nodeID1 = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
+		nodeID2 = "eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff"  // 28B
+	)
 	tests := []struct {
 		name string
 		// Setup
@@ -74,9 +71,9 @@ func TestEventProcessor(t *testing.T) {
 					"clusterName": testClusterName1,
 					"eventType":   "TASK_DEFINITION_EVENT",
 					"taskDefinitionEvent": map[string]any{
-						"taskId":      testTaskID1,
+						"taskId":      taskID1,
 						"taskName":    testTaskName1,
-						"nodeId":      testNodeID1,
+						"nodeId":      nodeID1,
 						"taskAttempt": 2,
 					},
 				},
@@ -84,28 +81,28 @@ func TestEventProcessor(t *testing.T) {
 					"clusterName": testClusterName1,
 					"eventType":   "TASK_DEFINITION_EVENT",
 					"taskDefinitionEvent": map[string]any{
-						"taskId":      testTaskID2,
+						"taskId":      taskID2,
 						"taskName":    testTaskName2,
-						"nodeId":      testNodeID2,
+						"nodeId":      nodeID2,
 						"taskAttempt": 1,
 					},
 				},
 			},
 			closeChan: true,
 			wantStoredEvents: map[string][]types.Task{
-				testTaskID1: {
+				taskID1: {
 					{
-						TaskID:      testTaskID1,
+						TaskID:      taskID1,
 						TaskName:    testTaskName1,
-						NodeID:      testNodeID1,
+						NodeID:      nodeID1,
 						TaskAttempt: 2,
 					},
 				},
-				testTaskID2: {
+				taskID2: {
 					{
-						TaskID:      testTaskID2,
+						TaskID:      taskID2,
 						TaskName:    testTaskName2,
-						NodeID:      testNodeID2,
+						NodeID:      nodeID2,
 						TaskAttempt: 1,
 					},
 				},
@@ -123,9 +120,9 @@ func TestEventProcessor(t *testing.T) {
 					"clusterName": testClusterName1,
 					"eventType":   "TASK_DEFINITION_EVENT",
 					"taskDefinitionEvent": map[string]any{
-						"taskId":      testTaskID1,
+						"taskId":      taskID1,
 						"taskName":    testTaskName1,
-						"nodeId":      testNodeID1,
+						"nodeId":      nodeID1,
 						"taskAttempt": 2,
 					},
 				},
@@ -135,11 +132,11 @@ func TestEventProcessor(t *testing.T) {
 			expectedErrType: context.Canceled,
 			// Event might be processed before cancellation is detected
 			wantStoredEvents: map[string][]types.Task{
-				testTaskID1: {
+				taskID1: {
 					{
-						TaskID:      testTaskID1,
+						TaskID:      taskID1,
 						TaskName:    testTaskName1,
-						NodeID:      testNodeID1,
+						NodeID:      nodeID1,
 						TaskAttempt: 2,
 					},
 				},
@@ -209,10 +206,23 @@ func TestEventProcessor(t *testing.T) {
 }
 
 func TestStoreEvent(t *testing.T) {
+	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
+	const (
+		jobID        = "aaaabbbb"                                                  // 4B
+		actorID      = "aaaabbbb1234aaaabbbb1234" + jobID                          // 12B unique + JobID
+		taskID1      = "ccccdddd5678cccc" + actorID                                // 8B unique + ActorID
+		taskID2      = "ccccdddd9012dddd" + actorID                                // 8B unique + ActorID
+		nodeID1      = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
+		nodeID2      = "eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff"  // 28B
+		upperNodeID1 = "AAAABBBB1234AAAABBBB1234AAAABBBB1234AAAABBBB1234AAAABBBB" // 28B uppercase
+		lowerNodeID1 = "aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb" // 28B lowercase
+		upperTaskID1 = "AAAABBBB5678AAAABBBB5678AAAABBBB5678AAAABBBB5678"         // 24B uppercase
+		lowerTaskID1 = "aaaabbbb5678aaaabbbb5678aaaabbbb5678aaaabbbb5678"         // 24B lowercase
+	)
 	initialTask := types.Task{
-		TaskID:      testTaskID1,
+		TaskID:      taskID1,
 		TaskName:    testTaskName1,
-		NodeID:      testNodeID1,
+		NodeID:      nodeID1,
 		TaskAttempt: 0,
 	}
 	tests := []struct {
@@ -242,16 +252,16 @@ func TestStoreEvent(t *testing.T) {
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: make(map[string]*types.TaskMap),
 			},
-			eventMap:          makeTaskEventMap(testTaskName1, testNodeID1, testTaskID1, testClusterName1, 0),
+			eventMap:          makeTaskEventMap(testTaskName1, nodeID1, taskID1, testClusterName1, 0),
 			wantErr:           false,
 			wantClusterCount:  1,
 			wantTaskInCluster: testClusterName1,
-			wantTaskID:        testTaskID1,
+			wantTaskID:        taskID1,
 			wantTasks: []types.Task{
 				{
-					TaskID:      testTaskID1,
+					TaskID:      taskID1,
 					TaskName:    testTaskName1,
-					NodeID:      testNodeID1,
+					NodeID:      nodeID1,
 					TaskAttempt: 0,
 				},
 			},
@@ -263,16 +273,16 @@ func TestStoreEvent(t *testing.T) {
 					testClusterName1: types.NewTaskMap(),
 				},
 			},
-			eventMap:          makeTaskEventMap(testTaskName2, testNodeID2, testTaskID2, testClusterName1, 1),
+			eventMap:          makeTaskEventMap(testTaskName2, nodeID2, taskID2, testClusterName1, 1),
 			wantErr:           false,
 			wantClusterCount:  1,
 			wantTaskInCluster: testClusterName1,
-			wantTaskID:        testTaskID2,
+			wantTaskID:        taskID2,
 			wantTasks: []types.Task{
 				{
-					TaskID:      testTaskID2,
+					TaskID:      taskID2,
 					TaskName:    testTaskName2,
-					NodeID:      testNodeID2,
+					NodeID:      nodeID2,
 					TaskAttempt: 1,
 				},
 			},
@@ -283,28 +293,28 @@ func TestStoreEvent(t *testing.T) {
 				ClusterTaskMap: map[string]*types.TaskMap{
 					testClusterName1: {
 						TaskMap: map[string][]types.Task{
-							testTaskID1: {initialTask},
+							taskID1: {initialTask},
 						},
 					},
 				},
 			},
-			eventMap:          makeTaskEventMap(testTaskName1, testNodeID1, testTaskID1, testClusterName1, 2),
+			eventMap:          makeTaskEventMap(testTaskName1, nodeID1, taskID1, testClusterName1, 2),
 			wantErr:           false,
 			wantClusterCount:  1,
 			wantTaskInCluster: testClusterName1,
-			wantTaskID:        testTaskID1,
+			wantTaskID:        taskID1,
 			// Now expects BOTH attempts to be stored
 			wantTasks: []types.Task{
 				{
-					TaskID:      testTaskID1,
+					TaskID:      taskID1,
 					TaskName:    testTaskName1,
-					NodeID:      testNodeID1,
+					NodeID:      nodeID1,
 					TaskAttempt: 0,
 				},
 				{
-					TaskID:      testTaskID1,
+					TaskID:      taskID1,
 					TaskName:    testTaskName1,
-					NodeID:      testNodeID1,
+					NodeID:      nodeID1,
 					TaskAttempt: 2,
 				},
 			},
@@ -333,16 +343,16 @@ func TestStoreEvent(t *testing.T) {
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: make(map[string]*types.TaskMap),
 			},
-			eventMap:          makeTaskEventMap(testTaskName1, testUpperNodeID1, testUpperTaskID1, testClusterName1, 0),
+			eventMap:          makeTaskEventMap(testTaskName1, upperNodeID1, upperTaskID1, testClusterName1, 0),
 			wantErr:           false,
 			wantClusterCount:  1,
 			wantTaskInCluster: testClusterName1,
-			wantTaskID:        testLowerTaskID1,
+			wantTaskID:        lowerTaskID1,
 			wantTasks: []types.Task{
 				{
-					TaskID:      testLowerTaskID1,
+					TaskID:      lowerTaskID1,
 					TaskName:    testTaskName1,
-					NodeID:      testLowerNodeID1,
+					NodeID:      lowerNodeID1,
 					TaskAttempt: 0,
 				},
 			},
@@ -352,16 +362,16 @@ func TestStoreEvent(t *testing.T) {
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: make(map[string]*types.TaskMap),
 			},
-			eventMap:          makeTaskEventMap(testTaskName1, testLowerNodeID1, testLowerTaskID1, testClusterName1, 0),
+			eventMap:          makeTaskEventMap(testTaskName1, lowerNodeID1, lowerTaskID1, testClusterName1, 0),
 			wantErr:           false,
 			wantClusterCount:  1,
 			wantTaskInCluster: testClusterName1,
-			wantTaskID:        testLowerTaskID1,
+			wantTaskID:        lowerTaskID1,
 			wantTasks: []types.Task{
 				{
-					TaskID:      testLowerTaskID1,
+					TaskID:      lowerTaskID1,
 					TaskName:    testTaskName1,
-					NodeID:      testLowerNodeID1,
+					NodeID:      lowerNodeID1,
 					TaskAttempt: 0,
 				},
 			},
@@ -457,6 +467,15 @@ func TestStoreEvent(t *testing.T) {
 // TestTaskLifecycleEventDeduplication verifies that duplicate events are correctly filtered
 // and out-of-order events are properly sorted
 func TestTaskLifecycleEventDeduplication(t *testing.T) {
+	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
+	const (
+		jobID    = "aaaabbbb"                                                  // 4B
+		actorID  = "aaaabbbb1234aaaabbbb1234" + jobID                          // 12B unique + JobID
+		taskID   = "ccccdddd5678cccc" + actorID                                // 8B unique + ActorID
+		nodeID   = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
+		workerID = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff"  // 28B
+	)
+
 	// Helper to create a StateEvent
 	makeStateEvent := func(state types.TaskStatus, timestampNano int64) types.TaskStateTransition {
 		return types.TaskStateTransition{
@@ -479,8 +498,8 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 				"taskId":           taskID,
 				"taskAttempt":      float64(attempt),
 				"stateTransitions": transitionsAny,
-				"nodeId":           testNodeID1,
-				"workerId":         testWorkerID1,
+				"nodeId":           nodeID,
+				"workerId":         workerID,
 			},
 		}
 	}
@@ -619,8 +638,8 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			// Pre-populate existing events if any
 			if len(tt.existingEvents) > 0 {
 				taskMap := h.ClusterTaskMap.GetOrCreateTaskMap(testClusterName1)
-				taskMap.CreateOrMergeAttempt(testTaskID1, 0, func(task *types.Task) {
-					task.TaskID = testTaskID1
+				taskMap.CreateOrMergeAttempt(taskID, 0, func(task *types.Task) {
+					task.TaskID = taskID
 					task.StateTransitions = tt.existingEvents
 					if len(tt.existingEvents) > 0 {
 						task.State = tt.existingEvents[len(tt.existingEvents)-1].State
@@ -629,7 +648,7 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Process the lifecycle event
-			eventMap := makeLifecycleEvent(testTaskID1, 0, tt.newTransitions)
+			eventMap := makeLifecycleEvent(taskID, 0, tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
@@ -640,7 +659,7 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			taskMap.Lock()
 			defer taskMap.Unlock()
 
-			tasks, exists := taskMap.TaskMap[testTaskID1]
+			tasks, exists := taskMap.TaskMap[taskID]
 			if !exists || len(tasks) == 0 {
 				t.Fatal("Task not found after processing")
 			}
@@ -770,6 +789,12 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 		},
 	}
 
+	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
+	const (
+		jobID   = "aaaabbbb"                          // 4B
+		actorID = "aaaabbbb1234aaaabbbb1234" + jobID  // 12B unique + JobID
+	)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewEventHandler(nil)
@@ -777,8 +802,8 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 			// Pre-populate existing events
 			if len(tt.existingEvents) > 0 {
 				actorMap := h.ClusterActorMap.GetOrCreateActorMap(testClusterName1)
-				actorMap.CreateOrMergeActor(testActorID1, func(a *types.Actor) {
-					a.ActorID = testActorID1
+				actorMap.CreateOrMergeActor(actorID, func(a *types.Actor) {
+					a.ActorID = actorID
 					a.Events = tt.existingEvents
 					if len(tt.existingEvents) > 0 {
 						a.State = tt.existingEvents[len(tt.existingEvents)-1].State
@@ -787,14 +812,14 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Process the lifecycle event
-			eventMap := makeActorLifecycleEvent(testActorID1, tt.newTransitions)
+			eventMap := makeActorLifecycleEvent(actorID, tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
 			// Get the actor and verify
-			actor, found := h.GetActorByID(testClusterName1, testActorID1)
+			actor, found := h.GetActorByID(testClusterName1, actorID)
 			if !found {
 				t.Fatal("Actor not found after processing")
 			}
@@ -935,14 +960,17 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 		},
 	}
 
+	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
+	const jobID = "aaaabbbb" // 4B
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewEventHandler(nil)
 
 			if len(tt.existingTransitions) > 0 {
 				jobMap := h.ClusterJobMap.GetOrCreateJobMap(testClusterName1)
-				jobMap.CreateOrMergeJob(testJobID1, func(job *types.Job) {
-					job.JobID = testJobID1
+				jobMap.CreateOrMergeJob(jobID, func(job *types.Job) {
+					job.JobID = jobID
 					job.StateTransitions = tt.existingTransitions
 					if len(tt.existingTransitions) > 0 {
 						job.State = tt.existingTransitions[len(tt.existingTransitions)-1].State
@@ -950,13 +978,13 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 				})
 			}
 
-			eventMap := makeDriverJobLifecycleEvent(testJobID1, tt.newTransitions)
+			eventMap := makeDriverJobLifecycleEvent(jobID, tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
-			job, exists := h.GetJobByJobID(testClusterName1, testJobID1)
+			job, exists := h.GetJobByJobID(testClusterName1, jobID)
 			if !exists {
 				t.Fatal("Job not found after processing")
 			}
@@ -976,6 +1004,15 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 func TestMultipleReprocessingCycles(t *testing.T) {
 	h := NewEventHandler(nil)
 
+	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
+	const (
+		jobID    = "aaaabbbb"                                                  // 4B
+		actorID  = "aaaabbbb1234aaaabbbb1234" + jobID                          // 12B unique + JobID
+		taskID   = "ccccdddd5678cccc" + actorID                                // 8B unique + ActorID
+		nodeID   = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
+		workerID = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff"  // 28B
+	)
+
 	// The same events that would be in an event file
 	// Use []any to match what storeEvent expects from JSON parsing
 	transitions := []any{
@@ -988,11 +1025,11 @@ func TestMultipleReprocessingCycles(t *testing.T) {
 		"eventType":   string(types.TASK_LIFECYCLE_EVENT),
 		"clusterName": testClusterName1,
 		"taskLifecycleEvent": map[string]any{
-			"taskId":           testTaskID1,
+			"taskId":           taskID,
 			"taskAttempt":      float64(0),
 			"stateTransitions": transitions,
-			"nodeId":           testNodeID1,
-			"workerId":         testWorkerID1,
+			"nodeId":           nodeID,
+			"workerId":         workerID,
 		},
 	}
 
@@ -1006,7 +1043,7 @@ func TestMultipleReprocessingCycles(t *testing.T) {
 		// Check event count after each cycle
 		taskMap := h.ClusterTaskMap.GetOrCreateTaskMap(testClusterName1)
 		taskMap.Lock()
-		tasks := taskMap.TaskMap[testTaskID1]
+		tasks := taskMap.TaskMap[taskID]
 		eventCount := len(tasks[0].StateTransitions)
 		taskMap.Unlock()
 

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -221,7 +221,7 @@ func TestStoreEvent(t *testing.T) {
 			},
 			eventMap: map[string]any{
 				"eventType":   "UNKNOWN_TYPE",
-				"clusterName": "c1",
+				"clusterName": testClusterName1,
 			},
 			wantErr:          false,
 			wantClusterCount: 0,
@@ -231,7 +231,7 @@ func TestStoreEvent(t *testing.T) {
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: make(map[string]*types.TaskMap),
 			},
-			eventMap:          makeTaskEventMap(testTaskName1, testNodeID1, testTaskID1, "cluster1", 0),
+			eventMap:          makeTaskEventMap(testTaskName1, testNodeID1, testTaskID1, testClusterName1, 0),
 			wantErr:           false,
 			wantClusterCount:  1,
 			wantTaskInCluster: testClusterName1,

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -28,6 +28,10 @@ const (
 	testBase64ID2    = "AwAAAA=="
 	testHexID1       = "02000000" // hex for base64 "AgAAAA=="
 	testHexID2       = "03000000" // hex for base64 "AwAAAA=="
+	testUpperHexID1  = "ABCDEF01"
+	testUpperHexID2  = "ABCDEF02"
+	testLowerHexID1  = "abcdef01"
+	testLowerHexID2  = "abcdef02"
 )
 
 func makeTaskEventMap(taskName, nodeId, taskID, cluster string, attempt int) map[string]any {
@@ -313,6 +317,44 @@ func TestStoreEvent(t *testing.T) {
 					TaskID:      testHexID2,
 					TaskName:    testTaskName1,
 					NodeID:      testHexID1,
+					TaskAttempt: 0,
+				},
+			},
+		},
+		{
+			name: "task event - uppercase hex IDs normalized to lowercase",
+			initialState: &types.ClusterTaskMap{
+				ClusterTaskMap: make(map[string]*types.TaskMap),
+			},
+			eventMap:          makeTaskEventMap(testTaskName1, testUpperHexID1, testUpperHexID2, testClusterName1, 0),
+			wantErr:           false,
+			wantClusterCount:  1,
+			wantTaskInCluster: testClusterName1,
+			wantTaskID:        testLowerHexID2,
+			wantTasks: []types.Task{
+				{
+					TaskID:      testLowerHexID2,
+					TaskName:    testTaskName1,
+					NodeID:      testLowerHexID1,
+					TaskAttempt: 0,
+				},
+			},
+		},
+		{
+			name: "task event - lowercase hex IDs are returned as-is",
+			initialState: &types.ClusterTaskMap{
+				ClusterTaskMap: make(map[string]*types.TaskMap),
+			},
+			eventMap:          makeTaskEventMap(testTaskName1, testLowerHexID1, testLowerHexID2, testClusterName1, 0),
+			wantErr:           false,
+			wantClusterCount:  1,
+			wantTaskInCluster: testClusterName1,
+			wantTaskID:        testLowerHexID2,
+			wantTasks: []types.Task{
+				{
+					TaskID:      testLowerHexID2,
+					TaskName:    testTaskName1,
+					NodeID:      testLowerHexID1,
 					TaskAttempt: 0,
 				},
 			},

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -14,17 +14,21 @@ import (
 // Test fixtures: pure-hex IDs so normalizeIDToHex is identity.
 // Use lowercase to match production hex output and avoid map-key collision.
 const (
-    testTaskID1      = "aaaaffff1234"
-    testTaskID2      = "bbbbffff5678"
-    testNodeID1      = "ccccffff9012"
-    testNodeID2      = "ddddffff3456"
+	testTaskID1      = "aaaaffff1234"
+	testTaskID2      = "bbbbffff5678"
+	testNodeID1      = "ccccffff9012"
+	testNodeID2      = "ddddffff3456"
 	testWorkerID1    = "eeeeffff7890"
 	testJobID1       = "ffffaaaa4321"
-    testActorID1     = "aaaabbbb6789"
-    testClusterName1 = "cluster1"
+	testActorID1     = "aaaabbbb6789"
+	testClusterName1 = "cluster1"
 	testClusterName2 = "cluster2"
-    testTaskName1    = "Name_12345"
-    testTaskName2    = "Name_54321"
+	testTaskName1    = "Name_12345"
+	testTaskName2    = "Name_54321"
+	testBase64ID1    = "AgAAAA=="
+	testBase64ID2    = "AwAAAA=="
+	testHexID1       = "02000000"
+	testHexID2       = "03000000"
 )
 
 func makeTaskEventMap(taskName, nodeId, taskID, cluster string, attempt int) map[string]any {
@@ -292,6 +296,25 @@ func TestStoreEvent(t *testing.T) {
 					TaskName:    testTaskName1,
 					NodeID:      testNodeID1,
 					TaskAttempt: 2,
+				},
+			},
+		},
+		{
+			name: "task event - base64 ID is normalized to hex",
+			initialState: &types.ClusterTaskMap{
+				ClusterTaskMap: make(map[string]*types.TaskMap),
+			},
+			eventMap:          makeTaskEventMap(testTaskName1, testBase64ID1, testBase64ID2, testClusterName1, 0),
+			wantErr:           false,
+			wantClusterCount:  1,
+			wantTaskInCluster: testClusterName1,
+			wantTaskID:        testHexID2,
+			wantTasks: []types.Task{
+				{
+					TaskID:      testHexID2,
+					TaskName:    testTaskName1,
+					NodeID:      testHexID1,
+					TaskAttempt: 0,
 				},
 			},
 		},

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
-// Test fixtures: pure-hex IDs so normalizeIDToHex is identity.
-// Use lowercase to match production hex output and avoid map-key collision.
 // ID fixtures follow Ray's ID specification
 // ref: https://github.com/ray-project/ray/blob/f229d5376eb87b09a3fa0b991323450de84df890/src/ray/design_docs/id_specification.md
 const (
+        // Pure-hex IDs to verify normalizeIDToHex is identity.
+        // Use lowercase to match production hex output and avoid map-key collision.
 	testJobID1    = "aaaabbbb"                                                 // 4B hex
 	testActorID1  = "aaaabbbb1234aaaabbbb1234" + testJobID1                    // 12B unique hex prefix
 	testTaskID1   = "ccccdddd5678cccc" + testActorID1                          // 8B unique hex prefix

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
-func makeTaskEventMap(taskName, nodeId, testTaskID, cluster string, attempt int) map[string]any {
+func makeTaskEventMap(taskName, nodeID, taskID, cluster string, attempt int) map[string]any {
 	return map[string]any{
 		"eventType":   string(types.TASK_DEFINITION_EVENT),
 		"clusterName": cluster,
 		"taskDefinitionEvent": map[string]any{
-			"taskId":      testTaskID,
+			"taskId":      taskID,
 			"taskName":    taskName,
-			"nodeId":      nodeId,
+			"nodeId":      nodeID,
 			"taskAttempt": attempt,
 		},
 	}

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -26,8 +26,8 @@ const (
 	testTaskName2    = "Name_54321"
 	testBase64ID1    = "AgAAAA=="
 	testBase64ID2    = "AwAAAA=="
-	testHexID1       = "02000000"
-	testHexID2       = "03000000"
+	testHexID1       = "02000000" // hex for base64 "AgAAAA=="
+	testHexID2       = "03000000" // hex for base64 "AwAAAA=="
 )
 
 func makeTaskEventMap(taskName, nodeId, taskID, cluster string, attempt int) map[string]any {

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -11,20 +11,12 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
-// Test fixtures: pure-hex IDs so normalizeIDToHex is identity.
-// Use lowercase to match production hex output and avoid map-key collision.
-const (
-	testClusterName1 = "cluster1"
-	testTaskName1    = "Name_12345"
-	testTaskName2    = "Name_54321"
-)
-
-func makeTaskEventMap(taskName, nodeId, taskID, cluster string, attempt int) map[string]any {
+func makeTaskEventMap(taskName, nodeId, testTaskID, cluster string, attempt int) map[string]any {
 	return map[string]any{
 		"eventType":   string(types.TASK_DEFINITION_EVENT),
 		"clusterName": cluster,
 		"taskDefinitionEvent": map[string]any{
-			"taskId":      taskID,
+			"taskId":      testTaskID,
 			"taskName":    taskName,
 			"nodeId":      nodeId,
 			"taskAttempt": attempt,
@@ -39,12 +31,16 @@ func TestEventProcessor(t *testing.T) {
 	const (
 		// Pure-hex IDs to verify normalizeIDToHex is identity.
         // Use lowercase to match production hex output and avoid map-key collision.
-		jobID   = "aaaabbbb"                                                  // 4B
-		actorID = "aaaabbbb1234aaaabbbb1234" + jobID                          // 12B unique + JobID
-		taskID1 = "ccccdddd5678cccc" + actorID                                // 8B unique + ActorID
-		taskID2 = "ccccdddd9012dddd" + actorID                                // 8B unique + ActorID
-		nodeID1 = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
-		nodeID2 = "eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff"  // 28B
+		testJobID       = "aaaabbbb"                                                  // 4B
+		testActorID     = "aaaabbbb1234aaaabbbb1234" + testJobID                          // 12B unique + JobID
+		testTaskID1     = "ccccdddd5678cccc" + testActorID                                // 8B unique + ActorID
+		testTaskID2     = "ccccdddd9012dddd" + testActorID                                // 8B unique + ActorID
+		testNodeID1     = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
+		testNodeID2     = "eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff"  // 28B
+
+		testClusterName = "cluster1"
+		testTaskName1   = "Name_12345"
+		testTaskName2   = "Name_54321"
 	)
 	tests := []struct {
 		name string
@@ -62,41 +58,41 @@ func TestEventProcessor(t *testing.T) {
 			name: "process multiple events then close channel",
 			eventsToSend: []map[string]any{
 				{
-					"clusterName": testClusterName1,
+					"clusterName": testClusterName,
 					"eventType":   "TASK_DEFINITION_EVENT",
 					"taskDefinitionEvent": map[string]any{
-						"taskId":      taskID1,
+						"taskId":      testTaskID1,
 						"taskName":    testTaskName1,
-						"nodeId":      nodeID1,
+						"nodeId":      testNodeID1,
 						"taskAttempt": 2,
 					},
 				},
 				{
-					"clusterName": testClusterName1,
+					"clusterName": testClusterName,
 					"eventType":   "TASK_DEFINITION_EVENT",
 					"taskDefinitionEvent": map[string]any{
-						"taskId":      taskID2,
+						"taskId":      testTaskID2,
 						"taskName":    testTaskName2,
-						"nodeId":      nodeID2,
+						"nodeId":      testNodeID2,
 						"taskAttempt": 1,
 					},
 				},
 			},
 			closeChan: true,
 			wantStoredEvents: map[string][]types.Task{
-				taskID1: {
+				testTaskID1: {
 					{
-						TaskID:      taskID1,
+						TaskID:      testTaskID1,
 						TaskName:    testTaskName1,
-						NodeID:      nodeID1,
+						NodeID:      testNodeID1,
 						TaskAttempt: 2,
 					},
 				},
-				taskID2: {
+				testTaskID2: {
 					{
-						TaskID:      taskID2,
+						TaskID:      testTaskID2,
 						TaskName:    testTaskName2,
-						NodeID:      nodeID2,
+						NodeID:      testNodeID2,
 						TaskAttempt: 1,
 					},
 				},
@@ -111,12 +107,12 @@ func TestEventProcessor(t *testing.T) {
 			name: "context canceled",
 			eventsToSend: []map[string]any{
 				{
-					"clusterName": testClusterName1,
+					"clusterName": testClusterName,
 					"eventType":   "TASK_DEFINITION_EVENT",
 					"taskDefinitionEvent": map[string]any{
-						"taskId":      taskID1,
+						"taskId":      testTaskID1,
 						"taskName":    testTaskName1,
-						"nodeId":      nodeID1,
+						"nodeId":      testNodeID1,
 						"taskAttempt": 2,
 					},
 				},
@@ -126,11 +122,11 @@ func TestEventProcessor(t *testing.T) {
 			expectedErrType: context.Canceled,
 			// Event might be processed before cancellation is detected
 			wantStoredEvents: map[string][]types.Task{
-				taskID1: {
+				testTaskID1: {
 					{
-						TaskID:      taskID1,
+						TaskID:      testTaskID1,
 						TaskName:    testTaskName1,
-						NodeID:      nodeID1,
+						NodeID:      testNodeID1,
 						TaskAttempt: 2,
 					},
 				},
@@ -191,7 +187,7 @@ func TestEventProcessor(t *testing.T) {
 
 			// Check stored events
 			if tt.wantStoredEvents != nil {
-				if diff := cmp.Diff(tt.wantStoredEvents, h.ClusterTaskMap.ClusterTaskMap[testClusterName1].TaskMap); diff != "" {
+				if diff := cmp.Diff(tt.wantStoredEvents, h.ClusterTaskMap.ClusterTaskMap[testClusterName].TaskMap); diff != "" {
 					t.Errorf("storeEventCalls diff (-want +got):\n%s", diff)
 				}
 			}
@@ -202,28 +198,32 @@ func TestEventProcessor(t *testing.T) {
 func TestStoreEvent(t *testing.T) {
 	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
 	const (
-		jobID        = "aaaabbbb"                                                  // 4B
-		actorID      = "aaaabbbb1234aaaabbbb1234" + jobID                          // 12B unique + JobID
-		taskID1      = "ccccdddd5678cccc" + actorID                                // 8B unique + ActorID
-		taskID2      = "ccccdddd9012dddd" + actorID                                // 8B unique + ActorID
-		nodeID1      = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
-		nodeID2      = "eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff"  // 28B
-		upperNodeID1 = "AAAABBBB1234AAAABBBB1234AAAABBBB1234AAAABBBB1234AAAABBBB" // 28B uppercase
-		lowerNodeID1 = "aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb" // 28B lowercase
-		upperTaskID1 = "AAAABBBB5678AAAABBBB5678AAAABBBB5678AAAABBBB5678"         // 24B uppercase
-		lowerTaskID1 = "aaaabbbb5678aaaabbbb5678aaaabbbb5678aaaabbbb5678"         // 24B lowercase
+		testJobID        = "aaaabbbb"                                                  // 4B
+		testActorID      = "aaaabbbb1234aaaabbbb1234" + testJobID                          // 12B unique + JobID
+		testTaskID1      = "ccccdddd5678cccc" + testActorID                                // 8B unique + ActorID
+		testTaskID2      = "ccccdddd9012dddd" + testActorID                                // 8B unique + ActorID
+		testNodeID1      = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
+		testNodeID2      = "eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff"  // 28B
+		testUpperNodeID1 = "AAAABBBB1234AAAABBBB1234AAAABBBB1234AAAABBBB1234AAAABBBB" // 28B uppercase
+		testLowerNodeID1 = "aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb" // 28B lowercase
+		testUpperTaskID1 = "AAAABBBB5678AAAABBBB5678AAAABBBB5678AAAABBBB5678"         // 24B uppercase
+		testLowerTaskID1 = "aaaabbbb5678aaaabbbb5678aaaabbbb5678aaaabbbb5678"         // 24B lowercase
 
 		// Base64 and Hex pairs to verify normalization of base64 to hex
 		testBase64ID1 = "AgAAAA=="
 		testBase64ID2 = "AwAAAA=="
 		testHexID1    = "02000000" // hex for base64 "AgAAAA=="
 		testHexID2    = "03000000" // hex for base64 "AwAAAA=="
+
+		testClusterName = "cluster1"
+		testTaskName1   = "Name_12345"
+		testTaskName2   = "Name_54321"
 	)
 
 	initialTask := types.Task{
-		TaskID:      taskID1,
+		TaskID:      testTaskID1,
 		TaskName:    testTaskName1,
-		NodeID:      nodeID1,
+		NodeID:      testNodeID1,
 		TaskAttempt: 0,
 	}
 	tests := []struct {
@@ -243,7 +243,7 @@ func TestStoreEvent(t *testing.T) {
 			},
 			eventMap: map[string]any{
 				"eventType":   "UNKNOWN_TYPE",
-				"clusterName": testClusterName1,
+				"clusterName": testClusterName,
 			},
 			wantErr:          false,
 			wantClusterCount: 0,
@@ -253,16 +253,16 @@ func TestStoreEvent(t *testing.T) {
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: make(map[string]*types.TaskMap),
 			},
-			eventMap:          makeTaskEventMap(testTaskName1, nodeID1, taskID1, testClusterName1, 0),
+			eventMap:          makeTaskEventMap(testTaskName1, testNodeID1, testTaskID1, testClusterName, 0),
 			wantErr:           false,
 			wantClusterCount:  1,
-			wantTaskInCluster: testClusterName1,
-			wantTaskID:        taskID1,
+			wantTaskInCluster: testClusterName,
+			wantTaskID:        testTaskID1,
 			wantTasks: []types.Task{
 				{
-					TaskID:      taskID1,
+					TaskID:      testTaskID1,
 					TaskName:    testTaskName1,
-					NodeID:      nodeID1,
+					NodeID:      testNodeID1,
 					TaskAttempt: 0,
 				},
 			},
@@ -271,19 +271,19 @@ func TestStoreEvent(t *testing.T) {
 			name: "task event - existing cluster, new task",
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: map[string]*types.TaskMap{
-					testClusterName1: types.NewTaskMap(),
+					testClusterName: types.NewTaskMap(),
 				},
 			},
-			eventMap:          makeTaskEventMap(testTaskName2, nodeID2, taskID2, testClusterName1, 1),
+			eventMap:          makeTaskEventMap(testTaskName2, testNodeID2, testTaskID2, testClusterName, 1),
 			wantErr:           false,
 			wantClusterCount:  1,
-			wantTaskInCluster: testClusterName1,
-			wantTaskID:        taskID2,
+			wantTaskInCluster: testClusterName,
+			wantTaskID:        testTaskID2,
 			wantTasks: []types.Task{
 				{
-					TaskID:      taskID2,
+					TaskID:      testTaskID2,
 					TaskName:    testTaskName2,
-					NodeID:      nodeID2,
+					NodeID:      testNodeID2,
 					TaskAttempt: 1,
 				},
 			},
@@ -292,30 +292,30 @@ func TestStoreEvent(t *testing.T) {
 			name: "task event - existing cluster and existing task with new attempt",
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: map[string]*types.TaskMap{
-					testClusterName1: {
+					testClusterName: {
 						TaskMap: map[string][]types.Task{
-							taskID1: {initialTask},
+							testTaskID1: {initialTask},
 						},
 					},
 				},
 			},
-			eventMap:          makeTaskEventMap(testTaskName1, nodeID1, taskID1, testClusterName1, 2),
+			eventMap:          makeTaskEventMap(testTaskName1, testNodeID1, testTaskID1, testClusterName, 2),
 			wantErr:           false,
 			wantClusterCount:  1,
-			wantTaskInCluster: testClusterName1,
-			wantTaskID:        taskID1,
+			wantTaskInCluster: testClusterName,
+			wantTaskID:        testTaskID1,
 			// Now expects BOTH attempts to be stored
 			wantTasks: []types.Task{
 				{
-					TaskID:      taskID1,
+					TaskID:      testTaskID1,
 					TaskName:    testTaskName1,
-					NodeID:      nodeID1,
+					NodeID:      testNodeID1,
 					TaskAttempt: 0,
 				},
 				{
-					TaskID:      taskID1,
+					TaskID:      testTaskID1,
 					TaskName:    testTaskName1,
-					NodeID:      nodeID1,
+					NodeID:      testNodeID1,
 					TaskAttempt: 2,
 				},
 			},
@@ -325,10 +325,10 @@ func TestStoreEvent(t *testing.T) {
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: make(map[string]*types.TaskMap),
 			},
-			eventMap:          makeTaskEventMap(testTaskName1, testBase64ID1, testBase64ID2, testClusterName1, 0),
+			eventMap:          makeTaskEventMap(testTaskName1, testBase64ID1, testBase64ID2, testClusterName, 0),
 			wantErr:           false,
 			wantClusterCount:  1,
-			wantTaskInCluster: testClusterName1,
+			wantTaskInCluster: testClusterName,
 			wantTaskID:        testHexID2,
 			wantTasks: []types.Task{
 				{
@@ -344,16 +344,16 @@ func TestStoreEvent(t *testing.T) {
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: make(map[string]*types.TaskMap),
 			},
-			eventMap:          makeTaskEventMap(testTaskName1, upperNodeID1, upperTaskID1, testClusterName1, 0),
+			eventMap:          makeTaskEventMap(testTaskName1, testUpperNodeID1, testUpperTaskID1, testClusterName, 0),
 			wantErr:           false,
 			wantClusterCount:  1,
-			wantTaskInCluster: testClusterName1,
-			wantTaskID:        lowerTaskID1,
+			wantTaskInCluster: testClusterName,
+			wantTaskID:        testLowerTaskID1,
 			wantTasks: []types.Task{
 				{
-					TaskID:      lowerTaskID1,
+					TaskID:      testLowerTaskID1,
 					TaskName:    testTaskName1,
-					NodeID:      lowerNodeID1,
+					NodeID:      testLowerNodeID1,
 					TaskAttempt: 0,
 				},
 			},
@@ -363,16 +363,16 @@ func TestStoreEvent(t *testing.T) {
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: make(map[string]*types.TaskMap),
 			},
-			eventMap:          makeTaskEventMap(testTaskName1, lowerNodeID1, lowerTaskID1, testClusterName1, 0),
+			eventMap:          makeTaskEventMap(testTaskName1, testLowerNodeID1, testLowerTaskID1, testClusterName, 0),
 			wantErr:           false,
 			wantClusterCount:  1,
-			wantTaskInCluster: testClusterName1,
-			wantTaskID:        lowerTaskID1,
+			wantTaskInCluster: testClusterName,
+			wantTaskID:        testLowerTaskID1,
 			wantTasks: []types.Task{
 				{
-					TaskID:      lowerTaskID1,
+					TaskID:      testLowerTaskID1,
 					TaskName:    testTaskName1,
-					NodeID:      lowerNodeID1,
+					NodeID:      testLowerNodeID1,
 					TaskAttempt: 0,
 				},
 			},
@@ -384,7 +384,7 @@ func TestStoreEvent(t *testing.T) {
 			},
 			eventMap: map[string]any{
 				"eventType":   string(types.TASK_DEFINITION_EVENT),
-				"clusterName": testClusterName1,
+				"clusterName": testClusterName,
 			},
 			wantErr: true,
 		},
@@ -395,7 +395,7 @@ func TestStoreEvent(t *testing.T) {
 			},
 			eventMap: map[string]any{
 				"eventType":           string(types.TASK_DEFINITION_EVENT),
-				"clusterName":         testClusterName1,
+				"clusterName":         testClusterName,
 				"taskDefinitionEvent": "not a map",
 			},
 			wantErr: true, // Marshal will fail
@@ -407,7 +407,7 @@ func TestStoreEvent(t *testing.T) {
 			},
 			eventMap: map[string]any{
 				"eventType":   string(types.TASK_DEFINITION_EVENT),
-				"clusterName": testClusterName1,
+				"clusterName": testClusterName,
 				"taskDefinitionEvent": map[string]any{
 					"taskId":      123, // Should be string
 					"taskAttempt": 0,
@@ -470,11 +470,12 @@ func TestStoreEvent(t *testing.T) {
 func TestTaskLifecycleEventDeduplication(t *testing.T) {
 	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
 	const (
-		jobID    = "aaaabbbb"                                                  // 4B
-		actorID  = "aaaabbbb1234aaaabbbb1234" + jobID                          // 12B unique + JobID
-		taskID   = "ccccdddd5678cccc" + actorID                                // 8B unique + ActorID
-		nodeID   = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
-		workerID = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff"  // 28B
+		testJobID       = "aaaabbbb"                                                  // 4B
+		testActorID     = "aaaabbbb1234aaaabbbb1234" + testJobID                          // 12B unique + JobID
+		testTaskID      = "ccccdddd5678cccc" + testActorID                                // 8B unique + ActorID
+		testNodeID      = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
+		testWorkerID    = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff"  // 28B
+		testClusterName = "cluster1"
 	)
 
 	// Helper to create a StateEvent
@@ -486,7 +487,7 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 	}
 
 	// Helper to create a TASK_LIFECYCLE_EVENT map
-	makeLifecycleEvent := func(taskID string, attempt int, transitions []map[string]any) map[string]any {
+	makeLifecycleEvent := func(testTaskID string, attempt int, transitions []map[string]any) map[string]any {
 		// Convert []map[string]any to []any for proper type assertion in storeEvent
 		transitionsAny := make([]any, len(transitions))
 		for i, t := range transitions {
@@ -494,13 +495,13 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 		}
 		return map[string]any{
 			"eventType":   string(types.TASK_LIFECYCLE_EVENT),
-			"clusterName": testClusterName1,
+			"clusterName": testClusterName,
 			"taskLifecycleEvent": map[string]any{
-				"taskId":           taskID,
+				"taskId":           testTaskID,
 				"taskAttempt":      float64(attempt),
 				"stateTransitions": transitionsAny,
-				"nodeId":           nodeID,
-				"workerId":         workerID,
+				"nodeId":           testNodeID,
+				"workerId":         testWorkerID,
 			},
 		}
 	}
@@ -638,9 +639,9 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 
 			// Pre-populate existing events if any
 			if len(tt.existingEvents) > 0 {
-				taskMap := h.ClusterTaskMap.GetOrCreateTaskMap(testClusterName1)
-				taskMap.CreateOrMergeAttempt(taskID, 0, func(task *types.Task) {
-					task.TaskID = taskID
+				taskMap := h.ClusterTaskMap.GetOrCreateTaskMap(testClusterName)
+				taskMap.CreateOrMergeAttempt(testTaskID, 0, func(task *types.Task) {
+					task.TaskID = testTaskID
 					task.StateTransitions = tt.existingEvents
 					if len(tt.existingEvents) > 0 {
 						task.State = tt.existingEvents[len(tt.existingEvents)-1].State
@@ -649,18 +650,18 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Process the lifecycle event
-			eventMap := makeLifecycleEvent(taskID, 0, tt.newTransitions)
+			eventMap := makeLifecycleEvent(testTaskID, 0, tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
 			// Get the task and verify
-			taskMap := h.ClusterTaskMap.GetOrCreateTaskMap(testClusterName1)
+			taskMap := h.ClusterTaskMap.GetOrCreateTaskMap(testClusterName)
 			taskMap.Lock()
 			defer taskMap.Unlock()
 
-			tasks, exists := taskMap.TaskMap[taskID]
+			tasks, exists := taskMap.TaskMap[testTaskID]
 			if !exists || len(tasks) == 0 {
 				t.Fatal("Task not found after processing")
 			}
@@ -687,6 +688,13 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 
 // TestActorLifecycleEventDeduplication verifies that duplicate actor events are correctly filtered
 func TestActorLifecycleEventDeduplication(t *testing.T) {
+	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
+	const (
+		testJobID       = "aaaabbbb"                         // 4B
+		testActorID     = "aaaabbbb1234aaaabbbb1234" + testJobID // 12B unique + JobID
+		testClusterName = "cluster1"
+	)
+
 	// Helper to create an ActorStateEvent
 	makeActorStateEvent := func(state types.StateType, timestampNano int64) types.ActorStateEvent {
 		return types.ActorStateEvent{
@@ -696,7 +704,7 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 	}
 
 	// Helper to create an ACTOR_LIFECYCLE_EVENT map
-	makeActorLifecycleEvent := func(actorID string, transitions []map[string]any) map[string]any {
+	makeActorLifecycleEvent := func(testActorID string, transitions []map[string]any) map[string]any {
 		// Convert []map[string]any to []any for proper type assertion in storeEvent
 		transitionsAny := make([]any, len(transitions))
 		for i, t := range transitions {
@@ -704,9 +712,9 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 		}
 		return map[string]any{
 			"eventType":   string(types.ACTOR_LIFECYCLE_EVENT),
-			"clusterName": testClusterName1,
+			"clusterName": testClusterName,
 			"actorLifecycleEvent": map[string]any{
-				"actorId":          actorID,
+				"actorId":          testActorID,
 				"stateTransitions": transitionsAny,
 			},
 		}
@@ -790,21 +798,15 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 		},
 	}
 
-	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
-	const (
-		jobID   = "aaaabbbb"                          // 4B
-		actorID = "aaaabbbb1234aaaabbbb1234" + jobID  // 12B unique + JobID
-	)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewEventHandler(nil)
 
 			// Pre-populate existing events
 			if len(tt.existingEvents) > 0 {
-				actorMap := h.ClusterActorMap.GetOrCreateActorMap(testClusterName1)
-				actorMap.CreateOrMergeActor(actorID, func(a *types.Actor) {
-					a.ActorID = actorID
+				actorMap := h.ClusterActorMap.GetOrCreateActorMap(testClusterName)
+				actorMap.CreateOrMergeActor(testActorID, func(a *types.Actor) {
+					a.ActorID = testActorID
 					a.Events = tt.existingEvents
 					if len(tt.existingEvents) > 0 {
 						a.State = tt.existingEvents[len(tt.existingEvents)-1].State
@@ -813,14 +815,14 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Process the lifecycle event
-			eventMap := makeActorLifecycleEvent(actorID, tt.newTransitions)
+			eventMap := makeActorLifecycleEvent(testActorID, tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
 			// Get the actor and verify
-			actor, found := h.GetActorByID(testClusterName1, actorID)
+			actor, found := h.GetActorByID(testClusterName, testActorID)
 			if !found {
 				t.Fatal("Actor not found after processing")
 			}
@@ -841,6 +843,12 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 // TestDriverJobLifeCycleEventDuplication tests that duplicate events are properly filtered and sorted
 // TODO(chiayi): Update once more fields are added to driver job event
 func TestDriverJobLifecycleEventDuplication(t *testing.T) {
+	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
+	const (
+		testJobID       = "aaaabbbb" // 4B
+		testClusterName = "cluster1"
+	)
+
 	makeDriverJobStateTransitionEvent := func(state types.JobState, timestampNano int64) types.JobStateTransition {
 		return types.JobStateTransition{
 			State:     state,
@@ -848,16 +856,16 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 		}
 	}
 
-	makeDriverJobLifecycleEvent := func(jobID string, transitions []map[string]any) map[string]any {
+	makeDriverJobLifecycleEvent := func(testJobID string, transitions []map[string]any) map[string]any {
 		transitionsAny := make([]any, len(transitions))
 		for i, t := range transitions {
 			transitionsAny[i] = t
 		}
 		return map[string]any{
 			"eventType":   string(types.DRIVER_JOB_LIFECYCLE_EVENT),
-			"clusterName": testClusterName1,
+			"clusterName": testClusterName,
 			"driverJobLifecycleEvent": map[string]any{
-				"jobId":            jobID,
+				"jobId":            testJobID,
 				"stateTransitions": transitionsAny,
 			},
 		}
@@ -961,17 +969,14 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 		},
 	}
 
-	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
-	const jobID = "aaaabbbb" // 4B
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewEventHandler(nil)
 
 			if len(tt.existingTransitions) > 0 {
-				jobMap := h.ClusterJobMap.GetOrCreateJobMap(testClusterName1)
-				jobMap.CreateOrMergeJob(jobID, func(job *types.Job) {
-					job.JobID = jobID
+				jobMap := h.ClusterJobMap.GetOrCreateJobMap(testClusterName)
+				jobMap.CreateOrMergeJob(testJobID, func(job *types.Job) {
+					job.JobID = testJobID
 					job.StateTransitions = tt.existingTransitions
 					if len(tt.existingTransitions) > 0 {
 						job.State = tt.existingTransitions[len(tt.existingTransitions)-1].State
@@ -979,13 +984,13 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 				})
 			}
 
-			eventMap := makeDriverJobLifecycleEvent(jobID, tt.newTransitions)
+			eventMap := makeDriverJobLifecycleEvent(testJobID, tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
-			job, exists := h.GetJobByJobID(testClusterName1, jobID)
+			job, exists := h.GetJobByJobID(testClusterName, testJobID)
 			if !exists {
 				t.Fatal("Job not found after processing")
 			}
@@ -1007,11 +1012,12 @@ func TestMultipleReprocessingCycles(t *testing.T) {
 
 	// IDs follow Ray's ID spec; see TestEventProcessor for rationale.
 	const (
-		jobID    = "aaaabbbb"                                                  // 4B
-		actorID  = "aaaabbbb1234aaaabbbb1234" + jobID                          // 12B unique + JobID
-		taskID   = "ccccdddd5678cccc" + actorID                                // 8B unique + ActorID
-		nodeID   = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
-		workerID = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff"  // 28B
+		testJobID       = "aaaabbbb"                                                  // 4B
+		testActorID     = "aaaabbbb1234aaaabbbb1234" + testJobID                          // 12B unique + JobID
+		testTaskID      = "ccccdddd5678cccc" + testActorID                                // 8B unique + ActorID
+		testNodeID      = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff"  // 28B
+		testWorkerID    = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff"  // 28B
+		testClusterName = "cluster1"
 	)
 
 	// The same events that would be in an event file
@@ -1024,13 +1030,13 @@ func TestMultipleReprocessingCycles(t *testing.T) {
 
 	eventMap := map[string]any{
 		"eventType":   string(types.TASK_LIFECYCLE_EVENT),
-		"clusterName": testClusterName1,
+		"clusterName": testClusterName,
 		"taskLifecycleEvent": map[string]any{
-			"taskId":           taskID,
+			"taskId":           testTaskID,
 			"taskAttempt":      float64(0),
 			"stateTransitions": transitions,
-			"nodeId":           nodeID,
-			"workerId":         workerID,
+			"nodeId":           testNodeID,
+			"workerId":         testWorkerID,
 		},
 	}
 
@@ -1042,9 +1048,9 @@ func TestMultipleReprocessingCycles(t *testing.T) {
 		}
 
 		// Check event count after each cycle
-		taskMap := h.ClusterTaskMap.GetOrCreateTaskMap(testClusterName1)
+		taskMap := h.ClusterTaskMap.GetOrCreateTaskMap(testClusterName)
 		taskMap.Lock()
-		tasks := taskMap.TaskMap[taskID]
+		tasks := taskMap.TaskMap[testTaskID]
 		eventCount := len(tasks[0].StateTransitions)
 		taskMap.Unlock()
 

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -11,6 +11,22 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
+// Test fixtures: pure-hex IDs so normalizeIDToHex is identity.
+// Use lowercase to match production hex output and avoid map-key collision.
+const (
+    testTaskID1      = "aaaaffff1234"
+    testTaskID2      = "bbbbffff5678"
+    testNodeID1      = "ccccffff9012"
+    testNodeID2      = "ddddffff3456"
+	testWorkerID1    = "eeeeffff7890"
+	testJobID1       = "ffffaaaa4321"
+    testActorID1     = "aaaabbbb6789"
+    testClusterName1 = "cluster1"
+	testClusterName2 = "cluster2"
+    testTaskName1    = "Name_12345"
+    testTaskName2    = "Name_54321"
+)
+
 func makeTaskEventMap(taskName, nodeId, taskID, cluster string, attempt int) map[string]any {
 	return map[string]any{
 		"eventType":   string(types.TASK_DEFINITION_EVENT),
@@ -25,16 +41,6 @@ func makeTaskEventMap(taskName, nodeId, taskID, cluster string, attempt int) map
 }
 
 func TestEventProcessor(t *testing.T) {
-	const TaskID1 = "AAaaFFff1234"
-	const TaskID2 = "BBbbFFff5678"
-	const NodeID1 = "CCccFFff9012"
-	const NodeID2 = "DDddFFff3456"
-
-	const TaskName1 = "Name_12345"
-	const TaskName2 = "Name_54321"
-
-	const ClusterName = "cluster1"
-
 	tests := []struct {
 		name string
 		// Setup
@@ -51,41 +57,41 @@ func TestEventProcessor(t *testing.T) {
 			name: "process multiple events then close channel",
 			eventsToSend: []map[string]any{
 				{
-					"clusterName": ClusterName,
+					"clusterName": testClusterName1,
 					"eventType":   "TASK_DEFINITION_EVENT",
 					"taskDefinitionEvent": map[string]any{
-						"taskId":      TaskID1,
-						"taskName":    TaskName1,
-						"nodeId":      NodeID1,
+						"taskId":      testTaskID1,
+						"taskName":    testTaskName1,
+						"nodeId":      testNodeID1,
 						"taskAttempt": 2,
 					},
 				},
 				{
-					"clusterName": ClusterName,
+					"clusterName": testClusterName1,
 					"eventType":   "TASK_DEFINITION_EVENT",
 					"taskDefinitionEvent": map[string]any{
-						"taskId":      TaskID2,
-						"taskName":    TaskName2,
-						"nodeId":      NodeID2,
+						"taskId":      testTaskID2,
+						"taskName":    testTaskName2,
+						"nodeId":      testNodeID2,
 						"taskAttempt": 1,
 					},
 				},
 			},
 			closeChan: true,
 			wantStoredEvents: map[string][]types.Task{
-				TaskID1: {
+				testTaskID1: {
 					{
-						TaskID:      TaskID1,
-						TaskName:    TaskName1,
-						NodeID:      NodeID1,
+						TaskID:      testTaskID1,
+						TaskName:    testTaskName1,
+						NodeID:      testNodeID1,
 						TaskAttempt: 2,
 					},
 				},
-				TaskID2: {
+				testTaskID2: {
 					{
-						TaskID:      TaskID2,
-						TaskName:    TaskName2,
-						NodeID:      NodeID2,
+						TaskID:      testTaskID2,
+						TaskName:    testTaskName2,
+						NodeID:      testNodeID2,
 						TaskAttempt: 1,
 					},
 				},
@@ -100,12 +106,12 @@ func TestEventProcessor(t *testing.T) {
 			name: "context canceled",
 			eventsToSend: []map[string]any{
 				{
-					"clusterName": ClusterName,
+					"clusterName": testClusterName1,
 					"eventType":   "TASK_DEFINITION_EVENT",
 					"taskDefinitionEvent": map[string]any{
-						"taskId":      TaskID1,
-						"taskName":    TaskName1,
-						"nodeId":      NodeID1,
+						"taskId":      testTaskID1,
+						"taskName":    testTaskName1,
+						"nodeId":      testNodeID1,
 						"taskAttempt": 2,
 					},
 				},
@@ -115,11 +121,11 @@ func TestEventProcessor(t *testing.T) {
 			expectedErrType: context.Canceled,
 			// Event might be processed before cancellation is detected
 			wantStoredEvents: map[string][]types.Task{
-				TaskID1: {
+				testTaskID1: {
 					{
-						TaskID:      TaskID1,
-						TaskName:    TaskName1,
-						NodeID:      NodeID1,
+						TaskID:      testTaskID1,
+						TaskName:    testTaskName1,
+						NodeID:      testNodeID1,
 						TaskAttempt: 2,
 					},
 				},
@@ -180,7 +186,7 @@ func TestEventProcessor(t *testing.T) {
 
 			// Check stored events
 			if tt.wantStoredEvents != nil {
-				if diff := cmp.Diff(tt.wantStoredEvents, h.ClusterTaskMap.ClusterTaskMap[ClusterName].TaskMap); diff != "" {
+				if diff := cmp.Diff(tt.wantStoredEvents, h.ClusterTaskMap.ClusterTaskMap[testClusterName1].TaskMap); diff != "" {
 					t.Errorf("storeEventCalls diff (-want +got):\n%s", diff)
 				}
 			}
@@ -189,17 +195,10 @@ func TestEventProcessor(t *testing.T) {
 }
 
 func TestStoreEvent(t *testing.T) {
-	const TaskID1 = "AAaaFFff1234"
-	const TaskID2 = "BBbbFFff5678"
-	const NodeID  = "CCccFFff9012"
-
-	const TaskName = "taskName123"
-	const ClusterName = "cluster1"
-
 	initialTask := types.Task{
-		TaskID:      TaskID1,
-		TaskName:    TaskName,
-		NodeID:      NodeID,
+		TaskID:      testTaskID1,
+		TaskName:    testTaskName1,
+		NodeID:      testNodeID1,
 		TaskAttempt: 0,
 	}
 	tests := []struct {
@@ -229,16 +228,16 @@ func TestStoreEvent(t *testing.T) {
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: make(map[string]*types.TaskMap),
 			},
-			eventMap:          makeTaskEventMap(TaskName, NodeID, TaskID1, ClusterName, 0),
+			eventMap:          makeTaskEventMap(testTaskName1, testNodeID1, testTaskID1, "cluster1", 0),
 			wantErr:           false,
 			wantClusterCount:  1,
-			wantTaskInCluster: ClusterName,
-			wantTaskID:        TaskID1,
+			wantTaskInCluster: testClusterName1,
+			wantTaskID:        testTaskID1,
 			wantTasks: []types.Task{
 				{
-					TaskID:      TaskID1,
-					TaskName:    TaskName,
-					NodeID:      NodeID,
+					TaskID:      testTaskID1,
+					TaskName:    testTaskName1,
+					NodeID:      testNodeID1,
 					TaskAttempt: 0,
 				},
 			},
@@ -247,19 +246,19 @@ func TestStoreEvent(t *testing.T) {
 			name: "task event - existing cluster, new task",
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: map[string]*types.TaskMap{
-					ClusterName: types.NewTaskMap(),
+					testClusterName1: types.NewTaskMap(),
 				},
 			},
-			eventMap:          makeTaskEventMap(TaskName, NodeID, TaskID2, ClusterName, 1),
+			eventMap:          makeTaskEventMap(testTaskName2, testNodeID2, testTaskID2, testClusterName1, 1),
 			wantErr:           false,
 			wantClusterCount:  1,
-			wantTaskInCluster: ClusterName,
-			wantTaskID:        TaskID2,
+			wantTaskInCluster: testClusterName1,
+			wantTaskID:        testTaskID2,
 			wantTasks: []types.Task{
 				{
-					TaskID:      TaskID2,
-					TaskName:    TaskName,
-					NodeID:      NodeID,
+					TaskID:      testTaskID2,
+					TaskName:    testTaskName2,
+					NodeID:      testNodeID2,
 					TaskAttempt: 1,
 				},
 			},
@@ -268,30 +267,30 @@ func TestStoreEvent(t *testing.T) {
 			name: "task event - existing cluster and existing task with new attempt",
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: map[string]*types.TaskMap{
-					ClusterName: {
+					testClusterName1: {
 						TaskMap: map[string][]types.Task{
-							TaskID1: {initialTask},
+							testTaskID1: {initialTask},
 						},
 					},
 				},
 			},
-			eventMap:          makeTaskEventMap(TaskName, NodeID, TaskID1, ClusterName, 2),
+			eventMap:          makeTaskEventMap(testTaskName1, testNodeID1, testTaskID1, testClusterName1, 2),
 			wantErr:           false,
 			wantClusterCount:  1,
-			wantTaskInCluster: ClusterName,
-			wantTaskID:        TaskID1,
+			wantTaskInCluster: testClusterName1,
+			wantTaskID:        testTaskID1,
 			// Now expects BOTH attempts to be stored
 			wantTasks: []types.Task{
 				{
-					TaskID:      TaskID1,
-					TaskName:    TaskName,
-					NodeID:      NodeID,
+					TaskID:      testTaskID1,
+					TaskName:    testTaskName1,
+					NodeID:      testNodeID1,
 					TaskAttempt: 0,
 				},
 				{
-					TaskID:      TaskID1,
-					TaskName:    TaskName,
-					NodeID:      NodeID,
+					TaskID:      testTaskID1,
+					TaskName:    testTaskName1,
+					NodeID:      testNodeID1,
 					TaskAttempt: 2,
 				},
 			},
@@ -303,7 +302,7 @@ func TestStoreEvent(t *testing.T) {
 			},
 			eventMap: map[string]any{
 				"eventType":   string(types.TASK_DEFINITION_EVENT),
-				"clusterName": "c1",
+				"clusterName": testClusterName1,
 			},
 			wantErr: true,
 		},
@@ -314,7 +313,7 @@ func TestStoreEvent(t *testing.T) {
 			},
 			eventMap: map[string]any{
 				"eventType":           string(types.TASK_DEFINITION_EVENT),
-				"clusterName":         "c1",
+				"clusterName":         testClusterName1,
 				"taskDefinitionEvent": "not a map",
 			},
 			wantErr: true, // Marshal will fail
@@ -326,7 +325,7 @@ func TestStoreEvent(t *testing.T) {
 			},
 			eventMap: map[string]any{
 				"eventType":   string(types.TASK_DEFINITION_EVENT),
-				"clusterName": "c1",
+				"clusterName": testClusterName1,
 				"taskDefinitionEvent": map[string]any{
 					"taskId":      123, // Should be string
 					"taskAttempt": 0,
@@ -404,13 +403,13 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 		}
 		return map[string]any{
 			"eventType":   string(types.TASK_LIFECYCLE_EVENT),
-			"clusterName": "test-cluster",
+			"clusterName": testClusterName1,
 			"taskLifecycleEvent": map[string]any{
 				"taskId":           taskID,
 				"taskAttempt":      float64(attempt),
 				"stateTransitions": transitionsAny,
-				"nodeId":           "node-1",
-				"workerId":         "worker-1",
+				"nodeId":           testNodeID1,
+				"workerId":         testWorkerID1,
 			},
 		}
 	}
@@ -542,17 +541,15 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 		},
 	}
 
-	const taskID = "AAaaFFff1234"
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewEventHandler(nil)
 
 			// Pre-populate existing events if any
 			if len(tt.existingEvents) > 0 {
-				taskMap := h.ClusterTaskMap.GetOrCreateTaskMap("test-cluster")
-				taskMap.CreateOrMergeAttempt(taskID, 0, func(task *types.Task) {
-					task.TaskID = taskID
+				taskMap := h.ClusterTaskMap.GetOrCreateTaskMap(testClusterName1)
+				taskMap.CreateOrMergeAttempt(testTaskID1, 0, func(task *types.Task) {
+					task.TaskID = testTaskID1
 					task.StateTransitions = tt.existingEvents
 					if len(tt.existingEvents) > 0 {
 						task.State = tt.existingEvents[len(tt.existingEvents)-1].State
@@ -561,18 +558,18 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Process the lifecycle event
-			eventMap := makeLifecycleEvent(taskID, 0, tt.newTransitions)
+			eventMap := makeLifecycleEvent(testTaskID1, 0, tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
 			// Get the task and verify
-			taskMap := h.ClusterTaskMap.GetOrCreateTaskMap("test-cluster")
+			taskMap := h.ClusterTaskMap.GetOrCreateTaskMap(testClusterName1)
 			taskMap.Lock()
 			defer taskMap.Unlock()
 
-			tasks, exists := taskMap.TaskMap[taskID]
+			tasks, exists := taskMap.TaskMap[testTaskID1]
 			if !exists || len(tasks) == 0 {
 				t.Fatal("Task not found after processing")
 			}
@@ -616,7 +613,7 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 		}
 		return map[string]any{
 			"eventType":   string(types.ACTOR_LIFECYCLE_EVENT),
-			"clusterName": "test-cluster",
+			"clusterName": testClusterName1,
 			"actorLifecycleEvent": map[string]any{
 				"actorId":          actorID,
 				"stateTransitions": transitionsAny,
@@ -702,17 +699,15 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 		},
 	}
 
-	const actorID = "AAaaFFff1234"
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := NewEventHandler(nil)
 
 			// Pre-populate existing events
 			if len(tt.existingEvents) > 0 {
-				actorMap := h.ClusterActorMap.GetOrCreateActorMap("test-cluster")
-				actorMap.CreateOrMergeActor(actorID, func(a *types.Actor) {
-					a.ActorID = actorID
+				actorMap := h.ClusterActorMap.GetOrCreateActorMap(testClusterName1)
+				actorMap.CreateOrMergeActor(testActorID1, func(a *types.Actor) {
+					a.ActorID = testActorID1
 					a.Events = tt.existingEvents
 					if len(tt.existingEvents) > 0 {
 						a.State = tt.existingEvents[len(tt.existingEvents)-1].State
@@ -721,14 +716,14 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Process the lifecycle event
-			eventMap := makeActorLifecycleEvent(actorID, tt.newTransitions)
+			eventMap := makeActorLifecycleEvent(testActorID1, tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
 			// Get the actor and verify
-			actor, found := h.GetActorByID("test-cluster", actorID)
+			actor, found := h.GetActorByID(testClusterName1, testActorID1)
 			if !found {
 				t.Fatal("Actor not found after processing")
 			}
@@ -763,7 +758,7 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 		}
 		return map[string]any{
 			"eventType":   string(types.DRIVER_JOB_LIFECYCLE_EVENT),
-			"clusterName": "test-cluster",
+			"clusterName": testClusterName1,
 			"driverJobLifecycleEvent": map[string]any{
 				"jobId":            jobID,
 				"stateTransitions": transitionsAny,
@@ -874,9 +869,9 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 			h := NewEventHandler(nil)
 
 			if len(tt.existingTransitions) > 0 {
-				jobMap := h.ClusterJobMap.GetOrCreateJobMap("test-cluster")
-				jobMap.CreateOrMergeJob("job-1", func(job *types.Job) {
-					job.JobID = "job-1"
+				jobMap := h.ClusterJobMap.GetOrCreateJobMap(testClusterName1)
+				jobMap.CreateOrMergeJob(testJobID1, func(job *types.Job) {
+					job.JobID = testJobID1
 					job.StateTransitions = tt.existingTransitions
 					if len(tt.existingTransitions) > 0 {
 						job.State = tt.existingTransitions[len(tt.existingTransitions)-1].State
@@ -884,13 +879,13 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 				})
 			}
 
-			eventMap := makeDriverJobLifecycleEvent("job-1", tt.newTransitions)
+			eventMap := makeDriverJobLifecycleEvent(testJobID1, tt.newTransitions)
 			err := h.storeEvent(eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
-			job, exists := h.GetJobByJobID("test-cluster", "job-1")
+			job, exists := h.GetJobByJobID(testClusterName1, testJobID1)
 			if !exists {
 				t.Fatal("Job not found after processing")
 			}
@@ -918,18 +913,15 @@ func TestMultipleReprocessingCycles(t *testing.T) {
 		map[string]any{"state": "FINISHED", "timestamp": time.Unix(0, 3000).Format(time.RFC3339Nano)},
 	}
 
-	// Use a pure hex task ID so normalizeIDToHex returns it unchanged.
-	const taskID = "AAaaFFff1234"
-
 	eventMap := map[string]any{
 		"eventType":   string(types.TASK_LIFECYCLE_EVENT),
-		"clusterName": "test-cluster",
+		"clusterName": testClusterName1,
 		"taskLifecycleEvent": map[string]any{
-			"taskId":           taskID,
+			"taskId":           testTaskID1,
 			"taskAttempt":      float64(0),
 			"stateTransitions": transitions,
-			"nodeId":           "node-1",
-			"workerId":         "worker-1",
+			"nodeId":           testNodeID1,
+			"workerId":         testWorkerID1,
 		},
 	}
 
@@ -941,9 +933,9 @@ func TestMultipleReprocessingCycles(t *testing.T) {
 		}
 
 		// Check event count after each cycle
-		taskMap := h.ClusterTaskMap.GetOrCreateTaskMap("test-cluster")
+		taskMap := h.ClusterTaskMap.GetOrCreateTaskMap(testClusterName1)
 		taskMap.Lock()
-		tasks := taskMap.TaskMap[taskID]
+		tasks := taskMap.TaskMap[testTaskID1]
 		eventCount := len(tasks[0].StateTransitions)
 		taskMap.Unlock()
 

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -498,7 +498,7 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 			"clusterName": testClusterName,
 			"taskLifecycleEvent": map[string]any{
 				"taskId":           testTaskID,
-				"taskAttempt":      0,
+				"taskAttempt":      float64(0),
 				"stateTransitions": transitionsAny,
 				"nodeId":           testNodeID,
 				"workerId":         testWorkerID,

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -13,25 +13,32 @@ import (
 
 // Test fixtures: pure-hex IDs so normalizeIDToHex is identity.
 // Use lowercase to match production hex output and avoid map-key collision.
+// ID fixtures follow Ray's ID specification
+// ref: https://github.com/ray-project/ray/blob/f229d5376eb87b09a3fa0b991323450de84df890/src/ray/design_docs/id_specification.md
 const (
-	testTaskID1      = "aaaaffff1234"
-	testTaskID2      = "bbbbffff5678"
-	testNodeID1      = "ccccffff9012"
-	testNodeID2      = "ddddffff3456"
-	testWorkerID1    = "eeeeffff7890"
-	testJobID1       = "ffffaaaa4321"
-	testActorID1     = "aaaabbbb6789"
+	testJobID1    = "aaaabbbb"                                                 // 4B hex
+	testActorID1  = "aaaabbbb1234aaaabbbb1234" + testJobID1                    // 12B unique hex prefix
+	testTaskID1   = "ccccdddd5678cccc" + testActorID1                          // 8B unique hex prefix
+	testTaskID2   = "ccccdddd9012dddd" + testActorID1                          // 8B unique hex prefix
+	testNodeID1   = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff" // 28B Node hex ID
+	testNodeID2   = "eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff9012eeeeffff" // 28B Node hex ID
+	testWorkerID1 = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff" // 28B Worker hex ID
+
+	// Upper and Lower case pairs to verify normalization to lowercase hex
+	testUpperNodeID1 = "AAAABBBB1234AAAABBBB1234AAAABBBB1234AAAABBBB1234AAAABBBB" // 28B Upper Node hex ID
+	testLowerNodeID1 = "aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb1234aaaabbbb" // 28B Lower Node hex ID
+	testUpperTaskID1 = "AAAABBBB5678AAAABBBB5678AAAABBBB5678AAAABBBB5678"         // 24B Upper Task hex ID
+	testLowerTaskID1 = "aaaabbbb5678aaaabbbb5678aaaabbbb5678aaaabbbb5678"         // 24B Lower Task hex ID
+
 	testClusterName1 = "cluster1"
 	testTaskName1    = "Name_12345"
 	testTaskName2    = "Name_54321"
-	testBase64ID1    = "AgAAAA=="
-	testBase64ID2    = "AwAAAA=="
-	testHexID1       = "02000000" // hex for base64 "AgAAAA=="
-	testHexID2       = "03000000" // hex for base64 "AwAAAA=="
-	testUpperHexID1  = "ABCDEF01"
-	testUpperHexID2  = "ABCDEF02"
-	testLowerHexID1  = "abcdef01"
-	testLowerHexID2  = "abcdef02"
+
+	// Base64 and Hex pairs to verify normalization of base64 to hex
+	testBase64ID1 = "AgAAAA=="
+	testBase64ID2 = "AwAAAA=="
+	testHexID1    = "02000000" // hex for base64 "AgAAAA=="
+	testHexID2    = "03000000" // hex for base64 "AwAAAA=="
 )
 
 func makeTaskEventMap(taskName, nodeId, taskID, cluster string, attempt int) map[string]any {
@@ -326,16 +333,16 @@ func TestStoreEvent(t *testing.T) {
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: make(map[string]*types.TaskMap),
 			},
-			eventMap:          makeTaskEventMap(testTaskName1, testUpperHexID1, testUpperHexID2, testClusterName1, 0),
+			eventMap:          makeTaskEventMap(testTaskName1, testUpperNodeID1, testUpperTaskID1, testClusterName1, 0),
 			wantErr:           false,
 			wantClusterCount:  1,
 			wantTaskInCluster: testClusterName1,
-			wantTaskID:        testLowerHexID2,
+			wantTaskID:        testLowerTaskID1,
 			wantTasks: []types.Task{
 				{
-					TaskID:      testLowerHexID2,
+					TaskID:      testLowerTaskID1,
 					TaskName:    testTaskName1,
-					NodeID:      testLowerHexID1,
+					NodeID:      testLowerNodeID1,
 					TaskAttempt: 0,
 				},
 			},
@@ -345,16 +352,16 @@ func TestStoreEvent(t *testing.T) {
 			initialState: &types.ClusterTaskMap{
 				ClusterTaskMap: make(map[string]*types.TaskMap),
 			},
-			eventMap:          makeTaskEventMap(testTaskName1, testLowerHexID1, testLowerHexID2, testClusterName1, 0),
+			eventMap:          makeTaskEventMap(testTaskName1, testLowerNodeID1, testLowerTaskID1, testClusterName1, 0),
 			wantErr:           false,
 			wantClusterCount:  1,
 			wantTaskInCluster: testClusterName1,
-			wantTaskID:        testLowerHexID2,
+			wantTaskID:        testLowerTaskID1,
 			wantTasks: []types.Task{
 				{
-					TaskID:      testLowerHexID2,
+					TaskID:      testLowerTaskID1,
 					TaskName:    testTaskName1,
-					NodeID:      testLowerHexID1,
+					NodeID:      testLowerNodeID1,
 					TaskAttempt: 0,
 				},
 			},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Several unit tests in pkg/eventserver were failing because test IDs like "task-1", "actor-1", and "ID_12345" were being silently transformed before storage.

normalizeIDToHex calls ConvertBase64ToHex, which:
1. Returns the value unchanged if it matches ^[0-9a-fA-F]+$ (pure hex)
2. Otherwise, attempts raw URL-safe base64 decoding (base64.RawURLEncoding)

https://github.com/ray-project/kuberay/blob/262d0f458af7fc9e820307fa72371acdd8df704a/historyserver/pkg/utils/utils.go#L103-L119

The fact that these non-pure-hex ids would changed can be verified through
```
cat > /tmp/try_b64.go << 'EOF'
package main

import (
    "fmt"
    "github.com/ray-project/kuberay/historyserver/pkg/utils"
)

func main() {
    inputStr := "task-1"
    result, err := utils.ConvertBase64ToHex(inputStr)
    if err != nil {
        fmt.Printf("Error: %v\n", err)
        return
    }
    fmt.Printf("Input: %s, Result: %s\n", inputStr, result)
}
EOF

go run /tmp/try_b64.go
```

Affected tests:
- TestMultipleReprocessingCycles — panicked with index out of range [0] with length 0
- TestTaskLifecycleEventDeduplication
- TestActorLifecycleEventDeduplication
- TestStoreEvent
- TestEventProcessor

## Test Environment
The test before and after fix has been run on 
1. Apple M3 (Arm) + Go 1.25.0
2. Intel Broadwell (x86_64) + Go 1.25.0

## Fix

Replace all test IDs with pure hex strings (e.g. "AAaaFFff1234"), which match the ^[0-9a-fA-F]+$ pattern in ConvertBase64ToHex and are returned unchanged. No production code or test logic is modified.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
