### PR TITLE
[History Server] Add compression library for history server

### DIFF
--- a/historyserver/pkg/compression/compression.go
+++ b/historyserver/pkg/compression/compression.go
@@ -1,0 +1,158 @@
+package compression
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CompressStream stream data in fixed chunks from src to dst through gzip,
+// ensuring constant memory usage regardless of payload size.
+func CompressStream(dst io.Writer, src io.Reader) error {
+	w := gzip.NewWriter(dst)
+	if _, err := io.Copy(w, src); err != nil {
+		w.Close()
+		return err
+	}
+	return w.Close()
+}
+
+// DecompressStream stream data in fixed chunks from src to dst through gzip.
+func DecompressStream(dst io.Writer, src io.Reader) error {
+	r, err := gzip.NewReader(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			logrus.Warnf("compression: failed to close gzip reader: %v", err)
+		}
+	}()
+
+	_, err = io.Copy(dst, r)
+	return err
+}
+
+// StorageWriter defines the duck-typed interface for storage handlers to avoid cyclic dependencies
+type StorageWriter interface {
+	WriteFile(file string, reader io.ReadSeeker) error
+}
+
+// WriteCompressedFile compresses a local file on the fly and uploads it to any active cloud provider.
+// It utilizes disk-based spooling to maintain constant memory usage (zero RAM expansion) regardless
+// of file size.
+func WriteCompressedFile(writer StorageWriter, remotePath string, localFilePath string) error {
+	// 1. Opens the uncompressed local file on disk.
+	rawFile, err := os.Open(localFilePath)
+	if err != nil {
+		return fmt.Errorf("compression: failed to open local file %q: %w", localFilePath, err)
+	}
+	defer func() {
+		if err := rawFile.Close(); err != nil {
+			logrus.Warnf("compression: failed to close local file %q: %v", localFilePath, err)
+		}
+	}()
+
+	// 2. Spools compressed output into an ephemeral temporary file via CompressStream.
+	tmpFile, err := os.CreateTemp("", "upload-*.gz")
+	if err != nil {
+		return fmt.Errorf("compression: failed to create temp file: %w", err)
+	}
+	defer func() {
+		if err := tmpFile.Close(); err != nil {
+			logrus.Warnf("compression: failed to close temp file %q: %v", tmpFile.Name(), err)
+		}
+		if err := os.Remove(tmpFile.Name()); err != nil {
+			logrus.Warnf("compression: failed to remove temp file %q: %v", tmpFile.Name(), err)
+		}
+	}()
+
+	if err := CompressStream(tmpFile, rawFile); err != nil {
+		return fmt.Errorf("compression: stream compression failed: %w", err)
+	}
+
+	// 3. Seeks the temp file to the beginning to satisfy io.ReadSeeker, which is required by cloud SDKs.
+	if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("compression: failed to seek temp file: %w", err)
+	}
+
+	// 4. Delegates the upload to the duck-typed StorageWriter.
+	if err := writer.WriteFile(remotePath, tmpFile); err != nil {
+		return fmt.Errorf("compression: failed to upload compressed file: %w", err)
+	}
+
+	return nil
+}
+
+// WriteCompressedBytes compresses an in-memory byte slice and uploads it to any active cloud provider.
+func WriteCompressedBytes(writer StorageWriter, remotePath string, data []byte) error {
+	var buf bytes.Buffer
+	if err := CompressStream(&buf, bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("compression: in-memory compression failed: %w", err)
+	}
+
+	if err := writer.WriteFile(remotePath, bytes.NewReader(buf.Bytes())); err != nil {
+		return fmt.Errorf("compression: failed to upload compressed bytes: %w", err)
+	}
+
+	return nil
+}
+
+// StorageContentReader defines the duck-typed interface for storage readers to avoid cyclic dependencies.
+type StorageContentReader interface {
+	GetContent(clusterId string, fileName string) io.Reader
+}
+
+// gzipReadCloser wraps a *gzip.Reader and the underlying reader so both are closed properly.
+type gzipReadCloser struct {
+	gzipReader *gzip.Reader
+	underlying io.Reader
+}
+
+func (g *gzipReadCloser) Read(p []byte) (n int, err error) {
+	return g.gzipReader.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	var errs []error
+
+	if err := g.gzipReader.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("gzip close: %w", err))
+	}
+
+	if closer, ok := g.underlying.(io.Closer); ok {
+		if err := closer.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("source close: %w", err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// ReadCompressedContent reads a gzip-compressed file from cloud storage and returns an io.ReadCloser.
+func ReadCompressedContent(reader StorageContentReader, clusterId string, fileName string) (io.ReadCloser, error) {
+	contentReader := reader.GetContent(clusterId, fileName)
+	if contentReader == nil {
+		return nil, errors.New("compression: file not found or nil reader returned by storage")
+	}
+
+	r, err := gzip.NewReader(contentReader)
+	if err != nil {
+		if closer, ok := contentReader.(io.Closer); ok {
+			if err := closer.Close(); err != nil {
+				logrus.Warnf("compression: failed to close underlying stream after gzip reader creation error: %v", err)
+			}
+		}
+		return nil, fmt.Errorf("compression: failed to create gzip reader: %w", err)
+	}
+
+	return &gzipReadCloser{
+		gzipReader: r,
+		underlying: contentReader,
+	}, nil
+}

--- a/historyserver/pkg/compression/compression_test.go
+++ b/historyserver/pkg/compression/compression_test.go
@@ -1,0 +1,129 @@
+package compression
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+func compressBytesForTest(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	err := CompressStream(&buf, bytes.NewReader(data))
+	return buf.Bytes(), err
+}
+
+func decompressBytesForTest(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	err := DecompressStream(&buf, bytes.NewReader(data))
+	return buf.Bytes(), err
+}
+
+func TestCompressDecompressStream(t *testing.T) {
+	originalData := []byte("Streaming log compression payload testing across io.Reader and io.Writer")
+
+	var compressedBuf bytes.Buffer
+	if err := CompressStream(&compressedBuf, bytes.NewReader(originalData)); err != nil {
+		t.Fatalf("CompressStream failed: %v", err)
+	}
+
+	var decompressedBuf bytes.Buffer
+	if err := DecompressStream(&decompressedBuf, &compressedBuf); err != nil {
+		t.Fatalf("DecompressStream failed: %v", err)
+	}
+
+	if !bytes.Equal(originalData, decompressedBuf.Bytes()) {
+		t.Fatalf("Stream decompressed data mismatch.\nExpected: %s\nGot: %s", originalData, decompressedBuf.Bytes())
+	}
+}
+
+type mockStorageWriter struct {
+	writtenData []byte
+}
+
+func (m *mockStorageWriter) WriteFile(file string, reader io.ReadSeeker) error {
+	var err error
+	m.writtenData, err = io.ReadAll(reader)
+	return err
+}
+
+func TestWriteCompressedFile(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test-raw-*.txt")
+	if err != nil {
+		t.Fatalf("CreateTemp failed: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	rawData := []byte("upload compression payload test")
+	if _, err := tmpFile.Write(rawData); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	tmpFile.Close()
+
+	mockWriter := &mockStorageWriter{}
+	if err := WriteCompressedFile(mockWriter, "test/remote.gz", tmpFile.Name()); err != nil {
+		t.Fatalf("WriteCompressedFile failed: %v", err)
+	}
+
+	decompressed, err := decompressBytesForTest(mockWriter.writtenData)
+	if err != nil {
+		t.Fatalf("decompressBytesForTest failed: %v", err)
+	}
+
+	if !bytes.Equal(rawData, decompressed) {
+		t.Fatalf("Decompressed written data mismatch.\nExpected: %s\nGot: %s", rawData, decompressed)
+	}
+}
+
+func TestWriteCompressedBytes(t *testing.T) {
+	rawData := []byte("upload in-memory bytes payload test")
+	mockWriter := &mockStorageWriter{}
+
+	if err := WriteCompressedBytes(mockWriter, "test/bytes.gz", rawData); err != nil {
+		t.Fatalf("WriteCompressedBytes failed: %v", err)
+	}
+
+	decompressed, err := decompressBytesForTest(mockWriter.writtenData)
+	if err != nil {
+		t.Fatalf("decompressBytesForTest failed: %v", err)
+	}
+
+	if !bytes.Equal(rawData, decompressed) {
+		t.Fatalf("Decompressed written bytes mismatch.\nExpected: %s\nGot: %s", rawData, decompressed)
+	}
+}
+
+type mockStorageReader struct {
+	content []byte
+}
+
+func (m *mockStorageReader) GetContent(clusterId string, fileName string) io.Reader {
+	if m.content == nil {
+		return nil
+	}
+	return bytes.NewReader(m.content)
+}
+
+func TestReadCompressedContent(t *testing.T) {
+	originalText := []byte("Universal cloud storage reader decompression test")
+	compressed, err := compressBytesForTest(originalText)
+	if err != nil {
+		t.Fatalf("compressBytesForTest failed: %v", err)
+	}
+
+	mockReader := &mockStorageReader{content: compressed}
+	rc, err := ReadCompressedContent(mockReader, "cluster-1", "log.gz")
+	if err != nil {
+		t.Fatalf("ReadCompressedContent failed: %v", err)
+	}
+	defer rc.Close()
+
+	decompressed, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("io.ReadAll failed: %v", err)
+	}
+
+	if !bytes.Equal(originalText, decompressed) {
+		t.Fatalf("Decompressed read content mismatch.\nExpected: %s\nGot: %s", originalText, decompressed)
+	}
+}


### PR DESCRIPTION
## Why are these changes needed?
This PR adds a compression library that could be used with the current reader and writer to compress and upload file to cloud provider. 

The current plan is to utilize compression for events only. Further discussion can be made if we want to compress logs as well. 

Some implementation details:
1. Use io.Copy under the hood to prevent OOM crashes
2. duck-typed interface to prevent cyclic dependency between pkg/storage/* and this one. 
3. `WriteCompressedFile(writer StorageWriter, remotePath string, localFilePath string)` can directly upload to storage solution with constant memory usage. 

## Related issue number
Part of #4827 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
