### PR TITLE
Implement disk-first event storage pipeline to reduce collector memory usage

### DIFF
--- a/historyserver/cmd/collector/main.go
+++ b/historyserver/cmd/collector/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -34,6 +35,14 @@ func main() {
 	pushInterval := time.Minute
 	runtimeClassConfigPath := "/var/collector-config/data"
 
+	// Event collector disk-first storage flags.
+	eventDataDir := "/tmp/ray/event-data"
+	eventRotationInterval := 5 * time.Minute
+	eventMaxFileSizeMB := 100
+	eventMaxDiskMB := 200
+	eventCompressionEnabled := true
+	eventFlushInterval := time.Hour
+
 	flag.StringVar(&role, "role", "Worker", "")
 	flag.StringVar(&runtimeClassName, "runtime-class-name", "", "")
 	flag.StringVar(&rayClusterName, "ray-cluster-name", "", "")
@@ -44,7 +53,54 @@ func main() {
 	flag.StringVar(&runtimeClassConfigPath, "runtime-class-config-path", "", "") //"/var/collector-config/data"
 	flag.DurationVar(&pushInterval, "push-interval", time.Minute, "")
 
+	flag.StringVar(&eventDataDir, "event-data-dir", eventDataDir, "Root directory for JSONL event files")
+	flag.DurationVar(&eventRotationInterval, "event-rotation-interval", eventRotationInterval, "Time threshold to rotate active JSONL file")
+	flag.IntVar(&eventMaxFileSizeMB, "event-max-file-size-mb", eventMaxFileSizeMB, "Size threshold (MB) to rotate active JSONL file")
+	flag.IntVar(&eventMaxDiskMB, "event-max-disk-mb", eventMaxDiskMB, "Max total disk usage (MB) before 503 backpressure")
+	flag.BoolVar(&eventCompressionEnabled, "event-compression-enabled", eventCompressionEnabled, "Single switch: enable local disk-first storage with gzip compression before upload (false uploads plain JSONL)")
+	flag.DurationVar(&eventFlushInterval, "event-flush-interval", eventFlushInterval, "In-memory buffer flush interval used when --event-compression-enabled=false (e.g. 5m). Default 1h matches legacy behavior")
+
 	flag.Parse()
+
+	// Override event collector settings from environment variables if present.
+	if v := os.Getenv("RAY_COLLECTOR_EVENT_DATA_DIR"); v != "" {
+		eventDataDir = v
+	}
+	if v := os.Getenv("RAY_COLLECTOR_EVENT_ROTATION_INTERVAL"); v != "" {
+		if parsed, err := time.ParseDuration(v); err == nil && parsed > 0 {
+			eventRotationInterval = parsed
+		} else {
+			logrus.Warnf("Invalid RAY_COLLECTOR_EVENT_ROTATION_INTERVAL=%s, using default %s", v, eventRotationInterval)
+		}
+	}
+	if v := os.Getenv("RAY_COLLECTOR_EVENT_MAX_FILE_SIZE_MB"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+			eventMaxFileSizeMB = parsed
+		} else {
+			logrus.Warnf("Invalid RAY_COLLECTOR_EVENT_MAX_FILE_SIZE_MB=%s, using default %d", v, eventMaxFileSizeMB)
+		}
+	}
+	if v := os.Getenv("RAY_COLLECTOR_EVENT_MAX_DISK_MB"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+			eventMaxDiskMB = parsed
+		} else {
+			logrus.Warnf("Invalid RAY_COLLECTOR_EVENT_MAX_DISK_MB=%s, using default %d", v, eventMaxDiskMB)
+		}
+	}
+	if v := os.Getenv("RAY_COLLECTOR_EVENT_COMPRESSION_ENABLED"); v != "" {
+		if parsed, err := strconv.ParseBool(v); err == nil {
+			eventCompressionEnabled = parsed
+		} else {
+			logrus.Warnf("Invalid RAY_COLLECTOR_EVENT_COMPRESSION_ENABLED=%s, using default %v", v, eventCompressionEnabled)
+		}
+	}
+	if v := os.Getenv("RAY_COLLECTOR_EVENT_FLUSH_INTERVAL"); v != "" {
+		if parsed, err := time.ParseDuration(v); err == nil && parsed > 0 {
+			eventFlushInterval = parsed
+		} else {
+			logrus.Warnf("Invalid RAY_COLLECTOR_EVENT_FLUSH_INTERVAL=%s, using default %s", v, eventFlushInterval)
+		}
+	}
 
 	var additionalEndpoints []string
 	if epStr := os.Getenv("RAY_COLLECTOR_ADDITIONAL_ENDPOINTS"); epStr != "" {
@@ -111,6 +167,13 @@ func main() {
 
 		AdditionalEndpoints:  additionalEndpoints,
 		EndpointPollInterval: endpointPollInterval,
+
+		EventDataDir:           eventDataDir,
+		EventRotationInterval:  eventRotationInterval,
+		EventMaxFileSizeMB:     eventMaxFileSizeMB,
+		EventMaxDiskMB:         eventMaxDiskMB,
+		EventCompressionEnabled: eventCompressionEnabled,
+		EventFlushInterval:      eventFlushInterval,
 	}
 	logrus.Info("Using collector config: ", globalConfig)
 
@@ -129,7 +192,14 @@ func main() {
 	// Create and initialize EventCollector
 	go func() {
 		defer wg.Done()
-		eventCollector := eventcollector.NewEventCollector(writer, rayRootDir, sessionDir, rayNodeId, rayClusterName, rayClusterNamespace, sessionName)
+		eventCollector := eventcollector.NewEventCollector(writer, rayRootDir, sessionDir, rayNodeId, rayClusterName, rayClusterNamespace, sessionName, eventcollector.Options{
+			DataDir:            eventDataDir,
+			RotationInterval:   eventRotationInterval,
+			MaxFileSizeBytes:   int64(eventMaxFileSizeMB) * 1024 * 1024,
+			MaxDiskBytes:       int64(eventMaxDiskMB) * 1024 * 1024,
+			CompressionEnabled: eventCompressionEnabled,
+			FlushInterval:      eventFlushInterval,
+		})
 		eventCollector.Run(stop, eventsPort)
 		logrus.Info("Event collector shutdown")
 	}()

--- a/historyserver/cmd/historyserver/main.go
+++ b/historyserver/cmd/historyserver/main.go
@@ -17,6 +17,15 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/historyserver"
 )
 
+const (
+	// defaultQPS is the default QPS value for the Kubernetes API client.
+	// Aligned with ray-operator defaults (configapi.DefaultQPS).
+	defaultQPS = float64(100)
+	// defaultBurst is the default burst value for the Kubernetes API client.
+	// Aligned with ray-operator defaults (configapi.DefaultBurst).
+	defaultBurst = 200
+)
+
 func main() {
 	runtimeClassName := ""
 	rayRootDir := ""
@@ -24,6 +33,8 @@ func main() {
 	runtimeClassConfigPath := ""
 	dashboardDir := ""
 	useKubernetesProxy := false
+	qps := defaultQPS
+	burst := defaultBurst
 	sessionProcessTimeout := historyserver.DefaultSessionProcessTimeout
 	flag.StringVar(&runtimeClassName, "runtime-class-name", "", "Storage backend: s3 / gcs / azureblob / aliyunoss / localtest")
 	flag.StringVar(&rayRootDir, "ray-root-dir", "", "Root dir inside the bucket")
@@ -31,6 +42,10 @@ func main() {
 	flag.StringVar(&dashboardDir, "dashboard-dir", "/dashboard", "Path to Ray Dashboard static assets")
 	flag.StringVar(&runtimeClassConfigPath, "runtime-class-config-path", "", "Path to backend config JSON")
 	flag.BoolVar(&useKubernetesProxy, "use-kubernetes-proxy", false, "Use local kubeconfig instead of in-cluster config")
+	flag.Float64Var(&qps, "kube-api-qps", defaultQPS,
+		"The QPS value for the client communicating with the Kubernetes API server.")
+	flag.IntVar(&burst, "kube-api-burst", defaultBurst,
+		"The maximum burst for throttling requests from this client to the Kubernetes API server.")
 	flag.DurationVar(&sessionProcessTimeout, "session-process-timeout", historyserver.DefaultSessionProcessTimeout, "Timeout duration for processing and loading a single Ray cluster session.")
 	flag.Parse()
 
@@ -38,7 +53,12 @@ func main() {
 		logrus.Fatal("--runtime-class-name is required")
 	}
 
-	cliMgr, err := historyserver.NewClientManager(kubeconfigs, useKubernetesProxy)
+	cliMgr, err := historyserver.NewClientManager(historyserver.ClientManagerConfig{
+		Kubeconfigs:        kubeconfigs,
+		UseKubernetesProxy: useKubernetesProxy,
+		QPS:                float32(qps),
+		Burst:              burst,
+	})
 	if err != nil {
 		logrus.Fatalf("Failed to create client manager: %v", err)
 	}

--- a/historyserver/cmd/historyserver/main.go
+++ b/historyserver/cmd/historyserver/main.go
@@ -11,19 +11,12 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	configapi "github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
+
 	"github.com/ray-project/kuberay/historyserver/pkg/collector"
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver"
 	"github.com/ray-project/kuberay/historyserver/pkg/historyserver"
-)
-
-const (
-	// defaultQPS is the default QPS value for the Kubernetes API client.
-	// Aligned with ray-operator defaults (configapi.DefaultQPS).
-	defaultQPS = float64(100)
-	// defaultBurst is the default burst value for the Kubernetes API client.
-	// Aligned with ray-operator defaults (configapi.DefaultBurst).
-	defaultBurst = 200
 )
 
 func main() {
@@ -33,8 +26,8 @@ func main() {
 	runtimeClassConfigPath := ""
 	dashboardDir := ""
 	useKubernetesProxy := false
-	qps := defaultQPS
-	burst := defaultBurst
+	qps := configapi.DefaultQPS
+	burst := configapi.DefaultBurst
 	sessionProcessTimeout := historyserver.DefaultSessionProcessTimeout
 	flag.StringVar(&runtimeClassName, "runtime-class-name", "", "Storage backend: s3 / gcs / azureblob / aliyunoss / localtest")
 	flag.StringVar(&rayRootDir, "ray-root-dir", "", "Root dir inside the bucket")
@@ -42,9 +35,9 @@ func main() {
 	flag.StringVar(&dashboardDir, "dashboard-dir", "/dashboard", "Path to Ray Dashboard static assets")
 	flag.StringVar(&runtimeClassConfigPath, "runtime-class-config-path", "", "Path to backend config JSON")
 	flag.BoolVar(&useKubernetesProxy, "use-kubernetes-proxy", false, "Use local kubeconfig instead of in-cluster config")
-	flag.Float64Var(&qps, "kube-api-qps", defaultQPS,
+	flag.Float64Var(&qps, "kube-api-qps", configapi.DefaultQPS,
 		"The QPS value for the client communicating with the Kubernetes API server.")
-	flag.IntVar(&burst, "kube-api-burst", defaultBurst,
+	flag.IntVar(&burst, "kube-api-burst", configapi.DefaultBurst,
 		"The maximum burst for throttling requests from this client to the Kubernetes API server.")
 	flag.DurationVar(&sessionProcessTimeout, "session-process-timeout", historyserver.DefaultSessionProcessTimeout, "Timeout duration for processing and loading a single Ray cluster session.")
 	flag.Parse()

--- a/historyserver/go.mod
+++ b/historyserver/go.mod
@@ -141,4 +141,6 @@ require (
 	google.golang.org/grpc v1.78.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	sigs.k8s.io/scheduler-plugins v0.31.8 // indirect
+	volcano.sh/apis v1.12.1 // indirect
 )

--- a/historyserver/go.sum
+++ b/historyserver/go.sum
@@ -521,7 +521,11 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
+sigs.k8s.io/scheduler-plugins v0.31.8 h1:Ie2EFRnkE9T2tBjxwypww7hJJyPRIwrXJNZeNxjP6QY=
+sigs.k8s.io/scheduler-plugins v0.31.8/go.mod h1:KkcXEbf9CYaoZ5ntbAMSYmquPq9MtSfXVpI31R6mHeM=
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0 h1:jTijUJbW353oVOd9oTlifJqOGEkUw2jB/fXCbTiQEco=
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=
+volcano.sh/apis v1.12.1 h1:yq5dVj/g21vnWObCIKsJKPhMoThpzDrHDD/GMouYVxk=
+volcano.sh/apis v1.12.1/go.mod h1:0XNNnIOevJSYNiXRmwhXUrYCcCcWcBeTY0nxrlkk03A=

--- a/historyserver/pkg/collector/eventcollector/eventcollector.go
+++ b/historyserver/pkg/collector/eventcollector/eventcollector.go
@@ -1,15 +1,19 @@
 package eventcollector
 
 import (
+	"bufio"
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/emicklei/go-restful/v3"
@@ -20,30 +24,44 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
-type Event struct {
-	Data      map[string]interface{}
-	Timestamp time.Time
+// Defaults for disk-first event storage. Kept aligned with the
+// collector-memory-control-proposal.md design document.
+const (
+	defaultRotationInterval = 5 * time.Minute
+	defaultMaxFileSizeBytes = int64(100) * 1024 * 1024
+	defaultMaxDiskBytes     = int64(200) * 1024 * 1024
+	defaultFlushInterval    = time.Hour
 
-	SessionName string
-	NodeID      string
+	rotationCheckInterval = 30 * time.Second
+	diskReconcileInterval = 1 * time.Minute
+	bufWriterSize         = 64 * 1024
+	diskPressureWatermark = 0.8
+	rotationQueueSize     = 256
+
+	categoryNodeEvents = "node_events"
+	categoryJobPrefix  = "job_events"
+)
+
+// Options groups tunables for disk-first event storage.
+type Options struct {
+	DataDir          string
+	RotationInterval time.Duration
+	MaxFileSizeBytes int64
+	MaxDiskBytes     int64
+	// CompressionEnabled is a single switch that controls the entire
+	// disk-first + gzip pipeline. When true, events are written to local
+	// JSONL files and rotated/gzipped/uploaded asynchronously. When false,
+	// events are buffered in-memory and periodically flushed to remote
+	// storage (legacy semantics).
+	CompressionEnabled bool
+	// FlushInterval controls how often the in-memory buffer is flushed when
+	// CompressionEnabled is false. Defaults to 1h (legacy behavior). Set
+	// lower for more frequent writes.
+	FlushInterval time.Duration
 }
 
-type EventCollector struct {
-	storageWriter      storage.StorageWriter
-	stopped            chan struct{}
-	clusterNamespace   string
-	sessionDir         string
-	nodeID             string
-	clusterName        string
-	sessionName        string
-	root               string
-	currentSessionName string
-	currentNodeID      string
-	events             []Event
-	flushInterval      time.Duration
-	mutex              sync.Mutex
-}
-
+// eventTypesWithJobID enumerates event types whose payload carries a jobId.
+// Mirrors the previous in-memory implementation.
 var eventTypesWithJobID = []string{
 	// Job Events (Driver Job)
 	"driverJobDefinitionEvent",
@@ -59,9 +77,101 @@ var eventTypesWithJobID = []string{
 	"actorDefinitionEvent",
 }
 
-func NewEventCollector(writer storage.StorageWriter, rootDir, sessionDir, nodeID, clusterName, clusterNamespace, sessionName string) *EventCollector {
+var nodeEventType = []string{"NODE_LIFECYCLE_EVENT", "NODE_DEFINITION_EVENT"}
+
+// activeFileState wraps the per-category append target.
+type activeFileState struct {
+	file        *os.File
+	writer      *bufio.Writer
+	path        string
+	category    string
+	sessionName string
+	nodeID      string
+	size        int64
+	createdAt   time.Time
+}
+
+// memEvent is the in-memory record used when CompressionEnabled is false.
+// Mirrors the legacy Event struct: captures the event payload along with the
+// nodeID/session snapshot taken at arrival time, so that periodic flushes
+// preserve the original sender attribution even if the collector's current
+// nodeID later changes.
+type memEvent struct {
+	data        map[string]interface{}
+	timestamp   time.Time
+	sessionName string
+	nodeID      string
+}
+
+// rotationTask describes a rotated JSONL file ready for compression + upload.
+type rotationTask struct {
+	jsonlPath   string
+	category    string
+	sessionName string
+	nodeID      string
+	createdAt   time.Time
+	size        int64
+}
+
+// EventCollector persists events to local disk as JSONL and asynchronously
+// compresses + uploads rotated files to remote storage.
+type EventCollector struct {
+	storageWriter storage.StorageWriter
+
+	stopped chan struct{} // closed after graceful shutdown completes
+
+	clusterNamespace   string
+	sessionDir         string
+	nodeID             string
+	clusterName        string
+	sessionName        string
+	root               string
+	currentSessionName string
+	currentNodeID      string
+
+	// Disk-first storage configuration.
+	dataDir            string
+	rotationInterval   time.Duration
+	maxFileSizeBytes   int64
+	maxDiskBytes       int64
+	compressionEnabled bool
+	flushInterval      time.Duration
+
+	writeMu       sync.Mutex
+	activeFiles   map[string]*activeFileState
+	rotationQueue chan rotationTask
+	totalDiskUsed atomic.Int64
+
+	// memEvents is the in-memory buffer used when compressionEnabled is
+	// false. Protected by writeMu.
+	memEvents []memEvent
+
+	workersWG sync.WaitGroup
+}
+
+// NewEventCollector constructs an EventCollector with disk-first storage.
+func NewEventCollector(
+	writer storage.StorageWriter,
+	rootDir, sessionDir, nodeID, clusterName, clusterNamespace, sessionName string,
+	opts Options,
+) *EventCollector {
+	if opts.DataDir == "" {
+		opts.DataDir = "/tmp/ray/event-data"
+	}
+	if opts.RotationInterval <= 0 {
+		opts.RotationInterval = defaultRotationInterval
+	}
+	if opts.MaxFileSizeBytes <= 0 {
+		opts.MaxFileSizeBytes = defaultMaxFileSizeBytes
+	}
+	if opts.MaxDiskBytes <= 0 {
+		opts.MaxDiskBytes = defaultMaxDiskBytes
+	}
+	if opts.FlushInterval <= 0 {
+		opts.FlushInterval = defaultFlushInterval
+	}
+
 	collector := &EventCollector{
-		events:             make([]Event, 0),
 		storageWriter:      writer,
 		root:               rootDir,
 		sessionDir:         sessionDir,
@@ -69,48 +179,90 @@ func NewEventCollector(writer storage.StorageWriter, rootDir, sessionDir, nodeID
 		clusterName:        clusterName,
 		clusterNamespace:   clusterNamespace,
 		sessionName:        sessionName,
-		mutex:              sync.Mutex{},
-		flushInterval:      time.Hour, // Default flush interval: 1 hour
+		currentSessionName: sessionName,
+		currentNodeID:      nodeID,
 		stopped:            make(chan struct{}),
-		currentSessionName: sessionName, // Initialize with configured sessionName
-		currentNodeID:      nodeID,      // Initialize with configured nodeID
+
+		dataDir:            opts.DataDir,
+		rotationInterval:   opts.RotationInterval,
+		maxFileSizeBytes:   opts.MaxFileSizeBytes,
+		maxDiskBytes:       opts.MaxDiskBytes,
+		compressionEnabled: opts.CompressionEnabled,
+		flushInterval:      opts.FlushInterval,
+		activeFiles:        make(map[string]*activeFileState),
+		rotationQueue:      make(chan rotationTask, rotationQueueSize),
 	}
 
-	// Start goroutine to watch nodeID file changes
+	// Start goroutine to watch nodeID file changes.
 	go collector.watchNodeIDFile()
 
 	return collector
 }
 
+// Run starts the HTTP server, rotation loop, compression/upload worker and
+// disk reconciler. It blocks until stop is closed.
 func (ec *EventCollector) Run(stop <-chan struct{}, port int) {
+	if ec.compressionEnabled {
+		if err := os.MkdirAll(ec.dataDir, 0o755); err != nil {
+			logrus.Errorf("Failed to create event data dir %s: %v", ec.dataDir, err)
+		}
+
+		// Initialize disk usage counter + resume any files left from a prior run.
+		ec.initDiskUsage()
+		ec.resumePendingFiles()
+	}
+
 	ws := new(restful.WebService)
 	ws.Path("/v1")
 	ws.Consumes(restful.MIME_JSON)
 	ws.Produces(restful.MIME_JSON)
-
 	ws.Route(ws.POST("/events").To(ec.PersistEvents))
-
 	restful.Add(ws)
 
 	go func() {
 		logrus.Infof("Starting event collector on port %d", port)
 		logrus.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
 	}()
-	go func() {
-		ec.periodicFlush()
-	}()
+
+	if ec.compressionEnabled {
+		ec.workersWG.Add(1)
+		go ec.rotationLoop()
+
+		ec.workersWG.Add(1)
+		go ec.compressionUploadWorker()
+
+		ec.workersWG.Add(1)
+		go ec.diskReconcileLoop()
+	} else {
+		logrus.Infof("Compression disabled: using in-memory buffer with flush interval %s", ec.flushInterval)
+		ec.workersWG.Add(1)
+		go ec.periodicMemFlushLoop()
+	}
 
 	<-stop
-	logrus.Info("Received stop signal, flushing events to storage")
-	ec.flushEvents()
-	close(ec.stopped)
+	logrus.Info("Received stop signal, draining events to storage")
+
+	// Signal workers to shut down. When the disk pipeline is active, rotate
+	// remaining active files so the upload worker can drain them. When the
+	// in-memory buffer is active, flush whatever is still buffered before
+	// stopping so no events are lost.
+	if ec.compressionEnabled {
+		close(ec.stopped)
+		ec.rotateAllFiles()
+	} else {
+		ec.flushAllMemEvents()
+		close(ec.stopped)
+	}
+
+	ec.workersWG.Wait()
 }
 
-// watchNodeIDFile watches the configured raylet_node_id file for content changes.
+// watchNodeIDFile watches the configured raylet_node_id file for content
+// changes; on change we rotate all active files so rotated content keeps the
+// old nodeID while subsequent writes use the new one.
 func (ec *EventCollector) watchNodeIDFile() {
 	nodeIDFilePath := utils.GetRayNodeIDPath()
 
-	// Create new watcher
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		logrus.Errorf("Failed to create file watcher: %v", err)
@@ -118,14 +270,10 @@ func (ec *EventCollector) watchNodeIDFile() {
 	}
 	defer watcher.Close()
 
-	// Add file to watch list
-	err = watcher.Add(nodeIDFilePath)
-	if err != nil {
-		logrus.Infof("Failed to add %s to watcher, will watch for file creation: %v", nodeIDFilePath, err)
-		// If file doesn't exist, watch parent directory
+	if err := watcher.Add(nodeIDFilePath); err != nil {
+		logrus.Infof("Failed to add %s to watcher, will watch parent directory: %v", nodeIDFilePath, err)
 		tmpRayRoot := utils.GetTmpRayRoot()
-		err = watcher.Add(tmpRayRoot)
-		if err != nil {
+		if err := watcher.Add(tmpRayRoot); err != nil {
 			logrus.Errorf("Failed to watch directory %s: %v", tmpRayRoot, err)
 			return
 		}
@@ -137,56 +285,48 @@ func (ec *EventCollector) watchNodeIDFile() {
 			if !ok {
 				return
 			}
-
-			// Check if this is the target file
-			if event.Name == nodeIDFilePath && (event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create) {
-				// Read file content
-				content, err := os.ReadFile(nodeIDFilePath)
-				if err != nil {
-					logrus.Errorf("Failed to read node ID file %s: %v", nodeIDFilePath, err)
-					continue
-				}
-
-				// Trim whitespace
-				newNodeID := strings.TrimSpace(string(content))
-				if newNodeID == "" {
-					continue
-				}
-
-				// Check if nodeID changed
-				ec.mutex.Lock()
-				if ec.currentNodeID != newNodeID {
-					oldNodeID := ec.currentNodeID
-					logrus.Infof("Node ID changed from %s to %s, flushing events", oldNodeID, newNodeID)
-
-					// Update current nodeID
-					ec.currentNodeID = newNodeID
-
-					// Collect events with same nodeID
-					var eventsToFlush []Event
-					var remainingEvents []Event
-					for _, event := range ec.events {
-						if event.NodeID == oldNodeID {
-							eventsToFlush = append(eventsToFlush, event)
-						} else if event.NodeID == newNodeID {
-							remainingEvents = append(remainingEvents, event)
-						} else {
-							logrus.Errorf("Drop event with nodeId %v, event: %v", event.NodeID, event.Data)
-						}
-					}
-
-					// Update event list, keep only events with different nodeID
-					ec.events = remainingEvents
-					ec.mutex.Unlock()
-
-					// Flush events with same nodeID
-					if len(eventsToFlush) > 0 {
-						go ec.flushEventsInternal(eventsToFlush)
-					}
-					continue
-				}
-				ec.mutex.Unlock()
+			if event.Name != nodeIDFilePath {
+				continue
 			}
+			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+				continue
+			}
+
+			content, err := os.ReadFile(nodeIDFilePath)
+			if err != nil {
+				logrus.Errorf("Failed to read node ID file %s: %v", nodeIDFilePath, err)
+				continue
+			}
+			newNodeID := strings.TrimSpace(string(content))
+			if newNodeID == "" {
+				continue
+			}
+
+			ec.writeMu.Lock()
+			if ec.currentNodeID == newNodeID {
+				ec.writeMu.Unlock()
+				continue
+			}
+			oldNodeID := ec.currentNodeID
+			logrus.Infof("Node ID changed from %s to %s, flushing/rotating events", oldNodeID, newNodeID)
+			ec.currentNodeID = newNodeID
+			if ec.compressionEnabled {
+				ec.rotateAllFilesLocked()
+				ec.writeMu.Unlock()
+			} else {
+				// Mirror legacy behavior: split buffered events by nodeID,
+				// flush those owned by the old nodeID, keep the ones already
+				// tagged with the new nodeID, drop anything else.
+				toFlush, dropped := ec.partitionMemEventsForNodeChangeLocked(oldNodeID, newNodeID)
+				ec.writeMu.Unlock()
+				if dropped > 0 {
+					logrus.Warnf("Dropped %d buffered events with stale nodeID during node change", dropped)
+				}
+				if len(toFlush) > 0 {
+					go ec.flushMemEventsInternal(toFlush)
+				}
+			}
+
 		case err, ok := <-watcher.Errors:
 			if !ok {
 				return
@@ -199,7 +339,18 @@ func (ec *EventCollector) watchNodeIDFile() {
 	}
 }
 
+// PersistEvents is the HTTP handler for POST /v1/events. When compression
+// is enabled it appends events to local JSONL files (rotated and uploaded
+// asynchronously). When compression is disabled it bypasses local disk and
+// uploads each request's events directly to remote storage.
 func (ec *EventCollector) PersistEvents(req *restful.Request, resp *restful.Response) {
+	// Disk pressure only applies when the local disk pipeline is in use.
+	if ec.compressionEnabled && ec.underDiskPressure() {
+		resp.AddHeader("Retry-After", "10")
+		resp.WriteErrorString(http.StatusServiceUnavailable, "event collector under disk pressure")
+		return
+	}
+
 	body, err := io.ReadAll(req.Request.Body)
 	if err != nil {
 		logrus.Errorf("Failed to read request body: %v", err)
@@ -214,190 +365,689 @@ func (ec *EventCollector) PersistEvents(req *restful.Request, resp *restful.Resp
 		return
 	}
 
+	if !ec.compressionEnabled {
+		ec.persistEventsBuffered(eventDatas, resp)
+		return
+	}
+
+	ec.writeMu.Lock()
+	defer ec.writeMu.Unlock()
+
+	touchedWriters := make(map[*activeFileState]struct{})
+
 	for _, eventData := range eventDatas {
-		// Parse timestamp
 		timestampStr, ok := eventData["timestamp"].(string)
 		if !ok {
 			logrus.Errorf("Event timestamp not found or not a string")
 			resp.WriteError(http.StatusBadRequest, fmt.Errorf("timestamp not found"))
 			return
 		}
-
-		// Get sessionName from event
 		sessionNameStr, ok := eventData["sessionName"].(string)
 		if !ok {
 			logrus.Errorf("Event sessionName not found or not a string")
 			resp.WriteError(http.StatusBadRequest, fmt.Errorf("sessionName not found"))
 			return
 		}
+		if _, err := time.Parse(time.RFC3339Nano, timestampStr); err != nil {
+			logrus.Errorf("Failed to parse timestamp: %v", err)
+			resp.WriteError(http.StatusBadRequest, err)
+			return
+		}
 
-		timestamp, err := time.Parse(time.RFC3339Nano, timestampStr)
+		// Session change: rotate all active files, then continue with the new session.
+		if ec.currentSessionName != sessionNameStr {
+			logrus.Infof("Session name changed from %s to %s, rotating active files", ec.currentSessionName, sessionNameStr)
+			ec.rotateAllFilesLocked()
+			ec.currentSessionName = sessionNameStr
+			touchedWriters = make(map[*activeFileState]struct{})
+		}
+
+		// Enrich event with the current node ID (matches prior behavior).
+		eventData["_nodeId"] = ec.currentNodeID
+
+		category := ec.categorize(eventData)
+
+		line, err := json.Marshal(eventData)
+		if err != nil {
+			logrus.Errorf("Failed to marshal event: %v", err)
+			continue
+		}
+
+		state, err := ec.getOrCreateActiveFileLocked(category, sessionNameStr)
+		if err != nil {
+			logrus.Errorf("Failed to open active file for %s: %v", category, err)
+			resp.WriteError(http.StatusInternalServerError, err)
+			return
+		}
+
+		n, err := state.writer.Write(line)
+		if err != nil {
+			logrus.Errorf("Failed to write event to %s: %v", state.path, err)
+			resp.WriteError(http.StatusInternalServerError, err)
+			return
+		}
+		m, err := state.writer.WriteString("\n")
+		if err != nil {
+			logrus.Errorf("Failed to write newline to %s: %v", state.path, err)
+			resp.WriteError(http.StatusInternalServerError, err)
+			return
+		}
+		written := int64(n + m)
+		state.size += written
+		ec.totalDiskUsed.Add(written)
+		touchedWriters[state] = struct{}{}
+	}
+
+	for state := range touchedWriters {
+		if err := state.writer.Flush(); err != nil {
+			logrus.Errorf("Failed to flush %s: %v", state.path, err)
+		}
+	}
+
+	resp.WriteHeader(http.StatusOK)
+}
+
+// persistEventsBuffered validates events and appends them to the in-memory
+// buffer. Used when CompressionEnabled is false. The buffer is flushed to
+// remote storage by periodicMemFlushLoop on the configured FlushInterval,
+// on node ID change, or on shutdown. This mirrors the legacy semantics:
+// events are grouped per (category, hour, nodeID, sessionName) at flush time
+// and uploaded as a JSON array to {root}/{cluster}_{ns}/{session}/{category}/
+// {nodeID}-{hour}.
+func (ec *EventCollector) persistEventsBuffered(eventDatas []map[string]interface{}, resp *restful.Response) {
+	for _, eventData := range eventDatas {
+		timestampStr, ok := eventData["timestamp"].(string)
+		if !ok {
+			logrus.Errorf("Event timestamp not found or not a string")
+			resp.WriteError(http.StatusBadRequest, fmt.Errorf("timestamp not found"))
+			return
+		}
+		sessionNameStr, ok := eventData["sessionName"].(string)
+		if !ok {
+			logrus.Errorf("Event sessionName not found or not a string")
+			resp.WriteError(http.StatusBadRequest, fmt.Errorf("sessionName not found"))
+			return
+		}
+		ts, err := time.Parse(time.RFC3339Nano, timestampStr)
 		if err != nil {
 			logrus.Errorf("Failed to parse timestamp: %v", err)
 			resp.WriteError(http.StatusBadRequest, err)
 			return
 		}
 
-		ec.mutex.Lock()
-		event := Event{
-			Data:        eventData,
-			Timestamp:   timestamp,
-			SessionName: sessionNameStr,
-			NodeID:      ec.currentNodeID, // Store currentNodeID when event arrived
-		}
-		ec.events = append(ec.events, event)
-
-		// Check if sessionName changed
-		if ec.currentSessionName != sessionNameStr {
-			logrus.Infof("Session name changed from %s to %s, flushing events", ec.currentSessionName, sessionNameStr)
-			// Save current events before flushing
-			eventsToFlush := make([]Event, len(ec.events))
-			copy(eventsToFlush, ec.events)
-
-			// Clear event list
-			ec.events = ec.events[:0]
-
-			// Update current sessionName
-			ec.currentSessionName = sessionNameStr
-
-			// Unlock before flushing
-			ec.mutex.Unlock()
-
-			// Flush previous events
-			ec.flushEventsInternal(eventsToFlush)
-			return
-		}
-		ec.mutex.Unlock()
-
-		logrus.Infof("Received event with ID: %v at %v, session: %s, node: %s", eventData["eventId"], timestamp, sessionNameStr, ec.currentNodeID)
+		// Snapshot currentNodeID inside the lock per-event to match the
+		// legacy behavior, so that a nodeID change mid-batch correctly
+		// attributes earlier events to the old node.
+		ec.writeMu.Lock()
+		ec.memEvents = append(ec.memEvents, memEvent{
+			data:        eventData,
+			timestamp:   ts,
+			sessionName: sessionNameStr,
+			nodeID:      ec.currentNodeID,
+		})
+		ec.writeMu.Unlock()
 	}
 
 	resp.WriteHeader(http.StatusOK)
 }
 
-func (ec *EventCollector) periodicFlush() {
+// periodicMemFlushLoop drains the in-memory buffer on a fixed interval.
+// Only started when CompressionEnabled is false.
+func (ec *EventCollector) periodicMemFlushLoop() {
+	defer ec.workersWG.Done()
 	ticker := time.NewTicker(ec.flushInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			logrus.Info("Periodic flush triggered")
-			ec.flushEvents()
+			ec.flushAllMemEvents()
 		case <-ec.stopped:
-			logrus.Info("Event collector stopped, exiting periodic flush")
 			return
 		}
 	}
 }
 
-func (ec *EventCollector) flushEvents() {
-	ec.mutex.Lock()
-	if len(ec.events) == 0 {
-		ec.mutex.Unlock()
-		logrus.Info("No events to flush")
+// flushAllMemEvents snapshots and uploads everything currently buffered.
+func (ec *EventCollector) flushAllMemEvents() {
+	ec.writeMu.Lock()
+	if len(ec.memEvents) == 0 {
+		ec.writeMu.Unlock()
+		return
+	}
+	toFlush := make([]memEvent, len(ec.memEvents))
+	copy(toFlush, ec.memEvents)
+	ec.memEvents = ec.memEvents[:0]
+	ec.writeMu.Unlock()
+
+	ec.flushMemEventsInternal(toFlush)
+}
+
+// partitionMemEventsForNodeChangeLocked splits the buffer on node-id change:
+// events tagged with oldNodeID are returned for immediate flush, events
+// tagged with newNodeID are retained for the next flush cycle, anything
+// else is dropped. Must be called with writeMu held.
+func (ec *EventCollector) partitionMemEventsForNodeChangeLocked(oldNodeID, newNodeID string) (toFlush []memEvent, dropped int) {
+	if len(ec.memEvents) == 0 {
+		return nil, 0
+	}
+	remaining := ec.memEvents[:0]
+	for _, evt := range ec.memEvents {
+		switch evt.nodeID {
+		case oldNodeID:
+			toFlush = append(toFlush, evt)
+		case newNodeID:
+			remaining = append(remaining, evt)
+		default:
+			dropped++
+		}
+	}
+	ec.memEvents = remaining
+	return toFlush, dropped
+}
+
+// flushMemEventsInternal groups events by (category, hour, nodeID,
+// sessionName) and uploads each group as a JSON array. Mirrors the legacy
+// flushEventsInternal grouping rules.
+func (ec *EventCollector) flushMemEventsInternal(events []memEvent) {
+	if len(events) == 0 {
 		return
 	}
 
-	// Copy current event list
-	eventsToFlush := make([]Event, len(ec.events))
-	copy(eventsToFlush, ec.events)
+	type bucket struct {
+		category    string
+		hourKey     string
+		nodeID      string
+		sessionName string
+		events      []memEvent
+	}
+	buckets := make(map[string]*bucket)
+	for _, evt := range events {
+		hourKey := evt.timestamp.Truncate(time.Hour).Format("2006-01-02-15")
+		category := ec.categorize(evt.data)
+		key := category + "|" + hourKey + "|" + evt.nodeID + "|" + evt.sessionName
+		b, ok := buckets[key]
+		if !ok {
+			b = &bucket{
+				category:    category,
+				hourKey:     hourKey,
+				nodeID:      evt.nodeID,
+				sessionName: evt.sessionName,
+			}
+			buckets[key] = b
+		}
+		b.events = append(b.events, evt)
+	}
 
-	// Clear event list
-	ec.events = ec.events[:0]
-	ec.mutex.Unlock()
+	var wg sync.WaitGroup
+	for _, b := range buckets {
+		wg.Add(1)
+		go func(b *bucket) {
+			defer wg.Done()
+			if err := ec.uploadMemBucket(b.category, b.hourKey, b.nodeID, b.sessionName, b.events); err != nil {
+				logrus.Errorf("Failed to upload bucket %s/%s: %v", b.category, b.hourKey, err)
+			}
+		}(b)
+	}
+	wg.Wait()
 
-	// Execute flush operation
-	ec.flushEventsInternal(eventsToFlush)
+	logrus.Infof("Flushed %d buffered events across %d buckets", len(events), len(buckets))
 }
 
-// flushEventsInternal performs the actual event flush
-func (ec *EventCollector) flushEventsInternal(eventsToFlush []Event) {
-	// Group events by hour and type
-	nodeEventsByHour := make(map[string][]Event) // Node-related events
-	jobEventsByHour := make(map[string][]Event)  // Job-related events
+// uploadMemBucket serializes a single bucket to a JSON array and uploads it
+// to the legacy storage key format (no extension, no nano suffix).
+func (ec *EventCollector) uploadMemBucket(category, hourKey, nodeID, sessionName string, events []memEvent) error {
+	if sessionName == "" {
+		sessionName = ec.sessionName
+	}
+	if nodeID == "" {
+		nodeID = ec.nodeID
+	}
 
-	// Categorize events
-	for _, event := range eventsToFlush {
-		hourKey := event.Timestamp.Truncate(time.Hour).Format("2006-01-02-15")
+	payload := make([]map[string]interface{}, len(events))
+	for i, e := range events {
+		payload[i] = e.data
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal bucket: %w", err)
+	}
 
-		// Check event type
-		if isNodeEvent(event.Data) {
-			// Node-related events
-			nodeEventsByHour[hourKey] = append(nodeEventsByHour[hourKey], event)
-		} else if jobID := getJobID(event.Data); jobID != "" {
-			// Job-related events, use jobID-hour as key
-			jobKey := fmt.Sprintf("%s-%s", jobID, hourKey)
-			jobEventsByHour[jobKey] = append(jobEventsByHour[jobKey], event)
-		} else {
-			// Default to node events
-			nodeEventsByHour[hourKey] = append(nodeEventsByHour[hourKey], event)
+	key := ec.buildLegacyEventStorageKey(category, hourKey, nodeID, sessionName)
+	if err := ec.storageWriter.CreateDirectory(path.Dir(key)); err != nil {
+		return fmt.Errorf("create remote dir %s: %w", path.Dir(key), err)
+	}
+	if err := ec.storageWriter.WriteFile(key, bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("upload %s: %w", key, err)
+	}
+	logrus.Infof("Flushed %d events to %s", len(events), key)
+	return nil
+}
+
+// buildLegacyEventStorageKey constructs the remote storage key in the
+// legacy format (no extension, no nano suffix), used by the in-memory
+// buffered path:
+//
+//	Node events: {root}/{clusterName}_{namespace}/{sessionName}/node_events/{nodeID}-{hour}
+//	Job events:  {root}/{clusterName}_{namespace}/{sessionName}/job_events/{jobID}/{nodeID}-{hour}
+func (ec *EventCollector) buildLegacyEventStorageKey(category, hourKey, nodeID, sessionName string) string {
+	return path.Join(
+		ec.root,
+		ec.clusterKey(),
+		sessionName,
+		category,
+		fmt.Sprintf("%s-%s", nodeID, hourKey),
+	)
+}
+
+// categorize determines the storage category path for an event.
+// - NODE_* events → "node_events"
+// - others with a jobID → "job_events/{jobID}"
+// - fallback → "node_events" (matches previous behavior)
+func (ec *EventCollector) categorize(eventData map[string]interface{}) string {
+	if isNodeEvent(eventData) {
+		return categoryNodeEvents
+	}
+	if jobID := getJobID(eventData); jobID != "" {
+		return path.Join(categoryJobPrefix, jobID)
+	}
+	return categoryNodeEvents
+}
+
+// getOrCreateActiveFileLocked returns the active file for a category,
+// opening one lazily if necessary. Must be called with writeMu held.
+func (ec *EventCollector) getOrCreateActiveFileLocked(category, sessionName string) (*activeFileState, error) {
+	if state, ok := ec.activeFiles[category]; ok {
+		return state, nil
+	}
+	return ec.openNewActiveFileLocked(category, sessionName)
+}
+
+// openNewActiveFileLocked opens a fresh JSONL file for the given category.
+// Must be called with writeMu held.
+func (ec *EventCollector) openNewActiveFileLocked(category, sessionName string) (*activeFileState, error) {
+	dir := filepath.Join(ec.dataDir, ec.clusterKey(), category)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+
+	createdAt := time.Now()
+	nodeID := ec.currentNodeID
+	fileName := fmt.Sprintf("%s_%d.jsonl", sanitizeFileComponent(nodeID), createdAt.UnixNano())
+	fullPath := filepath.Join(dir, fileName)
+
+	f, err := os.OpenFile(fullPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", fullPath, err)
+	}
+
+	state := &activeFileState{
+		file:        f,
+		writer:      bufio.NewWriterSize(f, bufWriterSize),
+		path:        fullPath,
+		category:    category,
+		sessionName: sessionName,
+		nodeID:      nodeID,
+		createdAt:   createdAt,
+	}
+	ec.activeFiles[category] = state
+	return state, nil
+}
+
+// clusterKey returns "{clusterName}_{namespace}" used as dataDir subdirectory.
+func (ec *EventCollector) clusterKey() string {
+	return fmt.Sprintf("%s_%s", ec.clusterName, ec.clusterNamespace)
+}
+
+// rotationLoop periodically checks rotation conditions for each active file.
+func (ec *EventCollector) rotationLoop() {
+	defer ec.workersWG.Done()
+	ticker := time.NewTicker(rotationCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			ec.checkRotation()
+		case <-ec.stopped:
+			return
+		}
+	}
+}
+
+func (ec *EventCollector) checkRotation() {
+	ec.writeMu.Lock()
+	defer ec.writeMu.Unlock()
+
+	now := time.Now()
+	for category, state := range ec.activeFiles {
+		if now.Sub(state.createdAt) >= ec.rotationInterval || state.size >= ec.maxFileSizeBytes {
+			if err := ec.rotateFileLocked(category); err != nil {
+				logrus.Errorf("Failed to rotate %s: %v", category, err)
+			}
+		}
+	}
+}
+
+// rotateAllFiles rotates every active file. Safe to call from any goroutine.
+func (ec *EventCollector) rotateAllFiles() {
+	ec.writeMu.Lock()
+	defer ec.writeMu.Unlock()
+	ec.rotateAllFilesLocked()
+}
+
+// rotateAllFilesLocked rotates every active file. Must be called with writeMu held.
+func (ec *EventCollector) rotateAllFilesLocked() {
+	for category := range ec.activeFiles {
+		if err := ec.rotateFileLocked(category); err != nil {
+			logrus.Errorf("Failed to rotate %s: %v", category, err)
+		}
+	}
+}
+
+// rotateFileLocked closes the active file for a category and queues it for
+// compression + upload. Must be called with writeMu held.
+func (ec *EventCollector) rotateFileLocked(category string) error {
+	state, ok := ec.activeFiles[category]
+	if !ok {
+		return nil
+	}
+	delete(ec.activeFiles, category)
+
+	if err := state.writer.Flush(); err != nil {
+		logrus.Errorf("Failed to flush %s before rotation: %v", state.path, err)
+	}
+	if err := state.file.Sync(); err != nil {
+		logrus.Warnf("Failed to sync %s before rotation: %v", state.path, err)
+	}
+	if err := state.file.Close(); err != nil {
+		logrus.Errorf("Failed to close %s before rotation: %v", state.path, err)
+	}
+
+	// Empty file: drop it without uploading to avoid useless uploads.
+	if state.size == 0 {
+		if err := os.Remove(state.path); err != nil && !os.IsNotExist(err) {
+			logrus.Warnf("Failed to remove empty rotated file %s: %v", state.path, err)
+		}
+		return nil
+	}
+
+	task := rotationTask{
+		jsonlPath:   state.path,
+		category:    state.category,
+		sessionName: state.sessionName,
+		nodeID:      state.nodeID,
+		createdAt:   state.createdAt,
+		size:        state.size,
+	}
+
+	select {
+	case ec.rotationQueue <- task:
+	default:
+		logrus.Warnf("rotation queue full, scheduling retry for %s", state.path)
+		go func(t rotationTask) {
+			time.Sleep(5 * time.Second)
+			select {
+			case ec.rotationQueue <- t:
+			case <-ec.stopped:
+			}
+		}(task)
+	}
+	return nil
+}
+
+// compressionUploadWorker drains rotationQueue.
+func (ec *EventCollector) compressionUploadWorker() {
+	defer ec.workersWG.Done()
+
+	drain := func() {
+		for {
+			select {
+			case task := <-ec.rotationQueue:
+				ec.processRotatedFile(task)
+			default:
+				return
+			}
 		}
 	}
 
-	// Upload all events concurrently
-	var wg sync.WaitGroup
-	errChan := make(chan error, len(nodeEventsByHour)+len(jobEventsByHour))
-
-	// Upload node-related events
-	for hour, events := range nodeEventsByHour {
-		wg.Add(1)
-		go func(hourKey string, hourEvents []Event) {
-			defer wg.Done()
-			if err := ec.flushNodeEventsForHour(hourKey, hourEvents); err != nil {
-				errChan <- err
-			}
-		}(hour, events)
+	for {
+		select {
+		case task := <-ec.rotationQueue:
+			ec.processRotatedFile(task)
+		case <-ec.stopped:
+			drain()
+			return
+		}
 	}
-
-	// Upload job-related events
-	for jobHour, events := range jobEventsByHour {
-		wg.Add(1)
-		go func(jobHourKey string, hourEvents []Event) {
-			defer wg.Done()
-			// Split jobID and hourKey
-			parts := strings.SplitN(jobHourKey, "-", 4) // Date format has 3 dashes, so use 4 parts
-			if len(parts) < 4 {
-				errChan <- fmt.Errorf("invalid job hour key: %s", jobHourKey)
-				return
-			}
-
-			jobID := parts[0]
-			hourKey := strings.Join(parts[1:], "-") // Rejoin time parts as hourKey
-
-			if err := ec.flushJobEventsForHour(jobID, hourKey, hourEvents); err != nil {
-				errChan <- err
-			}
-		}(jobHour, events)
-	}
-
-	wg.Wait()
-	close(errChan)
-
-	// Check for errors
-	for err := range errChan {
-		logrus.Errorf("Error flushing events: %v", err)
-	}
-
-	totalEvents := len(eventsToFlush)
-	logrus.Infof("Successfully flushed %d events to storage (%d node events, %d job events)",
-		totalEvents,
-		countEventsInMap(nodeEventsByHour),
-		countEventsInMap(jobEventsByHour))
 }
 
-// countEventsInMap counts total events in map
-func countEventsInMap(eventsMap map[string][]Event) int {
-	count := 0
-	for _, events := range eventsMap {
-		count += len(events)
+// processRotatedFile gzips the file (unless disabled), uploads it, then
+// cleans up the local copies.
+func (ec *EventCollector) processRotatedFile(task rotationTask) {
+	uploadPath := task.jsonlPath
+	var compressedPath string
+
+	if ec.compressionEnabled {
+		gzPath := task.jsonlPath + ".gz"
+		if err := gzipFile(task.jsonlPath, gzPath); err != nil {
+			logrus.Errorf("Failed to compress %s: %v", task.jsonlPath, err)
+			// Leave the .jsonl file for retry on next restart.
+			return
+		}
+		uploadPath = gzPath
+		compressedPath = gzPath
+		if info, err := os.Stat(gzPath); err == nil {
+			ec.totalDiskUsed.Add(info.Size())
+		}
 	}
-	return count
+
+	key := ec.buildEventStorageKey(task)
+
+	f, err := os.Open(uploadPath)
+	if err != nil {
+		logrus.Errorf("Failed to open %s for upload: %v", uploadPath, err)
+		return
+	}
+
+	// Ensure parent directory exists in remote storage (best-effort).
+	if err := ec.storageWriter.CreateDirectory(path.Dir(key)); err != nil {
+		logrus.Warnf("Failed to create remote directory %s: %v", path.Dir(key), err)
+	}
+
+	if err := ec.storageWriter.WriteFile(key, f); err != nil {
+		f.Close()
+		logrus.Errorf("Failed to upload %s to %s: %v", uploadPath, key, err)
+		// Keep both local files for retry on next restart.
+		return
+	}
+	f.Close()
+
+	// Clean up local files (decrement accounting best-effort).
+	if info, err := os.Stat(task.jsonlPath); err == nil {
+		ec.totalDiskUsed.Add(-info.Size())
+	}
+	if err := os.Remove(task.jsonlPath); err != nil && !os.IsNotExist(err) {
+		logrus.Warnf("Failed to remove %s after upload: %v", task.jsonlPath, err)
+	}
+
+	if compressedPath != "" {
+		if info, err := os.Stat(compressedPath); err == nil {
+			ec.totalDiskUsed.Add(-info.Size())
+		}
+		if err := os.Remove(compressedPath); err != nil && !os.IsNotExist(err) {
+			logrus.Warnf("Failed to remove %s after upload: %v", compressedPath, err)
+		}
+	}
+
+	logrus.Infof("Uploaded %d bytes to %s", task.size, key)
 }
 
-var nodeEventType = []string{"NODE_LIFECYCLE_EVENT", "NODE_DEFINITION_EVENT"}
+// buildEventStorageKey constructs the remote storage key for a rotated file.
+// Format includes a UnixNano suffix to avoid collisions when multiple files
+// are rotated within the same hour for the same nodeID+category:
+//
+//	Node events: {root}/{clusterName}_{namespace}/{sessionName}/node_events/{nodeID}-{hour}-{nanoTs}.jsonl.gz
+//	Job events:  {root}/{clusterName}_{namespace}/{sessionName}/job_events/{jobID}/{nodeID}-{hour}-{nanoTs}.jsonl.gz
+func (ec *EventCollector) buildEventStorageKey(task rotationTask) string {
+	hour := task.createdAt.Truncate(time.Hour).Format("2006-01-02-15")
+	sessionName := task.sessionName
+	if sessionName == "" {
+		sessionName = ec.sessionName
+	}
+	nodeID := task.nodeID
+	if nodeID == "" {
+		nodeID = ec.nodeID
+	}
 
-// isNodeEvent checks if event is node-related
+	ext := ".jsonl"
+	if ec.compressionEnabled {
+		ext = ".jsonl.gz"
+	}
+
+	fileName := fmt.Sprintf("%s-%s-%d%s", nodeID, hour, task.createdAt.UnixNano(), ext)
+	return path.Join(
+		ec.root,
+		ec.clusterKey(),
+		sessionName,
+		task.category,
+		fileName,
+	)
+}
+
+// diskReconcileLoop periodically reconciles totalDiskUsed with a real
+// directory walk to correct any drift.
+func (ec *EventCollector) diskReconcileLoop() {
+	defer ec.workersWG.Done()
+	ticker := time.NewTicker(diskReconcileInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if actual, err := dirSize(ec.dataDir); err == nil {
+				ec.totalDiskUsed.Store(actual)
+			} else {
+				logrus.Warnf("Failed to reconcile disk usage: %v", err)
+			}
+		case <-ec.stopped:
+			return
+		}
+	}
+}
+
+// initDiskUsage initializes the disk usage counter by walking dataDir once.
+func (ec *EventCollector) initDiskUsage() {
+	if size, err := dirSize(ec.dataDir); err == nil {
+		ec.totalDiskUsed.Store(size)
+	} else {
+		logrus.Warnf("Failed to compute initial disk usage for %s: %v", ec.dataDir, err)
+	}
+}
+
+// resumePendingFiles enqueues any files left behind by a prior run for upload.
+// Pre-existing .jsonl files are treated as rotated (already-closed) and
+// compressed+uploaded. Pre-existing .jsonl.gz files are re-uploaded directly.
+func (ec *EventCollector) resumePendingFiles() {
+	clusterRoot := filepath.Join(ec.dataDir, ec.clusterKey())
+	entries, err := os.Stat(clusterRoot)
+	if err != nil || !entries.IsDir() {
+		return
+	}
+
+	_ = filepath.Walk(clusterRoot, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(clusterRoot, p)
+		if err != nil {
+			return nil
+		}
+		// rel is like "node_events/<file>" or "job_events/<jobID>/<file>".
+		parts := strings.Split(filepath.ToSlash(rel), "/")
+		if len(parts) < 2 {
+			return nil
+		}
+		var category string
+		switch parts[0] {
+		case categoryNodeEvents:
+			category = categoryNodeEvents
+		case categoryJobPrefix:
+			if len(parts) < 3 {
+				return nil
+			}
+			category = path.Join(categoryJobPrefix, parts[1])
+		default:
+			return nil
+		}
+
+		name := info.Name()
+		task := rotationTask{
+			jsonlPath:   p,
+			category:    category,
+			sessionName: ec.currentSessionName,
+			nodeID:      ec.currentNodeID,
+			createdAt:   info.ModTime(),
+			size:        info.Size(),
+		}
+
+		switch {
+		case strings.HasSuffix(name, ".jsonl.gz"):
+			// Already compressed: upload as-is by pretending the jsonlPath is the .gz
+			// and disabling further compression for this task.
+			go ec.uploadOnly(task, p)
+		case strings.HasSuffix(name, ".jsonl"):
+			select {
+			case ec.rotationQueue <- task:
+			default:
+				logrus.Warnf("rotation queue full during resume, deferring %s", p)
+			}
+		}
+		return nil
+	})
+}
+
+// uploadOnly uploads a pre-existing compressed file to remote storage and
+// removes it locally. Used during startup resume for .jsonl.gz leftovers.
+func (ec *EventCollector) uploadOnly(task rotationTask, gzPath string) {
+	key := ec.buildEventStorageKey(task)
+	f, err := os.Open(gzPath)
+	if err != nil {
+		logrus.Errorf("Failed to open %s for resume upload: %v", gzPath, err)
+		return
+	}
+	if err := ec.storageWriter.CreateDirectory(path.Dir(key)); err != nil {
+		logrus.Warnf("Failed to create remote directory %s: %v", path.Dir(key), err)
+	}
+	if err := ec.storageWriter.WriteFile(key, f); err != nil {
+		f.Close()
+		logrus.Errorf("Failed to resume upload %s to %s: %v", gzPath, key, err)
+		return
+	}
+	f.Close()
+	if info, err := os.Stat(gzPath); err == nil {
+		ec.totalDiskUsed.Add(-info.Size())
+	}
+	if err := os.Remove(gzPath); err != nil && !os.IsNotExist(err) {
+		logrus.Warnf("Failed to remove %s after resume upload: %v", gzPath, err)
+	}
+	logrus.Infof("Resumed upload to %s", key)
+}
+
+// underDiskPressure reports whether new events should be rejected.
+func (ec *EventCollector) underDiskPressure() bool {
+	if ec.maxDiskBytes <= 0 {
+		return false
+	}
+	threshold := int64(float64(ec.maxDiskBytes) * diskPressureWatermark)
+	return ec.totalDiskUsed.Load() >= threshold
+}
+
+// isNodeEvent checks if event is node-related.
 func isNodeEvent(eventData map[string]interface{}) bool {
 	eventType, ok := eventData["eventType"].(string)
 	if !ok {
@@ -411,7 +1061,7 @@ func isNodeEvent(eventData map[string]interface{}) bool {
 	return false
 }
 
-// getJobID gets jobID associated with event
+// getJobID extracts a jobId from known nested event payloads.
 func getJobID(eventData map[string]interface{}) string {
 	for _, eventType := range eventTypesWithJobID {
 		if nestedEvent, ok := eventData[eventType].(map[string]interface{}); ok {
@@ -420,107 +1070,57 @@ func getJobID(eventData map[string]interface{}) string {
 			}
 		}
 	}
-
 	return ""
 }
 
-// flushNodeEventsForHour flushes node events to storage
-func (ec *EventCollector) flushNodeEventsForHour(hourKey string, events []Event) error {
-	// Create event data
-	eventsData := make([]map[string]interface{}, len(events))
-	for i, event := range events {
-		eventsData[i] = event.Data
-	}
-
-	data, err := json.Marshal(eventsData)
+// gzipFile compresses src into dst using gzip.
+func gzipFile(src, dst string) error {
+	in, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("failed to marshal node events: %w", err)
+		return err
 	}
+	defer in.Close()
 
-	reader := bytes.NewReader(data)
-
-	// Use sessionName from event, not config
-	sessionNameToUse := ec.sessionName // Default to configured sessionName
-	if len(events) > 0 && events[0].SessionName != "" {
-		sessionNameToUse = events[0].SessionName
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
 	}
+	defer out.Close()
 
-	// Use NodeID from event, not current NodeID
-	nodeIDToUse := ec.nodeID // Default to configured nodeID
-	if len(events) > 0 && events[0].NodeID != "" {
-		nodeIDToUse = events[0].NodeID
+	gz := gzip.NewWriter(out)
+	if _, err := io.Copy(gz, in); err != nil {
+		gz.Close()
+		return err
 	}
-
-	// Build node event storage path using event's nodeID
-	basePath := path.Join(
-		ec.root,
-		fmt.Sprintf("%s_%s", ec.clusterName, ec.clusterNamespace),
-		sessionNameToUse,
-		"node_events",
-		fmt.Sprintf("%s-%s", nodeIDToUse, hourKey))
-
-	// Ensure storage directory exists
-	dir := path.Dir(basePath)
-	if err := ec.storageWriter.CreateDirectory(dir); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	if err := gz.Close(); err != nil {
+		return err
 	}
-
-	// Write event file
-	if err := ec.storageWriter.WriteFile(basePath, reader); err != nil {
-		return fmt.Errorf("failed to write node events file %s: %w", basePath, err)
-	}
-
-	logrus.Infof("Successfully flushed %d node events for hour %s to %s, context: %s", len(events), hourKey, basePath, string(data))
-	return nil
+	return out.Sync()
 }
 
-// flushJobEventsForHour flushes job events to storage
-func (ec *EventCollector) flushJobEventsForHour(jobID, hourKey string, events []Event) error {
-	// Create event data
-	eventsData := make([]map[string]interface{}, len(events))
-	for i, event := range events {
-		eventsData[i] = event.Data
+// dirSize returns the total byte size of files under root.
+func dirSize(root string) (int64, error) {
+	var total int64
+	err := filepath.Walk(root, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total, err
+}
+
+// sanitizeFileComponent replaces path separators in filename components.
+func sanitizeFileComponent(s string) string {
+	if s == "" {
+		return "unknown"
 	}
-
-	data, err := json.Marshal(eventsData)
-	if err != nil {
-		return fmt.Errorf("failed to marshal job events: %w", err)
-	}
-
-	reader := bytes.NewReader(data)
-
-	// Use sessionName from event, not config
-	sessionNameToUse := ec.sessionName // Default to configured sessionName
-	if len(events) > 0 && events[0].SessionName != "" {
-		sessionNameToUse = events[0].SessionName
-	}
-
-	// Use NodeID from event, not current NodeID
-	nodeIDToUse := ec.nodeID // Default to configured nodeID
-	if len(events) > 0 && events[0].NodeID != "" {
-		nodeIDToUse = events[0].NodeID
-	}
-
-	// Build job event storage path using event's nodeID
-	basePath := path.Join(
-		ec.root,
-		fmt.Sprintf("%s_%s", ec.clusterName, ec.clusterNamespace),
-		sessionNameToUse,
-		"job_events",
-		jobID,
-		fmt.Sprintf("%s-%s", nodeIDToUse, hourKey))
-
-	// Ensure storage directory exists
-	dir := path.Dir(basePath)
-	if err := ec.storageWriter.CreateDirectory(dir); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", dir, err)
-	}
-
-	// Write event file
-	if err := ec.storageWriter.WriteFile(basePath, reader); err != nil {
-		return fmt.Errorf("failed to write job events file %s: %w", basePath, err)
-	}
-
-	logrus.Infof("Successfully flushed %d job events for job %s hour %s to %s", len(events), jobID, hourKey, basePath)
-	return nil
+	replacer := strings.NewReplacer("/", "_", string(os.PathSeparator), "_", " ", "_")
+	return replacer.Replace(s)
 }

--- a/historyserver/pkg/collector/eventcollector/eventcollector_test.go
+++ b/historyserver/pkg/collector/eventcollector/eventcollector_test.go
@@ -1,0 +1,717 @@
+package eventcollector
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------- Test-local MockWriter (thread-safe) ----------
+
+type mockWriter struct {
+	mu    sync.Mutex
+	dirs  map[string]bool
+	files map[string][]byte
+	// failNext causes the next WriteFile call to fail.
+	failNext bool
+}
+
+func newMockWriter() *mockWriter {
+	return &mockWriter{
+		dirs:  make(map[string]bool),
+		files: make(map[string][]byte),
+	}
+}
+
+func (m *mockWriter) CreateDirectory(p string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dirs[p] = true
+	return nil
+}
+
+func (m *mockWriter) WriteFile(file string, reader io.ReadSeeker) error {
+	m.mu.Lock()
+	if m.failNext {
+		m.failNext = false
+		m.mu.Unlock()
+		return assertErr("mock write failure")
+	}
+	m.mu.Unlock()
+
+	b, err := io.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.files[file] = b
+	return nil
+}
+
+func (m *mockWriter) get(file string) ([]byte, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.files[file]
+	return v, ok
+}
+
+func (m *mockWriter) fileKeys() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	keys := make([]string, 0, len(m.files))
+	for k := range m.files {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }
+
+// ---------- Helpers ----------
+
+// newTestCollector builds an EventCollector without starting Run(), so tests
+// do not spawn the nodeID watcher or HTTP server.
+func newTestCollector(t *testing.T, writer *mockWriter, opts Options) *EventCollector {
+	t.Helper()
+	if opts.DataDir == "" {
+		opts.DataDir = t.TempDir()
+	}
+	if opts.RotationInterval == 0 {
+		opts.RotationInterval = 5 * time.Minute
+	}
+	if opts.MaxFileSizeBytes == 0 {
+		opts.MaxFileSizeBytes = defaultMaxFileSizeBytes
+	}
+	if opts.MaxDiskBytes == 0 {
+		opts.MaxDiskBytes = defaultMaxDiskBytes
+	}
+
+	return &EventCollector{
+		storageWriter:      writer,
+		root:               "history",
+		sessionDir:         "/tmp/ray/session_latest",
+		nodeID:             "node-1",
+		clusterName:        "cluster",
+		clusterNamespace:   "ns",
+		sessionName:        "session_abc",
+		currentSessionName: "session_abc",
+		currentNodeID:      "node-1",
+		stopped:            make(chan struct{}),
+		dataDir:            opts.DataDir,
+		rotationInterval:   opts.RotationInterval,
+		maxFileSizeBytes:   opts.MaxFileSizeBytes,
+		maxDiskBytes:       opts.MaxDiskBytes,
+		compressionEnabled: opts.CompressionEnabled,
+		activeFiles:        make(map[string]*activeFileState),
+		rotationQueue:      make(chan rotationTask, rotationQueueSize),
+	}
+}
+
+// ---------- Pure helper function tests ----------
+
+func TestIsNodeEvent(t *testing.T) {
+	assert.True(t, isNodeEvent(map[string]interface{}{"eventType": "NODE_LIFECYCLE_EVENT"}))
+	assert.True(t, isNodeEvent(map[string]interface{}{"eventType": "NODE_DEFINITION_EVENT"}))
+	assert.False(t, isNodeEvent(map[string]interface{}{"eventType": "TASK_DEFINITION_EVENT"}))
+	assert.False(t, isNodeEvent(map[string]interface{}{}))
+}
+
+func TestGetJobID(t *testing.T) {
+	evt := map[string]interface{}{
+		"driverJobLifecycleEvent": map[string]interface{}{"jobId": "job-42"},
+	}
+	assert.Equal(t, "job-42", getJobID(evt))
+
+	evt2 := map[string]interface{}{
+		"taskDefinitionEvent": map[string]interface{}{"jobId": 7},
+	}
+	assert.Equal(t, "7", getJobID(evt2))
+
+	assert.Equal(t, "", getJobID(map[string]interface{}{}))
+	assert.Equal(t, "", getJobID(map[string]interface{}{"taskDefinitionEvent": map[string]interface{}{}}))
+}
+
+func TestCategorize(t *testing.T) {
+	ec := &EventCollector{}
+	assert.Equal(t, categoryNodeEvents,
+		ec.categorize(map[string]interface{}{"eventType": "NODE_LIFECYCLE_EVENT"}))
+
+	assert.Equal(t, path.Join(categoryJobPrefix, "job-1"),
+		ec.categorize(map[string]interface{}{
+			"eventType":           "TASK_DEFINITION_EVENT",
+			"taskDefinitionEvent": map[string]interface{}{"jobId": "job-1"},
+		}))
+
+	// fallback: neither node event nor recognizable jobID → node_events
+	assert.Equal(t, categoryNodeEvents,
+		ec.categorize(map[string]interface{}{"eventType": "UNKNOWN"}))
+}
+
+func TestSanitizeFileComponent(t *testing.T) {
+	assert.Equal(t, "unknown", sanitizeFileComponent(""))
+	assert.Equal(t, "a_b", sanitizeFileComponent("a/b"))
+	assert.Equal(t, "a_b_c", sanitizeFileComponent("a b/c"))
+}
+
+func TestGzipFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "in.txt")
+	require.NoError(t, os.WriteFile(src, []byte("hello world\nhello world\n"), 0o644))
+	dst := src + ".gz"
+
+	require.NoError(t, gzipFile(src, dst))
+
+	raw, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	gr, err := gzip.NewReader(bytes.NewReader(raw))
+	require.NoError(t, err)
+	defer gr.Close()
+	out, err := io.ReadAll(gr)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world\nhello world\n", string(out))
+}
+
+func TestDirSize(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a"), []byte("12345"), 0o644))
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "b"), []byte("abcdefg"), 0o644))
+
+	size, err := dirSize(dir)
+	require.NoError(t, err)
+	assert.Equal(t, int64(12), size)
+}
+
+// ---------- buildEventStorageKey ----------
+
+func TestBuildEventStorageKey_NodeEventsGzip(t *testing.T) {
+	ec := newTestCollector(t, newMockWriter(), Options{CompressionEnabled: true})
+	ts := time.Date(2026, 5, 13, 10, 30, 0, 0, time.UTC)
+	key := ec.buildEventStorageKey(rotationTask{
+		category:    categoryNodeEvents,
+		sessionName: "session_abc",
+		nodeID:      "node-1",
+		createdAt:   ts,
+	})
+	assert.Equal(t, fmt.Sprintf("history/cluster_ns/session_abc/node_events/node-1-2026-05-13-10-%d.jsonl.gz", ts.UnixNano()), key)
+}
+
+func TestBuildEventStorageKey_JobEventsNoCompression(t *testing.T) {
+	ec := newTestCollector(t, newMockWriter(), Options{CompressionEnabled: false})
+	ts := time.Date(2026, 1, 2, 3, 0, 0, 0, time.UTC)
+	key := ec.buildEventStorageKey(rotationTask{
+		category:    path.Join(categoryJobPrefix, "job-7"),
+		sessionName: "session_xyz",
+		nodeID:      "nX",
+		createdAt:   ts,
+	})
+	assert.Equal(t, fmt.Sprintf("history/cluster_ns/session_xyz/job_events/job-7/nX-2026-01-02-03-%d.jsonl", ts.UnixNano()), key)
+}
+
+// ---------- openNewActiveFile / rotateFileLocked ----------
+
+func TestOpenNewActiveFile_CreatesJSONLFile(t *testing.T) {
+	ec := newTestCollector(t, newMockWriter(), Options{})
+	state, err := ec.openNewActiveFileLocked(categoryNodeEvents, ec.currentSessionName)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	defer state.file.Close()
+
+	assert.True(t, strings.HasSuffix(state.path, ".jsonl"))
+	assert.Contains(t, state.path,
+		filepath.Join(ec.dataDir, "cluster_ns", categoryNodeEvents))
+
+	// File must exist on disk.
+	_, err = os.Stat(state.path)
+	require.NoError(t, err)
+	assert.Equal(t, "node-1", state.nodeID)
+}
+
+func TestRotateFileLocked_EmptyFileIsDropped(t *testing.T) {
+	writer := newMockWriter()
+	ec := newTestCollector(t, writer, Options{})
+
+	state, err := ec.openNewActiveFileLocked(categoryNodeEvents, ec.currentSessionName)
+	require.NoError(t, err)
+
+	jsonlPath := state.path
+	require.NoError(t, ec.rotateFileLocked(categoryNodeEvents))
+
+	// Empty file should be removed, and no rotation task should have been queued.
+	_, err = os.Stat(jsonlPath)
+	assert.True(t, os.IsNotExist(err))
+	assert.Empty(t, ec.rotationQueue)
+}
+
+// ---------- End-to-end: PersistEvents writes JSONL & rotation uploads gzip ----------
+
+func callPersistEvents(t *testing.T, ec *EventCollector, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/events", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", restful.MIME_JSON)
+	rec := httptest.NewRecorder()
+
+	req := restful.NewRequest(httpReq)
+	resp := restful.NewResponse(rec)
+	resp.SetRequestAccepts(restful.MIME_JSON)
+
+	ec.PersistEvents(req, resp)
+	return rec
+}
+
+func TestPersistEvents_AppendsJSONLToDisk(t *testing.T) {
+	ec := newTestCollector(t, newMockWriter(), Options{CompressionEnabled: true})
+
+	events := []map[string]interface{}{
+		{
+			"eventId":     "e1",
+			"eventType":   "NODE_LIFECYCLE_EVENT",
+			"timestamp":   time.Now().UTC().Format(time.RFC3339Nano),
+			"sessionName": ec.currentSessionName,
+		},
+		{
+			"eventId":   "e2",
+			"eventType": "TASK_DEFINITION_EVENT",
+			"taskDefinitionEvent": map[string]interface{}{
+				"jobId": "job-1",
+			},
+			"timestamp":   time.Now().UTC().Format(time.RFC3339Nano),
+			"sessionName": ec.currentSessionName,
+		},
+	}
+	body, err := json.Marshal(events)
+	require.NoError(t, err)
+
+	rec := callPersistEvents(t, ec, body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Two active files expected: node_events and job_events/job-1.
+	nodeState, ok := ec.activeFiles[categoryNodeEvents]
+	require.True(t, ok)
+	jobState, ok := ec.activeFiles[path.Join(categoryJobPrefix, "job-1")]
+	require.True(t, ok)
+
+	// Read node file from disk.
+	nodeBytes, err := os.ReadFile(nodeState.path)
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimRight(string(nodeBytes), "\n"), "\n")
+	require.Len(t, lines, 1)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &m))
+	assert.Equal(t, "e1", m["eventId"])
+	assert.Equal(t, "node-1", m["_nodeId"])
+
+	// Job file exists and has one line.
+	jobBytes, err := os.ReadFile(jobState.path)
+	require.NoError(t, err)
+	assert.Contains(t, string(jobBytes), `"eventId":"e2"`)
+
+	// Disk accounting reflects the total bytes written.
+	assert.Equal(t, int64(len(nodeBytes)+len(jobBytes)), ec.totalDiskUsed.Load())
+}
+
+func TestPersistEvents_SessionChangeRotates(t *testing.T) {
+	writer := newMockWriter()
+	ec := newTestCollector(t, writer, Options{CompressionEnabled: true})
+	// Start compression/upload worker so rotation actually lands in storage.
+	ec.workersWG.Add(1)
+	go ec.compressionUploadWorker()
+	defer func() {
+		close(ec.stopped)
+		ec.workersWG.Wait()
+	}()
+
+	first := []map[string]interface{}{{
+		"eventId":     "s1",
+		"eventType":   "NODE_LIFECYCLE_EVENT",
+		"timestamp":   time.Now().UTC().Format(time.RFC3339Nano),
+		"sessionName": "session_abc",
+	}}
+	body, _ := json.Marshal(first)
+	callPersistEvents(t, ec, body)
+
+	second := []map[string]interface{}{{
+		"eventId":     "s2",
+		"eventType":   "NODE_LIFECYCLE_EVENT",
+		"timestamp":   time.Now().UTC().Format(time.RFC3339Nano),
+		"sessionName": "session_new",
+	}}
+	body, _ = json.Marshal(second)
+	callPersistEvents(t, ec, body)
+
+	// Wait for upload worker to drain the rotated file.
+	require.Eventually(t, func() bool {
+		return len(writer.fileKeys()) >= 1
+	}, 2*time.Second, 20*time.Millisecond)
+
+	// Uploaded key should be under the old session.
+	keys := writer.fileKeys()
+	found := false
+	for _, k := range keys {
+		if strings.Contains(k, "/session_abc/node_events/") && strings.HasSuffix(k, ".jsonl.gz") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected uploaded key under old session, got: %v", keys)
+}
+
+func TestPersistEvents_RejectsUnderDiskPressure(t *testing.T) {
+	ec := newTestCollector(t, newMockWriter(), Options{
+		MaxDiskBytes:       100,
+		CompressionEnabled: true,
+	})
+	// 80% of 100 = 80. Load to 90 to trip the watermark.
+	ec.totalDiskUsed.Store(90)
+
+	body := []byte(`[{"eventId":"x","eventType":"NODE_LIFECYCLE_EVENT","timestamp":"2026-05-13T10:00:00Z","sessionName":"session_abc"}]`)
+	rec := callPersistEvents(t, ec, body)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "10", rec.Header().Get("Retry-After"))
+}
+
+func TestPersistEvents_BadJSONReturns400(t *testing.T) {
+	ec := newTestCollector(t, newMockWriter(), Options{})
+	rec := callPersistEvents(t, ec, []byte("not json"))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestPersistEvents_MissingTimestampReturns400(t *testing.T) {
+	ec := newTestCollector(t, newMockWriter(), Options{})
+	body := []byte(`[{"eventId":"x","eventType":"NODE_LIFECYCLE_EVENT","sessionName":"session_abc"}]`)
+	rec := callPersistEvents(t, ec, body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------- underDiskPressure ----------
+
+func TestUnderDiskPressure_Threshold(t *testing.T) {
+	ec := &EventCollector{maxDiskBytes: 100}
+	ec.totalDiskUsed.Store(79)
+	assert.False(t, ec.underDiskPressure())
+	ec.totalDiskUsed.Store(80)
+	assert.True(t, ec.underDiskPressure())
+
+	ec2 := &EventCollector{maxDiskBytes: 0}
+	ec2.totalDiskUsed.Store(1 << 30)
+	assert.False(t, ec2.underDiskPressure(), "disabled when maxDiskBytes <= 0")
+}
+
+// ---------- processRotatedFile uploads gzip ----------
+
+func TestProcessRotatedFile_GzipsAndUploadsThenCleansUp(t *testing.T) {
+	writer := newMockWriter()
+	ec := newTestCollector(t, writer, Options{CompressionEnabled: true})
+
+	// Create a pre-rotated JSONL file.
+	dir := filepath.Join(ec.dataDir, ec.clusterKey(), categoryNodeEvents)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	jsonlPath := filepath.Join(dir, "node-1_123.jsonl")
+	payload := []byte(`{"eventId":"a"}` + "\n" + `{"eventId":"b"}` + "\n")
+	require.NoError(t, os.WriteFile(jsonlPath, payload, 0o644))
+	ec.totalDiskUsed.Store(int64(len(payload)))
+
+	task := rotationTask{
+		jsonlPath:   jsonlPath,
+		category:    categoryNodeEvents,
+		sessionName: ec.currentSessionName,
+		nodeID:      "node-1",
+		createdAt:   time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC),
+		size:        int64(len(payload)),
+	}
+	ec.processRotatedFile(task)
+
+	// Local files should be gone.
+	_, err := os.Stat(jsonlPath)
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(jsonlPath + ".gz")
+	assert.True(t, os.IsNotExist(err))
+
+	// Upload happened with gzip payload.
+	expectedKey := fmt.Sprintf("history/cluster_ns/session_abc/node_events/node-1-2026-05-13-10-%d.jsonl.gz", task.createdAt.UnixNano())
+	raw, ok := writer.get(expectedKey)
+	require.True(t, ok, "uploaded keys: %v", writer.fileKeys())
+
+	gr, err := gzip.NewReader(bytes.NewReader(raw))
+	require.NoError(t, err)
+	defer gr.Close()
+	decoded, err := io.ReadAll(gr)
+	require.NoError(t, err)
+	assert.Equal(t, string(payload), string(decoded))
+}
+
+func TestProcessRotatedFile_NoCompressionUsesJSONLExtension(t *testing.T) {
+	writer := newMockWriter()
+	ec := newTestCollector(t, writer, Options{CompressionEnabled: false})
+
+	dir := filepath.Join(ec.dataDir, ec.clusterKey(), categoryNodeEvents)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	jsonlPath := filepath.Join(dir, "node-1_123.jsonl")
+	payload := []byte(`{"eventId":"a"}` + "\n")
+	require.NoError(t, os.WriteFile(jsonlPath, payload, 0o644))
+
+	task := rotationTask{
+		jsonlPath:   jsonlPath,
+		category:    categoryNodeEvents,
+		sessionName: ec.currentSessionName,
+		nodeID:      "node-1",
+		createdAt:   time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC),
+		size:        int64(len(payload)),
+	}
+	ec.processRotatedFile(task)
+
+	expectedKey := fmt.Sprintf("history/cluster_ns/session_abc/node_events/node-1-2026-05-13-10-%d.jsonl", task.createdAt.UnixNano())
+	raw, ok := writer.get(expectedKey)
+	require.True(t, ok, "uploaded keys: %v", writer.fileKeys())
+	assert.Equal(t, payload, raw)
+}
+
+// ---------- Rotation by size triggers on checkRotation ----------
+
+func TestCheckRotation_SizeTrigger(t *testing.T) {
+	writer := newMockWriter()
+	ec := newTestCollector(t, writer, Options{
+		RotationInterval: time.Hour, // ensure time won't trip
+		MaxFileSizeBytes: 10,
+	})
+
+	state, err := ec.openNewActiveFileLocked(categoryNodeEvents, ec.currentSessionName)
+	require.NoError(t, err)
+	_, err = state.writer.Write(bytes.Repeat([]byte("x"), 50))
+	require.NoError(t, err)
+	require.NoError(t, state.writer.Flush())
+	state.size = 50
+
+	ec.checkRotation()
+
+	// The category's active file must have been rotated away.
+	_, stillActive := ec.activeFiles[categoryNodeEvents]
+	assert.False(t, stillActive)
+
+	// A rotation task must be queued.
+	select {
+	case task := <-ec.rotationQueue:
+		assert.Equal(t, state.path, task.jsonlPath)
+	default:
+		t.Fatal("expected rotation task to be enqueued")
+	}
+}
+
+// ---------- Sanity: atomic disk counter types ----------
+
+func TestAtomicInt64Type(t *testing.T) {
+	var x atomic.Int64
+	x.Store(5)
+	assert.Equal(t, int64(5), x.Load())
+}
+
+// ---------- Direct upload (compression disabled) ----------
+
+// ---------- Buffered (compression disabled) ----------
+
+// When CompressionEnabled is false, PersistEvents must NOT touch local disk
+// and must NOT upload immediately; events are buffered and flushed by
+// flushAllMemEvents on the configured interval, on node-id change, or on
+// shutdown.
+func TestPersistEvents_Buffered_BuffersAndFlushes(t *testing.T) {
+	writer := newMockWriter()
+	ec := newTestCollector(t, writer, Options{CompressionEnabled: false, FlushInterval: time.Hour})
+
+	fixedTS := "2026-05-13T10:30:00Z"
+	events := []map[string]interface{}{
+		{
+			"eventId":     "e1",
+			"eventType":   "NODE_LIFECYCLE_EVENT",
+			"timestamp":   fixedTS,
+			"sessionName": ec.currentSessionName,
+		},
+		{
+			"eventId":   "e2",
+			"eventType": "TASK_DEFINITION_EVENT",
+			"taskDefinitionEvent": map[string]interface{}{
+				"jobId": "job-1",
+			},
+			"timestamp":   fixedTS,
+			"sessionName": ec.currentSessionName,
+		},
+	}
+	body, err := json.Marshal(events)
+	require.NoError(t, err)
+
+	rec := callPersistEvents(t, ec, body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Disk untouched; events buffered in memory; nothing uploaded yet.
+	assert.Empty(t, ec.activeFiles)
+	if _, err := os.Stat(ec.dataDir); err == nil {
+		entries, _ := os.ReadDir(ec.dataDir)
+		assert.Empty(t, entries, "dataDir should be empty when compression is disabled")
+	}
+	assert.Len(t, ec.memEvents, 2)
+	assert.Empty(t, writer.fileKeys(), "nothing should be uploaded before flush")
+
+	// Trigger flush.
+	ec.flushAllMemEvents()
+	assert.Empty(t, ec.memEvents, "buffer should be cleared after flush")
+
+	// Two remote files: one node_events, one job_events/job-1, legacy format
+	// (no extension, no nano suffix), payload is a JSON array.
+	keys := writer.fileKeys()
+	require.Len(t, keys, 2)
+	var nodeKey, jobKey string
+	for _, k := range keys {
+		assert.False(t, strings.HasSuffix(k, ".jsonl"), "buffered path must not use .jsonl suffix: %s", k)
+		assert.False(t, strings.HasSuffix(k, ".jsonl.gz"), "buffered path must not use .jsonl.gz suffix: %s", k)
+		switch {
+		case strings.Contains(k, "/node_events/"):
+			nodeKey = k
+		case strings.Contains(k, "/job_events/job-1/"):
+			jobKey = k
+		}
+	}
+	require.NotEmpty(t, nodeKey)
+	require.NotEmpty(t, jobKey)
+	assert.True(t, strings.HasSuffix(nodeKey, "node-1-2026-05-13-10"), "unexpected node key: %s", nodeKey)
+	assert.True(t, strings.HasSuffix(jobKey, "node-1-2026-05-13-10"), "unexpected job key: %s", jobKey)
+
+	nodeBytes, ok := writer.get(nodeKey)
+	require.True(t, ok)
+	var nodeArr []map[string]interface{}
+	require.NoError(t, json.Unmarshal(nodeBytes, &nodeArr), "node payload must be a JSON array")
+	require.Len(t, nodeArr, 1)
+	assert.Equal(t, "e1", nodeArr[0]["eventId"])
+	_, hasNodeIDField := nodeArr[0]["_nodeId"]
+	assert.False(t, hasNodeIDField, "buffered path must not inject _nodeId, matching legacy semantics")
+
+	jobBytes, ok := writer.get(jobKey)
+	require.True(t, ok)
+	var jobArr []map[string]interface{}
+	require.NoError(t, json.Unmarshal(jobBytes, &jobArr))
+	require.Len(t, jobArr, 1)
+	assert.Equal(t, "e2", jobArr[0]["eventId"])
+}
+
+// Disk pressure should NOT trigger 503 when compression is disabled.
+func TestPersistEvents_Buffered_IgnoresDiskPressure(t *testing.T) {
+	ec := newTestCollector(t, newMockWriter(), Options{
+		CompressionEnabled: false,
+		MaxDiskBytes:       100,
+	})
+	ec.totalDiskUsed.Store(999) // far above watermark
+
+	body := []byte(`[{"eventId":"x","eventType":"NODE_LIFECYCLE_EVENT","timestamp":"2026-05-13T10:00:00Z","sessionName":"session_abc"}]`)
+	rec := callPersistEvents(t, ec, body)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// Validation errors must still surface in the buffered path.
+func TestPersistEvents_Buffered_MissingTimestamp(t *testing.T) {
+	ec := newTestCollector(t, newMockWriter(), Options{CompressionEnabled: false})
+	body := []byte(`[{"eventId":"x","eventType":"NODE_LIFECYCLE_EVENT","sessionName":"session_abc"}]`)
+	rec := callPersistEvents(t, ec, body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// Events sharing the same (category, hour, nodeID, sessionName) must be
+// aggregated into a single file (legacy semantics).
+func TestFlushMemEvents_AggregatesByHourBucket(t *testing.T) {
+	writer := newMockWriter()
+	ec := newTestCollector(t, writer, Options{CompressionEnabled: false})
+
+	ts1, _ := time.Parse(time.RFC3339Nano, "2026-05-13T10:05:00Z")
+	ts2, _ := time.Parse(time.RFC3339Nano, "2026-05-13T10:50:00Z")
+	ts3, _ := time.Parse(time.RFC3339Nano, "2026-05-13T11:00:00Z") // different hour
+
+	ec.memEvents = []memEvent{
+		{data: map[string]interface{}{"eventId": "a", "eventType": "NODE_LIFECYCLE_EVENT"}, timestamp: ts1, sessionName: "s", nodeID: "n"},
+		{data: map[string]interface{}{"eventId": "b", "eventType": "NODE_LIFECYCLE_EVENT"}, timestamp: ts2, sessionName: "s", nodeID: "n"},
+		{data: map[string]interface{}{"eventId": "c", "eventType": "NODE_LIFECYCLE_EVENT"}, timestamp: ts3, sessionName: "s", nodeID: "n"},
+	}
+	ec.flushAllMemEvents()
+
+	keys := writer.fileKeys()
+	require.Len(t, keys, 2, "two hour buckets expected, got %v", keys)
+
+	var h10, h11 string
+	for _, k := range keys {
+		if strings.HasSuffix(k, "-2026-05-13-10") {
+			h10 = k
+		} else if strings.HasSuffix(k, "-2026-05-13-11") {
+			h11 = k
+		}
+	}
+	require.NotEmpty(t, h10)
+	require.NotEmpty(t, h11)
+
+	b10, _ := writer.get(h10)
+	var arr10 []map[string]interface{}
+	require.NoError(t, json.Unmarshal(b10, &arr10))
+	assert.Len(t, arr10, 2, "hour 10 bucket must aggregate events a and b")
+}
+
+// On node-id change, buffered events tagged with the old nodeID must be
+// flushed immediately; events tagged with the new nodeID stay buffered;
+// anything else is dropped.
+func TestPartitionMemEventsForNodeChange(t *testing.T) {
+	ec := newTestCollector(t, newMockWriter(), Options{CompressionEnabled: false})
+
+	ts := time.Now()
+	ec.memEvents = []memEvent{
+		{data: map[string]interface{}{"eventId": "old1", "eventType": "NODE_LIFECYCLE_EVENT"}, timestamp: ts, sessionName: "s", nodeID: "old"},
+		{data: map[string]interface{}{"eventId": "new1", "eventType": "NODE_LIFECYCLE_EVENT"}, timestamp: ts, sessionName: "s", nodeID: "new"},
+		{data: map[string]interface{}{"eventId": "stale", "eventType": "NODE_LIFECYCLE_EVENT"}, timestamp: ts, sessionName: "s", nodeID: "orphan"},
+		{data: map[string]interface{}{"eventId": "old2", "eventType": "NODE_LIFECYCLE_EVENT"}, timestamp: ts, sessionName: "s", nodeID: "old"},
+	}
+
+	ec.writeMu.Lock()
+	toFlush, dropped := ec.partitionMemEventsForNodeChangeLocked("old", "new")
+	ec.writeMu.Unlock()
+
+	assert.Equal(t, 1, dropped)
+	require.Len(t, toFlush, 2)
+	for _, e := range toFlush {
+		assert.Equal(t, "old", e.nodeID)
+	}
+	require.Len(t, ec.memEvents, 1)
+	assert.Equal(t, "new", ec.memEvents[0].nodeID)
+}
+
+// buildLegacyEventStorageKey must match the pre-disk-first key format.
+func TestBuildLegacyEventStorageKey(t *testing.T) {
+	ec := newTestCollector(t, newMockWriter(), Options{CompressionEnabled: false})
+
+	nodeKey := ec.buildLegacyEventStorageKey(categoryNodeEvents, "2026-05-13-10", "node-1", "session_abc")
+	assert.Equal(t, "history/cluster_ns/session_abc/node_events/node-1-2026-05-13-10", nodeKey)
+
+	jobKey := ec.buildLegacyEventStorageKey(path.Join(categoryJobPrefix, "job-7"), "2026-05-13-10", "node-1", "session_abc")
+	assert.Equal(t, "history/cluster_ns/session_abc/job_events/job-7/node-1-2026-05-13-10", jobKey)
+}
+
+// Default FlushInterval should fall back to 1h.
+func TestNewEventCollector_DefaultsFlushIntervalToOneHour(t *testing.T) {
+	ec := NewEventCollector(newMockWriter(), "history", "/tmp/s", "node-1", "cluster", "ns", "session_abc", Options{})
+	assert.Equal(t, time.Hour, ec.flushInterval)
+}
+
+

--- a/historyserver/pkg/collector/types/types.go
+++ b/historyserver/pkg/collector/types/types.go
@@ -24,6 +24,23 @@ type RayCollectorConfig struct {
 
 	AdditionalEndpoints  []string
 	EndpointPollInterval time.Duration
+
+	// Event collector disk-first storage configuration.
+	EventDataDir          string        // root directory for JSONL event files
+	EventRotationInterval time.Duration // time-based rotation trigger
+	EventMaxFileSizeMB    int           // size-based rotation trigger (MB)
+	EventMaxDiskMB        int           // backpressure threshold (MB)
+	// EventCompressionEnabled is a single switch that controls the entire
+	// disk-first + gzip pipeline. When true, events are written to local
+	// JSONL files and rotated/gzipped/uploaded asynchronously. When false,
+	// the local disk pipeline is bypassed entirely and events are buffered
+	// in-memory and periodically flushed (matching legacy semantics).
+	EventCompressionEnabled bool
+	// EventFlushInterval controls how often the in-memory buffer is flushed
+	// to remote storage when EventCompressionEnabled is false. Defaults to
+	// 1h to match the legacy behavior; can be set lower for more frequent
+	// writes.
+	EventFlushInterval time.Duration
 }
 
 // ValidateRayHanderConfig is

--- a/historyserver/pkg/eventserver/event_file_decode_test.go
+++ b/historyserver/pkg/eventserver/event_file_decode_test.go
@@ -1,0 +1,108 @@
+package eventserver
+
+import (
+	"bytes"
+	"compress/gzip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func gzipBytes(t *testing.T, src []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write(src)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	return buf.Bytes()
+}
+
+func TestIsValidEventFile(t *testing.T) {
+	cases := []struct {
+		name    string
+		fileName string
+		want    bool
+	}{
+		{"legacy plain", "node-abcd-2026-05-13-10", true},
+		{"new jsonl", "node-abcd-2026-05-13-10.jsonl", true},
+		{"new jsonl gz", "node-abcd-2026-05-13-10.jsonl.gz", true},
+		{"nano suffix jsonl.gz", "node-1-2026-05-13-10-1747123200000000000.jsonl.gz", true},
+		{"nano suffix jsonl", "node-1-2026-05-13-10-1747123200000000000.jsonl", true},
+		{"directory", "some-dir/", false},
+		{"unrelated", "foo.txt", false},
+		{"wrong hour", "node-abcd-2026-05-13-1", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isValidEventFile(tc.fileName))
+		})
+	}
+}
+
+func TestDecodeEventFileBytes_JSONArrayLegacy(t *testing.T) {
+	raw := []byte(`[{"eventId":"a","x":1},{"eventId":"b","x":2}]`)
+	out, err := decodeEventFileBytes("node-2026-05-13-10", raw)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	assert.Equal(t, "a", out[0]["eventId"])
+	assert.Equal(t, "b", out[1]["eventId"])
+}
+
+func TestDecodeEventFileBytes_JSONLPlain(t *testing.T) {
+	raw := []byte(`{"eventId":"a"}
+{"eventId":"b"}
+
+{"eventId":"c"}
+`)
+	out, err := decodeEventFileBytes("node-2026-05-13-10.jsonl", raw)
+	require.NoError(t, err)
+	require.Len(t, out, 3)
+	assert.Equal(t, "a", out[0]["eventId"])
+	assert.Equal(t, "b", out[1]["eventId"])
+	assert.Equal(t, "c", out[2]["eventId"])
+}
+
+func TestDecodeEventFileBytes_JSONLGzip(t *testing.T) {
+	plain := []byte(`{"eventId":"a"}` + "\n" + `{"eventId":"b"}` + "\n")
+	gz := gzipBytes(t, plain)
+	out, err := decodeEventFileBytes("node-2026-05-13-10.jsonl.gz", gz)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	assert.Equal(t, "a", out[0]["eventId"])
+	assert.Equal(t, "b", out[1]["eventId"])
+}
+
+func TestDecodeEventFileBytes_JSONArrayGzip(t *testing.T) {
+	plain := []byte(`[{"eventId":"x"}]`)
+	gz := gzipBytes(t, plain)
+	out, err := decodeEventFileBytes("legacy-2026-05-13-10.gz", gz)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "x", out[0]["eventId"])
+}
+
+func TestDecodeEventFileBytes_EmptyBytes(t *testing.T) {
+	out, err := decodeEventFileBytes("empty.jsonl", []byte{})
+	require.NoError(t, err)
+	assert.Nil(t, out)
+}
+
+func TestDecodeEventFileBytes_MalformedJSONLLinesSkipped(t *testing.T) {
+	raw := []byte(`{"eventId":"a"}
+not a json line
+{"eventId":"b"}
+`)
+	out, err := decodeEventFileBytes("malformed.jsonl", raw)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	assert.Equal(t, "a", out[0]["eventId"])
+	assert.Equal(t, "b", out[1]["eventId"])
+}
+
+func TestDecodeEventFileBytes_GzipCorrupt(t *testing.T) {
+	_, err := decodeEventFileBytes("bad.jsonl.gz", []byte("not gzipped"))
+	require.Error(t, err)
+}

--- a/historyserver/pkg/eventserver/eventserver.go
+++ b/historyserver/pkg/eventserver/eventserver.go
@@ -1,6 +1,9 @@
 package eventserver
 
 import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -27,7 +30,7 @@ type EventHandler struct {
 	ClusterLogEventMap *types.ClusterLogEventMap // For /events API (Log Events from logs/events/)
 }
 
-var eventFilePattern = regexp.MustCompile(`-\d{4}-\d{2}-\d{2}-\d{2}$`)
+var eventFilePattern = regexp.MustCompile(`-\d{4}-\d{2}-\d{2}-\d{2}(-\d+)?(\.jsonl(\.gz)?)?$`)
 
 // taskPrefix is extracted to avoid hard-coded "task::" usage
 const taskPrefix = "task::"
@@ -37,8 +40,64 @@ func isValidEventFile(fileName string) bool {
 	if strings.HasSuffix(fileName, "/") {
 		return false
 	}
-	// Only files matching {nodeId}-{YYYY-MM-DD-HH} format are valid event files
+	// Accept both legacy files ({nodeId}-{YYYY-MM-DD-HH}) and the new
+	// disk-first JSONL files ({nodeId}-{YYYY-MM-DD-HH}.jsonl[.gz]).
 	return eventFilePattern.MatchString(fileName)
+}
+
+// decodeEventFileBytes parses the raw bytes of an event file. It supports:
+//   - Legacy format: a single JSON array of event objects.
+//   - New format: JSONL (one compact JSON object per line).
+//   - Either may be transparently gzip-compressed when fileName ends in .gz.
+func decodeEventFileBytes(fileName string, raw []byte) ([]map[string]any, error) {
+	data := raw
+	if strings.HasSuffix(fileName, ".gz") {
+		gr, err := gzip.NewReader(bytes.NewReader(raw))
+		if err != nil {
+			return nil, fmt.Errorf("gzip reader for %s: %w", fileName, err)
+		}
+		defer gr.Close()
+		decompressed, err := io.ReadAll(gr)
+		if err != nil {
+			return nil, fmt.Errorf("gunzip %s: %w", fileName, err)
+		}
+		data = decompressed
+	}
+
+	trimmed := bytes.TrimLeft(data, " \t\r\n")
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+
+	// JSON array (legacy format) starts with '['.
+	if trimmed[0] == '[' {
+		var out []map[string]any
+		if err := json.Unmarshal(data, &out); err != nil {
+			return nil, fmt.Errorf("unmarshal JSON array %s: %w", fileName, err)
+		}
+		return out, nil
+	}
+
+	// Otherwise treat as JSONL: one object per non-empty line.
+	var out []map[string]any
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(line, &obj); err != nil {
+			logrus.Warnf("Skipping malformed JSONL line in %s: %v", fileName, err)
+			continue
+		}
+		out = append(out, obj)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan JSONL %s: %w", fileName, err)
+	}
+	return out, nil
 }
 
 func NewEventHandler(reader storage.StorageReader) *EventHandler {
@@ -59,6 +118,7 @@ func NewEventHandler(reader storage.StorageReader) *EventHandler {
 		ClusterLogEventMap: types.NewClusterLogEventMap(),
 	}
 }
+
 
 // storeEvent unmarshals the event map into the correct actor/task struct and then stores it into the corresonding list.
 func (h *EventHandler) storeEvent(clusterSessionKey string, eventMap map[string]any) error {
@@ -1415,11 +1475,11 @@ func (h *EventHandler) ProcessSingleSession(ctx context.Context, clusterInfo uti
 		}
 		rayEventsRead++
 
-		// json.Unmarshal and storeEvent failures are treated as corrupt-data errors:
+		// decodeEventFileBytes and storeEvent failures are treated as corrupt-data errors:
 		// retrying won't fix bad bytes, accepting partial loss.
-		var eventList []map[string]any
-		if err := json.Unmarshal(eventbytes, &eventList); err != nil {
-			logrus.Errorf("Failed to unmarshal events for file %s: %v", eventFile, err)
+		eventList, err := decodeEventFileBytes(eventFile, eventbytes)
+		if err != nil {
+			logrus.Errorf("Failed to decode events for file %s: %v", eventFile, err)
 			continue
 		}
 

--- a/historyserver/pkg/historyserver/clientmanager.go
+++ b/historyserver/pkg/historyserver/clientmanager.go
@@ -42,7 +42,24 @@ func (c *ClientManager) ListRayClusters(ctx context.Context) ([]*rayv1.RayCluste
 	return list, nil
 }
 
-func NewClientManager(kubeconfigs string, useKubernetesProxy bool) (*ClientManager, error) {
+type ClientManagerConfig struct {
+	Kubeconfigs        string
+	UseKubernetesProxy bool
+	QPS                float32
+	Burst              int
+}
+
+func NewClientManager(cfg ClientManagerConfig) (*ClientManager, error) {
+	kubeconfigs := cfg.Kubeconfigs
+	useKubernetesProxy := cfg.UseKubernetesProxy
+	qps := cfg.QPS
+	burst := cfg.Burst
+	if qps <= 0 {
+		qps = 50
+	}
+	if burst <= 0 {
+		burst = 100
+	}
 	kubeconfigList := []*rest.Config{}
 	if len(kubeconfigs) > 0 {
 		stringList := strings.Split(kubeconfigs, ",")
@@ -60,8 +77,8 @@ func NewClientManager(kubeconfigs string, useKubernetesProxy bool) (*ClientManag
 		if err != nil {
 			return nil, fmt.Errorf("failed to build config from kubeconfig: %w", err)
 		}
-		c.QPS = 50
-		c.Burst = 100
+		c.QPS = qps
+		c.Burst = burst
 		kubeconfigList = append(kubeconfigList, c)
 	} else {
 		var c *rest.Config
@@ -82,8 +99,8 @@ func NewClientManager(kubeconfigs string, useKubernetesProxy bool) (*ClientManag
 				return nil, fmt.Errorf("failed to build config from in-cluster kubeconfig: %w", err)
 			}
 		}
-		c.QPS = 50
-		c.Burst = 100
+		c.QPS = qps
+		c.Burst = burst
 		kubeconfigList = append(kubeconfigList, c)
 	}
 	scheme := runtime.NewScheme()

--- a/historyserver/pkg/historyserver/clientmanager.go
+++ b/historyserver/pkg/historyserver/clientmanager.go
@@ -54,12 +54,6 @@ func NewClientManager(cfg ClientManagerConfig) (*ClientManager, error) {
 	useKubernetesProxy := cfg.UseKubernetesProxy
 	qps := cfg.QPS
 	burst := cfg.Burst
-	if qps <= 0 {
-		qps = 50
-	}
-	if burst <= 0 {
-		burst = 100
-	}
 	kubeconfigList := []*rest.Config{}
 	if len(kubeconfigs) > 0 {
 		stringList := strings.Split(kubeconfigs, ",")


### PR DESCRIPTION
Replace in-memory event buffering with a disk-first JSONL pipeline where
events are appended directly to local files (O(1) memory per write), then
periodically rotated, gzip-compressed, and uploaded to remote storage.

- Add rotation loop (time/size thresholds), compression/upload worker,
  and disk reconciler goroutines with graceful shutdown draining
- Implement 503 backpressure when disk usage exceeds configurable limit
- Support crash recovery by resuming pending uploads on restart
- Add cmdline flags and env var overrides for all storage parameters
- Update eventserver to decode both legacy JSON-array and new JSONL/gzip
  formats with backward-compatible file pattern matching
- Include UnixNano suffix in remote storage keys to prevent overwrites
  when multiple files rotate within the same hour
- Add unit tests for eventcollector and event file decoding