### PR TITLE
Update observedGeneration during suspend lifecycle in RayService

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -390,6 +390,7 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 	if isSuspended {
 		if !rayServiceInstance.Spec.Suspend {
 			logger.Info("Spec.Suspend is false; exiting Suspended state and resuming reconcile")
+			bumpObservedGeneration(rayServiceInstance)
 			setCondition(rayServiceInstance, rayv1.RayServiceSuspended, metav1.ConditionFalse, rayv1.RayServiceResumed,
 				"Spec.Suspend is false; RayService has resumed.")
 			return ctrl.Result{}, nil
@@ -407,6 +408,7 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 			return ctrl.Result{}, nil
 		}
 		logger.Info("Spec.Suspend is true; committing transition to Suspending state")
+		bumpObservedGeneration(rayServiceInstance)
 		setCondition(rayServiceInstance, rayv1.RayServiceSuspending, metav1.ConditionTrue, rayv1.SuspendRequested,
 			"Spec.Suspend is true; will delete all Kubernetes resources owned by this RayService.")
 		setCondition(rayServiceInstance, rayv1.RayServiceReady, metav1.ConditionFalse, rayv1.SuspendInProgress, "RayService is suspending.")
@@ -430,6 +432,7 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 	}
 
 	if !allDeleted {
+		bumpObservedGeneration(rayServiceInstance)
 		setCondition(rayServiceInstance, rayv1.RayServiceSuspending, metav1.ConditionTrue, rayv1.SuspendInProgress,
 			"Waiting for all Kubernetes resources owned by this RayService to be deleted.")
 		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
@@ -441,6 +444,7 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 	// us here despite Spec.Suspend=false), since the status-only update
 	// below would not otherwise wake the controller up.
 	logger.Info("All RayService-owned resources deleted; transitioning to Suspended")
+	bumpObservedGeneration(rayServiceInstance)
 	setCondition(rayServiceInstance, rayv1.RayServiceSuspending, metav1.ConditionFalse, rayv1.SuspendComplete,
 		"All owned resources have been deleted.")
 	setCondition(rayServiceInstance, rayv1.RayServiceSuspended, metav1.ConditionTrue, rayv1.SuspendComplete, "All owned resources have been deleted.")
@@ -804,6 +808,15 @@ func calculateConditions(ctx context.Context, r *RayServiceReconciler, rayServic
 			setCondition(rayServiceInstance, rayv1.UpgradeInProgress, metav1.ConditionUnknown, rayv1.NoActiveCluster, "No active Ray cluster exists, and the RayService is not initializing. Please open a GitHub issue in the KubeRay repository.")
 		}
 	}
