### PR TITLE
Add RayService finalizer

### DIFF
--- a/apiserver/test/e2e/resource_manager_e2e_test.go
+++ b/apiserver/test/e2e/resource_manager_e2e_test.go
@@ -126,22 +126,22 @@ func TestListClusters(t *testing.T) {
 	// Create cluster
 	clustersList := []*api.Cluster{
 		{
-			Name:        tCtx.GetNextName(),
+			Name:        "test-cluster-1",
 			Namespace:   tCtx.GetNamespaceName(),
 			ClusterSpec: clusterSpec,
 		},
 		{
-			Name:        tCtx.GetNextName(),
+			Name:        "test-cluster-2",
 			Namespace:   tCtx.GetNamespaceName(),
 			ClusterSpec: clusterSpec,
 		},
 		{
-			Name:        tCtx.GetNextName(),
+			Name:        "test-cluster-3",
 			Namespace:   tCtx.GetNamespaceName(),
 			ClusterSpec: clusterSpec,
 		},
 		{
-			Name:        tCtx.GetNextName(),
+			Name:        "test-cluster-4",
 			Namespace:   tCtx.GetNamespaceName(),
 			ClusterSpec: clusterSpec,
 		},

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -139,6 +139,7 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 			}
 			return ctrl.Result{}, nil
 		}
+		logger.Info("Requeue RayService, waiting for RayClusters to be deleted")
 		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
 	}
 
@@ -149,6 +150,7 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 			logger.Error(err, "Failed to add finalizer to RayService")
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
 		}
