### PR TITLE
[History server] fix mismatch func signature

### DIFF
--- a/historyserver/pkg/eventserver/eventserver.go
+++ b/historyserver/pkg/eventserver/eventserver.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/ray-project/kuberay/historyserver/pkg/compression"
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 type EventHandler struct {
@@ -991,7 +992,7 @@ func normalizeActorIDsToHex(actor *types.Actor) {
 	actor.Address.WorkerID = normalizeIDToHex(actor.Address.WorkerID)
 }
 
-// GetNodeMap returns a thread-safe deep copy of all nodes for a given cluster session.
+// getNodeMap returns a thread-safe deep copy of all nodes for a given cluster session.
 func (h *EventHandler) getNodeMap(clusterSessionID string) map[string]types.Node {
 	h.ClusterNodeMap.RLock()
 	defer h.ClusterNodeMap.RUnlock()

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -8,10 +8,11 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
-	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
 func makeTaskEventMap(taskName, nodeID, taskID string, attempt int) map[string]any {
@@ -1072,7 +1073,7 @@ func TestProcessSingleSession(t *testing.T) {
 		err = h.ProcessSingleSession(context.Background(), clusterInfo)
 		require.NoError(t, err)
 
-		nodeMap := h.GetNodeMap("cluster_ns_session1")
+		nodeMap := h.getNodeMap("cluster_ns_session1")
 		assert.Len(t, nodeMap, 2)
 
 		// "YWJjZA==" -> hex "61626364" (abcd)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The method `GetNodeMap` is initial with lower case resulting in the building failure.

https://github.com/ray-project/kuberay/actions/runs/27789703070/job/82235345279

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
