### PR TITLE
[ray-operator] Clean up batch scheduler resources on suspend

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -377,6 +377,17 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 		}
 
+		// Clean up batch scheduler resources (e.g. zero out the Volcano PodGroup) now that the
+		// RayCluster is gone. The PodGroup is owned by the RayJob, not the RayCluster, so it is not
+		// garbage-collected when the cluster is deleted; without this it keeps holding queue
+		// resources while the RayJob is suspended. Must run before Status.RayClusterName is reset
+		// below, since CleanupOnCompletion relies on it to locate the PodGroup. Requeue on failure
+		// so the cleanup is retried while still in the Suspending status, rather than leaking the
+		// PodGroup once the status transitions to Suspended (which is no longer requeued).
+		if err := r.cleanupBatchSchedulerResources(ctx, rayJobInstance); err != nil {
+			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
+		}
+
 		// Reset the RayCluster and Ray job related status.
 		rayJobInstance.Status.RayClusterStatus = rayv1.RayClusterStatus{}
 		rayJobInstance.Status.RayClusterName = ""
@@ -1550,29 +1561,39 @@ func (r *RayJobReconciler) isDeletionActionCompleted(ctx context.Context, rayJob
 	return false, fmt.Errorf("unknown deletion policy for completion check: %s", policy)
 }
 
-// batchSchedulerOnCompletion performs cleanup of batch scheduler resources when a RayJob reaches complete/failed status.
-func (r *RayJobReconciler) batchSchedulerOnCompletion(ctx context.Context, rayJobInstance *rayv1.RayJob) {
-	logger := ctrl.LoggerFrom(ctx)
+// cleanupBatchSchedulerResources cleans up batch scheduler resources (e.g., zeroes out the Volcano
+// PodGroup) for the given RayJob and returns an error if the cleanup failed. Callers that must
+// guarantee the resources are released (e.g., suspend) should requeue on error; callers handling a
+// terminal state can swallow the error via batchSchedulerOnCompletion.
+func (r *RayJobReconciler) cleanupBatchSchedulerResources(ctx context.Context, rayJobInstance *rayv1.RayJob) error {
+	if r.options.BatchSchedulerManager == nil {
+		return nil
+	}
 
-	// Clean up batch scheduler resources (e.g., delete Volcano PodGroup)
-	if r.options.BatchSchedulerManager != nil {
-		scheduler, err := r.options.BatchSchedulerManager.GetScheduler()
-		if err != nil {
-			logger.Error(err, "Failed to get batch scheduler")
-			// Don't block the reconciliation on scheduler errors, just log the error
-		} else {
-			didUpdate, err := scheduler.CleanupOnCompletion(ctx, rayJobInstance)
-			if err != nil {
-				logger.Error(err, "Failed to cleanup batch scheduler resources")
-				r.Recorder.Eventf(rayJobInstance, corev1.EventTypeWarning, string(utils.FailedToCleanupBatchScheduler),
-					"Failed to cleanup batch scheduler resources for RayJob %s/%s: %v", rayJobInstance.Namespace, rayJobInstance.Name, err)
-				// Don't block the reconciliation on cleanup failures, just log the error
-			} else if didUpdate {
-				// emit event if cleanup was performed
-				r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, string(utils.BatchSchedulerCleanedUp),
-					"Cleaned up batch scheduler resources for RayJob %s/%s", rayJobInstance.Namespace, rayJobInstance.Name)
-			}
-		}
+	scheduler, err := r.options.BatchSchedulerManager.GetScheduler()
+	if err != nil {
+		return fmt.Errorf("failed to get batch scheduler: %w", err)
+	}
+
+	didUpdate, err := scheduler.CleanupOnCompletion(ctx, rayJobInstance)
+	if err != nil {
+		r.Recorder.Eventf(rayJobInstance, corev1.EventTypeWarning, string(utils.FailedToCleanupBatchScheduler),
+			"Failed to cleanup batch scheduler resources for RayJob %s/%s: %v", rayJobInstance.Namespace, rayJobInstance.Name, err)
+		return fmt.Errorf("failed to cleanup batch scheduler resources: %w", err)
+	}
+	if didUpdate {
+		r.Recorder.Eventf(rayJobInstance, corev1.EventTypeNormal, string(utils.BatchSchedulerCleanedUp),
+			"Cleaned up batch scheduler resources for RayJob %s/%s", rayJobInstance.Namespace, rayJobInstance.Name)
+	}
+	return nil
+}
+
+// batchSchedulerOnCompletion performs cleanup of batch scheduler resources when a RayJob reaches
+// complete/failed status. Cleanup failures are logged but not propagated, since a terminal RayJob
+// will not be requeued.
+func (r *RayJobReconciler) batchSchedulerOnCompletion(ctx context.Context, rayJobInstance *rayv1.RayJob) {
+	if err := r.cleanupBatchSchedulerResources(ctx, rayJobInstance); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "Failed to cleanup batch scheduler resources")
 	}
 }
 

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -377,13 +377,6 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
 		}
 
