### PR TITLE
Add http client metrics

### DIFF
--- a/.buildkite/values-kuberay-operator-override.yaml
+++ b/.buildkite/values-kuberay-operator-override.yaml
@@ -9,6 +9,9 @@
 # Usage examples:
 #   helm install kuberay-operator kuberay/kuberay-operator -f ../.buildkite/values-kuberay-operator-override.yaml
 #   (add or remove feature gates below as e2e scenarios expand)
+metrics:
+  enabled: true
+
 featureGates:
   - name: RayClusterStatusConditions
     enabled: true

--- a/apiserver/cmd/main.go
+++ b/apiserver/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 	"google.golang.org/grpc"
@@ -33,6 +34,7 @@ import (
 	"github.com/ray-project/kuberay/apiserver/pkg/util"
 	"github.com/ray-project/kuberay/apiserversdk"
 	api "github.com/ray-project/kuberay/proto/go_client"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils/httpclientmetrics"
 )
 
 var (
@@ -116,6 +118,10 @@ func startRPCServer(resourceManager *manager.ResourceManager, grpcTimeout time.D
 	// This is to enable `grpc_server_handling_seconds`, otherwise we won't have latency metrics.
 	// see https://github.com/grpc-ecosystem/go-grpc-prometheus/blob/master/README.md#histograms for details.
 	grpc_prometheus.EnableHandlingTimeHistogram()
+	// Register the Ray HTTP client metrics so instrumented outbound requests are exposed on /metrics.
+	if *collectMetricsFlag {
+		httpclientmetrics.RegisterMetrics(prometheus.DefaultRegisterer)
+	}
 	if err := s.Serve(listener); err != nil {
 		klog.Fatalf("Failed to serve gRPC listener: %v", err)
 	}

--- a/apiserver/pkg/server/ray_job_submission_service_server.go
+++ b/apiserver/pkg/server/ray_job_submission_service_server.go
@@ -41,7 +41,8 @@ type RayJobSubmissionServiceServer struct {
 // Create RayJobSubmissionServiceServer
 func NewRayJobSubmissionServiceServer(clusterServer *ClusterServer, options *RayJobSubmissionServiceServerOptions) *RayJobSubmissionServiceServer {
 	zl := zerolog.New(os.Stdout).Level(zerolog.DebugLevel)
-	return &RayJobSubmissionServiceServer{clusterServer: clusterServer, options: options, log: zerologr.New(&zl).WithName("jobsubmissionservice"), dashboardClientFunc: utils.GetRayDashboardClientFunc(context.Background(), nil, false)}
+	enableMetrics := options != nil && options.CollectMetrics
+	return &RayJobSubmissionServiceServer{clusterServer: clusterServer, options: options, log: zerologr.New(&zl).WithName("jobsubmissionservice"), dashboardClientFunc: utils.GetRayDashboardClientFunc(context.Background(), nil, false, enableMetrics)}
 }
 
 // Submit Ray job

--- a/config/grafana/KubeRay-Operator.json
+++ b/config/grafana/KubeRay-Operator.json
@@ -142,7 +142,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "The reconciliation rate is calculated by measuring the change in value between consecutive scrape intervals and dividing by the duration of the interval. For example, if the rate is 0.066 and the scrape interval is 30 seconds, it indicates that 2 reconciliations occurred during that interval (2 ÷ 30 = 0.066)",
+      "description": "The reconciliation rate is calculated by measuring the change in value between consecutive scrape intervals and dividing by the duration of the interval. For example, if the rate is 0.066 and the scrape interval is 30 seconds, it indicates that 2 reconciliations occurred during that interval (2 \u00f7 30 = 0.066)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2049,6 +2049,286 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "id": 100,
+      "panels": [],
+      "title": "HTTP Client",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "seconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 61
+      },
+      "id": 101,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, ray_endpoint, mode) (rate(kuberay_dashboard_client_request_duration_seconds_bucket{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m])))",
+          "legendFormat": "{{ray_endpoint}} ({{mode}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, ray_endpoint, mode) (rate(kuberay_proxy_client_request_duration_seconds_bucket{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m])))",
+          "legendFormat": "{{ray_endpoint}} ({{mode}})",
+          "refId": "B"
+        }
+      ],
+      "title": "HTTP Client Latency (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "req/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 61
+      },
+      "id": 102,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (ray_endpoint, method) (rate(kuberay_dashboard_client_requests_total{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m]))",
+          "legendFormat": "{{method}} {{ray_endpoint}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (ray_endpoint, method) (rate(kuberay_proxy_client_requests_total{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m]))",
+          "legendFormat": "{{method}} {{ray_endpoint}}",
+          "refId": "B"
+        }
+      ],
+      "title": "HTTP Client Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "req/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 61
+      },
+      "id": 103,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (code, mode) (rate(kuberay_dashboard_client_requests_total{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m]))",
+          "legendFormat": "dashboard {{code}} ({{mode}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (code, mode) (rate(kuberay_proxy_client_requests_total{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m]))",
+          "legendFormat": "proxy {{code}} ({{mode}})",
+          "refId": "B"
+        }
+      ],
+      "title": "HTTP Client Response Codes by Mode",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/config/grafana/KubeRay-Operator.json
+++ b/config/grafana/KubeRay-Operator.json
@@ -2144,12 +2144,12 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, ray_endpoint, mode) (rate(kuberay_proxy_client_request_duration_seconds_bucket{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, ray_endpoint, mode) (rate(kuberay_serve_client_request_duration_seconds_bucket{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m])))",
           "legendFormat": "{{ray_endpoint}} ({{mode}})",
           "refId": "B"
         }
       ],
-      "title": "HTTP Client Latency (p95)",
+      "title": "HTTP Client Response Time (p95)",
       "type": "timeseries"
     },
     {
@@ -2223,7 +2223,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (ray_endpoint, method) (rate(kuberay_dashboard_client_requests_total{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m]))",
+          "expr": "sum by (ray_endpoint, method) (rate(kuberay_dashboard_client_request_duration_seconds_count{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m]))",
           "legendFormat": "{{method}} {{ray_endpoint}}",
           "refId": "A"
         },
@@ -2233,7 +2233,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (ray_endpoint, method) (rate(kuberay_proxy_client_requests_total{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m]))",
+          "expr": "sum by (ray_endpoint, method) (rate(kuberay_serve_client_request_duration_seconds_count{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m]))",
           "legendFormat": "{{method}} {{ray_endpoint}}",
           "refId": "B"
         }
@@ -2312,7 +2312,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (code, mode) (rate(kuberay_dashboard_client_requests_total{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m]))",
+          "expr": "sum by (code, mode) (rate(kuberay_dashboard_client_request_duration_seconds_count{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m]))",
           "legendFormat": "dashboard {{code}} ({{mode}})",
           "refId": "A"
         },
@@ -2322,8 +2322,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (code, mode) (rate(kuberay_proxy_client_requests_total{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m]))",
-          "legendFormat": "proxy {{code}} ({{mode}})",
+          "expr": "sum by (code, mode) (rate(kuberay_serve_client_request_duration_seconds_count{namespace=\"$ControllerNamespace\", pod=\"$ControllerPod\"}[5m]))",
+          "legendFormat": "serve {{code}} ({{mode}})",
           "refId": "B"
         }
       ],

--- a/ray-operator/apis/config/v1alpha1/configuration_types.go
+++ b/ray-operator/apis/config/v1alpha1/configuration_types.go
@@ -91,9 +91,9 @@ type Configuration struct {
 }
 
 func (config Configuration) GetDashboardClient(ctx context.Context, mgr manager.Manager) func(rayCluster *rayv1.RayCluster, url string) (dashboardclient.RayDashboardClientInterface, error) {
-	return utils.GetRayDashboardClientFunc(ctx, mgr, config.UseKubernetesProxy)
+	return utils.GetRayDashboardClientFunc(ctx, mgr, config.UseKubernetesProxy, config.EnableMetrics)
 }
 
 func (config Configuration) GetHttpProxyClient(mgr manager.Manager) func(hostIp, podNamespace, podName string, port int) utils.RayHttpProxyClientInterface {
-	return utils.GetRayHttpProxyClientFunc(mgr, config.UseKubernetesProxy)
+	return utils.GetRayHttpProxyClientFunc(mgr, config.UseKubernetesProxy, config.EnableMetrics)
 }

--- a/ray-operator/config/overlays/test-overrides/deployment-override.yaml
+++ b/ray-operator/config/overlays/test-overrides/deployment-override.yaml
@@ -10,3 +10,4 @@ spec:
       - name: kuberay-operator
         args:
         - --feature-gates=RayClusterStatusConditions=true,RayJobDeletionPolicy=true,RayMultiHostIndexing=true,RayCronJob=true,RayServiceIncrementalUpgrade=true,SidecarSubmitterRestart=true
+        - --enable-metrics=true

--- a/ray-operator/controllers/ray/utils/httpclientmetrics/httpclient_metrics.go
+++ b/ray-operator/controllers/ray/utils/httpclientmetrics/httpclient_metrics.go
@@ -1,23 +1,12 @@
 package httpclientmetrics
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-)
-
-// ClientType identifies which Ray HTTP client is being instrumented.
-type ClientType string
-
-const (
-	// ClientTypeDashboard instruments the Ray dashboard API client.
-	ClientTypeDashboard ClientType = "dashboard"
-	// ClientTypeProxy instruments the Ray Serve proxy health-check client.
-	ClientTypeProxy ClientType = "proxy"
 )
 
 // Mode describes how the operator reaches the Ray component.
@@ -75,6 +64,16 @@ func RegisterMetrics(reg prometheus.Registerer) {
 	reg.MustRegister(proxyClientRequestsTotal)
 }
 
