### PR TITLE
[ray-operator] Allow disabling log_monitor via rayStartParams

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -1151,7 +1151,13 @@ func convertParamMap(rayStartParams map[string]string) (s string) {
 	flags := new(bytes.Buffer)
 	// specialParameterOptions' arguments can be true or false.
 	// For example, --log-color can be auto | false | true.
-	specialParameterOptions := []string{"log-color", "include-dashboard"}
+	// `include-log-monitor` is declared in Ray's CLI as `type=bool` (not
+	// `is_flag=True`), so the user needs to be able to pass `=false` to
+	// disable log_monitor. Without inclusion here, a value of `false` would
+	// be silently dropped, `--include-log-monitor` would not appear on the
+	// `ray start` command line, and Ray would default `include_log_monitor`
+	// to True.
+	specialParameterOptions := []string{"log-color", "include-dashboard", "include-log-monitor"}
 	for _, option := range keys {
 		argument := rayStartParams[option]
 		if utils.Contains([]string{"true", "false"}, strings.ToLower(argument)) && !utils.Contains(specialParameterOptions, option) {

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -1149,14 +1149,9 @@ func convertParamMap(rayStartParams map[string]string) (s string) {
 	sort.Strings(keys)
 
 	flags := new(bytes.Buffer)
-	// specialParameterOptions' arguments can be true or false.
-	// For example, --log-color can be auto | false | true.
-	// `include-log-monitor` is declared in Ray's CLI as `type=bool` (not
-	// `is_flag=True`), so the user needs to be able to pass `=false` to
-	// disable log_monitor. Without inclusion here, a value of `false` would
-	// be silently dropped, `--include-log-monitor` would not appear on the
-	// `ray start` command line, and Ray would default `include_log_monitor`
-	// to True.
+	// All `ray start` CLI flags that accept an explicit boolean value (e.g.
+	// `--flag=false`) must be listed here, otherwise a value of "false"
+	// gets silently dropped and the flag never reaches `ray start`.
 	specialParameterOptions := []string{"log-color", "include-dashboard", "include-log-monitor"}
 	for _, option := range keys {
 		argument := rayStartParams[option]

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -2228,6 +2228,24 @@ func TestGenerateRayStartCommand(t *testing.T) {
 			resource:       corev1.ResourceRequirements{},
 			expected:       "",
 		},
+		{
+			name:     "HeadNode with include-log-monitor=false",
+			nodeType: rayv1.HeadNode,
+			rayStartParams: map[string]string{
+				"include-log-monitor": "false",
+			},
+			resource: corev1.ResourceRequirements{},
+			expected: "ray start --head  --include-log-monitor=false ",
+		},
+		{
+			name:     "HeadNode with include-log-monitor=true",
+			nodeType: rayv1.HeadNode,
+			rayStartParams: map[string]string{
+				"include-log-monitor": "true",
+			},
+			resource: corev1.ResourceRequirements{},
+			expected: "ray start --head  --include-log-monitor=true ",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Why are these changes needed?

`convertParamMap` in `ray-operator/controllers/ray/common/pod.go` silently drops `rayStartParams` values of `"true"`/`"false"` (case-insensitive) for keys that are NOT in `specialParameterOptions`. Only `log-color` and `include-dashboard` are currently whitelisted. For Ray CLI flags declared as `type=bool` (rather than `is_flag=True`), the user needs to be able to pass `=false` to disable them — rendering them as bare `--flag` would only allow enabling.

The only `type=bool` flag on `ray start` currently missing from the whitelist is `--include-log-monitor`. Setting `rayStartParams: include-log-monitor: "false"` in a RayCluster spec therefore has no effect: KubeRay never emits the flag, and Ray defaults `include_log_monitor=True`, so `log_monitor.py` still spawns on every node.

At scale, this is more than a cosmetic problem. `log_monitor` reads every worker's local stdout/stderr files and publishes batched log records via the GCS `RAY_LOG_CHANNEL` pubsub channel. Each publish fans out to every subscriber via deep-copied reply protobufs. We hit this on a 130-node H200 cluster (~4,000 subscriber processes): `gcs_server` on the head pod reached 108 GB and was killed by Ray's memory monitor.

For Ray's `ray start`, only two flags are declared `type=bool`:
- `--include-dashboard` — already in the whitelist
- `--include-log-monitor` — added by this PR

So the whitelist becomes exhaustive for current Ray.

## Related issue number

N/A (filed as a fix while we were investigating an OOM; happy to add a tracking issue if you'd like).

## Checks

- [x] I've made sure the tests are passing.
- [x] Testing Strategy
  - [x] Unit tests — added two cases to `TestGenerateRayStartCommand` covering `include-log-monitor=false` and `include-log-monitor=true` rendering through `generateRayStartCommand`/`convertParamMap`.
  - [ ] Manual tests
  - [ ] This PR is not tested :(

## Manual verification (downstream)

End-to-end on KubeRay v1.6.0 with a downstream workaround that uses `"0"` instead of `"false"` (which bypasses the same code path): `log_monitor.py` confirmed not running, zero `RAY_LOG_CHANNEL` publishes in `gcs_server.out`, head pod RSS flat at 1.6 GB on a 6-node test cluster. With this PR, `"false"` would render correctly without needing the `"0"` workaround.