### PR TITLE
Avoid dashboard hard-code namespace to apiserver

### DIFF
--- a/dashboard/src/components/NamespaceProvider.tsx
+++ b/dashboard/src/components/NamespaceProvider.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { fetchRuntimeConfig } from "@/utils/constants";
 
 const NamespaceContext = React.createContext<string>("");
 
@@ -8,6 +9,14 @@ interface NamespaceProviderProps {
 
 const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }) => {
   const [namespace, setNamespace] = useState("default");
+
+  useEffect(() => {
+    fetchRuntimeConfig().then((cfg) => {
+      if (cfg.defaultNamespace) {
+        setNamespace(cfg.defaultNamespace);
+      }
+    });
+  }, []);
 
   // This useEffect is necessary since the window object is not available
   // during static generation. After the component is rendered on browser, we can use it.

--- a/dashboard/src/components/NamespaceProvider.tsx
+++ b/dashboard/src/components/NamespaceProvider.tsx
@@ -13,7 +13,9 @@ const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }) => {
   useEffect(() => {
     fetchRuntimeConfig().then((cfg) => {
       if (cfg.defaultNamespace) {
-        setNamespace((prev) => prev === "default" ? cfg.defaultNamespace! : prev);
+        setNamespace((prev) =>
+          prev === "default" ? cfg.defaultNamespace! : prev,
+        );
       }
     });
   }, []);

--- a/dashboard/src/components/NamespaceProvider.tsx
+++ b/dashboard/src/components/NamespaceProvider.tsx
@@ -13,7 +13,7 @@ const NamespaceProvider: React.FC<NamespaceProviderProps> = ({ children }) => {
   useEffect(() => {
     fetchRuntimeConfig().then((cfg) => {
       if (cfg.defaultNamespace) {
-        setNamespace(cfg.defaultNamespace);
+        setNamespace((prev) => prev === "default" ? cfg.defaultNamespace! : prev);
       }
     });
   }, []);

--- a/dashboard/src/utils/config-defaults.ts
+++ b/dashboard/src/utils/config-defaults.ts
@@ -9,6 +9,7 @@ export interface RuntimeConfig {
     apiPath: string;
     proxyEndpoint: string;
   };
+  defaultNamespace?: string;
 }
 
 // apiserver config defaults

--- a/dashboard/src/utils/config-server.ts
+++ b/dashboard/src/utils/config-server.ts
@@ -31,6 +31,11 @@ export function getServerConfig(): RuntimeConfig {
 
   const historyserver = getHistoryServerConfig();
 
+  const defaultNamespace =
+    process.env.NEXT_PUBLIC_DEFAULT_NAMESPACE ||
+    process.env.DEFAULT_NAMESPACE ||
+    defaultConfig.defaultNamespace;
+
   if (legacyApiUrl) {
     // Parse legacy URL format
     try {
@@ -42,6 +47,7 @@ export function getServerConfig(): RuntimeConfig {
           coreApiPath: apiVersion === "v2" ? "/api/v1" : undefined,
         },
         historyserver,
+        defaultNamespace,
       };
     } catch {
       // If not a valid URL, return as domain
@@ -52,6 +58,7 @@ export function getServerConfig(): RuntimeConfig {
           coreApiPath: defaultConfig.apiserver.coreApiPath,
         },
         historyserver,
+        defaultNamespace,
       };
     }
   }
@@ -73,5 +80,6 @@ export function getServerConfig(): RuntimeConfig {
         defaultConfig.apiserver.coreApiPath,
     },
     historyserver,
+    defaultNamespace,
   };
 }

--- a/dashboard/src/utils/constants.ts
+++ b/dashboard/src/utils/constants.ts
@@ -33,6 +33,8 @@ export async function fetchRuntimeConfig(): Promise<RuntimeConfig> {
             data.historyserver?.proxyEndpoint ||
             defaultConfig.historyserver.proxyEndpoint,
         },
+        defaultNamespace:
+          data.defaultNamespace || defaultConfig.defaultNamespace,
       };
       return runtimeConfig;
     }


### PR DESCRIPTION
## Why are these changes needed?

Currently dashboard hard-codes namespace to query as `default`.
For my production use case, (1) we have multiple namespaces in k8s cluster; (2) each team has its own namespace and that's how to do access control => I cannot use dashboard because of access control.

This PR tries to make "default" namespace configurable via an environment variable.

## Related issue number

Related to https://github.com/ray-project/kuberay/issues/4457

Disclaimer: this issue above mentioned requests for multiple namespace query support, but my PR is trying to fix the hard-coded namespace `default`.
For details, please refer to https://github.com/ray-project/kuberay/issues/4457#issuecomment-4357669644

I have deployed the change in my staging environment, and confirmed it works properly.
<img width="3350" height="1722" alt="image" src="https://github.com/user-attachments/assets/a6bcf41d-7a4d-4488-87ae-ab1d53ff7c68" />

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