-		// Clean up batch scheduler resources (e.g. zero out the Volcano PodGroup) now that the
-		// RayCluster is gone. The PodGroup is owned by the RayJob, not the RayCluster, so it is not
-		// garbage-collected when the cluster is deleted; without this it keeps holding queue
-		// resources while the RayJob is suspended. Must run before Status.RayClusterName is reset
-		// below, since CleanupOnCompletion relies on it to locate the PodGroup. Requeue on failure
-		// so the cleanup is retried while still in the Suspending status, rather than leaking the
-		// PodGroup once the status transitions to Suspended (which is no longer requeued).
 		if err := r.cleanupBatchSchedulerResources(ctx, rayJobInstance); err != nil {
 			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 		}
@@ -415,7 +408,11 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		// The RayJob is already suspended, we should not requeue it.
 		return ctrl.Result{}, nil
 	case rayv1.JobDeploymentStatusComplete, rayv1.JobDeploymentStatusFailed:
-		defer r.batchSchedulerOnCompletion(ctx, rayJobInstance)
+		defer func() {
+			if err := r.cleanupBatchSchedulerResources(ctx, rayJobInstance); err != nil {
+				logger.Error(err, "Failed to cleanup batch scheduler resources")
+			}
+		}()
 
 		// The RayJob has reached a terminal state. Handle the cleanup and deletion logic.
 		// If the RayJob uses an existing RayCluster, we must not delete it.
@@ -1563,8 +1560,7 @@ func (r *RayJobReconciler) isDeletionActionCompleted(ctx context.Context, rayJob
 
 // cleanupBatchSchedulerResources cleans up batch scheduler resources (e.g., zeroes out the Volcano
 // PodGroup) for the given RayJob and returns an error if the cleanup failed. Callers that must
-// guarantee the resources are released (e.g., suspend) should requeue on error; callers handling a
-// terminal state can swallow the error via batchSchedulerOnCompletion.
+// guarantee the resources are released (e.g., suspend) should requeue on error.
 func (r *RayJobReconciler) cleanupBatchSchedulerResources(ctx context.Context, rayJobInstance *rayv1.RayJob) error {
 	if r.options.BatchSchedulerManager == nil {
 		return nil
@@ -1586,15 +1582,6 @@ func (r *RayJobReconciler) cleanupBatchSchedulerResources(ctx context.Context, r
 			"Cleaned up batch scheduler resources for RayJob %s/%s", rayJobInstance.Namespace, rayJobInstance.Name)
 	}
 	return nil
-}
-
-// batchSchedulerOnCompletion performs cleanup of batch scheduler resources when a RayJob reaches
-// complete/failed status. Cleanup failures are logged but not propagated, since a terminal RayJob
-// will not be requeued.
-func (r *RayJobReconciler) batchSchedulerOnCompletion(ctx context.Context, rayJobInstance *rayv1.RayJob) {
-	if err := r.cleanupBatchSchedulerResources(ctx, rayJobInstance); err != nil {
-		ctrl.LoggerFrom(ctx).Error(err, "Failed to cleanup batch scheduler resources")
-	}
 }
 
 // selectMostImpactfulRule finds the rule with the most destructive policy from a given list.

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -943,3 +943,136 @@ func TestBatchSchedulerOnCompletionCalledWhenRayJobComplete(t *testing.T) {
 		})
 	}
 }