+		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
 	}
 
 	// Perform all validations and directly fail the RayService if any of the validation fails

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -123,8 +123,23 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
-	if !rayServiceInstance.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.reconcileRayServiceDeletion(ctx, rayServiceInstance)
+	r.cleanUpServeConfigCache(ctx, rayServiceInstance)
+	hasRayClustersToClean, err := r.cleanUpRayClusterInstance(ctx, rayServiceInstance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if !rayServiceInstance.DeletionTimestamp.IsZero() {
+		if !hasRayClustersToClean {
+			logger.Info("No RayClusters exist, removing finalizer")
+			controllerutil.RemoveFinalizer(rayServiceInstance, utils.RayServiceFinalizer)
+			if err := r.Update(ctx, rayServiceInstance); err != nil {
+				logger.Error(err, "Failed to remove finalizer for RayService")
+				return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
+			}
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
 	}
 
 	if !controllerutil.ContainsFinalizer(rayServiceInstance, utils.RayServiceFinalizer) {
@@ -151,12 +166,6 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, updateErr
 		}
 		return ctrl.Result{}, nil
-	}
-
-	r.cleanUpServeConfigCache(ctx, rayServiceInstance)
-	hasRayClustersToClean, err := r.cleanUpRayClusterInstance(ctx, rayServiceInstance)
-	if err != nil {
-		return ctrl.Result{}, err
 	}
 
 	// If the RayService has timed out during initialization, skip the rest of the reconciliation.
@@ -627,38 +636,6 @@ func (r *RayServiceReconciler) getRayServiceInstance(ctx context.Context, reques
 	return rayServiceInstance, nil
 }
 
-func (r *RayServiceReconciler) reconcileRayServiceDeletion(ctx context.Context, rayServiceInstance *rayv1.RayService) (ctrl.Result, error) {
-	logger := ctrl.LoggerFrom(ctx)
-	logger.Info("RayService is being deleted", "DeletionTimestamp", rayServiceInstance.ObjectMeta.DeletionTimestamp)
-
-	rayClusterList := rayv1.RayClusterList{}
-	if err := r.List(ctx, &rayClusterList, common.RayServiceRayClustersAssociationOptions(rayServiceInstance).ToListOptions()...); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if len(rayClusterList.Items) > 0 {
-		logger.Info("RayClusters still exist, triggering deletion", "count", len(rayClusterList.Items))
-		for _, cluster := range rayClusterList.Items {
-			if cluster.DeletionTimestamp.IsZero() {
-				logger.Info("Deleting RayCluster", "clusterName", cluster.Name)
-				if err := r.Delete(ctx, &cluster, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
-					logger.Error(err, "Failed to delete RayCluster", "clusterName", cluster.Name)
-					return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
-				}
-			}
-		}
-		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
-	}
-
-	logger.Info("No RayClusters exist, removing finalizer")
-	controllerutil.RemoveFinalizer(rayServiceInstance, utils.RayServiceFinalizer)
-	if err := r.Update(ctx, rayServiceInstance); err != nil {
-		logger.Error(err, "Failed to remove finalizer for RayService")
-		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
-	}
-	return ctrl.Result{}, nil
-}
-
 func isZeroDowntimeUpgradeEnabled(ctx context.Context, upgradeStrategy *rayv1.RayServiceUpgradeStrategy) bool {
 	// For LLM serving, some users might not have sufficient GPU resources to run two RayClusters simultaneously.
 	// Therefore, KubeRay offers ENABLE_ZERO_DOWNTIME as a feature flag for zero-downtime upgrades.
@@ -1050,6 +1027,7 @@ func (r *RayServiceReconciler) reconcileRayCluster(ctx context.Context, rayServi
 func (r *RayServiceReconciler) cleanUpRayClusterInstance(ctx context.Context, rayServiceInstance *rayv1.RayService) (bool, error) {
 	logger := ctrl.LoggerFrom(ctx)
 	rayClusterList := rayv1.RayClusterList{}
+	rayServiceIsDeleted := !rayServiceInstance.ObjectMeta.DeletionTimestamp.IsZero()
 
 	var err error
 	if err = r.List(ctx, &rayClusterList, common.RayServiceRayClustersAssociationOptions(rayServiceInstance).ToListOptions()...); err != nil {
@@ -1061,30 +1039,25 @@ func (r *RayServiceReconciler) cleanUpRayClusterInstance(ctx context.Context, ra
 	if rayServiceInstance.Spec.RayClusterDeletionDelaySeconds != nil {
 		deletionDelay = time.Duration(*rayServiceInstance.Spec.RayClusterDeletionDelaySeconds) * time.Second
 	}
+	if rayServiceIsDeleted {
+		deletionDelay = 0 * time.Second
+	}
 
 	hasRayClustersToClean := false
 	// Clean up RayCluster instances. Each instance is deleted after the configured deletion delay.
 	for _, rayClusterInstance := range rayClusterList.Items {
-		if rayClusterInstance.Name != rayServiceInstance.Status.ActiveServiceStatus.RayClusterName && rayClusterInstance.Name != rayServiceInstance.Status.PendingServiceStatus.RayClusterName {
+		if rayServiceIsDeleted || (rayClusterInstance.Name != rayServiceInstance.Status.ActiveServiceStatus.RayClusterName && rayClusterInstance.Name != rayServiceInstance.Status.PendingServiceStatus.RayClusterName) {
 			hasRayClustersToClean = true
 			cachedTimestamp, exists := r.RayClusterDeletionTimestamps.Get(rayClusterInstance.Name)
-			if !exists {
-				deletionTimestamp := metav1.Now().Add(deletionDelay)
-				r.RayClusterDeletionTimestamps.Set(rayClusterInstance.Name, deletionTimestamp)
-				logger.Info(
-					"Scheduled dangling RayCluster for deletion",
-					"rayClusterName", rayClusterInstance.Name,
-					"deletionDelay", deletionDelay.String(),
-					"deletionTimestamp", deletionTimestamp,
-				)
-			} else {
+			if exists || rayServiceIsDeleted {
 				reasonForDeletion := ""
-				if time.Now().After(cachedTimestamp) {
+				if rayServiceIsDeleted {
+					reasonForDeletion = "RayService is being deleted. Deleting RayCluster"
+				} else if time.Now().After(cachedTimestamp) {
 					reasonForDeletion = fmt.Sprintf("Deletion timestamp %s "+
 						"for RayCluster %s has passed. Deleting cluster "+
 						"immediately.", cachedTimestamp, rayClusterInstance.Name)
 				}
-
 				if reasonForDeletion != "" {
 					logger.Info("reconcileRayCluster", "delete Ray cluster", rayClusterInstance.Name, "reason", reasonForDeletion)
 					if err := r.Delete(ctx, &rayClusterInstance, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
@@ -1093,6 +1066,15 @@ func (r *RayServiceReconciler) cleanUpRayClusterInstance(ctx context.Context, ra
 					}
 					r.Recorder.Eventf(rayServiceInstance, corev1.EventTypeNormal, string(utils.DeletedRayCluster), "Deleted the RayCluster %s/%s", rayClusterInstance.Namespace, rayClusterInstance.Name)
 				}
+			} else {
+				deletionTimestamp := metav1.Now().Add(deletionDelay)
+				r.RayClusterDeletionTimestamps.Set(rayClusterInstance.Name, deletionTimestamp)
+				logger.Info(
+					"Scheduled dangling RayCluster for deletion",
+					"rayClusterName", rayClusterInstance.Name,
+					"deletionDelay", deletionDelay.String(),
+					"deletionTimestamp", deletionTimestamp,
+				)
 			}
 		}
 	}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -124,34 +124,7 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	}
 
 	if !rayServiceInstance.ObjectMeta.DeletionTimestamp.IsZero() {
-		logger.Info("RayService is being deleted", "DeletionTimestamp", rayServiceInstance.ObjectMeta.DeletionTimestamp)
-
-		rayClusterList := rayv1.RayClusterList{}
-		if err := r.List(ctx, &rayClusterList, common.RayServiceRayClustersAssociationOptions(rayServiceInstance).ToListOptions()...); err != nil {
-			return ctrl.Result{}, err
-		}
-
-		if len(rayClusterList.Items) > 0 {
-			logger.Info("RayClusters still exist, triggering deletion", "count", len(rayClusterList.Items))
-			for _, cluster := range rayClusterList.Items {
-				if cluster.DeletionTimestamp.IsZero() {
-					logger.Info("Deleting RayCluster", "clusterName", cluster.Name)
-					if err := r.Delete(ctx, &cluster, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
-						logger.Error(err, "Failed to delete RayCluster", "clusterName", cluster.Name)
-						return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
-					}
-				}
-			}
-			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
-		}
-
-		logger.Info("No RayClusters exist, removing finalizer")
-		controllerutil.RemoveFinalizer(rayServiceInstance, utils.RayServiceFinalizer)
-		if err := r.Update(ctx, rayServiceInstance); err != nil {
-			logger.Error(err, "Failed to remove finalizer for RayService")
-			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
-		}
-		return ctrl.Result{}, nil
+		return r.reconcileRayServiceDeletion(ctx, rayServiceInstance)
 	}
 
 	if !controllerutil.ContainsFinalizer(rayServiceInstance, utils.RayServiceFinalizer) {
@@ -652,6 +625,38 @@ func (r *RayServiceReconciler) getRayServiceInstance(ctx context.Context, reques
 		return nil, err
 	}
 	return rayServiceInstance, nil
+}
+
+func (r *RayServiceReconciler) reconcileRayServiceDeletion(ctx context.Context, rayServiceInstance *rayv1.RayService) (ctrl.Result, error) {
+	logger := ctrl.LoggerFrom(ctx)
+	logger.Info("RayService is being deleted", "DeletionTimestamp", rayServiceInstance.ObjectMeta.DeletionTimestamp)
+
+	rayClusterList := rayv1.RayClusterList{}
+	if err := r.List(ctx, &rayClusterList, common.RayServiceRayClustersAssociationOptions(rayServiceInstance).ToListOptions()...); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if len(rayClusterList.Items) > 0 {
+		logger.Info("RayClusters still exist, triggering deletion", "count", len(rayClusterList.Items))
+		for _, cluster := range rayClusterList.Items {
+			if cluster.DeletionTimestamp.IsZero() {
+				logger.Info("Deleting RayCluster", "clusterName", cluster.Name)
+				if err := r.Delete(ctx, &cluster, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+					logger.Error(err, "Failed to delete RayCluster", "clusterName", cluster.Name)
+					return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
+				}
+			}
+		}
+		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
+	}
+
+	logger.Info("No RayClusters exist, removing finalizer")
+	controllerutil.RemoveFinalizer(rayServiceInstance, utils.RayServiceFinalizer)
+	if err := r.Update(ctx, rayServiceInstance); err != nil {
+		logger.Error(err, "Failed to remove finalizer for RayService")
+		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
+	}
+	return ctrl.Result{}, nil
 }
 
 func isZeroDowntimeUpgradeEnabled(ctx context.Context, upgradeStrategy *rayv1.RayServiceUpgradeStrategy) bool {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -120,6 +121,46 @@ func (r *RayServiceReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	if manager := utils.ManagedByExternalController(rayServiceInstance.Spec.ManagedBy); manager != nil {
 		logger.Info("Skipping RayService managed by a custom controller", "managed-by", manager)
 		return ctrl.Result{}, nil
+	}
+
+	if !rayServiceInstance.ObjectMeta.DeletionTimestamp.IsZero() {
+		logger.Info("RayService is being deleted", "DeletionTimestamp", rayServiceInstance.ObjectMeta.DeletionTimestamp)
+
+		rayClusterList := rayv1.RayClusterList{}
+		if err := r.List(ctx, &rayClusterList, common.RayServiceRayClustersAssociationOptions(rayServiceInstance).ToListOptions()...); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if len(rayClusterList.Items) > 0 {
+			logger.Info("RayClusters still exist, triggering deletion", "count", len(rayClusterList.Items))
+			for _, cluster := range rayClusterList.Items {
+				if cluster.DeletionTimestamp.IsZero() {
+					logger.Info("Deleting RayCluster", "clusterName", cluster.Name)
+					if err := r.Delete(ctx, &cluster, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+						logger.Error(err, "Failed to delete RayCluster", "clusterName", cluster.Name)
+						return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
+					}
+				}
+			}
+			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
+		}
+
+		logger.Info("No RayClusters exist, removing finalizer")
+		controllerutil.RemoveFinalizer(rayServiceInstance, utils.RayServiceFinalizer)
+		if err := r.Update(ctx, rayServiceInstance); err != nil {
+			logger.Error(err, "Failed to remove finalizer for RayService")
+			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(rayServiceInstance, utils.RayServiceFinalizer) {
+		logger.Info("Adding finalizer to RayService", "finalizer", utils.RayServiceFinalizer)
+		controllerutil.AddFinalizer(rayServiceInstance, utils.RayServiceFinalizer)
+		if err := r.Update(ctx, rayServiceInstance); err != nil {
+			logger.Error(err, "Failed to add finalizer to RayService")
+			return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, err
+		}
 	}
 
 	// Perform all validations and directly fail the RayService if any of the validation fails

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
@@ -3049,6 +3050,126 @@ func TestReconcileServe_SkipConfigUpdateDuringRollback(t *testing.T) {
 			} else {
 				assert.Nil(t, fakeDashboardClient.LastUpdatedConfig)
 			}
+		})
+	}
+}
+
+func TestRayServiceFinalizer(t *testing.T) {
+	ctx := context.TODO()
+	namespace := "test-ns"
+
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+	_ = discoveryv1.AddToScheme(newScheme)
+
+	tests := []struct {
+		name            string
+		rayService      *rayv1.RayService
+		existingObjects []client.Object
+		validate        func(t *testing.T, fakeClient client.Client, namespacedName types.NamespacedName)
+	}{
+		{
+			name: "Add finalizer",
+			rayService: &rayv1.RayService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-rayservice", Namespace: namespace},
+			},
+			validate: func(t *testing.T, fakeClient client.Client, namespacedName types.NamespacedName) {
+				updatedRayService := &rayv1.RayService{}
+				err := fakeClient.Get(ctx, namespacedName, updatedRayService)
+				require.NoError(t, err)
+				require.Len(t, updatedRayService.Finalizers, 1)
+				assert.Equal(t, utils.RayServiceFinalizer, updatedRayService.Finalizers[0])
+			},
+		},
+		{
+			name: "Skip adding finalizer when managed by custom controller",
+			rayService: &rayv1.RayService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-rayservice", Namespace: namespace},
+				Spec: rayv1.RayServiceSpec{
+					ManagedBy: ptr.To("kueue.x-k8s.io/multikueue"),
+				},
+			},
+			validate: func(t *testing.T, fakeClient client.Client, namespacedName types.NamespacedName) {
+				updatedRayService := &rayv1.RayService{}
+				err := fakeClient.Get(ctx, namespacedName, updatedRayService)
+				require.NoError(t, err)
+				assert.Empty(t, updatedRayService.Finalizers)
+			},
+		},
+		{
+			name: "Delete with clusters",
+			rayService: &rayv1.RayService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-rayservice",
+					Namespace:         namespace,
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{utils.RayServiceFinalizer},
+				},
+			},
+			existingObjects: []client.Object{
+				&rayv1.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster",
+						Namespace: namespace,
+						Labels: map[string]string{
+							utils.RayOriginatedFromCRNameLabelKey: "test-rayservice",
+							utils.RayOriginatedFromCRDLabelKey:    utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, fakeClient client.Client, namespacedName types.NamespacedName) {
+				updatedRayService := &rayv1.RayService{}
+				err := fakeClient.Get(ctx, namespacedName, updatedRayService)
+				require.NoError(t, err)
+				assert.Contains(t, updatedRayService.Finalizers, utils.RayServiceFinalizer)
+			},
+		},
+		{
+			name: "Delete without clusters",
+			rayService: &rayv1.RayService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-rayservice",
+					Namespace:         namespace,
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{utils.RayServiceFinalizer},
+				},
+			},
+			validate: func(t *testing.T, fakeClient client.Client, namespacedName types.NamespacedName) {
+				updatedRayService := &rayv1.RayService{}
+				err := fakeClient.Get(ctx, namespacedName, updatedRayService)
+				assert.True(t, errors.IsNotFound(err), "Expected NotFound error, got %v", err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []runtime.Object{tt.rayService}
+			for _, obj := range tt.existingObjects {
+				objs = append(objs, obj)
+			}
+
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(newScheme).
+				WithRuntimeObjects(objs...).
+				WithStatusSubresource(tt.rayService).
+				Build()
+
+			reconciler := &RayServiceReconciler{
+				Client:       fakeClient,
+				Recorder:     &record.FakeRecorder{},
+				Scheme:       newScheme,
+				ServeConfigs: lru.New(10),
+			}
+
+			namespacedName := types.NamespacedName{Name: tt.rayService.Name, Namespace: tt.rayService.Namespace}
+
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: namespacedName})
+			require.NoError(t, err)
+
+			tt.validate(t, fakeClient, namespacedName)
 		})
 	}
 }

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -3158,10 +3158,11 @@ func TestRayServiceFinalizer(t *testing.T) {
 				Build()
 
 			reconciler := &RayServiceReconciler{
-				Client:       fakeClient,
-				Recorder:     &record.FakeRecorder{},
-				Scheme:       newScheme,
-				ServeConfigs: lru.New(10),
+				Client:                       fakeClient,
+				Recorder:                     &record.FakeRecorder{},
+				Scheme:                       newScheme,
+				ServeConfigs:                 lru.New(10),
+				RayClusterDeletionTimestamps: cmap.New[time.Time](),
 			}
 
 			namespacedName := types.NamespacedName{Name: tt.rayService.Name, Namespace: tt.rayService.Namespace}

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -268,6 +268,9 @@ const (
 	// Finalizers for RayJob
 	RayJobStopJobFinalizer = "ray.io/rayjob-finalizer"
 
+	// Finalizers for RayService
+	RayServiceFinalizer = "ray.io/rayservice-finalizer"
+
 	// RayNodeHeadGroupLabelValue is the value for the RayNodeGroupLabelKey label on a head node
 	RayNodeHeadGroupLabelValue      = "headgroup"
 	RayNodeSubmitterGroupLabelValue = "submittergroup"

--- a/ray-operator/test/e2erayservice/rayservice_initializing_timeout_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_initializing_timeout_test.go
@@ -118,8 +118,9 @@ func TestRayServiceInitializingTimeoutTerminalFailure(t *testing.T) {
 		"PendingServiceStatus.RayClusterName should be cleared after timeout")
 
 	// Verify ObservedGeneration is set
-	g.Expect(rayService.Status.ObservedGeneration).To(Equal(initialGeneration),
-		"ObservedGeneration should match the initial generation")
+	expectedGeneration := initialGeneration + 1
+	g.Expect(rayService.Status.ObservedGeneration).To(Equal(expectedGeneration),
+		"ObservedGeneration should be the initial generation + 1 after adding finalizer")
 
 	// Step 3: Update the RayService with valid config to test terminal failure behavior
 	LogWithTimestamp(test.T(), "Updating RayService spec with valid configuration to test terminal failure persistence")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Added a finalizer to the RaySevice, so the Kueue won't suspend Redis-cleanup job and it will be able to cleanup the RayCluster. When the RayCluster is removed, the RayService will be deleted. 

## Related issue number

https://github.com/ray-project/kuberay/issues/4773

## Checks

- [+] I've made sure the tests are passing.
- Testing Strategy
  - [+] Unit tests
  - [+] Manual tests
  - [ ] This PR is not tested :(