+// DashboardClientMetrics returns the collectors used for Ray dashboard client requests.
+func DashboardClientMetrics() (*prometheus.HistogramVec, *prometheus.CounterVec) {
+	return dashboardClientRequestDuration, dashboardClientRequestsTotal
+}
+
+// ProxyClientMetrics returns the collectors used for Ray Serve proxy client requests.
+func ProxyClientMetrics() (*prometheus.HistogramVec, *prometheus.CounterVec) {
+	return proxyClientRequestDuration, proxyClientRequestsTotal
+}
+
 // instrumentedRoundTripper wraps an http.RoundTripper to record request
 // duration and count metrics for outbound HTTP calls to Ray components.
 type instrumentedRoundTripper struct {
@@ -86,21 +85,12 @@ type instrumentedRoundTripper struct {
 
 // NewInstrumentedRoundTripper returns a new http.RoundTripper that records
 // latency and request count metrics.
-func NewInstrumentedRoundTripper(inner http.RoundTripper, clientType ClientType, mode Mode) http.RoundTripper {
+func NewInstrumentedRoundTripper(inner http.RoundTripper, histogram *prometheus.HistogramVec, counter *prometheus.CounterVec, mode Mode) http.RoundTripper {
 	if inner == nil {
 		inner = http.DefaultTransport
 	}
-	var histogram *prometheus.HistogramVec
-	var counter *prometheus.CounterVec
-	switch clientType {
-	case ClientTypeDashboard:
-		histogram = dashboardClientRequestDuration
-		counter = dashboardClientRequestsTotal
-	case ClientTypeProxy:
-		histogram = proxyClientRequestDuration
-		counter = proxyClientRequestsTotal
-	default:
-		panic(fmt.Sprintf("unknown clientType: %q", clientType))
+	if histogram == nil || counter == nil {
+		return inner
 	}
 	return &instrumentedRoundTripper{
 		inner:     inner,
@@ -135,8 +125,9 @@ func (t *instrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 func normalizeEndpoint(urlPath string) string {
 	// Strip Kubernetes API server proxy prefix if present.
 	// e.g., /api/v1/namespaces/default/services/svc:dashboard/proxy/api/jobs/id
-	if idx := strings.Index(urlPath, "/proxy/"); idx != -1 {
-		urlPath = urlPath[idx+len("/proxy"):]
+	const kubernetesProxyPathSegment = "/proxy/"
+	if idx := strings.LastIndex(urlPath, kubernetesProxyPathSegment); idx != -1 {
+		urlPath = urlPath[idx+len(kubernetesProxyPathSegment)-1:]
 	}
 
 	if strings.HasPrefix(urlPath, "/api/serve/") {

--- a/ray-operator/controllers/ray/utils/httpclientmetrics/httpclient_metrics.go
+++ b/ray-operator/controllers/ray/utils/httpclientmetrics/httpclient_metrics.go
@@ -1,0 +1,152 @@
+package httpclientmetrics
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// ClientType identifies which Ray HTTP client is being instrumented.
+type ClientType string
+
+const (
+	// ClientTypeDashboard instruments the Ray dashboard API client.
+	ClientTypeDashboard ClientType = "dashboard"
+	// ClientTypeProxy instruments the Ray Serve proxy health-check client.
+	ClientTypeProxy ClientType = "proxy"
+)
+
+// Mode describes how the operator reaches the Ray component.
+type Mode string
+
+const (
+	// ModeDirect means the operator connects directly to a pod IP or in-cluster Service.
+	ModeDirect Mode = "direct"
+	// ModeProxy means the operator proxies through the Kubernetes API server.
+	ModeProxy Mode = "proxy"
+)
+
+var (
+	dashboardClientRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kuberay_dashboard_client_request_duration_seconds",
+			Help:    "Latency of HTTP requests from the KubeRay operator to the Ray dashboard API, in seconds.",
+			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0},
+		},
+		[]string{"method", "ray_endpoint", "code", "mode"},
+	)
+
+	dashboardClientRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kuberay_dashboard_client_requests_total",
+			Help: "Total number of HTTP requests from the KubeRay operator to the Ray dashboard API.",
+		},
+		[]string{"method", "ray_endpoint", "code", "mode"},
+	)
+
+	proxyClientRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kuberay_proxy_client_request_duration_seconds",
+			Help:    "Latency of HTTP requests from the KubeRay operator to the Ray Serve proxy actor, in seconds.",
+			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0},
+		},
+		[]string{"method", "ray_endpoint", "code", "mode"},
+	)
+
+	proxyClientRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kuberay_proxy_client_requests_total",
+			Help: "Total number of HTTP requests from the KubeRay operator to the Ray Serve proxy actor.",
+		},
+		[]string{"method", "ray_endpoint", "code", "mode"},
+	)
+)
+
+// RegisterMetrics registers all HTTP client metrics with the given registerer.
+// This should be called from main.go when metrics are enabled, rather than via init().
+func RegisterMetrics(reg prometheus.Registerer) {
+	reg.MustRegister(dashboardClientRequestDuration)
+	reg.MustRegister(dashboardClientRequestsTotal)
+	reg.MustRegister(proxyClientRequestDuration)
+	reg.MustRegister(proxyClientRequestsTotal)
+}
+
+// instrumentedRoundTripper wraps an http.RoundTripper to record request
+// duration and count metrics for outbound HTTP calls to Ray components.
+type instrumentedRoundTripper struct {
+	inner     http.RoundTripper
+	histogram *prometheus.HistogramVec
+	counter   *prometheus.CounterVec
+	mode      string
+}
+
+// NewInstrumentedRoundTripper returns a new http.RoundTripper that records
+// latency and request count metrics.
+func NewInstrumentedRoundTripper(inner http.RoundTripper, clientType ClientType, mode Mode) http.RoundTripper {
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	var histogram *prometheus.HistogramVec
+	var counter *prometheus.CounterVec
+	switch clientType {
+	case ClientTypeDashboard:
+		histogram = dashboardClientRequestDuration
+		counter = dashboardClientRequestsTotal
+	case ClientTypeProxy:
+		histogram = proxyClientRequestDuration
+		counter = proxyClientRequestsTotal
+	default:
+		panic(fmt.Sprintf("unknown clientType: %q", clientType))
+	}
+	return &instrumentedRoundTripper{
+		inner:     inner,
+		histogram: histogram,
+		counter:   counter,
+		mode:      string(mode),
+	}
+}
+
+func (t *instrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	resp, err := t.inner.RoundTrip(req)
+	duration := time.Since(start).Seconds()
+
+	code := "error"
+	if err == nil && resp != nil {
+		code = strconv.Itoa(resp.StatusCode)
+	}
+
+	endpoint := normalizeEndpoint(req.URL.Path)
+	method := req.Method
+
+	t.histogram.WithLabelValues(method, endpoint, code, t.mode).Observe(duration)
+	t.counter.WithLabelValues(method, endpoint, code, t.mode).Inc()
+
+	return resp, err
+}
+
+// normalizeEndpoint maps a raw URL path to a low-cardinality label value.
+// It strips dynamic segments (e.g., job IDs) and Kubernetes proxy prefixes.
+// When adding new Ray API endpoints, add a corresponding mapping here.
+func normalizeEndpoint(urlPath string) string {
+	// Strip Kubernetes API server proxy prefix if present.
+	// e.g., /api/v1/namespaces/default/services/svc:dashboard/proxy/api/jobs/id
+	if idx := strings.Index(urlPath, "/proxy/"); idx != -1 {
+		urlPath = urlPath[idx+len("/proxy"):]
+	}
+
+	if strings.HasPrefix(urlPath, "/api/serve/") {
+		return "serve_applications"
+	}
+	if strings.HasPrefix(urlPath, "/api/jobs/") || urlPath == "/api/jobs" {
+		return "jobs"
+	}
+	if strings.HasPrefix(urlPath, "/-/") {
+		return "proxy_health"
+	}
+	return "unknown"
+}

--- a/ray-operator/controllers/ray/utils/httpclientmetrics/httpclient_metrics.go
+++ b/ray-operator/controllers/ray/utils/httpclientmetrics/httpclient_metrics.go
@@ -19,37 +19,35 @@ const (
 	ModeProxy Mode = "proxy"
 )
 
+// Endpoint label values used to keep metric cardinality low.
+const (
+	endpointServeApplications = "serve_applications"
+	endpointJobs              = "jobs"
+	endpointServeProxyHealth  = "serve_proxy_health"
+	endpointUnknown           = "unknown"
+)
+
+// requestDurationBuckets are the histogram buckets (in seconds) for Ray HTTP
+// client response times. The largest bucket matches the longest client timeout
+// (10s when proxying through the Kubernetes apiserver; direct requests time out
+// at 2s), so buckets above that ceiling would never receive observations.
+var requestDurationBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0}
+
 var (
 	dashboardClientRequestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "kuberay_dashboard_client_request_duration_seconds",
-			Help:    "Latency of HTTP requests from the KubeRay operator to the Ray dashboard API, in seconds.",
-			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0},
+			Help:    "Response time of HTTP requests from the KubeRay operator to the Ray dashboard API, in seconds.",
+			Buckets: requestDurationBuckets,
 		},
 		[]string{"method", "ray_endpoint", "code", "mode"},
 	)
 
-	dashboardClientRequestsTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "kuberay_dashboard_client_requests_total",
-			Help: "Total number of HTTP requests from the KubeRay operator to the Ray dashboard API.",
-		},
-		[]string{"method", "ray_endpoint", "code", "mode"},
-	)
-
-	proxyClientRequestDuration = prometheus.NewHistogramVec(
+	serveClientRequestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "kuberay_proxy_client_request_duration_seconds",
-			Help:    "Latency of HTTP requests from the KubeRay operator to the Ray Serve proxy actor, in seconds.",
-			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0},
-		},
-		[]string{"method", "ray_endpoint", "code", "mode"},
-	)
-
-	proxyClientRequestsTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "kuberay_proxy_client_requests_total",
-			Help: "Total number of HTTP requests from the KubeRay operator to the Ray Serve proxy actor.",
+			Name:    "kuberay_serve_client_request_duration_seconds",
+			Help:    "Response time of HTTP requests from the KubeRay operator to the Ray Serve proxy actor, in seconds.",
+			Buckets: requestDurationBuckets,
 		},
 		[]string{"method", "ray_endpoint", "code", "mode"},
 	)
