### PR TITLE
[History Server] Add default and "latest" path to `/enter_cluster`

### DIFF
--- a/historyserver/pkg/historyserver/clientmanager.go
+++ b/historyserver/pkg/historyserver/clientmanager.go
@@ -49,6 +49,14 @@ func (c *ClientManager) ListRayClusters(ctx context.Context) ([]*rayv1.RayCluste
 	return list, nil
 }
 
+func (c *ClientManager) GetRayCluster(ctx context.Context, namespace, name string) (*rayv1.RayCluster, error) {
+	var rayCluster rayv1.RayCluster
+	if err := c.Client().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &rayCluster); err != nil {
+		return nil, err
+	}
+	return &rayCluster, nil
+}
+
 type ClientManagerConfig struct {
 	Kubeconfigs        string
 	UseKubernetesProxy bool

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -3,24 +3,101 @@ package historyserver
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
-	"sort"
+	"strings"
 	"testing"
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+type mockStorageReader struct {
+	listCount int
+	clusters  []utils.ClusterInfo
+}
+
+func (m *mockStorageReader) List() []utils.ClusterInfo {
+	m.listCount++
+	return m.clusters
+}
+
+func (m *mockStorageReader) GetContent(clusterId string, fileName string) io.Reader {
+	return strings.NewReader("")
+}
+
+func (m *mockStorageReader) ListFiles(clusterId string, dir string) []string {
+	return nil
+}
 
 func TestEnterCluster(t *testing.T) {
 	// Reset default container to avoid polluting or using duplicate services across runs
 	restful.DefaultContainer = restful.NewContainer()
 
-	// Create ServerHandler with fake sessionLoader
+	mockReader := &mockStorageReader{
+		clusters: []utils.ClusterInfo{
+			// cluster-a (Single session)
+			{
+				Namespace:   "default",
+				Name:        "cluster-a",
+				SessionName: "session_2026-04-22_10-00-00_000000_1",
+				OwnerKind:   "RayJob",
+				OwnerName:   "job-a",
+			},
+			// cluster-b (Multi-session cluster: past session AND live session)
+			{
+				Namespace:       "default",
+				Name:            "cluster-b",
+				SessionName:     "session_2026-04-22_10-00-00_000000_1",
+				OwnerKind:       "RayService",
+				OwnerName:       "svc-b",
+				CreateTimeStamp: 1000, // Older
+			},
+			{
+				Namespace:       "default",
+				Name:            "cluster-b",
+				SessionName:     "live",
+				OwnerKind:       "RayService",
+				OwnerName:       "svc-b",
+				CreateTimeStamp: 2000, // Newer (latest)
+			},
+			// cluster-c (session resolved but triggers live resolution)
+			{
+				Namespace:   "default",
+				Name:        "cluster-c",
+				SessionName: "session_2026-04-22_10-00-00_000000_2_live",
+				OwnerKind:   "RayJob",
+				OwnerName:   "job-c",
+			},
+			// cluster-d (invalid session format)
+			{
+				Namespace:   "default",
+				Name:        "cluster-d",
+				SessionName: "invalid-session-name",
+			},
+		},
+	}
+
+	// Initialize fake client manager for tests
+	scheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(scheme)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	clientManager := &ClientManager{
+		clients: []client.Client{k8sClient},
+	}
+
+	// Create ServerHandler with fake sessionLoader and mockStorageReader
 	handler := &ServerHandler{
-		maxClusters: 100,
-		clustersMap: make(map[utils.ClusterKey][]utils.ClusterInfo),
+		maxClusters:   100,
+		reader:        mockReader,
+		clientManager: clientManager,
 	}
 
 	// Setup fake processor for sessionLoader
@@ -37,83 +114,19 @@ func TestEnterCluster(t *testing.T) {
 	}
 	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
 
-	// Single session cluster
-	keyA := utils.ClusterKey{
-		Namespace: "default",
-		Name:      "cluster-a",
-	}
-	handler.clustersMap[keyA] = []utils.ClusterInfo{
-		{
-			Namespace:   "default",
-			Name:        "cluster-a",
-			SessionName: "session_2026-04-22_10-00-00_000000_1",
-			OwnerKind:   "RayJob",
-			OwnerName:   "job-a",
-		},
-	}
-
-	// Multi-session cluster (past session AND live session)
-	keyB := utils.ClusterKey{
-		Namespace: "default",
-		Name:      "cluster-b",
-	}
-	handler.clustersMap[keyB] = []utils.ClusterInfo{
-		{
-			Namespace:       "default",
-			Name:            "cluster-b",
-			SessionName:     "session_2026-04-22_10-00-00_000000_1",
-			OwnerKind:       "RayService",
-			OwnerName:       "svc-b",
-			CreateTimeStamp: 1000, // Older
-		},
-		{
-			Namespace:       "default",
-			Name:            "cluster-b",
-			SessionName:     "live",
-			OwnerKind:       "RayService",
-			OwnerName:       "svc-b",
-			CreateTimeStamp: 2000, // Newer (latest)
-		},
-	}
-
-	// Cluster with session that is resolved but will trigger live resolution
-	keyC := utils.ClusterKey{
-		Namespace: "default",
-		Name:      "cluster-c",
-	}
-	handler.clustersMap[keyC] = []utils.ClusterInfo{
-		{
-			Namespace:   "default",
-			Name:        "cluster-c",
-			SessionName: "session_2026-04-22_10-00-00_000000_2_live",
-			OwnerKind:   "RayJob",
-			OwnerName:   "job-c",
-		},
-	}
-
-	// Cluster with invalid session format
-	keyD := utils.ClusterKey{
-		Namespace: "default",
-		Name:      "cluster-d",
-	}
-	handler.clustersMap[keyD] = []utils.ClusterInfo{
-		{
-			Namespace:   "default",
-			Name:        "cluster-d",
-			SessionName: "invalid-session-name",
-		},
-	}
-
-	// Explicitly sort `Multi-session cluster` to simulate listClusters post-sorting logic
-	sort.Sort(utils.ClusterInfoList(handler.clustersMap[keyB]))
-
 	// Register actual router
 	routerRayClusterSet(handler)
 
 	container := restful.DefaultContainer
 
 	t.Run("Verify sorted order of multi-session slice puts latest first", func(t *testing.T) {
-		sessions := handler.clustersMap[keyB]
+		clusters := handler.listClusters(100)
+		var sessions []utils.ClusterInfo
+		for _, c := range clusters {
+			if c.Name == "cluster-b" {
+				sessions = append(sessions, c)
+			}
+		}
 		if len(sessions) != 2 {
 			t.Fatalf("Expected 2 sessions, got %d", len(sessions))
 		}
@@ -143,7 +156,7 @@ func TestEnterCluster(t *testing.T) {
 		}
 	})
 
-	t.Run("Enter cluster with session that is resolved but triggers live resolution (Line 326 path)", func(t *testing.T) {
+	t.Run("Enter cluster with session that is actually live maps to live sentinel", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-c/session_2026-04-22_10-00-00_000000_2_live", nil)
 		resp := httptest.NewRecorder()
 		container.ServeHTTP(resp, req)
@@ -164,7 +177,7 @@ func TestEnterCluster(t *testing.T) {
 		}
 	})
 
-	t.Run("Enter cluster with invalid session name format (Line 310 path)", func(t *testing.T) {
+	t.Run("Enter cluster with invalid session name format rejects request", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-d/invalid-session-name", nil)
 		resp := httptest.NewRecorder()
 		container.ServeHTTP(resp, req)
@@ -173,4 +186,282 @@ func TestEnterCluster(t *testing.T) {
 			t.Fatalf("Expected status 400 (BadRequest), got %d", resp.Code)
 		}
 	})
+	t.Run("Enter cluster with 'latest' keyword resolves to newest session in the list", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-b/latest", nil)
+		resp := httptest.NewRecorder()
+		container.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d", resp.Code)
+		}
+
+		// Verify cookies are set to the ACTUAL newest session name ("live") rather than literal "latest"
+		cookies := resp.Result().Cookies()
+		cookieMap := make(map[string]*http.Cookie)
+		for _, cookie := range cookies {
+			cookieMap[cookie.Name] = cookie
+		}
+
+		if c, ok := cookieMap[COOKIE_CLUSTER_NAME_KEY]; !ok || c.Value != "cluster-b" {
+			t.Errorf("Expected cookie %s to be 'cluster-b', got %v", COOKIE_CLUSTER_NAME_KEY, c)
+		}
+		if c, ok := cookieMap[COOKIE_CLUSTER_NAMESPACE_KEY]; !ok || c.Value != "default" {
+			t.Errorf("Expected cookie %s to be 'default', got %v", COOKIE_CLUSTER_NAMESPACE_KEY, c)
+		}
+		if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "live" {
+			t.Errorf("Expected cookie %s to be 'live' (actual latest session name), got %v", COOKIE_SESSION_NAME_KEY, c)
+		}
+	})
+
+	t.Run("Enter cluster with no session parameter defaults to latest", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-b", nil)
+		resp := httptest.NewRecorder()
+		container.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d", resp.Code)
+		}
+
+		// Verify cookies are set to the ACTUAL newest session name ("live") rather than literal "latest"
+		cookies := resp.Result().Cookies()
+		cookieMap := make(map[string]*http.Cookie)
+		for _, cookie := range cookies {
+			cookieMap[cookie.Name] = cookie
+		}
+
+		if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "live" {
+			t.Errorf("Expected cookie %s to default to 'live' (actual latest session name), got %v", COOKIE_SESSION_NAME_KEY, c)
+		}
+	})
+}
+
+func TestEnterClusterLatestFromStorage(t *testing.T) {
+	restful.DefaultContainer = restful.NewContainer()
+
+	// Initialize fake client manager
+	scheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(scheme)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	clientManager := &ClientManager{
+		clients: []client.Client{k8sClient},
+	}
+
+	// Initialize mock reader with dummy data
+	mockReader := &mockStorageReader{
+		clusters: []utils.ClusterInfo{
+			{
+				Namespace:       "default",
+				Name:            "cluster-refresh",
+				SessionName:     "session_2026-04-22_10-00-00_000000_1",
+				CreateTimeStamp: 1000,
+			},
+			{
+				Namespace:       "default",
+				Name:            "cluster-refresh",
+				SessionName:     "session_2026-04-22_10-00-00_000000_2",
+				CreateTimeStamp: 2000, // Newer latest!
+			},
+		},
+	}
+
+	handler := &ServerHandler{
+		maxClusters:   100,
+		reader:        mockReader,
+		clientManager: clientManager,
+	}
+
+	fp := &fakeProcessor{
+		fn: func(ctx context.Context, info utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
+			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
+		},
+	}
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+
+	routerRayClusterSet(handler)
+	container := restful.DefaultContainer
+
+	// Call enter_cluster with "latest"
+	req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-refresh/latest", nil)
+	resp := httptest.NewRecorder()
+	container.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	// The mock reader's List() must be called to retrieve sessions from storage!
+	if mockReader.listCount == 0 {
+		t.Errorf("Expected StorageReader.List() to be called to retrieve sessions, but call count was 0")
+	}
+
+	// Verify the cookie is set to the newest session
+	cookies := resp.Result().Cookies()
+	cookieMap := make(map[string]*http.Cookie)
+	for _, cookie := range cookies {
+		cookieMap[cookie.Name] = cookie
+	}
+
+	if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "session_2026-04-22_10-00-00_000000_2" {
+		t.Errorf("Expected cookie %s to resolve to the new latest session 'session_2026-04-22_10-00-00_000000_2', got %v", COOKIE_SESSION_NAME_KEY, c)
+	}
+}
+
+func TestEnterClusterLatestPrioritizesLive(t *testing.T) {
+	restful.DefaultContainer = restful.NewContainer()
+
+	scheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(scheme)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-prioritize-live"},
+	}).Build()
+	clientManager := &ClientManager{
+		clients: []client.Client{k8sClient},
+	}
+
+	mockReader := &mockStorageReader{
+		clusters: []utils.ClusterInfo{
+			{
+				Namespace:       "default",
+				Name:            "cluster-prioritize-live",
+				SessionName:     "session_2026-04-22_10-00-00_000000_1",
+				CreateTimeStamp: 2000, // Newer timestamp on storage!
+			},
+		},
+	}
+
+	handler := &ServerHandler{
+		maxClusters:   100,
+		clientManager: clientManager,
+		reader:        mockReader,
+	}
+
+	fp := &fakeProcessor{
+		fn: func(ctx context.Context, info utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
+			return SessionStatusLive, nil, nil
+		},
+	}
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+
+	routerRayClusterSet(handler)
+	container := restful.DefaultContainer
+
+	// Call enter_cluster with "latest"
+	req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-prioritize-live/latest", nil)
+	resp := httptest.NewRecorder()
+	container.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	// Verify the cookie resolves to "live" (due to live prioritization) instead of the newer archived session
+	cookies := resp.Result().Cookies()
+	cookieMap := make(map[string]*http.Cookie)
+	for _, cookie := range cookies {
+		cookieMap[cookie.Name] = cookie
+	}
+
+	if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "live" {
+		t.Errorf("Expected cookie %s to prioritize 'live', got %v", COOKIE_SESSION_NAME_KEY, c)
+	}
+}
+
+func TestEnterClusterReturnsNotFoundWhenRemovedFromStorage(t *testing.T) {
+	restful.DefaultContainer = restful.NewContainer()
+
+	// 1. Storage reader returns an empty list (sessions were deleted/cleaned up)
+	mockReader := &mockStorageReader{
+		clusters: []utils.ClusterInfo{},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(scheme)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	clientManager := &ClientManager{
+		clients: []client.Client{k8sClient},
+	}
+
+	handler := &ServerHandler{
+		maxClusters:   100,
+		reader:        mockReader,
+		clientManager: clientManager,
+	}
+
+	fp := &fakeProcessor{
+		fn: func(ctx context.Context, info utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
+			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
+		},
+	}
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+
+	routerRayClusterSet(handler)
+	container := restful.DefaultContainer
+
+	// Call enter_cluster with "latest"
+	req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-removed-from-storage/latest", nil)
+	resp := httptest.NewRecorder()
+	container.ServeHTTP(resp, req)
+
+	// Since storage is configured but returned empty matching list, fallback should NOT occur, returning 404
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("Expected status 404 (NotFound), got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+type errorClient struct {
+	client.Client
+	err error
+}
+
+func (c *errorClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return c.err
+}
+
+func TestEnterClusterReturnsErrorOnTransientK8sError(t *testing.T) {
+	restful.DefaultContainer = restful.NewContainer()
+
+	// clientManager returns non-NotFound transient error (e.g. timeout)
+	transientErr := fmt.Errorf("connection timeout")
+	errClient := &errorClient{err: transientErr}
+	clientManager := &ClientManager{
+		clients: []client.Client{errClient},
+	}
+
+	// Storage contains a historical session entry
+	mockReader := &mockStorageReader{
+		clusters: []utils.ClusterInfo{
+			{
+				Namespace:       "default",
+				Name:            "cluster-transient-err",
+				SessionName:     "session_2026-04-22_10-00-00_000000_1",
+				CreateTimeStamp: 1000,
+			},
+		},
+	}
+
+	handler := &ServerHandler{
+		maxClusters:   100,
+		reader:        mockReader,
+		clientManager: clientManager,
+	}
+
+	fp := &fakeProcessor{
+		fn: func(ctx context.Context, info utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
+			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
+		},
+	}
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+
+	routerRayClusterSet(handler)
+	container := restful.DefaultContainer
+
+	// Request "latest" when K8s returns transient error
+	req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-transient-err/latest", nil)
+	resp := httptest.NewRecorder()
+	container.ServeHTTP(resp, req)
+
+	// Since non-NotFound errors are propagated upwards, it should return 500 InternalServerError rather than falling back to storage
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("Expected status 500 (StatusInternalServerError), got %d: %s", resp.Code, resp.Body.String())
+	}
 }

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"github.com/ray-project/kuberay/historyserver/pkg/compression"
 	eventtypes "github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
 	"github.com/sirupsen/logrus"
@@ -47,9 +48,9 @@ func (s *ServerHandler) listClusters(limit int) []utils.ClusterInfo {
 	// Initial continuation marker
 	logrus.Debugf("Prepare to get list clusters info ...")
 	ctx := context.Background()
-	liveClusters, _ := s.clientManager.ListRayClusters(ctx)
 	liveClusterNames := []string{}
 	liveClusterInfos := []utils.ClusterInfo{}
+	liveClusters, _ := s.clientManager.ListRayClusters(ctx)
 	for _, liveCluster := range liveClusters {
 		liveClusterInfo := utils.ClusterInfo{
 			Name:            liveCluster.Name,
@@ -69,44 +70,42 @@ func (s *ServerHandler) listClusters(limit int) []utils.ClusterInfo {
 	}
 	clusters = append(liveClusterInfos, clusters...)
 
-	clustersMap := make(map[utils.ClusterKey][]utils.ClusterInfo)
-	for _, c := range clusters {
-		key := utils.ClusterKey{
-			Namespace: c.Namespace,
-			Name:      c.Name,
-		}
-		clustersMap[key] = append(clustersMap[key], c)
-	}
-
-	for key := range clustersMap {
-		sort.Sort(utils.ClusterInfoList(clustersMap[key]))
-	}
-
-	s.mu.Lock()
-	s.clustersMap = clustersMap
-	s.mu.Unlock()
-
 	return clusters
 }
 
-func (s *ServerHandler) findSessionInMap(namespace, name, session string) (string, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	key := utils.ClusterKey{
-		Namespace: namespace,
-		Name:      name,
-	}
-	if list, ok := s.clustersMap[key]; ok {
-		if len(list) == 0 {
-			return "", false
+// resolveSession maps (namespace, name, session) to a concrete session name.
+func (s *ServerHandler) resolveSession(ctx context.Context, namespace, name, session string) (sessionName string, found bool, err error) {
+	isLatestOrEmpty := session == "latest" || session == ""
+
+	if isLatestOrEmpty || session == "live" {
+		_, err := s.clientManager.GetRayCluster(ctx, namespace, name)
+		if err == nil {
+			return "live", true, nil
 		}
-		for _, c := range list {
-			if c.SessionName == session {
-				return c.SessionName, true
-			}
+		if !apierrors.IsNotFound(err) {
+			return "", false, fmt.Errorf("failed to check live RayCluster %s/%s: %w", namespace, name, err)
+		}
+		if session == "live" {
+			return "", false, nil
 		}
 	}
-	return "", false
+
+	var sessions []utils.ClusterInfo
+	for _, c := range s.reader.List() {
+		if c.Namespace != namespace || c.Name != name {
+			continue
+		}
+		if c.SessionName == session {
+			return session, true, nil
+		}
+		sessions = append(sessions, c)
+	}
+
+	if isLatestOrEmpty && len(sessions) > 0 {
+		sort.Sort(utils.ClusterInfoList(sessions))
+		return sessions[0].SessionName, true, nil
+	}
+	return "", false, nil
 }
 
 func (s *ServerHandler) _getNodeLogs(rayClusterNameNamespace, sessionId, nodeId, folder, glob string) ([]byte, error) {

--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -302,14 +302,12 @@ func routerRayClusterSet(s *ServerHandler) {
 
 	ws.Path("/enter_cluster").Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON).Filter(RequestLogFilter)
 	enterHandler := func(r1 *restful.Request, r2 *restful.Response, namespace, name, session string) {
-		resolvedSession, found := s.findSessionInMap(namespace, name, session)
-		if !found {
-			if s.clientManager != nil && s.reader != nil {
-				s.listClusters(s.maxClusters)
-			}
-			resolvedSession, found = s.findSessionInMap(namespace, name, session)
+		resolvedSession, found, err := s.resolveSession(r1.Request.Context(), namespace, name, session)
+		if err != nil {
+			logrus.Errorf("Failed to resolve session %s/%s/%s: %v", namespace, name, session, err)
+			r2.WriteErrorString(http.StatusInternalServerError, err.Error())
+			return
 		}
-
 		if !found {
 			r2.WriteErrorString(http.StatusNotFound, fmt.Sprintf("cluster %s/%s with session %s not found", namespace, name, session))
 			return
@@ -359,6 +357,16 @@ func routerRayClusterSet(s *ServerHandler) {
 		Param(ws.PathParameter("name", "name")).
 		Param(ws.PathParameter("session", "session")).
 		Writes("")) // Placeholder for specific return type
+
+	ws.Route(ws.GET("/{namespace}/{name}").To(func(r1 *restful.Request, r2 *restful.Response) {
+		name := r1.PathParameter("name")
+		namespace := r1.PathParameter("namespace")
+		enterHandler(r1, r2, namespace, name, "latest")
+	}).
+		Doc("set cookie for cluster (defaults session to latest)").
+		Param(ws.PathParameter("namespace", "namespace")).
+		Param(ws.PathParameter("name", "name")).
+		Writes(""))
 }
 
 func (s *ServerHandler) RegisterRouter() {

--- a/historyserver/pkg/historyserver/server.go
+++ b/historyserver/pkg/historyserver/server.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
-	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/transport"
 )
@@ -26,9 +24,6 @@ type ServerHandler struct {
 	httpClient    *http.Client
 
 	useKubernetesProxy bool
-
-	mu          sync.RWMutex
-	clustersMap map[utils.ClusterKey][]utils.ClusterInfo
 }
 
 func NewServerHandler(c *types.RayHistoryServerConfig, dashboardDir string, reader storage.StorageReader, clientManager *ClientManager, sessionLoader *SessionLoader, useKubernetesProxy bool) (*ServerHandler, error) {


### PR DESCRIPTION
## Why are these changes needed?
This PR is a followup to #4856 and adds a `/enter_cluster` path that allows "latest" session as well as empty session field.

## Related issue number
Follow up to #4856 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