+}
+
+// bumpObservedGeneration updates status.observedGeneration for reconcile paths that
+// mutate status without running calculateStatus.
+func bumpObservedGeneration(rayServiceInstance *rayv1.RayService) {
+	if rayServiceInstance.Status.ObservedGeneration == rayServiceInstance.ObjectMeta.Generation {
+		return
+	}
+	rayServiceInstance.Status.ObservedGeneration = rayServiceInstance.ObjectMeta.Generation
 }
 
 func setCondition(rayServiceInstance *rayv1.RayService, conditionType rayv1.RayServiceConditionType, status metav1.ConditionStatus, reason rayv1.RayServiceConditionReason, message string) {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -390,7 +390,7 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 	if isSuspended {
 		if !rayServiceInstance.Spec.Suspend {
 			logger.Info("Spec.Suspend is false; exiting Suspended state and resuming reconcile")
-			bumpObservedGeneration(rayServiceInstance)
+			rayServiceInstance.Status.ObservedGeneration = rayServiceInstance.ObjectMeta.Generation
 			setCondition(rayServiceInstance, rayv1.RayServiceSuspended, metav1.ConditionFalse, rayv1.RayServiceResumed,
 				"Spec.Suspend is false; RayService has resumed.")
 			return ctrl.Result{}, nil
@@ -408,7 +408,7 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 			return ctrl.Result{}, nil
 		}
 		logger.Info("Spec.Suspend is true; committing transition to Suspending state")
-		bumpObservedGeneration(rayServiceInstance)
+		rayServiceInstance.Status.ObservedGeneration = rayServiceInstance.ObjectMeta.Generation
 		setCondition(rayServiceInstance, rayv1.RayServiceSuspending, metav1.ConditionTrue, rayv1.SuspendRequested,
 			"Spec.Suspend is true; will delete all Kubernetes resources owned by this RayService.")
 		setCondition(rayServiceInstance, rayv1.RayServiceReady, metav1.ConditionFalse, rayv1.SuspendInProgress, "RayService is suspending.")
@@ -432,7 +432,7 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 	}
 
 	if !allDeleted {
-		bumpObservedGeneration(rayServiceInstance)
+		rayServiceInstance.Status.ObservedGeneration = rayServiceInstance.ObjectMeta.Generation
 		setCondition(rayServiceInstance, rayv1.RayServiceSuspending, metav1.ConditionTrue, rayv1.SuspendInProgress,
 			"Waiting for all Kubernetes resources owned by this RayService to be deleted.")
 		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
@@ -444,7 +444,7 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 	// us here despite Spec.Suspend=false), since the status-only update
 	// below would not otherwise wake the controller up.
 	logger.Info("All RayService-owned resources deleted; transitioning to Suspended")
-	bumpObservedGeneration(rayServiceInstance)
+	rayServiceInstance.Status.ObservedGeneration = rayServiceInstance.ObjectMeta.Generation
 	setCondition(rayServiceInstance, rayv1.RayServiceSuspending, metav1.ConditionFalse, rayv1.SuspendComplete,
 		"All owned resources have been deleted.")
 	setCondition(rayServiceInstance, rayv1.RayServiceSuspended, metav1.ConditionTrue, rayv1.SuspendComplete, "All owned resources have been deleted.")
@@ -808,15 +808,6 @@ func calculateConditions(ctx context.Context, r *RayServiceReconciler, rayServic
 			setCondition(rayServiceInstance, rayv1.UpgradeInProgress, metav1.ConditionUnknown, rayv1.NoActiveCluster, "No active Ray cluster exists, and the RayService is not initializing. Please open a GitHub issue in the KubeRay repository.")
 		}
 	}
-}
-
-// bumpObservedGeneration updates status.observedGeneration for reconcile paths that
-// mutate status without running calculateStatus.
-func bumpObservedGeneration(rayServiceInstance *rayv1.RayService) {
-	if rayServiceInstance.Status.ObservedGeneration == rayServiceInstance.ObjectMeta.Generation {
-		return
-	}
-	rayServiceInstance.Status.ObservedGeneration = rayServiceInstance.ObjectMeta.Generation
 }
 
 func setCondition(rayServiceInstance *rayv1.RayService, conditionType rayv1.RayServiceConditionType, status metav1.ConditionStatus, reason rayv1.RayServiceConditionReason, message string) {

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -432,7 +432,6 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 	}
 
 	if !allDeleted {
-		rayServiceInstance.Status.ObservedGeneration = rayServiceInstance.ObjectMeta.Generation
 		setCondition(rayServiceInstance, rayv1.RayServiceSuspending, metav1.ConditionTrue, rayv1.SuspendInProgress,
 			"Waiting for all Kubernetes resources owned by this RayService to be deleted.")
 		return ctrl.Result{RequeueAfter: ServiceDefaultRequeueDuration}, nil
@@ -444,7 +443,6 @@ func (r *RayServiceReconciler) handleSuspend(ctx context.Context, rayServiceInst
 	// us here despite Spec.Suspend=false), since the status-only update
 	// below would not otherwise wake the controller up.
 	logger.Info("All RayService-owned resources deleted; transitioning to Suspended")
-	rayServiceInstance.Status.ObservedGeneration = rayServiceInstance.ObjectMeta.Generation
 	setCondition(rayServiceInstance, rayv1.RayServiceSuspending, metav1.ConditionFalse, rayv1.SuspendComplete,
 		"All owned resources have been deleted.")
 	setCondition(rayServiceInstance, rayv1.RayServiceSuspended, metav1.ConditionTrue, rayv1.SuspendComplete, "All owned resources have been deleted.")

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -3102,3 +3102,76 @@ func TestRayServiceFinalizer(t *testing.T) {
 		})
 	}
 }
