### PR TITLE
[Bug][RayService] Reset Ready=Initializing on resume so initializing-timeout fires

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -392,13 +392,9 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 			logger.Info("Spec.Suspend is false; exiting Suspended state and resuming reconcile")
 			setCondition(rayServiceInstance, rayv1.RayServiceSuspended, metav1.ConditionFalse, rayv1.RayServiceResumed,
 				"Spec.Suspend is false; RayService has resumed.")
-			// Reset RayServiceReady to Initializing on resume so the
-			// initializing-timeout (which guards on Reason==Initializing and
-			// measures elapsed time from LastTransitionTime) re-arms for the
-			// resumed attempt. RemoveStatusCondition + setCondition is used
-			// because meta.SetStatusCondition does not refresh
-			// LastTransitionTime when only the Reason changes (Status stays
-			// False across Suspended -> Initializing). See ray-project/kuberay#4892.
+			// Re-arm the initializing-timeout for the resumed attempt.
+			// Remove + Set forces a fresh LastTransitionTime because
+			// meta.SetStatusCondition only refreshes it when Status changes.
 			meta.RemoveStatusCondition(&rayServiceInstance.Status.Conditions, string(rayv1.RayServiceReady))
 			setCondition(rayServiceInstance, rayv1.RayServiceReady, metav1.ConditionFalse, rayv1.RayServiceInitializing,
 				"RayService is initializing after resuming from suspend.")

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -392,6 +392,16 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 			logger.Info("Spec.Suspend is false; exiting Suspended state and resuming reconcile")
 			setCondition(rayServiceInstance, rayv1.RayServiceSuspended, metav1.ConditionFalse, rayv1.RayServiceResumed,
 				"Spec.Suspend is false; RayService has resumed.")
+			// Reset RayServiceReady to Initializing on resume so the
+			// initializing-timeout (which guards on Reason==Initializing and
+			// measures elapsed time from LastTransitionTime) re-arms for the
+			// resumed attempt. RemoveStatusCondition + setCondition is used
+			// because meta.SetStatusCondition does not refresh
+			// LastTransitionTime when only the Reason changes (Status stays
+			// False across Suspended -> Initializing). See ray-project/kuberay#4892.
+			meta.RemoveStatusCondition(&rayServiceInstance.Status.Conditions, string(rayv1.RayServiceReady))
+			setCondition(rayServiceInstance, rayv1.RayServiceReady, metav1.ConditionFalse, rayv1.RayServiceInitializing,
+				"RayService is initializing after resuming from suspend.")
 			return ctrl.Result{}, nil
 		}
 		// Stay suspended; nothing to reconcile.

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -398,6 +398,9 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 			meta.RemoveStatusCondition(&rayServiceInstance.Status.Conditions, string(rayv1.RayServiceReady))
 			setCondition(rayServiceInstance, rayv1.RayServiceReady, metav1.ConditionFalse, rayv1.RayServiceInitializing,
 				"RayService is initializing after resuming from suspend.")
+			meta.RemoveStatusCondition(&rayServiceInstance.Status.Conditions, string(rayv1.UpgradeInProgress))
+			setCondition(rayServiceInstance, rayv1.UpgradeInProgress, metav1.ConditionFalse, rayv1.RayServiceInitializing,
+				"RayService is initializing after resuming from suspend.")
 			return ctrl.Result{}, nil
 		}
 		// Stay suspended; nothing to reconcile.

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2570,6 +2570,87 @@ func TestMarkFailedIfInitializingTimedOut(t *testing.T) {
 	}
 }
 
