### PR TITLE
[Chore][CI] Upgrade Ray version to 2.55.0 to support entrypointLabelSelector

### DIFF
--- a/.buildkite/setup-env.sh
+++ b/.buildkite/setup-env.sh
@@ -35,7 +35,7 @@ apt-get update
 apt-get install -y python3.11 python3-pip python3-venv python3-dev build-essential
 
 # Install requirements
-pip install --break-system-packages ray[default]==2.52.0
+pip install --break-system-packages ray[default]==2.55.0
 
 # Bypass Git's ownership check due to unconventional user IDs in Docker containers
 git config --global --add safe.directory /workdir

--- a/ray-operator/test/support/defaults.go
+++ b/ray-operator/test/support/defaults.go
@@ -1,7 +1,7 @@
 package support
 
 const (
-	RayVersion            = "2.52.0"
-	RayImage              = "rayproject/ray:2.52.0"
+	RayVersion            = "2.55.0"
+	RayImage              = "rayproject/ray:2.55.0"
 	KuberayUpgradeVersion = "v1.6.0"
 )


### PR DESCRIPTION
## Summary
- Upgrade CI Ray version from 2.52.0 to 2.55.0 so that `entrypointLabelSelector` is supported in the Ray job submission API/CLI
- `entrypoint_label_selector` was added in Ray 2.54.0 (ray-project/ray#59735), Ray 2.52.0 doesn't support it, causing `TestRayJobLightWeightMode` and `TestRayJobSidecarMode` to time out when `EntrypointLabelSelector` is enabled

## Test plan
- CI will validate by running the e2e RayJob tests which were previously failing