### PR TITLE
[History Server] [Refactor] Move and validate API server QPS and burst defaults

### DIFF
--- a/historyserver/cmd/historyserver/main.go
+++ b/historyserver/cmd/historyserver/main.go
@@ -17,12 +17,6 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/historyserver"
 )
 
-const (
-	// Aligned with ray-operator defaults (see ray-operator/apis/config/v1alpha1/defaults.go).
-	defaultKubeAPIQPS   = float64(100)
-	defaultKubeAPIBurst = 200
-)
-
 func main() {
 	runtimeClassName := ""
 	rayRootDir := ""
@@ -30,8 +24,8 @@ func main() {
 	runtimeClassConfigPath := ""
 	dashboardDir := ""
 	useKubernetesProxy := false
-	qps := defaultKubeAPIQPS
-	burst := defaultKubeAPIBurst
+	qps := historyserver.DefaultKubeAPIQPS
+	burst := historyserver.DefaultKubeAPIBurst
 	sessionProcessTimeout := historyserver.DefaultSessionProcessTimeout
 	flag.StringVar(&runtimeClassName, "runtime-class-name", "", "Storage backend: s3 / gcs / azureblob / aliyunoss / localtest")
 	flag.StringVar(&rayRootDir, "ray-root-dir", "", "Root dir inside the bucket")
@@ -39,15 +33,19 @@ func main() {
 	flag.StringVar(&dashboardDir, "dashboard-dir", "/dashboard", "Path to Ray Dashboard static assets")
 	flag.StringVar(&runtimeClassConfigPath, "runtime-class-config-path", "", "Path to backend config JSON")
 	flag.BoolVar(&useKubernetesProxy, "use-kubernetes-proxy", false, "Use local kubeconfig instead of in-cluster config")
-	flag.Float64Var(&qps, "kube-api-qps", defaultKubeAPIQPS,
-		"The QPS value for the client communicating with the Kubernetes API server.")
-	flag.IntVar(&burst, "kube-api-burst", defaultKubeAPIBurst,
-		"The maximum burst for throttling requests from this client to the Kubernetes API server.")
+	flag.Float64Var(&qps, "kube-api-qps", historyserver.DefaultKubeAPIQPS, "The QPS value for the client communicating with the Kubernetes API server.")
+	flag.IntVar(&burst, "kube-api-burst", historyserver.DefaultKubeAPIBurst, "The maximum burst for throttling requests from this client to the Kubernetes API server.")
 	flag.DurationVar(&sessionProcessTimeout, "session-process-timeout", historyserver.DefaultSessionProcessTimeout, "Timeout duration for processing and loading a single Ray cluster session.")
 	flag.Parse()
 
 	if runtimeClassName == "" {
 		logrus.Fatal("--runtime-class-name is required")
+	}
+	if qps <= 0 {
+		logrus.Fatalf("--kube-api-qps must be > 0, got %v", qps)
+	}
+	if burst <= 0 {
+		logrus.Fatalf("--kube-api-burst must be > 0, got %d", burst)
 	}
 
 	cliMgr, err := historyserver.NewClientManager(historyserver.ClientManagerConfig{

--- a/historyserver/pkg/historyserver/clientmanager.go
+++ b/historyserver/pkg/historyserver/clientmanager.go
@@ -16,6 +16,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	// Aligned with ray-operator defaults:
+	// https://github.com/ray-project/kuberay/blob/178e6c91/ray-operator/apis/config/v1alpha1/defaults.go#L12-L13
+	DefaultKubeAPIQPS   = float64(100)
+	DefaultKubeAPIBurst = 200
+)
+
 type ClientManager struct {
 	configs []*rest.Config
 	clients []client.Client
@@ -51,9 +58,9 @@ type ClientManagerConfig struct {
 
 func NewClientManager(cfg ClientManagerConfig) (*ClientManager, error) {
 	kubeconfigs := cfg.Kubeconfigs
-	useKubernetesProxy := cfg.UseKubernetesProxy
-	qps := cfg.QPS
-	burst := cfg.Burst
+
+	var c *rest.Config
+	var err error
 	kubeconfigList := []*rest.Config{}
 	if len(kubeconfigs) > 0 {
 		stringList := strings.Split(kubeconfigs, ",")
@@ -67,17 +74,12 @@ func NewClientManager(cfg ClientManagerConfig) (*ClientManager, error) {
 			return nil, fmt.Errorf("kubeconfig is empty")
 		}
 
-		c, err := clientcmd.BuildConfigFromFlags("", stringList[0])
+		c, err = clientcmd.BuildConfigFromFlags("", stringList[0])
 		if err != nil {
 			return nil, fmt.Errorf("failed to build config from kubeconfig: %w", err)
 		}
-		c.QPS = qps
-		c.Burst = burst
-		kubeconfigList = append(kubeconfigList, c)
 	} else {
-		var c *rest.Config
-		var err error
-		if useKubernetesProxy {
+		if cfg.UseKubernetesProxy {
 			// Load Kubernetes REST config from default kubeconfig locations (KUBECONFIG environment variable or ~/.kube/config)
 			// without interactive prompts.
 			loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -93,10 +95,11 @@ func NewClientManager(cfg ClientManagerConfig) (*ClientManager, error) {
 				return nil, fmt.Errorf("failed to build config from in-cluster kubeconfig: %w", err)
 			}
 		}
-		c.QPS = qps
-		c.Burst = burst
-		kubeconfigList = append(kubeconfigList, c)
 	}
+	c.QPS = cfg.QPS
+	c.Burst = cfg.Burst
+	kubeconfigList = append(kubeconfigList, c)
+
 	scheme := runtime.NewScheme()
 	utilruntime.Must(rayv1.AddToScheme(scheme))
 	clientList := []client.Client{}


### PR DESCRIPTION
## Why are these changes needed?

Previously, the API server QPS and burst constants were defined in `main.go`, breaking package cohesion. This PR moves the default values to `client_manager.go`, keeping them closer to the code that actually uses them.

Input validation is also added to catch invalid values early and prevent unexpected runtime behavior.

#### Notable Changes

- Default QPS and burst values are doubled compared to the original alpha defaults, which is an intentional behavioral change to align with `ray-operator`'s configuration.
- Flags are named `kube-api-qps` and `kube-api-burst`, following Kubernetes naming conventions.

## Related issue number

Follow-up of https://github.com/ray-project/kuberay/pull/4821.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
