### PR TITLE
[history server] Display history task logging

### DIFF
--- a/dashboard/src/app/history/logs/page.tsx
+++ b/dashboard/src/app/history/logs/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React from "react";
+import { useRouter } from "next/navigation";
+import { Box, IconButton, Typography } from "@mui/joy";
+import KeyboardBackspaceIcon from "@mui/icons-material/KeyboardBackspace";
+import { HistoryLogsPanel } from "@/components/HistoryLogs/HistoryLogsPanel";
+import { LogFileViewer } from "@/components/HistoryLogs/LogFileViewer";
+
+export default function HistoryLogsPage() {
+  const router = useRouter();
+  const [viewing, setViewing] = React.useState<{
+    nodeId: string;
+    filename: string;
+  } | null>(null);
+
+  if (viewing) {
+    return (
+      <LogFileViewer
+        nodeId={viewing.nodeId}
+        filename={viewing.filename}
+        onBack={() => setViewing(null)}
+      />
+    );
+  }
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: "flex",
+          my: 0.5,
+          gap: 1,
+          alignItems: "center",
+          ml: -0.8,
+        }}
+      >
+        <IconButton color="neutral" size="sm" onClick={router.back}>
+          <KeyboardBackspaceIcon />
+        </IconButton>
+        <Typography level="h3" component="h2">
+          History Logs
+        </Typography>
+      </Box>
+
+      <HistoryLogsPanel
+        onSelectFile={(nodeId, filename) => setViewing({ nodeId, filename })}
+      />
+    </>
+  );
+}

--- a/dashboard/src/app/history/page.tsx
+++ b/dashboard/src/app/history/page.tsx
@@ -26,7 +26,7 @@ const headCells: readonly HeadCell<ClusterRow>[] = [
   { id: "namespace", label: "Namespace", width: 140, sortable: true },
   { id: "sessionName", label: "Status", width: 100, sortable: true },
   { id: "createTimeStamp", label: "Created", width: 160, sortable: true },
-  { id: "tasks", label: "Actions", width: 120, sortable: false },
+  { id: "tasks", label: "Actions", width: 200, sortable: false },
 ];
 
 function toRow(c: HistoryClusterInfo): ClusterRow {
@@ -84,10 +84,10 @@ export default function HistoryClustersPage() {
     });
   }, [rows, search, statusFilter]);
 
