### PR TITLE
kubectl-plugin: add check to prevent directory traversals

### DIFF
--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -422,7 +422,21 @@ func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec 
 		}
 
 		// Construct the full local path and a directory for the tmp file logs
-		localFilePath := filepath.Join(path.Clean(options.outputDir), path.Clean(rayNode.Name), path.Clean(header.Name))
+		basePath := filepath.Join(path.Clean(options.outputDir), path.Clean(rayNode.Name))
+		localFilePath := filepath.Join(basePath, path.Clean(header.Name))
+
+		// Ensure the path is within the intended output directory to prevent directory traversal
+		absBasePath, err := filepath.Abs(basePath)
+		if err != nil {
+			return fmt.Errorf("error resolving absolute path for base directory: %w", err)
+		}
+		absLocalFilePath, err := filepath.Abs(localFilePath)
+		if err != nil {
+			return fmt.Errorf("error resolving absolute path for file %s: %w", header.Name, err)
+		}
+		if absLocalFilePath != absBasePath && !strings.HasPrefix(absLocalFilePath, absBasePath+string(filepath.Separator)) {
+			return fmt.Errorf("illegal file path in tar archive: %s", header.Name)
+		}
 
 		switch header.Typeflag {
 		case tar.TypeDir:

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -484,6 +484,62 @@ func TestDownloadRayLogFiles(t *testing.T) {
 	}
 }
 
+// createTraversalTarFile creates a fake tar file containing a path traversal file entry.
+func createTraversalTarFile(path string) (*bytes.Buffer, error) {
+	tarbuff := new(bytes.Buffer)
+	tw := tar.NewWriter(tarbuff)
+
+	hdr := &tar.Header{
+		Name:     path,
+		Mode:     0o644,
+		ModTime:  time.Now(),
+		Size:     int64(len("traversal content\n")),
+		Typeflag: tar.TypeReg,
+	}
+
+	if err := tw.WriteHeader(hdr); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write([]byte("traversal content\n")); err != nil {
+		return nil, err
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	return tarbuff, nil
+}
+
+func TestDownloadRayLogFiles_TraversalPrevention(t *testing.T) {
+	fakeDir, err := os.MkdirTemp("", "fake-directory")
+	require.NoError(t, err)
+	defer os.RemoveAll(fakeDir)
+
+	testStreams, _, _, _ := genericiooptions.NewTestIOStreams()
+	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+
+	fakeClusterLogOptions := NewClusterLogOptions(cmdFactory, testStreams)
+	fakeClusterLogOptions.ResourceName = "test-cluster"
+	fakeClusterLogOptions.outputDir = fakeDir
+
+	// create malicious tar file targeting ../outside.txt
+	fakeTar, err := createTraversalTarFile("../outside.txt")
+	require.NoError(t, err)
+
+	rayHead := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-kuberay-head-1",
+			Namespace: "test",
+		},
+	}
+
+	executor, _ := fakeNewSPDYExecutor("GET", &url.URL{}, fakeTar)
+
+	err = fakeClusterLogOptions.downloadRayLogFiles(context.Background(), executor, rayHead)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "illegal file path in tar archive")
+}
+
 // createTempKubeConfigFile creates a temporary kubeconfig file with the given current context.
 func createTempKubeConfigFile(t *testing.T, currentContext string) (string, error) {
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Why are these changes needed?

Add a check to avoid directory traversals when downloading logs with kubectl plugin

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
