### PR TITLE
[apiserver] validate request host before Do() to address gosec G704 (#4731)

### DIFF
--- a/apiserver/pkg/http/client.go
+++ b/apiserver/pkg/http/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	rpcStatus "google.golang.org/genproto/googleapis/rpc/status"
@@ -27,7 +28,10 @@ type KuberayAPIServerClient struct {
 	// Store http request handling function for unit test purpose.
 	ExecuteHttpRequest func(httpRequest *http.Request, URL string) ([]byte, *rpcStatus.Status, error)
 	baseURL            string
-	retryCfg           apiserversdkutil.RetryConfig
+	// baseURLHost is the parsed Host (host[:port]) of baseURL, used by executeRequest
+	// to verify each outbound request points at the configured server before issuing it.
+	baseURLHost string
+	retryCfg    apiserversdkutil.RetryConfig
 }
 
 type KuberayAPIServerClientError struct {
@@ -49,9 +53,17 @@ func IsNotFoundError(err error) bool {
 }
 
 func NewKuberayAPIServerClient(baseURL string, httpClient *http.Client, retryCfg apiserversdkutil.RetryConfig) *KuberayAPIServerClient {
+	// Pre-parse baseURL so executeRequest can verify each outbound request targets the
+	// configured host. A malformed baseURL leaves baseURLHost empty; executeRequest will
+	// then refuse to dispatch with a descriptive error.
+	var baseURLHost string
+	if parsed, err := url.Parse(baseURL); err == nil {
+		baseURLHost = parsed.Host
+	}
 	client := &KuberayAPIServerClient{
-		httpClient: httpClient,
-		baseURL:    baseURL,
+		httpClient:  httpClient,
+		baseURL:     baseURL,
+		baseURLHost: baseURLHost,
 		marshaler: &protojson.MarshalOptions{
 			Multiline:       true,
 			Indent:          "    ",
@@ -664,13 +676,29 @@ func (krc *KuberayAPIServerClient) executeRequest(httpRequest *http.Request, URL
 		}
 	}
 
+	// Pin every outbound request to the configured baseURL host. This both adds an explicit
+	// SSRF defense (a stray rewrite of httpRequest.URL becomes observable instead of silent)
+	// and gives gosec G704 a sanitization point so the linter no longer treats httpClient.Do
+	// as a tainted call.
+	if httpRequest.URL == nil {
+		return nil, nil, fmt.Errorf("failed to execute http request for url '%s': request URL is nil", URL)
+	}
+	if krc.baseURLHost == "" || httpRequest.URL.Host != krc.baseURLHost {
+		return nil, nil, fmt.Errorf(
+			"failed to execute http request for url '%s': request host %q does not match configured baseURL host %q",
+			URL, httpRequest.URL.Host, krc.baseURLHost)
+	}
+
 	doReq := func() ([]byte, int, error) {
 		// new ReadCloser for httpRequest body
 		if requestBodyBytes != nil {
 			httpRequest.Body = io.NopCloser(bytes.NewBuffer(requestBodyBytes))
 		}
 
-		response, err := krc.httpClient.Do(httpRequest) //nolint:gosec // URL is constructed from internal config, not user input
+		// httpRequest.URL.Host has been verified above to equal the baseURL host configured
+		// at NewKuberayAPIServerClient time, so this is not a tainted external destination.
+		// gosec G704's taint analysis cannot model that check, hence the suppression.
+		response, err := krc.httpClient.Do(httpRequest) //nolint:gosec // URL host is validated against configured baseURL above
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to execute http request for url '%s': %w", URL, err)
 		}

--- a/apiserver/pkg/http/client_test.go
+++ b/apiserver/pkg/http/client_test.go
@@ -214,7 +214,7 @@ func TestAPIServerClientRetry(t *testing.T) {
 				MaxBackoff:     util.HTTPClientDefaultMaxBackoff,
 				OverallTimeout: util.HTTPClientDefaultOverallTimeout,
 			}
-			client := NewKuberayAPIServerClient("baseurl", mockClient, retryCfg)
+			client := NewKuberayAPIServerClient("http://mock", mockClient, retryCfg)
 
 			body, status, err := client.executeRequest(req, "http://mock/test")
 
@@ -270,7 +270,7 @@ func TestAPIServerClientBackoff(t *testing.T) {
 		OverallTimeout: util.HTTPClientDefaultOverallTimeout,
 	}
 
-	client := NewKuberayAPIServerClient("baseurl", mockClient, retryCfg)
+	client := NewKuberayAPIServerClient("http://mock", mockClient, retryCfg)
 
 	ctx := context.Background()
 	req, err := http.NewRequestWithContext(ctx, "GET", "http://mock/test", nil)
@@ -312,7 +312,7 @@ func TestAPIServerClientOverallTimeout(t *testing.T) {
 		OverallTimeout: 1 * time.Millisecond,
 	}
 
-	client := NewKuberayAPIServerClient("baseurl", mockClient, retryCfg)
+	client := NewKuberayAPIServerClient("http://mock", mockClient, retryCfg)
 
 	ctx := context.Background()
 	req, err := http.NewRequestWithContext(ctx, "GET", "http://mock/test", nil)
@@ -323,4 +323,61 @@ func TestAPIServerClientOverallTimeout(t *testing.T) {
 	// Expect a timeout error
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "retry timeout exceeded context deadline")
+}
+
+// Verify executeRequest refuses to dispatch when the request URL host does not match the
+// configured baseURL host, defending against accidental SSRF (and giving gosec G704 a
+// sanitization point).
+func TestExecuteRequestRejectsForeignHost(t *testing.T) {
+	retryCfg := util.RetryConfig{
+		MaxRetry:       util.HTTPClientDefaultMaxRetry,
+		BackoffFactor:  util.HTTPClientDefaultBackoffFactor,
+		InitBackoff:    util.HTTPClientDefaultInitBackoff,
+		MaxBackoff:     util.HTTPClientDefaultMaxBackoff,
+		OverallTimeout: util.HTTPClientDefaultOverallTimeout,
+	}
+
+	transport := &mockTransport{statusSequence: []int{http.StatusOK}}
+	mockClient := &http.Client{Transport: transport}
+	client := NewKuberayAPIServerClient("http://configured-host:8888", mockClient, retryCfg)
+
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://attacker.example/evil", nil)
+	require.NoError(t, err)
+
+	body, status, err := client.executeRequest(req, "http://attacker.example/evil")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match configured baseURL host")
+	require.Nil(t, status)
+	require.Nil(t, body)
+	// The request must never reach the transport.
+	require.Equal(t, 0, transport.callCount)
+}
+
+// Verify executeRequest refuses to dispatch when the client was constructed with a
+// malformed baseURL that yields no host. Without this guard, gosec G704 has no
+// sanitization point and every Do() call would be flagged.
+func TestExecuteRequestRejectsEmptyBaseURLHost(t *testing.T) {
+	retryCfg := util.RetryConfig{
+		MaxRetry:       util.HTTPClientDefaultMaxRetry,
+		BackoffFactor:  util.HTTPClientDefaultBackoffFactor,
+		InitBackoff:    util.HTTPClientDefaultInitBackoff,
+		MaxBackoff:     util.HTTPClientDefaultMaxBackoff,
+		OverallTimeout: util.HTTPClientDefaultOverallTimeout,
+	}
+
+	transport := &mockTransport{statusSequence: []int{http.StatusOK}}
+	mockClient := &http.Client{Transport: transport}
+	// "baseurl" parses without error but yields an empty Host.
+	client := NewKuberayAPIServerClient("baseurl", mockClient, retryCfg)
+
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://mock/test", nil)
+	require.NoError(t, err)
+
+	_, _, err = client.executeRequest(req, "http://mock/test")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match configured baseURL host")
+	require.Equal(t, 0, transport.callCount)
 }


### PR DESCRIPTION
## Problem

#4703 upgrades golangci-lint to a version where `gosec G704` (SSRF via taint analysis) starts firing on `apiserver/pkg/http/client.go:673`:

```
apiserver/pkg/http/client.go:673:37: G704: SSRF via taint analysis (gosec)
		response, err := krc.httpClient.Do(httpRequest)
```

The URL passed to every method is built by concatenating `krc.baseURL` with request fields, which gosec treats as tainted. #4731 asks for a structural fix rather than a bare `//nolint:gosec` suppression.

## Direction

Add a host check at the same point: pre-parse `baseURL` once, then verify each request URL host matches it immediately before `httpClient.Do()`. Any stray rewrite of `httpRequest.URL` (the actual SSRF concern) becomes an explicit error instead of a silent foreign call.

I attempted to fully eliminate the suppression but gosec G704's taint analysis flags `Do(httpRequest)` purely on the URL's provenance (string concat from a struct field) and does not model the field-level host check as a sanitization. So a `//nolint:gosec` on the `Do()` line is still required; the change is to make that suppression honest by pointing at concrete validation rather than just claiming "internal config".

The remaining `//nolint:gosec` can go away only if the request-building path is refactored into a shape gosec's taint analysis recognizes, such as a pure `*url.URL`/`JoinPath` flow or a wrapper it can resolve.

## Evidence

Reproducer (against current `master`, since #4703 isn't merged yet but the new linter shows the same flag):

```bash
go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
cd kuberay
golangci-lint run --no-config -E gosec --timeout 5m ./apiserver/pkg/http/...
```

Before this change, output includes:

```
apiserver/pkg/http/client.go:673:37: G704: SSRF via taint analysis (gosec)
		response, err := krc.httpClient.Do(httpRequest)
```

After this change, with the project's actual lint config:

```bash
golangci-lint run --timeout 5m ./apiserver/pkg/http/...
0 issues.
```

Tested with `golangci-lint v2.11.4 / go1.26.2` on macOS arm64.

## Implementation

`apiserver/pkg/http/client.go`:

- New `baseURLHost` field, populated by `url.Parse` once in `NewKuberayAPIServerClient`.
- `executeRequest` now refuses to dispatch when `httpRequest.URL` is nil, when `baseURLHost` is empty (malformed input), or when `httpRequest.URL.Host` does not equal `baseURLHost`. The check sits immediately before `httpClient.Do()`.
- The kept `//nolint:gosec` on `Do()` now references the validation above.

`apiserver/pkg/http/client_test.go`:

- Existing `executeRequest` tests now construct the client with `"http://mock"` so the host check passes (request URL is `http://mock/test`).
- Two new tests:
  - `TestExecuteRequestRejectsForeignHost` - configured `http://configured-host:8888`, request to `http://attacker.example/evil`, expects validation error and `transport.callCount == 0`.
  - `TestExecuteRequestRejectsEmptyBaseURLHost` - covers the malformed-baseURL path.
- The two `TestUnmarshal*` tests still pass `"baseurl"` because they mock `ExecuteHttpRequest` and don't reach the validation.

## Interaction with #4703

If #4731 lands first, the `//nolint:gosec // URL is constructed from internal config, not user input` line that #4703 adds in the same spot can be dropped (or replaced by a rebase that picks up the version in this PR). If #4703 lands first, this PR will need a small rebase to remove that suppression and replace it with the version here. Either order works. Reviewers only need to watch for that rebase conflict.

## Verification

- [x] `go test ./apiserver/pkg/http/...` - all existing tests + 2 new tests pass
- [x] `golangci-lint run --timeout 5m ./apiserver/pkg/http/...` (project config) - 0 issues
- [x] `golangci-lint run --no-config -E gosec --timeout 5m ./apiserver/pkg/http/...` - G704 gone
- [x] `go build ./apiserver/...` - clean
