### PR TITLE
[Fix] [History Server] Normalize hex ID for data integrity

### DIFF
--- a/historyserver/pkg/utils/utils.go
+++ b/historyserver/pkg/utils/utils.go
@@ -19,6 +19,12 @@ const (
 	DATETIME_LAYOUT                       = "2006-01-02_15-04-05.000000"
 	// The following regex shouldn't be changed unless the ray session ID changes.
 	SESSION_ID_REGEX = `session_(\d{4}-\d{2}-\d{2})_(\d{2}-\d{2}-\d{2})_(\d{6})`
+	HEX_REGEX        = `^[0-9a-fA-F]+$`
+)
+
+var (
+	sessionIDRegex = regexp.MustCompile(SESSION_ID_REGEX)
+	hexRegex       = regexp.MustCompile(HEX_REGEX)
 )
 
 // EndpointPathToStorageKey converts a Ray Dashboard API endpoint path to a
@@ -34,8 +40,6 @@ func EndpointPathToStorageKey(endpointPath string) string {
 	trimmed := strings.Trim(endpointPath, "/")
 	return "restful__" + strings.ReplaceAll(trimmed, "/", "__")
 }
-
-var regex = regexp.MustCompile(SESSION_ID_REGEX)
 
 func GetLogDirByNameID(ossHistorySeverDir, rayClusterNameNamespace, rayNodeID, sessionId string) string {
 	return fmt.Sprintf("%s/", path.Clean(path.Join(ossHistorySeverDir, rayClusterNameNamespace, sessionId, RAY_SESSIONDIR_LOGDIR_NAME, rayNodeID)))
@@ -102,8 +106,8 @@ func GetRayNodeID() (string, error) {
 // It tries RawURLEncoding first (Ray's default), falling back to StdEncoding if that fails.
 func ConvertBase64ToHex(id string) (string, error) {
 	// Check if already hex (only [0-9a-f])
-	if matched, _ := regexp.MatchString("^[0-9a-fA-F]+$", id); matched {
-		return id, nil
+	if hexRegex.MatchString(id) {
+		return strings.ToLower(id), nil
 	}
 
 	// Try base64 decode
@@ -153,7 +157,7 @@ func BuildClusterSessionKey(clusterName, namespace, sessionName string) string {
 
 // GetDateTimeFromSessionID will convert sessionID string i.e. `session_2026-01-27_10-52-59_373533_1` to time.Time
 func GetDateTimeFromSessionID(sessionID string) (time.Time, error) {
-	matches := regex.FindStringSubmatch(sessionID)
+	matches := sessionIDRegex.FindStringSubmatch(sessionID)
 
 	if len(matches) < 4 {
 		return time.Time{}, fmt.Errorf("Invalid session string format, expected `session_YYYY-MM-DD_HH-MM-SS_MICROSECOND` got: %s", sessionID)

--- a/historyserver/pkg/utils/utils_test.go
+++ b/historyserver/pkg/utils/utils_test.go
@@ -41,6 +41,18 @@ func TestConvertBase64ToHex(t *testing.T) {
 			expectedHexStr: "AQAAAA_==",
 			expectError:    true,
 		},
+		{
+			scenario:       "Already hex with uppercase is normalized to lowercase",
+			base64Str:      "ABCDEF01",
+			expectedHexStr: "abcdef01",
+			expectError:    false,
+		},
+		{
+			scenario:       "Already hex with lowercase is returned as-is",
+			base64Str:      "abcdef01",
+			expectedHexStr: "abcdef01",
+			expectError:    false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Why are these changes needed?

Current base64 to hex conversion would return mixed-case ID in the hex path. However, the base64 path only returns lowercase  IDs `fmt.Sprintf("%x", idBytes)`.

This PR ensures all converted IDs are lowercase for data integrity. In addition, regex pre-compilation is used to improve performance.

## Related issue number

https://github.com/ray-project/kuberay/pull/4769

## Test Results

<img width="345" height="225" alt="Screenshot 2026-04-28 at 11 48 34 AM" src="https://github.com/user-attachments/assets/61494283-16a6-429f-b527-4f6c12a55442" />

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