+
+func TestBumpObservedGeneration(t *testing.T) {
+	t.Run("updates when behind metadata generation", func(t *testing.T) {
+		rs := &rayv1.RayService{
+			ObjectMeta: metav1.ObjectMeta{Generation: 7},
+			Status:     rayv1.RayServiceStatuses{ObservedGeneration: 3},
+		}
+		bumpObservedGeneration(rs)
+		assert.Equal(t, int64(7), rs.Status.ObservedGeneration)
+	})
+
+	t.Run("no-op when already current", func(t *testing.T) {
+		rs := &rayv1.RayService{
+			ObjectMeta: metav1.ObjectMeta{Generation: 7},
+			Status:     rayv1.RayServiceStatuses{ObservedGeneration: 7},
+		}
+		bumpObservedGeneration(rs)
+		assert.Equal(t, int64(7), rs.Status.ObservedGeneration)
+	})
+}
+
+func TestHandleSuspendObservedGeneration(t *testing.T) {
+	ctx := context.Background()
+	reconciler := &RayServiceReconciler{}
+
+	t.Run("entering Suspending bumps observedGeneration on conditions", func(t *testing.T) {
+		rs := &rayv1.RayService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "rayservice",
+				Namespace:  "default",
+				Generation: 5,
+			},
+			Spec: rayv1.RayServiceSpec{Suspend: true},
+			Status: rayv1.RayServiceStatuses{
+				ObservedGeneration: 2,
+			},
+		}
+
+		_, err := reconciler.handleSuspend(ctx, rs)
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), rs.Status.ObservedGeneration)
+
+		suspending := meta.FindStatusCondition(rs.Status.Conditions, string(rayv1.RayServiceSuspending))
+		require.NotNil(t, suspending)
+		assert.Equal(t, metav1.ConditionTrue, suspending.Status)
+		assert.Equal(t, int64(5), suspending.ObservedGeneration)
+	})
+
+	t.Run("idle Suspended does not bump observedGeneration", func(t *testing.T) {
+		rs := &rayv1.RayService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "rayservice",
+				Namespace:  "default",
+				Generation: 9,
+			},
+			Spec: rayv1.RayServiceSpec{Suspend: true},
+			Status: rayv1.RayServiceStatuses{
+				ObservedGeneration: 4,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(rayv1.RayServiceSuspended),
+						Status: metav1.ConditionTrue,
+						Reason: string(rayv1.SuspendComplete),
+					},
+				},
+			},
+		}
+
+		_, err := reconciler.handleSuspend(ctx, rs)
+		require.NoError(t, err)
+		assert.Equal(t, int64(4), rs.Status.ObservedGeneration)
+	})
+}

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -3103,26 +3103,6 @@ func TestRayServiceFinalizer(t *testing.T) {
 	}
 }
 
