### PR TITLE
[Autoscaler][Bug] inject RAY_enable_autoscaler_v2=false when user set autoscalerOptions.version=v1

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -216,9 +216,7 @@ func DefaultHeadPodTemplate(ctx context.Context, instance rayv1.RayCluster, head
 		if utils.IsAutoscalingV2Enabled(&instance.Spec) {
 			setAutoscalerV2EnvVars(&podTemplate)
 			podTemplate.Spec.RestartPolicy = corev1.RestartPolicyNever
-		}
-
-		if utils.IsAutoscalingV1Enabled(&instance.Spec) {
+		} else if utils.IsAutoscalingV1Enabled(&instance.Spec) {
 			setAutoscalerV1EnvVars(&podTemplate)
 		}
 	}

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -217,6 +217,10 @@ func DefaultHeadPodTemplate(ctx context.Context, instance rayv1.RayCluster, head
 			setAutoscalerV2EnvVars(&podTemplate)
 			podTemplate.Spec.RestartPolicy = corev1.RestartPolicyNever
 		}
+
+		if utils.IsAutoscalingV1Enabled(&instance.Spec) {
+			setAutoscalerV1EnvVars(&podTemplate)
+		}
 	}
 
 	configureGCSFaultTolerance(&podTemplate, instance, rayv1.HeadNode)
