### PR TITLE
[RayJob] Add GCS health wait to K8sJobMode submitter

### DIFF
--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -128,21 +128,27 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 	jobSubmitCommand := []string{"ray", "job", "submit", "--address", address}
 	jobFollowCommand := []string{"ray", "job", "logs", "--address", address, "--follow", jobId}
 
+	// Wait until Ray Dashboard GCS is healthy before proceeding.
+	// In SidecarMode the submitter shares the head Pod's network namespace, so we
+	// probe localhost. In K8sJobMode the submitter runs in a separate Pod and must
+	// reach the dashboard through the head Service.
+	var healthURL string
 	if submissionMode == rayv1.SidecarMode {
-		// Wait until Ray Dashboard GCS is healthy before proceeding.
-		rayDashboardGCSHealthCommand := fmt.Sprintf(
-			utils.BasePythonHealthCommand,
-			port,
-			utils.RayDashboardGCSHealthPath,
-			utils.DefaultReadinessProbeFailureThreshold,
-		)
-
-		waitLoop := []string{
-			"until", rayDashboardGCSHealthCommand, ">/dev/null", "2>&1", ";",
-			"do", "echo", strconv.Quote("Waiting for Ray Dashboard GCS to become healthy at " + address + " ..."), ";", "sleep", "2", ";", "done", ";",
-		}
-		cmd = append(cmd, waitLoop...)
+		healthURL = fmt.Sprintf("http://localhost:%d/%s", port, utils.RayDashboardGCSHealthPath)
+	} else {
+		healthURL = address + "/" + utils.RayDashboardGCSHealthPath
 	}
