### PR TITLE
[Test] Fix race in DELETE_RAYJOB_CR_AFTER_JOB_FINISHES envtest

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -532,7 +532,15 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to get Kubernetes Job")
 			})
 
-			It("RayJobs's JobDeploymentStatus transitions from Running to Complete.", func() {
+			It("RayJobs's JobDeploymentStatus transitions from Running to Complete and RayJob is deleted when DELETE_RAYJOB_CR_AFTER_JOB_FINISHES is set.", func() {
+				// Set the env var before the RayJob transitions to Complete so that
+				// handleShutdownAfterJobFinishes sees it on the first reconciliation
+				// after the job finishes. Setting it after the transition is racy because
+				// the reconciler may have already processed the shutdown path without
+				// the env var, returning with no requeue.
+				os.Setenv(utils.DELETE_RAYJOB_CR_AFTER_JOB_FINISHES, "true")
+				defer os.Unsetenv(utils.DELETE_RAYJOB_CR_AFTER_JOB_FINISHES)
+
 				// Update fake dashboard client to return job info with "Succeeded" status.
 				getJobInfo := func(context.Context, string) (*utiltypes.RayJobInfo, error) { //nolint:unparam // This is a mock function so parameters are required
 					return &utiltypes.RayJobInfo{JobStatus: rayv1.JobStatusSucceeded, EndTime: uint64(time.Now().UnixMilli())}, nil
@@ -553,19 +561,11 @@ var _ = Context("RayJob with different submission modes", func() {
 
 				updateK8sJobToComplete(ctx, job)
 
-				// RayJob transitions to Complete.
-				Eventually(
-					getRayJobDeploymentStatus(ctx, rayJob),
-					time.Second*5, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusComplete), "jobDeploymentStatus = %v", rayJob.Status.JobDeploymentStatus)
-			})
-
-			It("If DELETE_RAYJOB_CR_AFTER_JOB_FINISHES environement variable is set, RayJob should be deleted.", func() {
-				os.Setenv(utils.DELETE_RAYJOB_CR_AFTER_JOB_FINISHES, "true")
-				defer os.Unsetenv(utils.DELETE_RAYJOB_CR_AFTER_JOB_FINISHES)
+				// RayJob transitions to Complete and is then deleted because DELETE_RAYJOB_CR_AFTER_JOB_FINISHES is set.
 				Eventually(
 					func() bool {
 						return apierrors.IsNotFound(getResourceFunc(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob)())
-					}, time.Second*3, time.Millisecond*500).Should(BeTrue())
+					}, time.Second*10, time.Millisecond*500).Should(BeTrue())
 			})
 		})
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There is current a race in the test that sets `DELETE_RAY_JOB_CR_AFTER_JOB_FINISHES` (which gets exposed after some informer cache improvements made in K8s v1.36) where the env var may not be seen when `handleShutdwonAfterJobFinishes` (called by updateK8sJobToComplete in the test code)

This PR merges two **It** blocks to ensure that the env var is set prior to the updateK8sJobToComplete call and doesn't change anything else.

This is discussed in https://github.com/ray-project/kuberay/pull/4703/changes/BASE..46e967ffaf3ad3bfebe273394b4d34fbca802e05#r3157271602

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