@@ -247,6 +251,18 @@ func setAutoscalerV2EnvVars(podTemplate *corev1.PodTemplateSpec) {
 	podTemplate.Spec.Containers[utils.RayContainerIndex].Env = append(podTemplate.Spec.Containers[utils.RayContainerIndex].Env, corev1.EnvVar{
 		Name:  utils.RAY_ENABLE_AUTOSCALER_V2,
 		Value: "true",
+	})
+}
+
+// setAutoscalerV1EnvVars sets env vars for autoscaler v1 in the head node
+func setAutoscalerV1EnvVars(podTemplate *corev1.PodTemplateSpec) {
+	if podTemplate.Spec.Containers[utils.RayContainerIndex].Env == nil {
+		podTemplate.Spec.Containers[utils.RayContainerIndex].Env = []corev1.EnvVar{}
+	}
+
+	podTemplate.Spec.Containers[utils.RayContainerIndex].Env = append(podTemplate.Spec.Containers[utils.RayContainerIndex].Env, corev1.EnvVar{
+		Name:  utils.RAY_ENABLE_AUTOSCALER_V2,
+		Value: "false",
 	})
 }
 

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1175,8 +1175,13 @@ func TestHeadPodTemplate_WithAutoscalingEnabled(t *testing.T) {
 
 func TestDefaultHeadPodTemplate_Autoscaling(t *testing.T) {
 	clusterNoAutoscaling := instance.DeepCopy()
+	clusterAutoscalingVersionNotSet := instance.DeepCopy()
+	clusterAutoscalingVersionNotSet.Spec.EnableInTreeAutoscaling = new(true)
 	clusterAutoscalingV1 := instance.DeepCopy()
 	clusterAutoscalingV1.Spec.EnableInTreeAutoscaling = new(true)
+	clusterAutoscalingV1.Spec.AutoscalerOptions = &rayv1.AutoscalerOptions{
+		Version: ptr.To(rayv1.AutoscalerVersionV1),
+	}
 	clusterAutoscalingV2 := instance.DeepCopy()
 	clusterAutoscalingV2.Spec.EnableInTreeAutoscaling = new(true)
 	clusterAutoscalingV2.Spec.AutoscalerOptions = &rayv1.AutoscalerOptions{
@@ -1191,23 +1196,34 @@ func TestDefaultHeadPodTemplate_Autoscaling(t *testing.T) {
 		cluster                    rayv1.RayCluster
 		expectedHeadContainers     int
 		expectedAutoscalerV2EnvVar bool
+		expectedAutoscalerV1EnvVar bool
 	}{
 		"Pod template with autoscaling disabled should not have autoscaler container or other autoscaler related fields": {
 			cluster:                    *clusterNoAutoscaling,
 			expectedHeadContainers:     1,
 			expectedAutoscalerV2EnvVar: false,
+			expectedAutoscalerV1EnvVar: false,
+			expectedRestartPolicy:      "",
+		},
+		"Pod template with autoscaling version not set should not have autoscaler env var": {
+			cluster:                    *clusterAutoscalingVersionNotSet,
+			expectedHeadContainers:     2,
+			expectedAutoscalerV2EnvVar: false,
+			expectedAutoscalerV1EnvVar: false,
 			expectedRestartPolicy:      "",
 		},
 		"Pod template with autoscaling v1 enabled should the correct autoscaler v1 fields": {
 			cluster:                    *clusterAutoscalingV1,
 			expectedHeadContainers:     2,
 			expectedAutoscalerV2EnvVar: false,
+			expectedAutoscalerV1EnvVar: true,
 			expectedRestartPolicy:      "",
 		},
 		"Pod template with autoscaling v2 enabled should the correct autoscaler v2 fields": {
 			cluster:                    *clusterAutoscalingV2,
 			expectedHeadContainers:     2,
 			expectedAutoscalerV2EnvVar: true,
+			expectedAutoscalerV1EnvVar: false,
 			expectedRestartPolicy:      corev1.RestartPolicyNever,
 		},
 	}
@@ -1225,6 +1241,23 @@ func TestDefaultHeadPodTemplate_Autoscaling(t *testing.T) {
 				assert.Contains(t, podTemplateSpec.Spec.Containers[0].Env, corev1.EnvVar{
 					Name:  utils.RAY_ENABLE_AUTOSCALER_V2,
 					Value: "true",
+				})
+			} else {
+				assert.NotContains(t, podTemplateSpec.Spec.Containers[0].Env, corev1.EnvVar{
+					Name:  utils.RAY_ENABLE_AUTOSCALER_V2,
+					Value: "true",
+				})
+			}
+
+			if tc.expectedAutoscalerV1EnvVar {
+				assert.Contains(t, podTemplateSpec.Spec.Containers[0].Env, corev1.EnvVar{
+					Name:  utils.RAY_ENABLE_AUTOSCALER_V2,
+					Value: "false",
+				})
+			} else {
+				assert.NotContains(t, podTemplateSpec.Spec.Containers[0].Env, corev1.EnvVar{
+					Name:  utils.RAY_ENABLE_AUTOSCALER_V2,
+					Value: "false",
 				})
 			}
 
@@ -2180,6 +2213,62 @@ func TestSetAutoscalerV2EnvVars(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			setAutoscalerV2EnvVars(tc.podTemplate)
+			assert.Equal(t, tc.expectedEnvVars, tc.podTemplate.Spec.Containers[0].Env)
+		})
+	}
+}
+
+func TestSetAutoscalerV1EnvVars(t *testing.T) {
+	tests := map[string]struct {
+		podTemplate     *corev1.PodTemplateSpec
+		expectedEnvVars []corev1.EnvVar
+	}{
+		"Pod without env vars should have autoscaler v2 env var set to false": {
+			podTemplate: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{},
+					},
+				},
+			},
+			expectedEnvVars: []corev1.EnvVar{
+				{
+					Name:  utils.RAY_ENABLE_AUTOSCALER_V2,
+					Value: "false",
+				},
+			},
+		},
+		"Pod without autoscaler v2 env var should have autoscaler v2 env var set to false": {
+			podTemplate: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Env: []corev1.EnvVar{
+								{
+									Name:  "papal",
+									Value: "conclave",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedEnvVars: []corev1.EnvVar{
+				{
+					Name:  "papal",
+					Value: "conclave",
+				},
+				{
+					Name:  utils.RAY_ENABLE_AUTOSCALER_V2,
+					Value: "false",
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			setAutoscalerV1EnvVars(tc.podTemplate)
 			assert.Equal(t, tc.expectedEnvVars, tc.podTemplate.Spec.Containers[0].Env)
 		})
 	}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -749,6 +749,10 @@ func IsAutoscalingV2Enabled(spec *rayv1.RayClusterSpec) bool {
 	return spec != nil && spec.AutoscalerOptions != nil && spec.AutoscalerOptions.Version != nil && *spec.AutoscalerOptions.Version == rayv1.AutoscalerVersionV2
 }
 
+func IsAutoscalingV1Enabled(spec *rayv1.RayClusterSpec) bool {
+	return spec != nil && spec.AutoscalerOptions != nil && spec.AutoscalerOptions.Version != nil && *spec.AutoscalerOptions.Version == rayv1.AutoscalerVersionV1
+}
+
 // Check if the RayCluster has GCS fault tolerance enabled.
 func IsGCSFaultToleranceEnabled(spec *rayv1.RayClusterSpec, annotations map[string]string) bool {
 	v, ok := annotations[RayFTEnabledAnnotationKey]

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -1139,6 +1139,41 @@ func TestIsAutoscalingV2Enabled(t *testing.T) {
 	}
 }
 
+func TestIsAutoscalingV1Enabled(t *testing.T) {
+	tests := map[string]struct {
+		spec     *rayv1.RayClusterSpec
+		expected bool
+	}{
+		"should be false when spec is nil": {
+			spec:     nil,
+			expected: false,
+		},
+		"should be false when autoscaler options is nil": {
+			spec: &rayv1.RayClusterSpec{
+				AutoscalerOptions: nil,
+			},
+			expected: false,
+		},
+		"should be false when autoscaler options is not v1": {
+			spec: &rayv1.RayClusterSpec{
+				AutoscalerOptions: &rayv1.AutoscalerOptions{Version: ptr.To(rayv1.AutoscalerVersionV2)},
+			},
+			expected: false,
+		},
+		"should be true when autoscaler options is v1": {
+			spec: &rayv1.RayClusterSpec{
+				AutoscalerOptions: &rayv1.AutoscalerOptions{Version: ptr.To(rayv1.AutoscalerVersionV1)},
+			},
+			expected: true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsAutoscalingV1Enabled(tc.spec))
+		})
+	}
+}
+
 func TestIsGCSFaultToleranceEnabled(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, when users set autoscalerOptions.version=v1, it does not enforce RayCluster running autoscaler v1. 
We mirror the existing v2 pattern to inject v1 so user can use v1 if they explicitly set it.

### Ray's behavior on RAY_enable_autoscaler_v2
Ray determines the autoscaler version via RAY_enable_autoscaler_v2. Based on
ray_config.h's ConvertValue<bool>, "true" or "1" enables v2; anything else falls back to v1. 

https://github.com/ray-project/ray/blob/89b572259b7e98036074994e59ee2ace5092ba45/src/ray/common/ray_config.h#L44-L48

### Summary of the behavior after this pr

autoscalerOptions.version | KubeRay Injects | Ray Behavior
-- | -- | --
Not set | nothing | Ray default (v2 on Ray 2.47.0+)
v1 | RAY_enable_autoscaler_v2=false | autoscaler v1
v2 | RAY_enable_autoscaler_v2=true | autoscaler v2

## Related issue number

<!-- For example: "Closes #1234" -->

related PR #3578 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests