### PR TITLE
[history server]Bump sample manifests ray image to 2.55.0

### DIFF
--- a/historyserver/config/raycluster-azureblob.yaml
+++ b/historyserver/config/raycluster-azureblob.yaml
@@ -22,17 +22,23 @@ spec:
         - env:
           - name: RAY_TMP_ROOT
             value: &rayTmpRoot /tmp/ray
+          # Switch the event collection backend from the legacy Export API to Ray Event
           - name: RAY_enable_ray_event
             value: "true"
+          # Whether to enable the ray event to send to the event aggregator
+          # Currently, only task events are supported
           - name: RAY_enable_core_worker_ray_event_to_aggregator
             value: "true"
+          # External HTTP endpoint the aggregator forwards events to
+          # Pointed at the collector sidecar in this pod
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR
             value: "http://localhost:8084/v1/events"
+          # Comma-separated list of event types that are allowed to be exposed to external HTTP services
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES
             value: "TASK_DEFINITION_EVENT,TASK_LIFECYCLE_EVENT,ACTOR_TASK_DEFINITION_EVENT,
                     TASK_PROFILE_EVENT,DRIVER_JOB_DEFINITION_EVENT,DRIVER_JOB_LIFECYCLE_EVENT,
                     ACTOR_DEFINITION_EVENT,ACTOR_LIFECYCLE_EVENT,NODE_DEFINITION_EVENT,NODE_LIFECYCLE_EVENT"
-          image: rayproject/ray:2.52.0
+          image: rayproject/ray:2.55.0
           imagePullPolicy: IfNotPresent
           command:
           - 'echo "=========================================="; [ -d "$RAY_TMP_ROOT/session_latest" ] && dest="$RAY_TMP_ROOT/prev-logs/$(basename $(readlink "$RAY_TMP_ROOT/session_latest"))/$(cat "$RAY_TMP_ROOT/raylet_node_id")" && echo "dst is $dest" && mkdir -p "$dest" && mv "$RAY_TMP_ROOT/session_latest/logs" "$dest/logs"; echo "========================================="'
@@ -112,17 +118,23 @@ spec:
         - env:
           - name: RAY_TMP_ROOT
             value: *rayTmpRoot
+          # Switch the event collection backend from the legacy Export API to Ray Event
           - name: RAY_enable_ray_event
             value: "true"
+          # Whether to enable the ray event to send to the event aggregator
+          # Currently, only task events are supported
           - name: RAY_enable_core_worker_ray_event_to_aggregator
             value: "true"
+          # External HTTP endpoint the aggregator forwards events to
+          # Pointed at the collector sidecar in this pod
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR
             value: "http://localhost:8084/v1/events"
+          # Comma-separated list of event types that are allowed to be exposed to external HTTP services
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES
             value: "TASK_DEFINITION_EVENT,TASK_LIFECYCLE_EVENT,ACTOR_TASK_DEFINITION_EVENT,
                     TASK_PROFILE_EVENT,DRIVER_JOB_DEFINITION_EVENT,DRIVER_JOB_LIFECYCLE_EVENT,
                     ACTOR_DEFINITION_EVENT,ACTOR_LIFECYCLE_EVENT,NODE_DEFINITION_EVENT,NODE_LIFECYCLE_EVENT"
-          image: rayproject/ray:2.52.0
+          image: rayproject/ray:2.55.0
           command:
           - 'echo "=========================================="; [ -d "$RAY_TMP_ROOT/session_latest" ] && dest="$RAY_TMP_ROOT/prev-logs/$(basename $(readlink "$RAY_TMP_ROOT/session_latest"))/$(cat "$RAY_TMP_ROOT/raylet_node_id")" && echo "dst is $dest" && mkdir -p "$dest" && mv "$RAY_TMP_ROOT/session_latest/logs" "$dest/logs"; echo "========================================="'
           imagePullPolicy: IfNotPresent

--- a/historyserver/config/raycluster-gcs.yaml
+++ b/historyserver/config/raycluster-gcs.yaml
@@ -23,17 +23,23 @@ spec:
         - env:
           - name: RAY_TMP_ROOT
             value: &rayTmpRoot /tmp/ray
+          # Switch the event collection backend from the legacy Export API to Ray Event
           - name: RAY_enable_ray_event
             value: "true"
+          # Whether to enable the ray event to send to the event aggregator
+          # Currently, only task events are supported
           - name: RAY_enable_core_worker_ray_event_to_aggregator
             value: "true"
+          # External HTTP endpoint the aggregator forwards events to
+          # Pointed at the collector sidecar in this pod
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR
             value: "http://localhost:8084/v1/events"
