### PR TITLE
feat: expose leader election lease duration and renew deadline as flags

### DIFF
--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/go-logr/zapr"
 	routev1 "github.com/openshift/api/route/v1"
@@ -71,6 +72,8 @@ func main() {
 	var enableMetrics bool
 	var qps float64
 	var burst int
+	var leaseDuration time.Duration
+	var renewDeadline time.Duration
 
 	// TODO: remove flag-based config once Configuration API graduates to v1.
 	flag.StringVar(&metricsAddr, "metrics-addr", configapi.DefaultMetricsAddr, "The address the metric endpoint binds to.")
@@ -104,6 +107,8 @@ func main() {
 	flag.BoolVar(&enableMetrics, "enable-metrics", false, "Enable the emission of control plane metrics.")
 	flag.Float64Var(&qps, "qps", float64(configapi.DefaultQPS), "The QPS value for the client communicating with the Kubernetes API server.")
 	flag.IntVar(&burst, "burst", configapi.DefaultBurst, "The maximum burst for throttling requests from this client to the Kubernetes API server.")
+	flag.DurationVar(&leaseDuration, "leader-elect-lease-duration", 60*time.Second, "Duration a non-leader candidate waits before attempting to acquire leadership.")
+	flag.DurationVar(&renewDeadline, "leader-elect-renew-deadline", 40*time.Second, "Duration the leader retries renewing the lease before giving up.")
 
 	opts := k8szap.Options{
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
@@ -207,6 +212,8 @@ func main() {
 		LeaderElection:          *config.EnableLeaderElection,
 		LeaderElectionID:        "ray-operator-leader",
 		LeaderElectionNamespace: config.LeaderElectionNamespace,
+		LeaseDuration:           &leaseDuration,
+		RenewDeadline:           &renewDeadline,
 	}
 
 	// Manager Cache


### PR DESCRIPTION
## Summary

- Add `--leader-elect-lease-duration` and `--leader-elect-renew-deadline` CLI flags to `ray-operator/main.go`
- Wire them into `ctrl.Options{}` so controller-runtime uses them instead of its hardcoded defaults
- Default values: `LeaseDuration: 60s` (was 15s), `RenewDeadline: 40s` (was 10s)

## Context

kuberay-operator was experiencing fleet-wide CrashLoopBackOff due to leader election failures (AIPTS-1528). The root cause is etcd running a defrag job every ~24h, causing ~5min of API latency spikes (10s+). The controller-runtime default `RenewDeadline` of 10s has zero tolerance for this, causing `os.Exit(1)` on any renewal that hits the window.

Since kuberay did not expose these as flags, the only fix was to patch the binary directly.

## Test plan

- [ ] Build the image using the updated Dockerfile pointing to this branch
- [ ] Deploy to staging and verify no leader election failures during the next etcd defrag window (~24h)
- [ ] Confirm `--leader-elect-lease-duration` and `--leader-elect-renew-deadline` flags are accepted by the binary