### PR TITLE
[CI] Enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,13 @@ updates:
       all-dependencies: # for all other dependencies not listed above
         patterns:
           - "*"
+
+  # Maintain GitHub Actions referenced in .github/workflows/
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why are these changes needed?

All our current github actions are at a stale version, without auto-upgrade or CI no one will ever think about it.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
