### PR TITLE
test: cover OSS GetContent root-dir-inclusive request paths

### DIFF
--- a/historyserver/pkg/storage/aliyunoss/ray/ray_test.go
+++ b/historyserver/pkg/storage/aliyunoss/ray/ray_test.go
@@ -2,12 +2,18 @@ package ray
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
+	"github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss/credentials"
 	"github.com/sirupsen/logrus"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
@@ -34,18 +40,146 @@ func TestTrim(t *testing.T) {
 	t.Logf("test_path_join [%s]", test_path_join)
 }
 
-func TestGetContentPathComparison(t *testing.T) {
-	// fileName is a full path like the caller passes
-	fileName := "session_2026-04-09_06-41-42_754637_1/logs/abc123/events/event_RAYLET.log"
-	// f is a full key returned by _listFiles (onlyBase=false)
-	f := "session_2026-04-09_06-41-42_754637_1/logs/abc123/events/event_RAYLET.log"
+func newTestOSSClient(t *testing.T, handler http.Handler) *oss.Client {
+	t.Helper()
 
-	if path.Base(f) != path.Base(fileName) {
-		t.Errorf("expected path.Base(%q) == path.Base(%q)", f, fileName)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	cfg := oss.LoadDefaultConfig().
+		WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test-ak", "test-sk")).
+		WithRegion("cn-hangzhou").
+		WithEndpoint(server.URL).
+		WithUsePathStyle(true).
+		WithRetryMaxAttempts(1)
+	return oss.NewClient(cfg)
+}
+
+func TestGetContentUsesRootDirInObjectKey(t *testing.T) {
+	const (
+		bucket    = "test-bucket"
+		rootDir   = "tmp"
+		clusterID = "dlc1hphloqj7jax0_quotaf5jxu1uzuel"
+		fileName  = "session_2026-05-08_18-35-06_774618_1/logs/events/event_CORE_WORKER_256.log"
+		content   = "direct object content"
+	)
+	expectedPath := "/" + path.Join(bucket, rootDir, clusterID, fileName)
+
+	var (
+		mu       sync.Mutex
+		requests []string
+	)
+	client := newTestOSSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.URL.Path)
+		mu.Unlock()
+
+		if r.URL.Path != expectedPath {
+			http.NotFound(w, r)
+			return
+		}
+		if _, err := io.WriteString(w, content); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	handler := &RayLogsHandler{OssClient: client, OssBucket: bucket, OssRootDir: rootDir}
+
+	reader := handler.GetContent(clusterID, fileName)
+	if reader == nil {
+		mu.Lock()
+		defer mu.Unlock()
+		t.Fatalf("GetContent() returned nil after requests %v; want GET %q", requests, expectedPath)
 	}
-	// Verify old buggy comparison would fail
-	if path.Base(f) == fileName {
-		t.Errorf("old comparison should not match: path.Base(%q) == %q", f, fileName)
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read GetContent() result: %v", err)
+	}
+	if string(got) != content {
+		t.Fatalf("GetContent() = %q, want %q", got, content)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requests) != 1 || requests[0] != expectedPath {
+		t.Fatalf("GetContent() requested %v, want only [%q]", requests, expectedPath)
+	}
+}
+
+func TestGetContentFallbackUsesRootDirInListPrefix(t *testing.T) {
+	const (
+		bucket    = "test-bucket"
+		rootDir   = "tmp"
+		clusterID = "dlc1hphloqj7jax0_quotaf5jxu1uzuel"
+		fileName  = "session_2026-05-08_18-35-06_774618_1/logs/events/event_CORE_WORKER_256.log"
+		content   = "fallback object content"
+	)
+	expectedKey := path.Join(rootDir, clusterID, fileName)
+	expectedDir := path.Dir(expectedKey)
+	fallbackKey := path.Join(expectedDir, "worker-123", path.Base(fileName))
+	expectedPaths := []string{
+		"/" + path.Join(bucket, expectedKey),
+		"/" + bucket + "/",
+		"/" + path.Join(bucket, fallbackKey),
+	}
+
+	var (
+		mu         sync.Mutex
+		requests   []string
+		listPrefix string
+	)
+	client := newTestOSSClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPrefix := r.URL.Query().Get("prefix")
+		mu.Lock()
+		requests = append(requests, r.URL.Path)
+		if r.URL.Path == expectedPaths[1] && r.URL.Query().Get("list-type") == "2" {
+			listPrefix = requestPrefix
+		}
+		mu.Unlock()
+
+		switch {
+		case r.URL.Path == expectedPaths[0]:
+			http.NotFound(w, r)
+		case r.URL.Path == expectedPaths[1] && r.URL.Query().Get("list-type") == "2":
+			if requestPrefix != expectedDir+"/" {
+				http.Error(w, "unexpected list prefix: "+requestPrefix, http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			body := fmt.Sprintf("<ListBucketResult><Name>%s</Name><Prefix>%s/</Prefix><MaxKeys>100</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>%s</Key></Contents><KeyCount>1</KeyCount></ListBucketResult>", bucket, expectedDir, fallbackKey)
+			if _, err := io.WriteString(w, body); err != nil {
+				t.Errorf("write list response: %v", err)
+			}
+		case r.URL.Path == expectedPaths[2]:
+			if _, err := io.WriteString(w, content); err != nil {
+				t.Errorf("write object response: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	handler := &RayLogsHandler{OssClient: client, OssBucket: bucket, OssRootDir: rootDir}
+
+	reader := handler.GetContent(clusterID, fileName)
+	if reader == nil {
+		mu.Lock()
+		defer mu.Unlock()
+		t.Fatalf("GetContent() returned nil after requests %v with list prefix %q", requests, listPrefix)
+	}
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read GetContent() result: %v", err)
+	}
+	if string(got) != content {
+		t.Fatalf("GetContent() = %q, want %q", got, content)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Join(requests, "\n") != strings.Join(expectedPaths, "\n") {
+		t.Fatalf("GetContent() requested %v, want %v", requests, expectedPaths)
+	}
+	if listPrefix != expectedDir+"/" {
+		t.Fatalf("list prefix = %q, want %q", listPrefix, expectedDir+"/")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add SDK-level `httptest` coverage for direct `GetContent` requests using root-dir-inclusive OSS object keys
- cover the failed GET → root-dir-inclusive LIST → nested fallback GET sequence
- assert the exact object paths and list prefix sent on the wire

## Verification
- `go test ./pkg/storage/aliyunoss/ray`
- `go test -race ./pkg/storage/aliyunoss/ray`
- `go test ./pkg/... ./cmd/...` from `historyserver/`
- `go vet ./pkg/... ./cmd/...` from `historyserver/`
- `go test ./pkg/storage/aliyunoss/ray -run 'TestGetContent' -count=10`
- mutation check: restoring the old bare GET key and root-less fallback LIST prefix makes both new `GetContent` tests fail with the incorrect wire paths

Regression coverage for #4820. The production fix was merged in #4874.
