### PR TITLE
Implement finalizer timeout for Ray Clusters with Redis FT

### DIFF
--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -239,6 +239,24 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 			}
 
+			// Check finalizer timeout for RayService FT clusters and set requeue flag
+			// This is to handle edge cases where the finalizer doesn't get removed,
+			// thus preventing release of resource quotas.
+			var shouldRequeueForTimeout bool
+			if isOwnedByRayService(instance) {
+				deletionAge := time.Since(instance.DeletionTimestamp.Time)
+				configuredTimeout := getGCSFTDeletionTimeout()
+
+				if deletionAge >= configuredTimeout {
+					// Timeout exceeded - force delete immediately
+					// Do not wait for redis cleanup job processing below.
+					return r.forceDeleteStuckRayServiceCluster(ctx, instance)
+				} else {
+					// Set flag for Redis cleanup job processing to requeue instead of quitting.
+					shouldRequeueForTimeout = true
+				}
+			}
+
 			if len(redisCleanupJobs.Items) != 0 {
 				// Check whether the Redis cleanup Job has been completed.
 				redisCleanupJob := redisCleanupJobs.Items[0]
@@ -266,7 +284,11 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 							"redisStorageNamespace", redisCleanupJob.Annotations[utils.RayExternalStorageNSAnnotationKey],
 						)
 					}
-					return ctrl.Result{}, nil
+					if shouldRequeueForTimeout {
+						return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
+					} else {
+						return ctrl.Result{}, nil
+					}
 				}
 				// the redisCleanupJob is still running
 				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
@@ -2011,4 +2033,43 @@ func setDefaults(instance *rayv1.RayCluster) {
 			instance.Spec.WorkerGroupSpecs[i].RayStartParams = map[string]string{}
 		}
 	}
+}
+
+// isOwnedByRayService checks if the RayCluster is owned by a RayService
+func isOwnedByRayService(cluster *rayv1.RayCluster) bool {
+	if crdLabel, exists := cluster.Labels[utils.RayOriginatedFromCRDLabelKey]; exists {
+		return crdLabel == "RayService"
+	}
+	return false
+}
+
+// getGCSFTDeletionTimeout returns the configured timeout for RayService cluster auto-deletion
+func getGCSFTDeletionTimeout() time.Duration {
+	timeoutSeconds, err := strconv.Atoi(os.Getenv(utils.RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_ENV))
+	if err != nil || timeoutSeconds < 60 {
+		return utils.RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT * time.Second
+	}
+	return time.Duration(timeoutSeconds) * time.Second
+}
+
+// forceDeleteStuckRayServiceCluster removes the finalizer to allow stuck RayService clusters to be deleted
+func (r *RayClusterReconciler) forceDeleteStuckRayServiceCluster(ctx context.Context, instance *rayv1.RayCluster) (ctrl.Result, error) {
+	logger := ctrl.LoggerFrom(ctx)
+	deletionAge := time.Since(instance.DeletionTimestamp.Time)
+
+	logger.Info("Force deleting stuck RayService cluster - Redis cleanup timeout exceeded",
+		"cluster", instance.Name, "deletionAge", deletionAge,
+		"timeout", getGCSFTDeletionTimeout())
+
+	// Remove finalizer to allow deletion to proceed
+	controllerutil.RemoveFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer)
+	if err := r.Update(ctx, instance); err != nil {
+		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
+	}
+
+	// Record event for observability
+	r.Recorder.Eventf(instance, corev1.EventTypeWarning, "ForceDeletedStuckCluster",
+		"Force deleted RayService cluster after %v due to Redis cleanup timeout", deletionAge)
+
+	return ctrl.Result{}, nil // No requeue - deletion proceeds naturally
 }

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -242,18 +242,11 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 			// Check finalizer timeout for RayService FT clusters and set requeue flag
 			// This is to handle edge cases where the finalizer doesn't get removed,
 			// thus preventing release of resource quotas.
-			var shouldRequeueForTimeout bool
 			if isOwnedByRayService(instance) {
 				deletionAge := time.Since(instance.DeletionTimestamp.Time)
-				configuredTimeout := getGCSFTDeletionTimeout()
-
-				if deletionAge >= configuredTimeout {
-					// Timeout exceeded - force delete immediately
-					// Do not wait for redis cleanup job processing below.
+				if deletionAge >= getGCSFTDeletionTimeout(instance) {
+					// Timeout exceeded — force delete immediately; skip Redis cleanup job check.
 					return r.forceDeleteStuckRayServiceCluster(ctx, instance)
-				} else {
-					// Set flag for Redis cleanup job processing to requeue instead of quitting.
-					shouldRequeueForTimeout = true
 				}
 			}
 
@@ -284,11 +277,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 							"redisStorageNamespace", redisCleanupJob.Annotations[utils.RayExternalStorageNSAnnotationKey],
 						)
 					}
-					if shouldRequeueForTimeout {
-						return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
-					} else {
-						return ctrl.Result{}, nil
-					}
+					return ctrl.Result{}, nil
 				}
 				// the redisCleanupJob is still running
 				return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, nil
@@ -2038,18 +2027,22 @@ func setDefaults(instance *rayv1.RayCluster) {
 // isOwnedByRayService checks if the RayCluster is owned by a RayService
 func isOwnedByRayService(cluster *rayv1.RayCluster) bool {
 	if crdLabel, exists := cluster.Labels[utils.RayOriginatedFromCRDLabelKey]; exists {
-		return crdLabel == "RayService"
+		return crdLabel == utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD)
 	}
 	return false
 }
 
-// getGCSFTDeletionTimeout returns the configured timeout for RayService cluster auto-deletion
-func getGCSFTDeletionTimeout() time.Duration {
-	timeoutSeconds, err := strconv.Atoi(os.Getenv(utils.RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_ENV))
-	if err != nil || timeoutSeconds < 60 {
-		return utils.RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT * time.Second
+// getGCSFTDeletionTimeout returns the timeout for auto-deleting a stuck RayService cluster.
+// The value is read from the RayClusterGCSFTDeletionTimeoutAnnotation annotation on the
+// cluster (integer seconds). If the annotation is absent or cannot be parsed, the default
+// of RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT seconds is used.
+func getGCSFTDeletionTimeout(cluster *rayv1.RayCluster) time.Duration {
+	if annotationVal, exists := cluster.Annotations[utils.RayClusterGCSFTDeletionTimeoutAnnotation]; exists {
+		if timeoutSeconds, err := strconv.Atoi(annotationVal); err == nil && timeoutSeconds > 0 {
+			return time.Duration(timeoutSeconds) * time.Second
+		}
 	}
-	return time.Duration(timeoutSeconds) * time.Second
+	return utils.RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT * time.Second
 }
 
 // forceDeleteStuckRayServiceCluster removes the finalizer to allow stuck RayService clusters to be deleted
@@ -2059,7 +2052,7 @@ func (r *RayClusterReconciler) forceDeleteStuckRayServiceCluster(ctx context.Con
 
 	logger.Info("Force deleting stuck RayService cluster - Redis cleanup timeout exceeded",
 		"cluster", instance.Name, "deletionAge", deletionAge,
-		"timeout", getGCSFTDeletionTimeout())
+		"timeout", getGCSFTDeletionTimeout(instance))
 
 	// Remove finalizer to allow deletion to proceed
 	controllerutil.RemoveFinalizer(instance, utils.GCSFaultToleranceRedisCleanupFinalizer)
@@ -2067,9 +2060,10 @@ func (r *RayClusterReconciler) forceDeleteStuckRayServiceCluster(ctx context.Con
 		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, err
 	}
 
-	// Record event for observability
-	r.Recorder.Eventf(instance, corev1.EventTypeWarning, "ForceDeletedStuckCluster",
-		"Force deleted RayService cluster after %v due to Redis cleanup timeout", deletionAge)
+	storageNamespace := instance.Annotations[utils.RayExternalStorageNSAnnotationKey]
+	r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.ForceDeletedStuckCluster),
+		"Force deleted RayService cluster after %v due to Redis cleanup timeout; Redis storage namespace %q may need manual cleanup",
+		deletionAge, storageNamespace)
 
 	return ctrl.Result{}, nil // No requeue - deletion proceeds naturally
 }

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -240,13 +240,12 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 			}
 
 			// Check finalizer timeout for RayService FT clusters and set requeue flag
