### PR TITLE
[History Sever] Use compression library in collector and historyserver

### DIFF
--- a/historyserver/Dockerfile.collector
+++ b/historyserver/Dockerfile.collector
@@ -17,6 +17,7 @@ COPY pkg/collector/ pkg/collector/
 COPY pkg/storage/ pkg/storage/
 COPY pkg/utils/ pkg/utils/
 COPY pkg/eventserver/ pkg/eventserver/
+COPY pkg/compression/ pkg/compression/
 
 # Build the collector binary.
 COPY Makefile Makefile

--- a/historyserver/Dockerfile.historyserver
+++ b/historyserver/Dockerfile.historyserver
@@ -20,6 +20,7 @@ COPY pkg/historyserver/ pkg/historyserver/
 COPY pkg/storage/ pkg/storage/
 COPY pkg/utils/ pkg/utils/
 COPY pkg/eventserver/ pkg/eventserver/
+COPY pkg/compression/ pkg/compression/
 
 # Build the historyserver binary.
 COPY Makefile Makefile

--- a/historyserver/pkg/collector/eventcollector/eventcollector.go
+++ b/historyserver/pkg/collector/eventcollector/eventcollector.go
@@ -1,7 +1,6 @@
 package eventcollector
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,6 +15,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 
+	"github.com/ray-project/kuberay/historyserver/pkg/compression"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
@@ -437,8 +437,6 @@ func (ec *EventCollector) flushNodeEventsForHour(hourKey string, events []Event)
 		return fmt.Errorf("failed to marshal node events: %w", err)
 	}
 
-	reader := bytes.NewReader(data)
-
 	// Use sessionName from event, not config
 	sessionNameToUse := ec.sessionName // Default to configured sessionName
 	if len(events) > 0 && events[0].SessionName != "" {
@@ -454,7 +452,7 @@ func (ec *EventCollector) flushNodeEventsForHour(hourKey string, events []Event)
 	// Build node event storage path using event's nodeID
 	sessionPath := path.Clean(path.Join(ec.root, utils.AppendRayClusterNameNamespace(ec.clusterName, ec.clusterNamespace), sessionNameToUse))
 
-	basePath := path.Join(sessionPath, "node_events", fmt.Sprintf("%s-%s", nodeIDToUse, hourKey))
+	basePath := path.Join(sessionPath, "node_events", fmt.Sprintf("%s-%s.gz", nodeIDToUse, hourKey))
 
 	// Ensure storage directory exists
 	dir := path.Dir(basePath)
@@ -463,8 +461,9 @@ func (ec *EventCollector) flushNodeEventsForHour(hourKey string, events []Event)
 	}
 
 	// Write event file