-  const handleViewTasks = async (row: ClusterRow) => {
+  const handleNavigate = async (row: ClusterRow, target: string) => {
     try {
       await enterCluster(row.namespace, row.tasks, row.sessionName);
-      router.push("/history/tasks");
+      router.push(target);
     } catch (e) {
       console.error("Failed to enter cluster", e);
       showSnackBar("Error", `Failed to enter cluster: ${e}`, "danger");
@@ -112,13 +112,22 @@ export default function HistoryClustersPage() {
         </td>
         <td>{row.createTime}</td>
         <td>
-          <Button
-            size="sm"
-            variant="outlined"
-            onClick={() => handleViewTasks(row)}
-          >
-            Tasks →
-          </Button>
+          <Box sx={{ display: "flex", gap: 0.5 }}>
+            <Button
+              size="sm"
+              variant="outlined"
+              onClick={() => handleNavigate(row, "/history/tasks")}
+            >
+              Tasks
+            </Button>
+            <Button
+              size="sm"
+              variant="outlined"
+              onClick={() => handleNavigate(row, "/history/logs")}
+            >
+              Logs
+            </Button>
+          </Box>
         </td>
       </>
     );

--- a/dashboard/src/components/HistoryLogs/HistoryLogsPanel.tsx
+++ b/dashboard/src/components/HistoryLogs/HistoryLogsPanel.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import {
   Box,
+  Button,
   Chip,
   FormControl,
   FormLabel,
@@ -97,16 +98,19 @@ export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
     const nodeIds = nodes
       .map((node) => node.raylet?.nodeId)
       .filter((id): id is string => Boolean(id));
-    if (selectedNodeId && nodeIds.includes(selectedNodeId)) {
-      return;
-    }
 
-    const nextNodeId = nodeIds[0] ?? null;
-    if (selectedNodeId !== nextNodeId) {
-      setSelectedNodeId(nextNodeId);
-      setCategoryFilter(null);
-    }
-  }, [nodes, selectedNodeId]);
+    setSelectedNodeId((previousNodeId) => {
+      if (previousNodeId && nodeIds.includes(previousNodeId)) {
+        return previousNodeId;
+      }
+
+      const nextNodeId = nodeIds[0] ?? null;
+      if (previousNodeId !== nextNodeId) {
+        setCategoryFilter(null);
+      }
+      return nextNodeId;
+    });
+  }, [nodes]);
 
   // Build sorted list of (category, files)
   const sortedCategories = React.useMemo(() => {
@@ -162,7 +166,7 @@ export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
             value={categoryFilter}
             onChange={(_, v) => setCategoryFilter(v)}
           >
-            <Option value={null as any}>All</Option>
+            <Option value={null}>All</Option>
             {Object.keys(logFiles).map((cat) => (
               <Option key={cat} value={cat}>
                 {CATEGORY_LABELS[cat] || cat}
@@ -273,13 +277,19 @@ export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
                       </Box>
                     </td>
                     <td style={{ textAlign: "center" }}>
-                      <Typography
-                        level="body-xs"
+                      <Button
+                        size="sm"
+                        variant="outlined"
                         color="primary"
-                        fontWeight={600}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (selectedNodeId) {
+                            onSelectFile(selectedNodeId, file);
+                          }
+                        }}
                       >
                         View
-                      </Typography>
+                      </Button>
                     </td>
                   </tr>
                 )),

--- a/dashboard/src/components/HistoryLogs/HistoryLogsPanel.tsx
+++ b/dashboard/src/components/HistoryLogs/HistoryLogsPanel.tsx
@@ -14,7 +14,10 @@ import {
   Typography,
 } from "@mui/joy";
 import DescriptionIcon from "@mui/icons-material/Description";
-import { useHistoryNodes, useHistoryLogFiles } from "@/hooks/api/useHistoryLogs";
+import {
+  useHistoryNodes,
+  useHistoryLogFiles,
+} from "@/hooks/api/useHistoryLogs";
 import type { HistoryNodeSummary } from "@/types/historyserver";
 
 // Display order for log categories – most useful ones first
@@ -76,17 +79,32 @@ interface Props {
 }
 
 export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
-  const [selectedNodeId, setSelectedNodeId] = React.useState<string | null>(null);
-  const [categoryFilter, setCategoryFilter] = React.useState<string | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = React.useState<string | null>(
+    null,
+  );
+  const [categoryFilter, setCategoryFilter] = React.useState<string | null>(
+    null,
+  );
   const { nodes, isLoading: nodesLoading } = useHistoryNodes();
-  const { logFiles, isLoading: logsLoading, error: logsError } =
-    useHistoryLogFiles(selectedNodeId);
+  const {
+    logFiles,
+    isLoading: logsLoading,
+    error: logsError,
+  } = useHistoryLogFiles(selectedNodeId);
 
-  // Auto-select first node when nodes load
+  // Auto-select a valid node when nodes load or the active cluster changes.
   React.useEffect(() => {
-    if (!selectedNodeId && nodes.length > 0) {
-      const firstId = nodes[0]?.raylet?.nodeId;
-      if (firstId) setSelectedNodeId(firstId);
+    const nodeIds = nodes
+      .map((node) => node.raylet?.nodeId)
+      .filter((id): id is string => Boolean(id));
+    if (selectedNodeId && nodeIds.includes(selectedNodeId)) {
+      return;
+    }
+
+    const nextNodeId = nodeIds[0] ?? null;
+    if (selectedNodeId !== nextNodeId) {
+      setSelectedNodeId(nextNodeId);
+      setCategoryFilter(null);
     }
   }, [nodes, selectedNodeId]);
 
@@ -169,9 +187,11 @@ export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
           hoverRow
           stickyHeader
           sx={{
-            "--TableCell-headBackground": "var(--joy-palette-background-level1)",
+            "--TableCell-headBackground":
+              "var(--joy-palette-background-level1)",
             "--Table-headerUnderlineThickness": "1px",
-            "--TableRow-hoverBackground": "var(--joy-palette-background-level1)",
+            "--TableRow-hoverBackground":
+              "var(--joy-palette-background-level1)",
             "--TableCell-paddingY": "6px",
             "--TableCell-paddingX": "8px",
           }}
@@ -188,7 +208,8 @@ export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
               <tr>
                 <td colSpan={3} style={{ textAlign: "center" }}>
                   <Typography level="body-sm" color="danger">
-                    Failed to load logs{logsError.message ? `: ${logsError.message}` : ""}
+                    Failed to load logs
+                    {logsError.message ? `: ${logsError.message}` : ""}
                   </Typography>
                 </td>
               </tr>
@@ -226,7 +247,9 @@ export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
                   <tr
                     key={`${category}-${file}`}
                     style={{ cursor: "pointer" }}
-                    onClick={() => selectedNodeId && onSelectFile(selectedNodeId, file)}
+                    onClick={() =>
+                      selectedNodeId && onSelectFile(selectedNodeId, file)
+                    }
                   >
                     <td>
                       <Chip
@@ -238,7 +261,9 @@ export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
                       </Chip>
                     </td>
                     <td>
-                      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                      <Box
+                        sx={{ display: "flex", alignItems: "center", gap: 0.5 }}
+                      >
                         <DescriptionIcon
                           sx={{ fontSize: 16, color: "neutral.400" }}
                         />
@@ -248,7 +273,11 @@ export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
                       </Box>
                     </td>
                     <td style={{ textAlign: "center" }}>
-                      <Typography level="body-xs" color="primary" fontWeight={600}>
+                      <Typography
+                        level="body-xs"
+                        color="primary"
+                        fontWeight={600}
+                      >
                         View
                       </Typography>
                     </td>

--- a/dashboard/src/components/HistoryLogs/HistoryLogsPanel.tsx
+++ b/dashboard/src/components/HistoryLogs/HistoryLogsPanel.tsx
@@ -99,18 +99,16 @@ export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
       .map((node) => node.raylet?.nodeId)
       .filter((id): id is string => Boolean(id));
 
-    setSelectedNodeId((previousNodeId) => {
-      if (previousNodeId && nodeIds.includes(previousNodeId)) {
-        return previousNodeId;
-      }
+    if (selectedNodeId && nodeIds.includes(selectedNodeId)) {
+      return;
+    }
 
-      const nextNodeId = nodeIds[0] ?? null;
-      if (previousNodeId !== nextNodeId) {
-        setCategoryFilter(null);
-      }
-      return nextNodeId;
-    });
-  }, [nodes]);
+    const nextNodeId = nodeIds[0] ?? null;
+    if (selectedNodeId !== nextNodeId) {
+      setSelectedNodeId(nextNodeId);
+      setCategoryFilter(null);
+    }
+  }, [nodes, selectedNodeId]);
 
   // Build sorted list of (category, files)
   const sortedCategories = React.useMemo(() => {

--- a/dashboard/src/components/HistoryLogs/HistoryLogsPanel.tsx
+++ b/dashboard/src/components/HistoryLogs/HistoryLogsPanel.tsx
@@ -86,6 +86,7 @@ export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
   const [categoryFilter, setCategoryFilter] = React.useState<string | null>(
     null,
   );
+  const selectedNodeIdRef = React.useRef<string | null>(null);
   const { nodes, isLoading: nodesLoading } = useHistoryNodes();
   const {
     logFiles,
@@ -93,22 +94,28 @@ export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
     error: logsError,
   } = useHistoryLogFiles(selectedNodeId);
 
+  React.useEffect(() => {
+    selectedNodeIdRef.current = selectedNodeId;
+  }, [selectedNodeId]);
+
   // Auto-select a valid node when nodes load or the active cluster changes.
   React.useEffect(() => {
     const nodeIds = nodes
       .map((node) => node.raylet?.nodeId)
       .filter((id): id is string => Boolean(id));
+    const currentNodeId = selectedNodeIdRef.current;
 
-    if (selectedNodeId && nodeIds.includes(selectedNodeId)) {
+    if (currentNodeId && nodeIds.includes(currentNodeId)) {
       return;
     }
 
     const nextNodeId = nodeIds[0] ?? null;
-    if (selectedNodeId !== nextNodeId) {
+    if (currentNodeId !== nextNodeId) {
+      selectedNodeIdRef.current = nextNodeId;
       setSelectedNodeId(nextNodeId);
       setCategoryFilter(null);
     }
-  }, [nodes, selectedNodeId]);
+  }, [nodes]);
 
   // Build sorted list of (category, files)
   const sortedCategories = React.useMemo(() => {
@@ -141,6 +148,7 @@ export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
             placeholder={nodesLoading ? "Loading nodes…" : "Select a node"}
             value={selectedNodeId}
             onChange={(_, v) => {
+              selectedNodeIdRef.current = v;
               setSelectedNodeId(v);
               setCategoryFilter(null);
             }}

--- a/dashboard/src/components/HistoryLogs/HistoryLogsPanel.tsx
+++ b/dashboard/src/components/HistoryLogs/HistoryLogsPanel.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import React from "react";
+import {
+  Box,
+  Chip,
+  FormControl,
+  FormLabel,
+  Option,
+  Select,
+  Sheet,
+  Skeleton,
+  Table,
+  Typography,
+} from "@mui/joy";
+import DescriptionIcon from "@mui/icons-material/Description";
+import { useHistoryNodes, useHistoryLogFiles } from "@/hooks/api/useHistoryLogs";
+import type { HistoryNodeSummary } from "@/types/historyserver";
+
+// Display order for log categories – most useful ones first
+const CATEGORY_ORDER = [
+  "worker_out",
+  "worker_err",
+  "core_worker",
+  "driver",
+  "raylet",
+  "gcs_server",
+  "agent",
+  "dashboard",
+  "autoscaler",
+  "internal",
+];
+
+const CATEGORY_LABELS: Record<string, string> = {
+  worker_out: "Worker (stdout)",
+  worker_err: "Worker (stderr)",
+  core_worker: "Core Worker",
+  driver: "Driver",
+  raylet: "Raylet",
+  gcs_server: "GCS Server",
+  agent: "Agent",
+  dashboard: "Dashboard",
+  autoscaler: "Autoscaler",
+  internal: "Internal",
+};
+
+function categoryColor(
+  cat: string,
+): "primary" | "success" | "warning" | "danger" | "neutral" {
+  switch (cat) {
+    case "worker_out":
+    case "worker_err":
+      return "primary";
+    case "raylet":
+    case "gcs_server":
+      return "warning";
+    case "driver":
+      return "success";
+    default:
+      return "neutral";
+  }
+}
+
+function nodeLabel(node: HistoryNodeSummary): string {
+  const ip = node.ip || "unknown";
+  const id = node.raylet?.nodeId?.slice(0, 8) || "?";
+  const hostname = node.hostname || "";
+  if (hostname) {
+    return `${hostname} (${ip}) [${id}…]`;
+  }
+  return `${ip} [${id}…]`;
+}
+
+interface Props {
+  onSelectFile: (nodeId: string, filename: string) => void;
+}
+
+export const HistoryLogsPanel: React.FC<Props> = ({ onSelectFile }) => {
+  const [selectedNodeId, setSelectedNodeId] = React.useState<string | null>(null);
+  const [categoryFilter, setCategoryFilter] = React.useState<string | null>(null);
+  const { nodes, isLoading: nodesLoading } = useHistoryNodes();
+  const { logFiles, isLoading: logsLoading, error: logsError } =
+    useHistoryLogFiles(selectedNodeId);
+
+  // Auto-select first node when nodes load
+  React.useEffect(() => {
+    if (!selectedNodeId && nodes.length > 0) {
+      const firstId = nodes[0]?.raylet?.nodeId;
+      if (firstId) setSelectedNodeId(firstId);
+    }
+  }, [nodes, selectedNodeId]);
+
+  // Build sorted list of (category, files)
+  const sortedCategories = React.useMemo(() => {
+    const entries = Object.entries(logFiles);
+    const orderMap = new Map(CATEGORY_ORDER.map((c, i) => [c, i]));
+    entries.sort(([a], [b]) => {
+      const ia = orderMap.get(a) ?? 999;
+      const ib = orderMap.get(b) ?? 999;
+      return ia - ib;
+    });
+    if (categoryFilter) {
+      return entries.filter(([cat]) => cat === categoryFilter);
+    }
+    return entries;
+  }, [logFiles, categoryFilter]);
+
+  const totalFiles = React.useMemo(
+    () => Object.values(logFiles).reduce((s, arr) => s + arr.length, 0),
+    [logFiles],
+  );
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      {/* Controls */}
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5 }}>
+        <FormControl size="sm" sx={{ minWidth: 280 }}>
+          <FormLabel>Node</FormLabel>
+          <Select
+            size="sm"
+            placeholder={nodesLoading ? "Loading nodes…" : "Select a node"}
+            value={selectedNodeId}
+            onChange={(_, v) => {
+              setSelectedNodeId(v);
+              setCategoryFilter(null);
+            }}
+          >
+            {nodes.map((node) => {
+              const id = node.raylet?.nodeId;
+              return (
+                <Option key={id} value={id}>
+                  {nodeLabel(node)}
+                </Option>
+              );
+            })}
+          </Select>
+        </FormControl>
+
+        <FormControl size="sm" sx={{ minWidth: 160 }}>
+          <FormLabel>Category</FormLabel>
+          <Select
+            size="sm"
+            placeholder="All categories"
+            value={categoryFilter}
+            onChange={(_, v) => setCategoryFilter(v)}
+          >
+            <Option value={null as any}>All</Option>
+            {Object.keys(logFiles).map((cat) => (
+              <Option key={cat} value={cat}>
+                {CATEGORY_LABELS[cat] || cat}
+              </Option>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Box sx={{ display: "flex", alignItems: "flex-end", pb: 0.5 }}>
+          <Typography level="body-xs" textColor="neutral.400">
+            {totalFiles} file{totalFiles !== 1 ? "s" : ""}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Log files table */}
+      <Sheet
+        variant="outlined"
+        sx={{ borderRadius: "sm", overflow: "auto", minHeight: 0 }}
+      >
+        <Table
+          hoverRow
+          stickyHeader
+          sx={{
+            "--TableCell-headBackground": "var(--joy-palette-background-level1)",
+            "--Table-headerUnderlineThickness": "1px",
+            "--TableRow-hoverBackground": "var(--joy-palette-background-level1)",
+            "--TableCell-paddingY": "6px",
+            "--TableCell-paddingX": "8px",
+          }}
+        >
+          <thead>
+            <tr>
+              <th style={{ width: 140 }}>Category</th>
+              <th>Filename</th>
+              <th style={{ width: 80, textAlign: "center" }}>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {logsError ? (
+              <tr>
+                <td colSpan={3} style={{ textAlign: "center" }}>
+                  <Typography level="body-sm" color="danger">
+                    Failed to load logs{logsError.message ? `: ${logsError.message}` : ""}
+                  </Typography>
+                </td>
+              </tr>
+            ) : logsLoading || nodesLoading ? (
+              Array.from({ length: 6 }).map((_, i) => (
+                <tr key={i}>
+                  <td>
+                    <Skeleton variant="text" width={80} />
+                  </td>
+                  <td>
+                    <Skeleton animation="wave" variant="text" width="90%" />
+                  </td>
+                  <td />
+                </tr>
+              ))
+            ) : !selectedNodeId ? (
+              <tr>
+                <td colSpan={3} style={{ textAlign: "center" }}>
+                  <Typography level="body-sm" color="neutral">
+                    Select a node to view its log files.
+                  </Typography>
+                </td>
+              </tr>
+            ) : totalFiles === 0 ? (
+              <tr>
+                <td colSpan={3} style={{ textAlign: "center" }}>
+                  <Typography level="body-sm" color="neutral">
+                    No log files found for this node.
+                  </Typography>
+                </td>
+              </tr>
+            ) : (
+              sortedCategories.flatMap(([category, files]) =>
+                files.map((file) => (
+                  <tr
+                    key={`${category}-${file}`}
+                    style={{ cursor: "pointer" }}
+                    onClick={() => selectedNodeId && onSelectFile(selectedNodeId, file)}
+                  >
+                    <td>
+                      <Chip
+                        variant="soft"
+                        size="sm"
+                        color={categoryColor(category)}
+                      >
+                        {CATEGORY_LABELS[category] || category}
+                      </Chip>
+                    </td>
+                    <td>
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                        <DescriptionIcon
+                          sx={{ fontSize: 16, color: "neutral.400" }}
+                        />
+                        <Typography level="body-sm" noWrap>
+                          {file}
+                        </Typography>
+                      </Box>
+                    </td>
+                    <td style={{ textAlign: "center" }}>
+                      <Typography level="body-xs" color="primary" fontWeight={600}>
+                        View
+                      </Typography>
+                    </td>
+                  </tr>
+                )),
+              )
+            )}
+          </tbody>
+        </Table>
+      </Sheet>
+    </Box>
+  );
+};

--- a/dashboard/src/components/HistoryLogs/LogFileViewer.tsx
+++ b/dashboard/src/components/HistoryLogs/LogFileViewer.tsx
@@ -23,9 +23,17 @@ interface Props {
   onBack: () => void;
 }
 
-export const LogFileViewer: React.FC<Props> = ({ nodeId, filename, onBack }) => {
+export const LogFileViewer: React.FC<Props> = ({
+  nodeId,
+  filename,
+  onBack,
+}) => {
   const [lines, setLines] = React.useState(1000);
-  const { content, isLoading, error } = useLogFileContent(nodeId, filename, lines);
+  const { content, isLoading, error } = useLogFileContent(
+    nodeId,
+    filename,
+    lines,
+  );
   const [copied, setCopied] = React.useState(false);
 
   const handleCopy = async () => {
@@ -47,7 +55,9 @@ export const LogFileViewer: React.FC<Props> = ({ nodeId, filename, onBack }) => 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
       {/* Header */}
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+      <Box
+        sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}
+      >
         <IconButton size="sm" variant="plain" onClick={onBack}>
           <ArrowBackIcon />
         </IconButton>
@@ -60,14 +70,17 @@ export const LogFileViewer: React.FC<Props> = ({ nodeId, filename, onBack }) => 
       </Box>
 
       {/* Controls */}
-      <Box sx={{ display: "flex", gap: 1.5, alignItems: "flex-end", flexWrap: "wrap" }}>
+      <Box
+        sx={{
+          display: "flex",
+          gap: 1.5,
+          alignItems: "flex-end",
+          flexWrap: "wrap",
+        }}
+      >
         <FormControl size="sm" sx={{ minWidth: 120 }}>
           <FormLabel>Lines</FormLabel>
-          <Select
-            size="sm"
-            value={lines}
-            onChange={(_, v) => v && setLines(v)}
-          >
+          <Select size="sm" value={lines} onChange={(_, v) => v && setLines(v)}>
             <Option value={100}>100</Option>
             <Option value={500}>500</Option>
             <Option value={1000}>1,000</Option>

--- a/dashboard/src/components/HistoryLogs/LogFileViewer.tsx
+++ b/dashboard/src/components/HistoryLogs/LogFileViewer.tsx
@@ -17,6 +17,8 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { useLogFileContent } from "@/hooks/api/useHistoryLogs";
 
+const SKELETON_LINE_WIDTHS = [78, 92, 64, 86, 70, 95, 82, 68, 88, 74, 90, 66];
+
 interface Props {
   nodeId: string;
   filename: string;
@@ -125,12 +127,12 @@ export const LogFileViewer: React.FC<Props> = ({
           </Box>
         ) : isLoading ? (
           <Box sx={{ p: 2 }}>
-            {Array.from({ length: 12 }).map((_, i) => (
+            {SKELETON_LINE_WIDTHS.map((width, i) => (
               <Skeleton
                 key={i}
                 animation="wave"
                 variant="text"
-                width={`${60 + Math.random() * 35}%`}
+                width={`${width}%`}
                 sx={{ mb: 0.5 }}
               />
             ))}

--- a/dashboard/src/components/HistoryLogs/LogFileViewer.tsx
+++ b/dashboard/src/components/HistoryLogs/LogFileViewer.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import React from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  IconButton,
+  Option,
+  Select,
+  Sheet,
+  Skeleton,
+  Typography,
+} from "@mui/joy";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import { useLogFileContent } from "@/hooks/api/useHistoryLogs";
+
+interface Props {
+  nodeId: string;
+  filename: string;
+  onBack: () => void;
+}
+
+export const LogFileViewer: React.FC<Props> = ({ nodeId, filename, onBack }) => {
+  const [lines, setLines] = React.useState(1000);
+  const { content, isLoading, error } = useLogFileContent(nodeId, filename, lines);
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = async () => {
+    if (!content) return;
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard access might be blocked
+    }
+  };
+
+  const lineCount = React.useMemo(() => {
+    if (!content) return 0;
+    return content.split("\n").length;
+  }, [content]);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      {/* Header */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+        <IconButton size="sm" variant="plain" onClick={onBack}>
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography level="title-md" noWrap sx={{ flex: 1, minWidth: 0 }}>
+          {filename}
+        </Typography>
+        <Typography level="body-xs" textColor="neutral.400">
+          Node: {nodeId.slice(0, 12)}…
+        </Typography>
+      </Box>
+
+      {/* Controls */}
+      <Box sx={{ display: "flex", gap: 1.5, alignItems: "flex-end", flexWrap: "wrap" }}>
+        <FormControl size="sm" sx={{ minWidth: 120 }}>
+          <FormLabel>Lines</FormLabel>
+          <Select
+            size="sm"
+            value={lines}
+            onChange={(_, v) => v && setLines(v)}
+          >
+            <Option value={100}>100</Option>
+            <Option value={500}>500</Option>
+            <Option value={1000}>1,000</Option>
+            <Option value={5000}>5,000</Option>
+            <Option value={-1}>All</Option>
+          </Select>
+        </FormControl>
+
+        <Button
+          size="sm"
+          variant="outlined"
+          color="neutral"
+          startDecorator={<ContentCopyIcon sx={{ fontSize: 14 }} />}
+          onClick={handleCopy}
+          disabled={!content}
+        >
+          {copied ? "Copied" : "Copy"}
+        </Button>
+
+        {content && (
+          <Typography level="body-xs" textColor="neutral.400" sx={{ pb: 0.5 }}>
+            {lineCount} line{lineCount !== 1 ? "s" : ""}
+          </Typography>
+        )}
+      </Box>
+
+      {/* Content */}
+      <Sheet
+        variant="outlined"
+        sx={{
+          borderRadius: "sm",
+          overflow: "auto",
+          maxHeight: "calc(100vh - 260px)",
+          minHeight: 200,
+        }}
+      >
+        {error ? (
+          <Box sx={{ p: 2 }}>
+            <Typography level="body-sm" color="danger">
+              Failed to load log file{error.message ? `: ${error.message}` : ""}
+            </Typography>
+          </Box>
+        ) : isLoading ? (
+          <Box sx={{ p: 2 }}>
+            {Array.from({ length: 12 }).map((_, i) => (
+              <Skeleton
+                key={i}
+                animation="wave"
+                variant="text"
+                width={`${60 + Math.random() * 35}%`}
+                sx={{ mb: 0.5 }}
+              />
+            ))}
+          </Box>
+        ) : !content ? (
+          <Box sx={{ p: 2 }}>
+            <Typography level="body-sm" color="neutral">
+              Log file is empty.
+            </Typography>
+          </Box>
+        ) : (
+          <Box
+            component="pre"
+            sx={{
+              m: 0,
+              p: 1.5,
+              fontSize: "0.75rem",
+              fontFamily: "monospace",
+              lineHeight: 1.6,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-all",
+            }}
+          >
+            {content}
+          </Box>
+        )}
+      </Sheet>
+    </Box>
+  );
+};

--- a/dashboard/src/hooks/api/useHistoryClusters.ts
+++ b/dashboard/src/hooks/api/useHistoryClusters.ts
@@ -3,6 +3,13 @@ import { historyServerFetcher } from "@/utils/fetch";
 import type { HistoryClusterInfoList } from "@/types/historyserver";
 import { config } from "@/utils/constants";
 
+const isClusterScopedHistoryKey = (key: unknown) =>
+  typeof key === "string" &&
+  (key === "/api/v0/tasks" ||
+    key === "/nodes" ||
+    key.startsWith("/api/v0/logs?") ||
+    key.startsWith("log-content:"));
+
 export const useHistoryClusters = (refreshInterval: number = 5000) => {
   const { data, error, isLoading } = useSWR<HistoryClusterInfoList | any>(
     "/clusters",
@@ -26,8 +33,7 @@ export const useHistoryClusters = (refreshInterval: number = 5000) => {
         `Failed to enter cluster: ${res.status} ${res.statusText}`,
       );
     }
-    // Clean and refresh tasks cache
-    mutate("/api/v0/tasks", undefined, { revalidate: false });
+    await mutate(isClusterScopedHistoryKey, undefined, { revalidate: false });
   };
 
   return {

--- a/dashboard/src/hooks/api/useHistoryClusters.ts
+++ b/dashboard/src/hooks/api/useHistoryClusters.ts
@@ -6,12 +6,12 @@ import { config } from "@/utils/constants";
 const isClusterScopedHistoryKey = (key: unknown) =>
   typeof key === "string" &&
   (key === "/api/v0/tasks" ||
-    key === "/nodes" ||
+    key === "/nodes?view=summary" ||
     key.startsWith("/api/v0/logs?") ||
     key.startsWith("log-content:"));
 
 export const useHistoryClusters = (refreshInterval: number = 5000) => {
-  const { data, error, isLoading } = useSWR<HistoryClusterInfoList | any>(
+  const { data, error, isLoading } = useSWR<HistoryClusterInfoList>(
     "/clusters",
     historyServerFetcher,
     { refreshInterval },

--- a/dashboard/src/hooks/api/useHistoryLogs.ts
+++ b/dashboard/src/hooks/api/useHistoryLogs.ts
@@ -14,7 +14,8 @@ export const useHistoryNodes = (refreshInterval: number = 0) => {
     { refreshInterval },
   );
 
-  const nodes = (data?.data?.summary ?? []) as HistoryNodesResponse["data"]["summary"];
+  const nodes = (data?.data?.summary ??
+    []) as HistoryNodesResponse["data"]["summary"];
 
   return { nodes, isLoading, error };
 };
@@ -23,7 +24,9 @@ export const useHistoryLogFiles = (
   nodeId: string | null,
   refreshInterval: number = 0,
 ) => {
-  const key = nodeId ? `/api/v0/logs?node_id=${encodeURIComponent(nodeId)}` : null;
+  const key = nodeId
+    ? `/api/v0/logs?node_id=${encodeURIComponent(nodeId)}`
+    : null;
 
   const { data, error, isLoading } = useSWR<HistoryLogsResponse | any>(
     key,
@@ -42,9 +45,7 @@ export const useLogFileContent = (
   lines: number = 1000,
 ) => {
   const { data, error, isLoading } = useSWR<string | null>(
-    nodeId && filename
-      ? `log-content:${nodeId}:${filename}:${lines}`
-      : null,
+    nodeId && filename ? `log-content:${nodeId}:${filename}:${lines}` : null,
     async () => {
       if (!nodeId || !filename) return null;
       const proxyEndpoint = (await config.getHistoryServerUrl()).proxyEndpoint;
@@ -63,7 +64,8 @@ export const useLogFileContent = (
       // The proxy wraps text in JSON (NextResponse.json), unwrap it
       const body = await res.text();
       try {
-        return JSON.parse(body) as string;
+        const parsed = JSON.parse(body);
+        return typeof parsed === "string" ? parsed : body;
       } catch {
         return body;
       }

--- a/dashboard/src/hooks/api/useHistoryLogs.ts
+++ b/dashboard/src/hooks/api/useHistoryLogs.ts
@@ -8,8 +8,8 @@ import type {
 } from "@/types/historyserver";
 
 export const useHistoryNodes = (refreshInterval: number = 0) => {
-  const { data, error, isLoading } = useSWR<HistoryNodesResponse | any>(
-    "/nodes",
+  const { data, error, isLoading } = useSWR<HistoryNodesResponse>(
+    "/nodes?view=summary",
     historyServerFetcher,
     { refreshInterval },
   );
@@ -28,7 +28,7 @@ export const useHistoryLogFiles = (
     ? `/api/v0/logs?node_id=${encodeURIComponent(nodeId)}`
     : null;
 
-  const { data, error, isLoading } = useSWR<HistoryLogsResponse | any>(
+  const { data, error, isLoading } = useSWR<HistoryLogsResponse>(
     key,
     historyServerFetcher,
     { refreshInterval },

--- a/dashboard/src/hooks/api/useHistoryLogs.ts
+++ b/dashboard/src/hooks/api/useHistoryLogs.ts
@@ -1,0 +1,75 @@
+import useSWR from "swr";
+import { historyServerFetcher } from "@/utils/fetch";
+import { config } from "@/utils/constants";
+import type {
+  HistoryLogsResponse,
+  HistoryNodesResponse,
+  LogFilesByCategory,
+} from "@/types/historyserver";
+
+export const useHistoryNodes = (refreshInterval: number = 0) => {
+  const { data, error, isLoading } = useSWR<HistoryNodesResponse | any>(
+    "/nodes",
+    historyServerFetcher,
+    { refreshInterval },
+  );
+
+  const nodes = (data?.data?.summary ?? []) as HistoryNodesResponse["data"]["summary"];
+
+  return { nodes, isLoading, error };
+};
+
+export const useHistoryLogFiles = (
+  nodeId: string | null,
+  refreshInterval: number = 0,
+) => {
+  const key = nodeId ? `/api/v0/logs?node_id=${encodeURIComponent(nodeId)}` : null;
+
+  const { data, error, isLoading } = useSWR<HistoryLogsResponse | any>(
+    key,
+    historyServerFetcher,
+    { refreshInterval },
+  );
+
+  const logFiles = (data?.data?.result ?? {}) as LogFilesByCategory;
+
+  return { logFiles, isLoading, error };
+};
+
+export const useLogFileContent = (
+  nodeId: string | null,
+  filename: string | null,
+  lines: number = 1000,
+) => {
+  const { data, error, isLoading } = useSWR<string | null>(
+    nodeId && filename
+      ? `log-content:${nodeId}:${filename}:${lines}`
+      : null,
+    async () => {
+      if (!nodeId || !filename) return null;
+      const proxyEndpoint = (await config.getHistoryServerUrl()).proxyEndpoint;
+      const params = new URLSearchParams({
+        node_id: nodeId,
+        filename,
+        lines: String(lines),
+        filter_ansi_code: "true",
+      });
+      const res = await fetch(
+        `${proxyEndpoint}/api/v0/logs/file?${params.toString()}`,
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to fetch log file: ${res.status}`);
+      }
+      // The proxy wraps text in JSON (NextResponse.json), unwrap it
+      const body = await res.text();
+      try {
+        return JSON.parse(body) as string;
+      } catch {
+        return body;
+      }
+    },
+    { revalidateOnFocus: false },
+  );
+
+  return { content: data ?? null, isLoading, error };
+};

--- a/dashboard/src/types/historyserver.ts
+++ b/dashboard/src/types/historyserver.ts
@@ -43,3 +43,32 @@ export interface HistoryTasksResponse {
     };
   };
 }
+
+/** GET /nodes response for the node selector on the logs page */
+export interface HistoryNodeSummary {
+  hostname: string;
+  ip: string;
+  raylet: {
+    nodeId: string;
+    state: string;
+  };
+}
+
+export interface HistoryNodesResponse {
+  result: boolean;
+  msg: string;
+  data: {
+    summary: HistoryNodeSummary[];
+  };
+}
+
+/** GET /api/v0/logs?node_id=... response – log files categorised by component */
+export type LogFilesByCategory = Record<string, string[]>;
+
+export interface HistoryLogsResponse {
+  result: boolean;
+  msg: string;
+  data: {
+    result: LogFilesByCategory;
+  };
+}


### PR DESCRIPTION
## Why are these changes needed?

For the current history server UI, it's only providing limited task info, which is insufficient in production environment.
In the linked issue, I pasted the analysis on what history server could provide and what it actually provides now.
This PR adds task logging, which IMO is the most important piece for task inspection.

Result
<img width="3407" height="698" alt="image" src="https://github.com/user-attachments/assets/46a3dfdc-4d82-4085-997f-d78a8b1e79cf" />
<img width="3402" height="561" alt="image" src="https://github.com/user-attachments/assets/2f862458-165e-44b7-a988-31902f0f9d37" />
<img width="3402" height="375" alt="image" src="https://github.com/user-attachments/assets/cdeafb42-ee93-4981-912e-1db67fda9f02" />


## Related issue number

Closes https://github.com/ray-project/kuberay/issues/4817

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [X] Manual tests
  - [ ] This PR is not tested :(