-			// This is to handle edge cases where the finalizer doesn't get removed,
-			// thus preventing release of resource quotas.
-			if isOwnedByRayService(instance) {
+			if hasGCSFTFinalizer(instance) {
 				deletionAge := time.Since(instance.DeletionTimestamp.Time)
+				// This is to handle edge cases where the finalizer doesn't get removed,
+				// thus preventing release of resource quotas.
 				if deletionAge >= getGCSFTDeletionTimeout(instance) {
-					// Timeout exceeded — force delete immediately; skip Redis cleanup job check.
-					return r.forceDeleteStuckRayServiceCluster(ctx, instance)
+					return r.forceRemoveGCSFTFinalizer(ctx, instance)
 				}
 			}
 
@@ -2024,15 +2023,14 @@ func setDefaults(instance *rayv1.RayCluster) {
 	}
 }
 
-// isOwnedByRayService checks if the RayCluster is owned by a RayService
-func isOwnedByRayService(cluster *rayv1.RayCluster) bool {
-	if crdLabel, exists := cluster.Labels[utils.RayOriginatedFromCRDLabelKey]; exists {
-		return crdLabel == utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD)
-	}
-	return false
+// hasGCSFTFinalizer reports whether the GCS fault-tolerance Redis cleanup finalizer is
+// present on the cluster.
+func hasGCSFTFinalizer(cluster *rayv1.RayCluster) bool {
+	return controllerutil.ContainsFinalizer(cluster, utils.GCSFaultToleranceRedisCleanupFinalizer)
 }
 
-// getGCSFTDeletionTimeout returns the timeout for auto-deleting a stuck RayService cluster.
+// getGCSFTDeletionTimeout returns the timeout after which the GCS FT finalizer is
+// force-removed from a stuck RayCluster.
 // The value is read from the RayClusterGCSFTDeletionTimeoutAnnotation annotation on the
 // cluster (integer seconds). If the annotation is absent or cannot be parsed, the default
 // of RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT seconds is used.
@@ -2045,12 +2043,13 @@ func getGCSFTDeletionTimeout(cluster *rayv1.RayCluster) time.Duration {
 	return utils.RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT * time.Second
 }
 
-// forceDeleteStuckRayServiceCluster removes the finalizer to allow stuck RayService clusters to be deleted
-func (r *RayClusterReconciler) forceDeleteStuckRayServiceCluster(ctx context.Context, instance *rayv1.RayCluster) (ctrl.Result, error) {
+// forceRemoveGCSFTFinalizer forcibly removes the GCS FT Redis cleanup finalizer when the
+// cleanup job has been stuck past the configured timeout, unblocking cluster deletion.
+func (r *RayClusterReconciler) forceRemoveGCSFTFinalizer(ctx context.Context, instance *rayv1.RayCluster) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)
 	deletionAge := time.Since(instance.DeletionTimestamp.Time)
 