@@ -57,45 +55,43 @@ var (
 
 // RegisterMetrics registers all HTTP client metrics with the given registerer.
 // This should be called from main.go when metrics are enabled, rather than via init().
+// The histogram's _count series (with the same labels) already provides the total
+// request count, so no separate request counter is needed.
 func RegisterMetrics(reg prometheus.Registerer) {
 	reg.MustRegister(dashboardClientRequestDuration)
-	reg.MustRegister(dashboardClientRequestsTotal)
-	reg.MustRegister(proxyClientRequestDuration)
-	reg.MustRegister(proxyClientRequestsTotal)
+	reg.MustRegister(serveClientRequestDuration)
 }
 
-// DashboardClientMetrics returns the collectors used for Ray dashboard client requests.
-func DashboardClientMetrics() (*prometheus.HistogramVec, *prometheus.CounterVec) {
-	return dashboardClientRequestDuration, dashboardClientRequestsTotal
+// DashboardClientMetrics returns the histogram used for Ray dashboard client requests.
+func DashboardClientMetrics() *prometheus.HistogramVec {
+	return dashboardClientRequestDuration
 }
 
-// ProxyClientMetrics returns the collectors used for Ray Serve proxy client requests.
-func ProxyClientMetrics() (*prometheus.HistogramVec, *prometheus.CounterVec) {
-	return proxyClientRequestDuration, proxyClientRequestsTotal
+// ServeClientMetrics returns the histogram used for Ray Serve proxy client requests.
+func ServeClientMetrics() *prometheus.HistogramVec {
+	return serveClientRequestDuration
 }
 
 // instrumentedRoundTripper wraps an http.RoundTripper to record request
-// duration and count metrics for outbound HTTP calls to Ray components.
+// duration metrics for outbound HTTP calls to Ray components.
 type instrumentedRoundTripper struct {
 	inner     http.RoundTripper
 	histogram *prometheus.HistogramVec
-	counter   *prometheus.CounterVec
 	mode      string
 }
 
 // NewInstrumentedRoundTripper returns a new http.RoundTripper that records
-// latency and request count metrics.
-func NewInstrumentedRoundTripper(inner http.RoundTripper, histogram *prometheus.HistogramVec, counter *prometheus.CounterVec, mode Mode) http.RoundTripper {
+// response time metrics (the histogram's _count also yields the request count).
+func NewInstrumentedRoundTripper(inner http.RoundTripper, histogram *prometheus.HistogramVec, mode Mode) http.RoundTripper {
 	if inner == nil {
 		inner = http.DefaultTransport
 	}
-	if histogram == nil || counter == nil {
+	if histogram == nil {
 		return inner
 	}
 	return &instrumentedRoundTripper{
 		inner:     inner,
 		histogram: histogram,
-		counter:   counter,
 		mode:      string(mode),
 	}
 }
@@ -114,7 +110,6 @@ func (t *instrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	method := req.Method
 
 	t.histogram.WithLabelValues(method, endpoint, code, t.mode).Observe(duration)
-	t.counter.WithLabelValues(method, endpoint, code, t.mode).Inc()
 
 	return resp, err
 }
@@ -131,13 +126,13 @@ func normalizeEndpoint(urlPath string) string {
 	}
 
 	if strings.HasPrefix(urlPath, "/api/serve/") {
-		return "serve_applications"
+		return endpointServeApplications
 	}
 	if strings.HasPrefix(urlPath, "/api/jobs/") || urlPath == "/api/jobs" {
-		return "jobs"
+		return endpointJobs
 	}
 	if strings.HasPrefix(urlPath, "/-/") {
-		return "proxy_health"
+		return endpointServeProxyHealth
 	}
-	return "unknown"
+	return endpointUnknown
 }

--- a/ray-operator/controllers/ray/utils/httpclientmetrics/httpclient_metrics_test.go
+++ b/ray-operator/controllers/ray/utils/httpclientmetrics/httpclient_metrics_test.go
@@ -1,0 +1,337 @@
+package httpclientmetrics
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		urlPath  string
+		expected string
+	}{
+		{"serve applications", "/api/serve/applications/", "serve_applications"},
+		{"serve applications with query", "/api/serve/applications/?api_type=declarative", "serve_applications"},
+		{"jobs list", "/api/jobs/", "jobs"},
+		{"job info with ID", "/api/jobs/raysubmit_abc123", "jobs"},
+		{"job logs", "/api/jobs/raysubmit_abc123/logs", "jobs"},
+		{"job stop", "/api/jobs/raysubmit_abc123/stop", "jobs"},
+		{"job delete", "/api/jobs/raysubmit_abc123", "jobs"},
+		{"proxy health", "/-/healthz", "proxy_health"},
+		{"unknown path", "/unknown/path", "unknown"},
+		{"empty path", "", "unknown"},
+		{
+			"k8s proxy prefix with jobs",
+			"/api/v1/namespaces/default/services/svc:dashboard/proxy/api/jobs/raysubmit_abc123",
+			"jobs",
+		},
+		{
+			"k8s proxy prefix with serve",
+			"/api/v1/namespaces/default/services/svc:dashboard/proxy/api/serve/applications/",
+			"serve_applications",
+		},
+		{
+			"k8s pod proxy prefix with healthz",
+			"/api/v1/namespaces/default/pods/pod-name:8000/proxy/-/healthz",
+			"proxy_health",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeEndpoint(tt.urlPath)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// mockRoundTripper is a configurable http.RoundTripper for testing.
+type mockRoundTripper struct {
+	statusCode int
+	err        error
+}
+
+func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &http.Response{StatusCode: m.statusCode}, nil
+}
+
+func newTestMetrics(t *testing.T) (histogram *prometheus.HistogramVec, counter *prometheus.CounterVec) {
+	t.Helper()
+	histogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    t.Name() + "_request_duration_seconds",
+			Help:    "Test histogram.",
+			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0},
+		},
+		[]string{"method", "ray_endpoint", "code", "mode"},
+	)
+	counter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: t.Name() + "_requests_total",
+			Help: "Test counter.",
+		},
+		[]string{"method", "ray_endpoint", "code", "mode"},
+	)
+	return histogram, counter
+}
+
+func newTestInstrumentedRT(t *testing.T, inner http.RoundTripper, mode string) (http.RoundTripper, *prometheus.HistogramVec, *prometheus.CounterVec) {
+	t.Helper()
+	histogram, counter := newTestMetrics(t)
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	rt := &instrumentedRoundTripper{
+		inner:     inner,
+		histogram: histogram,
+		counter:   counter,
+		mode:      mode,
+	}
+	return rt, histogram, counter
+}
+
+// getHistogramSampleCount retrieves the sample count from a histogram observer.
+func getHistogramSampleCount(t *testing.T, histogram *prometheus.HistogramVec, labels ...string) uint64 {
+	t.Helper()
+	observer, err := histogram.GetMetricWithLabelValues(labels...)
+	require.NoError(t, err)
+	metric := &dto.Metric{}
+	h := observer.(prometheus.Metric)
+	err = h.Write(metric)
+	require.NoError(t, err)
+	return metric.GetHistogram().GetSampleCount()
+}
+
+func TestDashboardClientHistogram(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		path           string
+		statusCode     int
+		transportErr   error
+		expectedCode   string
+		expectedEP     string
+		expectedMethod string
+	}{
+		{
+			name:           "GET serve details 200",
+			method:         "GET",
+			path:           "/api/serve/applications/",
+			statusCode:     200,
+			expectedCode:   "200",
+			expectedEP:     "serve_applications",
+			expectedMethod: "GET",
+		},
+		{
+			name:           "PUT deploy 200",
+			method:         "PUT",
+			path:           "/api/serve/applications/",
+			statusCode:     200,
+			expectedCode:   "200",
+			expectedEP:     "serve_applications",
+			expectedMethod: "PUT",
+		},
+		{
+			name:           "GET job info 200",
+			method:         "GET",
+			path:           "/api/jobs/raysubmit_abc",
+			statusCode:     200,
+			expectedCode:   "200",
+			expectedEP:     "jobs",
+			expectedMethod: "GET",
+		},
+		{
+			name:           "POST submit job 200",
+			method:         "POST",
+			path:           "/api/jobs/",
+			statusCode:     200,
+			expectedCode:   "200",
+			expectedEP:     "jobs",
+			expectedMethod: "POST",
+		},
+		{
+			name:           "DELETE job 200",
+			method:         "DELETE",
+			path:           "/api/jobs/raysubmit_abc",
+			statusCode:     200,
+			expectedCode:   "200",
+			expectedEP:     "jobs",
+			expectedMethod: "DELETE",
+		},
+		{
+			name:           "GET job info 500",
+			method:         "GET",
+			path:           "/api/jobs/raysubmit_abc",
+			statusCode:     500,
+			expectedCode:   "500",
+			expectedEP:     "jobs",
+			expectedMethod: "GET",
+		},
+		{
+			name:           "GET job info 404",
+			method:         "GET",
+			path:           "/api/jobs/raysubmit_abc",
+			statusCode:     404,
+			expectedCode:   "404",
+			expectedEP:     "jobs",
+			expectedMethod: "GET",
+		},
+		{
+			name:           "transport error (timeout)",
+			method:         "GET",
+			path:           "/api/serve/applications/",
+			transportErr:   errors.New("context deadline exceeded"),
+			expectedCode:   "error",
+			expectedEP:     "serve_applications",
+			expectedMethod: "GET",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockRoundTripper{statusCode: tt.statusCode, err: tt.transportErr}
+			rt, histogram, _ := newTestInstrumentedRT(t, mock, "direct")
+
+			req, err := http.NewRequestWithContext(context.Background(), tt.method, "http://localhost:8265"+tt.path, nil)
+			require.NoError(t, err)
+
+			resp, rtErr := rt.RoundTrip(req)
+			if tt.transportErr != nil {
+				require.Error(t, rtErr)
+			} else {
+				require.NoError(t, rtErr)
+				assert.Equal(t, tt.statusCode, resp.StatusCode)
+			}
+
+			count := getHistogramSampleCount(t, histogram, tt.expectedMethod, tt.expectedEP, tt.expectedCode, "direct")
+			assert.Equal(t, uint64(1), count, "histogram should have recorded exactly 1 observation")
+		})
+	}
+}
+
+func TestDashboardClientHistogramModes(t *testing.T) {
+	for _, mode := range []string{"direct", "proxy"} {
+		t.Run("mode_"+mode, func(t *testing.T) {
+			mock := &mockRoundTripper{statusCode: 200}
+			rt, histogram, _ := newTestInstrumentedRT(t, mock, mode)
+
+			req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:8265/api/serve/applications/", nil)
+			require.NoError(t, err)
+
+			_, err = rt.RoundTrip(req)
+			require.NoError(t, err)
+
+			count := getHistogramSampleCount(t, histogram, "GET", "serve_applications", "200", mode)
+			assert.Equal(t, uint64(1), count)
+		})
+	}
+}
+
+func TestProxyClientHistogram(t *testing.T) {
+	mock := &mockRoundTripper{statusCode: 200}
+	rt, histogram, _ := newTestInstrumentedRT(t, mock, "direct")
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://10.0.0.1:8000/-/healthz", nil)
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.NoError(t, err)
+
+	count := getHistogramSampleCount(t, histogram, "GET", "proxy_health", "200", "direct")
+	assert.Equal(t, uint64(1), count)
+}
+
+func TestProxyClientHistogramError(t *testing.T) {
+	mock := &mockRoundTripper{err: errors.New("connection refused")}
+	rt, histogram, _ := newTestInstrumentedRT(t, mock, "proxy")
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://10.0.0.1:8000/-/healthz", nil)
+	require.NoError(t, err)
+
+	_, rtErr := rt.RoundTrip(req)
+	require.Error(t, rtErr)
+
+	count := getHistogramSampleCount(t, histogram, "GET", "proxy_health", "error", "proxy")
+	assert.Equal(t, uint64(1), count)
+}
+
+func TestDashboardClientCounter(t *testing.T) {
+	mock := &mockRoundTripper{statusCode: 200}
+	rt, _, counter := newTestInstrumentedRT(t, mock, "direct")
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:8265/api/serve/applications/", nil)
+	require.NoError(t, err)
+
+	// Call 3 times
+	for range 3 {
+		_, err = rt.RoundTrip(req)
+		require.NoError(t, err)
+	}
+
+	c, err := counter.GetMetricWithLabelValues("GET", "serve_applications", "200", "direct")
+	require.NoError(t, err)
+	assert.InDelta(t, float64(3), testutil.ToFloat64(c), 0)
+}
+
+func TestDashboardClientCounterError(t *testing.T) {
+	mock := &mockRoundTripper{err: errors.New("timeout")}
+	rt, _, counter := newTestInstrumentedRT(t, mock, "direct")
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:8265/api/jobs/raysubmit_abc", nil)
+	require.NoError(t, err)
+
+	_, _ = rt.RoundTrip(req)
+
+	c, err := counter.GetMetricWithLabelValues("GET", "jobs", "error", "direct")
+	require.NoError(t, err)
+	assert.InDelta(t, float64(1), testutil.ToFloat64(c), 0)
+}
+
+func TestProxyClientCounter(t *testing.T) {
+	mock := &mockRoundTripper{statusCode: 200}
+	rt, _, counter := newTestInstrumentedRT(t, mock, "direct")
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://10.0.0.1:8000/-/healthz", nil)
+	require.NoError(t, err)
+
+	for range 5 {
+		_, err = rt.RoundTrip(req)
+		require.NoError(t, err)
+	}
+
+	c, err := counter.GetMetricWithLabelValues("GET", "proxy_health", "200", "direct")
+	require.NoError(t, err)
+	assert.InDelta(t, float64(5), testutil.ToFloat64(c), 0)
+}
+
+func TestNewInstrumentedRoundTripperNilInner(t *testing.T) {
+	rt := NewInstrumentedRoundTripper(nil, ClientTypeDashboard, ModeDirect)
+	assert.NotNil(t, rt)
+}
+
+func TestNewInstrumentedRoundTripperClientTypes(t *testing.T) {
+	for _, clientType := range []ClientType{ClientTypeDashboard, ClientTypeProxy} {
+		t.Run(string(clientType), func(t *testing.T) {
+			rt := NewInstrumentedRoundTripper(http.DefaultTransport, clientType, ModeDirect)
+			assert.NotNil(t, rt)
+		})
+	}
+}
+
+func TestNewInstrumentedRoundTripperPanicsOnUnknownClientType(t *testing.T) {
+	assert.Panics(t, func() {
+		NewInstrumentedRoundTripper(http.DefaultTransport, "invalid", ModeDirect)
+	})
+}

