### PR TITLE
[kuberay-apiserver] do not set auth env vars by default

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -111,11 +111,6 @@ jobs:
         run: |
           kind load docker-image kuberay/apiserver:local
 
-      - name: Load image to kind cluster (security-proxy)
-        if: steps.list-changed.outputs.changed == 'true' && matrix.chart == 'kuberay-apiserver'
-        run: |
-          kind load docker-image kuberay/security-proxy:local
-
       - name: Install Custom Resource Definitions to kind cluster
         if: steps.list-changed.outputs.changed == 'true' && matrix.chart == 'ray-cluster'
         working-directory: helm-chart/kuberay-operator

--- a/helm-chart/kuberay-apiserver/README.md
+++ b/helm-chart/kuberay-apiserver/README.md
@@ -133,4 +133,4 @@ kubectl get pods
 | singleNamespaceInstall | bool | `false` | The chart can be installed by users with permissions to a single namespace only |
 | enableAPIServerV2 | bool | `true` | If set to true, APIServer v2 would be served on the same port as the APIServer v1. |
 | security.proxy | object | `{"pullPolicy":"IfNotPresent","repository":"quay.io/kuberay/security-proxy","tag":"nightly"}` | security proxy image. |
-| security.env | object | `{"ENABLE_GRPC":"true","GRPC_LOCAL_PORT":8987,"HTTP_LOCAL_PORT":8988,"SECURITY_PREFIX":"/","SECURITY_TOKEN":"12345"}` | security proxy environment variables. |
+| security.env | object | `{"ENABLE_GRPC":"true","GRPC_LOCAL_PORT":8987,"HTTP_LOCAL_PORT":8988,"SECURITY_PREFIX":"/"}` | security proxy environment variables. |

--- a/helm-chart/kuberay-apiserver/ci/ci-values.yaml
+++ b/helm-chart/kuberay-apiserver/ci/ci-values.yaml
@@ -2,9 +2,3 @@ image:
   repository: kuberay/apiserver
   tag: local
   pullPolicy: Never
-
-security:
-  proxy:
-    repository: kuberay/security-proxy
-    tag: local
-    pullPolicy: Never

--- a/helm-chart/kuberay-apiserver/ci/ci-values.yaml
+++ b/helm-chart/kuberay-apiserver/ci/ci-values.yaml
@@ -2,3 +2,7 @@ image:
   repository: kuberay/apiserver
   tag: local
   pullPolicy: Never
+
+security:
+  env:
+    SECURITY_TOKEN: "12345"

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -116,6 +116,7 @@ security:
   env:
     HTTP_LOCAL_PORT: 8988
     GRPC_LOCAL_PORT: 8987
-    SECURITY_TOKEN: "12345"
+    # SECURITY_TOKEN must be provided explicitly by the user or fetched from a Secret.
+    # SECURITY_TOKEN: "12345"
     SECURITY_PREFIX: "/"
     ENABLE_GRPC: "true"


### PR DESCRIPTION
## Why are these changes needed?

With the default helm chart, a user may accidentally set `SECURITY_TOKEN` to 12345 without knowing that they should  set this to a secure token. To avoid this, we should comment out the default value and require users to explicitly set it. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
