### PR TITLE
[RayService][Bug] applyServeTargetCapacity: accept int64/float64 for cached target_capacity (#4777)

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1442,18 +1442,18 @@ func targetCapacityAsInt32(v any) (int32, bool) {
 		if n < minInt32 || n > maxInt32 {
 			return 0, false
 		}
-		return int32(n), true //nolint:gosec // bounds-checked above
+		return int32(n), true
 	case float64:
 		// Reject NaN/Inf and values outside the int32 range.
 		if math.IsNaN(n) || math.IsInf(n, 0) || n < float64(minInt32) || n > float64(maxInt32) {
 			return 0, false
 		}
-		return int32(n), true //nolint:gosec // bounds-checked above
+		return int32(n), true
 	case int:
 		if int64(n) < minInt32 || int64(n) > maxInt32 {
 			return 0, false
 		}
-		return int32(n), true //nolint:gosec // bounds-checked above
+		return int32(n), true
 	case int32:
 		return n, true
 	default:

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1442,18 +1442,18 @@ func targetCapacityAsInt32(v any) (int32, bool) {
 		if n < minInt32 || n > maxInt32 {
 			return 0, false
 		}
-		return int32(n), true
+		return int32(n), true //nolint:gosec // bounds-checked above
 	case float64:
 		// Reject NaN/Inf and values outside the int32 range.
 		if math.IsNaN(n) || math.IsInf(n, 0) || n < float64(minInt32) || n > float64(maxInt32) {
 			return 0, false
 		}
-		return int32(n), true
+		return int32(n), true //nolint:gosec // bounds-checked above
 	case int:
 		if int64(n) < minInt32 || int64(n) > maxInt32 {
 			return 0, false
 		}
-		return int32(n), true
+		return int32(n), true //nolint:gosec // bounds-checked above
 	case int32:
 		return n, true
 	default:

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1424,6 +1424,43 @@ func (r *RayServiceReconciler) checkIfNeedTargetCapacityUpdate(ctx context.Conte
 	return true, "Active RayCluster TargetCapacity has not finished scaling down."
 }
 
+// targetCapacityAsInt32 coerces a target_capacity value as decoded from a
+// ServeConfigV2 YAML/JSON document into an int32. Returns ok=false for nil,
+// missing entries, values of any other type, or numeric values that don't
+// fit in int32. See #4777 for why both int64 and float64 must be accepted.
+//
+// Out-of-range int64 / int / float64 values are rejected rather than
+// silently truncated — gosec G115 flagged the previous unconditional
+// `int32(n)` conversions, and silent truncation here would put garbage in
+// the dashboard's target_capacity field instead of producing a clear
+// "unsupported value" log line upstream.
+func targetCapacityAsInt32(v any) (int32, bool) {
+	const maxInt32 = int64(math.MaxInt32)
+	const minInt32 = int64(math.MinInt32)
+	switch n := v.(type) {
+	case int64:
+		if n < minInt32 || n > maxInt32 {
+			return 0, false
+		}
+		return int32(n), true
+	case float64:
+		// Reject NaN/Inf and values outside the int32 range.
+		if math.IsNaN(n) || math.IsInf(n, 0) || n < float64(minInt32) || n > float64(maxInt32) {
+			return 0, false
+		}
+		return int32(n), true
+	case int:
+		if int64(n) < minInt32 || int64(n) > maxInt32 {
+			return 0, false
+		}
+		return int32(n), true
+	case int32:
+		return n, true
+	default:
+		return 0, false
+	}
+}
+
 // applyServeTargetCapacity updates the target_capacity for a given RayCluster's Serve applications.
 func (r *RayServiceReconciler) applyServeTargetCapacity(ctx context.Context, rayServiceInstance *rayv1.RayService, rayClusterInstance *rayv1.RayCluster, rayDashboardClient dashboardclient.RayDashboardClientInterface, goalTargetCapacity int32) error {
 	logger := ctrl.LoggerFrom(ctx).WithValues("RayCluster", rayClusterInstance.Name)
@@ -1439,9 +1476,20 @@ func (r *RayServiceReconciler) applyServeTargetCapacity(ctx context.Context, ray
 		return err
 	}
 
-	// Check if ServeConfig requires update
-	if currentTargetCapacity, ok := serveConfig["target_capacity"].(float64); ok {
-		if int32(currentTargetCapacity) == goalTargetCapacity {
+	// Check if ServeConfig requires update.
+	//
+	// k8s.io/apimachinery/util/yaml decodes integers as int64 (it routes
+	// JSON-compatible input through encoding/json with UseNumber off, and
+	// gopkg.in/yaml.v2 also returns int64 for plain integer scalars). The
+	// previous \`.(float64)\` assertion therefore *always* failed for
+	// ServeConfigV2 strings whose target_capacity is an integer — every
+	// reconcile took the slow path and called UpdateDeployments
+	// unconditionally even when the value was already current (#4777).
+	//
+	// Accept both int64 and float64 so the idempotency guard fires for
+	// either source.
+	if currentTargetCapacity, ok := targetCapacityAsInt32(serveConfig["target_capacity"]); ok {
+		if currentTargetCapacity == goalTargetCapacity {
 			logger.Info("target_capacity already updated on RayCluster", "target_capacity", currentTargetCapacity)
 			// No update required, return early
 			return nil

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1430,7 +1430,7 @@ func (r *RayServiceReconciler) checkIfNeedTargetCapacityUpdate(ctx context.Conte
 // fit in int32. See #4777 for why both int64 and float64 must be accepted.
 //
 // Out-of-range int64 / int / float64 values are rejected rather than
-// silently truncated — gosec G115 flagged the previous unconditional
+// silently truncated, gosec G115 flagged the previous unconditional
 // `int32(n)` conversions, and silent truncation here would put garbage in
 // the dashboard's target_capacity field instead of producing a clear
 // "unsupported value" log line upstream.
@@ -1482,7 +1482,7 @@ func (r *RayServiceReconciler) applyServeTargetCapacity(ctx context.Context, ray
 	// JSON-compatible input through encoding/json with UseNumber off, and
 	// gopkg.in/yaml.v2 also returns int64 for plain integer scalars). The
 	// previous \`.(float64)\` assertion therefore *always* failed for
-	// ServeConfigV2 strings whose target_capacity is an integer — every
+	// ServeConfigV2 strings whose target_capacity is an integer, every
 	// reconcile took the slow path and called UpdateDeployments
 	// unconditionally even when the value was already current (#4777).
 	//

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -3,6 +3,7 @@ package ray
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"reflect"
 	"strconv"
@@ -1998,6 +1999,78 @@ func TestReconcileServeTargetCapacity(t *testing.T) {
 				assert.Equal(t, tt.activeCapacity, *rayService.Status.ActiveServiceStatus.TargetCapacity)
 				expectedServeConfig := `{"target_capacity":` + strconv.Itoa(int(tt.expectedPendingCapacity)) + `}`
 				assert.JSONEq(t, expectedServeConfig, string(fakeDashboard.LastUpdatedConfig))
+			}
+		})
+	}
+}
+
+// Regression coverage for #4777. The previous implementation type-asserted
+// `serveConfig["target_capacity"]` as `float64`, but
+// `k8s.io/apimachinery/util/yaml.Unmarshal` decodes plain integer scalars
+// as `int64`. The assertion therefore always failed, the idempotency
+// branch was always skipped, and `applyServeTargetCapacity` would call
+// `UpdateDeployments` on every reconcile even when the cached and goal
+// values matched. This test pins the int64 path so the bug can't quietly
+// regress.
+func TestApplyServeTargetCapacity_SkipsUpdateWhenCachedMatchesGoal(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.RayServiceIncrementalUpgrade, true)
+
+	const goalCapacity int32 = 60
+	rayService := &rayv1.RayService{
+		Spec: rayv1.RayServiceSpec{
+			// `60` is a plain integer; util/yaml will decode it as int64.
+			ServeConfigV2: `{"target_capacity": 60}`,
+		},
+		Status: rayv1.RayServiceStatuses{
+			ActiveServiceStatus: rayv1.RayServiceStatus{
+				RayClusterName: "active",
+			},
+		},
+	}
+	rayCluster := &rayv1.RayCluster{ObjectMeta: metav1.ObjectMeta{Name: "active"}}
+
+	fakeDashboard := &utils.FakeRayDashboardClient{}
+	reconciler := &RayServiceReconciler{ServeConfigs: lru.New(10)}
+
+	err := reconciler.applyServeTargetCapacity(context.TODO(), rayService, rayCluster, fakeDashboard, goalCapacity)
+	require.NoError(t, err)
+	// The crucial assertion: when cached == goal, the dashboard client
+	// must NOT be called. Pre-fix this fired UpdateDeployments anyway.
+	assert.Empty(t, fakeDashboard.LastUpdatedConfig,
+		"applyServeTargetCapacity must skip UpdateDeployments when cached target_capacity already matches goal")
+}
+
+func TestTargetCapacityAsInt32(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want int32
+		ok   bool
+	}{
+		{"int64 from util/yaml", int64(60), 60, true},
+		{"float64 from json/yaml.v3", float64(60), 60, true},
+		{"int", 60, 60, true},
+		{"int32", int32(60), 60, true},
+		{"nil", nil, 0, false},
+		{"string is rejected", "60", 0, false},
+		{"map is rejected", map[string]any{}, 0, false},
+		// Out-of-range numeric values must be rejected rather than
+		// silently truncated (gosec G115). Pinning these so a future
+		// `int32(n)` shortcut can't regress the behavior.
+		{"int64 above MaxInt32 is rejected", int64(math.MaxInt32) + 1, 0, false},
+		{"int64 below MinInt32 is rejected", int64(math.MinInt32) - 1, 0, false},
+		{"float64 above MaxInt32 is rejected", float64(math.MaxInt32) + 1, 0, false},
+		{"float64 below MinInt32 is rejected", float64(math.MinInt32) - 1, 0, false},
+		{"float64 NaN is rejected", math.NaN(), 0, false},
+		{"float64 +Inf is rejected", math.Inf(1), 0, false},
+		{"float64 -Inf is rejected", math.Inf(-1), 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := targetCapacityAsInt32(tc.in)
+			assert.Equal(t, tc.ok, ok)
+			if tc.ok {
+				assert.Equal(t, tc.want, got)
 			}
 		})
 	}

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2935,7 +2935,7 @@ func TestShouldCompleteIncrementalRollback(t *testing.T) {
 		want           bool
 	}{
 		{
-			name:           "healthy pending at zero capacity and traffic — complete",
+			name:           "healthy pending at zero capacity and traffic, complete",
 			activeTC:       100,
 			activeTRP:      100,
 			pendingTC:      0,
@@ -2944,7 +2944,7 @@ func TestShouldCompleteIncrementalRollback(t *testing.T) {
 			want:           true,
 		},
 		{
-			name:           "unhealthy pending with leftover capacity — bypass complete",
+			name:           "unhealthy pending with leftover capacity, bypass complete",
 			activeTC:       100,
 			activeTRP:      100,
 			pendingTC:      30,
@@ -2953,7 +2953,7 @@ func TestShouldCompleteIncrementalRollback(t *testing.T) {
 			want:           true,
 		},
 		{
-			name:           "no pending RayCluster — complete when active is full",
+			name:           "no pending RayCluster, complete when active is full",
 			activeTC:       100,
 			activeTRP:      100,
 			pendingTC:      0,
@@ -2962,7 +2962,7 @@ func TestShouldCompleteIncrementalRollback(t *testing.T) {
 			want:           true,
 		},
 		{
-			name:           "healthy pending still holding target capacity — not complete",
+			name:           "healthy pending still holding target capacity, not complete",
 			activeTC:       100,
 			activeTRP:      100,
 			pendingTC:      50,


### PR DESCRIPTION
Closes #4777.

## Why

`applyServeTargetCapacity` reads the cached `ServeConfigV2` string,
unmarshals it with `k8s.io/apimachinery/util/yaml`, and asserts
`serveConfig["target_capacity"].(float64)` so it can skip
`UpdateDeployments` when the cached value already matches the goal.

`util/yaml` decodes plain integer scalars as `int64` (it routes
JSON-compatible input through `encoding/json` with `UseNumber` off,
and `gopkg.in/yaml.v2` also returns int64 for integer scalars). The
`float64` assertion therefore **always** failed for any
`target_capacity` written as a plain integer, the idempotency branch
was always skipped, and the controller called `UpdateDeployments` on
every reconcile even when the value was already current.

The existing `TestReconcileServeTargetCapacity` didn't catch this
because every case used a cached/goal **mismatch** (0 → 30 / 60 → 30
etc.), so the controller proceeded to the update branch in both the
intended-skip and intended-update flows, masking the bug entirely.

## Fix

- New `targetCapacityAsInt32(any) (int32, bool)` helper that accepts
  `int64`, `float64`, `int`, and `int32`, returning `int32`. Rejects
  `nil` / `string` / `map` / other types.
- `applyServeTargetCapacity` now uses the helper for the idempotency
  check.

## Tests

`ray-operator/controllers/ray/rayservice_controller_unit_test.go`:

- **`TestApplyServeTargetCapacity_SkipsUpdateWhenCachedMatchesGoal`**
 , the cached/goal scenario the previous suite never covered. Cached
  `ServeConfigV2 = '{"target_capacity": 60}'` and goal 60 must NOT
  call `UpdateDeployments`. Asserts `fakeDashboard.LastUpdatedConfig`
  stays empty.
- **`TestTargetCapacityAsInt32`**, 7 sub-cases covering int64,
  float64, int, int32, nil, string, map.
- The existing `TestReconcileServeTargetCapacity` still passes
  unchanged.

## Verification

- `go test ./controllers/ray/ -run "TestApplyServeTargetCapacity_SkipsUpdateWhenCachedMatchesGoal|TestTargetCapacityAsInt32|TestReconcileServeTargetCapacity"` → all green.
- I confirmed locally that reverting *just* the controller change
  while keeping the test makes the new
  `TestApplyServeTargetCapacity_SkipsUpdateWhenCachedMatchesGoal`
  fail with `Should be empty, but was [123 34 116 97 ... 54 48 125]`
 , the byte representation of `{"target_capacity":60}` that
  `UpdateDeployments` should never have been called with, i.e. the
  test catches the regression.