### PR TITLE
[Refactor][Test] Extract ApplyRayJobAndWaitForTerminal helper

### DIFF
--- a/ray-operator/test/e2erayjob/rayjob_cluster_selector_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_cluster_selector_test.go
@@ -52,13 +52,7 @@ env_vars:
 `).
 				WithSubmitterPodTemplate(JobSubmitterPodTemplateApplyConfiguration()))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
-		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
-
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+		rayJob := ApplyRayJobAndWaitForTerminal(test, rayJobAC)
 
 		// Assert the Ray job has completed successfully
 		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
@@ -76,13 +70,7 @@ env_vars:
 				WithShutdownAfterJobFinishes(false).
 				WithSubmitterPodTemplate(JobSubmitterPodTemplateApplyConfiguration()))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
-		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
-
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+		rayJob := ApplyRayJobAndWaitForTerminal(test, rayJobAC)
 
 		// Assert the Ray job has failed
 		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).

--- a/ray-operator/test/e2erayjob/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_lightweight_test.go
@@ -52,13 +52,7 @@ env_vars:
 						WithTemplate(PodTemplateSpecApplyConfiguration(HeadPodTemplateApplyConfiguration(),
 							MountConfigMap[corev1ac.PodTemplateSpecApplyConfiguration](jobs, "/home/ray/jobs"))))))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
-		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
-
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+		rayJob := ApplyRayJobAndWaitForTerminal(test, rayJobAC)
 
 		// Assert the RayJob has completed successfully
 		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
@@ -86,13 +80,7 @@ env_vars:
 				WithShutdownAfterJobFinishes(false).
 				WithRayClusterSpec(NewRayClusterSpec(MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
-		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
-
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+		rayJob := ApplyRayJobAndWaitForTerminal(test, rayJobAC)
 
 		// Assert the Ray job has failed
 		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).

--- a/ray-operator/test/e2erayjob/rayjob_sidecar_mode_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_sidecar_mode_test.go
@@ -54,13 +54,7 @@ env_vars:
 						WithTemplate(PodTemplateSpecApplyConfiguration(HeadPodTemplateApplyConfiguration(),
 							MountConfigMap[corev1ac.PodTemplateSpecApplyConfiguration](jobs, "/home/ray/jobs"))))))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
-		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
-
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+		rayJob := ApplyRayJobAndWaitForTerminal(test, rayJobAC)
 
 		// Assert the RayJob has completed successfully
 		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
@@ -88,13 +82,7 @@ env_vars:
 				WithShutdownAfterJobFinishes(false).
 				WithRayClusterSpec(NewRayClusterSpec(MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
-		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
-
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+		rayJob := ApplyRayJobAndWaitForTerminal(test, rayJobAC)
 
 		// Assert the Ray job has failed
 		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).

--- a/ray-operator/test/e2erayjob/rayjob_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_test.go
@@ -113,13 +113,7 @@ env_vars:
 				WithShutdownAfterJobFinishes(false).
 				WithSubmitterPodTemplate(JobSubmitterPodTemplateApplyConfiguration()))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
-		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
-
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+		rayJob := ApplyRayJobAndWaitForTerminal(test, rayJobAC)
 
 		// Assert the Ray job has failed
 		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).

--- a/ray-operator/test/e2erayjobsubmitter/rayjob_submitter_test.go
+++ b/ray-operator/test/e2erayjobsubmitter/rayjob_submitter_test.go
@@ -42,13 +42,7 @@ func TestRayJobSubmitter(t *testing.T) {
 				WithSubmitterPodTemplate(SubmitterPodTemplate).
 				WithShutdownAfterJobFinishes(true),
 		)
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
-		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
-
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+		rayJob := ApplyRayJobAndWaitForTerminal(test, rayJobAC)
 
 		// Assert the RayJob has completed successfully
 		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).

--- a/ray-operator/test/support/ray.go
+++ b/ray-operator/test/support/ray.go
@@ -15,6 +15,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
 )
 
 func RayCronJob(t Test, namespace, name string) func() (*rayv1.RayCronJob, error) {
@@ -69,6 +70,27 @@ func RayJobSucceeded(job *rayv1.RayJob) int32 {
 
 func RayJobClusterName(job *rayv1.RayJob) string {
 	return job.Status.RayClusterName
+}
+
+// ApplyRayJobAndWaitForTerminal applies the given RayJob configuration and waits for the
+// resulting RayJob to reach a terminal job status (Succeeded, Failed, or Stopped).
+// Returns the RayJob returned by the apply call.
+//
+// Tests that need a stricter completion state (e.g. Succeeded only) should chain an
+// additional assertion on the returned RayJob.
+func ApplyRayJobAndWaitForTerminal(t Test, rayJobAC *rayv1ac.RayJobApplyConfiguration) *rayv1.RayJob {
+	t.T().Helper()
+	g := NewWithT(t.T())
+
+	rayJob, err := t.Client().Ray().RayV1().RayJobs(*rayJobAC.Namespace).Apply(t.Ctx(), rayJobAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(t.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+	LogWithTimestamp(t.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+	g.Eventually(RayJob(t, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+
+	return rayJob
 }
 
 func RayCluster(t Test, namespace, name string) func() (*rayv1.RayCluster, error) {


### PR DESCRIPTION
## Problem
The `Apply RayJob` -> `wait for IsJobTerminal` block is duplicated across 8 e2e test sites in `ray-operator/test/`. A review on https://github.com/ray-project/kuberay/pull/4363 pointed out that the pattern belongs in `ray-operator/test/support/`.

## Direction
Extract `ApplyRayJobAndWaitForTerminal` into `support/ray.go`, alongside the existing `RayJob`/`GetRayJob` accessors and `VerifyContainerAuthTokenEnvVars`. Promote only the **tight** Apply-immediately-followed-by-`IsJobTerminal` pattern; leave alone sites that wait on a different deployment status (`Running`, `Failed`, `ValidationFailed`, ...) or interleave other logic between Apply and the terminal wait.

## Scope
The shared helper covers only the Apply-immediately-followed-by-`IsJobTerminal` path. The stricter deletion-strategy helpers stay local because they assert `JobStatusSucceeded` or `JobDeploymentStatusFailed` with `DeadlineExceeded`, which is narrower than the new helper.

## Validation
- `go build ./test/...` clean
- `go vet ./test/...` clean
- `gofmt -l ray-operator/test/` clean
- E2E tests not run locally (require kind cluster + Ray operator); covered by CI.

Closes #4373.