-	logger.Info("Force deleting stuck RayService cluster - Redis cleanup timeout exceeded",
+	logger.Info("Force-removing GCS FT finalizer — Redis cleanup job stuck past timeout",
 		"cluster", instance.Name, "deletionAge", deletionAge,
 		"timeout", getGCSFTDeletionTimeout(instance))
 
@@ -2062,7 +2061,7 @@ func (r *RayClusterReconciler) forceDeleteStuckRayServiceCluster(ctx context.Con
 
 	storageNamespace := instance.Annotations[utils.RayExternalStorageNSAnnotationKey]
 	r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.ForceDeletedStuckCluster),
-		"Force deleted RayService cluster after %v due to Redis cleanup timeout; Redis storage namespace %q may need manual cleanup",
+		"Force-removed GCS FT finalizer after %v due to Redis cleanup timeout; Redis storage namespace %q may need manual cleanup",
 		deletionAge, storageNamespace)
 
 	return ctrl.Result{}, nil // No requeue - deletion proceeds naturally

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -1732,22 +1732,6 @@ var _ = Context("Inside the default namespace", func() {
 		}
 
 		Describe("Helper function tests", func() {
-			It("Should correctly detect RayService ownership", func() {
-				cluster := rayClusterTemplate("helper-ownership-test", namespace)
-				Expect(isOwnedByRayService(cluster)).To(BeFalse())
-
-				cluster.Labels = map[string]string{
-					utils.RayOriginatedFromCRDLabelKey: utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
-				}
-				Expect(isOwnedByRayService(cluster)).To(BeTrue())
-
-				cluster.Labels[utils.RayOriginatedFromCRDLabelKey] = "SomeOtherCRD"
-				Expect(isOwnedByRayService(cluster)).To(BeFalse())
-
-				cluster.Labels = nil
-				Expect(isOwnedByRayService(cluster)).To(BeFalse())
-			})
-
 			It("Should return correct deletion timeout from annotation", func() {
 				cluster := rayClusterTemplate("helper-timeout-test", namespace)
 
@@ -1773,14 +1757,11 @@ var _ = Context("Inside the default namespace", func() {
 			})
 		})
 
-		Describe("Auto-deletion for stuck RayService clusters", Ordered, func() {
+		Describe("Auto-deletion for clusters with stuck GCS FT finalizer", Ordered, func() {
 			var clusterKey = client.ObjectKey{Name: "raycluster-redis-cleanup", Namespace: namespace}
 
 			BeforeAll(func() {
 				cluster := rayClusterTemplate(clusterKey.Name, namespace)
-				cluster.Labels = map[string]string{
-					utils.RayOriginatedFromCRDLabelKey: utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
-				}
 				cluster.Finalizers = []string{utils.GCSFaultToleranceRedisCleanupFinalizer}
 				Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
 				Eventually(
@@ -1788,12 +1769,10 @@ var _ = Context("Inside the default namespace", func() {
 					time.Second*3, time.Millisecond*500).Should(BeNil())
 			})
 
-			It("Should have finalizer and RayService ownership after creation", func() {
+			It("Should have GCS FT finalizer after creation", func() {
 				cluster := &rayv1.RayCluster{}
 				Expect(k8sClient.Get(ctx, clusterKey, cluster)).To(Succeed())
 				Expect(cluster.Finalizers).To(ContainElement(utils.GCSFaultToleranceRedisCleanupFinalizer))
-				Expect(cluster.Labels[utils.RayOriginatedFromCRDLabelKey]).To(Equal(
-					utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD)))
 			})
 
 			It("Should NOT auto-delete cluster before timeout", func() {
@@ -1825,7 +1804,7 @@ var _ = Context("Inside the default namespace", func() {
 				pastTime := metav1.NewTime(time.Now().Add(-20 * time.Minute))
 				cluster.DeletionTimestamp = &pastTime
 
-				result, err := newReconciler().forceDeleteStuckRayServiceCluster(ctx, cluster)
+				result, err := newReconciler().forceRemoveGCSFTFinalizer(ctx, cluster)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
 
@@ -1840,28 +1819,22 @@ var _ = Context("Inside the default namespace", func() {
 			})
 		})
 
-		Describe("Auto-deletion safety for standalone clusters", func() {
-			It("Should NEVER auto-delete a standalone cluster regardless of age", func() {
-				cluster := rayClusterTemplate("raycluster-standalone", namespace)
-				// No RayService ownership label
-				cluster.Finalizers = []string{utils.GCSFaultToleranceRedisCleanupFinalizer}
+		Describe("Auto-deletion safety for clusters without the GCS FT finalizer", func() {
+			It("Should NOT trigger force-delete when the GCS FT finalizer is absent", func() {
+				cluster := rayClusterTemplate("raycluster-no-finalizer", namespace)
+				// No GCS FT finalizer — hasGCSFTFinalizer must return false
+				Expect(hasGCSFTFinalizer(cluster)).To(BeFalse())
 
-				Expect(isOwnedByRayService(cluster)).To(BeFalse())
-
-				// Even with a very old in-memory timestamp, isOwnedByRayService guards the path
+				// Even with a very old in-memory timestamp, the missing finalizer guards the path
 				pastTime := metav1.NewTime(time.Now().Add(-2 * time.Hour))
 				cluster.DeletionTimestamp = &pastTime
-
-				Expect(isOwnedByRayService(cluster)).To(BeFalse())
+				Expect(hasGCSFTFinalizer(cluster)).To(BeFalse())
 			})
 		})
 
 		Describe("Integration with Redis cleanup flow", func() {
 			It("Should detect timeout and force-delete via Reconcile when annotation timeout elapses", func() {
 				cluster := rayClusterTemplate("raycluster-integration", namespace)
-				cluster.Labels = map[string]string{
-					utils.RayOriginatedFromCRDLabelKey: utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
-				}
 				// 1-second timeout so the test doesn't need to wait long
 				cluster.Annotations = map[string]string{
 					utils.RayClusterGCSFTDeletionTimeoutAnnotation: "1",

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -1837,6 +1837,7 @@ var _ = Context("Inside the default namespace", func() {
 				cluster := rayClusterTemplate("raycluster-integration", namespace)
 				// 1-second timeout so the test doesn't need to wait long
 				cluster.Annotations = map[string]string{
+					utils.RayFTEnabledAnnotationKey:                "true",
 					utils.RayClusterGCSFTDeletionTimeoutAnnotation: "1",
 				}
 				cluster.Finalizers = []string{utils.GCSFaultToleranceRedisCleanupFinalizer}

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -1712,6 +1713,217 @@ var _ = Context("Inside the default namespace", func() {
 				g.Expect(names).NotTo(ContainElement(unrelatedPodName), "unrelated pod must not appear in the manager's Pod store; got: %v", names)
 				g.Expect(cachedRayPods.Items).To(HaveLen(2), "this RayCluster has one head and one worker Pod in cache")
 			}, time.Second*10, time.Millisecond*300).Should(Succeed(), "wait for the manager informer to sync listed Pods")
+		})
+	})
+
+	Describe("RayCluster Redis cleanup finalizer timeout and auto-deletion", func() {
+		var (
+			ctx        = context.Background()
+			namespace  = "default"
+			rayCluster *rayv1.RayCluster
+			reconciler *RayClusterReconciler
+		)
+
+		BeforeEach(func() {
+			rayCluster = rayClusterTemplate("raycluster-redis-cleanup", namespace)
+			reconciler = &RayClusterReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: nil, // Not needed for unit tests
+			}
+		})
+
+		Describe("Helper function tests", func() {
+			It("Should correctly detect RayService ownership", func() {
+				// Test cluster without RayService ownership
+				Expect(isOwnedByRayService(rayCluster)).To(BeFalse())
+
+				// Test cluster with RayService ownership label
+				rayCluster.Labels = map[string]string{
+					utils.RayOriginatedFromCRDLabelKey: utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
+				}
+				Expect(isOwnedByRayService(rayCluster)).To(BeTrue())
+
+				// Test cluster with different ownership label
+				rayCluster.Labels[utils.RayOriginatedFromCRDLabelKey] = "SomeOtherCRD"
+				Expect(isOwnedByRayService(rayCluster)).To(BeFalse())
+
+				// Test cluster without labels
+				rayCluster.Labels = nil
+				Expect(isOwnedByRayService(rayCluster)).To(BeFalse())
+			})
+
+			It("Should return correct deletion timeout from environment variable", func() {
+				// Test default timeout when no env var is set
+				timeout := getGCSFTDeletionTimeout()
+				Expect(timeout).To(Equal(time.Duration(utils.RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT) * time.Second))
+
+				// Test with custom environment variable (this would require setting env var in real test environment)
+				// For unit test, we just verify the default behavior
+			})
+		})
+
+		Describe("Auto-deletion for stuck RayService clusters", Ordered, func() {
+			var redisCleanupFinalizer = "ray.io/gcs-ft-redis-cleanup-finalizer"
+
+			It("Should create RayService-owned cluster with Redis cleanup finalizer", func() {
+				// Set up cluster as owned by RayService
+				rayCluster.Labels = map[string]string{
+					utils.RayOriginatedFromCRDLabelKey: utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
+				}
+				rayCluster.Finalizers = []string{redisCleanupFinalizer}
+
+				err := k8sClient.Create(ctx, rayCluster)
+				Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
+
+				Eventually(
+					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
+					time.Second*3, time.Millisecond*500).Should(BeNil())
+
+				// Verify cluster has the finalizer and RayService ownership
+				Expect(rayCluster.Finalizers).To(ContainElement(redisCleanupFinalizer))
+				Expect(rayCluster.Labels[utils.RayOriginatedFromCRDLabelKey]).To(Equal(utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD)))
+			})
+
+			It("Should NOT auto-delete cluster before timeout", func() {
+				// Set deletion timestamp to recent time (within timeout)
+				recentTime := metav1.NewTime(time.Now().Add(-5 * time.Minute)) // 5 minutes ago, less than 15 minute default timeout
+				rayCluster.DeletionTimestamp = &recentTime
+
+				err := k8sClient.Update(ctx, rayCluster)
+				Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster deletion timestamp")
+
+				// Verify cluster still exists with finalizer
+				Eventually(
+					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
+					time.Second*3, time.Millisecond*500).Should(BeNil())
+				Expect(rayCluster.Finalizers).To(ContainElement(redisCleanupFinalizer))
+			})
+
+			It("Should auto-delete cluster after timeout", func() {
+				// Set deletion timestamp to old time (past timeout)
+				oldTime := metav1.NewTime(time.Now().Add(-20 * time.Minute)) // 20 minutes ago, past 15 minute default timeout
+				rayCluster.DeletionTimestamp = &oldTime
+
+				err := k8sClient.Update(ctx, rayCluster)
+				Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster deletion timestamp")
+
+				// Call the force delete function directly
+				result, err := reconciler.forceDeleteStuckRayServiceCluster(ctx, rayCluster)
+				Expect(err).NotTo(HaveOccurred(), "Force deletion should succeed")
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				// Verify finalizer is removed
+				Eventually(func() []string {
+					err := getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster)()
+					if err != nil {
+						return nil
+					}
+					return rayCluster.Finalizers
+				}, time.Second*3, time.Millisecond*500).ShouldNot(ContainElement(redisCleanupFinalizer))
+			})
+		})
+
+		Describe("Auto-deletion safety for standalone clusters", Ordered, func() {
+			var (
+				standaloneCluster     *rayv1.RayCluster
+				redisCleanupFinalizer = "ray.io/gcs-ft-redis-cleanup-finalizer"
+			)
+
+			BeforeEach(func() {
+				standaloneCluster = rayClusterTemplate("raycluster-standalone", namespace)
+				// Do NOT set RayService ownership label
+				standaloneCluster.Finalizers = []string{redisCleanupFinalizer}
+			})
+
+			It("Should create standalone cluster with Redis cleanup finalizer", func() {
+				err := k8sClient.Create(ctx, standaloneCluster)
+				Expect(err).NotTo(HaveOccurred(), "Failed to create standalone RayCluster")
+
+				Eventually(
+					getResourceFunc(ctx, client.ObjectKey{Name: standaloneCluster.Name, Namespace: namespace}, standaloneCluster),
+					time.Second*3, time.Millisecond*500).Should(BeNil())
+
+				// Verify cluster has the finalizer but NO RayService ownership
+				Expect(standaloneCluster.Finalizers).To(ContainElement(redisCleanupFinalizer))
+				Expect(standaloneCluster.Labels).NotTo(HaveKey(utils.RayOriginatedFromCRDLabelKey))
+			})
+
+			It("Should NEVER auto-delete standalone cluster even after timeout", func() {
+				// Set deletion timestamp to very old time (way past timeout)
+				veryOldTime := metav1.NewTime(time.Now().Add(-2 * time.Hour)) // 2 hours ago
+				standaloneCluster.DeletionTimestamp = &veryOldTime
+
+				err := k8sClient.Update(ctx, standaloneCluster)
+				Expect(err).NotTo(HaveOccurred(), "Failed to update standalone RayCluster deletion timestamp")
+
+				// Verify isOwnedByRayService returns false for standalone cluster
+				Expect(isOwnedByRayService(standaloneCluster)).To(BeFalse())
+
+				// Verify finalizer remains even after long timeout
+				Consistently(func() []string {
+					err := getResourceFunc(ctx, client.ObjectKey{Name: standaloneCluster.Name, Namespace: namespace}, standaloneCluster)()
+					if err != nil {
+						return nil
+					}
+					return standaloneCluster.Finalizers
+				}, time.Second*2, time.Millisecond*200).Should(ContainElement(redisCleanupFinalizer))
+			})
+		})
+
+		Describe("Integration with Redis cleanup flow", func() {
+			var (
+				rayServiceCluster     *rayv1.RayCluster
+				redisCleanupFinalizer = "ray.io/gcs-ft-redis-cleanup-finalizer"
+			)
+
+			BeforeEach(func() {
+				rayServiceCluster = rayClusterTemplate("raycluster-integration", namespace)
+				rayServiceCluster.Labels = map[string]string{
+					utils.RayOriginatedFromCRDLabelKey: utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
+				}
+				rayServiceCluster.Finalizers = []string{redisCleanupFinalizer}
+			})
+
+			It("Should handle auto-deletion within Redis cleanup reconciliation flow", func() {
+				// Create cluster
+				err := k8sClient.Create(ctx, rayServiceCluster)
+				Expect(err).NotTo(HaveOccurred(), "Failed to create RayService cluster")
+
+				Eventually(
+					getResourceFunc(ctx, client.ObjectKey{Name: rayServiceCluster.Name, Namespace: namespace}, rayServiceCluster),
+					time.Second*3, time.Millisecond*500).Should(BeNil())
+
+				// Simulate cluster stuck in deletion for a long time
+				oldTime := metav1.NewTime(time.Now().Add(-30 * time.Minute)) // 30 minutes ago
+				rayServiceCluster.DeletionTimestamp = &oldTime
+
+				err = k8sClient.Update(ctx, rayServiceCluster)
+				Expect(err).NotTo(HaveOccurred(), "Failed to set deletion timestamp")
+
+				// Run reconciliation - this should detect the timeout and force delete
+				req := ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      rayServiceCluster.Name,
+						Namespace: namespace,
+					},
+				}
+
+				result, err := reconciler.Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred(), "Reconciliation should succeed")
+
+				// Should return empty result (no requeue) since finalizer was removed
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				// Verify finalizer was removed
+				Eventually(func() []string {
+					err := getResourceFunc(ctx, client.ObjectKey{Name: rayServiceCluster.Name, Namespace: namespace}, rayServiceCluster)()
+					if err != nil {
+						return nil
+					}
+					return rayServiceCluster.Finalizers
+				}, time.Second*3, time.Millisecond*500).ShouldNot(ContainElement(redisCleanupFinalizer))
+			})
 		})
 	})
 })

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -1718,211 +1719,191 @@ var _ = Context("Inside the default namespace", func() {
 
 	Describe("RayCluster Redis cleanup finalizer timeout and auto-deletion", func() {
 		var (
-			ctx        = context.Background()
-			namespace  = "default"
-			rayCluster *rayv1.RayCluster
-			reconciler *RayClusterReconciler
+			ctx       = context.Background()
+			namespace = "default"
 		)
 
-		BeforeEach(func() {
-			rayCluster = rayClusterTemplate("raycluster-redis-cleanup", namespace)
-			reconciler = &RayClusterReconciler{
+		newReconciler := func() *RayClusterReconciler {
+			return &RayClusterReconciler{
 				Client:   k8sClient,
 				Scheme:   k8sClient.Scheme(),
-				Recorder: nil, // Not needed for unit tests
+				Recorder: record.NewFakeRecorder(10),
 			}
-		})
+		}
 
 		Describe("Helper function tests", func() {
 			It("Should correctly detect RayService ownership", func() {
-				// Test cluster without RayService ownership
-				Expect(isOwnedByRayService(rayCluster)).To(BeFalse())
+				cluster := rayClusterTemplate("helper-ownership-test", namespace)
+				Expect(isOwnedByRayService(cluster)).To(BeFalse())
 
-				// Test cluster with RayService ownership label
-				rayCluster.Labels = map[string]string{
+				cluster.Labels = map[string]string{
 					utils.RayOriginatedFromCRDLabelKey: utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
 				}
-				Expect(isOwnedByRayService(rayCluster)).To(BeTrue())
+				Expect(isOwnedByRayService(cluster)).To(BeTrue())
 
-				// Test cluster with different ownership label
-				rayCluster.Labels[utils.RayOriginatedFromCRDLabelKey] = "SomeOtherCRD"
-				Expect(isOwnedByRayService(rayCluster)).To(BeFalse())
+				cluster.Labels[utils.RayOriginatedFromCRDLabelKey] = "SomeOtherCRD"
+				Expect(isOwnedByRayService(cluster)).To(BeFalse())
 
-				// Test cluster without labels
-				rayCluster.Labels = nil
-				Expect(isOwnedByRayService(rayCluster)).To(BeFalse())
+				cluster.Labels = nil
+				Expect(isOwnedByRayService(cluster)).To(BeFalse())
 			})
 
-			It("Should return correct deletion timeout from environment variable", func() {
-				// Test default timeout when no env var is set
-				timeout := getGCSFTDeletionTimeout()
-				Expect(timeout).To(Equal(time.Duration(utils.RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT) * time.Second))
+			It("Should return correct deletion timeout from annotation", func() {
+				cluster := rayClusterTemplate("helper-timeout-test", namespace)
 
-				// Test with custom environment variable (this would require setting env var in real test environment)
-				// For unit test, we just verify the default behavior
+				// No annotation: returns default
+				Expect(getGCSFTDeletionTimeout(cluster)).To(Equal(
+					time.Duration(utils.RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT) * time.Second))
+
+				// Valid annotation
+				cluster.Annotations = map[string]string{
+					utils.RayClusterGCSFTDeletionTimeoutAnnotation: "120",
+				}
+				Expect(getGCSFTDeletionTimeout(cluster)).To(Equal(120 * time.Second))
+
+				// Non-numeric annotation falls back to default
+				cluster.Annotations[utils.RayClusterGCSFTDeletionTimeoutAnnotation] = "not-a-number"
+				Expect(getGCSFTDeletionTimeout(cluster)).To(Equal(
+					time.Duration(utils.RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT) * time.Second))
+
+				// Zero annotation falls back to default (zero is not a valid timeout)
+				cluster.Annotations[utils.RayClusterGCSFTDeletionTimeoutAnnotation] = "0"
+				Expect(getGCSFTDeletionTimeout(cluster)).To(Equal(
+					time.Duration(utils.RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT) * time.Second))
 			})
 		})
 
 		Describe("Auto-deletion for stuck RayService clusters", Ordered, func() {
-			var redisCleanupFinalizer = "ray.io/gcs-ft-redis-cleanup-finalizer"
+			var clusterKey = client.ObjectKey{Name: "raycluster-redis-cleanup", Namespace: namespace}
 
-			It("Should create RayService-owned cluster with Redis cleanup finalizer", func() {
-				// Set up cluster as owned by RayService
-				rayCluster.Labels = map[string]string{
+			BeforeAll(func() {
+				cluster := rayClusterTemplate(clusterKey.Name, namespace)
+				cluster.Labels = map[string]string{
 					utils.RayOriginatedFromCRDLabelKey: utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
 				}
-				rayCluster.Finalizers = []string{redisCleanupFinalizer}
-
-				err := k8sClient.Create(ctx, rayCluster)
-				Expect(err).NotTo(HaveOccurred(), "Failed to create RayCluster")
-
+				cluster.Finalizers = []string{utils.GCSFaultToleranceRedisCleanupFinalizer}
+				Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
 				Eventually(
-					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
+					getResourceFunc(ctx, clusterKey, cluster),
 					time.Second*3, time.Millisecond*500).Should(BeNil())
+			})
 
-				// Verify cluster has the finalizer and RayService ownership
-				Expect(rayCluster.Finalizers).To(ContainElement(redisCleanupFinalizer))
-				Expect(rayCluster.Labels[utils.RayOriginatedFromCRDLabelKey]).To(Equal(utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD)))
+			It("Should have finalizer and RayService ownership after creation", func() {
+				cluster := &rayv1.RayCluster{}
+				Expect(k8sClient.Get(ctx, clusterKey, cluster)).To(Succeed())
+				Expect(cluster.Finalizers).To(ContainElement(utils.GCSFaultToleranceRedisCleanupFinalizer))
+				Expect(cluster.Labels[utils.RayOriginatedFromCRDLabelKey]).To(Equal(
+					utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD)))
 			})
 
 			It("Should NOT auto-delete cluster before timeout", func() {
-				// Set deletion timestamp to recent time (within timeout)
-				recentTime := metav1.NewTime(time.Now().Add(-5 * time.Minute)) // 5 minutes ago, less than 15 minute default timeout
-				rayCluster.DeletionTimestamp = &recentTime
+				cluster := &rayv1.RayCluster{}
+				Expect(k8sClient.Get(ctx, clusterKey, cluster)).To(Succeed())
 
-				err := k8sClient.Update(ctx, rayCluster)
-				Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster deletion timestamp")
+				// Trigger real deletion — the server sets DeletionTimestamp to "now"
+				Expect(k8sClient.Delete(ctx, cluster)).To(Succeed())
 
-				// Verify cluster still exists with finalizer
-				Eventually(
-					getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
-				Expect(rayCluster.Finalizers).To(ContainElement(redisCleanupFinalizer))
+				// Wait for the server to stamp DeletionTimestamp
+				Eventually(func() bool {
+					c := &rayv1.RayCluster{}
+					return k8sClient.Get(ctx, clusterKey, c) == nil && !c.DeletionTimestamp.IsZero()
+				}, time.Second*3, time.Millisecond*500).Should(BeTrue())
+
+				// DeletionTimestamp is ~now, well under the 5-minute default timeout;
+				// finalizer should still be present.
+				Expect(k8sClient.Get(ctx, clusterKey, cluster)).To(Succeed())
+				Expect(cluster.Finalizers).To(ContainElement(utils.GCSFaultToleranceRedisCleanupFinalizer))
 			})
 
 			It("Should auto-delete cluster after timeout", func() {
-				// Set deletion timestamp to old time (past timeout)
-				oldTime := metav1.NewTime(time.Now().Add(-20 * time.Minute)) // 20 minutes ago, past 15 minute default timeout
-				rayCluster.DeletionTimestamp = &oldTime
+				// Cluster is already in deleting state (DeletionTimestamp set by previous test).
+				// Override in-memory only to simulate age past the 5-minute default.
+				cluster := &rayv1.RayCluster{}
+				Expect(k8sClient.Get(ctx, clusterKey, cluster)).To(Succeed())
+				Expect(cluster.DeletionTimestamp).NotTo(BeNil())
 
-				err := k8sClient.Update(ctx, rayCluster)
-				Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster deletion timestamp")
+				pastTime := metav1.NewTime(time.Now().Add(-20 * time.Minute))
+				cluster.DeletionTimestamp = &pastTime
 
-				// Call the force delete function directly
-				result, err := reconciler.forceDeleteStuckRayServiceCluster(ctx, rayCluster)
-				Expect(err).NotTo(HaveOccurred(), "Force deletion should succeed")
+				result, err := newReconciler().forceDeleteStuckRayServiceCluster(ctx, cluster)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
 
-				// Verify finalizer is removed
 				Eventually(func() []string {
-					err := getResourceFunc(ctx, client.ObjectKey{Name: rayCluster.Name, Namespace: namespace}, rayCluster)()
-					if err != nil {
+					c := &rayv1.RayCluster{}
+					if err := k8sClient.Get(ctx, clusterKey, c); err != nil {
 						return nil
 					}
-					return rayCluster.Finalizers
-				}, time.Second*3, time.Millisecond*500).ShouldNot(ContainElement(redisCleanupFinalizer))
+					return c.Finalizers
+				}, time.Second*3, time.Millisecond*500).ShouldNot(
+					ContainElement(utils.GCSFaultToleranceRedisCleanupFinalizer))
 			})
 		})
 
-		Describe("Auto-deletion safety for standalone clusters", Ordered, func() {
-			var (
-				standaloneCluster     *rayv1.RayCluster
-				redisCleanupFinalizer = "ray.io/gcs-ft-redis-cleanup-finalizer"
-			)
+		Describe("Auto-deletion safety for standalone clusters", func() {
+			It("Should NEVER auto-delete a standalone cluster regardless of age", func() {
+				cluster := rayClusterTemplate("raycluster-standalone", namespace)
+				// No RayService ownership label
+				cluster.Finalizers = []string{utils.GCSFaultToleranceRedisCleanupFinalizer}
 
-			BeforeEach(func() {
-				standaloneCluster = rayClusterTemplate("raycluster-standalone", namespace)
-				// Do NOT set RayService ownership label
-				standaloneCluster.Finalizers = []string{redisCleanupFinalizer}
-			})
+				Expect(isOwnedByRayService(cluster)).To(BeFalse())
 
-			It("Should create standalone cluster with Redis cleanup finalizer", func() {
-				err := k8sClient.Create(ctx, standaloneCluster)
-				Expect(err).NotTo(HaveOccurred(), "Failed to create standalone RayCluster")
+				// Even with a very old in-memory timestamp, isOwnedByRayService guards the path
+				pastTime := metav1.NewTime(time.Now().Add(-2 * time.Hour))
+				cluster.DeletionTimestamp = &pastTime
 
-				Eventually(
-					getResourceFunc(ctx, client.ObjectKey{Name: standaloneCluster.Name, Namespace: namespace}, standaloneCluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
-
-				// Verify cluster has the finalizer but NO RayService ownership
-				Expect(standaloneCluster.Finalizers).To(ContainElement(redisCleanupFinalizer))
-				Expect(standaloneCluster.Labels).NotTo(HaveKey(utils.RayOriginatedFromCRDLabelKey))
-			})
-
-			It("Should NEVER auto-delete standalone cluster even after timeout", func() {
-				// Set deletion timestamp to very old time (way past timeout)
-				veryOldTime := metav1.NewTime(time.Now().Add(-2 * time.Hour)) // 2 hours ago
-				standaloneCluster.DeletionTimestamp = &veryOldTime
-
-				err := k8sClient.Update(ctx, standaloneCluster)
-				Expect(err).NotTo(HaveOccurred(), "Failed to update standalone RayCluster deletion timestamp")
-
-				// Verify isOwnedByRayService returns false for standalone cluster
-				Expect(isOwnedByRayService(standaloneCluster)).To(BeFalse())
-
-				// Verify finalizer remains even after long timeout
-				Consistently(func() []string {
-					err := getResourceFunc(ctx, client.ObjectKey{Name: standaloneCluster.Name, Namespace: namespace}, standaloneCluster)()
-					if err != nil {
-						return nil
-					}
-					return standaloneCluster.Finalizers
-				}, time.Second*2, time.Millisecond*200).Should(ContainElement(redisCleanupFinalizer))
+				Expect(isOwnedByRayService(cluster)).To(BeFalse())
 			})
 		})
 
 		Describe("Integration with Redis cleanup flow", func() {
-			var (
-				rayServiceCluster     *rayv1.RayCluster
-				redisCleanupFinalizer = "ray.io/gcs-ft-redis-cleanup-finalizer"
-			)
-
-			BeforeEach(func() {
-				rayServiceCluster = rayClusterTemplate("raycluster-integration", namespace)
-				rayServiceCluster.Labels = map[string]string{
+			It("Should detect timeout and force-delete via Reconcile when annotation timeout elapses", func() {
+				cluster := rayClusterTemplate("raycluster-integration", namespace)
+				cluster.Labels = map[string]string{
 					utils.RayOriginatedFromCRDLabelKey: utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
 				}
-				rayServiceCluster.Finalizers = []string{redisCleanupFinalizer}
-			})
+				// 1-second timeout so the test doesn't need to wait long
+				cluster.Annotations = map[string]string{
+					utils.RayClusterGCSFTDeletionTimeoutAnnotation: "1",
+				}
+				cluster.Finalizers = []string{utils.GCSFaultToleranceRedisCleanupFinalizer}
 
-			It("Should handle auto-deletion within Redis cleanup reconciliation flow", func() {
-				// Create cluster
-				err := k8sClient.Create(ctx, rayServiceCluster)
-				Expect(err).NotTo(HaveOccurred(), "Failed to create RayService cluster")
+				Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+				clusterKey := client.ObjectKey{Name: cluster.Name, Namespace: namespace}
+
+				DeferCleanup(func() {
+					c := &rayv1.RayCluster{}
+					if err := k8sClient.Get(ctx, clusterKey, c); err != nil {
+						return
+					}
+					c.Finalizers = nil
+					_ = k8sClient.Update(ctx, c)
+					_ = k8sClient.Delete(ctx, c)
+				})
 
 				Eventually(
-					getResourceFunc(ctx, client.ObjectKey{Name: rayServiceCluster.Name, Namespace: namespace}, rayServiceCluster),
+					getResourceFunc(ctx, clusterKey, cluster),
 					time.Second*3, time.Millisecond*500).Should(BeNil())
 
-				// Simulate cluster stuck in deletion for a long time
-				oldTime := metav1.NewTime(time.Now().Add(-30 * time.Minute)) // 30 minutes ago
-				rayServiceCluster.DeletionTimestamp = &oldTime
+				// Trigger deletion; server stamps DeletionTimestamp = now
+				Expect(k8sClient.Delete(ctx, cluster)).To(Succeed())
 
-				err = k8sClient.Update(ctx, rayServiceCluster)
-				Expect(err).NotTo(HaveOccurred(), "Failed to set deletion timestamp")
+				// Wait for the 1-second annotation timeout to elapse
+				time.Sleep(2 * time.Second)
 
-				// Run reconciliation - this should detect the timeout and force delete
-				req := ctrl.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      rayServiceCluster.Name,
-						Namespace: namespace,
-					},
-				}
-
-				result, err := reconciler.Reconcile(ctx, req)
-				Expect(err).NotTo(HaveOccurred(), "Reconciliation should succeed")
-
-				// Should return empty result (no requeue) since finalizer was removed
+				req := ctrl.Request{NamespacedName: clusterKey}
+				result, err := newReconciler().Reconcile(ctx, req)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
 
-				// Verify finalizer was removed
 				Eventually(func() []string {
-					err := getResourceFunc(ctx, client.ObjectKey{Name: rayServiceCluster.Name, Namespace: namespace}, rayServiceCluster)()
-					if err != nil {
+					c := &rayv1.RayCluster{}
+					if err := k8sClient.Get(ctx, clusterKey, c); err != nil {
 						return nil
 					}
-					return rayServiceCluster.Finalizers
-				}, time.Second*3, time.Millisecond*500).ShouldNot(ContainElement(redisCleanupFinalizer))
+					return c.Finalizers
+				}, time.Second*3, time.Millisecond*500).ShouldNot(
+					ContainElement(utils.GCSFaultToleranceRedisCleanupFinalizer))
 			})
 		})
 	})

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -1758,7 +1758,7 @@ var _ = Context("Inside the default namespace", func() {
 		})
 
 		Describe("Auto-deletion for clusters with stuck GCS FT finalizer", Ordered, func() {
-			var clusterKey = client.ObjectKey{Name: "raycluster-redis-cleanup", Namespace: namespace}
+			clusterKey := client.ObjectKey{Name: "raycluster-redis-cleanup", Namespace: namespace}
 
 			BeforeAll(func() {
 				cluster := rayClusterTemplate(clusterKey.Name, namespace)
@@ -1766,7 +1766,7 @@ var _ = Context("Inside the default namespace", func() {
 				Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
 				Eventually(
 					getResourceFunc(ctx, clusterKey, cluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
+					time.Second*3, time.Millisecond*500).Should(Succeed())
 			})
 
 			It("Should have GCS FT finalizer after creation", func() {
@@ -1857,7 +1857,7 @@ var _ = Context("Inside the default namespace", func() {
 
 				Eventually(
 					getResourceFunc(ctx, clusterKey, cluster),
-					time.Second*3, time.Millisecond*500).Should(BeNil())
+					time.Second*3, time.Millisecond*500).Should(Succeed())
 
 				// Trigger deletion; server stamps DeletionTimestamp = now
 				Expect(k8sClient.Delete(ctx, cluster)).To(Succeed())

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3890,3 +3890,61 @@ func TestReconcilePodsWithAuthTokenSecretName(t *testing.T) {
 		assert.True(t, authTokenEnvFound, "Auth token env var with provided secret name not found")
 	}
 }
+
+func TestIsOwnedByRayService(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{name: "no labels", labels: nil, want: false},
+		{name: "RayService label", labels: map[string]string{
+			utils.RayOriginatedFromCRDLabelKey: utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
+		}, want: true},
+		{name: "other CRD label", labels: map[string]string{
+			utils.RayOriginatedFromCRDLabelKey: "SomeOtherCRD",
+		}, want: false},
+		{name: "unrelated labels", labels: map[string]string{"app": "foo"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &rayv1.RayCluster{}
+			cluster.Labels = tt.labels
+			assert.Equal(t, tt.want, isOwnedByRayService(cluster))
+		})
+	}
+}
+
+func TestGetGCSFTDeletionTimeout(t *testing.T) {
+	defaultTimeout := time.Duration(utils.RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT) * time.Second
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        time.Duration
+	}{
+		{name: "no annotation returns default", annotations: nil, want: defaultTimeout},
+		{name: "valid annotation", annotations: map[string]string{
+			utils.RayClusterGCSFTDeletionTimeoutAnnotation: "120",
+		}, want: 120 * time.Second},
+		{name: "non-numeric annotation falls back to default", annotations: map[string]string{
+			utils.RayClusterGCSFTDeletionTimeoutAnnotation: "not-a-number",
+		}, want: defaultTimeout},
+		{name: "zero annotation falls back to default", annotations: map[string]string{
+			utils.RayClusterGCSFTDeletionTimeoutAnnotation: "0",
+		}, want: defaultTimeout},
+		{name: "negative annotation falls back to default", annotations: map[string]string{
+			utils.RayClusterGCSFTDeletionTimeoutAnnotation: "-5",
+		}, want: defaultTimeout},
+		{name: "1-second annotation (minimum valid)", annotations: map[string]string{
+			utils.RayClusterGCSFTDeletionTimeoutAnnotation: "1",
+		}, want: 1 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &rayv1.RayCluster{}
+			cluster.Annotations = tt.annotations
+			assert.Equal(t, tt.want, getGCSFTDeletionTimeout(cluster))
+		})
+	}
+}

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -3891,26 +3891,22 @@ func TestReconcilePodsWithAuthTokenSecretName(t *testing.T) {
 	}
 }
 
-func TestIsOwnedByRayService(t *testing.T) {
+func TestHasGCSFTFinalizer(t *testing.T) {
 	tests := []struct {
-		name   string
-		labels map[string]string
-		want   bool
+		name       string
+		finalizers []string
+		want       bool
 	}{
-		{name: "no labels", labels: nil, want: false},
-		{name: "RayService label", labels: map[string]string{
-			utils.RayOriginatedFromCRDLabelKey: utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
-		}, want: true},
-		{name: "other CRD label", labels: map[string]string{
-			utils.RayOriginatedFromCRDLabelKey: "SomeOtherCRD",
-		}, want: false},
-		{name: "unrelated labels", labels: map[string]string{"app": "foo"}, want: false},
+		{name: "no finalizers", finalizers: nil, want: false},
+		{name: "GCS FT finalizer present", finalizers: []string{utils.GCSFaultToleranceRedisCleanupFinalizer}, want: true},
+		{name: "other finalizer only", finalizers: []string{"some-other-finalizer"}, want: false},
+		{name: "GCS FT among multiple finalizers", finalizers: []string{"other", utils.GCSFaultToleranceRedisCleanupFinalizer}, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cluster := &rayv1.RayCluster{}
-			cluster.Labels = tt.labels
-			assert.Equal(t, tt.want, isOwnedByRayService(cluster))
+			cluster.Finalizers = tt.finalizers
+			assert.Equal(t, tt.want, hasGCSFTFinalizer(cluster))
 		})
 	}
 }

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -190,8 +190,8 @@ const (
 	ENABLE_GCS_FT_REDIS_CLEANUP = "ENABLE_GCS_FT_REDIS_CLEANUP"
 
 	// RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT is the fallback timeout (in seconds)
-	// for auto-deleting stuck RayService clusters when the FT finalizer is not
-	// removed within that duration. Override per-cluster via the
+	// for force-removing the GCS FT finalizer from a stuck RayCluster when the cleanup
+	// job has not finished within that duration. Override per-cluster via the
 	// RayClusterGCSFTDeletionTimeoutAnnotation annotation.
 	RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT = 300 // in seconds; == 5 minutes
 

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -185,6 +185,12 @@ const (
 	// cleanup Job should be enabled. This is a feature flag for v1.0.0.
 	ENABLE_GCS_FT_REDIS_CLEANUP = "ENABLE_GCS_FT_REDIS_CLEANUP"
 
+	// This KubeRay operator environment variable is used to determine the timeout
+	// for auto-deleting stuck RayService clusters when the FT finalizer doesn't
+	// get removed for any reason.
+	RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_ENV     = "RAYCLUSTER_GCS_FT_DELETION_TIMEOUT"
+	RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT = 300 // in seconds; == 5 minutes
+
 	// This environment variable for the KubeRay operator is used to determine whether to enable
 	// the injection of readiness and liveness probes into Ray head and worker containers.
 	// Enabling this feature contributes to the robustness of Ray clusters. It is currently a feature

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -58,6 +58,10 @@ const (
 	// Ray GCS FT related annotations
 	RayFTEnabledAnnotationKey         = "ray.io/ft-enabled"
 	RayExternalStorageNSAnnotationKey = "ray.io/external-storage-namespace"
+	// RayClusterGCSFTDeletionTimeoutAnnotation overrides the default finalizer-removal
+	// timeout for a specific RayCluster (integer seconds; falls back to
+	// RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT when absent or invalid).
+	RayClusterGCSFTDeletionTimeoutAnnotation = "ray.io/gcs-ft-deletion-timeout"
 
 	// If this annotation is set to "true", the KubeRay operator will not modify the container's command.
 	// However, the generated `ray start` command will still be stored in the container's environment variable
@@ -185,10 +189,10 @@ const (
 	// cleanup Job should be enabled. This is a feature flag for v1.0.0.
 	ENABLE_GCS_FT_REDIS_CLEANUP = "ENABLE_GCS_FT_REDIS_CLEANUP"
 
-	// This KubeRay operator environment variable is used to determine the timeout
-	// for auto-deleting stuck RayService clusters when the FT finalizer doesn't
-	// get removed for any reason.
-	RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_ENV     = "RAYCLUSTER_GCS_FT_DELETION_TIMEOUT"
+	// RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT is the fallback timeout (in seconds)
+	// for auto-deleting stuck RayService clusters when the FT finalizer is not
+	// removed within that duration. Override per-cluster via the
+	// RayClusterGCSFTDeletionTimeoutAnnotation annotation.
 	RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT = 300 // in seconds; == 5 minutes
 
 	// This environment variable for the KubeRay operator is used to determine whether to enable
@@ -369,6 +373,7 @@ const (
 	// Redis Cleanup Job event list
 	CreatedRedisCleanupJob        K8sEventType = "CreatedRedisCleanupJob"
 	FailedToCreateRedisCleanupJob K8sEventType = "FailedToCreateRedisCleanupJob"
+	ForceDeletedStuckCluster      K8sEventType = "ForceDeletedStuckCluster"
 
 	// RayJob event list
 	InvalidRayJobSpec             K8sEventType = "InvalidRayJobSpec"

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -684,6 +684,11 @@ func IsJobFinished(j *batchv1.Job) (batchv1.JobConditionType, bool) {
 		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == corev1.ConditionTrue {
 			return c.Type, true
 		}
+		// FailureTarget appears ~tens-of-seconds before JobFailed when activeDeadlineSeconds
+		// is exceeded; treat it as a failed terminal state to avoid stalling the reconciler.
+		if c.Type == batchv1.JobFailureTarget && c.Status == corev1.ConditionTrue {
+			return batchv1.JobFailed, true
+		}
 	}
 	return "", false
 }

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2307,6 +2308,70 @@ func TestIsGatewayEqual(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := IsGatewayEqual(tt.existing, tt.desired)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsJobFinished(t *testing.T) {
+	makeJob := func(conditions ...batchv1.JobCondition) *batchv1.Job {
+		return &batchv1.Job{Status: batchv1.JobStatus{Conditions: conditions}}
+	}
+	cond := func(t batchv1.JobConditionType, s corev1.ConditionStatus) batchv1.JobCondition {
+		return batchv1.JobCondition{Type: t, Status: s}
+	}
+
+	tests := []struct {
+		name         string
+		job          *batchv1.Job
+		wantType     batchv1.JobConditionType
+		wantFinished bool
+	}{
+		{
+			name:         "no conditions",
+			job:          makeJob(),
+			wantFinished: false,
+		},
+		{
+			name:         "complete",
+			job:          makeJob(cond(batchv1.JobComplete, corev1.ConditionTrue)),
+			wantType:     batchv1.JobComplete,
+			wantFinished: true,
+		},
+		{
+			name:         "failed",
+			job:          makeJob(cond(batchv1.JobFailed, corev1.ConditionTrue)),
+			wantType:     batchv1.JobFailed,
+			wantFinished: true,
+		},
+		{
+			name:         "failure target only (activeDeadlineSeconds window before Failed appears)",
+			job:          makeJob(cond(batchv1.JobFailureTarget, corev1.ConditionTrue)),
+			wantType:     batchv1.JobFailed,
+			wantFinished: true,
+		},
+		{
+			name:         "failure target false status is not finished",
+			job:          makeJob(cond(batchv1.JobFailureTarget, corev1.ConditionFalse)),
+			wantFinished: false,
+		},
+		{
+			name: "failure target then failed",
+			job: makeJob(
+				cond(batchv1.JobFailureTarget, corev1.ConditionTrue),
+				cond(batchv1.JobFailed, corev1.ConditionTrue),
+			),
+			wantType:     batchv1.JobFailed,
+			wantFinished: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotFinished := IsJobFinished(tt.job)
+			assert.Equal(t, tt.wantFinished, gotFinished)
+			if tt.wantFinished {
+				assert.Equal(t, tt.wantType, gotType)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Why are these changes needed?

### Problem

There are scenarios where the Redis cleanup job for a Ray Service exits with an error and the corresponding Ray Cluster does not get its finalizer removed. This is a problem because it causes Kueue to hold on to the resource quotas; also, if Kueue chooses such a Ray Cluster for preemption, the preemption process will wait indefinitely.

There is no Kubernetes-native mechanism to set a timeout for the finalizer.

### Solution

Implement a finalizer timeout in the Ray Cluster controller for any RayCluster that carries the GCS FT Redis cleanup finalizer (i.e. has ENABLE_GCS_FT_REDIS_CLEANUP enabled and GCS FT configured). The timeout applies uniformly regardless of whether the cluster is owned by a RayService or used standalone (since nothing prevents the finalizer and annotation from being set on a standalone Ray Cluster that is not owned by a Ray Service).

The finalizer timeout works as below:

  - The timeout value defaults to RAYCLUSTER_GCS_FT_DELETION_TIMEOUT_DEFAULT (300 s / 5 min) and can be overridden per-cluster via the ray.io/gcs-ft-deletion-timeout annotation (integer seconds).
  - In the deletion path of rayClusterReconcile(), if the cluster has the GCS FT finalizer and the time since the deletion timestamp exceeds the timeout, the finalizer is force-removed immediately. This check happens before Redis cleanup job processing, so any issues there do not affect the last-resort removal.
  - If the Redis cleanup job completes normally (success or failure) before the timeout, the finalizer is removed via the normal path and reconciliation ends cleanly.
  - A Warning/ForceDeletedStuckCluster event is emitted on force-removal, including the
  ray.io/external-storage-namespace value so operators know which Redis namespace may need manual cleanup.

## Related issue number
Closes #4767

## Checks

- [x ] I've made sure the tests are passing.
- Testing Strategy
  - [ x] Unit tests
  - [x ] Manual tests
  - [ ] This PR is not tested :(
