### PR TITLE
[RayCluster][Kueue] Delete Services during suspension

### DIFF
--- a/docs/guidance/kubernetes-was.md
+++ b/docs/guidance/kubernetes-was.md
@@ -81,8 +81,8 @@ Once enabled and opted in, a RayCluster is scheduled as a single gang:
   install or run.
 - **Editing and scaling.** Changing worker groups or replica counts is picked up automatically — the gang requirement
   is updated to match the new cluster shape.
-- **Suspend and resume.** Suspending a RayCluster deletes its pods but keeps the Workload and PodGroup in place;
-  resuming reuses them so the recreated pods rejoin the same gang.
+- **Suspend and resume.** Suspending a RayCluster deletes its pods and the Kubernetes Services that expose them, but
+  keeps the Workload and PodGroup in place; resuming reuses them so the recreated pods rejoin the same gang.
 - **Cleanup.** The scheduling resources are garbage collected automatically when the RayCluster is deleted.
 
 You can confirm a cluster is being gang scheduled by checking that its pods carry a scheduling group:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -522,7 +522,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `upgradeStrategy` _[RayClusterUpgradeStrategy](#rayclusterupgradestrategy)_ | UpgradeStrategy defines the scaling policy used when upgrading the RayCluster |  |  |
 | `authOptions` _[AuthOptions](#authoptions)_ | AuthOptions specifies the authentication options for the RayCluster. |  |  |
-| `suspend` _boolean_ | Suspend indicates whether a RayCluster should be suspended.<br />A suspended RayCluster will have head pods and worker pods deleted. |  |  |
+| `suspend` _boolean_ | Suspend indicates whether a RayCluster should be suspended.<br />A suspended RayCluster has its head and worker Pods deleted, along with the<br />Kubernetes Services that expose them. Resuming the RayCluster recreates them.<br />The Services are recreated rather than preserved, so a ClusterIP, NodePort or<br />LoadBalancer address assigned to one does not survive a suspend and resume. |  |  |
 | `managedBy` _string_ | ManagedBy is an optional configuration for the controller or entity that manages a RayCluster.<br />The value must be either 'ray.io/kuberay-operator' or 'kueue.x-k8s.io/multikueue'.<br />The kuberay-operator reconciles a RayCluster which doesn't have this field at all or<br />the field value is the reserved string 'ray.io/kuberay-operator',<br />but delegates reconciling the RayCluster with 'kueue.x-k8s.io/multikueue' to the Kueue.<br />The field is immutable. |  |  |
 | `autoscalerOptions` _[AutoscalerOptions](#autoscaleroptions)_ | AutoscalerOptions specifies optional configuration for the Ray autoscaler. |  |  |
 | `headServiceAnnotations` _object (keys:string, values:string)_ |  |  |  |
@@ -981,7 +981,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `enableInTreeAutoscaling` _boolean_ | EnableInTreeAutoscaling indicates whether operator should create in tree autoscaling configs |  |  |
 | `autoscalerOptions` _[AutoscalerOptions](#autoscaleroptions)_ | AutoscalerOptions specifies optional configuration for the Ray autoscaler. |  |  |
-| `suspend` _boolean_ | Suspend indicates whether a RayCluster should be suspended.<br />A suspended RayCluster will have head pods and worker pods deleted. |  |  |
+| `suspend` _boolean_ | Suspend indicates whether a RayCluster should be suspended.<br />A suspended RayCluster has its head and worker Pods deleted, along with the<br />Kubernetes Services that expose them. Resuming the RayCluster recreates them.<br />The Services are recreated rather than preserved, so a ClusterIP, NodePort or<br />LoadBalancer address assigned to one does not survive a suspend and resume. |  |  |
 | `headServiceAnnotations` _object (keys:string, values:string)_ |  |  |  |
 | `headGroupSpec` _[HeadGroupSpec](#headgroupspec)_ | HeadGroupSpec is the spec for the head pod |  |  |
 | `rayVersion` _string_ | RayVersion is used to determine the command for the Kubernetes Job managed by RayJob |  |  |

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -19,7 +19,10 @@ type RayClusterSpec struct {
 	// +optional
 	AuthOptions *AuthOptions `json:"authOptions,omitempty"`
 	// Suspend indicates whether a RayCluster should be suspended.
-	// A suspended RayCluster will have head pods and worker pods deleted.
+	// A suspended RayCluster has its head and worker Pods deleted, along with the
+	// Kubernetes Services that expose them. Resuming the RayCluster recreates them.
+	// The Services are recreated rather than preserved, so a ClusterIP, NodePort or
+	// LoadBalancer address assigned to one does not survive a suspend and resume.
 	// +optional
 	Suspend *bool `json:"suspend,omitempty"`
 	// ManagedBy is an optional configuration for the controller or entity that manages a RayCluster.
@@ -560,7 +563,10 @@ type ClusterState string
 const (
 	Ready ClusterState = "ready"
 	// Failed is deprecated, but we keep it to avoid compilation errors in projects that import the KubeRay Golang module.
-	Failed    ClusterState = "failed"
+	Failed ClusterState = "failed"
+	// Suspended is set once the Pods of a suspending RayCluster are deleted. It does not
+	// wait for the owned Services, so it can be reached while the RayClusterSuspended
+	// condition still reports the teardown as in progress.
 	Suspended ClusterState = "suspended"
 )
 
@@ -660,7 +666,7 @@ const (
 	RayClusterReplicaFailure RayClusterConditionType = "ReplicaFailure"
 	// RayClusterSuspending is set to true when a user sets .Spec.Suspend to true, ensuring the atomicity of the suspend operation.
 	RayClusterSuspending RayClusterConditionType = "RayClusterSuspending"
-	// RayClusterSuspended is set to true when all Pods belonging to a suspending RayCluster are deleted. Note that RayClusterSuspending and RayClusterSuspended cannot both be true at the same time.
+	// RayClusterSuspended is set to true when all Pods and owned Services belonging to a suspending RayCluster are deleted. Note that RayClusterSuspending and RayClusterSuspended cannot both be true at the same time.
 	RayClusterSuspended RayClusterConditionType = "RayClusterSuspended"
 )
 

--- a/ray-operator/apis/ray/v1alpha1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1alpha1/raycluster_types.go
@@ -16,7 +16,10 @@ type RayClusterSpec struct {
 	// AutoscalerOptions specifies optional configuration for the Ray autoscaler.
 	AutoscalerOptions *AutoscalerOptions `json:"autoscalerOptions,omitempty"`
 	// Suspend indicates whether a RayCluster should be suspended.
-	// A suspended RayCluster will have head pods and worker pods deleted.
+	// A suspended RayCluster has its head and worker Pods deleted, along with the
+	// Kubernetes Services that expose them. Resuming the RayCluster recreates them.
+	// The Services are recreated rather than preserved, so a ClusterIP, NodePort or
+	// LoadBalancer address assigned to one does not survive a suspend and resume.
 	Suspend                *bool             `json:"suspend,omitempty"`
 	HeadServiceAnnotations map[string]string `json:"headServiceAnnotations,omitempty"`
 	// HeadGroupSpec is the spec for the head pod

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"runtime"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -149,6 +150,154 @@ func (r *RayClusterReconciler) deleteAllPods(ctx context.Context, filters common
 		return pods, r.DeleteAllOf(ctx, &corev1.Pod{}, filters.ToDeleteOptions()...)
 	}
 	return pods, nil
+}
+
+// rayClusterSuspendCommitted reports whether suspension teardown is authorized.
+//
+// Atomicity comes from a persisted RayClusterSuspending condition as the commit
+// point. Once committed, teardown must complete even if Spec.Suspend is changed
+// back to false. Without status conditions, Spec.Suspend is the source of truth.
+func rayClusterSuspendCommitted(instance *rayv1.RayCluster) bool {
+	if utils.FindRayClusterSuspendStatus(instance) == rayv1.RayClusterSuspending {
+		return true
+	}
+	return !features.Enabled(features.RayClusterStatusConditions) && ptr.Deref(instance.Spec.Suspend, false)
+}
+
+// rayClusterSuspendBlocksCreation reports whether creation of underlying resources
+// should be blocked for the RayCluster.
+func rayClusterSuspendBlocksCreation(instance *rayv1.RayCluster) bool {
+	if rayClusterSuspendCommitted(instance) {
+		return true
+	}
+	if !features.Enabled(features.RayClusterStatusConditions) {
+		return false
+	}
+	return utils.FindRayClusterSuspendStatus(instance) == rayv1.RayClusterSuspended ||
+		ptr.Deref(instance.Spec.Suspend, false)
+}
+
+// rayClusterSuspendDeletesServices covers the whole suspension, not only the teardown
+// window that the Pod deletion covers. Deleted Pods cannot come back on their own, so
+// that window is enough for them. Services left behind by an operator too old to delete
+// them still have to be collected, without asking the user to resume first.
+func rayClusterSuspendDeletesServices(instance *rayv1.RayCluster) bool {
+	if rayClusterSuspendCommitted(instance) {
+		return true
+	}
+	if !features.Enabled(features.RayClusterStatusConditions) {
+		return false
+	}
+	return utils.FindRayClusterSuspendStatus(instance) == rayv1.RayClusterSuspended
+}
+
+// deleteServicesForSuspend only issues the deletions. Whether they have finished is
+// remainingServicesForSuspend's question, and the suspend state machine's to act on.
+func (r *RayClusterReconciler) deleteServicesForSuspend(ctx context.Context, instance *rayv1.RayCluster, services []corev1.Service) error {
+	logger := ctrl.LoggerFrom(ctx)
+	for i := range services {
+		svc := &services[i]
+		if !metav1.IsControlledBy(svc, instance) {
+			continue
+		}
+		if !svc.DeletionTimestamp.IsZero() {
+			continue
+		}
+		logger.Info("Deleting Service due to suspension", "name", svc.Name)
+		if err := r.Delete(ctx, svc); err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, string(utils.FailedToDeleteService), string(utils.DeleteAction),
+				"Failed deleting Service %s/%s due to suspension for RayCluster %s/%s, %v",
+				svc.Namespace, svc.Name, instance.Namespace, instance.Name, err)
+			return err
+		}
+		r.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, string(utils.DeletedService), string(utils.DeleteAction),
+			"Deleted Service %s/%s due to suspension for RayCluster %s/%s",
+			svc.Namespace, svc.Name, instance.Namespace, instance.Name)
+	}
+	return nil
+}
+
+// remainingServicesForSuspend names the Services whose teardown is still outstanding. A
+// Service that is merely terminating is still outstanding: suspension completes on the
+// objects being gone, not on the deletes having been issued.
+//
+// What it reports has to stay identical to what the reconcilers delete. A Service named
+// here but never deleted would hold the suspension open forever.
+func (r *RayClusterReconciler) remainingServicesForSuspend(ctx context.Context, instance *rayv1.RayCluster) ([]string, error) {
+	var found []corev1.Service
+
+	headServices := corev1.ServiceList{}
+	if err := r.List(ctx, &headServices, common.RayClusterHeadServiceListOptions(instance)...); err != nil {
+		return nil, err
+	}
+	found = append(found, headServices.Items...)
+
+	headlessServices := corev1.ServiceList{}
+	if err := r.List(ctx, &headlessServices, common.RayClusterHeadlessServiceListOptions(instance)...); err != nil {
+		return nil, err
+	}
+	found = append(found, headlessServices.Items...)
+
+	// Same annotation gate as reconcileServeService. Without the annotation the serve
+	// Service is not deleted on suspend, so it must not be waited for either.
+	if enableServeServiceValue, exist := instance.Annotations[utils.EnableServeServiceKey]; exist && enableServeServiceValue == utils.EnableServeServiceTrue {
+		serveService := &corev1.Service{}
+		err := r.Get(ctx, common.RayClusterServeServiceNamespacedName(instance), serveService)
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, err
+		}
+		if err == nil {
+			found = append(found, *serveService)
+		}
+	}
+
+	var remaining []string
+	for i := range found {
+		if metav1.IsControlledBy(&found[i], instance) {
+			remaining = append(remaining, found[i].Name)
+		}
+	}
+	sort.Strings(remaining)
+	return remaining, nil
+}
+
+// suspendAwareReconcileFuncs orders one reconcile pass. A Pod may only start once the
+// resources it references exist, which is why creation reconciles it last.
+//
+// During a teardown the order carries weight the creation order does not: the caller
+// stops at the first error, so anything the suspend conditions wait on has to run
+// before anything that can fail for reasons of its own. Otherwise a single unrelated
+// failure leaves the Services undeleted and the cluster unable to resume.
+func (r *RayClusterReconciler) suspendAwareReconcileFuncs(instance *rayv1.RayCluster) []reconcileFunc {
+	if rayClusterSuspendCommitted(instance) {
+		return []reconcileFunc{
+			r.reconcilePods,
+			r.reconcileHeadService,
+			r.reconcileHeadlessService,
+			r.reconcileServeService,
+			r.reconcileAutoscalerServiceAccount,
+			r.reconcileAutoscalerRole,
+			r.reconcileAutoscalerRoleBinding,
+			r.reconcileIngress,
+			r.reconcileAuthSecret,
+			r.reconcileGCSStoragePVC,
+		}
+	}
+	return []reconcileFunc{
+		r.reconcileAutoscalerServiceAccount,
+		r.reconcileAutoscalerRole,
+		r.reconcileAutoscalerRoleBinding,
+		r.reconcileIngress,
+		r.reconcileAuthSecret,
+		r.reconcileHeadService,
+		r.reconcileHeadlessService,
+		r.reconcileServeService,
+		r.reconcileGCSStoragePVC,
+		r.reconcilePods,
+	}
 }
 
 func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance *rayv1.RayCluster) (ctrl.Result, error) {
@@ -356,20 +505,7 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 		return ctrl.Result{}, nil
 	}
 
-	reconcileFuncs := []reconcileFunc{
-		r.reconcileAutoscalerServiceAccount,
-		r.reconcileAutoscalerRole,
-		r.reconcileAutoscalerRoleBinding,
-		r.reconcileIngress,
-		r.reconcileAuthSecret,
-		r.reconcileHeadService,
-		r.reconcileHeadlessService,
-		r.reconcileServeService,
-		r.reconcileGCSStoragePVC,
-		r.reconcilePods,
-	}
-
-	for _, fn := range reconcileFuncs {
+	for _, fn := range r.suspendAwareReconcileFuncs(instance) {
 		if reconcileErr = fn(ctx, instance); reconcileErr != nil {
 			funcName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
 			logger.Error(reconcileErr, "Error reconcile resources", "function name", funcName)
@@ -613,6 +749,13 @@ func (r *RayClusterReconciler) reconcileHeadService(ctx context.Context, instanc
 
 	if err := r.List(ctx, &services, filterLabels...); err != nil {
 		return err
+	}
+
+	if rayClusterSuspendDeletesServices(instance) {
+		return r.deleteServicesForSuspend(ctx, instance, services.Items)
+	}
+	if rayClusterSuspendBlocksCreation(instance) {
+		return nil
 	}
 
 	// Check if there's existing head service in the cluster.
@@ -872,6 +1015,20 @@ func (r *RayClusterReconciler) reconcileServeService(ctx context.Context, instan
 		return nil
 	}
 
+	// The annotation gate above is load-bearing here: during an incremental upgrade the
+	// RayService controller owns a per-cluster serve Service under this same name, and
+	// only the annotation tells the two apart.
+	if rayClusterSuspendDeletesServices(instance) {
+		svc := &corev1.Service{}
+		if err := r.Get(ctx, common.RayClusterServeServiceNamespacedName(instance), svc); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+		return r.deleteServicesForSuspend(ctx, instance, []corev1.Service{*svc})
+	}
+	if rayClusterSuspendBlocksCreation(instance) {
+		return nil
+	}
+
 	// Retrieve the Service from the Kubernetes cluster with the name and namespace.
 	svc := &corev1.Service{}
 	err := r.Get(ctx, common.RayClusterServeServiceNamespacedName(instance), svc)
@@ -896,6 +1053,20 @@ func (r *RayClusterReconciler) reconcileServeService(ctx context.Context, instan
 
 // Return nil only when the headless service for multi-host worker groups is successfully created or already exists.
 func (r *RayClusterReconciler) reconcileHeadlessService(ctx context.Context, instance *rayv1.RayCluster) error {
+	// This sits ahead of the multi-host gate, unlike the serve Service: the label is
+	// KubeRay's own, so there is no foreign Service to confuse it with, and a group that
+	// has since shrunk to a single host still has a headless Service to collect.
+	if rayClusterSuspendDeletesServices(instance) {
+		services := corev1.ServiceList{}
+		if err := r.List(ctx, &services, common.RayClusterHeadlessServiceListOptions(instance)...); err != nil {
+			return err
+		}
+		return r.deleteServicesForSuspend(ctx, instance, services.Items)
+	}
+	if rayClusterSuspendBlocksCreation(instance) {
+		return nil
+	}
+
 	// Check if there are worker groups with NumOfHosts > 1 in the cluster
 	isMultiHost := false
 	for _, workerGroup := range instance.Spec.WorkerGroupSpecs {
@@ -938,10 +1109,7 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 	}
 
 	// if RayCluster is suspending, delete all pods and skip reconcile
-	suspendStatus := utils.FindRayClusterSuspendStatus(instance)
-	statusConditionGateEnabled := features.Enabled(features.RayClusterStatusConditions)
-	if suspendStatus == rayv1.RayClusterSuspending ||
-		(!statusConditionGateEnabled && instance.Spec.Suspend != nil && *instance.Spec.Suspend) {
+	if rayClusterSuspendCommitted(instance) {
 		if _, err := r.deleteAllPods(ctx, common.RayClusterAllPodsAssociationOptions(instance)); err != nil {
 			r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, string(utils.FailedToDeletePodCollection), string(utils.DeleteAction),
 				"Failed deleting Pods due to suspension for RayCluster %s/%s, %v",
@@ -955,14 +1123,8 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 		return nil
 	}
 
-	if statusConditionGateEnabled {
-		if suspendStatus == rayv1.RayClusterSuspended {
-			return nil // stop reconcilePods because the cluster is suspended.
-		}
-		// (suspendStatus != rayv1.RayClusterSuspending) is always true here because it has been checked above.
-		if instance.Spec.Suspend != nil && *instance.Spec.Suspend {
-			return nil // stop reconcilePods because the cluster is going to suspend.
-		}
+	if rayClusterSuspendBlocksCreation(instance) {
+		return nil
 	}
 
 	// Check if pods need to be recreated with Recreate upgradeStrategy
@@ -2062,14 +2224,42 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 		}
 
 		switch suspendStatus {
-		case rayv1.RayClusterSuspending:
+		case rayv1.RayClusterSuspending, rayv1.RayClusterSuspended:
+			// Suspending completes once the Pods and the Services this path tears down
+			// are gone. A Service only on its way out has not gone.
+			var remaining []string
 			if len(runtimePods.Items) == 0 {
+				// Provisioned describes the Pods, so it answers as soon as they are gone,
+				// whatever the Services are still doing.
 				meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
 					Type:    string(rayv1.RayClusterProvisioned),
 					Status:  metav1.ConditionFalse,
 					Reason:  rayv1.RayClusterPodsProvisioning,
 					Message: "RayCluster has been suspended",
 				})
+				var err error
+				if remaining, err = r.remainingServicesForSuspend(ctx, instance); err != nil {
+					return nil, err
+				}
+			}
+
+			switch {
+			case len(remaining) != 0:
+				// Also how a cluster suspended by an operator that predates this teardown
+				// converges: it arrives already reporting Suspended and has to give that
+				// up until its leftover Services are gone.
+				meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
+					Type:    string(rayv1.RayClusterSuspending),
+					Reason:  string(rayv1.RayClusterSuspending),
+					Status:  metav1.ConditionTrue,
+					Message: "Waiting for owned Services to be deleted: " + strings.Join(remaining, ", "),
+				})
+				meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
+					Type:   string(rayv1.RayClusterSuspended),
+					Reason: string(rayv1.RayClusterSuspended),
+					Status: metav1.ConditionFalse,
+				})
+			case len(runtimePods.Items) == 0 && suspendStatus == rayv1.RayClusterSuspending:
 				meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
 					Type:   string(rayv1.RayClusterSuspending),
 					Reason: string(rayv1.RayClusterSuspending),
@@ -2080,9 +2270,7 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 					Reason: string(rayv1.RayClusterSuspended),
 					Status: metav1.ConditionTrue,
 				})
-			}
-		case rayv1.RayClusterSuspended:
-			if instance.Spec.Suspend != nil && !*instance.Spec.Suspend {
+			case suspendStatus == rayv1.RayClusterSuspended && instance.Spec.Suspend != nil && !*instance.Spec.Suspend:
 				meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
 					Type:   string(rayv1.RayClusterSuspended),
 					Reason: string(rayv1.RayClusterSuspended),
@@ -2111,15 +2299,23 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 		}
 	}
 
+	// Keep the deprecated .Status.State Pod-gated for Kueue compatibility: Kueue reads
+	// Ready as the RayCluster's active signal, and nothing else writes this field back
+	// down, so delaying it for the Service teardown would delay the quota release.
 	if newInstance.Spec.Suspend != nil && *newInstance.Spec.Suspend && len(runtimePods.Items) == 0 {
 		newInstance.Status.State = rayv1.Suspended
 	}
 
-	if err := r.updateEndpoints(ctx, newInstance); err != nil {
+	// Read from what this reconcile observed, not from the status being computed: the
+	// resume pass clears the suspend conditions above, while the head Service only comes
+	// back on the following reconcile.
+	headServiceOptional := rayClusterSuspendBlocksCreation(instance) || reconcileErr != nil
+
+	if err := r.updateEndpoints(ctx, newInstance, headServiceOptional); err != nil {
 		return nil, err
 	}
 
-	if err := r.updateHeadInfo(ctx, newInstance); err != nil {
+	if err := r.updateHeadInfo(ctx, newInstance, headServiceOptional); err != nil {
 		return nil, err
 	}
 
@@ -2136,12 +2332,18 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 	return newInstance, nil
 }
 
-func (r *RayClusterReconciler) getHeadServiceIPAndName(ctx context.Context, instance *rayv1.RayCluster) (string, string, error) {
+// getHeadServiceIPAndName returns empty values without error when the headServiceOptional
+// is true. This is expected while suspending or resuming; returning
+// an error would prevent the suspension state from converging.
+func (r *RayClusterReconciler) getHeadServiceIPAndName(ctx context.Context, instance *rayv1.RayCluster, headServiceOptional bool) (string, string, error) {
 	runtimeServices := corev1.ServiceList{}
 	if err := r.List(ctx, &runtimeServices, common.RayClusterHeadServiceListOptions(instance)...); err != nil {
 		return "", "", err
 	}
 	if len(runtimeServices.Items) < 1 {
+		if headServiceOptional {
+			return "", "", nil
+		}
 		return "", "", fmt.Errorf("unable to find head service. cluster name %s, filter labels %v", instance.Name, common.RayClusterHeadServiceListOptions(instance))
 	} else if len(runtimeServices.Items) > 1 {
 		return "", "", fmt.Errorf("found multiple head services. cluster name %s, filter labels %v", instance.Name, common.RayClusterHeadServiceListOptions(instance))
@@ -2162,7 +2364,7 @@ func (r *RayClusterReconciler) getHeadServiceIPAndName(ctx context.Context, inst
 	return runtimeServices.Items[0].Spec.ClusterIP, runtimeServices.Items[0].Name, nil
 }
 
-func (r *RayClusterReconciler) updateEndpoints(ctx context.Context, instance *rayv1.RayCluster) error {
+func (r *RayClusterReconciler) updateEndpoints(ctx context.Context, instance *rayv1.RayCluster, headServiceOptional bool) error {
 	logger := ctrl.LoggerFrom(ctx)
 	// TODO: (@scarlet25151) There may be several K8s Services for a RayCluster.
 	// We assume we can find the right one by filtering Services with appropriate label selectors
@@ -2193,6 +2395,10 @@ func (r *RayClusterReconciler) updateEndpoints(ctx context.Context, instance *ra
 				logger.Info("updateStatus: Service port's targetPort is empty. Not adding it to RayCluster status.endpoints", "port", port)
 			}
 		}
+	} else if headServiceOptional {
+		// Endpoints that outlive the Service they were read from are worse than none.
+		logger.Info("updateEndpoints: The head Service is absent because this RayCluster is suspended. Clearing RayCluster status.endpoints", "serviceSelectors", filterLabels)
+		instance.Status.Endpoints = nil
 	} else {
 		logger.Info("updateEndpoints: Unable to find a Service for this RayCluster. Not adding RayCluster status.endpoints", "serviceSelectors", filterLabels)
 	}
@@ -2200,7 +2406,7 @@ func (r *RayClusterReconciler) updateEndpoints(ctx context.Context, instance *ra
 	return nil
 }
 
-func (r *RayClusterReconciler) updateHeadInfo(ctx context.Context, instance *rayv1.RayCluster) error {
+func (r *RayClusterReconciler) updateHeadInfo(ctx context.Context, instance *rayv1.RayCluster, headServiceOptional bool) error {
 	headPod, err := common.GetRayClusterHeadPod(ctx, r, instance)
 	if err != nil {
 		return err
@@ -2213,7 +2419,7 @@ func (r *RayClusterReconciler) updateHeadInfo(ctx context.Context, instance *ray
 		instance.Status.Head.PodName = ""
 	}
 
-	ip, name, err := r.getHeadServiceIPAndName(ctx, instance)
+	ip, name, err := r.getHeadServiceIPAndName(ctx, instance, headServiceOptional)
 	if err != nil {
 		return err
 	}

--- a/ray-operator/controllers/ray/raycluster_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_test.go
@@ -572,13 +572,28 @@ var _ = Context("Inside the default namespace", func() {
 	testSuspendRayCluster := func(withConditionDisabled bool) {
 		ctx := context.Background()
 		namespace := "default"
-		rayCluster := rayClusterTemplate("raycluster-suspend", namespace)
+		// envtest runs no garbage collector, so a deleted RayCluster's resources outlive
+		// the spec that made them. Without distinct names the second mode would inherit
+		// them and pass its assertions before doing any work.
+		clusterName := "raycluster-suspend"
+		if withConditionDisabled {
+			clusterName = "raycluster-suspend-no-condition"
+		}
+		rayCluster := rayClusterTemplate(clusterName, namespace)
 		headPods := corev1.PodList{}
 		workerPods := corev1.PodList{}
 		allPods := corev1.PodList{}
 		workerFilters := common.RayClusterGroupPodsAssociationOptions(rayCluster, rayCluster.Spec.WorkerGroupSpecs[0].GroupName).ToListOptions()
 		headFilters := common.RayClusterHeadPodsAssociationOptions(rayCluster).ToListOptions()
 		allFilters := common.RayClusterAllPodsAssociationOptions(rayCluster).ToListOptions()
+		headServices := corev1.ServiceList{}
+		headServiceFilters := common.RayClusterHeadServiceListOptions(rayCluster)
+		numHeadServices := func() (int, error) {
+			if err := k8sClient.List(ctx, &headServices, headServiceFilters...); err != nil {
+				return -1, err
+			}
+			return len(headServices.Items), nil
+		}
 
 		if withConditionDisabled {
 			features.SetFeatureGateDuringTest(GinkgoTB(), features.RayClusterStatusConditions, false)
@@ -610,6 +625,12 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*3, time.Millisecond*500).Should(Equal(numWorkerPods), fmt.Sprintf("workerGroup %v", workerPods.Items))
 		})
 
+		By("Check that the head Service is created", func() {
+			Eventually(
+				numHeadServices,
+				time.Second*3, time.Millisecond*500).Should(Equal(1), fmt.Sprintf("head services %v", headServices.Items))
+		})
+
 		By("Should delete all head and worker Pods if suspended", func() {
 			// suspend a Raycluster and check that all Pods are deleted.
 			err := updateRayClusterSuspendField(ctx, rayCluster, true)
@@ -627,6 +648,12 @@ var _ = Context("Inside the default namespace", func() {
 				time.Second*3, time.Millisecond*500).Should(Equal(0), fmt.Sprintf("all pods %v", allPods.Items))
 		})
 
+		By("Should delete the head Service if suspended", func() {
+			Eventually(
+				numHeadServices,
+				time.Second*3, time.Millisecond*500).Should(Equal(0), fmt.Sprintf("head services %v", headServices.Items))
+		})
+
 		By("RayCluster's .status.state should be updated to 'suspended' shortly after all Pods are terminated", func() {
 			Eventually(
 				getClusterState(ctx, namespace, rayCluster.Name),
@@ -638,6 +665,9 @@ var _ = Context("Inside the default namespace", func() {
 				// rayCluster.Status.Head.PodName will be cleared.
 				// rayCluster.Status.Head.PodIP will also be cleared, but we don't test it here since we don't have IPs in tests.
 				Expect(rayCluster.Status.Head.PodName).To(BeEmpty())
+				// The status derived from the head Service goes with it.
+				Expect(rayCluster.Status.Head.ServiceName).To(BeEmpty())
+				Expect(rayCluster.Status.Endpoints).To(BeEmpty())
 			}
 		})
 
@@ -692,6 +722,10 @@ var _ = Context("Inside the default namespace", func() {
 			err := updateRayClusterSuspendField(ctx, rayCluster, false)
 			Expect(err).NotTo(HaveOccurred(), "Failed to update RayCluster")
 
+			Eventually(
+				numHeadServices,
+				time.Second*3, time.Millisecond*500).Should(Equal(1), fmt.Sprintf("head services %v", headServices.Items))
+
 			// check that all pods are created
 			Eventually(
 				listResourceFunc(ctx, &headPods, headFilters...),
@@ -724,6 +758,7 @@ var _ = Context("Inside the default namespace", func() {
 				// rayCluster.Status.Head.PodName should have a value now.
 				// rayCluster.Status.Head.PodIP should also have a value now, but we don't test it here since we don't have IPs in tests.
 				Expect(rayCluster.Status.Head.PodName).NotTo(BeEmpty())
+				Expect(rayCluster.Status.Head.ServiceName).NotTo(BeEmpty())
 			}
 		})
 
@@ -748,6 +783,14 @@ var _ = Context("Inside the default namespace", func() {
 			rayCluster := rayClusterTemplate("raycluster-suspend-atomically", namespace)
 			allPods := corev1.PodList{}
 			allFilters := common.RayClusterAllPodsAssociationOptions(rayCluster).ToListOptions()
+			headServices := corev1.ServiceList{}
+			headServiceFilters := common.RayClusterHeadServiceListOptions(rayCluster)
+			numHeadServices := func() (int, error) {
+				if err := k8sClient.List(ctx, &headServices, headServiceFilters...); err != nil {
+					return -1, err
+				}
+				return len(headServices.Items), nil
+			}
 			numPods := 4 // 1 Head + 3 Workers
 			Expect(features.Enabled(features.RayClusterStatusConditions)).To(BeTrue())
 
@@ -778,6 +821,11 @@ var _ = Context("Inside the default namespace", func() {
 
 				Eventually(findRayClusterSuspendStatus, time.Second*3, time.Millisecond*500).
 					WithArguments(ctx, rayCluster).Should(Equal(rayv1.RayClusterSuspending))
+
+				// Both teardowns answer to the same condition, so this one proceeds even
+				// while the Pods are pinned by finalizers.
+				Eventually(numHeadServices, time.Second*3, time.Millisecond*500).
+					Should(Equal(0), fmt.Sprintf("head services %v", headServices.Items))
 			})
 
 			By("Should keep RayClusterSuspending consistently if we set `.Spec.Suspend` back to false", func() {
@@ -816,6 +864,10 @@ var _ = Context("Inside the default namespace", func() {
 					newNames = append(newNames, pod.Name)
 				}
 				Expect(newNames).NotTo(ConsistOf(oldNames))
+
+				// The head Service comes back with them.
+				Eventually(numHeadServices, time.Second*3, time.Millisecond*500).
+					Should(Equal(1), fmt.Sprintf("head services %v", headServices.Items))
 			})
 
 			By("Set suspend to true and all Pods should be deleted again", func() {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -22,6 +22,8 @@ import (
 	"math"
 	"os"
 	"reflect"
+	goruntime "runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -1158,6 +1160,432 @@ func TestReconcileHeadlessService(t *testing.T) {
 	assert.Len(t, serviceList.Items, 1, "Service list len is wrong")
 }
 
+// withSuspend builds the RayCluster shapes the suspend lifecycle actually produces.
+// Conditions take an explicit status instead of being removed, because that is what
+// the controller persists: a resumed RayCluster still carries a RayClusterSuspended
+// condition, only with its status flipped to False.
+func withSuspend(cluster *rayv1.RayCluster, suspend bool, conditions map[rayv1.RayClusterConditionType]metav1.ConditionStatus) *rayv1.RayCluster {
+	suspended := cluster.DeepCopy()
+	suspended.Spec.Suspend = new(suspend)
+	for condition, status := range conditions {
+		meta.SetStatusCondition(&suspended.Status.Conditions, metav1.Condition{
+			Type:   string(condition),
+			Reason: string(condition),
+			Status: status,
+		})
+	}
+	return suspended
+}
+
+func TestRayClusterSuspendPredicates(t *testing.T) {
+	setupTest(t)
+
+	tests := []struct {
+		name             string
+		condition        rayv1.RayClusterConditionType
+		suspend          bool
+		gateEnabled      bool
+		wantCommitted    bool
+		wantDeletesSvcs  bool
+		wantBlocksCreate bool
+	}{
+		{
+			// The reconcile that first observes .Spec.Suspend must not delete anything:
+			// RayClusterSuspending is the commit point and is not persisted yet. This is
+			// what makes the suspend operation atomic.
+			name:             "gate enabled, suspend requested but not yet committed",
+			suspend:          true,
+			gateEnabled:      true,
+			wantCommitted:    false,
+			wantDeletesSvcs:  false,
+			wantBlocksCreate: true,
+		},
+		{
+			name:             "gate enabled, suspending",
+			condition:        rayv1.RayClusterSuspending,
+			suspend:          true,
+			gateEnabled:      true,
+			wantCommitted:    true,
+			wantDeletesSvcs:  true,
+			wantBlocksCreate: true,
+		},
+		{
+			// Pods cannot come back on their own once suspended, but a Service can still
+			// be present - suspended by an operator that predates this cleanup, or
+			// re-created behind the controller's back - so the Service teardown stays
+			// armed while the Pod teardown does not.
+			name:             "gate enabled, suspended",
+			condition:        rayv1.RayClusterSuspended,
+			suspend:          true,
+			gateEnabled:      true,
+			wantCommitted:    false,
+			wantDeletesSvcs:  true,
+			wantBlocksCreate: true,
+		},
+		{
+			name:             "gate enabled, not suspended",
+			suspend:          false,
+			gateEnabled:      true,
+			wantCommitted:    false,
+			wantDeletesSvcs:  false,
+			wantBlocksCreate: false,
+		},
+		{
+			// Without the status conditions there is no commit point to wait for, so
+			// .Spec.Suspend drives the deletion directly.
+			name:             "gate disabled, suspend requested",
+			suspend:          true,
+			gateEnabled:      false,
+			wantCommitted:    true,
+			wantDeletesSvcs:  true,
+			wantBlocksCreate: true,
+		},
+		{
+			name:             "gate disabled, stale Suspended condition, resumed",
+			condition:        rayv1.RayClusterSuspended,
+			suspend:          false,
+			gateEnabled:      false,
+			wantCommitted:    false,
+			wantDeletesSvcs:  false,
+			wantBlocksCreate: false,
+		},
+		{
+			name:             "gate disabled, not suspended",
+			suspend:          false,
+			gateEnabled:      false,
+			wantCommitted:    false,
+			wantDeletesSvcs:  false,
+			wantBlocksCreate: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, tc.gateEnabled)
+
+			conditions := map[rayv1.RayClusterConditionType]metav1.ConditionStatus{}
+			if tc.condition != "" {
+				conditions[tc.condition] = metav1.ConditionTrue
+			}
+			cluster := withSuspend(testRayCluster, tc.suspend, conditions)
+
+			assert.Equal(t, tc.wantCommitted, rayClusterSuspendCommitted(cluster))
+			assert.Equal(t, tc.wantDeletesSvcs, rayClusterSuspendDeletesServices(cluster))
+			assert.Equal(t, tc.wantBlocksCreate, rayClusterSuspendBlocksCreation(cluster))
+		})
+	}
+}
+
+// TestRayClusterSuspendPredicatesIgnoreClearedConditions guards a trap: since a
+// cleared condition is kept with a False status rather than dropped, predicates that
+// looked for its presence would leave every RayCluster that has ever been suspended
+// permanently unable to rebuild itself.
+func TestRayClusterSuspendPredicatesIgnoreClearedConditions(t *testing.T) {
+	setupTest(t)
+	features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+	cluster := withSuspend(testRayCluster, false, map[rayv1.RayClusterConditionType]metav1.ConditionStatus{
+		rayv1.RayClusterSuspending: metav1.ConditionFalse,
+		rayv1.RayClusterSuspended:  metav1.ConditionFalse,
+	})
+
+	require.NotEmpty(t, cluster.Status.Conditions, "the cleared conditions must remain in the array")
+	assert.False(t, rayClusterSuspendCommitted(cluster))
+	assert.False(t, rayClusterSuspendDeletesServices(cluster))
+	assert.False(t, rayClusterSuspendBlocksCreation(cluster))
+}
+
+// TestReconcileServicesOnSuspend covers the Service teardown that brings RayCluster
+// suspension in line with the other KubeRay CRs.
+func TestReconcileServicesOnSuspend(t *testing.T) {
+	setupTest(t)
+
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	// Configured so that all three kinds of Service exist.
+	baseCluster := testRayCluster.DeepCopy()
+	baseCluster.UID = "raycluster-uid"
+	baseCluster.Annotations = map[string]string{utils.EnableServeServiceKey: utils.EnableServeServiceTrue}
+	baseCluster.Spec.WorkerGroupSpecs[0].NumOfHosts = 4
+
+	suspending := map[rayv1.RayClusterConditionType]metav1.ConditionStatus{rayv1.RayClusterSuspending: metav1.ConditionTrue}
+	suspended := map[rayv1.RayClusterConditionType]metav1.ConditionStatus{rayv1.RayClusterSuspended: metav1.ConditionTrue}
+	resumed := map[rayv1.RayClusterConditionType]metav1.ConditionStatus{rayv1.RayClusterSuspended: metav1.ConditionFalse}
+
+	ctx := context.TODO()
+
+	newReconciler := func(fakeClient client.Client, recorder events.EventRecorderLogger) *RayClusterReconciler {
+		return &RayClusterReconciler{
+			Client:                     fakeClient,
+			Recorder:                   recorder,
+			Scheme:                     scheme.Scheme,
+			rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
+		}
+	}
+
+	reconcileServices := func(t *testing.T, r *RayClusterReconciler, cluster *rayv1.RayCluster) {
+		t.Helper()
+		require.NoError(t, r.reconcileHeadService(ctx, cluster))
+		require.NoError(t, r.reconcileServeService(ctx, cluster))
+		require.NoError(t, r.reconcileHeadlessService(ctx, cluster))
+	}
+
+	serviceNames := func(t *testing.T, fakeClient client.Client, namespace string) []string {
+		t.Helper()
+		services := corev1.ServiceList{}
+		require.NoError(t, fakeClient.List(ctx, &services, client.InNamespace(namespace)))
+		names := make([]string, 0, len(services.Items))
+		for _, svc := range services.Items {
+			names = append(names, svc.Name)
+		}
+		return names
+	}
+
+	t.Run("suspending deletes the head, serve and headless Services", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		cluster := baseCluster.DeepCopy()
+		fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(cluster).Build()
+		r := newReconciler(fakeClient, &events.FakeRecorder{})
+
+		reconcileServices(t, r, cluster)
+		require.Len(t, serviceNames(t, fakeClient, cluster.Namespace), 3, "a running RayCluster should own three Services")
+
+		reconcileServices(t, r, withSuspend(cluster, true, suspending))
+		assert.Empty(t, serviceNames(t, fakeClient, cluster.Namespace), "suspending should delete all owned Services")
+	})
+
+	t.Run("a RayCluster suspended before this cleanup existed converges", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		cluster := baseCluster.DeepCopy()
+		fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(cluster).Build()
+		r := newReconciler(fakeClient, &events.FakeRecorder{})
+
+		reconcileServices(t, r, cluster)
+		require.Len(t, serviceNames(t, fakeClient, cluster.Namespace), 3)
+
+		// The cluster is long past the suspending phase, so a teardown armed only by
+		// RayClusterSuspending would never reach these Services.
+		reconcileServices(t, r, withSuspend(cluster, true, suspended))
+		assert.Empty(t, serviceNames(t, fakeClient, cluster.Namespace))
+	})
+
+	t.Run("suspending is idempotent once the Services are gone", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		cluster := withSuspend(baseCluster, true, suspending)
+		fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(cluster).Build()
+		r := newReconciler(fakeClient, &events.FakeRecorder{})
+
+		reconcileServices(t, r, cluster)
+		assert.Empty(t, serviceNames(t, fakeClient, cluster.Namespace))
+	})
+
+	t.Run("a suspended RayCluster does not re-create the Services", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		cluster := withSuspend(baseCluster, true, suspended)
+		fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(cluster).Build()
+		r := newReconciler(fakeClient, &events.FakeRecorder{})
+
+		reconcileServices(t, r, cluster)
+		assert.Empty(t, serviceNames(t, fakeClient, cluster.Namespace))
+	})
+
+	t.Run("suspend requested but not yet committed keeps the Services", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		cluster := baseCluster.DeepCopy()
+		fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(cluster).Build()
+		r := newReconciler(fakeClient, &events.FakeRecorder{})
+
+		reconcileServices(t, r, cluster)
+		require.Len(t, serviceNames(t, fakeClient, cluster.Namespace), 3)
+
+		// The spec asks for suspension but nothing has committed to it yet, so the user
+		// can still change their mind at no cost.
+		reconcileServices(t, r, withSuspend(cluster, true, nil))
+		assert.Len(t, serviceNames(t, fakeClient, cluster.Namespace), 3, "deletion must wait for the RayClusterSuspending commit point")
+	})
+
+	t.Run("without the status conditions .Spec.Suspend deletes the Services", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, false)
+
+		cluster := baseCluster.DeepCopy()
+		fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(cluster).Build()
+		r := newReconciler(fakeClient, &events.FakeRecorder{})
+
+		reconcileServices(t, r, cluster)
+		require.Len(t, serviceNames(t, fakeClient, cluster.Namespace), 3)
+
+		reconcileServices(t, r, withSuspend(cluster, true, nil))
+		assert.Empty(t, serviceNames(t, fakeClient, cluster.Namespace))
+	})
+
+	t.Run("resuming re-creates the Services only after the Suspended condition is cleared", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		cluster := withSuspend(baseCluster, true, suspended)
+		fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(cluster).Build()
+		r := newReconciler(fakeClient, &events.FakeRecorder{})
+
+		reconcileServices(t, r, cluster)
+		require.Empty(t, serviceNames(t, fakeClient, cluster.Namespace))
+
+		// A resume is observed one reconcile before it is recorded, and nothing may come
+		// back during that gap.
+		reconcileServices(t, r, withSuspend(baseCluster, false, suspended))
+		require.Empty(t, serviceNames(t, fakeClient, cluster.Namespace), "the Services must not return before the condition is cleared")
+
+		// Now that the status agrees, the Services return.
+		reconcileServices(t, r, withSuspend(baseCluster, false, resumed))
+		assert.Len(t, serviceNames(t, fakeClient, cluster.Namespace), 3)
+	})
+
+	t.Run("does not delete a serve Service this RayCluster does not manage", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		// During an incremental upgrade the RayService controller parents a serve Service
+		// to the RayCluster under this same name, without the annotation. Ownership is
+		// not enough to tell the two apart, so the annotation has to.
+		cluster := baseCluster.DeepCopy()
+		delete(cluster.Annotations, utils.EnableServeServiceKey)
+		foreignServeService := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      utils.GenerateServeServiceName(cluster.Name),
+				Namespace: cluster.Namespace,
+			},
+		}
+		require.NoError(t, controllerutil.SetControllerReference(cluster, foreignServeService, scheme.Scheme))
+		fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(cluster, foreignServeService).Build()
+		r := newReconciler(fakeClient, &events.FakeRecorder{})
+
+		reconcileServices(t, r, withSuspend(cluster, true, suspending))
+		assert.Equal(t, []string{foreignServeService.Name}, serviceNames(t, fakeClient, cluster.Namespace))
+	})
+
+	t.Run("does not delete Services this RayCluster does not own", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		// Wearing KubeRay's labels is enough to be adopted, but adopting is not owning.
+		cluster := baseCluster.DeepCopy()
+		foreignHeadService := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "not-created-by-kuberay",
+				Namespace: cluster.Namespace,
+				Labels:    common.HeadServiceLabels(*cluster),
+			},
+		}
+		fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(cluster, foreignHeadService).Build()
+		r := newReconciler(fakeClient, &events.FakeRecorder{})
+
+		reconcileServices(t, r, withSuspend(cluster, true, suspending))
+		assert.Equal(t, []string{foreignHeadService.Name}, serviceNames(t, fakeClient, cluster.Namespace))
+	})
+
+	t.Run("reports a failed deletion instead of silently leaving the Service behind", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		cluster := baseCluster.DeepCopy()
+		rejectDeletes := false
+		fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(cluster).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if rejectDeletes {
+						return k8serrors.NewInternalError(errors.New("delete rejected"))
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			}).Build()
+		recorder := events.NewFakeRecorder(10)
+		r := newReconciler(fakeClient, recorder)
+
+		reconcileServices(t, r, cluster)
+		require.Len(t, serviceNames(t, fakeClient, cluster.Namespace), 3)
+		drainEvents(recorder)
+
+		rejectDeletes = true
+		err := r.reconcileHeadService(ctx, withSuspend(cluster, true, suspending))
+		require.Error(t, err, "a failed Service deletion must not be reported as success")
+		assert.Contains(t, collectEvents(recorder), string(utils.FailedToDeleteService))
+		assert.Len(t, serviceNames(t, fakeClient, cluster.Namespace), 3, "the Service is still there")
+	})
+
+	t.Run("records an event for each deleted Service", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		cluster := baseCluster.DeepCopy()
+		fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(cluster).Build()
+		recorder := events.NewFakeRecorder(10)
+		r := newReconciler(fakeClient, recorder)
+
+		reconcileServices(t, r, cluster)
+		require.Len(t, serviceNames(t, fakeClient, cluster.Namespace), 3)
+		drainEvents(recorder)
+
+		reconcileServices(t, r, withSuspend(cluster, true, suspending))
+		recorded := collectEvents(recorder)
+		assert.Equal(t, 3, strings.Count(recorded, string(utils.DeletedService)), "one DeletedService event per Service, got: %s", recorded)
+	})
+
+	t.Run("does not re-delete a Service that is already terminating", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		cluster := baseCluster.DeepCopy()
+		deletes := 0
+		fakeClient := clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(cluster).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					deletes++
+					return c.Delete(ctx, obj, opts...)
+				},
+			}).Build()
+		r := newReconciler(fakeClient, &events.FakeRecorder{})
+		require.NoError(t, r.reconcileHeadService(ctx, cluster))
+
+		// Leave the Service terminating but not gone, the way a load balancer waits on
+		// its cloud controller to release the external address.
+		services := corev1.ServiceList{}
+		require.NoError(t, fakeClient.List(ctx, &services, common.RayClusterHeadServiceListOptions(cluster)...))
+		require.Len(t, services.Items, 1)
+		headService := services.Items[0]
+		headService.Finalizers = []string{"service.k8s.io/load-balancer-cleanup"}
+		require.NoError(t, fakeClient.Update(ctx, &headService))
+		require.NoError(t, fakeClient.Delete(ctx, &headService))
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(&headService), &headService))
+		require.False(t, headService.DeletionTimestamp.IsZero(), "the head Service should be terminating")
+
+		deletes = 0
+		require.NoError(t, r.reconcileHeadService(ctx, withSuspend(cluster, true, suspending)))
+		assert.Zero(t, deletes, "a terminating Service must not be deleted again")
+	})
+}
+
+func drainEvents(recorder *events.FakeRecorder) {
+	for {
+		select {
+		case <-recorder.Events:
+		default:
+			return
+		}
+	}
+}
+
+func collectEvents(recorder *events.FakeRecorder) string {
+	var recorded []string
+	for {
+		select {
+		case event := <-recorder.Events:
+			recorded = append(recorded, event)
+		default:
+			return strings.Join(recorded, "\n")
+		}
+	}
+}
+
 func getNotFailedPodItemNum(podList corev1.PodList) int {
 	count := 0
 	for _, aPod := range podList.Items {
@@ -1330,7 +1758,7 @@ func TestUpdateEndpoints(t *testing.T) {
 		Scheme:   scheme.Scheme,
 	}
 
-	if err := testRayClusterReconciler.updateEndpoints(ctx, testRayCluster); err != nil {
+	if err := testRayClusterReconciler.updateEndpoints(ctx, testRayCluster, false); err != nil {
 		t.Errorf("updateEndpoints failed: %v", err)
 	}
 
@@ -1439,11 +1867,12 @@ func TestGetHeadServiceIPAndName(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		expectedIP   string
-		expectedName string
-		services     []runtime.Object
-		returnsError bool
+		name                string
+		expectedIP          string
+		expectedName        string
+		services            []runtime.Object
+		headServiceOptional bool
+		returnsError        bool
 	}{
 		{
 			name:         "get expected Service IP if there's one head Service",
@@ -1460,11 +1889,29 @@ func TestGetHeadServiceIPAndName(t *testing.T) {
 			returnsError: true,
 		},
 		{
+			// The absence is expected, so it must not cost the caller its status write.
+			name:                "get empty head Service info if the head Service is optional",
+			services:            []runtime.Object{},
+			expectedIP:          "",
+			expectedName:        "",
+			headServiceOptional: true,
+			returnsError:        false,
+		},
+		{
 			name:         "get error if there's more than one head Service",
 			services:     append(testServices, extraHeadService),
 			expectedIP:   "",
 			expectedName: "",
 			returnsError: true,
+		},
+		{
+			// Ambiguity is a real problem either way.
+			name:                "get error if there's more than one head Service even when optional",
+			services:            append(testServices, extraHeadService),
+			expectedIP:          "",
+			expectedName:        "",
+			headServiceOptional: true,
+			returnsError:        true,
 		},
 	}
 
@@ -1478,7 +1925,7 @@ func TestGetHeadServiceIPAndName(t *testing.T) {
 				rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
 			}
 
-			ip, name, err := testRayClusterReconciler.getHeadServiceIPAndName(context.TODO(), testRayCluster)
+			ip, name, err := testRayClusterReconciler.getHeadServiceIPAndName(context.TODO(), testRayCluster, tc.headServiceOptional)
 			if tc.returnsError {
 				require.Error(t, err, "getHeadServiceIPAndName should return error")
 			} else {
@@ -1508,7 +1955,7 @@ func TestGetHeadServiceIPAndNameOnHeadlessService(t *testing.T) {
 		Scheme:   scheme.Scheme,
 	}
 
-	ip, name, err := testRayClusterReconciler.getHeadServiceIPAndName(context.TODO(), testRayCluster)
+	ip, name, err := testRayClusterReconciler.getHeadServiceIPAndName(context.TODO(), testRayCluster, false)
 
 	require.NoError(t, err)
 	assert.Equal(t, headNodeIP, ip, "getHeadServiceIPAndName returned unexpected IP")
@@ -4656,4 +5103,298 @@ func TestReconcile_TLSAutoGenerate_RejectsWithoutCertManager(t *testing.T) {
 		}
 	}
 	assert.True(t, foundEvent, "expected a warning event about cert-manager")
+}
+
+func TestCalculateStatusSuspendWaitsForOwnedServices(t *testing.T) {
+	setupTest(t)
+
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+
+	suspending := map[rayv1.RayClusterConditionType]metav1.ConditionStatus{rayv1.RayClusterSuspending: metav1.ConditionTrue}
+
+	// Configured so that all three kinds of Service exist.
+	baseCluster := testRayCluster.DeepCopy()
+	baseCluster.UID = "raycluster-uid"
+	baseCluster.Annotations = map[string]string{utils.EnableServeServiceKey: utils.EnableServeServiceTrue}
+	baseCluster.Spec.WorkerGroupSpecs[0].NumOfHosts = 4
+
+	ctx := context.Background()
+
+	own := func(t *testing.T, svc *corev1.Service) *corev1.Service {
+		t.Helper()
+		require.NoError(t, controllerutil.SetControllerReference(baseCluster, svc, scheme.Scheme))
+		return svc
+	}
+	headService := func(t *testing.T) *corev1.Service {
+		t.Helper()
+		svc, err := common.BuildServiceForHeadPod(ctx, *baseCluster, nil, nil)
+		require.NoError(t, err)
+		svc.Spec.ClusterIP = "aaa.bbb.ccc.ddd"
+		return own(t, svc)
+	}
+	serveService := func(t *testing.T) *corev1.Service {
+		t.Helper()
+		svc, err := common.BuildServeServiceForRayCluster(ctx, *baseCluster)
+		require.NoError(t, err)
+		return own(t, svc)
+	}
+	headlessService := func(t *testing.T) *corev1.Service {
+		t.Helper()
+		return own(t, common.BuildHeadlessServiceForRayCluster(*baseCluster))
+	}
+
+	newReconciler := func(objects ...runtime.Object) *RayClusterReconciler {
+		return &RayClusterReconciler{
+			Client:   clientFake.NewClientBuilder().WithScheme(newScheme).WithRuntimeObjects(objects...).Build(),
+			Recorder: &events.FakeRecorder{},
+			Scheme:   scheme.Scheme,
+		}
+	}
+
+	// Each kind of owned Service has to hold the suspension open on its own. One that
+	// does not is a Service the state machine would stop waiting for.
+	for _, tc := range []struct {
+		build func(*testing.T) *corev1.Service
+		name  string
+	}{
+		{name: "head", build: headService},
+		{name: "serve", build: serveService},
+		{name: "headless", build: headlessService},
+	} {
+		t.Run("the "+tc.name+" Service alone holds the suspension open", func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+			cluster := withSuspend(baseCluster, true, suspending)
+
+			r := newReconciler(cluster, tc.build(t))
+			newInstance, err := r.calculateStatus(ctx, cluster, nil)
+			require.NoError(t, err)
+			assert.True(t, meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterSuspending)))
+			assert.False(t, meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterSuspended)))
+		})
+	}
+
+	t.Run("the suspension completes once every owned Service is gone", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		cluster := withSuspend(baseCluster, true, suspending)
+
+		r := newReconciler(cluster)
+		newInstance, err := r.calculateStatus(ctx, cluster, nil)
+		require.NoError(t, err)
+		assert.False(t, meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterSuspending)))
+		assert.True(t, meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterSuspended)))
+	})
+
+	t.Run("a Service on its way out still holds the suspension open", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		// A cluster that was running arrives here already provisioned.
+		cluster := withSuspend(baseCluster, true, map[rayv1.RayClusterConditionType]metav1.ConditionStatus{
+			rayv1.RayClusterSuspending:  metav1.ConditionTrue,
+			rayv1.RayClusterProvisioned: metav1.ConditionTrue,
+		})
+
+		// A LoadBalancer Service commonly stays terminating while its finalizer runs.
+		terminating := headService(t)
+		terminating.Finalizers = []string{"service.kubernetes.io/load-balancer-cleanup"}
+		r := newReconciler(cluster, terminating)
+		require.NoError(t, r.Delete(ctx, terminating))
+		lingering := &corev1.Service{}
+		require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(terminating), lingering))
+		require.False(t, lingering.DeletionTimestamp.IsZero(), "the fixture must be terminating, not gone")
+
+		newInstance, err := r.calculateStatus(ctx, cluster, nil)
+		require.NoError(t, err)
+		assert.False(t, meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterSuspended)))
+		// Provisioned describes the Pods, which are already gone.
+		assert.False(t, meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterProvisioned)))
+	})
+
+	t.Run("the blocking Services are named in the Suspending condition", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		// A stalled suspension has to say which Service it is waiting on.
+		cluster := withSuspend(baseCluster, true, suspending)
+
+		r := newReconciler(cluster, headService(t))
+		newInstance, err := r.calculateStatus(ctx, cluster, nil)
+		require.NoError(t, err)
+		condition := meta.FindStatusCondition(newInstance.Status.Conditions, string(rayv1.RayClusterSuspending))
+		require.NotNil(t, condition)
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Contains(t, condition.Message, "head")
+	})
+
+	t.Run("a missing head Service is still an error outside a suspension", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		// The head Service is only optional while the suspension explains its absence.
+		cluster := baseCluster.DeepCopy()
+
+		r := newReconciler(cluster)
+		_, err := r.calculateStatus(ctx, cluster, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to find head service")
+	})
+
+	t.Run("a cluster suspended before this teardown gives up its Suspended condition", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		// An operator that predates the Service teardown leaves a suspended cluster whose
+		// Services are still there. Reporting Suspended would claim a teardown that has
+		// not happened, and would let a resume run straight into them.
+		suspended := map[rayv1.RayClusterConditionType]metav1.ConditionStatus{rayv1.RayClusterSuspended: metav1.ConditionTrue}
+		cluster := withSuspend(baseCluster, true, suspended)
+
+		terminating := headService(t)
+		terminating.Finalizers = []string{"service.kubernetes.io/load-balancer-cleanup"}
+		r := newReconciler(cluster, terminating)
+		require.NoError(t, r.Delete(ctx, terminating))
+
+		newInstance, err := r.calculateStatus(ctx, cluster, nil)
+		require.NoError(t, err)
+		assert.False(t, meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterSuspended)))
+		condition := meta.FindStatusCondition(newInstance.Status.Conditions, string(rayv1.RayClusterSuspending))
+		require.NotNil(t, condition)
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Contains(t, condition.Message, "head")
+	})
+
+	t.Run("a resume still clears the Suspended condition once the Services are gone", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		suspended := map[rayv1.RayClusterConditionType]metav1.ConditionStatus{rayv1.RayClusterSuspended: metav1.ConditionTrue}
+		cluster := withSuspend(baseCluster, false, suspended)
+
+		r := newReconciler(cluster)
+		newInstance, err := r.calculateStatus(ctx, cluster, nil)
+		require.NoError(t, err)
+		assert.False(t, meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterSuspended)))
+		assert.False(t, meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterSuspending)))
+	})
+
+	t.Run("the serve Service is ignored without the annotation", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		// During an incremental upgrade the RayService controller parents a serve Service
+		// to the RayCluster under this same name, without the annotation. Suspension does
+		// not delete that one, so it must not wait for it either.
+		cluster := withSuspend(baseCluster, true, suspending)
+		delete(cluster.Annotations, utils.EnableServeServiceKey)
+
+		r := newReconciler(cluster, serveService(t))
+		newInstance, err := r.calculateStatus(ctx, cluster, nil)
+		require.NoError(t, err)
+		assert.True(t, meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterSuspended)))
+	})
+
+	t.Run("a Service this RayCluster does not own never holds up the suspension", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		cluster := withSuspend(baseCluster, true, suspending)
+
+		// A Service that only matches the labels is adopted but not owned. Suspension
+		// does not delete it, so it must not be waited for either.
+		foreign := headService(t)
+		foreign.OwnerReferences[0].UID = "a-different-raycluster-uid"
+
+		r := newReconciler(cluster, foreign)
+		newInstance, err := r.calculateStatus(ctx, cluster, nil)
+		require.NoError(t, err)
+		assert.True(t, meta.IsStatusConditionTrue(newInstance.Status.Conditions, string(rayv1.RayClusterSuspended)))
+	})
+
+	// Kueue reads .Status.State to decide when to release the reserved quota, so this
+	// pins the timing the operator promises it.
+	for _, tc := range []struct {
+		name string
+		gate bool
+	}{
+		{name: "with the status conditions", gate: true},
+		{name: "without the status conditions", gate: false},
+	} {
+		t.Run(".Status.State is not gated on the Services, "+tc.name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, tc.gate)
+
+			cluster := withSuspend(baseCluster, true, suspending)
+
+			r := newReconciler(cluster, headService(t))
+			newInstance, err := r.calculateStatus(ctx, cluster, nil)
+			require.NoError(t, err)
+			assert.Equal(t, rayv1.Suspended, newInstance.Status.State,
+				"the Pods are gone, so Kueue must be free to release the quota")
+		})
+	}
+}
+
+func TestSuspendAwareReconcileFuncsOrdering(t *testing.T) {
+	setupTest(t)
+
+	r := &RayClusterReconciler{}
+	name := func(fn reconcileFunc) string {
+		full := goruntime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+		return full[strings.LastIndex(full, ".")+1:]
+	}
+	indexOf := func(t *testing.T, funcs []reconcileFunc, want string) int {
+		t.Helper()
+		for i, fn := range funcs {
+			if strings.HasPrefix(name(fn), want) {
+				return i
+			}
+		}
+		t.Fatalf("%s is not in the reconcile order", want)
+		return -1
+	}
+
+	t.Run("creation reconciles the Pods last", func(t *testing.T) {
+		funcs := r.suspendAwareReconcileFuncs(testRayCluster.DeepCopy())
+		assert.Equal(t, len(funcs)-1, indexOf(t, funcs, "reconcilePods"),
+			"a Pod may only start once the resources it references exist")
+	})
+
+	t.Run("a committed suspend reconciles the teardown first", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		suspending := map[rayv1.RayClusterConditionType]metav1.ConditionStatus{rayv1.RayClusterSuspending: metav1.ConditionTrue}
+		funcs := r.suspendAwareReconcileFuncs(withSuspend(testRayCluster, true, suspending))
+
+		// The caller stops at the first error, so an unrelated failure placed ahead of
+		// the teardown would strand the suspension.
+		pods := indexOf(t, funcs, "reconcilePods")
+		assert.Equal(t, 0, pods, "freeing the Pods is what suspending is for")
+		for _, svc := range []string{"reconcileHeadService", "reconcileHeadlessService", "reconcileServeService"} {
+			for _, mayFail := range []string{
+				"reconcileAutoscalerServiceAccount",
+				"reconcileAutoscalerRole",
+				"reconcileAutoscalerRoleBinding",
+				"reconcileIngress",
+				"reconcileAuthSecret",
+				"reconcileGCSStoragePVC",
+			} {
+				assert.Less(t, indexOf(t, funcs, svc), indexOf(t, funcs, mayFail),
+					"%s must be torn down before %s can fail the pass", svc, mayFail)
+			}
+		}
+	})
+
+	t.Run("both orders reconcile the same resources", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+		suspending := map[rayv1.RayClusterConditionType]metav1.ConditionStatus{rayv1.RayClusterSuspending: metav1.ConditionTrue}
+		names := func(funcs []reconcileFunc) []string {
+			out := make([]string, 0, len(funcs))
+			for _, fn := range funcs {
+				out = append(out, name(fn))
+			}
+			sort.Strings(out)
+			return out
+		}
+		assert.Equal(t,
+			names(r.suspendAwareReconcileFuncs(testRayCluster.DeepCopy())),
+			names(r.suspendAwareReconcileFuncs(withSuspend(testRayCluster, true, suspending))),
+			"reordering must not drop or add a reconciler")
+	})
 }

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -146,7 +146,7 @@ func firstNotReadyContainerStatus(pod *corev1.Pod) (reason string, message strin
 //	rayv1.RayClusterSuspending:
 //	  False by default
 //	  False -> True: when `spec.Suspend` is true.
-//	  True -> False: when all Pods are deleted, set rayv1.RayClusterSuspended from False to True.
+//	  True -> False: when all Pods and owned Services are deleted, set rayv1.RayClusterSuspended from False to True.
 //	rayv1.RayClusterSuspended
 //	  False by default
 //	  False -> True: when suspending transitions from True to False

--- a/ray-operator/pkg/client/applyconfiguration/ray/v1/rayclusterspec.go
+++ b/ray-operator/pkg/client/applyconfiguration/ray/v1/rayclusterspec.go
@@ -14,7 +14,10 @@ type RayClusterSpecApplyConfiguration struct {
 	// AuthOptions specifies the authentication options for the RayCluster.
 	AuthOptions *AuthOptionsApplyConfiguration `json:"authOptions,omitempty"`
 	// Suspend indicates whether a RayCluster should be suspended.
-	// A suspended RayCluster will have head pods and worker pods deleted.
+	// A suspended RayCluster has its head and worker Pods deleted, along with the
+	// Kubernetes Services that expose them. Resuming the RayCluster recreates them.
+	// The Services are recreated rather than preserved, so a ClusterIP, NodePort or
+	// LoadBalancer address assigned to one does not survive a suspend and resume.
 	Suspend *bool `json:"suspend,omitempty"`
 	// ManagedBy is an optional configuration for the controller or entity that manages a RayCluster.
 	// The value must be either 'ray.io/kuberay-operator' or 'kueue.x-k8s.io/multikueue'.

--- a/ray-operator/test/e2e/raycluster_test.go
+++ b/ray-operator/test/e2e/raycluster_test.go
@@ -109,6 +109,11 @@ func TestRayClusterSuspend(t *testing.T) {
 	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
 		Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionFalse, rayv1.RayClusterPodsProvisioning)))
 
