### PR TITLE
[Doc] Update text-summarizer sample to ray-ml 2.49.2

### DIFF
--- a/ray-operator/config/samples/ray-service.text-summarizer.yaml
+++ b/ray-operator/config/samples/ray-service.text-summarizer.yaml
@@ -10,7 +10,7 @@ spec:
         runtime_env:
           working_dir: "https://github.com/ray-project/serve_config_examples/archive/607d1264c2c998e4a85eaf5403efcd3bc9ed3039.zip"
   rayClusterConfig:
-    rayVersion: "2.46.0" # Should match the Ray version in the image of the containers
+    rayVersion: "2.49.2" # Should match the Ray version in the image of the containers
     ######################headGroupSpecs#################################
     # Ray head pod template.
     headGroupSpec:
@@ -20,7 +20,7 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray-ml:2.46.0.0e19ea-py39-gpu
+            image: rayproject/ray-ml:2.49.2.deprecated-py311-gpu
             volumeMounts:
             - mountPath: /tmp/ray
               name: ray-logs
@@ -46,7 +46,7 @@ spec:
         spec:
           containers:
           - name: ray-worker
-            image: rayproject/ray-ml:2.46.0.0e19ea-py39-gpu
+            image: rayproject/ray-ml:2.49.2.deprecated-py311-gpu
             resources:
               limits:
                 cpu: "4"


### PR DESCRIPTION
The image rayproject/ray-ml:2.46.0.0e19ea-py39-gpu no longer exists on Docker Hub, so the sample fails to pull. Bump both the image and rayVersion to 2.49.2.deprecated-py311-gpu / 2.49.2.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
