### PR TITLE
Fix/kubectl plugin log fd leak and g115（#4779）

### DIFF
--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -434,28 +434,44 @@ func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec 
 				return fmt.Errorf("Error creating directory: %w", err)
 			}
 		case tar.TypeReg:
-			// Check for overflow: G115
+			// Fix G115: header.Mode is int64; on 32-bit platforms os.FileMode is
+			// uint32, so values outside [0, math.MaxUint32] would overflow.
+			// Skip the file and log a warning instead of silently truncating the
+			// permission bits.
 			if header.Mode < 0 || header.Mode > math.MaxUint32 {
-				fmt.Fprintf(options.ioStreams.Out, "file mode out side of acceptable value %d skipping file\n", header.Mode)
+				fmt.Fprintf(options.ioStreams.Out, "skipping file %q: mode value %d is outside the valid range for os.FileMode\n", header.Name, header.Mode)
+				header, err = tarReader.Next()
+				if header == nil && err != nil && !errors.Is(err, io.EOF) {
+					return fmt.Errorf("error while extracting tar file with error: %w", err)
+				}
+				continue
 			}
-			// Create file and write contents
-			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //nolint:gosec // overflow is guarded by bounds check above
-			if err != nil {
-				return fmt.Errorf("Error creating file: %w", err)
-			}
-			defer outFile.Close()
-			// This is to limit the copy size for a decompression bomb, currently set arbitrarily
-			for {
-				n, err := io.CopyN(outFile, tarReader, 1000000)
+			// Fix FD leak: use a closure so that outFile.Close() is called at the
+			// end of each loop iteration rather than when downloadRayLogFiles
+			// returns.  A defer inside a loop body only fires on function return,
+			// which would exhaust file descriptors for archives with many entries.
+			if err := func() error {
+				outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //#nosec G115 -- range checked above
 				if err != nil {
-					if errors.Is(err, io.EOF) {
+					return fmt.Errorf("Error creating file: %w", err)
+				}
+				defer outFile.Close()
+				// Limit individual copy size to guard against decompression bombs.
+				for {
+					n, err := io.CopyN(outFile, tarReader, 1000000)
+					if err != nil {
+						if errors.Is(err, io.EOF) {
+							break
+						}
+						return fmt.Errorf("failed while writing to file: %w", err)
+					}
+					if n == 0 {
 						break
 					}
-					return fmt.Errorf("failed while writing to file: %w", err)
 				}
-				if n == 0 {
-					break
-				}
+				return nil
+			}(); err != nil {
+				return err
 			}
 		default:
 			fmt.Printf("Ignoring unsupported file type: %b", header.Typeflag)

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -482,6 +483,185 @@ func TestDownloadRayLogFiles(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, curr.Body, string(actualContent))
 	}
+}
+
+// createFakeTarFileWithInvalidMode creates a tar archive that contains one regular file
+// with a header.Mode value outside the valid [0, math.MaxUint32] range (negative).
+// This exercises the G115 overflow-guard path added in the fix.
+func createFakeTarFileWithInvalidMode() (*bytes.Buffer, error) {
+	tarbuff := new(bytes.Buffer)
+	tw := tar.NewWriter(tarbuff)
+
+	// A valid directory entry so the archive is well-formed.
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeDir,
+		Name:     "/",
+		Mode:     0o755,
+	}); err != nil {
+		return nil, err
+	}
+
+	// A regular file whose Mode is negative – this triggers the G115 overflow guard.
+	body := []byte("should be skipped")
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "bad-mode-file.txt",
+		Mode:     -1, // invalid: negative value overflows uint32
+		Size:     int64(len(body)),
+	}); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write(body); err != nil {
+		return nil, err
+	}
+
+	// A normal file that should still be extracted after the bad one is skipped.
+	body2 := []byte("hello from valid file\n")
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "valid-file.txt",
+		Mode:     0o644,
+		Size:     int64(len(body2)),
+	}); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write(body2); err != nil {
+		return nil, err
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	return tarbuff, nil
+}
+
+// createFakeTarFileWithManyFiles creates a tar archive with n regular files.
+// Used to verify that the FD-leak fix keeps all file descriptors closed during
+// the loop (i.e. no "too many open files" error).
+func createFakeTarFileWithManyFiles(n int) (*bytes.Buffer, error) {
+	tarbuff := new(bytes.Buffer)
+	tw := tar.NewWriter(tarbuff)
+
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeDir,
+		Name:     "/",
+		Mode:     0o755,
+	}); err != nil {
+		return nil, err
+	}
+
+	for i := range n {
+		body := []byte(fmt.Sprintf("content of file %d\n", i))
+		if err := tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     fmt.Sprintf("file%04d.txt", i),
+			Mode:     0o644,
+			Size:     int64(len(body)),
+		}); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write(body); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	return tarbuff, nil
+}
+
+// TestDownloadRayLogFiles_SkipsFileWithInvalidMode is a regression test for the
+// G115 integer-overflow fix.  A tar entry whose header.Mode is outside the
+// valid [0, math.MaxUint32] range must be skipped with a warning; the
+// subsequent valid entry must still be extracted normally.
+func TestDownloadRayLogFiles_SkipsFileWithInvalidMode(t *testing.T) {
+	fakeDir := t.TempDir()
+
+	testStreams, _, out, _ := genericiooptions.NewTestIOStreams()
+	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+
+	opts := NewClusterLogOptions(cmdFactory, testStreams)
+	opts.ResourceName = "test-cluster"
+	opts.outputDir = fakeDir
+
+	fakeTar, err := createFakeTarFileWithInvalidMode()
+	require.NoError(t, err)
+
+	rayHead := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-kuberay-head-1",
+			Namespace: "test",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{Name: "mycontainer", Image: "nginx:latest"}},
+		},
+	}
+
+	executor, _ := fakeNewSPDYExecutor("GET", &url.URL{}, fakeTar)
+	err = opts.downloadRayLogFiles(context.Background(), executor, rayHead)
+	require.NoError(t, err, "downloadRayLogFiles must not return an error for an out-of-range mode")
+
+	// The warning message must have been printed.
+	assert.Contains(t, out.String(), "skipping file",
+		"a warning must be printed for the file with the invalid mode")
+
+	// The bad file must NOT have been created.
+	badPath := filepath.Join(fakeDir, rayHead.Name, "bad-mode-file.txt")
+	_, statErr := os.Stat(badPath)
+	assert.True(t, os.IsNotExist(statErr),
+		"bad-mode-file.txt must not be created when mode is out of range")
+
+	// The valid file that follows the bad one MUST have been created.
+	validPath := filepath.Join(fakeDir, rayHead.Name, "valid-file.txt")
+	content, readErr := os.ReadFile(validPath)
+	require.NoError(t, readErr, "valid-file.txt must be created even after a skipped entry")
+	assert.Equal(t, "hello from valid file\n", string(content))
+}
+
+// TestDownloadRayLogFiles_NoFDLeakWithManyFiles is a regression test for the
+// file-descriptor leak fix.  Before the fix, defer outFile.Close() inside the
+// loop body deferred all closes until function return; with a large archive
+// this exhausted the per-process FD limit and returned "too many open files".
+// The test extracts 300 files – well above the typical per-process soft limit
+// of 256 on macOS and comfortably above the default 1024 on Linux when the
+// test binary itself already holds several descriptors.
+func TestDownloadRayLogFiles_NoFDLeakWithManyFiles(t *testing.T) {
+	const fileCount = 300
+
+	fakeDir := t.TempDir()
+	testStreams, _, _, _ := genericiooptions.NewTestIOStreams()
+	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+
+	opts := NewClusterLogOptions(cmdFactory, testStreams)
+	opts.ResourceName = "test-cluster"
+	opts.outputDir = fakeDir
+
+	fakeTar, err := createFakeTarFileWithManyFiles(fileCount)
+	require.NoError(t, err)
+
+	rayHead := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-kuberay-head-1",
+			Namespace: "test",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{Name: "mycontainer", Image: "nginx:latest"}},
+		},
+	}
+
+	executor, _ := fakeNewSPDYExecutor("GET", &url.URL{}, fakeTar)
+
+	// Must not return an error ("too many open files" would surface here).
+	err = opts.downloadRayLogFiles(context.Background(), executor, rayHead)
+	require.NoError(t, err, "downloadRayLogFiles must not exhaust file descriptors")
+
+	// Verify all files were actually written.
+	podDir := filepath.Join(fakeDir, rayHead.Name)
+	entries, err := os.ReadDir(podDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, fileCount,
+		"all %d files must be extracted without FD exhaustion", fileCount)
 }
 
 // createTempKubeConfigFile creates a temporary kubeconfig file with the given current context.

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -551,7 +551,7 @@ func createFakeTarFileWithManyFiles(n int) (*bytes.Buffer, error) {
 	}
 
 	for i := range n {
-		body := []byte(fmt.Sprintf("content of file %d\n", i))
+		body := fmt.Appendf(nil, "content of file %d\n", i)
 		if err := tw.WriteHeader(&tar.Header{
 			Typeflag: tar.TypeReg,
 			Name:     fmt.Sprintf("file%04d.txt", i),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1.Integer Overflow (G115): After detecting an overflow of header.Mode, a continue statement was added to ensure the decompression of the corresponding file is properly skipped, instead of merely printing a warning and proceeding with risky type conversion.


2.File Descriptor Leak (FD Leak): The logic for file opening, content copying and the defer outFile.Close() statement inside the for loop was encapsulated in an immediately-invoked anonymous function (closure). This ensures the file handle is closed via defer at the end of each loop iteration, resolving the file descriptor exhaustion issue during bulk file decompression.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #4779
## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