+// TestHandleSuspendResumeResetsReadyToInitializing verifies that resuming a
+// RayService from the Suspended state resets the RayServiceReady condition
+// back to Reason=Initializing with a fresh LastTransitionTime, so that
+// markFailedOnInitializingTimeout can fire on the resumed attempt. See
+// ray-project/kuberay#4892.
+func TestHandleSuspendResumeResetsReadyToInitializing(t *testing.T) {
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	// Stale timestamp from the suspend transition. If the resume path does
+	// not refresh LastTransitionTime on RayServiceReady, the
+	// initializing-timeout check will compare against this old time and
+	// either fire instantly or never re-arm correctly.
+	suspendTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+
+	rs := &rayv1.RayService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rayservice",
+			Namespace: "default",
+		},
+		Spec: rayv1.RayServiceSpec{
+			Suspend: false,
+		},
+		Status: rayv1.RayServiceStatuses{
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(rayv1.RayServiceSuspended),
+					Status:             metav1.ConditionTrue,
+					Reason:             string(rayv1.SuspendComplete),
+					LastTransitionTime: suspendTime,
+				},
+				{
+					Type:               string(rayv1.RayServiceSuspending),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(rayv1.SuspendComplete),
+					LastTransitionTime: suspendTime,
+				},
+				{
+					Type:               string(rayv1.RayServiceReady),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(rayv1.SuspendComplete),
+					LastTransitionTime: suspendTime,
+				},
+				{
+					Type:               string(rayv1.UpgradeInProgress),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(rayv1.SuspendComplete),
+					LastTransitionTime: suspendTime,
+				},
+				{
+					Type:               string(rayv1.RollbackInProgress),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(rayv1.SuspendComplete),
+					LastTransitionTime: suspendTime,
+				},
+			},
+		},
+	}
+
+	ctx := context.TODO()
+	fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).Build()
+	r := &RayServiceReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme.Scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	_, err := r.handleSuspend(ctx, rs)
+	require.NoError(t, err)
+
+	readyCond := meta.FindStatusCondition(rs.Status.Conditions, string(rayv1.RayServiceReady))
+	require.NotNil(t, readyCond, "RayServiceReady condition must exist after resume")
+
+	assert.Equal(t, string(rayv1.RayServiceInitializing), readyCond.Reason,
+		"RayServiceReady reason must be Initializing on resume; otherwise initializing-timeout will not fire (#4892)")
+
+	assert.WithinDuration(t, time.Now(), readyCond.LastTransitionTime.Time, 5*time.Second,
+		"RayServiceReady LastTransitionTime must reset on resume; otherwise initializing-timeout will use the stale suspend timestamp")
+}
+
 func Test_RayServiceReconcileManagedBy(t *testing.T) {
 	newScheme := runtime.NewScheme()
 	_ = rayv1.AddToScheme(newScheme)

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2573,8 +2573,7 @@ func TestMarkFailedIfInitializingTimedOut(t *testing.T) {
 // TestHandleSuspendResumeResetsReadyToInitializing verifies that resuming a
 // RayService from the Suspended state resets the RayServiceReady condition
 // back to Reason=Initializing with a fresh LastTransitionTime, so that
-// markFailedOnInitializingTimeout can fire on the resumed attempt. See
-// ray-project/kuberay#4892.
+// markFailedOnInitializingTimeout can fire on the resumed attempt.
 func TestHandleSuspendResumeResetsReadyToInitializing(t *testing.T) {
 	newScheme := runtime.NewScheme()
 	_ = rayv1.AddToScheme(newScheme)
@@ -2645,7 +2644,7 @@ func TestHandleSuspendResumeResetsReadyToInitializing(t *testing.T) {
 	require.NotNil(t, readyCond, "RayServiceReady condition must exist after resume")
 
 	assert.Equal(t, string(rayv1.RayServiceInitializing), readyCond.Reason,
-		"RayServiceReady reason must be Initializing on resume; otherwise initializing-timeout will not fire (#4892)")
+		"RayServiceReady reason must be Initializing on resume; otherwise initializing-timeout will not fire")
 
 	assert.WithinDuration(t, time.Now(), readyCond.LastTransitionTime.Time, 5*time.Second,
 		"RayServiceReady LastTransitionTime must reset on resume; otherwise initializing-timeout will use the stale suspend timestamp")

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2648,6 +2648,15 @@ func TestHandleSuspendResumeResetsReadyToInitializing(t *testing.T) {
 
 	assert.WithinDuration(t, time.Now(), readyCond.LastTransitionTime.Time, 5*time.Second,
 		"RayServiceReady LastTransitionTime must reset on resume; otherwise initializing-timeout will use the stale suspend timestamp")
+
+	upgradeCond := meta.FindStatusCondition(rs.Status.Conditions, string(rayv1.UpgradeInProgress))
+	require.NotNil(t, upgradeCond, "UpgradeInProgress condition must exist after resume")
+
+	assert.Equal(t, string(rayv1.RayServiceInitializing), upgradeCond.Reason,
+		"UpgradeInProgress reason must be Initializing on resume; otherwise calculateConditions may set it to NoActiveCluster")
+
+	assert.WithinDuration(t, time.Now(), upgradeCond.LastTransitionTime.Time, 5*time.Second,
+		"UpgradeInProgress LastTransitionTime must reset on resume")
 }
 
 func Test_RayServiceReconcileManagedBy(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When a RayService is suspended and then resumed (`Spec.Suspend` toggled `true -> false`), the `initializing-timeout` annotation is silently disarmed for the resumed attempt.

**Root cause.** The resume branch of `handleSuspend` only flips `RayServiceSuspended` to `False` and leaves `RayServiceReady` at `Reason=SuspendComplete` with the stale suspend `LastTransitionTime`. Because `markFailedOnInitializingTimeout` guards on `Reason == RayServiceInitializing` and measures elapsed time from `LastTransitionTime`:

- The Reason guard fails, so the timeout check returns early.
- Even if the Reason were re-set, `meta.SetStatusCondition` does **not** refresh `LastTransitionTime` when only the Reason changes (Status stays `False` across the `SuspendComplete -> Initializing` transition), so the timer would still be anchored at the suspend moment.

A resumed RayService can therefore hang forever waiting for a head Pod that never comes up, with no timeout event, no terminal state, and no cleanup — exactly the behavior the `initializing-timeout` annotation was designed to prevent.

**Fix.** In the resume branch of `handleSuspend`, remove and re-add `RayServiceReady` with `Reason=Initializing`. `RemoveStatusCondition` is needed because `meta.SetStatusCondition` preserves `LastTransitionTime` on no-Status-change; removing first forces a fresh timestamp on re-add. This is the same idiom already used elsewhere in this file (`controllers/ray/rayservice_controller.go:701`).

**Test evidence.**

Failing on master before the fix:

```
--- FAIL: TestHandleSuspendResumeResetsReadyToInitializing (0.05s)
    rayservice_controller_unit_test.go:2647:
        Error: Not equal:
              expected: "Initializing"
              actual  : "SuspendComplete"
        Test: TestHandleSuspendResumeResetsReadyToInitializing
        Messages: RayServiceReady reason must be Initializing on resume; otherwise initializing-timeout will not fire (#4892)
    rayservice_controller_unit_test.go:2650:
        Error: Max difference between [...] allowed is 5s, but difference was 1h0m0.045239334s
        Messages: RayServiceReady LastTransitionTime must reset on resume; otherwise initializing-timeout will use the stale suspend timestamp
```

Passing after the fix:

```
=== RUN   TestHandleSuspendResumeResetsReadyToInitializing
--- PASS: TestHandleSuspendResumeResetsReadyToInitializing (0.04s)
PASS
ok      github.com/ray-project/kuberay/ray-operator/controllers/ray     1.323s
```

All other RayService unit tests in the package continue to pass.

## Related issue number

Closes #4892

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