--- a/ray-operator/controllers/ray/utils/httpclientmetrics/httpclient_metrics_test.go
+++ b/ray-operator/controllers/ray/utils/httpclientmetrics/httpclient_metrics_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,34 +18,34 @@ func TestNormalizeEndpoint(t *testing.T) {
 		urlPath  string
 		expected string
 	}{
-		{"serve applications", "/api/serve/applications/", "serve_applications"},
-		{"jobs list", "/api/jobs/", "jobs"},
-		{"job info with ID", "/api/jobs/raysubmit_abc123", "jobs"},
-		{"job logs", "/api/jobs/raysubmit_abc123/logs", "jobs"},
-		{"job stop", "/api/jobs/raysubmit_abc123/stop", "jobs"},
-		{"job delete", "/api/jobs/raysubmit_abc123", "jobs"},
-		{"proxy health", "/-/healthz", "proxy_health"},
-		{"unknown path", "/unknown/path", "unknown"},
-		{"empty path", "", "unknown"},
+		{"serve applications", "/api/serve/applications/", endpointServeApplications},
+		{"jobs list", "/api/jobs/", endpointJobs},
+		{"job info with ID", "/api/jobs/raysubmit_abc123", endpointJobs},
+		{"job logs", "/api/jobs/raysubmit_abc123/logs", endpointJobs},
+		{"job stop", "/api/jobs/raysubmit_abc123/stop", endpointJobs},
+		{"job delete", "/api/jobs/raysubmit_abc123", endpointJobs},
+		{"proxy health", "/-/healthz", endpointServeProxyHealth},
+		{"unknown path", "/unknown/path", endpointUnknown},
+		{"empty path", "", endpointUnknown},
 		{
 			"k8s proxy prefix with jobs",
 			"/api/v1/namespaces/default/services/svc:dashboard/proxy/api/jobs/raysubmit_abc123",
-			"jobs",
+			endpointJobs,
 		},
 		{
 			"k8s proxy prefix with namespace named proxy",
 			"/api/v1/namespaces/proxy/services/svc:dashboard/proxy/api/jobs/raysubmit_abc123",
-			"jobs",
+			endpointJobs,
 		},
 		{
 			"k8s proxy prefix with serve",
 			"/api/v1/namespaces/default/services/svc:dashboard/proxy/api/serve/applications/",
-			"serve_applications",
+			endpointServeApplications,
 		},
 		{
 			"k8s pod proxy prefix with healthz",
 			"/api/v1/namespaces/default/pods/pod-name:8000/proxy/-/healthz",
-			"proxy_health",
+			endpointServeProxyHealth,
 		},
 	}
 
@@ -71,31 +70,23 @@ func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return &http.Response{StatusCode: m.statusCode}, nil
 }
 
-func newTestMetrics(t *testing.T) (histogram *prometheus.HistogramVec, counter *prometheus.CounterVec) {
+func newTestMetrics(t *testing.T) *prometheus.HistogramVec {
 	t.Helper()
-	histogram = prometheus.NewHistogramVec(
+	return prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    t.Name() + "_request_duration_seconds",
 			Help:    "Test histogram.",
-			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0},
+			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0},
 		},
 		[]string{"method", "ray_endpoint", "code", "mode"},
 	)
-	counter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: t.Name() + "_requests_total",
-			Help: "Test counter.",
-		},
-		[]string{"method", "ray_endpoint", "code", "mode"},
-	)
-	return histogram, counter
 }
 
