### PR TITLE
[History Server] Set owner info cookie and update logs file structure

### DIFF
--- a/historyserver/cmd/collector/main.go
+++ b/historyserver/cmd/collector/main.go
@@ -197,7 +197,7 @@ func main() {
 	// Create and initialize EventCollector
 	go func() {
 		defer wg.Done()
-		eventCollector := eventcollector.NewEventCollector(writer, rayRootDir, activeSessionDir, rayNodeId, rayClusterName, rayClusterNamespace, sessionName)
+		eventCollector := eventcollector.NewEventCollector(writer, rayRootDir, activeSessionDir, rayNodeId, rayClusterName, rayClusterNamespace, sessionName, ownerKind, ownerName)
 		eventCollector.Run(stop, eventsPort)
 		logrus.Info("Event collector shutdown")
 	}()

--- a/historyserver/html/select_cluster.html
+++ b/historyserver/html/select_cluster.html
@@ -654,7 +654,7 @@
                 showError(null);
                 renderTable();
 
-                fetch(`/enter_cluster/${namespace}/${name}/${session}`)
+                fetch(`/enter_cluster/${namespace}/raycluster/${name}/${session}`)
                     .then(res => {
                         if (!res.ok) throw new Error(`${res.status}: ${res.statusText || 'Error'}`);
                         return res.json();

--- a/historyserver/pkg/collector/eventcollector/eventcollector.go
+++ b/historyserver/pkg/collector/eventcollector/eventcollector.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ray-project/kuberay/historyserver/pkg/compression"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clusterlogs"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
@@ -35,6 +36,8 @@ type EventCollector struct {
 	clusterName        string
 	sessionName        string
 	root               string
+	ownerKind          string
+	ownerName          string
 	currentSessionName string
 	currentNodeID      string
 	events             []Event
@@ -57,7 +60,7 @@ var eventTypesWithJobID = []string{
 	"actorDefinitionEvent",
 }
 
-func NewEventCollector(writer storage.StorageWriter, rootDir, sessionDir, nodeID, clusterName, clusterNamespace, sessionName string) *EventCollector {
+func NewEventCollector(writer storage.StorageWriter, rootDir, sessionDir, nodeID, clusterName, clusterNamespace, sessionName, ownerKind, ownerName string) *EventCollector {
 	collector := &EventCollector{
 		events:             make([]Event, 0),
 		storageWriter:      writer,
@@ -67,6 +70,8 @@ func NewEventCollector(writer storage.StorageWriter, rootDir, sessionDir, nodeID
 		clusterName:        clusterName,
 		clusterNamespace:   clusterNamespace,
 		sessionName:        sessionName,
+		ownerKind:          ownerKind,
+		ownerName:          ownerName,
 		mutex:              sync.Mutex{},
 		flushInterval:      time.Hour, // Default flush interval: 1 hour
 		stopped:            make(chan struct{}),
@@ -381,10 +386,9 @@ func (ec *EventCollector) flushNodeEventsForHour(hourKey string, events []Event)
 		nodeIDToUse = events[0].NodeID
 	}
 
-	// Build node event storage path using event's nodeID
-	sessionPath := path.Clean(path.Join(ec.root, utils.AppendRayClusterNameNamespace(ec.clusterName, ec.clusterNamespace), sessionNameToUse))
-
-	basePath := path.Join(sessionPath, "node_events", fmt.Sprintf("%s-%s.gz", nodeIDToUse, hourKey))
+	// Build node event storage path using event's nodeID and session
+	nodeEventsDir := clusterlogs.NodeEventsDir(ec.root, ec.ownerKind, ec.ownerName, ec.clusterNamespace, ec.clusterName, sessionNameToUse, nodeIDToUse)
+	basePath := path.Join(nodeEventsDir, fmt.Sprintf("%s-%s.gz", nodeIDToUse, hourKey))
 
 	// Ensure storage directory exists
 	dir := path.Dir(basePath)
@@ -427,10 +431,9 @@ func (ec *EventCollector) flushJobEventsForHour(jobID, hourKey string, events []
 		nodeIDToUse = events[0].NodeID
 	}
 
-	// Build job event storage path using event's nodeID
-	sessionPath := path.Clean(path.Join(ec.root, utils.AppendRayClusterNameNamespace(ec.clusterName, ec.clusterNamespace), sessionNameToUse))
-
-	basePath := path.Join(sessionPath, "job_events", jobID, fmt.Sprintf("%s-%s.gz", nodeIDToUse, hourKey))
+	// Build job event storage path using event's nodeID and session
+	jobEventsDir := clusterlogs.JobEventsDir(ec.root, ec.ownerKind, ec.ownerName, ec.clusterNamespace, ec.clusterName, sessionNameToUse, nodeIDToUse, jobID)
+	basePath := path.Join(jobEventsDir, fmt.Sprintf("%s-%s.gz", nodeIDToUse, hourKey))
 
 	// Ensure storage directory exists
 	dir := path.Dir(basePath)

--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clusterlogs"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage/clustermetadata"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
@@ -198,7 +199,7 @@ func (r *RayLogHandler) processSessionLatestLogFile(absoluteLogPathName, session
 	subdir, _ := filepath.Split(relativePath)
 
 	// Build the object name using the standard path structure
-	logDir := utils.GetLogDirByNameID(r.RootDir, utils.AppendRayClusterNameNamespace(r.RayClusterName, r.RayClusterNamespace), nodeID, sessionID)
+	logDir := clusterlogs.LogsDir(r.RootDir, r.OwnerKind, r.OwnerName, r.RayClusterNamespace, r.RayClusterName, sessionID, nodeID)
 
 	if subdir != "" && subdir != "." {
 		// Remove trailing separator if present
@@ -635,7 +636,7 @@ func (r *RayLogHandler) processPrevLogFile(absoluteLogPathName, localLogDir, ses
 	subdir, _ := filepath.Split(relativePath)
 
 	// Build the object name using the standard path structure
-	logDir := utils.GetLogDirByNameID(r.RootDir, utils.AppendRayClusterNameNamespace(r.RayClusterName, r.RayClusterNamespace), nodeID, sessionID)
+	logDir := clusterlogs.LogsDir(r.RootDir, r.OwnerKind, r.OwnerName, r.RayClusterNamespace, r.RayClusterName, sessionID, nodeID)
 
 	if subdir != "" && subdir != "." {
 		// Remove trailing separator if present

--- a/historyserver/pkg/collector/logcollector/runtime/runtime.go
+++ b/historyserver/pkg/collector/logcollector/runtime/runtime.go
@@ -1,9 +1,7 @@
 package runtime
 
 import (
-	"fmt"
 	"net/http"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -13,6 +11,7 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/logcollector/runtime/logcollector"
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clusterlogs"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
@@ -53,7 +52,7 @@ func NewCollector(config *types.RayCollectorConfig, writer storage.StorageWriter
 
 	logDir := strings.TrimSpace(filepath.Join(config.SessionDir, utils.RAY_SESSIONDIR_LOGDIR_NAME))
 	handler.LogDir = logDir
-	clusterRootDir := fmt.Sprintf("%s/", path.Clean(path.Join(handler.RootDir, utils.AppendRayClusterNameNamespace(handler.RayClusterName, handler.RayClusterNamespace))))
+	clusterRootDir := clusterlogs.Prefix(handler.RootDir, handler.OwnerKind, handler.OwnerName, handler.RayClusterNamespace, handler.RayClusterName)
 	handler.ClusterDir = clusterRootDir
 
 	return &handler

--- a/historyserver/pkg/eventserver/eventserver.go
+++ b/historyserver/pkg/eventserver/eventserver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/compression"
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clusterlogs"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
@@ -460,24 +461,37 @@ func (h *EventHandler) storeEvent(clusterSessionKey string, eventMap map[string]
 	return nil
 }
 
+func (h *EventHandler) getClusterLogPathPrefix(clusterInfo utils.ClusterInfo) string {
+	return clusterlogs.Prefix("", clusterInfo.OwnerKind, clusterInfo.OwnerName, clusterInfo.Namespace, clusterInfo.Name)
+}
+
 // getAllJobEventFiles get all the job event files for the given cluster.
-// Assuming that the events file object follow the format root/clustername/sessionid/job_events/{job-*}/*
 func (h *EventHandler) getAllJobEventFiles(clusterInfo utils.ClusterInfo) []string {
 	var allJobFiles []string
-	clusterNameID := clusterInfo.Name + "_" + clusterInfo.Namespace
-	jobEventDirPrefix := clusterInfo.SessionName + "/job_events/"
-	jobDirList := h.reader.ListFiles(clusterNameID, jobEventDirPrefix)
+	clusterLogPathPrefix := h.getClusterLogPathPrefix(clusterInfo)
 
-	for _, jobDir := range jobDirList {
-		// Skip non-directory entries
-		if !strings.HasSuffix(jobDir, "/") {
-			continue
+	// Check candidate prefixes: both flat (<sessionName>/job_events/) and hierarchical (<nodeName>/<sessionName>/job_events/)
+	var candidatePrefixes []string
+	candidatePrefixes = append(candidatePrefixes, clusterInfo.SessionName+"/job_events/")
+	for _, rawEntry := range h.reader.ListFiles(clusterLogPathPrefix, clusterInfo.SessionName) {
+		if strings.HasSuffix(rawEntry, "/") {
+			nodeName := strings.TrimSuffix(rawEntry, "/")
+			candidatePrefixes = append(candidatePrefixes, clusterlogs.RelJobEventsDir(clusterInfo.SessionName, nodeName, "")+"/")
 		}
-		jobDirPath := jobEventDirPrefix + jobDir
-		jobFiles := h.reader.ListFiles(clusterNameID, jobDirPath)
-		for _, jobFile := range jobFiles {
-			if isValidEventFile(jobFile) {
-				allJobFiles = append(allJobFiles, jobDirPath+jobFile)
+	}
+
+	for _, jobEventDirPrefix := range candidatePrefixes {
+		jobDirList := h.reader.ListFiles(clusterLogPathPrefix, jobEventDirPrefix)
+		for _, jobDir := range jobDirList {
+			if !strings.HasSuffix(jobDir, "/") {
+				continue
+			}
+			jobDirPath := jobEventDirPrefix + jobDir
+			jobFiles := h.reader.ListFiles(clusterLogPathPrefix, jobDirPath)
+			for _, jobFile := range jobFiles {
+				if isValidEventFile(jobFile) {
+					allJobFiles = append(allJobFiles, jobDirPath+jobFile)
+				}
 			}
 		}
 	}
@@ -486,17 +500,25 @@ func (h *EventHandler) getAllJobEventFiles(clusterInfo utils.ClusterInfo) []stri
 
 // getAllNodeEventFiles retrieves all node event files for the given cluster
 func (h *EventHandler) getAllNodeEventFiles(clusterInfo utils.ClusterInfo) []string {
-	clusterNameID := clusterInfo.Name + "_" + clusterInfo.Namespace
-	nodeEventDirPrefix := clusterInfo.SessionName + "/node_events/"
-	nodeEventFileNames := h.reader.ListFiles(clusterNameID, nodeEventDirPrefix)
+	clusterLogPathPrefix := h.getClusterLogPathPrefix(clusterInfo)
 
-	// Filter out directories (items ending with /) and build full paths
+	var candidatePrefixes []string
+	candidatePrefixes = append(candidatePrefixes, clusterInfo.SessionName+"/node_events/")
+	for _, rawEntry := range h.reader.ListFiles(clusterLogPathPrefix, clusterInfo.SessionName) {
+		if strings.HasSuffix(rawEntry, "/") {
+			nodeName := strings.TrimSuffix(rawEntry, "/")
+			candidatePrefixes = append(candidatePrefixes, clusterlogs.RelNodeEventsDir(clusterInfo.SessionName, nodeName)+"/")
+		}
+	}
+
 	var nodeEventFiles []string
-	for _, fileName := range nodeEventFileNames {
-		// Skip directories
-		if isValidEventFile(fileName) {
-			fullPath := nodeEventDirPrefix + fileName
-			nodeEventFiles = append(nodeEventFiles, fullPath)
+	for _, nodeEventDirPrefix := range candidatePrefixes {
+		nodeEventFileNames := h.reader.ListFiles(clusterLogPathPrefix, nodeEventDirPrefix)
+		for _, fileName := range nodeEventFileNames {
+			if isValidEventFile(fileName) {
+				fullPath := nodeEventDirPrefix + fileName
+				nodeEventFiles = append(nodeEventFiles, fullPath)
+			}
 		}
 	}
 	return nodeEventFiles
@@ -1018,7 +1040,7 @@ func (h *EventHandler) getNodeMap(clusterSessionID string) map[string]types.Node
 // TODO(jiangjiawei1103): Empty event file list vs ListFiles outage is ambiguous without
 // StorageReader interface surfacing errors.
 func (h *EventHandler) ProcessSingleSession(ctx context.Context, clusterInfo utils.ClusterInfo) error {
-	clusterNameNamespace := clusterInfo.Name + "_" + clusterInfo.Namespace
+	clusterLogPathPrefix := h.getClusterLogPathPrefix(clusterInfo)
 	clusterSessionKey := utils.BuildClusterSessionKey(clusterInfo.Name, clusterInfo.Namespace, clusterInfo.SessionName)
 
 	// ClusterLogEventMap backs only the /events endpoint, so log event read failures must not
@@ -1042,14 +1064,14 @@ func (h *EventHandler) ProcessSingleSession(ctx context.Context, clusterInfo uti
 
 		var eventioReader io.Reader
 		if strings.HasSuffix(eventFile, ".gz") {
-			rc, err := compression.ReadCompressedContent(h.reader, clusterNameNamespace, eventFile)
+			rc, err := compression.ReadCompressedContent(h.reader, clusterLogPathPrefix, eventFile)
 			if err != nil {
 				logrus.Errorf("Failed to decompress event file %s: %v", eventFile, err)
 				continue
 			}
 			eventioReader = rc
 		} else {
-			eventioReader = h.reader.GetContent(clusterNameNamespace, eventFile)
+			eventioReader = h.reader.GetContent(clusterLogPathPrefix, eventFile)
 		}
 
 		if eventioReader == nil {

--- a/historyserver/pkg/eventserver/eventserver.go
+++ b/historyserver/pkg/eventserver/eventserver.go
@@ -461,6 +461,8 @@ func (h *EventHandler) storeEvent(clusterSessionKey string, eventMap map[string]
 	return nil
 }
 
+// getClusterLogPathPrefix returns the cluster storage prefix:
+// e.g., cluster-history/{ownerKind}/{namespace}/{ownerName}/{clusterName}
 func (h *EventHandler) getClusterLogPathPrefix(clusterInfo utils.ClusterInfo) string {
 	return clusterlogs.Prefix("", clusterInfo.OwnerKind, clusterInfo.OwnerName, clusterInfo.Namespace, clusterInfo.Name)
 }
@@ -470,9 +472,8 @@ func (h *EventHandler) getAllJobEventFiles(clusterInfo utils.ClusterInfo) []stri
 	var allJobFiles []string
 	clusterLogPathPrefix := h.getClusterLogPathPrefix(clusterInfo)
 
-	// Check candidate prefixes: both flat (<sessionName>/job_events/) and hierarchical (<nodeName>/<sessionName>/job_events/)
+	// Check candidate prefixes under each node (<sessionName>/<nodeName>/job_events/)
 	var candidatePrefixes []string
-	candidatePrefixes = append(candidatePrefixes, clusterInfo.SessionName+"/job_events/")
 	for _, rawEntry := range h.reader.ListFiles(clusterLogPathPrefix, clusterInfo.SessionName) {
 		if strings.HasSuffix(rawEntry, "/") {
 			nodeName := strings.TrimSuffix(rawEntry, "/")
@@ -502,8 +503,8 @@ func (h *EventHandler) getAllJobEventFiles(clusterInfo utils.ClusterInfo) []stri
 func (h *EventHandler) getAllNodeEventFiles(clusterInfo utils.ClusterInfo) []string {
 	clusterLogPathPrefix := h.getClusterLogPathPrefix(clusterInfo)
 
+	// Check candidate prefixes under each node (<sessionName>/<nodeName>/node_events/)
 	var candidatePrefixes []string
-	candidatePrefixes = append(candidatePrefixes, clusterInfo.SessionName+"/node_events/")
 	for _, rawEntry := range h.reader.ListFiles(clusterLogPathPrefix, clusterInfo.SessionName) {
 		if strings.HasSuffix(rawEntry, "/") {
 			nodeName := strings.TrimSuffix(rawEntry, "/")

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -958,12 +958,12 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("returns error when every listed file fails I/O", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster_ns", "session1/job_events/", []string{"job-01000000/"})
-		mock.addDir("cluster_ns", "session1/job_events/job-01000000/",
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{"job-01000000/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/job-01000000/",
 			[]string{"01000000-2024-01-01-00.gz"})
-		mock.addDir("cluster_ns", "session1/node_events/",
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/",
 			[]string{"node1-2024-01-01-00.gz"})
-		mock.addDir("cluster_ns", "session1/logs", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{})
 
 		h := NewEventHandler(mock)
 		err := h.ProcessSingleSession(context.Background(), clusterInfo)
@@ -973,9 +973,9 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("empty file list returns nil (legit empty session)", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster_ns", "session1/job_events/", []string{})
-		mock.addDir("cluster_ns", "session1/node_events/", []string{})
-		mock.addDir("cluster_ns", "session1/logs", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{})
 
 		h := NewEventHandler(mock)
 		err := h.ProcessSingleSession(context.Background(), clusterInfo)
@@ -984,7 +984,7 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("partial success does not return error", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster_ns", "session1/node_events/",
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/",
 			[]string{"node1-2024-01-01-00.gz", "node2-2024-01-01-00.gz"})
 
 		var buf bytes.Buffer
@@ -993,9 +993,9 @@ func TestProcessSingleSession(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, gw.Close())
 
-		mock.addFile("cluster_ns", "session1/node_events/node1-2024-01-01-00.gz", buf.String())
-		mock.addDir("cluster_ns", "session1/job_events/", []string{})
-		mock.addDir("cluster_ns", "session1/logs", []string{})
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node_events/node1-2024-01-01-00.gz", buf.String())
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{})
 
 		h := NewEventHandler(mock)
 		err = h.ProcessSingleSession(context.Background(), clusterInfo)
@@ -1004,7 +1004,7 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("all corrupt JSON does not return error", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster_ns", "session1/node_events/",
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/",
 			[]string{"node1-2024-01-01-00.gz", "node2-2024-01-01-00.gz"})
 
 		var buf bytes.Buffer
@@ -1013,10 +1013,10 @@ func TestProcessSingleSession(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, gw.Close())
 
-		mock.addFile("cluster_ns", "session1/node_events/node1-2024-01-01-00.gz", buf.String())
-		mock.addFile("cluster_ns", "session1/node_events/node2-2024-01-01-00.gz", buf.String())
-		mock.addDir("cluster_ns", "session1/job_events/", []string{})
-		mock.addDir("cluster_ns", "session1/logs", []string{})
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node_events/node1-2024-01-01-00.gz", buf.String())
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node_events/node2-2024-01-01-00.gz", buf.String())
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{})
 
 		h := NewEventHandler(mock)
 		err = h.ProcessSingleSession(context.Background(), clusterInfo)
@@ -1025,10 +1025,10 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("log events failure alone does not surface as error", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster_ns", "session1/job_events/", []string{})
-		mock.addDir("cluster_ns", "session1/node_events/", []string{})
-		mock.addDir("cluster_ns", "session1/logs", []string{"node1/"})
-		mock.addDir("cluster_ns", "session1/logs/node1/events", []string{"event_GCS.log"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{"node1/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs/node1/events", []string{"event_GCS.log"})
 
 		h := NewEventHandler(mock)
 		err := h.ProcessSingleSession(context.Background(), clusterInfo)
@@ -1037,10 +1037,10 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("ray events failure surfaces; log events failure stays silent", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster_ns", "session1/node_events/", []string{"node1-2024-01-01-00.gz"})
-		mock.addDir("cluster_ns", "session1/job_events/", []string{})
-		mock.addDir("cluster_ns", "session1/logs", []string{"node1/"})
-		mock.addDir("cluster_ns", "session1/logs/node1/events", []string{"event_GCS.log"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/", []string{"node1-2024-01-01-00.gz"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{"node1/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs/node1/events", []string{"event_GCS.log"})
 
 		h := NewEventHandler(mock)
 		err := h.ProcessSingleSession(context.Background(), clusterInfo)
@@ -1051,7 +1051,7 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("transparent decompression of compressed .gz files and reading uncompressed legacy files", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster_ns", "session1/node_events/",
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/",
 			[]string{"node1-2024-01-01-00.gz", "node2-2024-01-01-00"})
 
 		// 1. Compress node1 event file
@@ -1060,14 +1060,14 @@ func TestProcessSingleSession(t *testing.T) {
 		_, err := gw.Write([]byte(`[{"eventType":"NODE_DEFINITION_EVENT","nodeDefinitionEvent":{"nodeId":"YWJjZA=="}}]`))
 		require.NoError(t, err)
 		require.NoError(t, gw.Close())
-		mock.addFile("cluster_ns", "session1/node_events/node1-2024-01-01-00.gz", buf.String())
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node_events/node1-2024-01-01-00.gz", buf.String())
 
 		// 2. Keep node2 event file uncompressed
-		mock.addFile("cluster_ns", "session1/node_events/node2-2024-01-01-00",
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node_events/node2-2024-01-01-00",
 			`[{"eventType":"NODE_DEFINITION_EVENT","nodeDefinitionEvent":{"nodeId":"ZWZnaA=="}}]`)
 
-		mock.addDir("cluster_ns", "session1/job_events/", []string{})
-		mock.addDir("cluster_ns", "session1/logs", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{})
 
 		h := NewEventHandler(mock)
 		err = h.ProcessSingleSession(context.Background(), clusterInfo)

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -958,10 +958,11 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("returns error when every listed file fails I/O", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{"job-01000000/"})
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/job-01000000/",
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1", []string{"node1/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/job_events/", []string{"job-01000000/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/job_events/job-01000000/",
 			[]string{"01000000-2024-01-01-00.gz"})
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/",
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/node_events/",
 			[]string{"node1-2024-01-01-00.gz"})
 		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{})
 
@@ -973,8 +974,9 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("empty file list returns nil (legit empty session)", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{})
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1", []string{"node1/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/node_events/", []string{})
 		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{})
 
 		h := NewEventHandler(mock)
@@ -984,8 +986,11 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("partial success does not return error", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/",
-			[]string{"node1-2024-01-01-00.gz", "node2-2024-01-01-00.gz"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1", []string{"node1/", "node2/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/node_events/",
+			[]string{"node1-2024-01-01-00.gz"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node2/node_events/",
+			[]string{"node2-2024-01-01-00.gz"})
 
 		var buf bytes.Buffer
 		gw := gzip.NewWriter(&buf)
@@ -993,8 +998,9 @@ func TestProcessSingleSession(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, gw.Close())
 
-		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node_events/node1-2024-01-01-00.gz", buf.String())
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{})
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node1/node_events/node1-2024-01-01-00.gz", buf.String())
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node2/job_events/", []string{})
 		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{})
 
 		h := NewEventHandler(mock)
@@ -1004,8 +1010,11 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("all corrupt JSON does not return error", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/",
-			[]string{"node1-2024-01-01-00.gz", "node2-2024-01-01-00.gz"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1", []string{"node1/", "node2/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/node_events/",
+			[]string{"node1-2024-01-01-00.gz"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node2/node_events/",
+			[]string{"node2-2024-01-01-00.gz"})
 
 		var buf bytes.Buffer
 		gw := gzip.NewWriter(&buf)
@@ -1013,9 +1022,10 @@ func TestProcessSingleSession(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, gw.Close())
 
-		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node_events/node1-2024-01-01-00.gz", buf.String())
-		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node_events/node2-2024-01-01-00.gz", buf.String())
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{})
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node1/node_events/node1-2024-01-01-00.gz", buf.String())
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node2/node_events/node2-2024-01-01-00.gz", buf.String())
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node2/job_events/", []string{})
 		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{})
 
 		h := NewEventHandler(mock)
@@ -1025,8 +1035,9 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("log events failure alone does not surface as error", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{})
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1", []string{"node1/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/node_events/", []string{})
 		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{"node1/"})
 		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs/node1/events", []string{"event_GCS.log"})
 
@@ -1037,8 +1048,9 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("ray events failure surfaces; log events failure stays silent", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/", []string{"node1-2024-01-01-00.gz"})
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1", []string{"node1/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/node_events/", []string{"node1-2024-01-01-00.gz"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/job_events/", []string{})
 		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{"node1/"})
 		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs/node1/events", []string{"event_GCS.log"})
 
@@ -1051,8 +1063,11 @@ func TestProcessSingleSession(t *testing.T) {
 
 	t.Run("transparent decompression of compressed .gz files and reading uncompressed legacy files", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node_events/",
-			[]string{"node1-2024-01-01-00.gz", "node2-2024-01-01-00"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1", []string{"node1/", "node2/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/node_events/",
+			[]string{"node1-2024-01-01-00.gz"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node2/node_events/",
+			[]string{"node2-2024-01-01-00"})
 
 		// 1. Compress node1 event file
 		var buf bytes.Buffer
@@ -1060,13 +1075,14 @@ func TestProcessSingleSession(t *testing.T) {
 		_, err := gw.Write([]byte(`[{"eventType":"NODE_DEFINITION_EVENT","nodeDefinitionEvent":{"nodeId":"YWJjZA=="}}]`))
 		require.NoError(t, err)
 		require.NoError(t, gw.Close())
-		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node_events/node1-2024-01-01-00.gz", buf.String())
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node1/node_events/node1-2024-01-01-00.gz", buf.String())
 
 		// 2. Keep node2 event file uncompressed
-		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node_events/node2-2024-01-01-00",
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node2/node_events/node2-2024-01-01-00",
 			`[{"eventType":"NODE_DEFINITION_EVENT","nodeDefinitionEvent":{"nodeId":"ZWZnaA=="}}]`)
 
-		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/job_events/", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node2/job_events/", []string{})
 		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/logs", []string{})
 
 		h := NewEventHandler(mock)

--- a/historyserver/pkg/eventserver/log_event_reader.go
+++ b/historyserver/pkg/eventserver/log_event_reader.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clusterlogs"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 	"github.com/sirupsen/logrus"
 )
@@ -53,60 +54,46 @@ func NewLogEventReader(reader storage.StorageReader) *LogEventReader {
 // Return an error if any listed file fails to read (total or partial).
 func (r *LogEventReader) ReadLogEvents(clusterInfo utils.ClusterInfo, clusterSessionKey string, eventStore *types.ClusterLogEventMap) error {
 	// Build cluster ID used by StorageReader
-	clusterID := clusterInfo.Name + "_" + clusterInfo.Namespace
+	// Build cluster ID (clusterLogPathPrefix) used by StorageReader
+	clusterLogPathPrefix := clusterlogs.Prefix("", clusterInfo.OwnerKind, clusterInfo.OwnerName, clusterInfo.Namespace, clusterInfo.Name)
 
 	// Get or create the JobEventMap for this cluster session
 	jobEventMap := eventStore.GetOrCreateJobEventMap(clusterSessionKey)
 
-	// Path: {sessionName}/logs/
-	logsBaseDir := path.Join(clusterInfo.SessionName, utils.RAY_SESSIONDIR_LOGDIR_NAME)
-
-	// List all items under logs/ to find node directories
-	// Note: ListFiles returns base names only (e.g., "node1/", "node2/")
-	nodeEntries := r.reader.ListFiles(clusterID, logsBaseDir)
-
-	// Filter to get node IDs (only directories end with "/")
-	// This matches the pattern used in eventserver.go getAllJobEventFiles()
+	// Find candidate nodes under {sessionName}/
 	var nodeIDs []string
-	for _, entry := range nodeEntries {
-		// Skip non-directory entries (files don't end with "/")
-		if !strings.HasSuffix(entry, "/") {
-			continue
-		}
-		// Remove trailing "/" to get node ID
-		nodeID := strings.TrimSuffix(entry, "/")
-		if nodeID != "" {
-			nodeIDs = append(nodeIDs, nodeID)
+	for _, entry := range r.reader.ListFiles(clusterLogPathPrefix, clusterInfo.SessionName) {
+		if strings.HasSuffix(entry, "/") {
+			nodeID := strings.TrimSuffix(entry, "/")
+			if nodeID != "" {
+				nodeIDs = append(nodeIDs, nodeID)
+			}
 		}
 	}
-	logrus.Debugf("Found %d node directories for cluster %s: %v", len(nodeIDs), clusterSessionKey, nodeIDs)
+	logrus.Debugf("Found candidate node directories for cluster %s: %v", clusterSessionKey, nodeIDs)
 
 	total := 0
 	read := 0
 	for _, nodeID := range nodeIDs {
-		// Path: {sessionName}/logs/{nodeId}/events/
-		eventsDir := path.Join(clusterInfo.SessionName, utils.RAY_SESSIONDIR_LOGDIR_NAME, nodeID, "events")
-		// Note: ListFiles returns base names only (e.g., "event_GCS.log")
-		eventFileNames := r.reader.ListFiles(clusterID, eventsDir)
-
-		for _, fileName := range eventFileNames {
-			// Only process event_*.log files
-			if !strings.HasPrefix(fileName, "event_") || !strings.HasSuffix(fileName, ".log") {
-				continue
+		// Candidate events dirs: hierarchical (<sessionName>/<nodeId>/logs/events) and flat (<sessionName>/logs/<nodeId>/events)
+		candidateEventsDirs := []string{
+			path.Join(clusterlogs.RelLogsDir(clusterInfo.SessionName, nodeID), "events"),
+			path.Join(clusterInfo.SessionName, utils.RAY_SESSIONDIR_LOGDIR_NAME, nodeID, "events"),
+		}
+		for _, eventsDir := range candidateEventsDirs {
+			eventFileNames := r.reader.ListFiles(clusterLogPathPrefix, eventsDir)
+			for _, fileName := range eventFileNames {
+				if !strings.HasPrefix(fileName, "event_") || !strings.HasSuffix(fileName, ".log") {
+					continue
+				}
+				eventFilePath := path.Join(eventsDir, fileName)
+				total++
+				if err := r.readEventFile(clusterLogPathPrefix, eventFilePath, jobEventMap); err != nil {
+					logrus.Warnf("Failed to read event file %s: %v", eventFilePath, err)
+					continue
+				}
+				read++
 			}
-
-			// Build full path relative to clusterID for GetContent
-			eventFilePath := path.Join(clusterInfo.SessionName, utils.RAY_SESSIONDIR_LOGDIR_NAME, nodeID, "events", fileName)
-
-			// Read and parse the event file
-			// Note: Duplicate events are handled by JobEventMap's deduplication using event_id as key.
-			// This matches the design of existing RayEvents reading in eventserver.go.
-			total++
-			if err := r.readEventFile(clusterID, eventFilePath, jobEventMap); err != nil {
-				logrus.Warnf("Failed to read event file %s: %v", eventFilePath, err)
-				continue
-			}
-			read++
 		}
 	}
 

--- a/historyserver/pkg/eventserver/log_event_reader.go
+++ b/historyserver/pkg/eventserver/log_event_reader.go
@@ -49,11 +49,10 @@ func NewLogEventReader(reader storage.StorageReader) *LogEventReader {
 // ReadLogEvents reads all Log Events from logs/{nodeId}/events/event_*.log files
 // and stores them in the provided ClusterLogEventMap.
 //
-// Path structure in storage: {clusterName}_{namespace}/{sessionName}/logs/{nodeId}/events/event_*.log
+// Path structure in storage: cluster-history/{ownerKind}/{namespace}/{ownerName}/{clusterName}/{sessionName}/{nodeId}/logs/events/event_*.log
 //
 // Return an error if any listed file fails to read (total or partial).
 func (r *LogEventReader) ReadLogEvents(clusterInfo utils.ClusterInfo, clusterSessionKey string, eventStore *types.ClusterLogEventMap) error {
-	// Build cluster ID used by StorageReader
 	// Build cluster ID (clusterLogPathPrefix) used by StorageReader
 	clusterLogPathPrefix := clusterlogs.Prefix("", clusterInfo.OwnerKind, clusterInfo.OwnerName, clusterInfo.Namespace, clusterInfo.Name)
 
@@ -75,25 +74,20 @@ func (r *LogEventReader) ReadLogEvents(clusterInfo utils.ClusterInfo, clusterSes
 	total := 0
 	read := 0
 	for _, nodeID := range nodeIDs {
-		// Candidate events dirs: hierarchical (<sessionName>/<nodeId>/logs/events) and flat (<sessionName>/logs/<nodeId>/events)
-		candidateEventsDirs := []string{
-			path.Join(clusterlogs.RelLogsDir(clusterInfo.SessionName, nodeID), "events"),
-			path.Join(clusterInfo.SessionName, utils.RAY_SESSIONDIR_LOGDIR_NAME, nodeID, "events"),
-		}
-		for _, eventsDir := range candidateEventsDirs {
-			eventFileNames := r.reader.ListFiles(clusterLogPathPrefix, eventsDir)
-			for _, fileName := range eventFileNames {
-				if !strings.HasPrefix(fileName, "event_") || !strings.HasSuffix(fileName, ".log") {
-					continue
-				}
-				eventFilePath := path.Join(eventsDir, fileName)
-				total++
-				if err := r.readEventFile(clusterLogPathPrefix, eventFilePath, jobEventMap); err != nil {
-					logrus.Warnf("Failed to read event file %s: %v", eventFilePath, err)
-					continue
-				}
-				read++
+		// Events directory: hierarchical (<sessionName>/<nodeId>/logs/events)
+		eventsDir := path.Join(clusterlogs.RelLogsDir(clusterInfo.SessionName, nodeID), "events")
+		eventFileNames := r.reader.ListFiles(clusterLogPathPrefix, eventsDir)
+		for _, fileName := range eventFileNames {
+			if !strings.HasPrefix(fileName, "event_") || !strings.HasSuffix(fileName, ".log") {
+				continue
 			}
+			eventFilePath := path.Join(eventsDir, fileName)
+			total++
+			if err := r.readEventFile(clusterLogPathPrefix, eventFilePath, jobEventMap); err != nil {
+				logrus.Warnf("Failed to read event file %s: %v", eventFilePath, err)
+				continue
+			}
+			read++
 		}
 	}
 

--- a/historyserver/pkg/eventserver/log_event_reader_test.go
+++ b/historyserver/pkg/eventserver/log_event_reader_test.go
@@ -124,11 +124,11 @@ func TestReadEventFile(t *testing.T) {
 			testGlobalEvent,
 			testJobEvent, // duplicate event_id — should be deduped
 		}, "\n") + "\n"
-		mock.addFile("cluster_ns", "session/logs/node1/events/event_JOBS.log", content)
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session/node1/logs/events/event_JOBS.log", content)
 
 		reader := NewLogEventReader(mock)
 		jobEventMap := types.NewJobEventMap()
-		err := reader.readEventFile("cluster_ns", "session/logs/node1/events/event_JOBS.log", jobEventMap)
+		err := reader.readEventFile("cluster-history/raycluster/ns/cluster", "session/node1/logs/events/event_JOBS.log", jobEventMap)
 		require.NoError(t, err)
 
 		events := jobEventMap.GetAllEvents()
@@ -144,11 +144,11 @@ func TestReadEventFile(t *testing.T) {
 			"INVALID JSON",
 			noIDEvent,
 		}, "\n") + "\n"
-		mock.addFile("cluster_ns", "session/logs/node1/events/event_GCS.log", content)
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session/node1/logs/events/event_GCS.log", content)
 
 		reader := NewLogEventReader(mock)
 		jobEventMap := types.NewJobEventMap()
-		err := reader.readEventFile("cluster_ns", "session/logs/node1/events/event_GCS.log", jobEventMap)
+		err := reader.readEventFile("cluster-history/raycluster/ns/cluster", "session/node1/logs/events/event_GCS.log", jobEventMap)
 		require.NoError(t, err)
 
 		events := jobEventMap.GetAllEvents()
@@ -157,11 +157,11 @@ func TestReadEventFile(t *testing.T) {
 
 	t.Run("restores escaped newlines in message", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addFile("cluster_ns", "session/logs/node1/events/event_GCS.log", testNewlineEvent+"\n")
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session/node1/logs/events/event_GCS.log", testNewlineEvent+"\n")
 
 		reader := NewLogEventReader(mock)
 		jobEventMap := types.NewJobEventMap()
-		err := reader.readEventFile("cluster_ns", "session/logs/node1/events/event_GCS.log", jobEventMap)
+		err := reader.readEventFile("cluster-history/raycluster/ns/cluster", "session/node1/logs/events/event_GCS.log", jobEventMap)
 		require.NoError(t, err)
 
 		events := jobEventMap.GetAllEvents()
@@ -171,15 +171,15 @@ func TestReadEventFile(t *testing.T) {
 
 	t.Run("handles empty file and missing file", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addFile("cluster_ns", "session/logs/node1/events/event_GCS.log", "")
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session/node1/logs/events/event_GCS.log", "")
 		reader := NewLogEventReader(mock)
 
 		jobEventMap := types.NewJobEventMap()
-		err := reader.readEventFile("cluster_ns", "session/logs/node1/events/event_GCS.log", jobEventMap)
+		err := reader.readEventFile("cluster-history/raycluster/ns/cluster", "session/node1/logs/events/event_GCS.log", jobEventMap)
 		require.NoError(t, err)
 		assert.Empty(t, jobEventMap.GetAllEvents())
 
-		err = reader.readEventFile("cluster_ns", "nonexistent", types.NewJobEventMap())
+		err = reader.readEventFile("cluster-history/raycluster/ns/cluster", "nonexistent", types.NewJobEventMap())
 		assert.Error(t, err)
 	})
 }
@@ -188,13 +188,13 @@ func TestReadLogEvents(t *testing.T) {
 	t.Run("reads events from multiple nodes, skips non-event files", func(t *testing.T) {
 		mock := newLogEventMockReader()
 
-		mock.addDir("cluster_ns", "session1/logs", []string{"node1/", "node2/", "stray_file.txt"})
-		mock.addDir("cluster_ns", "session1/logs/node1/events", []string{"event_GCS.log", "debug.log"})
-		mock.addDir("cluster_ns", "session1/logs/node2/events", []string{"event_RAYLET.log"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1", []string{"node1/", "node2/", "stray_file.txt"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/logs/events", []string{"event_GCS.log", "debug.log"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node2/logs/events", []string{"event_RAYLET.log"})
 
-		mock.addFile("cluster_ns", "session1/logs/node1/events/event_GCS.log",
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node1/logs/events/event_GCS.log",
 			`{"event_id":"e1","source_type":"GCS","severity":"INFO","message":"from node1","timestamp":"1770635700"}`+"\n")
-		mock.addFile("cluster_ns", "session1/logs/node2/events/event_RAYLET.log",
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node2/logs/events/event_RAYLET.log",
 			`{"event_id":"e2","source_type":"RAYLET","severity":"WARNING","message":"from node2","timestamp":"1770635800"}`+"\n")
 
 		reader := NewLogEventReader(mock)
@@ -210,7 +210,7 @@ func TestReadLogEvents(t *testing.T) {
 
 	t.Run("handles empty cluster with no nodes", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster_ns", "session1/logs", []string{})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1", []string{})
 
 		reader := NewLogEventReader(mock)
 		store := types.NewClusterLogEventMap()
@@ -224,8 +224,8 @@ func TestReadLogEvents(t *testing.T) {
 	t.Run("returns error when every listed file fails to read", func(t *testing.T) {
 		// Intentionally skip addFile.
 		mock := newLogEventMockReader()
-		mock.addDir("cluster_ns", "session1/logs", []string{"node1/"})
-		mock.addDir("cluster_ns", "session1/logs/node1/events", []string{"event_GCS.log", "event_RAYLET.log"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1", []string{"node1/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/logs/events", []string{"event_GCS.log", "event_RAYLET.log"})
 
 		reader := NewLogEventReader(mock)
 		store := types.NewClusterLogEventMap()
@@ -238,9 +238,9 @@ func TestReadLogEvents(t *testing.T) {
 
 	t.Run("partial read surfaces error but preserves successful events", func(t *testing.T) {
 		mock := newLogEventMockReader()
-		mock.addDir("cluster_ns", "session1/logs", []string{"node1/"})
-		mock.addDir("cluster_ns", "session1/logs/node1/events", []string{"event_GCS.log", "event_RAYLET.log"})
-		mock.addFile("cluster_ns", "session1/logs/node1/events/event_GCS.log",
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1", []string{"node1/"})
+		mock.addDir("cluster-history/raycluster/ns/cluster", "session1/node1/logs/events", []string{"event_GCS.log", "event_RAYLET.log"})
+		mock.addFile("cluster-history/raycluster/ns/cluster", "session1/node1/logs/events/event_GCS.log",
 			`{"event_id":"e1","source_type":"GCS","severity":"INFO","message":"ok","timestamp":"1770635700"}`+"\n")
 
 		reader := NewLogEventReader(mock)

--- a/historyserver/pkg/historyserver/clientmanager.go
+++ b/historyserver/pkg/historyserver/clientmanager.go
@@ -33,14 +33,14 @@ func (c *ClientManager) Client() client.Client {
 	return c.clients[0]
 }
 
-func (c *ClientManager) ListRayClusters(ctx context.Context) ([]*rayv1.RayCluster, error) {
+func (c *ClientManager) ListRayClusters(ctx context.Context, opts ...client.ListOption) ([]*rayv1.RayCluster, error) {
 	list := []*rayv1.RayCluster{}
-	for _, c := range c.clients {
+	for _, cl := range c.clients {
 		listOfRayCluster := rayv1.RayClusterList{}
-		err := c.List(ctx, &listOfRayCluster)
+		err := cl.List(ctx, &listOfRayCluster, opts...)
 		if err != nil {
 			logrus.Errorf("Failed to list RayClusters: %v", err)
-			continue
+			return nil, err
 		}
 		for _, rayCluster := range listOfRayCluster.Items {
 			list = append(list, &rayCluster)

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -48,7 +48,7 @@ func TestEnterCluster(t *testing.T) {
 				Namespace:   "default",
 				Name:        "cluster-a",
 				SessionName: "session_2026-04-22_10-00-00_000000_1",
-				OwnerKind:   "RayJob",
+				OwnerKind:   "rayjob",
 				OwnerName:   "job-a",
 			},
 			// cluster-b (Multi-session cluster: past session AND live session)
@@ -56,7 +56,7 @@ func TestEnterCluster(t *testing.T) {
 				Namespace:       "default",
 				Name:            "cluster-b",
 				SessionName:     "session_2026-04-22_10-00-00_000000_1",
-				OwnerKind:       "RayService",
+				OwnerKind:       "rayservice",
 				OwnerName:       "svc-b",
 				CreateTimeStamp: 1000, // Older
 			},
@@ -64,7 +64,7 @@ func TestEnterCluster(t *testing.T) {
 				Namespace:       "default",
 				Name:            "cluster-b",
 				SessionName:     "live",
-				OwnerKind:       "RayService",
+				OwnerKind:       "rayservice",
 				OwnerName:       "svc-b",
 				CreateTimeStamp: 2000, // Newer (latest)
 			},
@@ -73,7 +73,7 @@ func TestEnterCluster(t *testing.T) {
 				Namespace:   "default",
 				Name:        "cluster-c",
 				SessionName: "session_2026-04-22_10-00-00_000000_2_live",
-				OwnerKind:   "RayJob",
+				OwnerKind:   "rayjob",
 				OwnerName:   "job-c",
 			},
 			// cluster-d (invalid session format)
@@ -137,7 +137,7 @@ func TestEnterCluster(t *testing.T) {
 	})
 
 	t.Run("Enter existing single-session cluster with explicit session (Successful Dead Session Loading)", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-a/session_2026-04-22_10-00-00_000000_1", nil)
+		req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-a/session_2026-04-22_10-00-00_000000_1", nil)
 		resp := httptest.NewRecorder()
 		container.ServeHTTP(resp, req)
 
@@ -157,7 +157,7 @@ func TestEnterCluster(t *testing.T) {
 	})
 
 	t.Run("Enter cluster with session that is actually live maps to live sentinel", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-c/session_2026-04-22_10-00-00_000000_2_live", nil)
+		req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-c/session_2026-04-22_10-00-00_000000_2_live", nil)
 		resp := httptest.NewRecorder()
 		container.ServeHTTP(resp, req)
 
@@ -178,7 +178,7 @@ func TestEnterCluster(t *testing.T) {
 	})
 
 	t.Run("Enter cluster with invalid session name format rejects request", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-d/invalid-session-name", nil)
+		req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-d/invalid-session-name", nil)
 		resp := httptest.NewRecorder()
 		container.ServeHTTP(resp, req)
 
@@ -187,7 +187,7 @@ func TestEnterCluster(t *testing.T) {
 		}
 	})
 	t.Run("Enter cluster with 'latest' keyword resolves to newest session in the list", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-b/latest", nil)
+		req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-b/latest", nil)
 		resp := httptest.NewRecorder()
 		container.ServeHTTP(resp, req)
 
@@ -214,7 +214,7 @@ func TestEnterCluster(t *testing.T) {
 	})
 
 	t.Run("Enter cluster with no session parameter defaults to latest", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-b", nil)
+		req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-b", nil)
 		resp := httptest.NewRecorder()
 		container.ServeHTTP(resp, req)
 
@@ -281,7 +281,7 @@ func TestEnterClusterLatestFromStorage(t *testing.T) {
 	container := restful.DefaultContainer
 
 	// Call enter_cluster with "latest"
-	req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-refresh/latest", nil)
+	req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-refresh/latest", nil)
 	resp := httptest.NewRecorder()
 	container.ServeHTTP(resp, req)
 
@@ -346,7 +346,7 @@ func TestEnterClusterLatestPrioritizesLive(t *testing.T) {
 	container := restful.DefaultContainer
 
 	// Call enter_cluster with "latest"
-	req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-prioritize-live/latest", nil)
+	req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-prioritize-live/latest", nil)
 	resp := httptest.NewRecorder()
 	container.ServeHTTP(resp, req)
 
@@ -398,7 +398,7 @@ func TestEnterClusterReturnsNotFoundWhenRemovedFromStorage(t *testing.T) {
 	container := restful.DefaultContainer
 
 	// Call enter_cluster with "latest"
-	req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-removed-from-storage/latest", nil)
+	req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-removed-from-storage/latest", nil)
 	resp := httptest.NewRecorder()
 	container.ServeHTTP(resp, req)
 
@@ -456,7 +456,7 @@ func TestEnterClusterReturnsErrorOnTransientK8sError(t *testing.T) {
 	container := restful.DefaultContainer
 
 	// Request "latest" when K8s returns transient error
-	req := httptest.NewRequest("GET", "/enter_cluster/default/cluster-transient-err/latest", nil)
+	req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-transient-err/latest", nil)
 	resp := httptest.NewRecorder()
 	container.ServeHTTP(resp, req)
 
@@ -464,4 +464,94 @@ func TestEnterClusterReturnsErrorOnTransientK8sError(t *testing.T) {
 	if resp.Code != http.StatusInternalServerError {
 		t.Fatalf("Expected status 500 (StatusInternalServerError), got %d: %s", resp.Code, resp.Body.String())
 	}
+}
+
+func TestEnterClusterRayJobAndRayService(t *testing.T) {
+	restful.DefaultContainer = restful.NewContainer()
+
+	mockReader := &mockStorageReader{
+		clusters: []utils.ClusterInfo{
+			{
+				Namespace:       "default",
+				Name:            "rayjob-cluster",
+				SessionName:     "session_2026-04-22_10-00-00_000000_1",
+				CreateTimeStamp: 1000,
+				OwnerKind:       "rayjob",
+				OwnerName:       "my-job",
+			},
+			{
+				Namespace:       "default",
+				Name:            "rayservice-cluster",
+				SessionName:     "session_2026-04-22_10-00-00_000000_2",
+				CreateTimeStamp: 2000,
+				OwnerKind:       "rayservice",
+				OwnerName:       "my-service",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(scheme)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	clientManager := &ClientManager{
+		clients: []client.Client{k8sClient},
+	}
+
+	handler := &ServerHandler{
+		maxClusters:   100,
+		reader:        mockReader,
+		clientManager: clientManager,
+	}
+
+	fp := &fakeProcessor{
+		fn: func(ctx context.Context, info utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
+			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
+		},
+	}
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+
+	routerRayClusterSet(handler)
+	container := restful.DefaultContainer
+
+	t.Run("Enter RayJob by owner name without session defaults to latest", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/enter_cluster/default/rayjob/my-job", nil)
+		resp := httptest.NewRecorder()
+		container.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+		}
+		cookies := resp.Result().Cookies()
+		cookieMap := make(map[string]*http.Cookie)
+		for _, cookie := range cookies {
+			cookieMap[cookie.Name] = cookie
+		}
+		if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "session_2026-04-22_10-00-00_000000_1" {
+			t.Errorf("Expected cookie %s to be 'session_2026-04-22_10-00-00_000000_1', got %v", COOKIE_SESSION_NAME_KEY, c)
+		}
+		if c, ok := cookieMap[COOKIE_OWNER_KIND_KEY]; !ok || c.Value != "rayjob" {
+			t.Errorf("Expected cookie %s to be 'rayjob', got %v", COOKIE_OWNER_KIND_KEY, c)
+		}
+	})
+
+	t.Run("Enter RayService by owner name with specific session", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/enter_cluster/default/rayservice/my-service/session_2026-04-22_10-00-00_000000_2", nil)
+		resp := httptest.NewRecorder()
+		container.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+		}
+		cookies := resp.Result().Cookies()
+		cookieMap := make(map[string]*http.Cookie)
+		for _, cookie := range cookies {
+			cookieMap[cookie.Name] = cookie
+		}
+		if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "session_2026-04-22_10-00-00_000000_2" {
+			t.Errorf("Expected cookie %s to be 'session_2026-04-22_10-00-00_000000_2', got %v", COOKIE_SESSION_NAME_KEY, c)
+		}
+		if c, ok := cookieMap[COOKIE_OWNER_KIND_KEY]; !ok || c.Value != "rayservice" {
+			t.Errorf("Expected cookie %s to be 'rayservice', got %v", COOKIE_OWNER_KIND_KEY, c)
+		}
+	})
 }

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -14,10 +14,10 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"github.com/ray-project/kuberay/historyserver/pkg/compression"
 	eventtypes "github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -22,6 +22,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	rayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -46,28 +49,54 @@ func filterAnsiEscapeCodes(content []byte) []byte {
 	return ansiEscapePattern.ReplaceAll(content, []byte(""))
 }
 
+func buildLiveClusterInfo(liveCluster *rayv1.RayCluster) utils.ClusterInfo {
+	var ownerKind, ownerName string
+	if ownerRef := metav1.GetControllerOf(liveCluster); ownerRef != nil {
+		k := strings.ToLower(ownerRef.Kind)
+		// Only set owner info for the Kuberay CRD resources for now.
+		if k == utils.RayJobKind || k == utils.RayServiceKind || k == utils.RayClusterKind {
+			ownerKind = k
+			ownerName = ownerRef.Name
+		} else {
+			logrus.Warnf("RayCluster %s/%s has an unknown owner controller kind %q, which is currently not supported", liveCluster.Namespace, liveCluster.Name, ownerRef.Kind)
+		}
+	}
+	return utils.ClusterInfo{
+		Name:            liveCluster.Name,
+		Namespace:       liveCluster.Namespace,
+		CreateTime:      liveCluster.CreationTimestamp.String(),
+		CreateTimeStamp: liveCluster.CreationTimestamp.Unix(),
+		SessionName:     "live",
+		OwnerKind:       ownerKind,
+		OwnerName:       ownerName,
+	}
+}
+
+func crdLabelValueFor(kindLower string) string {
+	switch kindLower {
+	case utils.RayJobKind:
+		return "RayJob"
+	case utils.RayServiceKind:
+		return "RayService"
+	case utils.RayClusterKind:
+		return "RayCluster"
+	default:
+		return kindLower
+	}
+}
+
 func (s *ServerHandler) listClusters(limit int) []utils.ClusterInfo {
 	// Initial continuation marker
 	logrus.Debugf("Prepare to get list clusters info ...")
 	ctx := context.Background()
 	liveClusterNames := []string{}
 	liveClusterInfos := []utils.ClusterInfo{}
-	liveClusters, _ := s.clientManager.ListRayClusters(ctx)
+	liveClusters, err := s.clientManager.ListRayClusters(ctx)
+	if err != nil {
+		logrus.Errorf("Failed to list live RayClusters: %v", err)
+	}
 	for _, liveCluster := range liveClusters {
-		var ownerKind, ownerName string
-		if ownerRef := metav1.GetControllerOf(liveCluster); ownerRef != nil {
-			ownerKind = strings.ToLower(ownerRef.Kind)
-			ownerName = ownerRef.Name
-		}
-		liveClusterInfo := utils.ClusterInfo{
-			Name:            liveCluster.Name,
-			Namespace:       liveCluster.Namespace,
-			CreateTime:      liveCluster.CreationTimestamp.String(),
-			CreateTimeStamp: liveCluster.CreationTimestamp.Unix(),
-			SessionName:     "live",
-			OwnerKind:       ownerKind,
-			OwnerName:       ownerName,
-		}
+		liveClusterInfo := buildLiveClusterInfo(liveCluster)
 		liveClusterInfos = append(liveClusterInfos, liveClusterInfo)
 		liveClusterNames = append(liveClusterNames, liveCluster.Name)
 	}
@@ -86,54 +115,40 @@ func (s *ServerHandler) listClusters(limit int) []utils.ClusterInfo {
 func (s *ServerHandler) resolveSession(ctx context.Context, namespace, resourceType, resourceName, session string) (utils.ClusterInfo, bool, error) {
 	isLatestOrEmpty := session == "latest" || session == ""
 	resTypeLower := strings.ToLower(resourceType)
+	if resTypeLower != utils.RayClusterKind && resTypeLower != utils.RayJobKind && resTypeLower != utils.RayServiceKind {
+		return utils.ClusterInfo{}, false, fmt.Errorf("unsupported resource kind: %q (must be raycluster, rayjob, or rayservice)", resourceType)
+	}
 
 	// Check live clusters first if applicable
 	if isLatestOrEmpty || session == "live" {
 		if resTypeLower == utils.RayClusterKind {
 			liveCluster, err := s.clientManager.GetRayCluster(ctx, namespace, resourceName)
 			if err == nil {
-				var ownerKind, ownerName string
-				if ownerRef := metav1.GetControllerOf(liveCluster); ownerRef != nil {
-					ownerKind = strings.ToLower(ownerRef.Kind)
-					ownerName = ownerRef.Name
-				}
-				liveClusterInfo := utils.ClusterInfo{
-					Name:            liveCluster.Name,
-					Namespace:       liveCluster.Namespace,
-					CreateTime:      liveCluster.CreationTimestamp.String(),
-					CreateTimeStamp: liveCluster.CreationTimestamp.Unix(),
-					SessionName:     "live",
-					OwnerKind:       ownerKind,
-					OwnerName:       ownerName,
-				}
-				return liveClusterInfo, true, nil
+				return buildLiveClusterInfo(liveCluster), true, nil
 			} else if !apierrors.IsNotFound(err) {
 				return utils.ClusterInfo{}, false, fmt.Errorf("failed to check live RayCluster %s/%s: %w", namespace, resourceName, err)
 			}
 		} else {
-			liveClusters, err := s.clientManager.ListRayClusters(ctx)
-			if err == nil {
-				for _, liveCluster := range liveClusters {
-					if liveCluster.Namespace != namespace {
-						continue
-					}
-					if ownerRef := metav1.GetControllerOf(liveCluster); ownerRef != nil {
-						if strings.EqualFold(ownerRef.Kind, resourceType) && ownerRef.Name == resourceName {
-							liveClusterInfo := utils.ClusterInfo{
-								Name:            liveCluster.Name,
-								Namespace:       liveCluster.Namespace,
-								CreateTime:      liveCluster.CreationTimestamp.String(),
-								CreateTimeStamp: liveCluster.CreationTimestamp.Unix(),
-								SessionName:     "live",
-								OwnerKind:       ownerRef.Kind,
-								OwnerName:       ownerRef.Name,
-							}
-							return liveClusterInfo, true, nil
-						}
-					}
-				}
-			} else {
+			// Both labels are needed: name alone is ambiguous since a RayJob and a
+			// RayService in the same namespace can share a name.
+			liveClusters, err := s.clientManager.ListRayClusters(ctx,
+				client.InNamespace(namespace),
+				client.MatchingLabels{
+					rayutils.RayOriginatedFromCRNameLabelKey: resourceName,
+					rayutils.RayOriginatedFromCRDLabelKey:    crdLabelValueFor(resTypeLower),
+				},
+			)
+			if err != nil {
 				return utils.ClusterInfo{}, false, fmt.Errorf("failed to list live RayClusters: %w", err)
+			}
+			// TODO: A RayService owns both an active and a pending cluster during an upgrade. Needs to decide which one to take.
+			if len(liveClusters) > 0 {
+				info := buildLiveClusterInfo(liveClusters[0])
+				if info.OwnerKind == "" {
+					info.OwnerKind = resTypeLower
+					info.OwnerName = resourceName
+				}
+				return info, true, nil
 			}
 		}
 		if session == "live" {
@@ -160,10 +175,13 @@ func (s *ServerHandler) resolveSession(ctx context.Context, namespace, resourceT
 		if c.SessionName == session {
 			return c, true, nil
 		}
-		sessions = append(sessions, c)
+		// If session is latest or "", we fall back to picking the latest dead session.
+		if isLatestOrEmpty {
+			sessions = append(sessions, c)
+		}
 	}
 
-	if isLatestOrEmpty && len(sessions) > 0 {
+	if len(sessions) > 0 {
 		sort.Sort(utils.ClusterInfoList(sessions))
 		return sessions[0], true, nil
 	}
@@ -612,9 +630,8 @@ func (s *ServerHandler) ipToNodeId(clusterLogPathPrefix, sessionID, nodeIP strin
 		return "", fmt.Errorf("node_ip is empty")
 	}
 
-	// Use targeted listing to find candidate node_events directories
+	// Use targeted listing to find node_events directories under each node
 	var candidatePrefixes []string
-	candidatePrefixes = append(candidatePrefixes, sessionID+"/node_events/")
 	for _, rawEntry := range s.reader.ListFiles(clusterLogPathPrefix, sessionID) {
 		if strings.HasSuffix(rawEntry, "/") {
 			nodeName := strings.TrimSuffix(rawEntry, "/")

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/ray-project/kuberay/historyserver/pkg/compression"
 	eventtypes "github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clusterlogs"
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,43 +82,97 @@ func (s *ServerHandler) listClusters(limit int) []utils.ClusterInfo {
 	return clusters
 }
 
-// resolveSession maps (namespace, name, session) to a concrete session name.
-func (s *ServerHandler) resolveSession(ctx context.Context, namespace, name, session string) (sessionName string, found bool, err error) {
+// resolveSession maps (namespace, resourceType, resourceName, session) to a concrete ClusterInfo.
+func (s *ServerHandler) resolveSession(ctx context.Context, namespace, resourceType, resourceName, session string) (utils.ClusterInfo, bool, error) {
 	isLatestOrEmpty := session == "latest" || session == ""
+	resTypeLower := strings.ToLower(resourceType)
 
+	// Check live clusters first if applicable
 	if isLatestOrEmpty || session == "live" {
-		_, err := s.clientManager.GetRayCluster(ctx, namespace, name)
-		if err == nil {
-			return "live", true, nil
-		}
-		if !apierrors.IsNotFound(err) {
-			return "", false, fmt.Errorf("failed to check live RayCluster %s/%s: %w", namespace, name, err)
+		if resTypeLower == utils.RayClusterKind {
+			liveCluster, err := s.clientManager.GetRayCluster(ctx, namespace, resourceName)
+			if err == nil {
+				var ownerKind, ownerName string
+				if ownerRef := metav1.GetControllerOf(liveCluster); ownerRef != nil {
+					ownerKind = strings.ToLower(ownerRef.Kind)
+					ownerName = ownerRef.Name
+				}
+				liveClusterInfo := utils.ClusterInfo{
+					Name:            liveCluster.Name,
+					Namespace:       liveCluster.Namespace,
+					CreateTime:      liveCluster.CreationTimestamp.String(),
+					CreateTimeStamp: liveCluster.CreationTimestamp.Unix(),
+					SessionName:     "live",
+					OwnerKind:       ownerKind,
+					OwnerName:       ownerName,
+				}
+				return liveClusterInfo, true, nil
+			} else if !apierrors.IsNotFound(err) {
+				return utils.ClusterInfo{}, false, fmt.Errorf("failed to check live RayCluster %s/%s: %w", namespace, resourceName, err)
+			}
+		} else {
+			liveClusters, err := s.clientManager.ListRayClusters(ctx)
+			if err == nil {
+				for _, liveCluster := range liveClusters {
+					if liveCluster.Namespace != namespace {
+						continue
+					}
+					if ownerRef := metav1.GetControllerOf(liveCluster); ownerRef != nil {
+						if strings.EqualFold(ownerRef.Kind, resourceType) && ownerRef.Name == resourceName {
+							liveClusterInfo := utils.ClusterInfo{
+								Name:            liveCluster.Name,
+								Namespace:       liveCluster.Namespace,
+								CreateTime:      liveCluster.CreationTimestamp.String(),
+								CreateTimeStamp: liveCluster.CreationTimestamp.Unix(),
+								SessionName:     "live",
+								OwnerKind:       ownerRef.Kind,
+								OwnerName:       ownerRef.Name,
+							}
+							return liveClusterInfo, true, nil
+						}
+					}
+				}
+			} else {
+				return utils.ClusterInfo{}, false, fmt.Errorf("failed to list live RayClusters: %w", err)
+			}
 		}
 		if session == "live" {
-			return "", false, nil
+			return utils.ClusterInfo{}, false, nil
 		}
 	}
 
+	// Check stored clusters
 	var sessions []utils.ClusterInfo
 	for _, c := range s.reader.List() {
-		if c.Namespace != namespace || c.Name != name {
+		if c.Namespace != namespace {
 			continue
 		}
+		if resTypeLower == utils.RayClusterKind {
+			if c.Name != resourceName {
+				continue
+			}
+		} else {
+			if strings.ToLower(c.OwnerKind) != resTypeLower || c.OwnerName != resourceName {
+				continue
+			}
+		}
+
 		if c.SessionName == session {
-			return session, true, nil
+			return c, true, nil
 		}
 		sessions = append(sessions, c)
 	}
 
 	if isLatestOrEmpty && len(sessions) > 0 {
 		sort.Sort(utils.ClusterInfoList(sessions))
-		return sessions[0].SessionName, true, nil
+		return sessions[0], true, nil
 	}
-	return "", false, nil
+
+	return utils.ClusterInfo{}, false, nil
 }
 
-func (s *ServerHandler) _getNodeLogs(rayClusterNameNamespace, sessionId, nodeId, folder, glob string) ([]byte, error) {
-	logPath := path.Join(sessionId, utils.RAY_SESSIONDIR_LOGDIR_NAME, nodeId)
+func (s *ServerHandler) _getNodeLogs(clusterLogPathPrefix, sessionId, nodeId, folder, glob string) ([]byte, error) {
+	logPath := clusterlogs.RelLogsDir(sessionId, nodeId)
 	if folder != "" {
 		logPath = path.Join(logPath, folder)
 	}
@@ -126,13 +181,13 @@ func (s *ServerHandler) _getNodeLogs(rayClusterNameNamespace, sessionId, nodeId,
 	// Use recursive listing when glob contains ** to support cross-directory matching.
 	var matchedFiles []string
 	if glob == "" {
-		matchedFiles = s.reader.ListFiles(rayClusterNameNamespace, logPath)
+		matchedFiles = s.reader.ListFiles(clusterLogPathPrefix, logPath)
 	} else {
 		var files []string
 		if strings.Contains(glob, "**") {
-			files = s.listFilesRecursive(rayClusterNameNamespace, logPath)
+			files = s.listFilesRecursive(clusterLogPathPrefix, logPath)
 		} else {
-			files = s.reader.ListFiles(rayClusterNameNamespace, logPath)
+			files = s.reader.ListFiles(clusterLogPathPrefix, logPath)
 		}
 		for _, file := range files {
 			matched, err := doublestar.Match(glob, file)
@@ -216,9 +271,9 @@ func categorizeLogFiles(files []string) map[string][]string {
 	return result
 }
 
-func (s *ServerHandler) _getNodeLogFile(clusterSessionKey, rayClusterNameNamespace, sessionID string, options GetLogFileOptions) ([]byte, error) {
+func (s *ServerHandler) _getNodeLogFile(clusterSessionKey, clusterLogPathPrefix, sessionID string, options GetLogFileOptions) ([]byte, error) {
 	// Resolve node_id and filename based on options
-	nodeID, filename, err := s.resolveLogFilename(clusterSessionKey, rayClusterNameNamespace, sessionID, options)
+	nodeID, filename, err := s.resolveLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID, options)
 	if err != nil {
 		// Preserve HTTPError status code if already set, otherwise use BadRequest
 		var httpErr *utils.HTTPError
@@ -228,9 +283,9 @@ func (s *ServerHandler) _getNodeLogFile(clusterSessionKey, rayClusterNameNamespa
 		return nil, utils.NewHTTPError(err, http.StatusBadRequest)
 	}
 
-	// Build log path
-	logPath := path.Join(sessionID, utils.RAY_SESSIONDIR_LOGDIR_NAME, nodeID, filename)
-	reader := s.reader.GetContent(rayClusterNameNamespace, logPath)
+	// Build log path using clusterlogs helper (<nodeID>/<sessionID>/logs/<filename>)
+	logPath := path.Join(clusterlogs.RelLogsDir(sessionID, nodeID), filename)
+	reader := s.reader.GetContent(clusterLogPathPrefix, logPath)
 
 	if reader == nil {
 		return nil, utils.NewHTTPError(fmt.Errorf("log file not found: %s", logPath), http.StatusNotFound)
@@ -305,7 +360,7 @@ func (s *ServerHandler) _getNodeLogFile(clusterSessionKey, rayClusterNameNamespa
 // resolveLogFilename resolves the log file node_id and filename based on the provided options.
 // This mirrors Ray Dashboard's resolve_filename logic.
 // The sessionID parameter is required for task_id resolution to search worker log files.
-func (s *ServerHandler) resolveLogFilename(clusterSessionKey, clusterNameID, sessionID string, options GetLogFileOptions) (nodeID, filename string, err error) {
+func (s *ServerHandler) resolveLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID string, options GetLogFileOptions) (nodeID, filename string, err error) {
 	// If filename is explicitly provided, use it and ignore suffix
 	if options.Filename != "" {
 		if options.NodeID == "" {
@@ -321,17 +376,17 @@ func (s *ServerHandler) resolveLogFilename(clusterSessionKey, clusterNameID, ses
 
 	// If task_id is provided, resolve from task events
 	if options.TaskID != "" {
-		return s.resolveTaskLogFilename(clusterSessionKey, clusterNameID, sessionID, options.TaskID, options.AttemptNumber, options.Suffix)
+		return s.resolveTaskLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID, options.TaskID, options.AttemptNumber, options.Suffix)
 	}
 
 	// If actor_id is provided, resolve from actor events
 	if options.ActorID != "" {
-		return s.resolveActorLogFilename(clusterSessionKey, clusterNameID, sessionID, options.ActorID, options.Suffix)
+		return s.resolveActorLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID, options.ActorID, options.Suffix)
 	}
 
 	// If pid is provided, resolve worker log file
 	if options.PID > 0 {
-		return s.resolvePidLogFilename(clusterNameID, sessionID, options.NodeID, options.PID, options.Suffix)
+		return s.resolvePidLogFilename(clusterLogPathPrefix, sessionID, options.NodeID, options.PID, options.Suffix)
 	}
 
 	return "", "", fmt.Errorf("must provide one of: filename, task_id, actor_id, or pid")
@@ -339,7 +394,7 @@ func (s *ServerHandler) resolveLogFilename(clusterSessionKey, clusterNameID, ses
 
 // resolvePidLogFilename resolves a log file by PID.
 // It requires a nodeID and searches for a log file with a name ending in "-{pid}.{suffix}".
-func (s *ServerHandler) resolvePidLogFilename(clusterNameID, sessionID, nodeID string, pid int, suffix string) (string, string, error) {
+func (s *ServerHandler) resolvePidLogFilename(clusterLogPathPrefix, sessionID, nodeID string, pid int, suffix string) (string, string, error) {
 	if nodeID == "" {
 		return "", "", fmt.Errorf("node_id is required for pid resolution")
 	}
@@ -350,8 +405,8 @@ func (s *ServerHandler) resolvePidLogFilename(clusterNameID, sessionID, nodeID s
 		return "", "", fmt.Errorf("failed to decode node_id: %w", err)
 	}
 
-	logPath := path.Join(sessionID, utils.RAY_SESSIONDIR_LOGDIR_NAME, nodeIDHex)
-	files := s.reader.ListFiles(clusterNameID, logPath)
+	logPath := clusterlogs.RelLogsDir(sessionID, nodeIDHex)
+	files := s.reader.ListFiles(clusterLogPathPrefix, logPath)
 
 	pidSuffix := fmt.Sprintf("-%d.%s", pid, suffix)
 
@@ -380,7 +435,7 @@ func getTasksByID(tasks []eventtypes.Task, taskID string) ([]eventtypes.Task, bo
 // resolveTaskLogFilename resolves log file for a task by querying task events.
 // This mirrors Ray Dashboard's _resolve_task_filename logic.
 // The sessionID parameter is required for searching worker log files when task_log_info is not available.
-func (s *ServerHandler) resolveTaskLogFilename(clusterSessionKey, clusterNameID, sessionID, taskID string, attemptNumber int, suffix string) (nodeID, filename string, err error) {
+func (s *ServerHandler) resolveTaskLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID, taskID string, attemptNumber int, suffix string) (nodeID, filename string, err error) {
 	snap, ok := s.sessionLoader.GetSnapshot(clusterSessionKey)
 	if !ok {
 		return "", "", fmt.Errorf("snapshot not found for %s", clusterSessionKey)
@@ -447,7 +502,7 @@ func (s *ServerHandler) resolveTaskLogFilename(clusterSessionKey, clusterNameID,
 			taskID, attemptNumber,
 		)
 	}
-	nodeIDHex, logFilename, err := s.findWorkerLogFile(clusterNameID, sessionID, foundTask.NodeID, foundTask.WorkerID, suffix)
+	nodeIDHex, logFilename, err := s.findWorkerLogFile(clusterLogPathPrefix, sessionID, foundTask.NodeID, foundTask.WorkerID, suffix)
 	if err != nil {
 		return "", "", fmt.Errorf(
 			"failed to find worker log file for task %s (attempt %d, worker_id=%s, node_id=%s): %w",
@@ -460,7 +515,7 @@ func (s *ServerHandler) resolveTaskLogFilename(clusterSessionKey, clusterNameID,
 
 // resolveActorLogFilename resolves log file for an actor by querying actor events.
 // This mirrors Ray Dashboard's _resolve_actor_filename logic.
-func (s *ServerHandler) resolveActorLogFilename(clusterSessionKey, clusterNameID, sessionID, actorID, suffix string) (nodeID, filename string, err error) {
+func (s *ServerHandler) resolveActorLogFilename(clusterSessionKey, clusterLogPathPrefix, sessionID, actorID, suffix string) (nodeID, filename string, err error) {
 	snap, ok := s.sessionLoader.GetSnapshot(clusterSessionKey)
 	if !ok {
 		return "", "", fmt.Errorf("snapshot not found for %s", clusterSessionKey)
@@ -496,7 +551,7 @@ func (s *ServerHandler) resolveActorLogFilename(clusterSessionKey, clusterNameID
 
 	// Find worker log file by worker_id
 	nodeIDHex, logFilename, err := s.findWorkerLogFile(
-		clusterNameID,
+		clusterLogPathPrefix,
 		sessionID,
 		actor.Address.NodeID,
 		actor.Address.WorkerID,
@@ -516,7 +571,7 @@ func (s *ServerHandler) resolveActorLogFilename(clusterSessionKey, clusterNameID
 // Worker log files follow the pattern: worker-{worker_id_hex}-{job_id_hex}-{pid}.{suffix}
 // Ref: https://github.com/ray-project/ray/blob/219ee7037bbdc02f66b58a814c9ad2618309c19e/src/ray/core_worker/core_worker_process.cc#L80-L80
 // Returns (nodeIDHex, filename, error).
-func (s *ServerHandler) findWorkerLogFile(clusterNameID, sessionID, nodeID, workerID, suffix string) (string, string, error) {
+func (s *ServerHandler) findWorkerLogFile(clusterLogPathPrefix, sessionID, nodeID, workerID, suffix string) (string, string, error) {
 	// Convert to hex if not already is
 	nodeIDHex, err := utils.ConvertBase64ToHex(nodeID)
 	if err != nil {
@@ -530,8 +585,8 @@ func (s *ServerHandler) findWorkerLogFile(clusterNameID, sessionID, nodeID, work
 	}
 
 	// List all files in the node's log directory
-	logPath := path.Join(sessionID, utils.RAY_SESSIONDIR_LOGDIR_NAME, nodeIDHex)
-	files := s.reader.ListFiles(clusterNameID, logPath)
+	logPath := clusterlogs.RelLogsDir(sessionID, nodeIDHex)
+	files := s.reader.ListFiles(clusterLogPathPrefix, logPath)
 
 	// Search for files matching pattern: worker-{worker_id_hex}-*.{suffix}
 	workerPrefix := fmt.Sprintf("worker-%s-", workerIDHex)
@@ -552,43 +607,54 @@ func (s *ServerHandler) findWorkerLogFile(clusterNameID, sessionID, nodeID, work
 // ipToNodeId resolves node_id from node_ip by querying node_events from storage.
 // This mirrors Ray Dashboard's ip_to_node_id logic.
 // Returns node_id in hex format if found, error otherwise.
-func (s *ServerHandler) ipToNodeId(rayClusterNameNamespace, sessionID, nodeIP string) (string, error) {
+func (s *ServerHandler) ipToNodeId(clusterLogPathPrefix, sessionID, nodeIP string) (string, error) {
 	if nodeIP == "" {
 		return "", fmt.Errorf("node_ip is empty")
 	}
 
-	// List all node_events files
-	nodeEventsPath := path.Join(sessionID, "node_events")
-	files := s.reader.ListFiles(rayClusterNameNamespace, nodeEventsPath)
-
-	// Parse each node event file to find matching node_ip
-	for _, file := range files {
-		filePath := path.Join(nodeEventsPath, file)
-		nodeIDHex, found := s.searchNodeIDHexInEventFile(rayClusterNameNamespace, filePath, nodeIP)
-		if found {
-			logrus.Infof("Resolved node_ip %s to node_id %s", nodeIP, nodeIDHex)
-			return nodeIDHex, nil
+	// Use targeted listing to find candidate node_events directories
+	var candidatePrefixes []string
+	candidatePrefixes = append(candidatePrefixes, sessionID+"/node_events/")
+	for _, rawEntry := range s.reader.ListFiles(clusterLogPathPrefix, sessionID) {
+		if strings.HasSuffix(rawEntry, "/") {
+			nodeName := strings.TrimSuffix(rawEntry, "/")
+			candidatePrefixes = append(candidatePrefixes, clusterlogs.RelNodeEventsDir(sessionID, nodeName)+"/")
 		}
 	}
 
-	return "", fmt.Errorf("node_id not found for node_ip=%s", nodeIP)
+	for _, nodeEventDirPrefix := range candidatePrefixes {
+		nodeEventFileNames := s.reader.ListFiles(clusterLogPathPrefix, nodeEventDirPrefix)
+		for _, fileName := range nodeEventFileNames {
+			if strings.HasSuffix(fileName, "/") {
+				continue
+			}
+			fullPath := nodeEventDirPrefix + fileName
+			nodeIDHex, found := s.searchNodeIDHexInEventFile(clusterLogPathPrefix, fullPath, nodeIP)
+			if found {
+				logrus.Infof("Resolved node_ip %s to node_id %s in session %s", nodeIP, nodeIDHex, sessionID)
+				return nodeIDHex, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("node_id not found for node_ip=%s in session=%s", nodeIP, sessionID)
 }
 
 // searchNodeIDHexInEventFile searches for a node with the given IP in a single event file.
 // Returns (nodeIDHex, true) if found, ("", false) otherwise.
-func (s *ServerHandler) searchNodeIDHexInEventFile(rayClusterNameNamespace, filePath, nodeIP string) (string, bool) {
+func (s *ServerHandler) searchNodeIDHexInEventFile(clusterLogPathPrefix, filePath, nodeIP string) (string, bool) {
 	var reader io.Reader
 	var err error
 	if strings.HasSuffix(filePath, ".gz") {
 		var rc io.ReadCloser
-		rc, err = compression.ReadCompressedContent(s.reader, rayClusterNameNamespace, filePath)
+		rc, err = compression.ReadCompressedContent(s.reader, clusterLogPathPrefix, filePath)
 		if err != nil {
 			logrus.Warnf("Failed to decompress node event file %s: %v", filePath, err)
 			return "", false
 		}
 		reader = rc
 	} else {
-		reader = s.reader.GetContent(rayClusterNameNamespace, filePath)
+		reader = s.reader.GetContent(clusterLogPathPrefix, filePath)
 	}
 
 	if reader == nil {

--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -330,7 +330,7 @@ func routerRayClusterSet(s *ServerHandler) {
 			return
 		}
 		if !found {
-			r2.WriteErrorString(http.StatusNotFound, fmt.Sprintf("cluster not found"))
+			r2.WriteErrorString(http.StatusNotFound, fmt.Sprintf("cluster %s/%s/%s with session %s not found", namespace, resourceType, resourceName, session))
 			return
 		}
 
@@ -988,6 +988,11 @@ func (s *ServerHandler) buildFormattedClusterStatus(snap *eventserver.SessionSna
 	for nodeID := range snap.Nodes {
 		nodeIDs = append(nodeIDs, nodeID)
 	}
+	// Fallback: snap.Nodes is populated from parsed node events in event storage.
+	// If node events were disabled, failed to upload, or the node crashed early
+	// before emitting events, snap.Nodes may be empty even if log files (such as debug_state.txt)
+	// exist in the object store. We scan the storage directory under the session to discover
+	// node IDs directly so we can still read debug_state.txt.
 	if len(nodeIDs) == 0 {
 		rawEntries := s.reader.ListFiles(clusterLogPathPrefix, sessionName+"/")
 		for _, e := range rawEntries {
@@ -1189,6 +1194,8 @@ func ensurePlacementGroupFields(data []byte) []byte {
 	return patched
 }
 
+// getClusterLogPathPrefix returns the cluster storage prefix:
+// e.g., cluster-history/{ownerKind}/{clusterNamespace}/{ownerName}/{clusterName}
 func (s *ServerHandler) getClusterLogPathPrefix(req *restful.Request) string {
 	clusterName, _ := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
 	clusterNamespace, _ := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
@@ -1941,9 +1948,12 @@ func (s *ServerHandler) CookieHandle(req *restful.Request, resp *restful.Respons
 		resp.WriteHeaderAndEntity(http.StatusBadRequest, fmt.Sprintf("invalid cookie values: path traversal not allowed (cluster_name=%s, cluster_namespace=%s, session_name=%s)", clusterName.Value, clusterNamespace.Value, sessionName.Value))
 		return
 	}
-	if ownerKind.Value != "" && !fs.ValidPath(ownerKind.Value) {
-		resp.WriteHeaderAndEntity(http.StatusBadRequest, fmt.Sprintf("invalid cookie values: path traversal not allowed (owner_kind=%s)", ownerKind.Value))
-		return
+	if ownerKind.Value != "" {
+		kindLower := strings.ToLower(ownerKind.Value)
+		if kindLower != utils.RayClusterKind && kindLower != utils.RayJobKind && kindLower != utils.RayServiceKind {
+			resp.WriteHeaderAndEntity(http.StatusBadRequest, fmt.Sprintf("invalid cookie values: unsupported owner_kind=%s (must be raycluster, rayjob, or rayservice)", ownerKind.Value))
+			return
+		}
 	}
 	if ownerName.Value != "" && !fs.ValidPath(ownerName.Value) {
 		resp.WriteHeaderAndEntity(http.StatusBadRequest, fmt.Sprintf("invalid cookie values: path traversal not allowed (owner_name=%s)", ownerName.Value))

--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ray-project/kuberay/historyserver/html"
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver"
 	eventtypes "github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clusterlogs"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
@@ -33,6 +34,8 @@ const (
 	COOKIE_CLUSTER_NAME_KEY      = "cluster_name"
 	COOKIE_CLUSTER_NAMESPACE_KEY = "cluster_namespace"
 	COOKIE_SESSION_NAME_KEY      = "session_name"
+	COOKIE_OWNER_KIND_KEY        = "owner_kind"
+	COOKIE_OWNER_NAME_KEY        = "owner_name"
 	COOKIE_DASHBOARD_VERSION_KEY = "dashboard_version"
 
 	ATTRIBUTE_SERVICE_NAME = "cluster_service_name"
@@ -313,28 +316,36 @@ func routerRayClusterSet(s *ServerHandler) {
 	defer restful.Add(ws)
 
 	ws.Path("/enter_cluster").Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON).Filter(RequestLogFilter)
-	enterHandler := func(r1 *restful.Request, r2 *restful.Response, namespace, name, session string) {
-		resolvedSession, found, err := s.resolveSession(r1.Request.Context(), namespace, name, session)
+	enterHandler := func(r1 *restful.Request, r2 *restful.Response, namespace, resourceType, resourceName, session string) {
+		kindLower := strings.ToLower(resourceType)
+		if kindLower != utils.RayClusterKind && kindLower != utils.RayJobKind && kindLower != utils.RayServiceKind {
+			r2.WriteErrorString(http.StatusBadRequest, fmt.Sprintf("unsupported resource kind: %q (must be raycluster, rayjob, or rayservice)", resourceType))
+			return
+		}
+
+		resolvedClusterInfo, found, err := s.resolveSession(r1.Request.Context(), namespace, resourceType, resourceName, session)
 		if err != nil {
-			logrus.Errorf("Failed to resolve session %s/%s/%s: %v", namespace, name, session, err)
+			logrus.Errorf("Failed to resolve session %s/%s/%s/%s: %v", namespace, resourceType, resourceName, session, err)
 			r2.WriteErrorString(http.StatusInternalServerError, err.Error())
 			return
 		}
 		if !found {
-			r2.WriteErrorString(http.StatusNotFound, fmt.Sprintf("cluster %s/%s with session %s not found", namespace, name, session))
+			r2.WriteErrorString(http.StatusNotFound, fmt.Sprintf("cluster not found"))
 			return
 		}
 
+		resolvedName := resolvedClusterInfo.Name
+		resolvedSession := resolvedClusterInfo.SessionName
+
 		if resolvedSession != "live" {
 			if ParseSessionTimestamp(resolvedSession).IsZero() {
-				logrus.Warnf("Rejecting invalid session name: %s/%s/%s", namespace, name, resolvedSession)
+				logrus.Warnf("Rejecting invalid session name: %s/%s/%s", namespace, resolvedName, resolvedSession)
 				r2.WriteErrorString(http.StatusBadRequest, fmt.Sprintf("invalid session name: %q", resolvedSession))
 				return
 			}
-			info := utils.ClusterInfo{Name: name, Namespace: namespace, SessionName: resolvedSession}
-			live, err := s.sessionLoader.LoadSession(r1.Request.Context(), info)
+			live, err := s.sessionLoader.LoadSession(r1.Request.Context(), resolvedClusterInfo)
 			if err != nil {
-				logrus.Errorf("Failed to load session %s/%s/%s: %v", namespace, name, resolvedSession, err)
+				logrus.Errorf("Failed to load session %s/%s/%s: %v", namespace, resolvedName, resolvedSession, err)
 				r2.WriteErrorString(http.StatusInternalServerError, err.Error())
 				return
 			}
@@ -346,39 +357,46 @@ func routerRayClusterSet(s *ServerHandler) {
 			}
 		}
 
-		http.SetCookie(r2, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_CLUSTER_NAME_KEY, Value: name})
+		http.SetCookie(r2, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_CLUSTER_NAME_KEY, Value: resolvedName})
 		http.SetCookie(r2, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_CLUSTER_NAMESPACE_KEY, Value: namespace})
 		http.SetCookie(r2, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_SESSION_NAME_KEY, Value: resolvedSession})
+		http.SetCookie(r2, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_OWNER_KIND_KEY, Value: resolvedClusterInfo.OwnerKind})
+		http.SetCookie(r2, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_OWNER_NAME_KEY, Value: resolvedClusterInfo.OwnerName})
 
 		r2.WriteJson(map[string]interface{}{
 			"result":    "success",
-			"name":      name,
+			"name":      resolvedName,
 			"namespace": namespace,
 			"session":   resolvedSession,
 		}, "application/json")
 	}
 
-	ws.Route(ws.GET("/{namespace}/{name}/{session}").To(func(r1 *restful.Request, r2 *restful.Response) {
-		name := r1.PathParameter("name")
+	ws.Route(ws.GET("/{namespace}/{kind}/{name}").To(func(r1 *restful.Request, r2 *restful.Response) {
 		namespace := r1.PathParameter("namespace")
-		session := r1.PathParameter("session")
-		enterHandler(r1, r2, namespace, name, session)
-	}).
-		Doc("set cookie for cluster").
-		Param(ws.PathParameter("namespace", "namespace")).
-		Param(ws.PathParameter("name", "name")).
-		Param(ws.PathParameter("session", "session")).
-		Writes("")) // Placeholder for specific return type
-
-	ws.Route(ws.GET("/{namespace}/{name}").To(func(r1 *restful.Request, r2 *restful.Response) {
+		kind := r1.PathParameter("kind")
 		name := r1.PathParameter("name")
-		namespace := r1.PathParameter("namespace")
-		enterHandler(r1, r2, namespace, name, "latest")
+		enterHandler(r1, r2, namespace, kind, name, "latest")
 	}).
 		Doc("set cookie for cluster (defaults session to latest)").
 		Param(ws.PathParameter("namespace", "namespace")).
+		Param(ws.PathParameter("kind", "kind (raycluster, rayjob, or rayservice)")).
 		Param(ws.PathParameter("name", "name")).
 		Writes(""))
+
+	ws.Route(ws.GET("/{namespace}/{kind}/{name}/{session}").To(func(r1 *restful.Request, r2 *restful.Response) {
+		namespace := r1.PathParameter("namespace")
+		kind := r1.PathParameter("kind")
+		name := r1.PathParameter("name")
+		session := r1.PathParameter("session")
+		enterHandler(r1, r2, namespace, kind, name, session)
+	}).
+		Doc("set cookie for cluster").
+		Param(ws.PathParameter("namespace", "namespace")).
+		Param(ws.PathParameter("kind", "kind (raycluster, rayjob, or rayservice)")).
+		Param(ws.PathParameter("name", "name")).
+		Param(ws.PathParameter("session", "session")).
+		Writes(""))
+
 }
 
 func (s *ServerHandler) RegisterRouter() {
@@ -931,7 +949,8 @@ func (s *ServerHandler) getClusterStatus(req *restful.Request, resp *restful.Res
 		}
 
 		// Build cluster status from debug_state.txt and snapshot data
-		statusString := s.buildFormattedClusterStatus(snap, clusterName, clusterNamespace, sessionName)
+		clusterLogPathPrefix := s.getClusterLogPathPrefix(req)
+		statusString := s.buildFormattedClusterStatus(snap, clusterLogPathPrefix, clusterName, sessionName)
 
 		response := FormattedClusterStatusResponse{
 			Result: true,
@@ -963,17 +982,29 @@ func (s *ServerHandler) getClusterStatus(req *restful.Request, resp *restful.Res
 }
 
 // buildFormattedClusterStatus reconstructs the cluster status from debug_state.txt and pending tasks and actors
-func (s *ServerHandler) buildFormattedClusterStatus(snap *eventserver.SessionSnapshot, clusterName, clusterNamespace, sessionName string) string {
+func (s *ServerHandler) buildFormattedClusterStatus(snap *eventserver.SessionSnapshot, clusterLogPathPrefix, clusterName, sessionName string) string {
 	builder := NewClusterStatusBuilder()
-	clusterNameID := clusterName + "_" + clusterNamespace
-	logsPath := path.Join(sessionName, utils.RAY_SESSIONDIR_LOGDIR_NAME)
-	nodeIDs := s.reader.ListFiles(clusterNameID, logsPath)
+	var nodeIDs []string
+	for nodeID := range snap.Nodes {
+		nodeIDs = append(nodeIDs, nodeID)
+	}
+	if len(nodeIDs) == 0 {
+		rawEntries := s.reader.ListFiles(clusterLogPathPrefix, sessionName+"/")
+		for _, e := range rawEntries {
+			if strings.HasSuffix(e, "/") {
+				name := strings.TrimSuffix(e, "/")
+				if name != clusterlogs.LogsSubDir && name != clusterlogs.NodeEventsSubDir && name != clusterlogs.JobEventsSubDir && name != utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME {
+					nodeIDs = append(nodeIDs, name)
+				}
+			}
+		}
+	}
 	successCount := 0
 
 	for _, nodeID := range nodeIDs {
-		debugStatePath := path.Join(logsPath, nodeID, "debug_state.txt")
+		debugStatePath := path.Join(clusterlogs.RelLogsDir(sessionName, nodeID), "debug_state.txt")
 
-		reader := s.reader.GetContent(clusterNameID, debugStatePath)
+		reader := s.reader.GetContent(clusterLogPathPrefix, debugStatePath)
 		if reader == nil {
 			logrus.Debugf("No debug_state.txt found for node %s", nodeID)
 			continue
@@ -1017,18 +1048,16 @@ func (s *ServerHandler) buildFormattedClusterStatus(snap *eventserver.SessionSna
 }
 
 func (s *ServerHandler) getClusterMetadata(req *restful.Request, resp *restful.Response) {
-	clusterName := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
-	clusterNamespace := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
 	sessionName := req.Attribute(COOKIE_SESSION_NAME_KEY).(string)
 	if sessionName == "live" {
 		s.redirectRequest(req, resp)
 		return
 	}
 
-	clusterNameID := clusterName + "_" + clusterNamespace
+	clusterLogPathPrefix := s.getClusterLogPathPrefix(req)
 	storageKey := utils.EndpointPathToStorageKey("/api/v0/cluster_metadata")
 	endpointPath := path.Join(sessionName, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
-	reader := s.reader.GetContent(clusterNameID, endpointPath)
+	reader := s.reader.GetContent(clusterLogPathPrefix, endpointPath)
 	if reader == nil {
 		resp.WriteErrorString(http.StatusNotFound, "Cluster metadata not found")
 		return
@@ -1052,15 +1081,13 @@ func (s *ServerHandler) getClusterMetadata(req *restful.Request, resp *restful.R
 // Storage key convention: the request path "/api/v0/nodes/summary" maps to
 // storage key "restful__api__v0__nodes__summary" under {sessionName}/fetched_endpoints/.
 func (s *ServerHandler) getAdditionalEndpoint(req *restful.Request, resp *restful.Response) {
-	clusterName := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
-	clusterNamespace := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
 	sessionName := req.Attribute(COOKIE_SESSION_NAME_KEY).(string)
 	if sessionName == "live" {
 		s.redirectRequest(req, resp)
 		return
 	}
 
-	clusterNameID := clusterName + "_" + clusterNamespace
+	clusterLogPathPrefix := s.getClusterLogPathPrefix(req)
 
 	// Use the full request URI (path + query) for storage key lookup.
 	// The collector stores keys using the full endpoint URL from RAY_COLLECTOR_ADDITIONAL_ENDPOINTS,
@@ -1068,7 +1095,7 @@ func (s *ServerHandler) getAdditionalEndpoint(req *restful.Request, resp *restfu
 	// RequestURI() includes query params when present, and equals URL.Path when absent.
 	storageKey := utils.EndpointPathToStorageKey(req.Request.URL.RequestURI())
 	endpointPath := path.Join(sessionName, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
-	reader := s.reader.GetContent(clusterNameID, endpointPath)
+	reader := s.reader.GetContent(clusterLogPathPrefix, endpointPath)
 	if reader == nil {
 		// For known frontend endpoints, return empty but valid JSON responses instead of 404.
 		// This prevents the frontend from showing error states for endpoints that may not have been
@@ -1162,9 +1189,15 @@ func ensurePlacementGroupFields(data []byte) []byte {
 	return patched
 }
 
+func (s *ServerHandler) getClusterLogPathPrefix(req *restful.Request) string {
+	clusterName, _ := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
+	clusterNamespace, _ := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
+	ownerKind, _ := req.Attribute(COOKIE_OWNER_KIND_KEY).(string)
+	ownerName, _ := req.Attribute(COOKIE_OWNER_NAME_KEY).(string)
+	return clusterlogs.Prefix("", ownerKind, ownerName, clusterNamespace, clusterName)
+}
+
 func (s *ServerHandler) getNodeLogs(req *restful.Request, resp *restful.Response) {
-	clusterNameID := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
-	clusterNamespace := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
 	sessionName := req.Attribute(COOKIE_SESSION_NAME_KEY).(string)
 	if sessionName == "live" {
 		s.redirectRequest(req, resp)
@@ -1192,7 +1225,8 @@ func (s *ServerHandler) getNodeLogs(req *restful.Request, resp *restful.Response
 			folder = base
 		}
 	}
-	data, err := s._getNodeLogs(clusterNameID+"_"+clusterNamespace, sessionName, nodeID, folder, glob)
+	clusterLogPathPrefix := s.getClusterLogPathPrefix(req)
+	data, err := s._getNodeLogs(clusterLogPathPrefix, sessionName, nodeID, folder, glob)
 	if err != nil {
 		logrus.Errorf("Error: %v", err)
 		resp.WriteError(400, err)
@@ -1376,8 +1410,9 @@ func (s *ServerHandler) getNodeLogFile(req *restful.Request, resp *restful.Respo
 	}
 
 	// Only resolve node_ip to node_id from stored events for dead cluster
+	clusterLogPathPrefix := s.getClusterLogPathPrefix(req)
 	if options.NodeID == "" && options.NodeIP != "" {
-		nodeID, err := s.ipToNodeId(clusterNameID+"_"+clusterNamespace, sessionName, options.NodeIP)
+		nodeID, err := s.ipToNodeId(clusterLogPathPrefix, sessionName, options.NodeIP)
 		if err != nil {
 			resp.WriteErrorString(http.StatusNotFound,
 				fmt.Sprintf("Cannot find matching node_id for a given node ip %s", options.NodeIP))
@@ -1386,7 +1421,7 @@ func (s *ServerHandler) getNodeLogFile(req *restful.Request, resp *restful.Respo
 		options.NodeID = nodeID
 	}
 
-	content, err := s._getNodeLogFile(clusterSessionKey, clusterNameID+"_"+clusterNamespace, sessionName, options)
+	content, err := s._getNodeLogFile(clusterSessionKey, clusterLogPathPrefix, sessionName, options)
 	if err != nil {
 		var httpErr *utils.HTTPError
 		if errors.As(err, &httpErr) {
@@ -1891,15 +1926,35 @@ func (s *ServerHandler) CookieHandle(req *restful.Request, resp *restful.Respons
 		return
 	}
 
+	// It is okay for owner to be empty but they should still be available
+	ownerKind, err := req.Request.Cookie(COOKIE_OWNER_KIND_KEY)
+	if err != nil {
+		ownerKind = &http.Cookie{Name: COOKIE_OWNER_KIND_KEY, Value: ""}
+	}
+	ownerName, err := req.Request.Cookie(COOKIE_OWNER_NAME_KEY)
+	if err != nil {
+		ownerName = &http.Cookie{Name: COOKIE_OWNER_NAME_KEY, Value: ""}
+	}
+
 	// Validate cookie values to prevent path traversal attacks
 	if !fs.ValidPath(clusterName.Value) || !fs.ValidPath(clusterNamespace.Value) || !fs.ValidPath(sessionName.Value) {
 		resp.WriteHeaderAndEntity(http.StatusBadRequest, fmt.Sprintf("invalid cookie values: path traversal not allowed (cluster_name=%s, cluster_namespace=%s, session_name=%s)", clusterName.Value, clusterNamespace.Value, sessionName.Value))
+		return
+	}
+	if ownerKind.Value != "" && !fs.ValidPath(ownerKind.Value) {
+		resp.WriteHeaderAndEntity(http.StatusBadRequest, fmt.Sprintf("invalid cookie values: path traversal not allowed (owner_kind=%s)", ownerKind.Value))
+		return
+	}
+	if ownerName.Value != "" && !fs.ValidPath(ownerName.Value) {
+		resp.WriteHeaderAndEntity(http.StatusBadRequest, fmt.Sprintf("invalid cookie values: path traversal not allowed (owner_name=%s)", ownerName.Value))
 		return
 	}
 
 	http.SetCookie(resp, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_CLUSTER_NAME_KEY, Value: clusterName.Value})
 	http.SetCookie(resp, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_CLUSTER_NAMESPACE_KEY, Value: clusterNamespace.Value})
 	http.SetCookie(resp, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_SESSION_NAME_KEY, Value: sessionName.Value})
+	http.SetCookie(resp, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_OWNER_KIND_KEY, Value: ownerKind.Value})
+	http.SetCookie(resp, &http.Cookie{MaxAge: 600, Path: "/", Name: COOKIE_OWNER_NAME_KEY, Value: ownerName.Value})
 
 	if sessionName.Value == "live" {
 		// Always query K8s to get the service name to prevent SSRF attacks.
@@ -1915,6 +1970,8 @@ func (s *ServerHandler) CookieHandle(req *restful.Request, resp *restful.Respons
 	req.SetAttribute(COOKIE_CLUSTER_NAME_KEY, clusterName.Value)
 	req.SetAttribute(COOKIE_SESSION_NAME_KEY, sessionName.Value)
 	req.SetAttribute(COOKIE_CLUSTER_NAMESPACE_KEY, clusterNamespace.Value)
+	req.SetAttribute(COOKIE_OWNER_KIND_KEY, ownerKind.Value)
+	req.SetAttribute(COOKIE_OWNER_NAME_KEY, ownerName.Value)
 	logrus.Infof("Request URL %s", req.Request.URL.String())
 	chain.ProcessFilter(req, resp)
 }

--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -998,7 +998,7 @@ func (s *ServerHandler) buildFormattedClusterStatus(snap *eventserver.SessionSna
 		for _, e := range rawEntries {
 			if strings.HasSuffix(e, "/") {
 				name := strings.TrimSuffix(e, "/")
-				if name != clusterlogs.LogsSubDir && name != clusterlogs.NodeEventsSubDir && name != clusterlogs.JobEventsSubDir && name != utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME {
+				if name != utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME {
 					nodeIDs = append(nodeIDs, name)
 				}
 			}

--- a/historyserver/pkg/historyserver/timezone.go
+++ b/historyserver/pkg/historyserver/timezone.go
@@ -20,13 +20,11 @@ func (s *ServerHandler) getTimezone(req *restful.Request, resp *restful.Response
 		return
 	}
 
-	clusterName := req.Attribute(COOKIE_CLUSTER_NAME_KEY).(string)
-	clusterNamespace := req.Attribute(COOKIE_CLUSTER_NAMESPACE_KEY).(string)
-	clusterNameID := clusterName + "_" + clusterNamespace
+	clusterLogPathPrefix := s.getClusterLogPathPrefix(req)
 
 	storageKey := utils.EndpointPathToStorageKey(timezoneEndpoint)
 	endpointPath := path.Join(sessionName, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
-	reader := s.reader.GetContent(clusterNameID, endpointPath)
+	reader := s.reader.GetContent(clusterLogPathPrefix, endpointPath)
 	if reader == nil {
 		resp.Header().Set("Content-Type", "application/json")
 		resp.Write([]byte(`{"offset":"","value":""}`))

--- a/historyserver/pkg/storage/clusterlogs/clusterlogs.go
+++ b/historyserver/pkg/storage/clusterlogs/clusterlogs.go
@@ -1,0 +1,97 @@
+package clusterlogs
+
+import (
+	"path"
+	"strings"
+
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+)
+
+const (
+	ClusterHistoryDir = "cluster-history"
+	LogsSubDir        = "logs"
+	NodeEventsSubDir  = "node_events"
+	JobEventsSubDir   = "job_events"
+)
+
+// Prefix returns the hierarchical cluster directory prefix under rootDir:
+// - raycluster: rootDir/cluster-history/raycluster/<namespace>/<cluster-name>
+// - rayjob:     rootDir/cluster-history/rayjob/<namespace>/<rayjob-name>/<cluster-name>
+// - rayservice: rootDir/cluster-history/rayservice/<namespace>/<rayservice-name>/<cluster-name>
+func Prefix(rootDir, ownerKind, ownerName, namespace, clusterName string) string {
+	k := strings.ToLower(strings.TrimSpace(ownerKind))
+	hasOwner := (k == utils.RayJobKind || k == utils.RayServiceKind) && strings.TrimSpace(ownerName) != ""
+
+	subDir := utils.RayClusterKind
+	if hasOwner {
+		subDir = k
+	}
+
+	parts := []string{ClusterHistoryDir, subDir, namespace}
+	if hasOwner {
+		parts = append(parts, strings.TrimSpace(ownerName))
+	}
+	parts = append(parts, clusterName)
+
+	if rootDir == "" {
+		return path.Join(parts...)
+	}
+	return path.Join(rootDir, path.Join(parts...))
+}
+
+// SessionDir returns the path to a session's directory under a cluster:
+// <prefix>/<session-name>
+func SessionDir(rootDir, ownerKind, ownerName, namespace, clusterName, sessionName string) string {
+	cp := Prefix(rootDir, ownerKind, ownerName, namespace, clusterName)
+	return path.Join(cp, sessionName)
+}
+
+// NodeDir returns the path to a node's directory under a session:
+// <prefix>/<session-name>/<node-name>
+func NodeDir(rootDir, ownerKind, ownerName, namespace, clusterName, sessionName, nodeName string) string {
+	sDir := SessionDir(rootDir, ownerKind, ownerName, namespace, clusterName, sessionName)
+	return path.Join(sDir, nodeName)
+}
+
+// LogsDir returns the log directory for a specific node and session:
+// <prefix>/<session-name>/<node-name>/logs
+func LogsDir(rootDir, ownerKind, ownerName, namespace, clusterName, sessionName, nodeName string) string {
+	nDir := NodeDir(rootDir, ownerKind, ownerName, namespace, clusterName, sessionName, nodeName)
+	return path.Join(nDir, LogsSubDir)
+}
+
+// NodeEventsDir returns the node_events directory for a specific node and session:
+// <prefix>/<session-name>/<node-name>/node_events
+func NodeEventsDir(rootDir, ownerKind, ownerName, namespace, clusterName, sessionName, nodeName string) string {
+	nDir := NodeDir(rootDir, ownerKind, ownerName, namespace, clusterName, sessionName, nodeName)
+	return path.Join(nDir, NodeEventsSubDir)
+}
+
+// JobEventsDir returns the job_events directory for a specific node and session (and optional jobID):
+// <prefix>/<session-name>/<node-name>/job_events/[jobID]
+func JobEventsDir(rootDir, ownerKind, ownerName, namespace, clusterName, sessionName, nodeName, jobID string) string {
+	nDir := NodeDir(rootDir, ownerKind, ownerName, namespace, clusterName, sessionName, nodeName)
+	if jobID == "" {
+		return path.Join(nDir, JobEventsSubDir)
+	}
+	return path.Join(nDir, JobEventsSubDir, jobID)
+}
+
+// RelLogsDir returns: <session-name>/<node-name>/logs
+func RelLogsDir(sessionName, nodeName string) string {
+	return path.Join(sessionName, nodeName, LogsSubDir)
+}
+
+// RelNodeEventsDir returns: <session-name>/<node-name>/node_events
+func RelNodeEventsDir(sessionName, nodeName string) string {
+	return path.Join(sessionName, nodeName, NodeEventsSubDir)
+}
+
+// RelJobEventsDir returns: <session-name>/<node-name>/job_events/[jobID]
+func RelJobEventsDir(sessionName, nodeName, jobID string) string {
+	p := path.Join(sessionName, nodeName, JobEventsSubDir)
+	if jobID == "" {
+		return p
+	}
+	return path.Join(p, jobID)
+}

--- a/historyserver/pkg/storage/clusterlogs/clusterlogs.go
+++ b/historyserver/pkg/storage/clusterlogs/clusterlogs.go
@@ -27,16 +27,13 @@ func Prefix(rootDir, ownerKind, ownerName, namespace, clusterName string) string
 		subDir = k
 	}
 
-	parts := []string{ClusterHistoryDir, subDir, namespace}
+	parts := []string{rootDir, ClusterHistoryDir, subDir, namespace}
 	if hasOwner {
 		parts = append(parts, strings.TrimSpace(ownerName))
 	}
 	parts = append(parts, clusterName)
 
-	if rootDir == "" {
-		return path.Join(parts...)
-	}
-	return path.Join(rootDir, path.Join(parts...))
+	return path.Join(parts...)
 }
 
 // SessionDir returns the path to a session's directory under a cluster:

--- a/historyserver/pkg/storage/clusterlogs/clusterlogs_test.go
+++ b/historyserver/pkg/storage/clusterlogs/clusterlogs_test.go
@@ -1,0 +1,61 @@
+package clusterlogs
+
+import (
+	"testing"
+)
+
+func TestClusterLogsPaths(t *testing.T) {
+	rootDir := ""
+	ownerKind := "rayjob"
+	ownerName := "job-1"
+	ns := "default"
+	cluster := "cluster-1"
+	session := "session-1"
+	node := "node-1"
+	jobID := "01000000"
+
+	wantPrefix := "cluster-history/rayjob/default/job-1/cluster-1"
+	if got := Prefix(rootDir, ownerKind, ownerName, ns, cluster); got != wantPrefix {
+		t.Errorf("Prefix() = %q, want %q", got, wantPrefix)
+	}
+
+	wantSession := wantPrefix + "/session-1"
+	if got := SessionDir(rootDir, ownerKind, ownerName, ns, cluster, session); got != wantSession {
+		t.Errorf("SessionDir() = %q, want %q", got, wantSession)
+	}
+
+	wantNode := wantSession + "/node-1"
+	if got := NodeDir(rootDir, ownerKind, ownerName, ns, cluster, session, node); got != wantNode {
+		t.Errorf("NodeDir() = %q, want %q", got, wantNode)
+	}
+
+	wantLogs := wantNode + "/logs"
+	if got := LogsDir(rootDir, ownerKind, ownerName, ns, cluster, session, node); got != wantLogs {
+		t.Errorf("LogsDir() = %q, want %q", got, wantLogs)
+	}
+
+	wantNodeEvents := wantNode + "/node_events"
+	if got := NodeEventsDir(rootDir, ownerKind, ownerName, ns, cluster, session, node); got != wantNodeEvents {
+		t.Errorf("NodeEventsDir() = %q, want %q", got, wantNodeEvents)
+	}
+
+	wantJobEvents := wantNode + "/job_events/01000000"
+	if got := JobEventsDir(rootDir, ownerKind, ownerName, ns, cluster, session, node, jobID); got != wantJobEvents {
+		t.Errorf("JobEventsDir() = %q, want %q", got, wantJobEvents)
+	}
+
+	wantJobEventsNoID := wantNode + "/job_events"
+	if got := JobEventsDir(rootDir, ownerKind, ownerName, ns, cluster, session, node, ""); got != wantJobEventsNoID {
+		t.Errorf("JobEventsDir(no jobID) = %q, want %q", got, wantJobEventsNoID)
+	}
+
+	if got := RelLogsDir(session, node); got != "session-1/node-1/logs" {
+		t.Errorf("RelLogsDir() = %q", got)
+	}
+	if got := RelNodeEventsDir(session, node); got != "session-1/node-1/node_events" {
+		t.Errorf("RelNodeEventsDir() = %q", got)
+	}
+	if got := RelJobEventsDir(session, node, jobID); got != "session-1/node-1/job_events/01000000" {
+		t.Errorf("RelJobEventsDir() = %q", got)
+	}
+}

--- a/historyserver/pkg/utils/types.go
+++ b/historyserver/pkg/utils/types.go
@@ -11,8 +11,9 @@ type ClusterInfo struct {
 }
 
 type ClusterKey struct {
-	Namespace string
-	Name      string
+	Namespace    string
+	ResourceType string
+	ResourceName string
 }
 
 type ClusterInfoList []ClusterInfo

--- a/historyserver/pkg/utils/types.go
+++ b/historyserver/pkg/utils/types.go
@@ -10,12 +10,6 @@ type ClusterInfo struct {
 	OwnerName       string `json:"ownerName,omitempty"`
 }
 
-type ClusterKey struct {
-	Namespace    string
-	ResourceType string
-	ResourceName string
-}
-
 type ClusterInfoList []ClusterInfo
 
 func (a ClusterInfoList) Len() int           { return len(a) }

--- a/historyserver/pkg/utils/utils.go
+++ b/historyserver/pkg/utils/utils.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -46,10 +45,6 @@ func EndpointPathToStorageKey(endpointPath string) string {
 	return "restful__" + strings.ReplaceAll(trimmed, "/", "__")
 }
 
-func GetLogDirByNameID(ossHistorySeverDir, rayClusterNameNamespace, rayNodeID, sessionId string) string {
-	return fmt.Sprintf("%s/", path.Clean(path.Join(ossHistorySeverDir, rayClusterNameNamespace, sessionId, RAY_SESSIONDIR_LOGDIR_NAME, rayNodeID)))
-}
-
 const (
 	// connector is the separator for creating flat storage keys.
 	//
@@ -73,10 +68,6 @@ const (
 	// DO NOT CHANGE: Would break existing stored data paths
 	Connector = "_"
 )
-
-func AppendRayClusterNameNamespace(rayClusterName, rayClusterNamespace string) string {
-	return fmt.Sprintf("%s%s%s", rayClusterName, Connector, rayClusterNamespace)
-}
 
 // IsSessionDirActive checks if the raylet socket is running. Connection means raylet is active.
 func IsSessionDirActive(sessionDir string) bool {

--- a/historyserver/test/e2e/azureblob_collector_test.go
+++ b/historyserver/test/e2e/azureblob_collector_test.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clusterlogs"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 	. "github.com/ray-project/kuberay/historyserver/test/support"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
@@ -61,11 +62,10 @@ func testAzureBlobUploadOnGracefulShutdown(test Test, g *WithT, namespace *corev
 
 	_ = ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
 
-	clusterNameID := fmt.Sprintf("%s_%s", rayCluster.Name, namespace.Name)
 	sessionID := GetSessionIDFromHeadPod(test, g, rayCluster)
 	headNodeID := GetNodeIDFromPod(test, g, HeadPod(test, rayCluster), "ray-head")
 	workerNodeID := GetNodeIDFromPod(test, g, FirstWorkerPod(test, rayCluster), "ray-worker")
-	sessionPrefix := fmt.Sprintf("log/%s/%s/", clusterNameID, sessionID)
+	sessionPrefix := fmt.Sprintf("%s/", clusterlogs.SessionDir("log", "", "", rayCluster.Namespace, rayCluster.Name, sessionID))
 
 	err := test.Client().Ray().RayV1().
 		RayClusters(rayCluster.Namespace).
@@ -87,11 +87,10 @@ func testAzureBlobSeparatesFilesBySession(test Test, g *WithT, namespace *corev1
 
 	_ = ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
 
-	clusterNameID := fmt.Sprintf("%s_%s", rayCluster.Name, namespace.Name)
 	sessionID := GetSessionIDFromHeadPod(test, g, rayCluster)
 	headNodeID := GetNodeIDFromPod(test, g, HeadPod(test, rayCluster), "ray-head")
 	workerNodeID := GetNodeIDFromPod(test, g, FirstWorkerPod(test, rayCluster), "ray-worker")
-	sessionPrefix := fmt.Sprintf("log/%s/%s/", clusterNameID, sessionID)
+	sessionPrefix := fmt.Sprintf("%s/", clusterlogs.SessionDir("log", "", "", rayCluster.Namespace, rayCluster.Name, sessionID))
 
 	killContainerAndWaitForRestart(test, g, HeadPod(test, rayCluster), "ray-head")
 	killContainerAndWaitForRestart(test, g, FirstWorkerPod(test, rayCluster), "ray-worker")
@@ -111,8 +110,7 @@ func testAzureBlobResumesUploadsOnRestart(test Test, g *WithT, namespace *corev1
 
 	dummySessionID := fmt.Sprintf("test-recovery-session-%s", namespace.Name)
 	dummyNodeID := fmt.Sprintf("head-node-%s", namespace.Name)
-	clusterNameID := fmt.Sprintf("%s_%s", rayCluster.Name, namespace.Name)
-	sessionPrefix := fmt.Sprintf("log/%s/%s/", clusterNameID, dummySessionID)
+	sessionPrefix := fmt.Sprintf("%s/", clusterlogs.SessionDir("log", "", "", rayCluster.Namespace, rayCluster.Name, dummySessionID))
 
 	headPod, err := GetHeadPod(test, rayCluster)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -148,7 +146,7 @@ func testAzureBlobResumesUploadsOnRestart(test Test, g *WithT, namespace *corev1
 
 	LogWithTimestamp(test.T(), "Verifying file2.log was uploaded to Azure Blob (idempotency check)")
 	g.Eventually(func(gg Gomega) {
-		logsPrefix := sessionPrefix + "logs/"
+		logsPrefix := sessionPrefix
 		containerClient := azureClient.ServiceClient().NewContainerClient(AzureContainerName)
 		pager := containerClient.NewListBlobsFlatPager(&azblob.ListBlobsFlatOptions{
 			Prefix: &logsPrefix,
@@ -205,8 +203,8 @@ func testAzureBlobResumesUploadsOnRestart(test Test, g *WithT, namespace *corev1
 func verifyAzureBlobSessionDirs(test Test, g *WithT, azureClient *azblob.Client, sessionPrefix string, headNodeID string, workerNodeID string) {
 	containerClient := azureClient.ServiceClient().NewContainerClient(AzureContainerName)
 
-	headLogDirPrefix := fmt.Sprintf("%slogs/%s", sessionPrefix, headNodeID)
-	workerLogDirPrefix := fmt.Sprintf("%slogs/%s", sessionPrefix, workerNodeID)
+	headLogDirPrefix := fmt.Sprintf("%s%s/logs", sessionPrefix, headNodeID)
+	workerLogDirPrefix := fmt.Sprintf("%s%s/logs", sessionPrefix, workerNodeID)
 
 	LogWithTimestamp(test.T(), "Verifying raylet.out, gcs_server.out, and monitor.out exist in head log directory %s", headLogDirPrefix)
 	for _, fileName := range []string{"raylet.out", "gcs_server.out", "monitor.out"} {
@@ -218,29 +216,10 @@ func verifyAzureBlobSessionDirs(test Test, g *WithT, azureClient *azblob.Client,
 
 	LogWithTimestamp(test.T(), "Verifying all %d event types are covered, except for EVENT_TYPE_UNSPECIFIED: %v", len(types.AllEventTypes)-1, types.AllEventTypes)
 	g.Eventually(func(gg Gomega) {
-		var uploadedEvents []rayEvent
-
-		nodeEventsPrefix := sessionPrefix + "node_events/"
-		nodeEvents, err := loadRayEventsFromAzureBlob(containerClient, nodeEventsPrefix)
+		events, err := loadRayEventsFromAzureBlob(containerClient, sessionPrefix)
 		gg.Expect(err).NotTo(HaveOccurred())
-		uploadedEvents = append(uploadedEvents, nodeEvents...)
-		LogWithTimestamp(test.T(), "Loaded %d events from node_events", len(nodeEvents))
 
-		jobEventsPrefix := sessionPrefix + "job_events/"
-		jobDirs, err := listAzureBlobDirectories(containerClient, jobEventsPrefix)
-		gg.Expect(err).NotTo(HaveOccurred())
-		gg.Expect(jobDirs).NotTo(BeEmpty())
-		LogWithTimestamp(test.T(), "Found %d job directories: %v", len(jobDirs), jobDirs)
-
-		for _, jobDir := range jobDirs {
-			jobDirPrefix := jobEventsPrefix + jobDir + "/"
-			jobEvents, err := loadRayEventsFromAzureBlob(containerClient, jobDirPrefix)
-			gg.Expect(err).NotTo(HaveOccurred())
-			uploadedEvents = append(uploadedEvents, jobEvents...)
-			LogWithTimestamp(test.T(), "Loaded %d events from job_events/%s", len(jobEvents), jobDir)
-		}
-
-		assertAllEventTypesCovered(test, gg, uploadedEvents)
+		assertAllEventTypesCovered(test, gg, events)
 	}, TestTimeoutMedium).Should(Succeed())
 }
 
@@ -284,7 +263,7 @@ func loadRayEventsFromAzureBlob(containerClient *container.Client, prefix string
 		}
 
 		for _, blob := range resp.Segment.BlobItems {
-			if blob.Name == nil || strings.HasSuffix(*blob.Name, "/") {
+			if blob.Name == nil || strings.HasSuffix(*blob.Name, "/") || (!strings.Contains(*blob.Name, "/node_events/") && !strings.Contains(*blob.Name, "/job_events/")) {
 				continue
 			}
 

--- a/historyserver/test/e2e/collector_test.go
+++ b/historyserver/test/e2e/collector_test.go
@@ -19,6 +19,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clusterlogs"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 	. "github.com/ray-project/kuberay/historyserver/test/support"
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
@@ -89,10 +90,9 @@ func TestCollector(t *testing.T) {
 //   - job_events: Trigger EventCollector.flushEvents, which calls ec.flushJobEventsForHour to process in-memory job events
 //
 // 5. Verify logs, node_events, and job_events are successfully uploaded to S3. Expected S3 path structure:
-//   - {S3BucketName}/log/{clusterName}_{clusterNamespace}/{sessionID}/logs/...
-//   - {S3BucketName}/log/{clusterName}_{clusterNamespace}/{sessionID}/node_events/...
-//   - {S3BucketName}/log/{clusterName}_{clusterNamespace}/{sessionID}/job_events/AgAAAA==/...
-//   - {S3BucketName}/log/{clusterName}_{clusterNamespace}/{sessionID}/job_events/AQAAAA==/...
+//   - {S3BucketName}/log/cluster-history/raycluster/{clusterNamespace}/{clusterName}/{sessionID}/{nodeID}/logs/...
+//   - {S3BucketName}/log/cluster-history/raycluster/{clusterNamespace}/{clusterName}/{sessionID}/{nodeID}/node_events/...
+//   - {S3BucketName}/log/cluster-history/raycluster/{clusterNamespace}/{clusterName}/{sessionID}/{nodeID}/job_events/...
 //
 // For detailed verification logic, please refer to verifyS3SessionDirs.
 //
@@ -104,11 +104,10 @@ func testCollectorUploadOnGracefulShutdown(test Test, g *WithT, namespace *corev
 	_ = ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
 
 	// Define variables for constructing S3 object prefix.
-	clusterNameID := fmt.Sprintf("%s_%s", rayCluster.Name, rayCluster.Namespace)
 	sessionID := GetSessionIDFromHeadPod(test, g, rayCluster)
 	headNodeID := GetNodeIDFromPod(test, g, HeadPod(test, rayCluster), "ray-head")
 	workerNodeID := GetNodeIDFromPod(test, g, FirstWorkerPod(test, rayCluster), "ray-worker")
-	sessionPrefix := fmt.Sprintf("log/%s/%s/", clusterNameID, sessionID)
+	sessionPrefix := fmt.Sprintf("%s/", clusterlogs.SessionDir("log", "", "", rayCluster.Namespace, rayCluster.Name, sessionID))
 
 	// Delete the Ray cluster to trigger log uploading and event flushing on deletion.
 	err := test.Client().Ray().RayV1().
@@ -151,11 +150,10 @@ func testCollectorSeparatesFilesBySession(test Test, g *WithT, namespace *corev1
 	// Submit a Ray job to the existing cluster.
 	_ = ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
 
-	clusterNameID := fmt.Sprintf("%s_%s", rayCluster.Name, rayCluster.Namespace)
 	sessionID := GetSessionIDFromHeadPod(test, g, rayCluster)
 	headNodeID := GetNodeIDFromPod(test, g, HeadPod(test, rayCluster), "ray-head")
 	workerNodeID := GetNodeIDFromPod(test, g, FirstWorkerPod(test, rayCluster), "ray-worker")
-	sessionPrefix := fmt.Sprintf("log/%s/%s/", clusterNameID, sessionID)
+	sessionPrefix := fmt.Sprintf("%s/", clusterlogs.SessionDir("log", "", "", rayCluster.Namespace, rayCluster.Name, sessionID))
 
 	// NOTE: We use `kill 1` to simulate Kubernetes OOMKilled behavior.
 	// Before Kubernetes 1.28 (cgroups v1), if one process in a multi-process container exceeded its memory limit,
@@ -198,8 +196,7 @@ func testCollectorResumesUploadsOnRestart(test Test, g *WithT, namespace *corev1
 	// Use namespace name to ensure test isolation (avoid conflicts from previous test runs)
 	dummySessionID := fmt.Sprintf("test-recovery-session-%s", namespace.Name)
 	dummyNodeID := fmt.Sprintf("head-node-%s", namespace.Name)
-	clusterNameID := fmt.Sprintf("%s_%s", rayCluster.Name, rayCluster.Namespace)
-	sessionPrefix := fmt.Sprintf("log/%s/%s/", clusterNameID, dummySessionID)
+	sessionPrefix := fmt.Sprintf("%s/", clusterlogs.SessionDir("log", "", "", rayCluster.Namespace, rayCluster.Name, dummySessionID))
 
 	// Inject "leftover" logs BEFORE killing collector.
 	// This ensures files exist when collector restarts and performs its initial scan.
@@ -244,7 +241,7 @@ func testCollectorResumesUploadsOnRestart(test Test, g *WithT, namespace *corev1
 	LogWithTimestamp(test.T(), "Verifying file2.log was uploaded to S3 (idempotency check)")
 	g.Eventually(func(gg Gomega) {
 		// List all objects under the session logs prefix
-		logsPrefix := sessionPrefix + "logs/"
+		logsPrefix := sessionPrefix
 		objects, err := s3Client.ListObjectsV2(&s3.ListObjectsV2Input{
 			Bucket: aws.String(S3BucketName),
 			Prefix: aws.String(logsPrefix),
@@ -325,10 +322,10 @@ func verifySessionDirectoriesExist(test Test, g *WithT, rayCluster *rayv1.RayClu
 func testCollectorStoresClusterMetadata(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 
-	clusterNameID := fmt.Sprintf("%s_%s", rayCluster.Name, rayCluster.Namespace)
 	sessionID := GetSessionIDFromHeadPod(test, g, rayCluster)
 	storageKey := utils.EndpointPathToStorageKey("/api/v0/cluster_metadata")
-	metaKey := fmt.Sprintf("log/%s/%s/%s/%s", clusterNameID, sessionID, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
+	sessionDir := clusterlogs.SessionDir("log", "", "", rayCluster.Namespace, rayCluster.Name, sessionID)
+	metaKey := fmt.Sprintf("%s/%s/%s", sessionDir, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
 
 	LogWithTimestamp(test.T(), "Waiting for cluster metadata to appear at S3 key: %s", metaKey)
 
@@ -380,10 +377,10 @@ func testCollectorStoresClusterMetadata(test Test, g *WithT, namespace *corev1.N
 func testCollectorStoresTimezone(test Test, g *WithT, namespace *corev1.Namespace, s3Client *s3.S3) {
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 
-	clusterNameID := fmt.Sprintf("%s_%s", rayCluster.Name, rayCluster.Namespace)
 	sessionID := GetSessionIDFromHeadPod(test, g, rayCluster)
 	storageKey := utils.EndpointPathToStorageKey(EndpointTimezone)
-	timezoneKey := fmt.Sprintf("log/%s/%s/%s/%s", clusterNameID, sessionID, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
+	sessionDir := clusterlogs.SessionDir("log", "", "", rayCluster.Namespace, rayCluster.Name, sessionID)
+	timezoneKey := fmt.Sprintf("%s/%s/%s", sessionDir, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
 
 	LogWithTimestamp(test.T(), "Waiting for timezone data to appear at S3 key: %s", timezoneKey)
 
@@ -440,11 +437,11 @@ func testCollectorStoresPlacementGroups(test Test, g *WithT, namespace *corev1.N
 	// collector captures non-empty data when polling /api/v0/placement_groups.
 	ApplyRayJobAndWaitForCompletion(test, g, namespace, rayCluster)
 
-	clusterNameID := fmt.Sprintf("%s_%s", rayCluster.Name, rayCluster.Namespace)
 	sessionID := GetSessionIDFromHeadPod(test, g, rayCluster)
 	// The collector stores the endpoint with query params (as configured in RAY_COLLECTOR_ADDITIONAL_ENDPOINTS).
 	storageKey := utils.EndpointPathToStorageKey("/api/v0/placement_groups?detail=1&limit=10000")
-	pgKey := fmt.Sprintf("log/%s/%s/%s/%s", clusterNameID, sessionID, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
+	sessionDir := clusterlogs.SessionDir("log", "", "", rayCluster.Namespace, rayCluster.Name, sessionID)
+	pgKey := fmt.Sprintf("%s/%s/%s", sessionDir, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
 
 	LogWithTimestamp(test.T(), "Waiting for placement groups data to appear at S3 key: %s", pgKey)
 
@@ -502,8 +499,8 @@ func testCollectorStoresPlacementGroups(test Test, g *WithT, namespace *corev1.N
 // NOTE: Since flushed node and job events are nondeterministic, we need to aggregate them first before verifying event type coverage.
 func verifyS3SessionDirs(test Test, g *WithT, s3Client *s3.S3, sessionPrefix string, headNodeID string, workerNodeID string) {
 	// Verify file contents in logs/ directory.
-	headLogDirPrefix := fmt.Sprintf("%slogs/%s", sessionPrefix, headNodeID)
-	workerLogDirPrefix := fmt.Sprintf("%slogs/%s", sessionPrefix, workerNodeID)
+	headLogDirPrefix := fmt.Sprintf("%s%s/logs", sessionPrefix, headNodeID)
+	workerLogDirPrefix := fmt.Sprintf("%s%s/logs", sessionPrefix, workerNodeID)
 
 	LogWithTimestamp(test.T(), "Verifying raylet.out, gcs_server.out, and monitor.out exist in head log directory %s", headLogDirPrefix)
 	for _, fileName := range []string{"raylet.out", "gcs_server.out", "monitor.out"} {
@@ -516,31 +513,10 @@ func verifyS3SessionDirs(test Test, g *WithT, s3Client *s3.S3, sessionPrefix str
 	// Verify event type coverage in node_events/ and job_events/ directories.
 	LogWithTimestamp(test.T(), "Verifying all %d event types are covered, except for EVENT_TYPE_UNSPECIFIED: %v", len(types.AllEventTypes)-1, types.AllEventTypes)
 	g.Eventually(func(gg Gomega) {
-		uploadedEvents := []rayEvent{}
-
-		// Load events from node_events directory.
-		nodeEventsPrefix := sessionPrefix + "node_events/"
-		nodeEvents, err := loadRayEventsFromS3(s3Client, S3BucketName, nodeEventsPrefix)
+		events, err := loadRayEventsFromS3(s3Client, S3BucketName, sessionPrefix)
 		gg.Expect(err).NotTo(HaveOccurred())
-		uploadedEvents = append(uploadedEvents, nodeEvents...)
-		LogWithTimestamp(test.T(), "Loaded %d events from node_events", len(nodeEvents))
 
-		// Dynamically discover and load events from job_events directories.
-		jobEventsPrefix := sessionPrefix + "job_events/"
-		jobDirs, err := ListS3Directories(s3Client, S3BucketName, jobEventsPrefix)
-		gg.Expect(err).NotTo(HaveOccurred())
-		gg.Expect(jobDirs).NotTo(BeEmpty())
-		LogWithTimestamp(test.T(), "Found %d job directories: %v", len(jobDirs), jobDirs)
-
-		for _, jobDir := range jobDirs {
-			jobDirPrefix := jobEventsPrefix + jobDir + "/"
-			jobEvents, err := loadRayEventsFromS3(s3Client, S3BucketName, jobDirPrefix)
-			gg.Expect(err).NotTo(HaveOccurred())
-			uploadedEvents = append(uploadedEvents, jobEvents...)
-			LogWithTimestamp(test.T(), "Loaded %d events from job_events/%s", len(jobEvents), jobDir)
-		}
-
-		assertAllEventTypesCovered(test, gg, uploadedEvents)
+		assertAllEventTypesCovered(test, gg, events)
 	}, TestTimeoutMedium).Should(Succeed())
 }
 
@@ -580,7 +556,7 @@ func loadRayEventsFromS3(s3Client *s3.S3, bucket string, prefix string) ([]rayEv
 
 	for _, obj := range objects.Contents {
 		fileKey := aws.StringValue(obj.Key)
-		if strings.HasSuffix(fileKey, "/") {
+		if strings.HasSuffix(fileKey, "/") || (!strings.Contains(fileKey, "/node_events/") && !strings.Contains(fileKey, "/job_events/")) {
 			continue
 		}
 

--- a/historyserver/test/e2e/historyserver_test.go
+++ b/historyserver/test/e2e/historyserver_test.go
@@ -18,6 +18,7 @@ import (
 
 	. "github.com/ray-project/kuberay/ray-operator/test/support"
 
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clusterlogs"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 	. "github.com/ray-project/kuberay/historyserver/test/support"
 )
@@ -2142,10 +2143,10 @@ func testDeadClusterMetadata(test Test, g *WithT, namespace *corev1.Namespace, s
 	rayCluster := PrepareTestEnv(test, g, namespace, s3Client)
 
 	// Wait for cluster metadata to be stored in S3 by the collector before deleting the cluster.
-	clusterNameID := fmt.Sprintf("%s_%s", rayCluster.Name, rayCluster.Namespace)
 	sessionID := GetSessionIDFromHeadPod(test, g, rayCluster)
 	storageKey := utils.EndpointPathToStorageKey("/api/v0/cluster_metadata")
-	metaKey := fmt.Sprintf("log/%s/%s/%s/%s", clusterNameID, sessionID, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
+	sessionDir := clusterlogs.SessionDir("log", "", "", rayCluster.Namespace, rayCluster.Name, sessionID)
+	metaKey := fmt.Sprintf("%s/%s/%s", sessionDir, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
 	LogWithTimestamp(test.T(), "Waiting for cluster metadata to appear at S3 key: %s", metaKey)
 
 	g.Eventually(func(gg Gomega) {
@@ -2226,10 +2227,10 @@ func testDeadClusterPlacementGroups(test Test, g *WithT, namespace *corev1.Names
 
 	// Wait for placement groups data to be stored in S3 by the collector before deleting the cluster.
 	// The collector stores the endpoint with query params, so the storage key includes them.
-	clusterNameID := fmt.Sprintf("%s_%s", rayCluster.Name, rayCluster.Namespace)
 	sessionID := GetSessionIDFromHeadPod(test, g, rayCluster)
 	storageKey := utils.EndpointPathToStorageKey("/api/v0/placement_groups?detail=1&limit=10000")
-	pgKey := fmt.Sprintf("log/%s/%s/%s/%s", clusterNameID, sessionID, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
+	sessionDir := clusterlogs.SessionDir("log", "", "", rayCluster.Namespace, rayCluster.Name, sessionID)
+	pgKey := fmt.Sprintf("%s/%s/%s", sessionDir, utils.RAY_SESSIONDIR_FETCHED_ENDPOINTS_NAME, storageKey)
 	LogWithTimestamp(test.T(), "Waiting for placement groups data to appear at S3 key: %s", pgKey)
 
 	g.Eventually(func(gg Gomega) {
@@ -2465,7 +2466,7 @@ func testDeadClusterTaskSummarizeFuncName(test Test, g *WithT, namespace *corev1
 
 // setClusterContext sets the cluster context via /enter_cluster/ endpoint and verifies the response.
 func setClusterContext(test Test, g *WithT, client *http.Client, historyServerURL, namespace, clusterName, session string) {
-	enterURL := fmt.Sprintf("%s/enter_cluster/%s/%s/%s", historyServerURL, namespace, clusterName, session)
+	enterURL := fmt.Sprintf("%s/enter_cluster/%s/raycluster/%s/%s", historyServerURL, namespace, clusterName, session)
 	LogWithTimestamp(test.T(), "Setting cluster context: %s", enterURL)
 
 	g.Eventually(func(gg Gomega) {


### PR DESCRIPTION
This is a followup to https://github.com/ray-project/kuberay/pull/4907 
## Why are these changes needed?
This pr updates paths for `enter_cluster` to allow users to also input owner information.
Previously `/enter_cluster` only accepted {namespace}/{name}/{session}, where {name} was strictly the RayCluster name. This PR expends the route to include owner kind (raycluster, rayjob, rayservice).
```
GET /enter_cluster/{namespace}/{kind}/{name} (defaults session to latest)
GET /enter_cluster/{namespace}/{kind}/{name}/{session}
```
By inputting the owner, history server will also set the necessary owner_kind and owner_name cookie.

Along with setting the owner cookie, this PR also utilizes the owner information and update the log file structure.
The log file structure is updated to this format as discussed in #4774: 
```
cluster-history/
  raycluster/
    <namespace>/
      <cluster-name>/
          <session-name>/
             <node-name>/
                job_events/
                node_events/
                logs/
  rayjob/
    <namespace>/
      <rayjob-name>/
        <cluster-name>/
          <session-name>/
             <node-name>/
                job_events/
                node_events/
                logs/
  rayservice/
    <namespace>/
      <rayservice-name>/
        <cluster-name>/
          <session-name>/
             <node-name>/
                job_events/
                node_events/
                logs/
```
<img width="839" height="431" alt="image" src="https://github.com/user-attachments/assets/45b4859e-d49a-4a88-9349-f3c18fee8fdf" />


## Related issue number
Followup for https://github.com/ray-project/kuberay/pull/4907 and part of #4708 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