+	// Only Pods consume quota, so suspend deletes them to free it for e.g. Kueue.
+	g.Eventually(Pods(test, namespace.Name,
+		LabelSelector(utils.RayClusterLabelKey+"="+rayCluster.Name)), TestTimeoutMedium).
+		Should(BeEmpty())
+
 	rayClusterAC = rayClusterAC.WithSpec(rayClusterAC.Spec.WithSuspend(false))
 	rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/ray-operator/test/e2e/raycluster_test.go
+++ b/ray-operator/test/e2e/raycluster_test.go
@@ -109,6 +109,16 @@ func TestRayClusterSuspend(t *testing.T) {
 	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
 		Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionFalse, rayv1.RayClusterPodsProvisioning)))
 
+	// Suspending releases the quota the Pods hold and takes the Services that expose
+	// them with it. This cluster is single-host and has no serve Service, so the head
+	// Service is the only one to look for - and the only one this selector would match.
+	g.Eventually(Pods(test, namespace.Name,
+		LabelSelector(utils.RayClusterLabelKey+"="+rayCluster.Name)), TestTimeoutMedium).
+		Should(BeEmpty())
+	g.Eventually(Services(test, namespace.Name,
+		LabelSelector(utils.RayClusterLabelKey+"="+rayCluster.Name)), TestTimeoutMedium).
+		Should(BeEmpty())
+
 	rayClusterAC = rayClusterAC.WithSpec(rayClusterAC.Spec.WithSuspend(false))
 	rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -121,6 +131,11 @@ func TestRayClusterSuspend(t *testing.T) {
 		Should(WithTransform(StatusCondition(rayv1.HeadPodReady), MatchCondition(metav1.ConditionTrue, rayv1.HeadPodRunningAndReady)))
 	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
 		Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionTrue, rayv1.AllPodRunningAndReadyFirstTime)))
