### PR TITLE
[fix] fixing test issues in TestDeletionStrategy

### DIFF
--- a/ray-operator/test/e2erayjob/rayjob_deletion_strategy_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_deletion_strategy_test.go
@@ -13,6 +13,8 @@ import (
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 )
 
+const activeDeadlineAfterRunningSeconds int32 = 1
+
 func TestDeletionStrategy(t *testing.T) {
 	// Note: This test suite requires the RayJobDeletionPolicy feature gate to be enabled
 	tests := []struct {
@@ -147,7 +149,7 @@ env_vars:
 
 	// Verify cluster still exists (head pod should remain)
 	LogWithTimestamp(test.T(), "Verifying cluster still exists (head pod should remain)...")
-	g.Consistently(RayCluster(test, namespace.Name, rayClusterName), 10*time.Second).
+	g.Consistently(RayCluster(test, namespace.Name, rayClusterName), 10*time.Second, 1*time.Second).
 		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
 
 	// Verify head pod still exists
@@ -469,12 +471,11 @@ env_vars:
 }
 
 func testDeletionRulesWithJobDeploymentStatusFailedAndDeleteWorkersPolicy(test Test, g *WithT, namespace *corev1.Namespace, cm *corev1.ConfigMap) {
-	// Create a RayJob with DeleteWorkers policy, short activeDeadlineSeconds, and short TTL for faster testing.
+	// Create a RayJob with DeleteWorkers policy and short TTL for faster testing.
 	rayJobAC := rayv1ac.RayJob("delete-workers-after-jobdeploymentstatus-failed", namespace.Name).
 		WithSpec(rayv1ac.RayJobSpec().
 			WithRayClusterSpec(NewRayClusterSpec(MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](cm, "/home/ray/jobs"))).
 			WithEntrypoint("python /home/ray/jobs/long_running.py").
-			WithActiveDeadlineSeconds(45).       // Short deadline for failing the JobDeploymentStatus, but making sure the cluster is running
 			WithShutdownAfterJobFinishes(false). // Required when using DeletionStrategy
 			WithDeletionStrategy(rayv1ac.DeletionStrategy().
 				WithDeletionRules(
@@ -539,7 +540,7 @@ func testDeletionRulesWithJobDeploymentStatusFailedAndDeleteWorkersPolicy(test T
 
 	// Verify cluster still exists (head pod should remain).
 	LogWithTimestamp(test.T(), "Verifying cluster still exists (head pod should remain)...")
-	g.Consistently(RayCluster(test, namespace.Name, rayClusterName), 10*time.Second).
+	g.Consistently(RayCluster(test, namespace.Name, rayClusterName), 10*time.Second, 1*time.Second).
 		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
 
 	// Verify head pod still exists.
@@ -558,12 +559,11 @@ func testDeletionRulesWithJobDeploymentStatusFailedAndDeleteWorkersPolicy(test T
 }
 
 func testDeletionRulesWithJobDeploymentStatusFailedAndDeleteClusterPolicy(test Test, g *WithT, namespace *corev1.Namespace, cm *corev1.ConfigMap) {
-	// Create a RayJob with DeleteCluster policy, short activeDeadlineSeconds, and short TTL for faster testing.
+	// Create a RayJob with DeleteCluster policy and short TTL for faster testing.
 	rayJobAC := rayv1ac.RayJob("delete-cluster-after-jobdeploymentstatus-failed", namespace.Name).
 		WithSpec(rayv1ac.RayJobSpec().
 			WithRayClusterSpec(NewRayClusterSpec(MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](cm, "/home/ray/jobs"))).
 			WithEntrypoint("python /home/ray/jobs/long_running.py").
-			WithActiveDeadlineSeconds(45).       // Short deadline for failing the JobDeploymentStatus, but making sure the cluster is running
 			WithShutdownAfterJobFinishes(false). // Required when using DeletionStrategy
 			WithDeletionStrategy(rayv1ac.DeletionStrategy().
 				WithDeletionRules(
@@ -603,12 +603,11 @@ func testDeletionRulesWithJobDeploymentStatusFailedAndDeleteClusterPolicy(test T
 }
 
 func testDeletionRulesWithJobDeploymentStatusFailedAndDeleteSelfPolicy(test Test, g *WithT, namespace *corev1.Namespace, cm *corev1.ConfigMap) {
-	// Create a RayJob with DeleteSelf policy, short activeDeadlineSeconds, and short TTL for faster testing.
+	// Create a RayJob with DeleteSelf policy and short TTL for faster testing.
 	rayJobAC := rayv1ac.RayJob("delete-self-after-jobdeploymentstatus-failed", namespace.Name).
 		WithSpec(rayv1ac.RayJobSpec().
 			WithRayClusterSpec(NewRayClusterSpec(MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](cm, "/home/ray/jobs"))).
 			WithEntrypoint("python /home/ray/jobs/long_running.py").
-			WithActiveDeadlineSeconds(45).       // Short deadline for failing the JobDeploymentStatus, but making sure the cluster is running
 			WithShutdownAfterJobFinishes(false). // Required when using DeletionStrategy
 			WithDeletionStrategy(rayv1ac.DeletionStrategy().
 				WithDeletionRules(
@@ -645,12 +644,11 @@ func testDeletionRulesWithJobDeploymentStatusFailedAndDeleteSelfPolicy(test Test
 }
 
 func testDeletionRulesWithJobDeploymentStatusFailedAndDeleteNonePolicy(test Test, g *WithT, namespace *corev1.Namespace, cm *corev1.ConfigMap) {
-	// Create a RayJob with DeleteNone policy, short activeDeadlineSeconds, and short TTL for faster testing.
+	// Create a RayJob with DeleteNone policy and short TTL for faster testing.
 	rayJobAC := rayv1ac.RayJob("delete-none-after-jobdeploymentstatus-failed", namespace.Name).
 		WithSpec(rayv1ac.RayJobSpec().
 			WithRayClusterSpec(NewRayClusterSpec(MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](cm, "/home/ray/jobs"))).
 			WithEntrypoint("python /home/ray/jobs/long_running.py").
-			WithActiveDeadlineSeconds(45).       // Short deadline for failing the JobDeploymentStatus, but making sure the cluster is running
 			WithShutdownAfterJobFinishes(false). // Required when using DeletionStrategy
 			WithDeletionStrategy(rayv1ac.DeletionStrategy().
 				WithDeletionRules(
@@ -714,22 +712,32 @@ func applyRayJobAndWaitForCompletion(test Test, g *WithT, namespace *corev1.Name
 	return rayJob
 }
 
-// applyRayJobAndWaitForJobDeploymentStatusFailed applies the ray job and waits for JobDeploymentStatus to become Failed due to activeDeadlineSeconds timeout.
+// applyRayJobAndWaitForJobDeploymentStatusFailed applies the RayJob, waits until it is running, then
+// sets a short activeDeadlineSeconds and waits for JobDeploymentStatus to become Failed due to timeout.
 func applyRayJobAndWaitForJobDeploymentStatusFailed(test Test, g *WithT, namespace *corev1.Namespace, rayJobAC *rayv1ac.RayJobApplyConfiguration) *rayv1.RayJob {
 	rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
 	g.Expect(err).NotTo(HaveOccurred())
 	LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+	LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to become Running before setting activeDeadlineSeconds...", rayJob.Namespace, rayJob.Name)
+	g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		Should(SatisfyAll(
+			WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusRunning)),
+			WithTransform(RayJobStatus, Equal(rayv1.JobStatusRunning)),
+		))
+
+	LogWithTimestamp(test.T(), "Setting activeDeadlineSeconds=%d for RayJob %s/%s", activeDeadlineAfterRunningSeconds, rayJob.Namespace, rayJob.Name)
+	rayJobAC.Spec.WithActiveDeadlineSeconds(activeDeadlineAfterRunningSeconds)
+	rayJob, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
 
 	LogWithTimestamp(test.T(), "Waiting for JobDeploymentStatus to become Failed and Reason to be DeadlineExceeded...")
 	g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 		Should(SatisfyAll(
 			WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)),
 			WithTransform(RayJobReason, Equal(rayv1.DeadlineExceeded)),
+			WithTransform(RayJobStatus, Equal(rayv1.JobStatusRunning)),
 		))
-
-	LogWithTimestamp(test.T(), "Verifying JobStatus is Running...")
-	g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
-		Should(WithTransform(RayJobStatus, Equal(rayv1.JobStatusRunning)))
 
 	return rayJob
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes potential races in the TestDeletionStrategy tests.

Previously the tests created long-running RayJobs with `activeDeadlineSeconds=45` set then expected JobDeploymentStatus=Failed and JobStatus=RUNNING
Sometimes the deadline would fire before the controller observed the JobStatus=RUNNING state and JobStatus would remain empty causing the test to time out

This PR updates the tests so

1. The RayJob is created without `activeDeadlineSeconds`
2. Wait for the RayJob to reach JobDeploymentStatus=RUNNING and JobStatus=RUNNING
3. Apply `activeDeadlineSeconds=1`
4. Wait for JobDeploymentStatus=Failed and Reason=DeadlineExceeded
5. then move on the validationg the different deletion policy behaviors

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Fixes #4741 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
