### PR TITLE
[RayJob][SidecarMode] Optionally wait for head-node schedulability before submit (prevent counterpart to #4399)

### DIFF
--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -133,11 +133,17 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 	// In SidecarMode the submitter shares the head Pod's network namespace, so we
 	// probe localhost. In K8sJobMode the submitter runs in a separate Pod and must
 	// reach the dashboard through the head Service.
+	healthPath := utils.RayDashboardGCSHealthPath
+	healthWaitMsg := "Waiting for Ray Dashboard GCS to become healthy at "
+	if submissionMode == rayv1.SidecarMode && features.Enabled(features.SidecarWaitForHeadSchedulable) {
+		healthPath = utils.RayNodeSchedulableHealthPath
+		healthWaitMsg = "Waiting for Ray head node to become schedulable at "
+	}
 	var healthURL string
 	if submissionMode == rayv1.SidecarMode {
-		healthURL = fmt.Sprintf("http://localhost:%d/%s", port, utils.RayDashboardGCSHealthPath)
+		healthURL = fmt.Sprintf("http://localhost:%d/%s", port, healthPath)
 	} else {
-		healthURL = address + "/" + utils.RayDashboardGCSHealthPath
+		healthURL = address + "/" + healthPath
 	}
 	rayDashboardGCSHealthCommand := fmt.Sprintf(
 		utils.BasePythonHealthCommand,
@@ -147,7 +153,7 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 
 	waitLoop := []string{
 		"until", rayDashboardGCSHealthCommand, ">/dev/null", "2>&1", ";",
-		"do", "echo", strconv.Quote("Waiting for Ray Dashboard GCS to become healthy at " + address + " ..."), ";", "sleep", "2", ";", "done", ";",
+		"do", "echo", strconv.Quote(healthWaitMsg + address + " ..."), ";", "sleep", "2", ";", "done", ";",
 	}
 	cmd = append(cmd, waitLoop...)
 

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -260,6 +261,35 @@ func TestBuildJobSubmitCommandWithSidecarModeAndFeatureGate(t *testing.T) {
 	command, err := BuildJobSubmitCommand(testRayJob, rayv1.SidecarMode)
 	require.NoError(t, err)
 	assert.Equal(t, expected, command)
+}
+
+func TestBuildJobSubmitCommandWithSidecarModeWaitForHeadSchedulable(t *testing.T) {
+	testRayJob := rayJobTemplate()
+	testRayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers = []corev1.Container{
+		{
+			Ports: []corev1.ContainerPort{
+				{
+					Name:          utils.DashboardPortName,
+					ContainerPort: utils.DefaultDashboardPort,
+				},
+			},
+		},
+	}
+
+	// Gate off (default): wait on GCS health, not node-schedulable.
+	commandGateOff, err := BuildJobSubmitCommand(testRayJob, rayv1.SidecarMode)
+	require.NoError(t, err)
+	joinedOff := strings.Join(commandGateOff, " ")
+	assert.Contains(t, joinedOff, utils.RayDashboardGCSHealthPath)
+	assert.NotContains(t, joinedOff, utils.RayNodeSchedulableHealthPath)
+
+	// Gate on: node-schedulable wait replaces the GCS wait (it subsumes GCS health).
+	features.SetFeatureGateDuringTest(t, features.SidecarWaitForHeadSchedulable, true)
+	commandGateOn, err := BuildJobSubmitCommand(testRayJob, rayv1.SidecarMode)
+	require.NoError(t, err)
+	joinedOn := strings.Join(commandGateOn, " ")
+	assert.Contains(t, joinedOn, utils.RayNodeSchedulableHealthPath)
+	assert.NotContains(t, joinedOn, utils.RayDashboardGCSHealthPath)
 }
 
 func TestBuildJobSubmitCommandWithK8sJobModeAndYAML(t *testing.T) {

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -267,6 +267,7 @@ const (
 	// TODO (kevin85421): Should we take the dashboard process into account?
 	RayAgentRayletHealthPath                 = "api/local_raylet_healthz"
 	RayDashboardGCSHealthPath                = "api/gcs_healthz"
+	RayNodeSchedulableHealthPath             = "api/node_schedulable_healthz"
 	RayDashboardGCSHealthCheckTimeoutSeconds = 10
 	RayServeProxyHealthPath                  = "-/healthz"
 	// BaseWgetHealthCommand checks a single health URL; args: timeout_sec, port, path (no leading slash).

--- a/ray-operator/pkg/features/features.go
+++ b/ray-operator/pkg/features/features.go
@@ -56,6 +56,13 @@ const (
 	// Requires Kubernetes v1.35+ since it supports ContainerRestartPolicy by default starting in v1.35 and Ray v2.54.0+.
 	SidecarSubmitterRestart featuregate.Feature = "SidecarSubmitterRestart"
 
+	// owner: @tmrtmrtmrtmr
+	// rep: N/A
+	// alpha: v1.7
+	//
+	// Makes the SidecarMode submitter wait until the head node is schedulable before submitting.
+	SidecarWaitForHeadSchedulable featuregate.Feature = "SidecarWaitForHeadSchedulable"
+
 	// owner: @chipspeak @kryanbeane
 	// rep: N/A
 	// alpha: v1.7
@@ -69,13 +76,14 @@ func init() {
 }
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	RayClusterStatusConditions:   {Default: true, PreRelease: featuregate.Beta},
-	RayJobDeletionPolicy:         {Default: true, PreRelease: featuregate.Beta},
-	RayMultiHostIndexing:         {Default: true, PreRelease: featuregate.Beta},
-	RayServiceIncrementalUpgrade: {Default: false, PreRelease: featuregate.Alpha},
-	RayCronJob:                   {Default: false, PreRelease: featuregate.Alpha},
-	SidecarSubmitterRestart:      {Default: false, PreRelease: featuregate.Alpha},
-	RayClusterNetworkIsolation:   {Default: false, PreRelease: featuregate.Alpha},
+	RayClusterStatusConditions:    {Default: true, PreRelease: featuregate.Beta},
+	RayJobDeletionPolicy:          {Default: true, PreRelease: featuregate.Beta},
+	RayMultiHostIndexing:          {Default: true, PreRelease: featuregate.Beta},
+	RayServiceIncrementalUpgrade:  {Default: false, PreRelease: featuregate.Alpha},
+	RayCronJob:                    {Default: false, PreRelease: featuregate.Alpha},
+	SidecarSubmitterRestart:       {Default: false, PreRelease: featuregate.Alpha},
+	SidecarWaitForHeadSchedulable: {Default: false, PreRelease: featuregate.Alpha},
+	RayClusterNetworkIsolation:    {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // SetFeatureGateDuringTest is a helper method to override feature gates in tests.


### PR DESCRIPTION
## Why are these changes needed?

In SidecarMode, the submitter waits only for `api/gcs_healthz` before `ray job submit`. That reflects GCS-process liveness, not head-node schedulability: when the entrypoint runs as the default head-pinned driver, there is a bootstrap window where GCS is up but the head node is not yet in the GCS actor-scheduler resource view, so the supervisor actor (`soft=False`) is transiently infeasible and the job fails.

This adds an alpha feature gate `SidecarWaitForHeadSchedulable` (off by default). When enabled, the SidecarMode submitter waits on `api/node_schedulable_healthz` instead of `api/gcs_healthz` — that endpoint reflects resource-view membership, which subsumes GCS health, so it replaces (not stacks) the existing wait. The job is only submitted once the head node is actually placeable.

This is the prevent counterpart to the restart-based recovery in #4399 (`SidecarSubmitterRestart`); the two are complementary. Off by default because the endpoint is new in Ray (ray-project/ray#64287, design ray-project/ray#64285) — enabling it against an older Ray would loop forever.

## Related issue number

Implements ray-project/kuberay#4943. Related to #4399. Depends on ray-project/ray#64287.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests (`go test ./controllers/ray/common/...`): gate off keeps the GCS wait byte-identical; gate on swaps it to the schedulable wait (asserts the GCS path is gone and the schedulable path is present).
