### PR TITLE
[CI] Make build-start-operator.sh fail fast on setup errors

### DIFF
--- a/.buildkite/build-start-operator.sh
+++ b/.buildkite/build-start-operator.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # This script is used to start the operator in the buildkite test-e2e steps.
 
@@ -6,15 +7,16 @@
 # released version from helm as actual users might. Ray ci is also always expected
 # to kick off from the release branch so tests should match up accordingly.
 
-if [ "$IS_FROM_RAY_RELEASE_AUTOMATION" = 1 ]; then
+if [ "${IS_FROM_RAY_RELEASE_AUTOMATION:-0}" = 1 ]; then
     helm repo update
     echo "Installing helm chart with test override values (feature gates enabled as needed)"
     # NOTE: The override file is CI/test-only. It is NOT part of the released chart defaults.
     helm install kuberay-operator kuberay/kuberay-operator -f ../.buildkite/values-kuberay-operator-override.yaml
-    KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly-extra-py310-cpu" && export KUBERAY_TEST_RAY_IMAGE
+    KUBERAY_TEST_RAY_IMAGE="rayproject/ray:nightly-extra-py310-cpu"
+    export KUBERAY_TEST_RAY_IMAGE
 else
-    IMG=kuberay/operator:nightly make docker-image &&
-    kind load docker-image kuberay/operator:nightly &&
+    IMG=kuberay/operator:nightly make docker-image
+    kind load docker-image kuberay/operator:nightly
     echo "Deploying operator with test overrides (feature gates via test-overrides overlay)"
     IMG=kuberay/operator:nightly make deploy-with-override
 fi

--- a/.buildkite/build-start-operator.sh
+++ b/.buildkite/build-start-operator.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 
 # This script is used to start the operator in the buildkite test-e2e steps.
 
 # When starting from the ray ci release automation, we want to install the latest
 # released version from helm as actual users might. Ray ci is also always expected
 # to kick off from the release branch so tests should match up accordingly.
+#
+# NOTE: Do not enable `set -u` (nounset) here. This script is sourced by the
+# Buildkite steps, so shell options propagate to the caller; downstream steps
+# reference $KUBERAY_TEST_RAY_IMAGE without a default and would fail under -u
+# when the variable is not set (e.g. in the non-release path).
 
-if [ "${IS_FROM_RAY_RELEASE_AUTOMATION:-0}" = 1 ]; then
+if [ "$IS_FROM_RAY_RELEASE_AUTOMATION" = 1 ]; then
     helm repo update
     echo "Installing helm chart with test override values (feature gates enabled as needed)"
     # NOTE: The override file is CI/test-only. It is NOT part of the released chart defaults.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`.buildkite/build-start-operator.sh` previously chained:

```bash
IMG=kuberay/operator:nightly make docker-image &&
kind load docker-image kuberay/operator:nightly &&
echo "Deploying operator with test overrides ..."
IMG=kuberay/operator:nightly make deploy-with-override
```

If `make docker-image` failed (e.g. transient `504 Gateway Time-out` from `registry-1.docker.io`), the `&&` chain short-circuited but `make deploy-with-override` still ran as a separate command. The script returned the exit code of the last command (`0`), so callers thought setup succeeded. Downstream `kubectl wait deployment kuberay-operator` then timed out because the operator image was never built/loaded — hiding the real cause in a misleading readiness timeout.

This change enables `set -euo pipefail` and removes the `&&` chain so any failing step aborts the script immediately and propagates a non-zero exit code to callers. Affects all Buildkite e2e steps that source this script; success path is unchanged.

## Related issue number

Closes #4879

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(