### PR TITLE
[RayCronJob] Use deterministic child RayJob names to prevent duplicate firings

### DIFF
--- a/ray-operator/controllers/ray/raycronjob_controller.go
+++ b/ray-operator/controllers/ray/raycronjob_controller.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -118,10 +117,16 @@ func (r *RayCronJobReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 		return ctrl.Result{}, err
 	}
 	if err := r.Create(ctx, rayJob); err != nil {
-		logger.Error(err, "Failed to create RayJob from RayCronJob")
-		return ctrl.Result{}, err
+		if !errors.IsAlreadyExists(err) {
+			logger.Error(err, "Failed to create RayJob from RayCronJob")
+			return ctrl.Result{}, err
+		}
+		// The deterministic name means a RayJob for this tick already exists, so a previous
+		// reconcile already scheduled it. Treat as success and still advance LastScheduleTime.
+		logger.Info("RayJob for this tick already exists, skipping creation", "rayJobName", rayJob.Name, "namespace", rayJob.Namespace)
+	} else {
+		logger.Info("Successfully created RayJob", "rayJobName", rayJob.Name, "namespace", rayJob.Namespace)
 	}
-	logger.Info("Successfully created RayJob", "rayJobName", rayJob.Name, "namespace", rayJob.Namespace)
 	rayCronJobInstance.Status.LastScheduleTime = &metav1.Time{Time: now}
 
 	// Set next schedule time
@@ -153,10 +158,20 @@ func (r *RayCronJobReconciler) updateRayCronJobStatus(ctx context.Context, oldRa
 	return nil
 }
 