-func newTestInstrumentedRT(t *testing.T, inner http.RoundTripper, mode string) (http.RoundTripper, *prometheus.HistogramVec, *prometheus.CounterVec) {
+func newTestInstrumentedRT(t *testing.T, inner http.RoundTripper, mode string) (http.RoundTripper, *prometheus.HistogramVec) {
 	t.Helper()
-	histogram, counter := newTestMetrics(t)
-	rt := NewInstrumentedRoundTripper(inner, histogram, counter, Mode(mode))
-	return rt, histogram, counter
+	histogram := newTestMetrics(t)
+	rt := NewInstrumentedRoundTripper(inner, histogram, Mode(mode))
+	return rt, histogram
 }
 
 // getHistogramSampleCount retrieves the sample count from a histogram observer.
@@ -127,7 +118,7 @@ func TestInstrumentedRoundTripper_RecordsHistogram(t *testing.T) {
 			path:           "/api/serve/applications/",
 			statusCode:     200,
 			expectedCode:   "200",
-			expectedEP:     "serve_applications",
+			expectedEP:     endpointServeApplications,
 			expectedMethod: "GET",
 		},
 		{
@@ -136,7 +127,7 @@ func TestInstrumentedRoundTripper_RecordsHistogram(t *testing.T) {
 			path:           "/api/serve/applications/",
 			statusCode:     200,
 			expectedCode:   "200",
-			expectedEP:     "serve_applications",
+			expectedEP:     endpointServeApplications,
 			expectedMethod: "PUT",
 		},
 		{
@@ -145,7 +136,7 @@ func TestInstrumentedRoundTripper_RecordsHistogram(t *testing.T) {
 			path:           "/api/jobs/raysubmit_abc",
 			statusCode:     200,
 			expectedCode:   "200",
-			expectedEP:     "jobs",
+			expectedEP:     endpointJobs,
 			expectedMethod: "GET",
 		},
 		{
@@ -154,7 +145,7 @@ func TestInstrumentedRoundTripper_RecordsHistogram(t *testing.T) {
 			path:           "/api/jobs/",
 			statusCode:     200,
 			expectedCode:   "200",
-			expectedEP:     "jobs",
+			expectedEP:     endpointJobs,
 			expectedMethod: "POST",
 		},
 		{
@@ -163,7 +154,7 @@ func TestInstrumentedRoundTripper_RecordsHistogram(t *testing.T) {
 			path:           "/api/jobs/raysubmit_abc",
 			statusCode:     200,
 			expectedCode:   "200",
-			expectedEP:     "jobs",
+			expectedEP:     endpointJobs,
 			expectedMethod: "DELETE",
 		},
 		{
@@ -172,7 +163,7 @@ func TestInstrumentedRoundTripper_RecordsHistogram(t *testing.T) {
 			path:           "/api/jobs/raysubmit_abc",
 			statusCode:     500,
 			expectedCode:   "500",
-			expectedEP:     "jobs",
+			expectedEP:     endpointJobs,
 			expectedMethod: "GET",
 		},
 		{
@@ -181,7 +172,7 @@ func TestInstrumentedRoundTripper_RecordsHistogram(t *testing.T) {
 			path:           "/api/jobs/raysubmit_abc",
 			statusCode:     404,
 			expectedCode:   "404",
-			expectedEP:     "jobs",
+			expectedEP:     endpointJobs,
 			expectedMethod: "GET",
 		},
 		{
@@ -190,7 +181,7 @@ func TestInstrumentedRoundTripper_RecordsHistogram(t *testing.T) {
 			path:           "/-/healthz",
 			statusCode:     200,
 			expectedCode:   "200",
-			expectedEP:     "proxy_health",
+			expectedEP:     endpointServeProxyHealth,
 			expectedMethod: "GET",
 		},
 	}
@@ -198,7 +189,7 @@ func TestInstrumentedRoundTripper_RecordsHistogram(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &mockRoundTripper{statusCode: tt.statusCode, err: tt.transportErr}
-			rt, histogram, _ := newTestInstrumentedRT(t, mock, "direct")
+			rt, histogram := newTestInstrumentedRT(t, mock, "direct")
 
 			req, err := http.NewRequestWithContext(context.Background(), tt.method, "http://localhost:8265"+tt.path, nil)
 			require.NoError(t, err)
@@ -221,7 +212,7 @@ func TestInstrumentedRoundTripper_Modes(t *testing.T) {
 	for _, mode := range []string{"direct", "proxy"} {
 		t.Run("mode_"+mode, func(t *testing.T) {
 			mock := &mockRoundTripper{statusCode: 200}
-			rt, histogram, _ := newTestInstrumentedRT(t, mock, mode)
+			rt, histogram := newTestInstrumentedRT(t, mock, mode)
 
 			req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:8265/api/serve/applications/", nil)
 			require.NoError(t, err)
@@ -229,7 +220,7 @@ func TestInstrumentedRoundTripper_Modes(t *testing.T) {
 			_, err = rt.RoundTrip(req)
 			require.NoError(t, err)
 
-			count := getHistogramSampleCount(t, histogram, "GET", "serve_applications", "200", mode)
+			count := getHistogramSampleCount(t, histogram, "GET", endpointServeApplications, "200", mode)
 			assert.Equal(t, uint64(1), count)
 		})
 	}
@@ -237,7 +228,7 @@ func TestInstrumentedRoundTripper_Modes(t *testing.T) {
 
 func TestInstrumentedRoundTripper_TransportError(t *testing.T) {
 	mock := &mockRoundTripper{err: errors.New("context deadline exceeded")}
-	rt, histogram, _ := newTestInstrumentedRT(t, mock, "proxy")
+	rt, histogram := newTestInstrumentedRT(t, mock, "proxy")
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:8265/api/serve/applications/", nil)
 	require.NoError(t, err)
@@ -245,15 +236,17 @@ func TestInstrumentedRoundTripper_TransportError(t *testing.T) {
 	_, rtErr := rt.RoundTrip(req)
 	require.Error(t, rtErr)
 
-	count := getHistogramSampleCount(t, histogram, "GET", "serve_applications", "error", "proxy")
+	// The histogram must record the failed request with code="error" so that its
+	// _count series accounts for transport failures in error-rate calculations.
+	count := getHistogramSampleCount(t, histogram, "GET", endpointServeApplications, "error", "proxy")
 	assert.Equal(t, uint64(1), count)
 }
 
-func TestInstrumentedRoundTripper_CounterIncrement(t *testing.T) {
+func TestInstrumentedRoundTripper_RequestCount(t *testing.T) {
 	tests := []struct {
 		name           string
 		url            string
-		calls          int
+		calls          uint64
 		expectedEP     string
 		expectedCode   string
 		expectedMethod string
@@ -262,7 +255,7 @@ func TestInstrumentedRoundTripper_CounterIncrement(t *testing.T) {
 			name:           "serve applications",
 			url:            "http://localhost:8265/api/serve/applications/",
 			calls:          3,
-			expectedEP:     "serve_applications",
+			expectedEP:     endpointServeApplications,
 			expectedCode:   "200",
 			expectedMethod: "GET",
 		},
@@ -270,7 +263,7 @@ func TestInstrumentedRoundTripper_CounterIncrement(t *testing.T) {
 			name:           "proxy health",
 			url:            "http://10.0.0.1:8000/-/healthz",
 			calls:          5,
-			expectedEP:     "proxy_health",
+			expectedEP:     endpointServeProxyHealth,
 			expectedCode:   "200",
 			expectedMethod: "GET",
 		},
@@ -279,7 +272,7 @@ func TestInstrumentedRoundTripper_CounterIncrement(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &mockRoundTripper{statusCode: 200}
-			rt, _, counter := newTestInstrumentedRT(t, mock, "direct")
+			rt, histogram := newTestInstrumentedRT(t, mock, "direct")
 
 			req, err := http.NewRequestWithContext(context.Background(), tt.expectedMethod, tt.url, nil)
 			require.NoError(t, err)
@@ -289,21 +282,58 @@ func TestInstrumentedRoundTripper_CounterIncrement(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			c, err := counter.GetMetricWithLabelValues(tt.expectedMethod, tt.expectedEP, tt.expectedCode, "direct")
-			require.NoError(t, err)
-			assert.InDelta(t, float64(tt.calls), testutil.ToFloat64(c), 0)
+			// The histogram's _count series yields the total request count.
+			count := getHistogramSampleCount(t, histogram, tt.expectedMethod, tt.expectedEP, tt.expectedCode, "direct")
+			assert.Equal(t, tt.calls, count)
 		})
 	}
 }
 
 func TestNewInstrumentedRoundTripperNilInner(t *testing.T) {
-	histogram, counter := newTestMetrics(t)
-	rt := NewInstrumentedRoundTripper(nil, histogram, counter, ModeDirect)
+	histogram := newTestMetrics(t)
+	rt := NewInstrumentedRoundTripper(nil, histogram, ModeDirect)
 	assert.NotNil(t, rt)
 }
 
 func TestNewInstrumentedRoundTripperNoopsWithoutCollectors(t *testing.T) {
 	inner := &mockRoundTripper{statusCode: 200}
-	rt := NewInstrumentedRoundTripper(inner, nil, nil, ModeDirect)
+	rt := NewInstrumentedRoundTripper(inner, nil, ModeDirect)
 	assert.Same(t, inner, rt)
+}
+
+func TestRegisterMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	require.NotPanics(t, func() { RegisterMetrics(reg) })
+	assertHistogramsRegistered(t, reg)
+}
+
+// TestRegisterMetricsWithDefaultRegisterer mirrors the API server wiring, which
+// registers with prometheus.DefaultRegisterer and exposes metrics via
+// promhttp.Handler() (backed by prometheus.DefaultGatherer).
+func TestRegisterMetricsWithDefaultRegisterer(t *testing.T) {
+	require.NotPanics(t, func() { RegisterMetrics(prometheus.DefaultRegisterer) })
+	assertHistogramsRegistered(t, prometheus.DefaultGatherer)
+}
+
+// assertHistogramsRegistered records one observation on each histogram and
+// verifies both metric families are emitted by the given gatherer.
+func assertHistogramsRegistered(t *testing.T, gatherer prometheus.Gatherer) {
+	t.Helper()
+	dashboardClientRequestDuration.WithLabelValues("GET", endpointJobs, "200", string(ModeDirect)).Observe(0.01)
+	serveClientRequestDuration.WithLabelValues("GET", endpointServeProxyHealth, "200", string(ModeDirect)).Observe(0.01)
+
+	families, err := gatherer.Gather()
+	require.NoError(t, err)
+
+	registered := make(map[string]bool)
+	for _, mf := range families {
+		registered[mf.GetName()] = true
+	}
+
+	for _, name := range []string{
+		"kuberay_dashboard_client_request_duration_seconds",
+		"kuberay_serve_client_request_duration_seconds",
+	} {
+		assert.True(t, registered[name], "expected metric %q to be registered", name)
+	}
 }

--- a/ray-operator/controllers/ray/utils/httpclientmetrics/httpclient_metrics_test.go
+++ b/ray-operator/controllers/ray/utils/httpclientmetrics/httpclient_metrics_test.go
@@ -20,7 +20,6 @@ func TestNormalizeEndpoint(t *testing.T) {
 		expected string
 	}{
 		{"serve applications", "/api/serve/applications/", "serve_applications"},
-		{"serve applications with query", "/api/serve/applications/?api_type=declarative", "serve_applications"},
 		{"jobs list", "/api/jobs/", "jobs"},
 		{"job info with ID", "/api/jobs/raysubmit_abc123", "jobs"},
 		{"job logs", "/api/jobs/raysubmit_abc123/logs", "jobs"},
@@ -32,6 +31,11 @@ func TestNormalizeEndpoint(t *testing.T) {
 		{
 			"k8s proxy prefix with jobs",
 			"/api/v1/namespaces/default/services/svc:dashboard/proxy/api/jobs/raysubmit_abc123",
+			"jobs",
+		},
+		{
+			"k8s proxy prefix with namespace named proxy",
+			"/api/v1/namespaces/proxy/services/svc:dashboard/proxy/api/jobs/raysubmit_abc123",
 			"jobs",
 		},
 		{
@@ -90,15 +94,7 @@ func newTestMetrics(t *testing.T) (histogram *prometheus.HistogramVec, counter *
 func newTestInstrumentedRT(t *testing.T, inner http.RoundTripper, mode string) (http.RoundTripper, *prometheus.HistogramVec, *prometheus.CounterVec) {
 	t.Helper()
 	histogram, counter := newTestMetrics(t)
-	if inner == nil {
-		inner = http.DefaultTransport
-	}
-	rt := &instrumentedRoundTripper{
-		inner:     inner,
-		histogram: histogram,
-		counter:   counter,
-		mode:      mode,
-	}
+	rt := NewInstrumentedRoundTripper(inner, histogram, counter, Mode(mode))
 	return rt, histogram, counter
 }
 
@@ -114,7 +110,7 @@ func getHistogramSampleCount(t *testing.T, histogram *prometheus.HistogramVec, l
 	return metric.GetHistogram().GetSampleCount()
 }
 
-func TestDashboardClientHistogram(t *testing.T) {
+func TestInstrumentedRoundTripper_RecordsHistogram(t *testing.T) {
 	tests := []struct {
 		name           string
 		method         string
@@ -189,12 +185,12 @@ func TestDashboardClientHistogram(t *testing.T) {
 			expectedMethod: "GET",
 		},
 		{
-			name:           "transport error (timeout)",
+			name:           "GET proxy health 200",
 			method:         "GET",
-			path:           "/api/serve/applications/",
-			transportErr:   errors.New("context deadline exceeded"),
-			expectedCode:   "error",
-			expectedEP:     "serve_applications",
+			path:           "/-/healthz",
+			statusCode:     200,
+			expectedCode:   "200",
+			expectedEP:     "proxy_health",
 			expectedMethod: "GET",
 		},
 	}
@@ -221,7 +217,7 @@ func TestDashboardClientHistogram(t *testing.T) {
 	}
 }
 
-func TestDashboardClientHistogramModes(t *testing.T) {
+func TestInstrumentedRoundTripper_Modes(t *testing.T) {
 	for _, mode := range []string{"direct", "proxy"} {
 		t.Run("mode_"+mode, func(t *testing.T) {
 			mock := &mockRoundTripper{statusCode: 200}
@@ -239,99 +235,75 @@ func TestDashboardClientHistogramModes(t *testing.T) {
 	}
 }
 
-func TestProxyClientHistogram(t *testing.T) {
-	mock := &mockRoundTripper{statusCode: 200}
-	rt, histogram, _ := newTestInstrumentedRT(t, mock, "direct")
-
-	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://10.0.0.1:8000/-/healthz", nil)
-	require.NoError(t, err)
-
-	_, err = rt.RoundTrip(req)
-	require.NoError(t, err)
-
-	count := getHistogramSampleCount(t, histogram, "GET", "proxy_health", "200", "direct")
-	assert.Equal(t, uint64(1), count)
-}
-
-func TestProxyClientHistogramError(t *testing.T) {
-	mock := &mockRoundTripper{err: errors.New("connection refused")}
+func TestInstrumentedRoundTripper_TransportError(t *testing.T) {
+	mock := &mockRoundTripper{err: errors.New("context deadline exceeded")}
 	rt, histogram, _ := newTestInstrumentedRT(t, mock, "proxy")
 
-	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://10.0.0.1:8000/-/healthz", nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:8265/api/serve/applications/", nil)
 	require.NoError(t, err)
 
 	_, rtErr := rt.RoundTrip(req)
 	require.Error(t, rtErr)
 
-	count := getHistogramSampleCount(t, histogram, "GET", "proxy_health", "error", "proxy")
+	count := getHistogramSampleCount(t, histogram, "GET", "serve_applications", "error", "proxy")
 	assert.Equal(t, uint64(1), count)
 }
 
-func TestDashboardClientCounter(t *testing.T) {
-	mock := &mockRoundTripper{statusCode: 200}
-	rt, _, counter := newTestInstrumentedRT(t, mock, "direct")
-
-	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:8265/api/serve/applications/", nil)
-	require.NoError(t, err)
-
-	// Call 3 times
-	for range 3 {
-		_, err = rt.RoundTrip(req)
-		require.NoError(t, err)
+func TestInstrumentedRoundTripper_CounterIncrement(t *testing.T) {
+	tests := []struct {
+		name           string
+		url            string
+		calls          int
+		expectedEP     string
+		expectedCode   string
+		expectedMethod string
+	}{
+		{
+			name:           "serve applications",
+			url:            "http://localhost:8265/api/serve/applications/",
+			calls:          3,
+			expectedEP:     "serve_applications",
+			expectedCode:   "200",
+			expectedMethod: "GET",
+		},
+		{
+			name:           "proxy health",
+			url:            "http://10.0.0.1:8000/-/healthz",
+			calls:          5,
+			expectedEP:     "proxy_health",
+			expectedCode:   "200",
+			expectedMethod: "GET",
+		},
 	}
 
-	c, err := counter.GetMetricWithLabelValues("GET", "serve_applications", "200", "direct")
-	require.NoError(t, err)
-	assert.InDelta(t, float64(3), testutil.ToFloat64(c), 0)
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockRoundTripper{statusCode: 200}
+			rt, _, counter := newTestInstrumentedRT(t, mock, "direct")
 
-func TestDashboardClientCounterError(t *testing.T) {
-	mock := &mockRoundTripper{err: errors.New("timeout")}
-	rt, _, counter := newTestInstrumentedRT(t, mock, "direct")
+			req, err := http.NewRequestWithContext(context.Background(), tt.expectedMethod, tt.url, nil)
+			require.NoError(t, err)
 
-	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:8265/api/jobs/raysubmit_abc", nil)
-	require.NoError(t, err)
+			for range tt.calls {
+				_, err = rt.RoundTrip(req)
+				require.NoError(t, err)
+			}
 
-	_, _ = rt.RoundTrip(req)
-
-	c, err := counter.GetMetricWithLabelValues("GET", "jobs", "error", "direct")
-	require.NoError(t, err)
-	assert.InDelta(t, float64(1), testutil.ToFloat64(c), 0)
-}
-
-func TestProxyClientCounter(t *testing.T) {
-	mock := &mockRoundTripper{statusCode: 200}
-	rt, _, counter := newTestInstrumentedRT(t, mock, "direct")
-
-	req, err := http.NewRequestWithContext(context.Background(), "GET", "http://10.0.0.1:8000/-/healthz", nil)
-	require.NoError(t, err)
-
-	for range 5 {
-		_, err = rt.RoundTrip(req)
-		require.NoError(t, err)
-	}
-
-	c, err := counter.GetMetricWithLabelValues("GET", "proxy_health", "200", "direct")
-	require.NoError(t, err)
-	assert.InDelta(t, float64(5), testutil.ToFloat64(c), 0)
-}
-
-func TestNewInstrumentedRoundTripperNilInner(t *testing.T) {
-	rt := NewInstrumentedRoundTripper(nil, ClientTypeDashboard, ModeDirect)
-	assert.NotNil(t, rt)
-}
-
-func TestNewInstrumentedRoundTripperClientTypes(t *testing.T) {
-	for _, clientType := range []ClientType{ClientTypeDashboard, ClientTypeProxy} {
-		t.Run(string(clientType), func(t *testing.T) {
-			rt := NewInstrumentedRoundTripper(http.DefaultTransport, clientType, ModeDirect)
-			assert.NotNil(t, rt)
+			c, err := counter.GetMetricWithLabelValues(tt.expectedMethod, tt.expectedEP, tt.expectedCode, "direct")
+			require.NoError(t, err)
+			assert.InDelta(t, float64(tt.calls), testutil.ToFloat64(c), 0)
 		})
 	}
 }
 
-func TestNewInstrumentedRoundTripperPanicsOnUnknownClientType(t *testing.T) {
-	assert.Panics(t, func() {
-		NewInstrumentedRoundTripper(http.DefaultTransport, "invalid", ModeDirect)
-	})
+func TestNewInstrumentedRoundTripperNilInner(t *testing.T) {
+	histogram, counter := newTestMetrics(t)
+	rt := NewInstrumentedRoundTripper(nil, histogram, counter, ModeDirect)
+	assert.NotNil(t, rt)
+}
+
+func TestNewInstrumentedRoundTripperNoopsWithoutCollectors(t *testing.T) {
+	inner := &mockRoundTripper{statusCode: 200}
+	rt := NewInstrumentedRoundTripper(inner, nil, nil, ModeDirect)
+	assert.Same(t, inner, rt)
 }

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -978,7 +978,7 @@ func FetchHeadServiceURL(ctx context.Context, cli client.Client, rayCluster *ray
 	return headServiceURL, nil
 }
 
-func GetRayDashboardClientFunc(ctx context.Context, mgr manager.Manager, useKubernetesProxy bool) func(rayCluster *rayv1.RayCluster, url string) (dashboardclient.RayDashboardClientInterface, error) {
+func GetRayDashboardClientFunc(ctx context.Context, mgr manager.Manager, useKubernetesProxy bool, enableMetrics bool) func(rayCluster *rayv1.RayCluster, url string) (dashboardclient.RayDashboardClientInterface, error) {
 	return func(rayCluster *rayv1.RayCluster, url string) (dashboardclient.RayDashboardClientInterface, error) {
 		dashboardClient := &dashboardclient.RayDashboardClient{}
 		var authToken string
@@ -1027,14 +1027,17 @@ func GetRayDashboardClientFunc(ctx context.Context, mgr manager.Manager, useKube
 			httpClient.Transport = mgr.GetHTTPClient().Transport
 			dashboardURL = fmt.Sprintf("%s/api/v1/namespaces/%s/services/%s:dashboard/proxy", mgr.GetConfig().Host, rayCluster.Namespace, headSvcName)
 		}
-		httpClient.Transport = httpclientmetrics.NewInstrumentedRoundTripper(httpClient.Transport, httpclientmetrics.ClientTypeDashboard, mode)
+		if enableMetrics {
+			histogram, counter := httpclientmetrics.DashboardClientMetrics()
+			httpClient.Transport = httpclientmetrics.NewInstrumentedRoundTripper(httpClient.Transport, histogram, counter, mode)
+		}
 		dashboardClient.InitClient(httpClient, dashboardURL, authToken)
 
 		return dashboardClient, nil
 	}
 }
 
-func GetRayHttpProxyClientFunc(mgr manager.Manager, useKubernetesProxy bool) func(hostIp, podNamespace, podName string, port int) RayHttpProxyClientInterface {
+func GetRayHttpProxyClientFunc(mgr manager.Manager, useKubernetesProxy bool, enableMetrics bool) func(hostIp, podNamespace, podName string, port int) RayHttpProxyClientInterface {
 	return func(hostIp, podNamespace, podName string, port int) RayHttpProxyClientInterface {
 		httpClient := &http.Client{
 			Timeout: rayHTTPClientTimeout(useKubernetesProxy),
@@ -1048,7 +1051,10 @@ func GetRayHttpProxyClientFunc(mgr manager.Manager, useKubernetesProxy bool) fun
 			httpClient.Transport = mgr.GetHTTPClient().Transport
 			httpProxyURL = fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s:%d/proxy/", mgr.GetConfig().Host, podNamespace, podName, port)
 		}
-		httpClient.Transport = httpclientmetrics.NewInstrumentedRoundTripper(httpClient.Transport, httpclientmetrics.ClientTypeProxy, mode)
+		if enableMetrics {
+			histogram, counter := httpclientmetrics.ProxyClientMetrics()
+			httpClient.Transport = httpclientmetrics.NewInstrumentedRoundTripper(httpClient.Transport, histogram, counter, mode)
+		}
 
 		return &RayHttpProxyClient{
 			client:       httpClient,

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -1028,8 +1028,8 @@ func GetRayDashboardClientFunc(ctx context.Context, mgr manager.Manager, useKube
 			dashboardURL = fmt.Sprintf("%s/api/v1/namespaces/%s/services/%s:dashboard/proxy", mgr.GetConfig().Host, rayCluster.Namespace, headSvcName)
 		}
 		if enableMetrics {
-			histogram, counter := httpclientmetrics.DashboardClientMetrics()
-			httpClient.Transport = httpclientmetrics.NewInstrumentedRoundTripper(httpClient.Transport, histogram, counter, mode)
+			histogram := httpclientmetrics.DashboardClientMetrics()
+			httpClient.Transport = httpclientmetrics.NewInstrumentedRoundTripper(httpClient.Transport, histogram, mode)
 		}
 		dashboardClient.InitClient(httpClient, dashboardURL, authToken)
 
@@ -1052,8 +1052,8 @@ func GetRayHttpProxyClientFunc(mgr manager.Manager, useKubernetesProxy bool, ena
 			httpProxyURL = fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s:%d/proxy/", mgr.GetConfig().Host, podNamespace, podName, port)
 		}
 		if enableMetrics {
-			histogram, counter := httpclientmetrics.ProxyClientMetrics()
-			httpClient.Transport = httpclientmetrics.NewInstrumentedRoundTripper(httpClient.Transport, histogram, counter, mode)
+			histogram := httpclientmetrics.ServeClientMetrics()
+			httpClient.Transport = httpclientmetrics.NewInstrumentedRoundTripper(httpClient.Transport, histogram, mode)
 		}
 
 		return &RayHttpProxyClient{

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -34,6 +34,7 @@ import (
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils/dashboardclient"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils/httpclientmetrics"
 	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 )
 
@@ -1010,7 +1011,9 @@ func GetRayDashboardClientFunc(ctx context.Context, mgr manager.Manager, useKube
 		}
 		dashboardURL := fmt.Sprintf("http://%s", url)
 
+		mode := httpclientmetrics.ModeDirect
 		if useKubernetesProxy {
+			mode = httpclientmetrics.ModeProxy
 			var err error
 			headSvcName := rayCluster.Status.Head.ServiceName
 			if headSvcName == "" {
@@ -1024,6 +1027,7 @@ func GetRayDashboardClientFunc(ctx context.Context, mgr manager.Manager, useKube
 			httpClient.Transport = mgr.GetHTTPClient().Transport
 			dashboardURL = fmt.Sprintf("%s/api/v1/namespaces/%s/services/%s:dashboard/proxy", mgr.GetConfig().Host, rayCluster.Namespace, headSvcName)
 		}
+		httpClient.Transport = httpclientmetrics.NewInstrumentedRoundTripper(httpClient.Transport, httpclientmetrics.ClientTypeDashboard, mode)
 		dashboardClient.InitClient(httpClient, dashboardURL, authToken)
 
 		return dashboardClient, nil
@@ -1037,11 +1041,14 @@ func GetRayHttpProxyClientFunc(mgr manager.Manager, useKubernetesProxy bool) fun
 		}
 		httpProxyURL := fmt.Sprintf("http://%s:%d/", hostIp, port)
 
+		mode := httpclientmetrics.ModeDirect
 		if useKubernetesProxy {
+			mode = httpclientmetrics.ModeProxy
 			// Use the manager's transport for TLS and API server authentication.
 			httpClient.Transport = mgr.GetHTTPClient().Transport
 			httpProxyURL = fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s:%d/proxy/", mgr.GetConfig().Host, podNamespace, podName, port)
 		}
+		httpClient.Transport = httpclientmetrics.NewInstrumentedRoundTripper(httpClient.Transport, httpclientmetrics.ClientTypeProxy, mode)
 
 		return &RayHttpProxyClient{
 			client:       httpClient,

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/openshift/api v0.0.0-20251214014457-bfa868a22401
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -67,12 +68,12 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/metrics"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils/httpclientmetrics"
 	"github.com/ray-project/kuberay/ray-operator/internal/managercache"
 	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 	webhooks "github.com/ray-project/kuberay/ray-operator/pkg/webhooks/v1"
@@ -283,6 +284,7 @@ func main() {
 			rayJobMetricsManager,
 			rayServiceMetricsManager,
 		)
+		httpclientmetrics.RegisterMetrics(ctrlmetrics.Registry)
 	}
 
 	batchSchedulerManager, err = batchscheduler.NewSchedulerManager(ctx, config, restConfig, mgr.GetClient())

--- a/ray-operator/test/e2erayjob/rayjob_httpclient_metrics_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_httpclient_metrics_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
@@ -50,15 +49,8 @@ env_vars:
 	g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 		Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
 
-	// Find the operator pod to scrape metrics.
-	operatorPods, err := test.Client().Core().CoreV1().Pods("").List(test.Ctx(), metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/component=kuberay-operator",
-	})
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(operatorPods.Items).NotTo(BeEmpty(), "kuberay-operator pod not found")
-
-	operatorPod := operatorPods.Items[0]
-	LogWithTimestamp(test.T(), "Found operator pod %s/%s", operatorPod.Namespace, operatorPod.Name)
+	// Find a ready operator pod to scrape metrics.
+	operatorPod := GetReadyOperatorPod(g, test)
 
 	// Create a curl pod to scrape the operator's metrics endpoint from within the cluster.
 	curlPodName := "metrics-curl-pod"

--- a/ray-operator/test/e2erayjob/rayjob_httpclient_metrics_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_httpclient_metrics_test.go
@@ -1,0 +1,96 @@
+package e2erayjob
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
+	. "github.com/ray-project/kuberay/ray-operator/test/support"
+)
+
+// TestRayJobHTTPClientMetrics verifies that the kuberay operator emits Prometheus
+// histogram and counter metrics for outbound HTTP requests to the Ray dashboard
+// jobs API. A RayJob exercises the dashboard client's jobs endpoint (SubmitJob,
+// GetJobInfo) during reconciliation.
+func TestRayJobHTTPClientMetrics(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+
+	namespace := test.NewTestNamespace()
+
+	// Job scripts
+	jobsAC := NewConfigMap(namespace.Name, Files(test, "counter.py"))
+	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), jobsAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
+
+	// Deploy a RayJob — the operator will call the dashboard client's jobs API.
+	rayJobAC := rayv1ac.RayJob("metrics-test", namespace.Name).
+		WithSpec(rayv1ac.RayJobSpec().
+			WithRayClusterSpec(NewRayClusterSpec(MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).
+			WithEntrypoint("python /home/ray/jobs/counter.py").
+			WithRuntimeEnvYAML(`
+env_vars:
+  counter_name: test_counter
+`).
+			WithShutdownAfterJobFinishes(true).
+			WithSubmitterPodTemplate(JobSubmitterPodTemplateApplyConfiguration()))
+
+	rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+	// Wait for the RayJob to complete — this ensures dashboard client calls to the jobs API have been made.
+	LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+	g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+
+	// Find the operator pod to scrape metrics.
+	operatorPods, err := test.Client().Core().CoreV1().Pods("").List(test.Ctx(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/component=kuberay-operator",
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(operatorPods.Items).NotTo(BeEmpty(), "kuberay-operator pod not found")
+
+	operatorPod := operatorPods.Items[0]
+	LogWithTimestamp(test.T(), "Found operator pod %s/%s", operatorPod.Namespace, operatorPod.Name)
+
+	// Create a curl pod to scrape the operator's metrics endpoint from within the cluster.
+	curlPodName := "metrics-curl-pod"
+	curlContainerName := "curl"
+	curlPod, err := CreateCurlPod(g, test, curlPodName, curlContainerName, namespace.Name)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Scrape the operator metrics via its pod IP.
+	metricsURL := fmt.Sprintf("http://%s:8080/metrics", operatorPod.Status.PodIP)
+	LogWithTimestamp(test.T(), "Scraping operator metrics from %s", metricsURL)
+	stdout, stderr := ExecPodCmd(test, curlPod, curlContainerName, []string{"curl", "-sS", "-f", metricsURL})
+	g.Expect(stderr.String()).To(BeEmpty(), "curl stderr should be empty; metrics scrape may have failed")
+	metricsOutput := stdout.String()
+
+	// Assert dashboard client metrics for the jobs endpoint are present.
+	g.Expect(metricsOutput).To(ContainSubstring("kuberay_dashboard_client_request_duration_seconds_count"),
+		"Dashboard client histogram count should be present")
+	g.Expect(metricsOutput).To(ContainSubstring("kuberay_dashboard_client_requests_total"),
+		"Dashboard client counter should be present")
+
+	// Assert the jobs endpoint label appears (from SubmitJob / GetJobInfo calls).
+	g.Expect(metricsOutput).To(ContainSubstring(`ray_endpoint="jobs"`),
+		"Expected jobs ray_endpoint label from SubmitJob/GetJobInfo calls")
+
+	// Assert successful response codes appear.
+	g.Expect(metricsOutput).To(ContainSubstring(`code="200"`),
+		"Expected successful response code 200 in metrics")
+
+	// Log all matching metric lines for debugging.
+	for line := range strings.SplitSeq(metricsOutput, "\n") {
+		if strings.Contains(line, "kuberay_dashboard_client") && !strings.HasPrefix(line, "#") {
+			LogWithTimestamp(test.T(), "Metric: %s", strings.TrimSpace(line))
+		}
+	}
+}

--- a/ray-operator/test/e2erayjob/rayjob_httpclient_metrics_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_httpclient_metrics_test.go
@@ -68,8 +68,6 @@ env_vars:
 	// Assert dashboard client metrics for the jobs endpoint are present.
 	g.Expect(metricsOutput).To(ContainSubstring("kuberay_dashboard_client_request_duration_seconds_count"),
 		"Dashboard client histogram count should be present")
-	g.Expect(metricsOutput).To(ContainSubstring("kuberay_dashboard_client_requests_total"),
-		"Dashboard client counter should be present")
 
 	// Assert the jobs endpoint label appears (from SubmitJob / GetJobInfo calls).
 	g.Expect(metricsOutput).To(ContainSubstring(`ray_endpoint="jobs"`),
@@ -79,10 +77,15 @@ env_vars:
 	g.Expect(metricsOutput).To(ContainSubstring(`code="200"`),
 		"Expected successful response code 200 in metrics")
 
-	// Log all matching metric lines for debugging.
-	for line := range strings.SplitSeq(metricsOutput, "\n") {
-		if strings.Contains(line, "kuberay_dashboard_client") && !strings.HasPrefix(line, "#") {
-			LogWithTimestamp(test.T(), "Metric: %s", strings.TrimSpace(line))
+	// Log matching metric lines for debugging only when the test fails.
+	test.T().Cleanup(func() {
+		if !test.T().Failed() {
+			return
 		}
-	}
+		for line := range strings.SplitSeq(metricsOutput, "\n") {
+			if strings.Contains(line, "kuberay_dashboard_client") && !strings.HasPrefix(line, "#") {
+				LogWithTimestamp(test.T(), "Metric: %s", strings.TrimSpace(line))
+			}
+		}
+	})
 }

--- a/ray-operator/test/e2erayservice/rayservice_httpclient_metrics_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_httpclient_metrics_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
@@ -37,15 +36,8 @@ func TestRayServiceHTTPClientMetrics(t *testing.T) {
 	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).
 		Should(WithTransform(IsRayServiceReady, BeTrue()))
 
-	// Find the operator pod.
-	operatorPods, err := test.Client().Core().CoreV1().Pods("").List(test.Ctx(), metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/component=kuberay-operator",
-	})
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(operatorPods.Items).NotTo(BeEmpty(), "kuberay-operator pod not found")
-
-	operatorPod := operatorPods.Items[0]
-	LogWithTimestamp(test.T(), "Found operator pod %s/%s", operatorPod.Namespace, operatorPod.Name)
+	// Find a ready operator pod to scrape metrics.
+	operatorPod := GetReadyOperatorPod(g, test)
 
 	// Create a curl pod to scrape the operator's metrics endpoint from within the cluster.
 	curlPodName := "metrics-curl-pod"

--- a/ray-operator/test/e2erayservice/rayservice_httpclient_metrics_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_httpclient_metrics_test.go
@@ -1,0 +1,94 @@
+package e2erayservice
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
+	. "github.com/ray-project/kuberay/ray-operator/test/support"
+)
+
+// TestRayServiceHTTPClientMetrics verifies that the kuberay operator emits
+// Prometheus histogram and counter metrics for outbound HTTP requests to both
+// the Ray dashboard API and the Ray Serve proxy actor. A RayService exercises
+// both code paths: the dashboard client (GetServeDetails, UpdateDeployments)
+// and the proxy client (CheckProxyActorHealth).
+func TestRayServiceHTTPClientMetrics(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+
+	namespace := test.NewTestNamespace()
+
+	// Deploy a RayService and wait for it to be ready.
+	rayServiceName := "rayservice-metrics-test"
+
+	rayServiceFullAC := rayv1ac.RayService(rayServiceName, namespace.Name).WithSpec(RayServiceSampleYamlApplyConfiguration())
+
+	rayService, err := test.Client().Ray().RayV1().RayServices(namespace.Name).Apply(test.Ctx(), rayServiceFullAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Created RayService %s/%s successfully", rayService.Namespace, rayService.Name)
+
+	// Wait for RayService to be ready - this ensures both dashboard and proxy client calls have been made.
+	LogWithTimestamp(test.T(), "Waiting for RayService %s/%s to be ready", rayService.Namespace, rayService.Name)
+	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).
+		Should(WithTransform(IsRayServiceReady, BeTrue()))
+
+	// Find the operator pod.
+	operatorPods, err := test.Client().Core().CoreV1().Pods("").List(test.Ctx(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/component=kuberay-operator",
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(operatorPods.Items).NotTo(BeEmpty(), "kuberay-operator pod not found")
+
+	operatorPod := operatorPods.Items[0]
+	LogWithTimestamp(test.T(), "Found operator pod %s/%s", operatorPod.Namespace, operatorPod.Name)
+
+	// Create a curl pod to scrape the operator's metrics endpoint from within the cluster.
+	curlPodName := "metrics-curl-pod"
+	curlContainerName := "curl"
+	curlPod, err := CreateCurlPod(g, test, curlPodName, curlContainerName, namespace.Name)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Scrape the operator metrics via its pod IP.
+	metricsURL := fmt.Sprintf("http://%s:8080/metrics", operatorPod.Status.PodIP)
+	LogWithTimestamp(test.T(), "Scraping operator metrics from %s", metricsURL)
+	stdout, stderr := ExecPodCmd(test, curlPod, curlContainerName, []string{"curl", "-sS", "-f", metricsURL})
+	g.Expect(stderr.String()).To(BeEmpty(), "curl stderr should be empty; metrics scrape may have failed")
+	metricsOutput := stdout.String()
+
+	// Assert all 4 metrics are present.
+	expectedMetrics := []string{
+		"kuberay_dashboard_client_request_duration_seconds_bucket",
+		"kuberay_dashboard_client_request_duration_seconds_count",
+		"kuberay_dashboard_client_requests_total",
+		"kuberay_proxy_client_request_duration_seconds_bucket",
+		"kuberay_proxy_client_request_duration_seconds_count",
+		"kuberay_proxy_client_requests_total",
+	}
+
+	for _, metric := range expectedMetrics {
+		g.Expect(metricsOutput).To(ContainSubstring(metric),
+			"Expected metric %q to be present in metrics output", metric)
+	}
+
+	// Assert expected endpoint labels appear.
+	g.Expect(metricsOutput).To(ContainSubstring(`ray_endpoint="serve_applications"`),
+		"Expected serve_applications ray_endpoint label from GetServeDetails/UpdateDeployments calls")
+	g.Expect(metricsOutput).To(ContainSubstring(`ray_endpoint="proxy_health"`),
+		"Expected proxy_health ray_endpoint label from CheckProxyActorHealth calls")
+
+	// Assert successful response codes appear.
+	g.Expect(metricsOutput).To(ContainSubstring(`code="200"`),
+		"Expected successful response code 200 in metrics")
+
+	// Log all matching metric lines for debugging.
+	for line := range strings.SplitSeq(metricsOutput, "\n") {
+		if (strings.Contains(line, "kuberay_dashboard_client") || strings.Contains(line, "kuberay_proxy_client")) && !strings.HasPrefix(line, "#") {
+			LogWithTimestamp(test.T(), "Metric: %s", strings.TrimSpace(line))
+		}
+	}
+}

--- a/ray-operator/test/e2erayservice/rayservice_httpclient_metrics_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_httpclient_metrics_test.go
@@ -52,14 +52,12 @@ func TestRayServiceHTTPClientMetrics(t *testing.T) {
 	g.Expect(stderr.String()).To(BeEmpty(), "curl stderr should be empty; metrics scrape may have failed")
 	metricsOutput := stdout.String()
 
-	// Assert all 4 metrics are present.
+	// Assert all histogram metrics are present.
 	expectedMetrics := []string{
 		"kuberay_dashboard_client_request_duration_seconds_bucket",
 		"kuberay_dashboard_client_request_duration_seconds_count",
-		"kuberay_dashboard_client_requests_total",
-		"kuberay_proxy_client_request_duration_seconds_bucket",
-		"kuberay_proxy_client_request_duration_seconds_count",
-		"kuberay_proxy_client_requests_total",
+		"kuberay_serve_client_request_duration_seconds_bucket",
+		"kuberay_serve_client_request_duration_seconds_count",
 	}
 
 	for _, metric := range expectedMetrics {
@@ -70,17 +68,22 @@ func TestRayServiceHTTPClientMetrics(t *testing.T) {
 	// Assert expected endpoint labels appear.
 	g.Expect(metricsOutput).To(ContainSubstring(`ray_endpoint="serve_applications"`),
 		"Expected serve_applications ray_endpoint label from GetServeDetails/UpdateDeployments calls")
-	g.Expect(metricsOutput).To(ContainSubstring(`ray_endpoint="proxy_health"`),
-		"Expected proxy_health ray_endpoint label from CheckProxyActorHealth calls")
+	g.Expect(metricsOutput).To(ContainSubstring(`ray_endpoint="serve_proxy_health"`),
+		"Expected serve_proxy_health ray_endpoint label from CheckProxyActorHealth calls")
 
 	// Assert successful response codes appear.
 	g.Expect(metricsOutput).To(ContainSubstring(`code="200"`),
 		"Expected successful response code 200 in metrics")
 
-	// Log all matching metric lines for debugging.
-	for line := range strings.SplitSeq(metricsOutput, "\n") {
-		if (strings.Contains(line, "kuberay_dashboard_client") || strings.Contains(line, "kuberay_proxy_client")) && !strings.HasPrefix(line, "#") {
-			LogWithTimestamp(test.T(), "Metric: %s", strings.TrimSpace(line))
+	// Log matching metric lines for debugging only when the test fails.
+	test.T().Cleanup(func() {
+		if !test.T().Failed() {
+			return
 		}
-	}
+		for line := range strings.SplitSeq(metricsOutput, "\n") {
+			if (strings.Contains(line, "kuberay_dashboard_client") || strings.Contains(line, "kuberay_serve_client")) && !strings.HasPrefix(line, "#") {
+				LogWithTimestamp(test.T(), "Metric: %s", strings.TrimSpace(line))
+			}
+		}
+	})
 }

--- a/ray-operator/test/sampleyaml/support.go
+++ b/ray-operator/test/sampleyaml/support.go
@@ -74,7 +74,7 @@ func QueryDashboardGetAppStatus(t Test, rayCluster *rayv1.RayCluster) func(Gomeg
 
 		g.Expect(err).ToNot(HaveOccurred())
 		url := fmt.Sprintf("127.0.0.1:%d", localPort)
-		rayDashboardClientFunc := utils.GetRayDashboardClientFunc(t.Ctx(), nil, false)
+		rayDashboardClientFunc := utils.GetRayDashboardClientFunc(t.Ctx(), nil, false, false)
 		rayDashboardClient, err := rayDashboardClientFunc(rayCluster, url)
 		g.Expect(err).ToNot(HaveOccurred())
 		serveDetails, err := rayDashboardClient.GetServeDetails(t.Ctx())

--- a/ray-operator/test/support/core.go
+++ b/ray-operator/test/support/core.go
@@ -32,6 +32,29 @@ func Pods(t Test, namespace string, options ...Option[*metav1.ListOptions]) func
 	}
 }
 
+// GetReadyOperatorPod returns a running and ready kuberay-operator pod with a pod IP.
+func GetReadyOperatorPod(g *gomega.WithT, t Test) *corev1.Pod {
+	var operatorPod *corev1.Pod
+	g.Eventually(func(g gomega.Gomega) bool {
+		operatorPods, err := t.Client().Core().CoreV1().Pods("").List(t.Ctx(), metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/component=kuberay-operator",
+		})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		for i := range operatorPods.Items {
+			pod := &operatorPods.Items[i]
+			if IsPodRunningAndReady(pod) && pod.Status.PodIP != "" {
+				operatorPod = pod.DeepCopy()
+				return true
+			}
+		}
+		return false
+	}, TestTimeoutShort).Should(gomega.BeTrue(), "no kuberay-operator pod was running, ready, and assigned a PodIP")
+
+	LogWithTimestamp(t.T(), "Found ready operator pod %s/%s", operatorPod.Namespace, operatorPod.Name)
+	return operatorPod
+}
+
 func storeAllPodLogs(t Test, namespace *corev1.Namespace) {
 	t.T().Helper()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Adds Prometheus histrogram metrics to output HTTP requests from the operator to dashboard and server apis to enable p95/p99 latency tracking and error rate monitoring.
This will help debug timeout issues and also look at performance differences between direct and proxied calls.
- Adds a new row to the grafna dashboard definition json file


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Fixes #4697 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
  
 I also verified this in a kind cluster
 
<img width="1671" height="295" alt="image" src="https://github.com/user-attachments/assets/948eeb7d-c5b0-41d3-bc2d-ec71edc61436" />

## Local testing

To test this out locally

1. create a kind cluster
1. vuild and load the local kuberay operator into kind:
   ```bash
   cd ray-operator
   make docker-image IMG=kuberay/operator:metrics-test
   kind load docker-image kuberay/operator:metrics-test --name <cluster-name>
   ```
1. Install the local operator with the ServiceMonitor enabled and labeled for Prometheus:
   ```bash
   helm install kuberay-operator helm-chart/kuberay-operator \
     --set image.repository=kuberay/operator \
     --set image.tag=metrics-test \
     --set image.pullPolicy=IfNotPresent \
     --set metrics.serviceMonitor.enabled=true \
     --set metrics.serviceMonitor.additionalLabels.release=prometheus
   ```

> Note `metrics.enabled=true1 is set by default for the helm chart so `--enable-metrics=true` is not needed when installing via helm

to view the raw metrics query

1. run
  ```bash
   OPERATOR_POD=$(kubectl get pods -l app.kubernetes.io/component=kuberay-operator -o   jsonpath='{.items[0].metadata.name}')
  kubectl port-forward pod/$OPERATOR_POD 8080:8080 &
```
2. query the metrics
```bash
curl -s localhost:8080/metrics 
```

to view the metrics in grafana

1. Install Prometheus and load the KubeRay dashboards:
   ```bash
   ./install/prometheus/install.sh --auto-load-dashboard true
   ```
1. Port-forward Grafana:
   ```bash
   kubectl -n prometheus-system port-forward svc/prometheus-grafana 3000:80 &
   ```
1. open the grafana dashboard at localhost:3000