-func TestBumpObservedGeneration(t *testing.T) {
-	t.Run("updates when behind metadata generation", func(t *testing.T) {
-		rayService := &rayv1.RayService{
-			ObjectMeta: metav1.ObjectMeta{Generation: 7},
-			Status:     rayv1.RayServiceStatuses{ObservedGeneration: 3},
-		}
-		bumpObservedGeneration(rayService)
-		assert.Equal(t, int64(7), rayService.Status.ObservedGeneration)
-	})
-
-	t.Run("no-op when already current", func(t *testing.T) {
-		rayService := &rayv1.RayService{
-			ObjectMeta: metav1.ObjectMeta{Generation: 7},
-			Status:     rayv1.RayServiceStatuses{ObservedGeneration: 7},
-		}
-		bumpObservedGeneration(rayService)
-		assert.Equal(t, int64(7), rayService.Status.ObservedGeneration)
-	})
-}
-
 func TestHandleSuspendObservedGeneration(t *testing.T) {
 	ctx := context.Background()
 	reconciler := &RayServiceReconciler{}

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -3105,21 +3105,21 @@ func TestRayServiceFinalizer(t *testing.T) {
 
 func TestBumpObservedGeneration(t *testing.T) {
 	t.Run("updates when behind metadata generation", func(t *testing.T) {
-		rs := &rayv1.RayService{
+		rayService := &rayv1.RayService{
 			ObjectMeta: metav1.ObjectMeta{Generation: 7},
 			Status:     rayv1.RayServiceStatuses{ObservedGeneration: 3},
 		}
-		bumpObservedGeneration(rs)
-		assert.Equal(t, int64(7), rs.Status.ObservedGeneration)
+		bumpObservedGeneration(rayService)
+		assert.Equal(t, int64(7), rayService.Status.ObservedGeneration)
 	})
 
 	t.Run("no-op when already current", func(t *testing.T) {
-		rs := &rayv1.RayService{
+		rayService := &rayv1.RayService{
 			ObjectMeta: metav1.ObjectMeta{Generation: 7},
 			Status:     rayv1.RayServiceStatuses{ObservedGeneration: 7},
 		}
-		bumpObservedGeneration(rs)
-		assert.Equal(t, int64(7), rs.Status.ObservedGeneration)
+		bumpObservedGeneration(rayService)
+		assert.Equal(t, int64(7), rayService.Status.ObservedGeneration)
 	})
 }
 
@@ -3128,7 +3128,7 @@ func TestHandleSuspendObservedGeneration(t *testing.T) {
 	reconciler := &RayServiceReconciler{}
 
 	t.Run("entering Suspending bumps observedGeneration on conditions", func(t *testing.T) {
-		rs := &rayv1.RayService{
+		rayService := &rayv1.RayService{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "rayservice",
 				Namespace:  "default",
@@ -3140,18 +3140,18 @@ func TestHandleSuspendObservedGeneration(t *testing.T) {
 			},
 		}
 
-		_, err := reconciler.handleSuspend(ctx, rs)
+		_, err := reconciler.handleSuspend(ctx, rayService)
 		require.NoError(t, err)
-		assert.Equal(t, int64(5), rs.Status.ObservedGeneration)
+		assert.Equal(t, int64(5), rayService.Status.ObservedGeneration)
 
-		suspending := meta.FindStatusCondition(rs.Status.Conditions, string(rayv1.RayServiceSuspending))
+		suspending := meta.FindStatusCondition(rayService.Status.Conditions, string(rayv1.RayServiceSuspending))
 		require.NotNil(t, suspending)
 		assert.Equal(t, metav1.ConditionTrue, suspending.Status)
 		assert.Equal(t, int64(5), suspending.ObservedGeneration)
 	})
 
 	t.Run("idle Suspended does not bump observedGeneration", func(t *testing.T) {
-		rs := &rayv1.RayService{
+		rayService := &rayv1.RayService{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       "rayservice",
 				Namespace:  "default",
@@ -3170,8 +3170,8 @@ func TestHandleSuspendObservedGeneration(t *testing.T) {
 			},
 		}
 
-		_, err := reconciler.handleSuspend(ctx, rs)
+		_, err := reconciler.handleSuspend(ctx, rayService)
 		require.NoError(t, err)
-		assert.Equal(t, int64(4), rs.Status.ObservedGeneration)
+		assert.Equal(t, int64(4), rayService.Status.ObservedGeneration)
 	})
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
When `Spec.Suspend` is set to true, `metadata.generation` is incremented by Kubernetes, but `handleSuspend` previously returned on certain paths without updating `status.observedGeneration`. This caused `observedGeneration` to lag behind generation, making it appear as if the controller had not yet reconciled the latest spec change.

This PR ensures that `status.observedGeneration` is updated during the suspend lifecycle, since suspend reconciliation bypasses `calculateStatus()` and would otherwise leave it stale. Unit tests are added to verify the behavior for each path in the suspend lifecycle.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #4891 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