+func getTimeHashInMinutes(scheduledTime time.Time) int64 {
+	return scheduledTime.Unix() / 60
+}
+
+// getRayJobName builds a deterministic child name so a repeated Create for the same tick
+// collides with AlreadyExists instead of creating a duplicate (matches batch/v1 CronJob).
+func getRayJobName(cronJobName string, scheduledTime time.Time) string {
+	return fmt.Sprintf("%s-%d", cronJobName, getTimeHashInMinutes(scheduledTime))
+}
+
 func (r *RayCronJobReconciler) constructRayJob(cronJob *rayv1.RayCronJob, expectedTimestamp time.Time) (*rayv1.RayJob, error) {
 	rayJob := &rayv1.RayJob{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cronJob.Name, rand.String(5)),
+			Name:      getRayJobName(cronJob.Name, expectedTimestamp),
 			Namespace: cronJob.Namespace,
 			Labels: map[string]string{
 				utils.RayCronJobNameLabelKey: cronJob.Name,

--- a/ray-operator/controllers/ray/raycronjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycronjob_controller_unit_test.go
@@ -2,6 +2,7 @@ package ray
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -315,6 +316,75 @@ func TestRayCronJobReconcile_Suspend(t *testing.T) {
 	default:
 		t.Error("Expected a suspend event to be recorded, but none was found")
 	}
+}
+
+func TestGetRayJobName_Deterministic(t *testing.T) {
+	tick := time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)
+
+	// The suffix is the whole-minute Unix timestamp, so the same name + tick always yields
+	// the same child name. A duplicate Create for the same tick then collides (AlreadyExists)
+	// instead of producing a second RayJob.
+	name := getRayJobName("test-cronjob", tick)
+	assert.Equal(t, fmt.Sprintf("test-cronjob-%d", tick.Unix()/60), name)
+
+	// Different ticks must yield different names so consecutive scheduled runs don't collide.
+	nextTick := time.Date(2024, 1, 1, 0, 10, 0, 0, time.UTC)
+	assert.NotEqual(t, name, getRayJobName("test-cronjob", nextTick))
+}
+
+// TestRayCronJobReconcile_NoDuplicateOnStaleStatus reproduces the race in
+// https://github.com/ray-project/kuberay/issues/4849: the controller reconciles the same
+// scheduled tick twice before the LastScheduleTime status write is observed (informer-cache
+// lag). The second pass reads a stale LastScheduleTime, passes the schedule gate, and must
+// NOT create a second child RayJob for the same tick.
+func TestRayCronJobReconcile_NoDuplicateOnStaleStatus(t *testing.T) {
+	ctx := context.Background()
+
+	cronSchedule := "*/5 * * * *" // Every 5 minutes
+	staleLastSchedule := metav1.NewTime(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	// now is just past the 00:05:00 tick so the tick is due in both passes.
+	fakeCurrTime := time.Date(2024, 1, 1, 0, 5, 30, 0, time.UTC)
+
+	rayCronJob := rayCronJobTemplate("test-cronjob", "default", cronSchedule)
+	rayCronJob.Status = rayv1.RayCronJobStatus{LastScheduleTime: &staleLastSchedule}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, rayv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(rayCronJob).
+		WithStatusSubresource(rayCronJob).
+		Build()
+
+	reconciler := &RayCronJobReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: &record.FakeRecorder{},
+		clock:    clocktesting.NewFakeClock(fakeCurrTime),
+	}
+
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-cronjob", Namespace: "default"}}
+
+	// Pass 1: schedules the tick and (in the real controller) writes LastScheduleTime.
+	_, err := reconciler.Reconcile(ctx, request)
+	require.NoError(t, err)
+
+	// Simulate informer-cache lag: pass 1's status write is not yet observable, so reset
+	// LastScheduleTime back to its stale value before pass 2 reads it.
+	cronJobForReset := &rayv1.RayCronJob{}
+	require.NoError(t, fakeClient.Get(ctx, request.NamespacedName, cronJobForReset))
+	cronJobForReset.Status.LastScheduleTime = &staleLastSchedule
+	require.NoError(t, fakeClient.Status().Update(ctx, cronJobForReset))
+
+	// Pass 2: reads the stale LastScheduleTime and passes the schedule gate again.
+	_, err = reconciler.Reconcile(ctx, request)
+	require.NoError(t, err)
+
+	rayJobList := &rayv1.RayJobList{}
+	require.NoError(t, fakeClient.List(ctx, rayJobList))
+	assert.Len(t, rayJobList.Items, 1, "the same scheduled tick must produce exactly one child RayJob")
 }
 
 func TestUpdateRayCronJobStatus(t *testing.T) {

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -301,6 +301,10 @@ const (
 	// MaxRayJobNameLength is the maximum RayJob name to make sure it pass the RayCluster validation
 	// Minus 6 since we append 6 characters to the RayJob name to create the cluster (GenerateRayClusterName).
 	MaxRayJobNameLength = MaxRayClusterNameLength - 6
+	// MaxRayCronJobNameLength is the maximum RayCronJob name to make sure its child RayJob passes
+	// validation. Minus 11 for the "-<minuteHash>" suffix (dash + up to a 10-digit Unix-minute hash)
+	// appended to create the child RayJob name (getRayJobName).
+	MaxRayCronJobNameLength = MaxRayJobNameLength - 11
 )
 
 type ServiceType string

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -726,6 +726,11 @@ func validateLegacyDeletionPolicies(rayJob *rayv1.RayJob) error {
 
 // ValidateRayCronJobSpec validates the RayCronJob specification
 func ValidateRayCronJobSpec(rayCronJob *rayv1.RayCronJob) error {
+	// Bound the name so the deterministic child RayJob name (getRayJobName) stays valid.
+	if len(rayCronJob.Name) > MaxRayCronJobNameLength {
+		return fmt.Errorf("RayCronJob name should be no more than %d characters", MaxRayCronJobNameLength)
+	}
+
 	// Validate cron schedule format
 	if _, err := cron.ParseStandard(rayCronJob.Spec.Schedule); err != nil {
 		return fmt.Errorf("invalid cron schedule: %w", err)

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -2454,6 +2454,37 @@ func TestValidateRayCronJobSpec(t *testing.T) {
 			expectError: true,
 			errorMsg:    "invalid RayJob template",
 		},
+		{
+			name: "RayCronJob name too long",
+			cronJob: &rayv1.RayCronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      strings.Repeat("a", MaxRayCronJobNameLength+1),
+					Namespace: "default",
+				},
+				Spec: rayv1.RayCronJobSpec{
+					Schedule: "*/5 * * * *",
+					JobTemplate: rayv1.RayJobSpec{
+						Entrypoint: "python test.py",
+						RayClusterSpec: &rayv1.RayClusterSpec{
+							HeadGroupSpec: rayv1.HeadGroupSpec{
+								Template: corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										Containers: []corev1.Container{
+											{
+												Name:  "ray-head",
+												Image: "rayproject/ray:2.9.0",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "RayCronJob name should be no more than",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Why are these changes needed?

A single scheduled tick could create two or more child RayJobs. The child name used a random suffix (`<cronjob>-<rand.String(5)>`), so when the controller reconciled the same tick twice before the `LastScheduleTime` status write became visible (informer-cache lag, even at `reconcileConcurrency: 1`), the second pass passed the schedule gate and created a differently-named child instead of colliding. Each duplicate spun up its own ephemeral RayCluster, doubling cost.

Mirror the upstream `batch/v1` CronJob controller:

- **Name children deterministically** as `<cronjob>-<unixSeconds/60>` via `getRayJobName`, so a repeated Create for the same tick collides with `AlreadyExists`.
- **Treat `AlreadyExists` on Create as success** and still advance `LastScheduleTime`, covering both the informer-lag and `reconcileConcurrency > 1` races.
- **Add `MaxRayCronJobNameLength` validation**, since the deterministic suffix is longer than the old random one and would otherwise risk an invalid child name.

> Note on the name limit: `MaxRayCronJobNameLength` (36) follows upstream's reserve-11 convention (`-` + up to a 10-digit minute hash). RayCronJob names of 37–41 chars that previously appeared to "work" already produced child RayJobs >47 chars that silently failed `ValidateRayJobMetadata` downstream (the RayCluster never got created). This change surfaces that as an explicit validation error up front instead.

## Related issue number

Fixes #4849

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
    - `TestRayCronJobReconcile_NoDuplicateOnStaleStatus` — drives `Reconcile` twice for the same tick without an intervening status flush. Fails (2 children) on the old random-suffix naming, passes (1 child) with the fix.
    - `TestGetRayJobName_Deterministic` — same name + tick is stable; different ticks differ.
    - Added a `MaxRayCronJobNameLength` case to `TestValidateRayCronJobSpec`.
  - [ ] Manual tests
  - [ ] This PR is not tested :(