### PR TITLE
[release-1.6] bump versions referenced in chart READMEs

### DIFF
--- a/helm-chart/kuberay-apiserver/README.md
+++ b/helm-chart/kuberay-apiserver/README.md
@@ -29,7 +29,7 @@ helm version
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer without security proxy
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2 --set security=null
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.2 --set security=null
 ```
 
 - Install the nightly version
@@ -52,7 +52,7 @@ helm install kuberay-apiserver . --set security=null
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.2
 ```
 
 - Install the nightly version
@@ -79,7 +79,7 @@ To list the `kuberay-apiserver` release:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART
-# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.4.2
+# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.6.2
 ```
 
 ## Uninstall the Chart

--- a/helm-chart/kuberay-apiserver/README.md.gotmpl
+++ b/helm-chart/kuberay-apiserver/README.md.gotmpl
@@ -34,7 +34,7 @@ helm version
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer without security proxy
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2 --set security=null
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.2 --set security=null
 ```
 
 - Install the nightly version
@@ -57,7 +57,7 @@ helm install kuberay-apiserver . --set security=null
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.2
 ```
 
 - Install the nightly version
@@ -84,7 +84,7 @@ To list the `kuberay-apiserver` release:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART
-# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.4.2
+# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.6.2
 ```
 
 ## Uninstall the Chart

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -102,7 +102,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.0.0-rc.0
+    targetRevision: v1.6.2
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -122,7 +122,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.0.0-rc.0
+    targetRevision: v1.6.2
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true

--- a/helm-chart/kuberay-operator/README.md.gotmpl
+++ b/helm-chart/kuberay-operator/README.md.gotmpl
@@ -104,7 +104,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.0.0-rc.0
+    targetRevision: v1.6.2
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -124,7 +124,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.0.0-rc.0
+    targetRevision: v1.6.2
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -30,15 +30,15 @@ kind create cluster
 # Step 2: Register a Helm chart repo
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Step 3: Install both CRDs and KubeRay operator v1.1.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0
+# Step 3: Install both CRDs and KubeRay operator v1.6.2.
+helm install kuberay-operator kuberay/kuberay-operator --version 1.6.2
 
 # Step 4: Install a RayCluster custom resource
 # (For x86_64 users)
-helm install raycluster kuberay/ray-cluster --version 1.1.0
+helm install raycluster kuberay/ray-cluster --version 1.6.2
 # (For arm64 users, e.g. Mac M1)
 # See here for all available arm64 images: https://hub.docker.com/r/rayproject/ray/tags?page=1&name=aarch64
-helm install raycluster kuberay/ray-cluster --version 1.1.0 --set image.tag=nightly-aarch64
+helm install raycluster kuberay/ray-cluster --version 1.6.2 --set image.tag=nightly-aarch64
 
 # Step 5: Verify the installation of KubeRay operator and RayCluster
 kubectl get pods

--- a/helm-chart/ray-cluster/README.md.gotmpl
+++ b/helm-chart/ray-cluster/README.md.gotmpl
@@ -32,15 +32,15 @@ kind create cluster
 # Step 2: Register a Helm chart repo
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Step 3: Install both CRDs and KubeRay operator v1.1.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0
+# Step 3: Install both CRDs and KubeRay operator v1.6.2.
+helm install kuberay-operator kuberay/kuberay-operator --version 1.6.2
 
 # Step 4: Install a RayCluster custom resource
 # (For x86_64 users)
-helm install raycluster kuberay/ray-cluster --version 1.1.0
+helm install raycluster kuberay/ray-cluster --version 1.6.2
 # (For arm64 users, e.g. Mac M1)
 # See here for all available arm64 images: https://hub.docker.com/r/rayproject/ray/tags?page=1&name=aarch64
-helm install raycluster kuberay/ray-cluster --version 1.1.0 --set image.tag=nightly-aarch64
+helm install raycluster kuberay/ray-cluster --version 1.6.2 --set image.tag=nightly-aarch64
 
 # Step 5: Verify the installation of KubeRay operator and RayCluster
 kubectl get pods


### PR DESCRIPTION
This change adds back manual changes that were made in the kuberay-helm repo. This converges KubeRay repo as the source of truth for helm charts going forward in release-1.6 branch.