### PR TITLE
[Feature][History Server] Support /api/v0/nodes endpoint using event data

### DIFF
--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -186,6 +186,15 @@ func routerAPI(s *ServerHandler) {
 		Produces(restful.MIME_JSON).
 		Writes("")) // Placeholder for specific return type
 
+	ws.Route(ws.GET("/v0/nodes").To(s.getV0Nodes).Filter(s.CookieHandle).
+		Doc("Get all node information for a given cluster (State API)").
+		Param(ws.QueryParameter("limit", "limit")).
+		Param(ws.QueryParameter("timeout", "timeout")).
+		Param(ws.QueryParameter("filter_keys", "filter_keys")).
+		Param(ws.QueryParameter("filter_predicates", "filter_predicates")).
+		Param(ws.QueryParameter("filter_values", "filter_values")).
+		Writes("")) // Placeholder for specific return type
+
 	// Fallback route for additional polled endpoints stored in storage by the collector.
 	// This must be registered last because go-restful matches more specific routes first.
 	ws.Route(ws.GET("/{subpath:*}").To(s.getAdditionalEndpoint).Filter(s.CookieHandle).
@@ -602,6 +611,103 @@ func (s *ServerHandler) getNode(req *restful.Request, resp *restful.Response) {
 	}
 
 	resp.Write(data)
+}
+
+func (s *ServerHandler) getV0Nodes(req *restful.Request, resp *restful.Response) {
+	sessionName := req.Attribute(COOKIE_SESSION_NAME_KEY).(string)
+	if sessionName == "live" {
+		s.redirectRequest(req, resp)
+		return
+	}
+
+	clusterName := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
+	clusterNamespace := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
+	clusterSessionKey := utils.BuildClusterSessionKey(clusterName, clusterNamespace, sessionName)
+	nodeMap := s.eventHandler.GetNodeMap(clusterSessionKey)
+
+	nodes := make([]eventtypes.Node, 0, len(nodeMap))
+	for _, node := range nodeMap {
+		nodes = append(nodes, node)
+	}
+
+	numTotal := len(nodes)
+	numAfterTruncation := numTotal
+	numFiltered := numTotal
+
+	formattedNodes := make([]map[string]interface{}, 0, len(nodes))
+	for _, node := range nodes {
+		formattedNodes = append(formattedNodes, formatNodeForStateAPI(node))
+	}
+
+	response := RespNodesInfo{
+		Result: true,
+		Msg:    "",
+		Data: NodeData{
+			Result: NodeDataResult{
+				BaseStateAPIResult: BaseStateAPIResult{
+					Total:                 numTotal,
+					NumAfterTruncation:    numAfterTruncation,
+					NumFiltered:           numFiltered,
+					Result:                formattedNodes,
+					Warnings:              []string{},
+					PartialFailureWarning: "",
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(response)
+	if err != nil {
+		logrus.Errorf("Failed to marshal nodes response: %v", err)
+		resp.WriteErrorString(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	resp.Header().Set("Content-Type", "application/json")
+	resp.Write(data)
+}
+
+func formatNodeForStateAPI(node eventtypes.Node) map[string]interface{} {
+	state := "DEAD"
+	if len(node.StateTransitions) > 0 {
+		state = string(node.StateTransitions[len(node.StateTransitions)-1].State)
+	}
+
+	isHeadNode := false
+	if val, ok := node.Labels["ray.io/node-type"]; ok && val == "head" {
+		isHeadNode = true
+	}
+
+	var startTimeMs int64
+	if !node.StartTimestamp.IsZero() {
+		startTimeMs = node.StartTimestamp.UnixMilli()
+	}
+
+	result := map[string]interface{}{
+		"node_id":               node.NodeID,
+		"node_ip":               node.NodeIPAddress,
+		"node_manager_address":  node.NodeIPAddress,
+		"state":                 state,
+		"node_manager_hostname": node.Hostname,
+		"node_name":             node.NodeName,
+		"instance_id":           node.InstanceID,
+		"instance_type_name":    node.InstanceTypeName,
+		"is_head_node":          isHeadNode,
+		"labels":                node.Labels,
+		"start_time_ms":         startTimeMs,
+		"end_time_ms":           0,
+		"state_message":         "",
+	}
+
+	for i := len(node.StateTransitions) - 1; i >= 0; i-- {
+		tr := node.StateTransitions[i]
+		if tr.State == eventtypes.NODE_ALIVE && len(tr.Resources) > 0 {
+			result["resources_total"] = tr.Resources
+			break
+		}
+	}
+
+	return result
 }
 
 func (s *ServerHandler) getEvents(req *restful.Request, resp *restful.Response) {
@@ -1619,12 +1725,14 @@ func (s *ServerHandler) getTasks(req *restful.Request, resp *restful.Response) {
 		Msg:    "",
 		Data: TaskData{
 			Result: TaskDataResult{
-				Total:                 numTotal,
-				Result:                formattedTasks,
-				NumAfterTruncation:    numAfterTruncation,
-				NumFiltered:           numFiltered,
-				PartialFailureWarning: "",
-				Warnings:              nil,
+				BaseStateAPIResult: BaseStateAPIResult{
+					Total:                 numTotal,
+					Result:                formattedTasks,
+					NumAfterTruncation:    numAfterTruncation,
+					NumFiltered:           numFiltered,
+					PartialFailureWarning: "",
+					Warnings:              nil,
+				},
 			},
 		},
 	}

--- a/historyserver/pkg/historyserver/router_test.go
+++ b/historyserver/pkg/historyserver/router_test.go
@@ -1,0 +1,87 @@
+package historyserver
+
+import (
+	"testing"
+	"time"
+
+	eventtypes "github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
+)
+
+func TestFormatNodeForStateAPI(t *testing.T) {
+	// Case 1: Node with no transitions
+	node1 := eventtypes.Node{
+		NodeID:         "node1",
+		NodeIPAddress:  "192.168.1.1",
+		StartTimestamp: time.UnixMilli(1714512000000),
+		Labels:         map[string]string{"ray.io/node-type": "worker"},
+	}
+
+	result1 := formatNodeForStateAPI(node1)
+
+	if result1["state"] != "DEAD" {
+		t.Errorf("Expected state to be DEAD, got %v", result1["state"])
+	}
+	if result1["node_id"] != "node1" {
+		t.Errorf("Expected node_id to be node1, got %v", result1["node_id"])
+	}
+	if result1["is_head_node"] != false {
+		t.Errorf("Expected is_head_node to be false, got %v", result1["is_head_node"])
+	}
+
+	// Case 2: Node with ALIVE transition and resources
+	node2 := eventtypes.Node{
+		NodeID:         "node2",
+		NodeIPAddress:  "192.168.1.2",
+		StartTimestamp: time.UnixMilli(1714512000000),
+		Labels:         map[string]string{"ray.io/node-type": "head"},
+		StateTransitions: []eventtypes.NodeStateTransition{
+			{
+				State:     eventtypes.NODE_ALIVE,
+				Timestamp: time.UnixMilli(1714512000000),
+				Resources: map[string]float64{"CPU": 4.0},
+			},
+		},
+	}
+
+	result2 := formatNodeForStateAPI(node2)
+
+	if result2["state"] != "ALIVE" {
+		t.Errorf("Expected state to be ALIVE, got %v", result2["state"])
+	}
+	if result2["is_head_node"] != true {
+		t.Errorf("Expected is_head_node to be true, got %v", result2["is_head_node"])
+	}
+	resources, ok := result2["resources_total"].(map[string]float64)
+	if !ok || resources["CPU"] != 4.0 {
+		t.Errorf("Expected CPU resource to be 4.0, got %v", resources)
+	}
+
+	// Case 3: Node with DEAD transition (should keep resources from previous ALIVE transition)
+	node3 := eventtypes.Node{
+		NodeID:         "node3",
+		NodeIPAddress:  "192.168.1.3",
+		StartTimestamp: time.UnixMilli(1714512000000),
+		StateTransitions: []eventtypes.NodeStateTransition{
+			{
+				State:     eventtypes.NODE_ALIVE,
+				Timestamp: time.UnixMilli(1714512000000),
+				Resources: map[string]float64{"CPU": 2.0},
+			},
+			{
+				State:     eventtypes.NODE_DEAD,
+				Timestamp: time.UnixMilli(1714512001000),
+				Resources: map[string]float64{}, // Dead transition usually has empty resources
+			},
+		},
+	}
+
+	result3 := formatNodeForStateAPI(node3)
+
+	if result3["state"] != "DEAD" {
+		t.Errorf("Expected state to be DEAD, got %v", result3["state"])
+	}
+	resources3, ok := result3["resources_total"].(map[string]float64)
+	if !ok || resources3["CPU"] != 2.0 {
+		t.Errorf("Expected CPU resource to be 2.0 (preserved from ALIVE state), got %v", resources3)
+	}
+}

--- a/historyserver/pkg/historyserver/types.go
+++ b/historyserver/pkg/historyserver/types.go
@@ -31,13 +31,17 @@ type GetLogFileOptions struct {
 }
 
 // TODO(jwj): Can be extracted to a task-specific interface, e.g., TaskSummaryProvider.
-type TaskDataResult struct {
+type BaseStateAPIResult struct {
 	Total                 int                      `json:"total"`
 	NumAfterTruncation    int                      `json:"num_after_truncation"`
 	NumFiltered           int                      `json:"num_filtered"`
 	Result                []map[string]interface{} `json:"result"`
 	PartialFailureWarning string                   `json:"partial_failure_warning"`
 	Warnings              []string                 `json:"warnings"`
+}
+
+type TaskDataResult struct {
+	BaseStateAPIResult
 }
 
 type TaskData struct {
@@ -48,6 +52,20 @@ type RespTasksInfo struct {
 	Result bool     `json:"result"`
 	Msg    string   `json:"msg"`
 	Data   TaskData `json:"data"`
+}
+
+type NodeDataResult struct {
+	BaseStateAPIResult
+}
+
+type NodeData struct {
+	Result NodeDataResult `json:"result"`
+}
+
+type RespNodesInfo struct {
+	Result bool     `json:"result"`
+	Msg    string   `json:"msg"`
+	Data   NodeData `json:"data"`
 }
 
 type ReplyActorInfo struct {


### PR DESCRIPTION
## Why are these changes needed?
Support /api/v0/nodes endpoint using event data

This PR:
- Implements /v0/nodes route and handlers in router.go to serve node data reconstructed from events
- Refactors TaskDataResult and NodeDataResult in types.go to use struct embedding (BaseStateAPIResult) to avoid duplication while maintaining separate types for future divergence
- Adds unit tests for formatNodeForStateAPI in router_test.go

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Issue: https://github.com/ray-project/kuberay/issues/4710

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
