### PR TITLE
fix(kubectl-plugin): close file immediately after write loop to prevent FD leak (fixes #4695)

### DIFF
--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -437,7 +437,7 @@ func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec 
 				continue
 			}
 			// Create file and write contents
-			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //nolint:gosec // G115: bounds check above
+			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 			if err != nil {
 				return fmt.Errorf("Error creating file: %w", err)
 			}

--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -432,26 +432,32 @@ func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec 
 		case tar.TypeReg:
 			// Check for overflow: G115
 			if header.Mode < 0 || header.Mode > math.MaxUint32 {
-				fmt.Fprintf(options.ioStreams.Out, "file mode out side of acceptable value %d skipping file\n", header.Mode)
+				fmt.Fprintf(options.ioStreams.Out, "file mode out of acceptable range %d, skipping file\n", header.Mode)
+				header, err = tarReader.Next()
+				continue
 			}
 			// Create file and write contents
-			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //nolint:gosec // overflow is guarded by bounds check above
+			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //nolint:gosec // G115: bounds check above
 			if err != nil {
 				return fmt.Errorf("Error creating file: %w", err)
 			}
-			defer outFile.Close()
+			var fileNeedsClose bool
 			// This is to limit the copy size for a decompression bomb, currently set arbitrarily
 			for {
-				n, err := io.CopyN(outFile, tarReader, 1000000)
-				if err != nil {
+				if _, err := io.CopyN(outFile, tarReader, 1000000); err != nil {
+					// io.CopyN returns EOF when a file ends normally OR when the tar stream is exhausted.
+					// Only close and break on EOF — any other error propagates via return below.
 					if errors.Is(err, io.EOF) {
+						fileNeedsClose = true
 						break
 					}
+					// Write error: close file before returning (leaks if close fails, same as original defer)
+					outFile.Close()
 					return fmt.Errorf("failed while writing to file: %w", err)
 				}
-				if n == 0 {
-					break
-				}
+			}
+			if fileNeedsClose {
+				_ = outFile.Close()
 			}
 		default:
 			fmt.Printf("Ignoring unsupported file type: %b", header.Typeflag)


### PR DESCRIPTION
## Summary

Two bugs fixed in `kubectl-plugin/pkg/cmd/log/log.go`:

### Bug 1: File descriptor leak from `defer` inside loop
`defer outFile.Close()` was placed inside the tar extraction loop. Each iteration opens a file but only schedules its close for when the parent function returns. For large tarballs, this keeps thousands of FDs open simultaneously, causing \&quot;too many open files\&quot; errors.

**Fix:** Replaced `defer outFile.Close()` with an explicit, immediately-called `outFile.Close()` after the `io.CopyN` loop completes.

### Bug 2: G115 bounds check fall-through
When `header.Mode` was out of uint32 range, the code printed a warning but then **fell through** to create the file anyway (with mode 0). No `continue` meant it would attempt to read the next tar header from a corrupted state.

**Fix:** Added `continue` after the bounds warning to skip the invalid file cleanly.

### Changes
- Remove `defer outFile.Close()` inside the tar loop → use explicit close after write loop
- Add `continue` after G115 bounds check to prevent fall-through
- Improve `//nolint:gosec` comment clarity
- Fix grammar: `out side of acceptable value` → `out of acceptable range`

### Testing
`go test ./pkg/cmd/log/...` passes, build succeeds.

Fixes #4695