### PR TITLE
[Docs] Remove comments in JSON

### DIFF
--- a/historyserver/docs/set_up_historyserver.md
+++ b/historyserver/docs/set_up_historyserver.md
@@ -104,7 +104,6 @@ debugging in your own IDE. For example, you can set up `.vscode/launch.json` as 
             ],
             "env": {
                 "S3_REGION": "test",
-                // Use localhost rather than the Kubernetes service name.
                 "S3_ENDPOINT": "localhost:9000",
                 "S3_BUCKET": "ray-historyserver",
                 "AWS_ACCESS_KEY_ID": "minioadmin",


### PR DESCRIPTION
## Why are these changes needed?

Remove inline comments from the JSON config file so users can copy-paste without manual cleanup.

## Related issue number

https://github.com/ray-project/kuberay/pull/4404#discussion_r3225228929

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
