### PR TITLE
[History server] History server to cache cluster info 

### DIFF
--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -1,0 +1,223 @@
+package historyserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+)
+
+func TestEnterCluster(t *testing.T) {
+	// Reset default container to avoid polluting or using duplicate services across runs
+	restful.DefaultContainer = restful.NewContainer()
+
+	// 1. Create ServerHandler with a pre-populated clustersMap and a fake sessionLoader
+	handler := &ServerHandler{
+		maxClusters: 100,
+		clustersMap: make(map[utils.ClusterKey][]utils.ClusterInfo),
+	}
+
+	// Setup fake processor for sessionLoader
+	fp := &fakeProcessor{
+		fn: func(ctx context.Context, info utils.ClusterInfo) (SessionStatus, error) {
+			if info.SessionName == "session_2026-04-22_10-00-00_000000_1" {
+				return SessionStatusProcessed, nil
+			}
+			if info.SessionName == "session_2026-04-22_10-00-00_000000_2_live" {
+				return SessionStatusLive, nil
+			}
+			return SessionStatusEventsErr, fmt.Errorf("unknown session")
+		},
+	}
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout)
+
+	// Single session cluster
+	keyA := utils.ClusterKey{
+		Namespace: "default",
+		Name:      "cluster-a",
+	}
+	handler.clustersMap[keyA] = []utils.ClusterInfo{
+		{
+			Namespace:   "default",
+			Name:        "cluster-a",
+			SessionName: "session_2026-04-22_10-00-00_000000_1",
+			OwnerKind:   "RayJob",
+			OwnerName:   "job-a",
+		},
+	}
+
+	// Multi-session cluster (past session AND live session)
+	keyB := utils.ClusterKey{
+		Namespace: "default",
+		Name:      "cluster-b",
+	}
+	handler.clustersMap[keyB] = []utils.ClusterInfo{
+		{
+			Namespace:       "default",
+			Name:            "cluster-b",
+			SessionName:     "session_2026-04-22_10-00-00_000000_1",
+			OwnerKind:       "RayService",
+			OwnerName:       "svc-b",
+			CreateTimeStamp: 1000, // Older
+		},
+		{
+			Namespace:       "default",
+			Name:            "cluster-b",
+			SessionName:     "live",
+			OwnerKind:       "RayService",
+			OwnerName:       "svc-b",
+			CreateTimeStamp: 2000, // Newer (latest)
+		},
+	}
+
+	// Cluster with session that is resolved but will trigger live resolution
+	keyC := utils.ClusterKey{
+		Namespace: "default",
+		Name:      "cluster-c",
+	}
+	handler.clustersMap[keyC] = []utils.ClusterInfo{
+		{
+			Namespace:   "default",
+			Name:        "cluster-c",
+			SessionName: "session_2026-04-22_10-00-00_000000_2_live",
+			OwnerKind:   "RayJob",
+			OwnerName:   "job-c",
+		},
+	}
+
+	// Cluster with invalid session format
+	keyD := utils.ClusterKey{
+		Namespace: "default",
+		Name:      "cluster-d",
+	}
+	handler.clustersMap[keyD] = []utils.ClusterInfo{
+		{
+			Namespace:   "default",
+			Name:        "cluster-d",
+			SessionName: "invalid-session-name",
+		},
+	}
+
+	// Explicitly sort `Multi-session cluster` to simulate listClusters post-sorting logic
+	sort.Sort(utils.ClusterInfoList(handler.clustersMap[keyB]))
+
+	// Register actual router
+	routerRayClusterSet(handler)
+
+	container := restful.DefaultContainer
+
+	t.Run("Verify sorted order of multi-session slice puts latest first", func(t *testing.T) {
+		sessions := handler.clustersMap[keyB]
+		if len(sessions) != 2 {
+			t.Fatalf("Expected 2 sessions, got %d", len(sessions))
+		}
+		// Index 0 must be the newer session (live, timestamp 2000)
+		if sessions[0].SessionName != "live" {
+			t.Errorf("Expected latest session 'live' at index 0, got %s", sessions[0].SessionName)
+		}
+	})
+
+	t.Run("Enter existing single-session cluster with explicit session (Successful Dead Session Loading)", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-a/session_2026-04-22_10-00-00_000000_1", nil)
+		resp := httptest.NewRecorder()
+		container.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+		}
+
+		cookies := resp.Result().Cookies()
+		cookieMap := make(map[string]*http.Cookie)
+		for _, cookie := range cookies {
+			cookieMap[cookie.Name] = cookie
+		}
+
+		if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "session_2026-04-22_10-00-00_000000_1" {
+			t.Errorf("Expected cookie %s to be 'session_2026-04-22_10-00-00_000000_1', got %v", COOKIE_SESSION_NAME_KEY, c)
+		}
+	})
+
+	t.Run("Enter cluster with 'latest' keyword resolves to newest session in the list", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-b/latest", nil)
+		resp := httptest.NewRecorder()
+		container.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d", resp.Code)
+		}
+
+		// Verify cookies are set to the ACTUAL newest session name ("live") rather than literal "latest"
+		cookies := resp.Result().Cookies()
+		cookieMap := make(map[string]*http.Cookie)
+		for _, cookie := range cookies {
+			cookieMap[cookie.Name] = cookie
+		}
+
+		if c, ok := cookieMap[COOKIE_CLUSTER_NAME_KEY]; !ok || c.Value != "cluster-b" {
+			t.Errorf("Expected cookie %s to be 'cluster-b', got %v", COOKIE_CLUSTER_NAME_KEY, c)
+		}
+		if c, ok := cookieMap[COOKIE_CLUSTER_NAMESPACE_KEY]; !ok || c.Value != "default" {
+			t.Errorf("Expected cookie %s to be 'default', got %v", COOKIE_CLUSTER_NAMESPACE_KEY, c)
+		}
+		if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "live" {
+			t.Errorf("Expected cookie %s to be 'live' (actual latest session name), got %v", COOKIE_SESSION_NAME_KEY, c)
+		}
+	})
+
+	t.Run("Enter cluster with NO session parameter defaults to latest", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-b", nil)
+		resp := httptest.NewRecorder()
+		container.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d", resp.Code)
+		}
+
+		// Verify cookies are set to the ACTUAL newest session name ("live") rather than literal "latest"
+		cookies := resp.Result().Cookies()
+		cookieMap := make(map[string]*http.Cookie)
+		for _, cookie := range cookies {
+			cookieMap[cookie.Name] = cookie
+		}
+
+		if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "live" {
+			t.Errorf("Expected cookie %s to default to 'live' (actual latest session name), got %v", COOKIE_SESSION_NAME_KEY, c)
+		}
+	})
+
+	t.Run("Enter cluster with session that is resolved but triggers live resolution (Line 326 path)", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-c/session_2026-04-22_10-00-00_000000_2_live", nil)
+		resp := httptest.NewRecorder()
+		container.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+		}
+
+		cookies := resp.Result().Cookies()
+		cookieMap := make(map[string]*http.Cookie)
+		for _, cookie := range cookies {
+			cookieMap[cookie.Name] = cookie
+		}
+
+		// Since the fake processor returns SessionStatusLive for this session, resolvedSession is set to "live"
+		if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "live" {
+			t.Errorf("Expected cookie %s to be 'live' (resolved from timestamp because cluster is live), got %v", COOKIE_SESSION_NAME_KEY, c)
+		}
+	})
+
+	t.Run("Enter cluster with invalid session name format (Line 310 path)", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-d/invalid-session-name", nil)
+		resp := httptest.NewRecorder()
+		container.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("Expected status 400 (BadRequest), got %d", resp.Code)
+		}
+	})
+}

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -16,7 +16,7 @@ func TestEnterCluster(t *testing.T) {
 	// Reset default container to avoid polluting or using duplicate services across runs
 	restful.DefaultContainer = restful.NewContainer()
 
-	// 1. Create ServerHandler with a pre-populated clustersMap and a fake sessionLoader
+	// Create ServerHandler with fake sessionLoader
 	handler := &ServerHandler{
 		maxClusters: 100,
 		clustersMap: make(map[utils.ClusterKey][]utils.ClusterInfo),
@@ -139,54 +139,6 @@ func TestEnterCluster(t *testing.T) {
 
 		if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "session_2026-04-22_10-00-00_000000_1" {
 			t.Errorf("Expected cookie %s to be 'session_2026-04-22_10-00-00_000000_1', got %v", COOKIE_SESSION_NAME_KEY, c)
-		}
-	})
-
-	t.Run("Enter cluster with 'latest' keyword resolves to newest session in the list", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-b/latest", nil)
-		resp := httptest.NewRecorder()
-		container.ServeHTTP(resp, req)
-
-		if resp.Code != http.StatusOK {
-			t.Fatalf("Expected status 200, got %d", resp.Code)
-		}
-
-		// Verify cookies are set to the ACTUAL newest session name ("live") rather than literal "latest"
-		cookies := resp.Result().Cookies()
-		cookieMap := make(map[string]*http.Cookie)
-		for _, cookie := range cookies {
-			cookieMap[cookie.Name] = cookie
-		}
-
-		if c, ok := cookieMap[COOKIE_CLUSTER_NAME_KEY]; !ok || c.Value != "cluster-b" {
-			t.Errorf("Expected cookie %s to be 'cluster-b', got %v", COOKIE_CLUSTER_NAME_KEY, c)
-		}
-		if c, ok := cookieMap[COOKIE_CLUSTER_NAMESPACE_KEY]; !ok || c.Value != "default" {
-			t.Errorf("Expected cookie %s to be 'default', got %v", COOKIE_CLUSTER_NAMESPACE_KEY, c)
-		}
-		if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "live" {
-			t.Errorf("Expected cookie %s to be 'live' (actual latest session name), got %v", COOKIE_SESSION_NAME_KEY, c)
-		}
-	})
-
-	t.Run("Enter cluster with NO session parameter defaults to latest", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-b", nil)
-		resp := httptest.NewRecorder()
-		container.ServeHTTP(resp, req)
-
-		if resp.Code != http.StatusOK {
-			t.Fatalf("Expected status 200, got %d", resp.Code)
-		}
-
-		// Verify cookies are set to the ACTUAL newest session name ("live") rather than literal "latest"
-		cookies := resp.Result().Cookies()
-		cookieMap := make(map[string]*http.Cookie)
-		for _, cookie := range cookies {
-			cookieMap[cookie.Name] = cookie
-		}
-
-		if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "live" {
-			t.Errorf("Expected cookie %s to default to 'live' (actual latest session name), got %v", COOKIE_SESSION_NAME_KEY, c)
 		}
 	})
 

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -99,9 +99,6 @@ func (s *ServerHandler) findSessionInMap(namespace, name, session string) (strin
 		if len(list) == 0 {
 			return "", false
 		}
-		if session == "latest" || session == "" {
-			return list[0].SessionName, true
-		}
 		for _, c := range list {
 			if c.SessionName == session {
 				return c.SessionName, true

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -67,7 +67,48 @@ func (s *ServerHandler) listClusters(limit int) []utils.ClusterInfo {
 		clusters = clusters[:limit]
 	}
 	clusters = append(liveClusterInfos, clusters...)
+
+	clustersMap := make(map[utils.ClusterKey][]utils.ClusterInfo)
+	for _, c := range clusters {
+		key := utils.ClusterKey{
+			Namespace: c.Namespace,
+			Name:      c.Name,
+		}
+		clustersMap[key] = append(clustersMap[key], c)
+	}
+
+	for key := range clustersMap {
+		sort.Sort(utils.ClusterInfoList(clustersMap[key]))
+	}
+
+	s.mu.Lock()
+	s.clustersMap = clustersMap
+	s.mu.Unlock()
+
 	return clusters
+}
+
+func (s *ServerHandler) findSessionInMap(namespace, name, session string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	key := utils.ClusterKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+	if list, ok := s.clustersMap[key]; ok {
+		if len(list) == 0 {
+			return "", false
+		}
+		if session == "latest" || session == "" {
+			return list[0].SessionName, true
+		}
+		for _, c := range list {
+			if c.SessionName == session {
+				return c.SessionName, true
+			}
+		}
+	}
+	return "", false
 }
 
 func (s *ServerHandler) _getNodeLogs(rayClusterNameNamespace, sessionId, nodeId, folder, glob string) ([]byte, error) {

--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -297,7 +297,9 @@ func routerRayClusterSet(s *ServerHandler) {
 	enterHandler := func(r1 *restful.Request, r2 *restful.Response, namespace, name, session string) {
 		resolvedSession, found := s.findSessionInMap(namespace, name, session)
 		if !found {
-			s.listClusters(s.maxClusters)
+			if s.clientManager != nil && s.reader != nil {
+				s.listClusters(s.maxClusters)
+			}
 			resolvedSession, found = s.findSessionInMap(namespace, name, session)
 		}
 
@@ -350,16 +352,6 @@ func routerRayClusterSet(s *ServerHandler) {
 		Param(ws.PathParameter("name", "name")).
 		Param(ws.PathParameter("session", "session")).
 		Writes("")) // Placeholder for specific return type
-
-	ws.Route(ws.GET("/{namespace}/{name}").To(func(r1 *restful.Request, r2 *restful.Response) {
-		name := r1.PathParameter("name")
-		namespace := r1.PathParameter("namespace")
-		enterHandler(r1, r2, namespace, name, "latest")
-	}).
-		Doc("set cookie for cluster (defaults session to latest)").
-		Param(ws.PathParameter("namespace", "namespace")).
-		Param(ws.PathParameter("name", "name")).
-		Writes(""))
 }
 
 func (s *ServerHandler) RegisterRouter() {

--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -294,21 +294,28 @@ func routerRayClusterSet(s *ServerHandler) {
 	defer restful.Add(ws)
 
 	ws.Path("/enter_cluster").Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON).Filter(RequestLogFilter)
-	ws.Route(ws.GET("/{namespace}/{name}/{session}").To(func(r1 *restful.Request, r2 *restful.Response) {
-		name := r1.PathParameter("name")
-		namespace := r1.PathParameter("namespace")
-		session := r1.PathParameter("session")
+	enterHandler := func(r1 *restful.Request, r2 *restful.Response, namespace, name, session string) {
+		resolvedSession, found := s.findSessionInMap(namespace, name, session)
+		if !found {
+			s.listClusters(s.maxClusters)
+			resolvedSession, found = s.findSessionInMap(namespace, name, session)
+		}
 
-		if session != "live" {
-			if ParseSessionTimestamp(session).IsZero() {
-				logrus.Warnf("Rejecting invalid session name: %s/%s/%s", namespace, name, session)
-				r2.WriteErrorString(http.StatusBadRequest, fmt.Sprintf("invalid session name: %q", session))
+		if !found {
+			r2.WriteErrorString(http.StatusNotFound, fmt.Sprintf("cluster %s/%s with session %s not found", namespace, name, session))
+			return
+		}
+
+		if resolvedSession != "live" {
+			if ParseSessionTimestamp(resolvedSession).IsZero() {
+				logrus.Warnf("Rejecting invalid session name: %s/%s/%s", namespace, name, resolvedSession)
+				r2.WriteErrorString(http.StatusBadRequest, fmt.Sprintf("invalid session name: %q", resolvedSession))
 				return
 			}
-			info := utils.ClusterInfo{Name: name, Namespace: namespace, SessionName: session}
+			info := utils.ClusterInfo{Name: name, Namespace: namespace, SessionName: resolvedSession}
 			live, err := s.sessionLoader.LoadSession(r1.Request.Context(), info)
 			if err != nil {
-				logrus.Errorf("Failed to load session %s/%s/%s: %v", namespace, name, session, err)
+				logrus.Errorf("Failed to load session %s/%s/%s: %v", namespace, name, resolvedSession, err)
 				r2.WriteErrorString(http.StatusInternalServerError, err.Error())
 				return
 			}
@@ -316,27 +323,43 @@ func routerRayClusterSet(s *ServerHandler) {
 			// Users might use the complete session name to enter a live cluster,
 			// so "live" sentinel is set to avoid querying empty in-memory state.
 			if live {
-				session = "live"
+				resolvedSession = "live"
 			}
 		}
 
-		// Set cookies only after a successful load (dead) or a skip (live).
 		http.SetCookie(r2, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_CLUSTER_NAME_KEY, Value: name})
 		http.SetCookie(r2, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_CLUSTER_NAMESPACE_KEY, Value: namespace})
-		http.SetCookie(r2, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_SESSION_NAME_KEY, Value: session})
+		http.SetCookie(r2, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_SESSION_NAME_KEY, Value: resolvedSession})
 
 		r2.WriteJson(map[string]interface{}{
 			"result":    "success",
 			"name":      name,
 			"namespace": namespace,
-			"session":   session,
+			"session":   resolvedSession,
 		}, "application/json")
+	}
+
+	ws.Route(ws.GET("/{namespace}/{name}/{session}").To(func(r1 *restful.Request, r2 *restful.Response) {
+		name := r1.PathParameter("name")
+		namespace := r1.PathParameter("namespace")
+		session := r1.PathParameter("session")
+		enterHandler(r1, r2, namespace, name, session)
 	}).
 		Doc("set cookie for cluster").
 		Param(ws.PathParameter("namespace", "namespace")).
 		Param(ws.PathParameter("name", "name")).
 		Param(ws.PathParameter("session", "session")).
 		Writes("")) // Placeholder for specific return type
+
+	ws.Route(ws.GET("/{namespace}/{name}").To(func(r1 *restful.Request, r2 *restful.Response) {
+		name := r1.PathParameter("name")
+		namespace := r1.PathParameter("namespace")
+		enterHandler(r1, r2, namespace, name, "latest")
+	}).
+		Doc("set cookie for cluster (defaults session to latest)").
+		Param(ws.PathParameter("namespace", "namespace")).
+		Param(ws.PathParameter("name", "name")).
+		Writes(""))
 }
 
 func (s *ServerHandler) RegisterRouter() {

--- a/historyserver/pkg/historyserver/server.go
+++ b/historyserver/pkg/historyserver/server.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/transport"
 )
@@ -26,6 +28,9 @@ type ServerHandler struct {
 	httpClient    *http.Client
 
 	useKubernetesProxy bool
+
+	mu          sync.RWMutex
+	clustersMap map[utils.ClusterKey][]utils.ClusterInfo
 }
 
 func NewServerHandler(c *types.RayHistoryServerConfig, dashboardDir string, reader storage.StorageReader, clientManager *ClientManager, eventHandler *eventserver.EventHandler, sessionLoader *SessionLoader, useKubernetesProxy bool) (*ServerHandler, error) {

--- a/historyserver/pkg/utils/types.go
+++ b/historyserver/pkg/utils/types.go
@@ -13,8 +13,6 @@ type ClusterInfo struct {
 type ClusterKey struct {
 	Namespace string
 	Name      string
-	OwnerKind string
-	OwnerName string
 }
 
 type ClusterInfoList []ClusterInfo

--- a/historyserver/pkg/utils/types.go
+++ b/historyserver/pkg/utils/types.go
@@ -10,6 +10,13 @@ type ClusterInfo struct {
 	OwnerName       string `json:"ownerName,omitempty"`
 }
 
+type ClusterKey struct {
+	Namespace string
+	Name      string
+	OwnerKind string
+	OwnerName string
+}
+
 type ClusterInfoList []ClusterInfo
 
 func (a ClusterInfoList) Len() int           { return len(a) }


### PR DESCRIPTION
## Why are these changes needed?
`OwnerKind` and `OwnerName` will be required to find the right path for logs, history server will have to hold on to the clusterInfo in order to know what cookies to set. 

As stated in #4774 this is part of updating log directory to:
```
cluster-history/
  rayjob/
    <namespace>/
      <rayjob-name>/
        <cluster-name>/
          <session-name>/
             <node-name>/
                job_events/
                node_events/
                logs/
  <RayCluster with similar file structure>
  <RayService with similar file structure>
```

History server will hold on to a map of clusterInfo when `clusters/` is called. `enter_cluster/` will check if the user input exists in the map. 

## Related issue number
Part of #4708 

Next PR will be the updating the log directory structure (different PR since I think it will be too big).

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
