### PR TITLE
[apiserver][test] Trust E2E_API_SERVER_RAY_IMAGE verbatim (closes #4346)

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -19,6 +19,11 @@ else
 endif
 # Kuberay API Server base URL to use in end to end tests
 E2E_API_SERVER_URL ?= http://localhost:31888
+# Export so `go test` subprocesses pick them up via os.Getenv. Without this,
+# the e2e helpers fall back to their hard-coded defaults and disagree with the
+# image preloaded into kind by `load-ray-test-image`.
+export E2E_API_SERVER_RAY_IMAGE
+export E2E_API_SERVER_URL
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (, $(shell go env GOBIN))

--- a/apiserver/test/e2e/apiserversdk/types.go
+++ b/apiserver/test/e2e/apiserversdk/types.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -121,12 +120,6 @@ func withRayImage() contextOption {
 		rayImage := os.Getenv("E2E_API_SERVER_RAY_IMAGE")
 		if strings.TrimSpace(rayImage) == "" {
 			rayImage = RayImage + "-py310"
-		}
-		// detect if we are running on arm64 machine, most likely apple silicon
-		// the os name is not checked as it also possible that it might be linux
-		// also check if the image does not have the `-aarch64` suffix
-		if runtime.GOARCH == "arm64" && !strings.HasSuffix(rayImage, "-aarch64") {
-			rayImage = rayImage + "-aarch64"
 		}
 		testingContext.rayImage = rayImage
 		return nil

--- a/apiserver/test/e2e/types.go
+++ b/apiserver/test/e2e/types.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -139,12 +138,6 @@ func withRayImage() contextOption {
 		rayImage := os.Getenv("E2E_API_SERVER_RAY_IMAGE")
 		if strings.TrimSpace(rayImage) == "" {
 			rayImage = RayImage + "-py310"
-		}
-		// detect if we are running on arm64 machine, most likely apple silicon
-		// the os name is not checked as it also possible that it might be linux
-		// also check if the image does not have the `-aarch64` suffix
-		if runtime.GOARCH == "arm64" && !strings.HasSuffix(rayImage, "-aarch64") {
-			rayImage = rayImage + "-aarch64"
 		}
 		testingContext.rayImage = rayImage
 		return nil


### PR DESCRIPTION
## Why are these changes needed?

`withRayImage` in `apiserver/test/e2e/types.go` and `apiserver/test/e2e/apiserversdk/types.go` second-guesses the configured Ray image: when `runtime.GOARCH == "arm64"`, it auto-appends `-aarch64` to whatever `E2E_API_SERVER_RAY_IMAGE` is set to. This prevents Apple-silicon developers from running the apiserver e2e suite against an x86_64-only remote cluster — the use case reported in #4346.

#4348 already removed the same pattern from `ray-operator/test/support/environment.go`. This PR applies the same cleanup to the two remaining occurrences in the apiserver tests, completing #4346.

`apiserver/Makefile:14-16` already provides the correct arm64-suffixed default for arm64 hosts via `ifeq (arm64, $(shell go env GOARCH))`, so `make test` behavior on arm64 is preserved without any in-Go-code mangling.

## Related issue number

Closes #4346.
Follow-up to #4348.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests — `go build ./...` and `go vet ./test/...` pass on darwin/arm64. The change is a pure deletion mirroring the merged #4348; CI will exercise the Makefile path on both arm64 and amd64 runners.
  - [ ] This PR is not tested :(
