### PR TITLE
feat: add optional PodDisruptionBudget to ray-cluster Helm chart

### DIFF
--- a/helm-chart/ray-cluster/Chart.yaml
+++ b/helm-chart/ray-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 description: A Helm chart for deploying the RayCluster with the kuberay operator.
 
-version: 1.1.0
+version: 1.2.0
 
 home: https://github.com/ray-project/kuberay
 

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -1,6 +1,6 @@
 # RayCluster
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying the RayCluster with the kuberay operator.
 
@@ -170,3 +170,7 @@ helm uninstall raycluster
 | additionalWorkerGroups.smallGroup.topologySpreadConstraints | list | `[]` |  |
 | additionalWorkerGroups.smallGroup.rayStartParams | object | `{}` |  |
 | service.type | string | `"ClusterIP"` |  |
+| podDisruptionBudget.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the RayCluster. |
+| podDisruptionBudget.minAvailable | int | `1` | Minimum number of pods that must remain available during a voluntary disruption. An absolute number or a percentage (e.g. "50%"). Mutually exclusive with maxUnavailable; when both are set, minAvailable takes precedence. |
+| podDisruptionBudget.maxUnavailable | string | `""` | Maximum number of pods that can be unavailable during a voluntary disruption. An absolute number or a percentage (e.g. "50%"). Set minAvailable to null to use this instead. |
+| podDisruptionBudget.selectorLabels | object | `{}` | Extra labels to merge into the PDB selector. By default the PDB selects every pod of this RayCluster through the operator-managed `ray.io/cluster` label. |

--- a/helm-chart/ray-cluster/templates/poddisruptionbudget.yaml
+++ b/helm-chart/ray-cluster/templates/poddisruptionbudget.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     {{- include "ray-cluster.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.podDisruptionBudget.minAvailable }}
+  {{- if not (kindIs "invalid" .Values.podDisruptionBudget.minAvailable) }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else if and (not (kindIs "invalid" .Values.podDisruptionBudget.maxUnavailable)) (ne (toString .Values.podDisruptionBudget.maxUnavailable) "") }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
   selector:

--- a/helm-chart/ray-cluster/templates/poddisruptionbudget.yaml
+++ b/helm-chart/ray-cluster/templates/poddisruptionbudget.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ray-cluster.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ray-cluster.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      ray.io/cluster: {{ include "ray-cluster.fullname" . }}
+      {{- with .Values.podDisruptionBudget.selectorLabels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/helm-chart/ray-cluster/tests/poddisruptionbudget_test.yaml
+++ b/helm-chart/ray-cluster/tests/poddisruptionbudget_test.yaml
@@ -43,6 +43,31 @@ tests:
       - notExists:
           path: spec.minAvailable
 
+  - it: Should render `minAvailable` when set to `0`
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 0
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 0
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: Should render `maxUnavailable` when set to `0`
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: null
+        maxUnavailable: 0
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 0
+      - notExists:
+          path: spec.minAvailable
+
   - it: Should prefer `minAvailable` when both are set
     set:
       podDisruptionBudget:

--- a/helm-chart/ray-cluster/tests/poddisruptionbudget_test.yaml
+++ b/helm-chart/ray-cluster/tests/poddisruptionbudget_test.yaml
@@ -1,0 +1,71 @@
+suite: Test RayCluster PodDisruptionBudget
+
+templates:
+  - poddisruptionbudget.yaml
+
+release:
+  name: test
+  namespace: ray
+
+tests:
+  - it: Should not create a PodDisruptionBudget by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create a PodDisruptionBudget when `podDisruptionBudget.enabled` is `true`
+    set:
+      podDisruptionBudget:
+        enabled: true
+    asserts:
+      - containsDocument:
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          name: test-kuberay
+          namespace: ray
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["ray.io/cluster"]
+          value: test-kuberay
+
+  - it: Should use `maxUnavailable` when `minAvailable` is unset
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: null
+        maxUnavailable: "50%"
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: "50%"
+      - notExists:
+          path: spec.minAvailable
+
+  - it: Should prefer `minAvailable` when both are set
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+        maxUnavailable: "50%"
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: Should merge `podDisruptionBudget.selectorLabels` into the selector
+    set:
+      podDisruptionBudget:
+        enabled: true
+        selectorLabels:
+          ray.io/node-type: head
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["ray.io/cluster"]
+          value: test-kuberay
+      - equal:
+          path: spec.selector.matchLabels["ray.io/node-type"]
+          value: head

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -426,3 +426,21 @@ additionalWorkerGroups:
 service:
   # This is optional, and the default is ClusterIP.
   type: ClusterIP
+
+# Configuration for an optional PodDisruptionBudget covering the RayCluster pods.
+# Disabled by default. Enable to limit voluntary disruptions (node drains, cluster
+# autoscaler scale-down) of the Ray head and worker pods.
+# See https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+  # -- Whether to create a PodDisruptionBudget for the RayCluster.
+  enabled: false
+  # -- Minimum number of pods that must remain available during a voluntary disruption.
+  # An absolute number or a percentage (e.g. "50%"). Mutually exclusive with maxUnavailable;
+  # when both are set, minAvailable takes precedence.
+  minAvailable: 1
+  # -- Maximum number of pods that can be unavailable during a voluntary disruption.
+  # An absolute number or a percentage (e.g. "50%"). Set minAvailable to null to use this instead.
+  maxUnavailable: ""
+  # -- Extra labels to merge into the PDB selector. By default the PDB selects every pod
+  # of this RayCluster through the operator-managed `ray.io/cluster` label.
+  selectorLabels: {}


### PR DESCRIPTION
## Why are these changes needed?

The `ray-cluster` Helm chart has no way to declare a `PodDisruptionBudget` for the RayCluster pods. Without a PDB, voluntary disruptions — node drains during maintenance, cluster-autoscaler scale-down — can evict the Ray head and/or all workers at once, disrupting running jobs.

This adds an **opt-in** `PodDisruptionBudget` to the chart, disabled by default so existing installs are unaffected:

- New `podDisruptionBudget` block in `values.yaml` (`enabled: false` by default), supporting `minAvailable` (default `1`) / `maxUnavailable`, plus `selectorLabels` to extend the selector.
- New `templates/poddisruptionbudget.yaml`, guarded by `{{- if .Values.podDisruptionBudget.enabled }}`, rendering `policy/v1`. The selector targets the operator-managed `ray.io/cluster` label so it reliably matches every pod of this RayCluster; `minAvailable` takes precedence when both knobs are set.
- Chart `version` bumped `1.1.0` → `1.2.0`.
- `helm-unittest` suite `tests/poddisruptionbudget_test.yaml` covering disabled-default, enabled, `maxUnavailable`, precedence, and `selectorLabels` merge.

Verified locally: `helm lint`, `helm unittest --strict` (109 tests pass), and `ct lint` (version increment validated) — matching the chart CI in `.github/workflows/helm.yaml`.

## Related issue number

N/A — net-new opt-in feature.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests (`helm unittest --strict`, 5 new PDB cases)
  - [x] Manual tests (`helm template` rendered for PDB enabled / disabled / custom `maxUnavailable` + `selectorLabels`; `helm lint` + `ct lint` pass)
  - [ ] This PR is not tested :(