-	if err := ec.storageWriter.WriteFile(basePath, reader); err != nil {
-		return fmt.Errorf("failed to write node events file %s: %w", basePath, err)
+	writeErr := compression.WriteCompressedBytes(ec.storageWriter, basePath, data)
+	if writeErr != nil {
+		return fmt.Errorf("failed to write node events file %s: %w", basePath, writeErr)
 	}
 
 	logrus.Infof("Successfully flushed %d node events for hour %s to %s, context: %s", len(events), hourKey, basePath, string(data))
@@ -484,8 +483,6 @@ func (ec *EventCollector) flushJobEventsForHour(jobID, hourKey string, events []
 		return fmt.Errorf("failed to marshal job events: %w", err)
 	}
 
-	reader := bytes.NewReader(data)
-
 	// Use sessionName from event, not config
 	sessionNameToUse := ec.sessionName // Default to configured sessionName
 	if len(events) > 0 && events[0].SessionName != "" {
@@ -501,7 +498,7 @@ func (ec *EventCollector) flushJobEventsForHour(jobID, hourKey string, events []
 	// Build job event storage path using event's nodeID
 	sessionPath := path.Clean(path.Join(ec.root, utils.AppendRayClusterNameNamespace(ec.clusterName, ec.clusterNamespace), sessionNameToUse))
 
-	basePath := path.Join(sessionPath, "job_events", jobID, fmt.Sprintf("%s-%s", nodeIDToUse, hourKey))
+	basePath := path.Join(sessionPath, "job_events", jobID, fmt.Sprintf("%s-%s.gz", nodeIDToUse, hourKey))
 
 	// Ensure storage directory exists
 	dir := path.Dir(basePath)
@@ -510,8 +507,9 @@ func (ec *EventCollector) flushJobEventsForHour(jobID, hourKey string, events []
 	}
 
 	// Write event file
-	if err := ec.storageWriter.WriteFile(basePath, reader); err != nil {
-		return fmt.Errorf("failed to write job events file %s: %w", basePath, err)
+	writeErr := compression.WriteCompressedBytes(ec.storageWriter, basePath, data)
+	if writeErr != nil {
+		return fmt.Errorf("failed to write job events file %s: %w", basePath, writeErr)
 	}
 
 	logrus.Infof("Successfully flushed %d job events for job %s hour %s to %s", len(events), jobID, hourKey, basePath)

--- a/historyserver/pkg/eventserver/eventserver.go
+++ b/historyserver/pkg/eventserver/eventserver.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ray-project/kuberay/historyserver/pkg/compression"
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
@@ -27,7 +28,7 @@ type EventHandler struct {
 	ClusterLogEventMap *types.ClusterLogEventMap // For /events API (Log Events from logs/events/)
 }
 
-var eventFilePattern = regexp.MustCompile(`-\d{4}-\d{2}-\d{2}-\d{2}$`)
+var eventFilePattern = regexp.MustCompile(`-\d{4}-\d{2}-\d{2}-\d{2}(\.gz)?$`)
 
 // taskPrefix is extracted to avoid hard-coded "task::" usage
 const taskPrefix = "task::"
@@ -1401,14 +1402,28 @@ func (h *EventHandler) ProcessSingleSession(ctx context.Context, clusterInfo uti
 		}
 		logrus.Debugf("Reading event file: %s", eventFile)
 
-		// GetContent and io.ReadAll failures are treated as transient storage errors:
-		// skip this file and continue.
-		eventioReader := h.reader.GetContent(clusterNameNamespace, eventFile)
+		var eventioReader io.Reader
+		if strings.HasSuffix(eventFile, ".gz") {
+			rc, err := compression.ReadCompressedContent(h.reader, clusterNameNamespace, eventFile)
+			if err != nil {
+				logrus.Errorf("Failed to decompress event file %s: %v", eventFile, err)
+				continue
+			}
+			eventioReader = rc
+		} else {
+			eventioReader = h.reader.GetContent(clusterNameNamespace, eventFile)
+		}
+
 		if eventioReader == nil {
 			logrus.Errorf("Failed to get content for event file: %s, skipping", eventFile)
 			continue
 		}
+
 		eventbytes, err := io.ReadAll(eventioReader)
+		if closer, ok := eventioReader.(io.Closer); ok {
+			closer.Close()
+		}
+
 		if err != nil {
 			logrus.Errorf("Failed to read events for file %s: %v", eventFile, err)
 			continue

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -1,6 +1,8 @@
 package eventserver
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"testing"
 	"time"
@@ -957,9 +959,9 @@ func TestProcessSingleSession(t *testing.T) {
 		mock := newLogEventMockReader()
 		mock.addDir("cluster_ns", "session1/job_events/", []string{"job-01000000/"})
 		mock.addDir("cluster_ns", "session1/job_events/job-01000000/",
-			[]string{"01000000-2024-01-01-00"})
+			[]string{"01000000-2024-01-01-00.gz"})
 		mock.addDir("cluster_ns", "session1/node_events/",
-			[]string{"node1-2024-01-01-00"})
+			[]string{"node1-2024-01-01-00.gz"})
 		mock.addDir("cluster_ns", "session1/logs", []string{})
 
 		h := NewEventHandler(mock)
@@ -982,28 +984,41 @@ func TestProcessSingleSession(t *testing.T) {
 	t.Run("partial success does not return error", func(t *testing.T) {
 		mock := newLogEventMockReader()
 		mock.addDir("cluster_ns", "session1/node_events/",
-			[]string{"node1-2024-01-01-00", "node2-2024-01-01-00"})
-		mock.addFile("cluster_ns", "session1/node_events/node1-2024-01-01-00",
-			`[{"eventType":"NODE_DEFINITION_EVENT","nodeDefinitionEvent":{"nodeId":"YWJjZA=="}}]`)
+			[]string{"node1-2024-01-01-00.gz", "node2-2024-01-01-00.gz"})
+
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		_, err := gw.Write([]byte(`[{"eventType":"NODE_DEFINITION_EVENT","nodeDefinitionEvent":{"nodeId":"YWJjZA=="}}]`))
+		require.NoError(t, err)
+		require.NoError(t, gw.Close())
+
+		mock.addFile("cluster_ns", "session1/node_events/node1-2024-01-01-00.gz", buf.String())
 		mock.addDir("cluster_ns", "session1/job_events/", []string{})
 		mock.addDir("cluster_ns", "session1/logs", []string{})
 
 		h := NewEventHandler(mock)
-		err := h.ProcessSingleSession(context.Background(), clusterInfo)
+		err = h.ProcessSingleSession(context.Background(), clusterInfo)
 		require.NoError(t, err)
 	})
 
 	t.Run("all corrupt JSON does not return error", func(t *testing.T) {
 		mock := newLogEventMockReader()
 		mock.addDir("cluster_ns", "session1/node_events/",
-			[]string{"node1-2024-01-01-00", "node2-2024-01-01-00"})
-		mock.addFile("cluster_ns", "session1/node_events/node1-2024-01-01-00", "this is not json")
-		mock.addFile("cluster_ns", "session1/node_events/node2-2024-01-01-00", "neither is this")
+			[]string{"node1-2024-01-01-00.gz", "node2-2024-01-01-00.gz"})
+
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		_, err := gw.Write([]byte("this is not json"))
+		require.NoError(t, err)
+		require.NoError(t, gw.Close())
+
+		mock.addFile("cluster_ns", "session1/node_events/node1-2024-01-01-00.gz", buf.String())
+		mock.addFile("cluster_ns", "session1/node_events/node2-2024-01-01-00.gz", buf.String())
 		mock.addDir("cluster_ns", "session1/job_events/", []string{})
 		mock.addDir("cluster_ns", "session1/logs", []string{})
 
 		h := NewEventHandler(mock)
-		err := h.ProcessSingleSession(context.Background(), clusterInfo)
+		err = h.ProcessSingleSession(context.Background(), clusterInfo)
 		require.NoError(t, err)
 	})
 
@@ -1021,7 +1036,7 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("ray events failure surfaces; log events failure stays silent", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster_ns", "session1/node_events/", []string{"node1-2024-01-01-00"})
+		mock.addDir("cluster_ns", "session1/node_events/", []string{"node1-2024-01-01-00.gz"})
 		mock.addDir("cluster_ns", "session1/job_events/", []string{})
 		mock.addDir("cluster_ns", "session1/logs", []string{"node1/"})
 		mock.addDir("cluster_ns", "session1/logs/node1/events", []string{"event_GCS.log"})
@@ -1031,5 +1046,41 @@ func TestProcessSingleSession(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "read 0 of 1 event files")
 		assert.NotContains(t, err.Error(), "log event")
+	})
+
+	t.Run("transparent decompression of compressed .gz files and reading uncompressed legacy files", func(t *testing.T) {
+		mock := newLogEventMockReader()
+		mock.addDir("cluster_ns", "session1/node_events/",
+			[]string{"node1-2024-01-01-00.gz", "node2-2024-01-01-00"})
+
+		// 1. Compress node1 event file
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		_, err := gw.Write([]byte(`[{"eventType":"NODE_DEFINITION_EVENT","nodeDefinitionEvent":{"nodeId":"YWJjZA=="}}]`))
+		require.NoError(t, err)
+		require.NoError(t, gw.Close())
+		mock.addFile("cluster_ns", "session1/node_events/node1-2024-01-01-00.gz", buf.String())
+
+		// 2. Keep node2 event file uncompressed
+		mock.addFile("cluster_ns", "session1/node_events/node2-2024-01-01-00",
+			`[{"eventType":"NODE_DEFINITION_EVENT","nodeDefinitionEvent":{"nodeId":"ZWZnaA=="}}]`)
+
+		mock.addDir("cluster_ns", "session1/job_events/", []string{})
+		mock.addDir("cluster_ns", "session1/logs", []string{})
+
+		h := NewEventHandler(mock)
+		err = h.ProcessSingleSession(context.Background(), clusterInfo)
+		require.NoError(t, err)
+
+		nodeMap := h.GetNodeMap("cluster_ns_session1")
+		assert.Len(t, nodeMap, 2)
+
+		// "YWJjZA==" -> hex "61626364" (abcd)
+		_, ok := nodeMap["61626364"]
+		assert.True(t, ok, "node1 (compressed) should be successfully loaded")
+
+		// "ZWZnaA==" -> hex "65666768" (efgh)
+		_, ok = nodeMap["65666768"]
+		assert.True(t, ok, "node2 (uncompressed) should be successfully loaded")
 	})
 }

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/ray-project/kuberay/historyserver/pkg/compression"
 	eventtypes "github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
 	"github.com/sirupsen/logrus"
 
@@ -520,9 +521,25 @@ func (s *ServerHandler) ipToNodeId(rayClusterNameNamespace, sessionID, nodeIP st
 // searchNodeIDHexInEventFile searches for a node with the given IP in a single event file.
 // Returns (nodeIDHex, true) if found, ("", false) otherwise.
 func (s *ServerHandler) searchNodeIDHexInEventFile(rayClusterNameNamespace, filePath, nodeIP string) (string, bool) {
-	reader := s.reader.GetContent(rayClusterNameNamespace, filePath)
+	var reader io.Reader
+	var err error
+	if strings.HasSuffix(filePath, ".gz") {
+		var rc io.ReadCloser
+		rc, err = compression.ReadCompressedContent(s.reader, rayClusterNameNamespace, filePath)
+		if err != nil {
+			logrus.Warnf("Failed to decompress node event file %s: %v", filePath, err)
+			return "", false
+		}
+		reader = rc
+	} else {
+		reader = s.reader.GetContent(rayClusterNameNamespace, filePath)
+	}
+
 	if reader == nil {
 		return "", false
+	}
+	if closer, ok := reader.(io.Closer); ok {
+		defer closer.Close()
 	}
 
 	data, err := io.ReadAll(reader)

--- a/historyserver/test/e2e/azureblob_collector_test.go
+++ b/historyserver/test/e2e/azureblob_collector_test.go
@@ -1,9 +1,11 @@
 package e2e
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -293,7 +295,22 @@ func loadRayEventsFromAzureBlob(containerClient *container.Client, prefix string
 			}
 
 			var fileEvents []rayEvent
-			decodeErr := json.NewDecoder(downloadResp.Body).Decode(&fileEvents)
+			var reader io.Reader = downloadResp.Body
+			var gzReader *gzip.Reader
+			if strings.HasSuffix(*blob.Name, ".gz") {
+				var err error
+				gzReader, err = gzip.NewReader(downloadResp.Body)
+				if err != nil {
+					downloadResp.Body.Close()
+					return nil, fmt.Errorf("failed to create gzip reader for %s: %w", *blob.Name, err)
+				}
+				reader = gzReader
+			}
+
+			decodeErr := json.NewDecoder(reader).Decode(&fileEvents)
+			if gzReader != nil {
+				gzReader.Close()
+			}
 			downloadResp.Body.Close()
 
 			if decodeErr != nil {

--- a/historyserver/test/e2e/collector_test.go
+++ b/historyserver/test/e2e/collector_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -593,11 +594,27 @@ func loadRayEventsFromS3(s3Client *s3.S3, bucket string, prefix string) ([]rayEv
 		}
 
 		var fileEvents []rayEvent
-		if err := json.NewDecoder(content.Body).Decode(&fileEvents); err != nil {
-			content.Body.Close()
-			return nil, fmt.Errorf("failed to decode Ray events from %s: %w", fileKey, err)
+		var reader io.Reader = content.Body
+		var gzReader *gzip.Reader
+		if strings.HasSuffix(fileKey, ".gz") {
+			var err error
+			gzReader, err = gzip.NewReader(content.Body)
+			if err != nil {
+				content.Body.Close()
+				return nil, fmt.Errorf("failed to create gzip reader for %s: %w", fileKey, err)
+			}
+			reader = gzReader
+		}
+
+		decodeErr := json.NewDecoder(reader).Decode(&fileEvents)
+		if gzReader != nil {
+			gzReader.Close()
 		}
 		content.Body.Close()
+
+		if decodeErr != nil {
+			return nil, fmt.Errorf("failed to decode Ray events from %s: %w", fileKey, decodeErr)
+		}
 
 		events = append(events, fileEvents...)
 	}


### PR DESCRIPTION
## Why are these changes needed?
This PR is for utilizing the compression library from #4828 in the collector and historyserver components

## Related issue number
#4804 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