+          # Comma-separated list of event types that are allowed to be exposed to external HTTP services
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES
             value: "TASK_DEFINITION_EVENT,TASK_LIFECYCLE_EVENT,ACTOR_TASK_DEFINITION_EVENT,
                     TASK_PROFILE_EVENT,DRIVER_JOB_DEFINITION_EVENT,DRIVER_JOB_LIFECYCLE_EVENT,
                     ACTOR_DEFINITION_EVENT,ACTOR_LIFECYCLE_EVENT,NODE_DEFINITION_EVENT,NODE_LIFECYCLE_EVENT"
-          image: rayproject/ray:2.52.0
+          image: rayproject/ray:2.55.0
           imagePullPolicy: IfNotPresent
           command:
           - 'echo "=========================================="; [ -d "$RAY_TMP_ROOT/session_latest" ] && dest="$RAY_TMP_ROOT/prev-logs/$(basename $(readlink "$RAY_TMP_ROOT/session_latest"))/$(cat "$RAY_TMP_ROOT/raylet_node_id")" && echo "dst is $dest" && mkdir -p "$dest" && mv "$RAY_TMP_ROOT/session_latest/logs" "$dest/logs"; echo "========================================="'
@@ -137,17 +143,23 @@ spec:
         - env:
           - name: RAY_TMP_ROOT
             value: *rayTmpRoot
+          # Switch the event collection backend from the legacy Export API to Ray Event
           - name: RAY_enable_ray_event
             value: "true"
+          # Whether to enable the ray event to send to the event aggregator
+          # Currently, only task events are supported
           - name: RAY_enable_core_worker_ray_event_to_aggregator
             value: "true"
+          # External HTTP endpoint the aggregator forwards events to
+          # Pointed at the collector sidecar in this pod
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR
             value: "http://localhost:8084/v1/events"
+          # Comma-separated list of event types that are allowed to be exposed to external HTTP services
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES
             value: "TASK_DEFINITION_EVENT,TASK_LIFECYCLE_EVENT,ACTOR_TASK_DEFINITION_EVENT,
                     TASK_PROFILE_EVENT,DRIVER_JOB_DEFINITION_EVENT,DRIVER_JOB_LIFECYCLE_EVENT,
                     ACTOR_DEFINITION_EVENT,ACTOR_LIFECYCLE_EVENT,NODE_DEFINITION_EVENT,NODE_LIFECYCLE_EVENT"
-          image: rayproject/ray:2.52.0
+          image: rayproject/ray:2.55.0
           command:
           - 'echo "=========================================="; [ -d "$RAY_TMP_ROOT/session_latest" ] && dest="$RAY_TMP_ROOT/prev-logs/$(basename $(readlink "$RAY_TMP_ROOT/session_latest"))/$(cat "$RAY_TMP_ROOT/raylet_node_id")" && echo "dst is $dest" && mkdir -p "$dest" && mv "$RAY_TMP_ROOT/session_latest/logs" "$dest/logs"; echo "========================================="'
           imagePullPolicy: IfNotPresent

--- a/historyserver/config/raycluster.yaml
+++ b/historyserver/config/raycluster.yaml
@@ -22,19 +22,23 @@ spec:
         - env:
           - name: RAY_TMP_ROOT
             value: &rayTmpRoot /tmp/ray
+          # Switch the event collection backend from the legacy Export API to Ray Event
           - name: RAY_enable_ray_event
             value: "true"
+          # Whether to enable the ray event to send to the event aggregator
+          # Currently, only task events are supported
           - name: RAY_enable_core_worker_ray_event_to_aggregator
             value: "true"
+          # External HTTP endpoint the aggregator forwards events to
+          # Pointed at the collector sidecar in this pod
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR
             value: "http://localhost:8084/v1/events"
-            # in ray 2.52.0, we need to set RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES
-            # in ray 2.53.0 (noy yet done). we need to set RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISHER_HTTP_ENDPOINT_EXPOSABLE_EVENT_TYPES
+          # Comma-separated list of event types that are allowed to be exposed to external HTTP services
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES
             value: "TASK_DEFINITION_EVENT,TASK_LIFECYCLE_EVENT,ACTOR_TASK_DEFINITION_EVENT,
                     TASK_PROFILE_EVENT,DRIVER_JOB_DEFINITION_EVENT,DRIVER_JOB_LIFECYCLE_EVENT,
                     ACTOR_DEFINITION_EVENT,ACTOR_LIFECYCLE_EVENT,NODE_DEFINITION_EVENT,NODE_LIFECYCLE_EVENT"