+
+	// Resuming re-creates the Services that were deleted during suspension.
+	g.Eventually(Services(test, namespace.Name,
+		LabelSelector(utils.RayClusterLabelKey+"="+rayCluster.Name)), TestTimeoutMedium).
+		ShouldNot(BeEmpty())
 }
 
 func TestRayClusterWithResourceQuota(t *testing.T) {

--- a/ray-operator/test/support/core.go
+++ b/ray-operator/test/support/core.go
@@ -32,6 +32,20 @@ func Pods(t Test, namespace string, options ...Option[*metav1.ListOptions]) func
 	}
 }
 
+func Services(t Test, namespace string, options ...Option[*metav1.ListOptions]) func(g gomega.Gomega) []corev1.Service {
+	return func(g gomega.Gomega) []corev1.Service {
+		listOptions := &metav1.ListOptions{}
+
+		for _, option := range options {
+			g.Expect(option.applyTo(listOptions)).To(gomega.Succeed())
+		}
+
+		services, err := t.Client().Core().CoreV1().Services(namespace).List(t.Ctx(), *listOptions)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		return services.Items
+	}
+}
+
 func storeAllPodLogs(t Test, namespace *corev1.Namespace) {
 	t.T().Helper()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Suspending a RayCluster deleted its Pods but left the head, serve, and headless Services behind. This made standalone RayCluster inconsistent with the other suspend paths.

This PR deletes those Services while suspended and recreates them on resume. It preserves the existing suspend commit point, but tears Pods down before Services so a failed Service deletion cannot block quota release.

The status path now tolerates the head Service being absent during suspension, allowing the suspend/resume transition to complete normally.

Scope is limited to the Pods and Services called out in #4876. Other owned resources have different lifecycle semantics and are left unchanged.

One behavior worth calling out: `RayClusterSuspended` still becomes true once the Pods are gone, rather than waiting for every owned resource to be deleted.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #4876


## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
