### PR TITLE
Remove cpu limit for rayservice e2e test

### DIFF
--- a/ray-operator/test/e2erayservice/support.go
+++ b/ray-operator/test/e2erayservice/support.go
@@ -127,7 +127,6 @@ func RayServiceSampleYamlApplyConfiguration() *rayv1ac.RayServiceSpecApplyConfig
 									corev1.ResourceMemory: resource.MustParse("2Gi"),
 								}).
 								WithLimits(corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("2"),
 									corev1.ResourceMemory: resource.MustParse("3Gi"),
 								})))))))
 }

--- a/ray-operator/test/e2erayservice/support.go
+++ b/ray-operator/test/e2erayservice/support.go
@@ -80,6 +80,12 @@ func RayServiceSampleYamlApplyConfiguration() *rayv1ac.RayServiceSpecApplyConfig
               price: 2
             ray_actor_options:
               num_cpus: 0.1
+          - name: PearStand
+            num_replicas: 1
+            user_config:
+              price: 4
+            ray_actor_options:
+              num_cpus: 0.1
           - name: FruitMarket
             num_replicas: 1
             ray_actor_options:

--- a/ray-operator/test/e2erayservice/testdata/ray-service.ft.yaml
+++ b/ray-operator/test/e2erayservice/testdata/ray-service.ft.yaml
@@ -49,7 +49,6 @@ spec:
                   cpu: 300m
                   memory: 1G
                 limits:
-                  cpu: 500m
                   memory: 2G
     workerGroupSpecs:
       - replicas: 1
@@ -68,7 +67,6 @@ spec:
                     cpu: 300m
                     memory: 1G
                   limits:
-                    cpu: 500m
                     memory: 1G
 ---
 kind: ConfigMap

--- a/ray-operator/test/e2erayservice/testdata/rayservice.autoscaling.yaml
+++ b/ray-operator/test/e2erayservice/testdata/rayservice.autoscaling.yaml
@@ -68,4 +68,5 @@ spec:
                     cpu: "300m"
                     memory: "1G"
                   limits:
+                    cpu: "500m"
                     memory: "1G"

--- a/ray-operator/test/e2erayservice/testdata/rayservice.autoscaling.yaml
+++ b/ray-operator/test/e2erayservice/testdata/rayservice.autoscaling.yaml
@@ -43,7 +43,6 @@ spec:
                   cpu: "1"
                   memory: 1G
                 limits:
-                  cpu: "1"
                   memory: 2G
               ports:
                 - containerPort: 6379
@@ -69,5 +68,4 @@ spec:
                     cpu: "300m"
                     memory: "1G"
                   limits:
-                    cpu: "500m"
                     memory: "1G"

--- a/ray-operator/test/e2erayservice/testdata/rayservice.deletiondelay.yaml
+++ b/ray-operator/test/e2erayservice/testdata/rayservice.deletiondelay.yaml
@@ -61,5 +61,4 @@ spec:
                     cpu: "300m"
                     memory: "1G"
                   limits:
-                    cpu: "500m"
                     memory: "1G"

--- a/ray-operator/test/e2erayservice/testdata/rayservice.deletiondelay.yaml
+++ b/ray-operator/test/e2erayservice/testdata/rayservice.deletiondelay.yaml
@@ -33,7 +33,6 @@ spec:
                   cpu: "300m"
                   memory: "1G"
                 limits:
-                  cpu: "500m"
                   memory: "2G"
               ports:
                 - containerPort: 6379

--- a/ray-operator/test/e2erayservice/testdata/rayservice.static.yaml
+++ b/ray-operator/test/e2erayservice/testdata/rayservice.static.yaml
@@ -32,7 +32,6 @@ spec:
                   cpu: "300m"
                   memory: "1G"
                 limits:
-                  cpu: "500m"
                   memory: "2G"
               ports:
                 - containerPort: 6379
@@ -60,5 +59,4 @@ spec:
                     cpu: "300m"
                     memory: "1G"
                   limits:
-                    cpu: "500m"
                     memory: "1G"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Remove CPU resource limits from RayService e2e test specs.

Previously, a 500m CPU limit on the head pod caused dashboard startup timeouts and flaky tests (fixed in #4702 by raising the limit to 1).
However, CPU limits are unnecessary in this test environment and can still cause throttling under load. Removing them entirely eliminates this type of  flakiness rather than tuning the limit value.
[ref](https://www.numeratorengineering.com/requests-are-all-you-need-cpu-limits-and-throttling-in-kubernetes/)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