-          image: rayproject/ray:2.52.0
+          image: rayproject/ray:2.55.0
           imagePullPolicy: IfNotPresent
           command:
           - 'echo "=========================================="; [ -d "$RAY_TMP_ROOT/session_latest" ] && dest="$RAY_TMP_ROOT/prev-logs/$(basename $(readlink "$RAY_TMP_ROOT/session_latest"))/$(cat "$RAY_TMP_ROOT/raylet_node_id")" && echo "dst is $dest" && mkdir -p "$dest" && mv "$RAY_TMP_ROOT/session_latest/logs" "$dest/logs"; echo "========================================="'
@@ -152,19 +156,23 @@ spec:
         - env:
           - name: RAY_TMP_ROOT
             value: *rayTmpRoot
+          # Switch the event collection backend from the legacy Export API to Ray Event.
           - name: RAY_enable_ray_event
             value: "true"
+          # Whether to enable the ray event to send to the event aggregator.
+          # Currently, only task events are supported.
           - name: RAY_enable_core_worker_ray_event_to_aggregator
             value: "true"
+          # External HTTP endpoint the aggregator forwards events to.
+          # Pointed at the collector sidecar in this pod.
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR
             value: "http://localhost:8084/v1/events"
-            # in ray 2.52.0, we need to set RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES
-            # in ray 2.53.0 (not yet done). we need to set RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISHER_HTTP_ENDPOINT_EXPOSABLE_EVENT_TYPES
+          # Comma-separated list of event types that are allowed to be exposed to external HTTP services
           - name: RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES
             value: "TASK_DEFINITION_EVENT,TASK_LIFECYCLE_EVENT,ACTOR_TASK_DEFINITION_EVENT,
                     TASK_PROFILE_EVENT,DRIVER_JOB_DEFINITION_EVENT,DRIVER_JOB_LIFECYCLE_EVENT,
                     ACTOR_DEFINITION_EVENT,ACTOR_LIFECYCLE_EVENT,NODE_DEFINITION_EVENT,NODE_LIFECYCLE_EVENT"
-          image: rayproject/ray:2.52.0
+          image: rayproject/ray:2.55.0
           command:
           - 'echo "=========================================="; [ -d "$RAY_TMP_ROOT/session_latest" ] && dest="$RAY_TMP_ROOT/prev-logs/$(basename $(readlink "$RAY_TMP_ROOT/session_latest"))/$(cat "$RAY_TMP_ROOT/raylet_node_id")" && echo "dst is $dest" && mkdir -p "$dest" && mv "$RAY_TMP_ROOT/session_latest/logs" "$dest/logs"; echo "========================================="'
           imagePullPolicy: IfNotPresent

--- a/historyserver/test/support/historyserver.go
+++ b/historyserver/test/support/historyserver.go
@@ -39,6 +39,7 @@ const (
       "serveDeployment": "rayServeDeploymentDashboard",
       "serveLlm": "rayServeLlmDashboard",
       "data": "rayDataDashboard",
+      "dataLlm": "rayDataLlmDashboard",
       "train": "rayTrainDashboard"
     },
     "dashboardDatasource": "Prometheus",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Part of #4710. Bumps the historyserver sample manifests from ray `2.52.0` to `2.55.0` so the history server can collect event fields and event types that don't exist in 2.52.0. The relevant upstream work is tracked under https://github.com/ray-project/ray/issues/60129.                                                                                                                                   
  ## Events and fields reachable after this bump                                                                                                                                          
  
| Event | New fields / new event | Upstream PR | Ray version |
|---|---|---|---|
| `NodeDefinitionEvent` | `hostname`, `node_name`, `instance_id`, `instance_type_name` | ray-project/ray#60314 | 2.54.0 |
| `ActorDefinitionEvent` | `call_site`, `parent_id`, `ref_ids` | ray-project/ray#60287 + ray-project/ray#60288 | 2.55.0 |
| `ActorLifecycleEvent.StateTransition` | `repr_name`, `pid`, `port`, `restart_reason` (new enum: `ACTOR_FAILURE` / `LINEAGE_RECONSTRUCTION` / `NODE_PREEMPTION`) | ray-project/ray#60287 + ray-project/ray#60288 | 2.55.0 |
| `TaskLifecycleEvent` | `task_log_info` (stdout/stderr file + offsets), `is_debugger_paused`, `actor_repr_name` | ray-project/ray#60287 + ray-project/ray#60288 | 2.55.0 |
| `PlacementGroupDefinitionEvent` / `PlacementGroupLifecycleEvent` (new event types) | full schema | ray-project/ray#60449 | 2.55.0 |

## Related issue number
#4710

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
