### PR TITLE
[Refactor] Use RayNodeTypeLabelKey constant in CalculateAvailableRepl…

### DIFF
--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -465,7 +465,7 @@ func CalculateReadyReplicas(pods corev1.PodList) int32 {
 func CalculateAvailableReplicas(pods corev1.PodList) int32 {
 	count := int32(0)
 	for _, pod := range pods.Items {
-		if val, ok := pod.Labels["ray.io/node-type"]; !ok || val != string(rayv1.WorkerNode) {
+		if val, ok := pod.Labels[RayNodeTypeLabelKey]; !ok || val != string(rayv1.WorkerNode) {
 			continue
 		}
 		if pod.Status.Phase == corev1.PodRunning {


### PR DESCRIPTION
## Why are these changes needed?
`CalculateAvailableReplicas` was using the hardcoded string `"ray.io/node-type"`.
This refactor replaces it with the existing `RayNodeTypeLabelKey` constant, matching how the sibling function `CalculateReadyReplicas` already references the label.

## Related issue number

Closes #4948 
## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
