### PR TITLE
[History Server] Replace private getter assertions with BuildSnapshot() in history server unit tests

### DIFF
--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -652,7 +652,8 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 			}
 
 			// Get the actor and verify
-			actor, found := h.BuildSnapshot(clusterInfo).Actors[testActorID]
+			snap := h.BuildSnapshot(clusterInfo)
+			actor, found := snap.Actors[testActorID]
 			if !found {
 				t.Fatal("Actor not found after processing")
 			}
@@ -819,7 +820,8 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
-			job, exists := h.BuildSnapshot(clusterInfo).Jobs[testJobID]
+			snap := h.BuildSnapshot(clusterInfo)
+			job, exists := snap.Jobs[testJobID]
 			if !exists {
 				t.Fatal("Job not found after processing")
 			}
@@ -1075,15 +1077,15 @@ func TestProcessSingleSession(t *testing.T) {
 		err = h.ProcessSingleSession(context.Background(), clusterInfo)
 		require.NoError(t, err)
 
-		nodes := h.BuildSnapshot(clusterInfo).Nodes
-		assert.Len(t, nodes, 2)
+		snap := h.BuildSnapshot(clusterInfo)
+		assert.Len(t, snap.Nodes, 2)
 
 		// "YWJjZA==" -> hex "61626364" (abcd)
-		_, ok := nodes["61626364"]
+		_, ok := snap.Nodes["61626364"]
 		assert.True(t, ok, "node1 (compressed) should be successfully loaded")
 
 		// "ZWZnaA==" -> hex "65666768" (efgh)
-		_, ok = nodes["65666768"]
+		_, ok = snap.Nodes["65666768"]
 		assert.True(t, ok, "node2 (uncompressed) should be successfully loaded")
 	})
 }

--- a/historyserver/pkg/eventserver/eventserver_test.go
+++ b/historyserver/pkg/eventserver/eventserver_test.go
@@ -519,10 +519,12 @@ func TestTaskLifecycleEventDeduplication(t *testing.T) {
 func TestActorLifecycleEventDeduplication(t *testing.T) {
 	// IDs follow Ray's ID spec; see TestStoreEvent for rationale.
 	const (
-		testJobID       = "aaaabbbb"                             // 4B
-		testActorID     = "aaaabbbb1234aaaabbbb1234" + testJobID // 12B unique + JobID
-		testClusterName = "cluster1"
+		testJobID   = "aaaabbbb"                             // 4B
+		testActorID = "aaaabbbb1234aaaabbbb1234" + testJobID // 12B unique + JobID
 	)
+
+	clusterInfo := utils.ClusterInfo{Name: "cluster", Namespace: "ns", SessionName: "session1"}
+	clusterSessionKey := utils.BuildClusterSessionKey(clusterInfo.Name, clusterInfo.Namespace, clusterInfo.SessionName)
 
 	// Helper to create an ActorStateEvent
 	makeActorStateEvent := func(state types.StateType, timestampNano int64) types.ActorStateEvent {
@@ -632,7 +634,7 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 
 			// Pre-populate existing events
 			if len(tt.existingEvents) > 0 {
-				actorMap := h.ClusterActorMap.GetOrCreateActorMap(testClusterName)
+				actorMap := h.ClusterActorMap.GetOrCreateActorMap(clusterSessionKey)
 				actorMap.CreateOrMergeActor(testActorID, func(a *types.Actor) {
 					a.ActorID = testActorID
 					a.Events = tt.existingEvents
@@ -644,13 +646,13 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 
 			// Process the lifecycle event
 			eventMap := makeActorLifecycleEvent(tt.newTransitions)
-			err := h.storeEvent(testClusterName, eventMap)
+			err := h.storeEvent(clusterSessionKey, eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
 			// Get the actor and verify
-			actor, found := h.getActorsMap(testClusterName)[testActorID]
+			actor, found := h.BuildSnapshot(clusterInfo).Actors[testActorID]
 			if !found {
 				t.Fatal("Actor not found after processing")
 			}
@@ -672,10 +674,10 @@ func TestActorLifecycleEventDeduplication(t *testing.T) {
 // TODO(chiayi): Update once more fields are added to driver job event
 func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 	// IDs follow Ray's ID spec; see TestStoreEvent for rationale.
-	const (
-		testJobID       = "aaaabbbb" // 4B
-		testClusterName = "cluster1"
-	)
+	const testJobID = "aaaabbbb" // 4B
+
+	clusterInfo := utils.ClusterInfo{Name: "cluster", Namespace: "ns", SessionName: "session1"}
+	clusterSessionKey := utils.BuildClusterSessionKey(clusterInfo.Name, clusterInfo.Namespace, clusterInfo.SessionName)
 
 	makeDriverJobStateTransitionEvent := func(state types.JobState, timestampNano int64) types.JobStateTransition {
 		return types.JobStateTransition{
@@ -801,7 +803,7 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 			h := NewEventHandler(nil)
 
 			if len(tt.existingTransitions) > 0 {
-				jobMap := h.ClusterJobMap.GetOrCreateJobMap(testClusterName)
+				jobMap := h.ClusterJobMap.GetOrCreateJobMap(clusterSessionKey)
 				jobMap.CreateOrMergeJob(testJobID, func(job *types.Job) {
 					job.JobID = testJobID
 					job.StateTransitions = tt.existingTransitions
@@ -812,12 +814,12 @@ func TestDriverJobLifecycleEventDuplication(t *testing.T) {
 			}
 
 			eventMap := makeDriverJobLifecycleEvent(tt.newTransitions)
-			err := h.storeEvent(testClusterName, eventMap)
+			err := h.storeEvent(clusterSessionKey, eventMap)
 			if err != nil {
 				t.Fatalf("storeEvent() unexpected error: %v", err)
 			}
 
-			job, exists := h.getJobsMap(testClusterName)[testJobID]
+			job, exists := h.BuildSnapshot(clusterInfo).Jobs[testJobID]
 			if !exists {
 				t.Fatal("Job not found after processing")
 			}
@@ -1073,15 +1075,15 @@ func TestProcessSingleSession(t *testing.T) {
 		err = h.ProcessSingleSession(context.Background(), clusterInfo)
 		require.NoError(t, err)
 
-		nodeMap := h.getNodeMap("cluster_ns_session1")
-		assert.Len(t, nodeMap, 2)
+		nodes := h.BuildSnapshot(clusterInfo).Nodes
+		assert.Len(t, nodes, 2)
 
 		// "YWJjZA==" -> hex "61626364" (abcd)
-		_, ok := nodeMap["61626364"]
+		_, ok := nodes["61626364"]
 		assert.True(t, ok, "node1 (compressed) should be successfully loaded")
 
 		// "ZWZnaA==" -> hex "65666768" (efgh)
-		_, ok = nodeMap["65666768"]
+		_, ok = nodes["65666768"]
 		assert.True(t, ok, "node2 (uncompressed) should be successfully loaded")
 	})
 }


### PR DESCRIPTION
## Why are these changes needed?
The unit tests asserted on internal state via the private getters `getActorsMap`, `getJobsMap`, and `getNodeMap`, coupling the tests to implementation details. Since `BuildSnapshot()` is the only exported accessor and is the single source of truth for what we serve, the tests now assert on the snapshot's `Actors`, `Jobs`, and `Nodes` fields instead.

## Related issue number

Closes #4937 
## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
