### PR TITLE
[Test][RayJob] Assert all owned resources deleted on suspend

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2634,7 +2634,7 @@ func TestHandleSuspendResumeResetsReadyToInitializing(t *testing.T) {
 	r := &RayServiceReconciler{
 		Client:   fakeClient,
 		Scheme:   scheme.Scheme,
-		Recorder: record.NewFakeRecorder(10),
+		Recorder: events.NewFakeRecorder(10),
 	}
 
 	_, err := r.handleSuspend(ctx, rs)

--- a/ray-operator/test/e2erayjob/rayjob_suspend_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_suspend_test.go
@@ -57,13 +57,29 @@ func TestRayJobSuspend(t *testing.T) {
 		// Assert the RayCluster has been torn down
 		_, err = GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
 		g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		clusterName := rayJob.Status.RayClusterName
 
 		// Assert the submitter Job has been cascade deleted
 		g.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
 
-		// TODO (kevin85421): Check whether the Pods associated with the RayCluster and the submitter Job have been deleted.
-		// For Kubernetes Jobs, the default deletion behavior is "orphanDependents," which means the Pods will not be
-		// cascade-deleted with the Kubernetes Job by default.
+		// Assert all Pods owned by the RayCluster (head + workers) have been deleted.
+		g.Eventually(Pods(test, namespace.Name,
+			LabelSelector(utils.RayClusterLabelKey+"="+clusterName)), TestTimeoutMedium).
+			Should(BeEmpty())
+
+		// Assert the submitter Pod (created by the submitter K8s Job) has been deleted.
+		g.Eventually(Pods(test, namespace.Name,
+			LabelSelector("job-name="+rayJob.Name)), TestTimeoutMedium).
+			Should(BeEmpty())
+
+		// Assert all Services owned by the RayCluster (head Service, serve Service) have been deleted.
+		g.Eventually(func(gg Gomega) {
+			svcList, err := test.Client().Core().CoreV1().Services(namespace.Name).List(test.Ctx(), metav1.ListOptions{
+				LabelSelector: utils.RayClusterLabelKey + "=" + clusterName,
+			})
+			gg.Expect(err).NotTo(HaveOccurred())
+			gg.Expect(svcList.Items).To(BeEmpty())
+		}, TestTimeoutMedium).Should(Succeed())
 
 		LogWithTimestamp(test.T(), "Resume the RayJob by updating `suspend` to false.")
 		rayJobAC.Spec.WithSuspend(false)

--- a/ray-operator/test/e2erayjob/rayjob_suspend_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_suspend_test.go
@@ -72,7 +72,7 @@ func TestRayJobSuspend(t *testing.T) {
 			LabelSelector("job-name="+rayJob.Name)), TestTimeoutMedium).
 			Should(BeEmpty())
 
-		// Assert all Services owned by the RayCluster (head Service, serve Service) have been deleted.
+		// Assert all Services owned by the RayCluster have been deleted.
 		g.Eventually(func(gg Gomega) {
 			svcList, err := test.Client().Core().CoreV1().Services(namespace.Name).List(test.Ctx(), metav1.ListOptions{
 				LabelSelector: utils.RayClusterLabelKey + "=" + clusterName,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR resolves the line-64 TODO @kevin85421 left in `TestRayJobSuspend` and verify the resource clean-up asked in issue #4875:

> *"It's better to ensure all K8s resources owned by the RayJob CR are deleted when the RayJob CR is 'suspended'. I briefly read the code, and the current behavior seems to match what's described above. If this is already the case, please also make sure there's a test to verify it."* — @kevin85421 

### Investigation findings (no controller change needed)

- `deleteSubmitterJob` (`ray-operator/controllers/ray/rayjob_controller.go:745`) explicitly uses `metav1.DeletePropagationBackground`, so the submitter Job's child Pod is cascade-deleted by the K8s garbage collector.
- `deleteClusterResources` (`ray-operator/controllers/ray/rayjob_controller.go:784`) deletes the RayCluster CR via the default propagation policy (Background on the K8s API server), so head/worker Pods and head/serve Services owned by the RayCluster are likewise cascade-deleted.

So the controller behavior already matches expectation. The gap was test coverage.

### What this PR adds

After the existing assertions that the RayCluster CR and the submitter Job are gone, the test now also asserts (each via `Eventually` to tolerate async GC):

- All Pods labeled `ray.io/cluster=<clusterName>` are gone (head + workers).
- The submitter Pod labeled `job-name=<rayJobName>` is gone.
- All Services labeled `ray.io/cluster=<clusterName>` are gone (head Service, serve Service).

If a future controller change accidentally drops resource cleanup on suspend, this test will catch it.

### Why no production code change

My investigation agrees: the two delete helpers in `rayjob_controller.go` already use cascading propagation.

## Related issue number

Closes #4875

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