+
+// TestBatchSchedulerCleanupCalledWhenRayJobSuspending verifies that batch scheduler resources are
+// cleaned up when a RayJob is suspended/retrying. Unlike the terminal (Complete/Failed) path, the
+// suspend path must requeue on cleanup failure rather than swallow the error, otherwise the PodGroup
+// would leak once the status transitions to Suspended (which is no longer requeued).
+func TestBatchSchedulerCleanupCalledWhenRayJobSuspending(t *testing.T) {
+	tests := []struct {
+		name                string
+		jobDeploymentStatus rayv1.JobDeploymentStatus
+		expectedStatus      rayv1.JobDeploymentStatus
+		cleanupErr          error
+		cleanupDidUpdate    bool
+		expectReconcileErr  bool
+		expectCleanupEvent  string
+	}{
+		{
+			name:                "Suspending - cleanup succeeds, transitions to Suspended",
+			jobDeploymentStatus: rayv1.JobDeploymentStatusSuspending,
+			expectedStatus:      rayv1.JobDeploymentStatusSuspended,
+			cleanupDidUpdate:    true,
+			expectCleanupEvent:  string(utils.BatchSchedulerCleanedUp),
+		},
+		{
+			name:                "Retrying - cleanup succeeds, transitions to New",
+			jobDeploymentStatus: rayv1.JobDeploymentStatusRetrying,
+			expectedStatus:      rayv1.JobDeploymentStatusNew,
+			cleanupDidUpdate:    true,
+			expectCleanupEvent:  string(utils.BatchSchedulerCleanedUp),
+		},
+		{
+			name:                "Suspending - cleanup fails, requeues and stays Suspending",
+			jobDeploymentStatus: rayv1.JobDeploymentStatusSuspending,
+			expectedStatus:      rayv1.JobDeploymentStatusSuspending,
+			cleanupErr:          errors.New("cleanup failed"),
+			expectReconcileErr:  true,
+			expectCleanupEvent:  string(utils.FailedToCleanupBatchScheduler),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			newScheme := runtime.NewScheme()
+			_ = rayv1.AddToScheme(newScheme)
+			_ = batchv1.AddToScheme(newScheme)
+
+			rayJob := &rayv1.RayJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-rayjob",
+					Namespace: "default",
+				},
+				Spec: rayv1.RayJobSpec{
+					Entrypoint: "echo hello",
+					RayClusterSpec: &rayv1.RayClusterSpec{
+						HeadGroupSpec: rayv1.HeadGroupSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "ray-head",
+											Image: "rayproject/ray:latest",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: rayv1.RayJobStatus{
+					JobDeploymentStatus: tc.jobDeploymentStatus,
+					// The RayCluster and submitter Job are intentionally absent from the fake client,
+					// so deleteClusterResources/deleteSubmitterJob treat them as already deleted and
+					// the reconcile proceeds to the batch scheduler cleanup.
+					RayClusterName: "test-raycluster",
+				},
+			}
+
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(newScheme).
+				WithRuntimeObjects(rayJob).
+				WithStatusSubresource(rayJob).
+				Build()
+
+			fakeScheduler := &fakeBatchScheduler{
+				cleanupDidUpdate: tc.cleanupDidUpdate,
+				cleanupErr:       tc.cleanupErr,
+			}
+			schedulerManager := batchscheduler.NewSchedulerManagerForTest(fakeScheduler)
+
+			recorder := record.NewFakeRecorder(100)
+
+			reconciler := &RayJobReconciler{
+				Client:   fakeClient,
+				Recorder: recorder,
+				Scheme:   newScheme,
+				options: RayJobReconcilerOptions{
+					BatchSchedulerManager: schedulerManager,
+				},
+			}
+
+			ctx := context.Background()
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      rayJob.Name,
+					Namespace: rayJob.Namespace,
+				},
+			})
+			if tc.expectReconcileErr {
+				require.Error(t, err, "Reconcile should requeue with an error when cleanup fails during suspend")
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.True(t, fakeScheduler.cleanupCalled, "CleanupOnCompletion should have been called when RayJob is in %s status", tc.jobDeploymentStatus)
+			assert.Equal(t, rayJob.Name, fakeScheduler.cleanupObject.GetName(), "CleanupOnCompletion should receive the correct RayJob object")
+
+			updated := &rayv1.RayJob{}
+			require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: rayJob.Name, Namespace: rayJob.Namespace}, updated))
+			assert.Equal(t, tc.expectedStatus, updated.Status.JobDeploymentStatus)
+
+			if tc.expectCleanupEvent != "" {
+				var foundEvent bool
+				for len(recorder.Events) > 0 {
+					event := <-recorder.Events
+					if strings.Contains(event, tc.expectCleanupEvent) {
+						foundEvent = true
+						break
+					}
+				}
+				assert.True(t, foundEvent, "Expected event %q to be emitted", tc.expectCleanupEvent)
+			}
+		})
+	}
+}

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -948,7 +948,7 @@ func TestBatchSchedulerOnCompletionCalledWhenRayJobComplete(t *testing.T) {
 // cleaned up when a RayJob is suspended/retrying. Unlike the terminal (Complete/Failed) path, the
 // suspend path must requeue on cleanup failure rather than swallow the error, otherwise the PodGroup
 // would leak once the status transitions to Suspended (which is no longer requeued).
-func TestBatchSchedulerCleanupCalledWhenRayJobSuspending(t *testing.T) {
+func TestBatchSchedulerCleanupCalledWhenRayJobSuspendingOrRetrying(t *testing.T) {
 	tests := []struct {
 		name                string
 		jobDeploymentStatus rayv1.JobDeploymentStatus
@@ -976,6 +976,14 @@ func TestBatchSchedulerCleanupCalledWhenRayJobSuspending(t *testing.T) {
 			name:                "Suspending - cleanup fails, requeues and stays Suspending",
 			jobDeploymentStatus: rayv1.JobDeploymentStatusSuspending,
 			expectedStatus:      rayv1.JobDeploymentStatusSuspending,
+			cleanupErr:          errors.New("cleanup failed"),
+			expectReconcileErr:  true,
+			expectCleanupEvent:  string(utils.FailedToCleanupBatchScheduler),
+		},
+		{
+			name:                "Retrying - cleanup fails, requeues and stays Retrying",
+			jobDeploymentStatus: rayv1.JobDeploymentStatusRetrying,
+			expectedStatus:      rayv1.JobDeploymentStatusRetrying,
 			cleanupErr:          errors.New("cleanup failed"),
 			expectReconcileErr:  true,
 			expectCleanupEvent:  string(utils.FailedToCleanupBatchScheduler),
@@ -1050,12 +1058,12 @@ func TestBatchSchedulerCleanupCalledWhenRayJobSuspending(t *testing.T) {
 				},
 			})
 			if tc.expectReconcileErr {
-				require.Error(t, err, "Reconcile should requeue with an error when cleanup fails during suspend")
+				require.Error(t, err, "Reconcile should requeue with an error when cleanup fails during suspend/retry")
 			} else {
 				require.NoError(t, err)
 			}
 
-			assert.True(t, fakeScheduler.cleanupCalled, "CleanupOnCompletion should have been called when RayJob is in %s status", tc.jobDeploymentStatus)
+			require.True(t, fakeScheduler.cleanupCalled, "CleanupOnCompletion should have been called when RayJob is in %s status", tc.jobDeploymentStatus)
 			assert.Equal(t, rayJob.Name, fakeScheduler.cleanupObject.GetName(), "CleanupOnCompletion should receive the correct RayJob object")
 
 			updated := &rayv1.RayJob{}


### PR DESCRIPTION
## Why are these changes needed?

When a RayJob is suspended, the reconciler deletes its RayCluster to release
compute resources. However, when gang scheduling is enabled, the Volcano
`PodGroup` for a RayJob is owned by the **RayJob** itself, not by the RayCluster.
As a result it is **not** garbage-collected when the cluster is deleted, and its
`MinMember` / `MinResources` stay at the pre-suspend values.

Volcano keeps reserving that capacity against the queue for a job that no longer
has any running pods, so a suspended RayJob silently holds queue resources and
can block other jobs in the same queue.

The terminal (Complete/Failed) path already cleans this up via
`batchSchedulerOnCompletion`, but the Suspending/Retrying path did not.

This PR:

- Invokes the batch scheduler's `CleanupOnCompletion` in the
  `Suspending`/`Retrying` branch, **before** `Status.RayClusterName` is reset
  (the cleanup relies on it to locate the PodGroup). With the cluster gone, the
  PodGroup is recalculated to empty resources, so it no longer reserves queue
  capacity.
- Requeues on cleanup failure while still in `Suspending`, so the cleanup is
  retried instead of leaking the PodGroup once the status transitions to
  `Suspended` (which is no longer requeued).
- Refactors the shared logic into `cleanupBatchSchedulerResources`, which returns
  an error. The suspend path propagates it (requeue); the terminal path keeps the
  previous log-and-continue behavior via `batchSchedulerOnCompletion`, since a
  terminal RayJob is not requeued.

This is a no-op when no batch scheduler is configured (the default scheduler
performs no cleanup).

## Related issue number

Closes #4939

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

Unit test: `TestBatchSchedulerCleanupCalledWhenRayJobSuspending` covers that the
batch scheduler cleanup is invoked on the Suspending/Retrying path, transitions
the status on success, and requeues (returns an error) without transitioning to
Suspended when cleanup fails.

Manual test: with `--batch-scheduler=volcano`, ran a RayJob with a Volcano queue,
then set `suspend: true`. Before the change the RayJob's PodGroup remained with
its old `MinMember`/`MinResources` (still reserving queue capacity); after the
change the PodGroup is recalculated to empty resources on suspend.