+	rayDashboardGCSHealthCommand := fmt.Sprintf(
+		utils.BasePythonHealthCommand,
+		healthURL,
+		utils.DefaultReadinessProbeFailureThreshold,
+	)
+
+	waitLoop := []string{
+		"until", rayDashboardGCSHealthCommand, ">/dev/null", "2>&1", ";",
+		"do", "echo", strconv.Quote("Waiting for Ray Dashboard GCS to become healthy at " + address + " ..."), ";", "sleep", "2", ";", "done", ";",
+	}
+	cmd = append(cmd, waitLoop...)
 
 	// In Sidecar mode, we only support RayJob level retry, which means that the submitter retry won't happen,
 	// so we won't have to check if the job has been submitted.

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -71,6 +71,10 @@ pip: ["python-multipart==0.0.6"]
 func TestBuildJobSubmitCommandWithK8sJobMode(t *testing.T) {
 	testRayJob := rayJobTemplate()
 	expected := []string{
+		"until",
+		fmt.Sprintf(utils.BasePythonHealthCommand, "http://127.0.0.1:8265/"+utils.RayDashboardGCSHealthPath, utils.DefaultReadinessProbeFailureThreshold),
+		">/dev/null", "2>&1", ";",
+		"do", "echo", strconv.Quote("Waiting for Ray Dashboard GCS to become healthy at http://127.0.0.1:8265 ..."), ";", "sleep", "2", ";", "done", ";",
 		"if",
 		"!", "ray", "job", "status", "--address", "http://127.0.0.1:8265", "testJobId", ">/dev/null", "2>&1",
 		";", "then",
@@ -108,8 +112,7 @@ func TestBuildJobSubmitCommandWithSidecarMode(t *testing.T) {
 		"until",
 		fmt.Sprintf(
 			utils.BasePythonHealthCommand,
-			utils.DefaultDashboardPort,
-			utils.RayDashboardGCSHealthPath,
+			fmt.Sprintf("http://localhost:%d/%s", utils.DefaultDashboardPort, utils.RayDashboardGCSHealthPath),
 			utils.DefaultReadinessProbeFailureThreshold,
 		),
 		">/dev/null", "2>&1", ";",
@@ -198,16 +201,16 @@ func TestBuildJobSubmitCommandWithSidecarModeCustomDashboardPort(t *testing.T) {
 	assert.NotContains(t, command[1], "wget")
 }
 
-func TestBuildJobSubmitCommandWithK8sJobModeNoSidecarHealthWaitLoop(t *testing.T) {
+func TestBuildJobSubmitCommandWithK8sJobModeHealthWaitLoop(t *testing.T) {
 	testRayJob := rayJobTemplate()
 	command, err := BuildJobSubmitCommand(testRayJob, rayv1.K8sJobMode)
 	require.NoError(t, err)
-	assert.NotContains(t, command, "until")
-	for _, arg := range command {
-		assert.NotContains(t, arg, utils.RayDashboardGCSHealthPath)
-		assert.NotContains(t, arg, "python -c")
-		assert.NotContains(t, arg, "wget")
-	}
+	require.GreaterOrEqual(t, len(command), 2)
+	assert.Equal(t, "until", command[0])
+	assert.Contains(t, command[1], "python -c")
+	assert.Contains(t, command[1], utils.RayDashboardGCSHealthPath)
+	assert.Contains(t, command[1], "127.0.0.1:8265")
+	assert.NotContains(t, command[1], "wget")
 }
 
 func TestBuildJobSubmitCommandWithK8sJobModeAndYAML(t *testing.T) {
@@ -231,6 +234,10 @@ pip: ["python-multipart==0.0.6"]
 		},
 	}
 	expected := []string{
+		"until",
+		fmt.Sprintf(utils.BasePythonHealthCommand, "http://127.0.0.1:8265/"+utils.RayDashboardGCSHealthPath, utils.DefaultReadinessProbeFailureThreshold),
+		">/dev/null", "2>&1", ";",
+		"do", "echo", strconv.Quote("Waiting for Ray Dashboard GCS to become healthy at http://127.0.0.1:8265 ..."), ";", "sleep", "2", ";", "done", ";",
 		"if",
 		"!", "ray", "job", "status", "--address", "http://127.0.0.1:8265", "testJobId", ">/dev/null", "2>&1",
 		";", "then",
@@ -255,7 +262,8 @@ pip: ["python-multipart==0.0.6"]
 		if expected[i] == "--runtime-env-json" {
 			// Decode the JSON string from the next element.
 			var expectedMap, actualMap map[string]any
-			unquoteExpected, err1 := strconv.Unquote(expected[i+1]) //nolint:gosec // loop bounds guarantee i+1 is valid
+			//nolint:gosec // G602: test invariant guarantees "--runtime-env-json" is followed by a value.
+			unquoteExpected, err1 := strconv.Unquote(expected[i+1])
 			require.NoError(t, err1)
 
 			unquotedCommand, err2 := strconv.Unquote(command[i+1])

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -3,6 +3,7 @@ package ray
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -187,13 +188,18 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	submitterTemplate, err = getSubmitterTemplate(rayJobInstanceWithTemplate, rayClusterInstance)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/bin/bash", "-ce", "--"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	assert.Equal(t, []string{"if ! ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job submit --address http://test-url --no-wait --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
+	expectedK8sJobModeArgs := []string{
+		"until " + fmt.Sprintf(utils.BasePythonHealthCommand, "http://test-url/"+utils.RayDashboardGCSHealthPath, utils.DefaultReadinessProbeFailureThreshold) +
+			" >/dev/null 2>&1 ; do echo \"Waiting for Ray Dashboard GCS to become healthy at http://test-url ...\" ; sleep 2 ; done ; " +
+			"if ! ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job submit --address http://test-url --no-wait --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi ; ray job logs --address http://test-url --follow test-job-id",
+	}
+	assert.Equal(t, expectedK8sJobModeArgs, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 
 	// Test 3: User did not provide template, should use the image of the Ray Head
 	submitterTemplate, err = getSubmitterTemplate(rayJobInstanceWithoutTemplate, rayClusterInstance)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/bin/bash", "-ce", "--"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Command)
-	assert.Equal(t, []string{"if ! ray job status --address http://test-url test-job-id >/dev/null 2>&1 ; then ray job submit --address http://test-url --no-wait --submission-id test-job-id -- echo no quote 'single quote' \"double quote\" ; fi ; ray job logs --address http://test-url --follow test-job-id"}, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
+	assert.Equal(t, expectedK8sJobModeArgs, submitterTemplate.Spec.Containers[utils.RayContainerIndex].Args)
 	assert.Equal(t, "rayproject/ray:custom-version", submitterTemplate.Spec.Containers[utils.RayContainerIndex].Image)
 
 	// Test 4: Check default PYTHONUNBUFFERED setting

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -259,9 +259,9 @@ const (
 	// BaseWgetHealthCommand checks a single health URL; args: timeout_sec, port, path (no leading slash).
 	// This is used for Ray versions that rely on exec probes and assume common CLI tools exist in the image.
 	BaseWgetHealthCommand = "wget --tries 1 -T %d -q -O- http://localhost:%d/%s | grep success"
-	// BasePythonHealthCommand checks a single health URL; args: port, path (no leading slash), timeout_sec.
+	// BasePythonHealthCommand checks a single health URL; args: url, timeout_sec.
 	// This is used when wget is not available (e.g. slim Ray images).
-	BasePythonHealthCommand = `python -c "import urllib.request; r=urllib.request.urlopen('http://localhost:%d/%s', timeout=%d); exit(0 if b'success' in r.read() else 1)"`
+	BasePythonHealthCommand = `python -c "import urllib.request; r=urllib.request.urlopen('%s', timeout=%d); exit(0 if b'success' in r.read() else 1)"`
 	RayNodeHealthPath       = "/api/healthz"
 
 	// Finalizers for RayJob


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In K8sJobMode, the submitter Job can start before the Ray Dashboard HTTP server (port 8265) is ready, causing `ray job submit` to fail with a connection error and exhaust its `backoffLimit`. See #4760 .

This is a regression introduced in Ray 2.53.0. KubeRay switches the head pod readiness probe for Ray >= 2.53.0 from an exec probe (which checked **both** port 52365 and port 8265) to an HTTP probe on port 52365 only ([`pod.go`](https://github.com/ray-project/kuberay/blob/master/ray-operator/controllers/ray/common/pod.go#L466-L474)). The unified `/api/healthz` endpoint on 52365 checks GCS + Raylet via gRPC but has no dependency on port 8265 ([`healthz_agent.py`](https://github.com/ray-project/ray/blob/master/python/ray/dashboard/modules/reporter/healthz_agent.py#L76-L96)). The pod becomes "Ready" while the Dashboard is still starting, and `ray job submit` fails immediately on connection refused (zero internal retry, [`dashboard_sdk.py`](https://github.com/ray-project/ray/blob/master/python/ray/dashboard/modules/dashboard_sdk.py#L302-L337)).

On Ray < 2.53.0, the exec probe's port 8265 check (`api/gcs_healthz`) acted as an implicit Dashboard readiness gate. When the probe passed, all subprocess modules including `JobHead` were initialized and the job submission API was accepting requests, because `DashboardHead.run()` waits for all modules before starting the HTTP server ([`head.py` L410-448](https://github.com/ray-project/ray/blob/master/python/ray/dashboard/head.py#L410-L448)).

SidecarMode already handles this with an `until` health-check loop that polls `api/gcs_healthz` on port 8265 before running `ray job submit`. K8sJobMode skipped this entirely. This PR extends the same wait loop to K8sJobMode, with the URL pointing at the head Service instead of localhost. Retries happen within the same Pod, so they don't consume `backoffLimit`.

As part of this change, `BasePythonHealthCommand` is generalized from `(port, path, timeout)` with a hardcoded `http://localhost` to `(url, timeout)`, so both modes reuse the same constant instead of duplicating the Python one-liner.

#### Behavioral note

Previously (Ray < 2.53.0), the readiness probe on port 8265 acted as an implicit Dashboard gate -- if the Dashboard never started, the pod stayed not-Ready and `preRunningDeadlineSeconds` would eventually expire the RayJob.
With this change, the cluster can become Ready before the Dashboard is up (because the readiness probe only checks port 52365), and the submitter waits inside an `until` loop.
If the Dashboard never starts and no `submitterConfig.activeDeadlineSeconds` is set, the submitter will wait indefinitely.
In practice this is rare -- if GCS and Raylet are healthy (confirmed by the readiness probe), the Dashboard almost always starts; if the Dashboard process crashes, liveness probes restart the head pod. Users on resource-constrained clusters should set `activeDeadlineSeconds` as a safety net.

This matches the existing SidecarMode behavior, which has used the same infinite wait loop since it was introduced.

#### Local reproduction

```
Ray      CPU    Before fix                After fix
------   -----  ------------------------  --------------------------
2.53.0   200m   Failed (SubmissionFailed)  Submitter waits (no fail)
2.53.0   300m   Failed (SubmissionFailed)  Complete
2.53.0   500m   Complete                   Complete
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #4760 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
