### PR TITLE
[CI] Upgrade to checkout action v5

### DIFF
--- a/.github/workflows/consistency-check.yaml
+++ b/.github/workflows/consistency-check.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -43,7 +43,7 @@ jobs:
           echo "BRANCH=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -23,7 +23,7 @@ jobs:
         go-version: v1.26
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -116,7 +116,7 @@ jobs:
         go-version: v1.26
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -218,7 +218,7 @@ jobs:
         script: core.setFailed('This action can only be run on tags')
 
     - name: Check out code into dashboard directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -269,7 +269,7 @@ jobs:
         go-version: v1.26
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 

--- a/.github/workflows/kubectl-plugin-release.yaml
+++ b/.github/workflows/kubectl-plugin-release.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Error if not a tag

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Lint (pre-commit)
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v3
       - uses: actions/setup-node@v4
         with:
@@ -41,7 +41,7 @@ jobs:
           go-version: v1.26
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           # When checking out the repository that
           # triggered a workflow, this defaults to the reference or SHA for that event.
@@ -146,7 +146,7 @@ jobs:
           go-version: v1.26
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           ref: ${{github.event.pull_request.head.sha}}
 
@@ -175,7 +175,7 @@ jobs:
           go-version: v1.26
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           # When checking out the repository that
           # triggered a workflow, this defaults to the reference or SHA for that event.
@@ -278,7 +278,7 @@ jobs:
         go-version: v1.26
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
         # When checking out the repository that
         # triggered a workflow, this defaults to the reference or SHA for that event.
@@ -391,7 +391,7 @@ jobs:
           go-version: v1.26
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           # When checking out the repository that
           # triggered a workflow, this defaults to the reference or SHA for that event.
@@ -422,7 +422,7 @@ jobs:
           go-version: v1.26
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           ref: ${{github.event.pull_request.head.sha}}
 


### PR DESCRIPTION
## Why are these changes needed?

This PR upgrades CI checkout from v2 to v5, which seem to be the latest stable
https://github.com/actions/checkout#scenarios

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
