### PR TITLE
ray-operator: disallow overriding Serve Service names

### DIFF
--- a/ray-operator/controllers/ray/common/association.go
+++ b/ray-operator/controllers/ray/common/association.go
@@ -140,12 +140,7 @@ func RayServiceRayClustersAssociationOptions(rayService *rayv1.RayService) Assoc
 }
 
 func RayServiceServeServiceNamespacedName(rayService *rayv1.RayService) types.NamespacedName {
-	if rayService.Spec.ServeService != nil && rayService.Spec.ServeService.Name != "" {
-		return types.NamespacedName{
-			Namespace: rayService.Namespace, // We do not respect s.Spec.ServeService.Namespace intentionally. Ref: https://github.com/ray-project/kuberay/blob/f6b4c3126654d1ef42965abc781846624b8e5dfc/ray-operator/controllers/ray/common/service.go#L298
-			Name:      rayService.Spec.ServeService.Name,
-		}
-	}
+	// We intentionally do not respect s.Spec.ServceService.Namespace or s.Spec.ServceService.Name
 	return types.NamespacedName{
 		Namespace: rayService.Namespace,
 		Name:      utils.GenerateServeServiceName(rayService.Name),

--- a/ray-operator/controllers/ray/common/association_test.go
+++ b/ray-operator/controllers/ray/common/association_test.go
@@ -40,7 +40,7 @@ func TestRayServiceServeServiceNamespacedNameForUserSpecifiedServeService(t *tes
 	namespaced := RayServiceServeServiceNamespacedName(testRayServiceWithServeService)
 	assert.Equal(t, svc.Namespace, namespaced.Namespace)
 	assert.Equal(t, svc.Name, namespaced.Name)
-	assert.Equal(t, "user-custom-name", namespaced.Name)
+	assert.Equal(t, "rayservice-sample-serve-svc", namespaced.Name)
 }
 
 // TestRayClusterServeServiceNamespacedName tests the function for generating a NamespacedName for a RayCluster's serve service

--- a/ray-operator/controllers/ray/common/service.go
+++ b/ray-operator/controllers/ray/common/service.go
@@ -61,7 +61,7 @@ func BuildServiceForHeadPod(ctx context.Context, cluster rayv1.RayCluster, label
 		annotations = make(map[string]string)
 	}
 
-	defaultName, err := utils.GenerateHeadServiceName(utils.RayClusterCRD, cluster.Spec, cluster.Name)
+	headServiceName, err := utils.GenerateHeadServiceName(utils.RayClusterCRD, cluster.Spec, cluster.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -80,6 +80,7 @@ func BuildServiceForHeadPod(ctx context.Context, cluster rayv1.RayCluster, label
 		// Use the provided "custom" HeadService.
 		// Deep copy the HeadService to avoid modifying the original object
 		headService := cluster.Spec.HeadGroupSpec.HeadService.DeepCopy()
+		headService.Name = headServiceName
 
 		// For the selector, ignore any custom HeadService selectors or labels.
 		headService.Spec.Selector = selector
@@ -104,7 +105,6 @@ func BuildServiceForHeadPod(ctx context.Context, cluster rayv1.RayCluster, label
 		headService.Spec.Ports = append(headService.Spec.Ports, ports...)
 
 		setLabelsforUserProvidedService(headService, labelsForService)
-		setNameforUserProvidedService(ctx, headService, defaultName)
 		setNamespaceforUserProvidedService(ctx, headService, defaultNamespace)
 		setServiceTypeForUserProvidedService(ctx, headService, defaultType)
 
@@ -113,7 +113,7 @@ func BuildServiceForHeadPod(ctx context.Context, cluster rayv1.RayCluster, label
 
 	headService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        defaultName,
+			Name:        headServiceName,
 			Namespace:   defaultNamespace,
 			Labels:      labelsForService,
 			Annotations: annotations,
@@ -204,7 +204,7 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 		selectorLabels[utils.RayClusterServingServiceLabelKey] = utils.EnableRayClusterServingServiceTrue
 	}
 
-	defaultName := utils.GenerateServeServiceName(name)
+	serveServiceName := utils.GenerateServeServiceName(name)
 	defaultNamespace := namespace
 	defaultType := rayCluster.Spec.HeadGroupSpec.ServiceType
 	if isRayService {
@@ -234,6 +234,7 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 			// Use the provided "custom" ServeService.
 			// Deep copy the ServeService to avoid modifying the original object
 			serveService := rayService.Spec.ServeService.DeepCopy()
+			serveService.Name = serveServiceName
 
 			// For the selector, ignore any custom ServeService selectors or labels.
 			serveService.Spec.Selector = selectorLabels
@@ -265,7 +266,6 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 			}
 
 			setLabelsforUserProvidedService(serveService, labels)
-			setNameforUserProvidedService(ctx, serveService, defaultName)
 			setNamespaceforUserProvidedService(ctx, serveService, defaultNamespace)
 			setServiceTypeForUserProvidedService(ctx, serveService, defaultType)
 
@@ -281,7 +281,7 @@ func BuildServeService(ctx context.Context, rayService rayv1.RayService, rayClus
 
 	serveService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      defaultName,
+			Name:      serveServiceName,
 			Namespace: defaultNamespace,
 			Labels:    labels,
 		},
@@ -375,19 +375,6 @@ func setNamespaceforUserProvidedService(ctx context.Context, service *corev1.Ser
 	}
 
 	service.ObjectMeta.Namespace = defaultNamespace
-}
-
-func setNameforUserProvidedService(ctx context.Context, service *corev1.Service, defaultName string) {
-	log := ctrl.LoggerFrom(ctx)
-	// If the user has not specified a name, use the default name passed
-	if service.ObjectMeta.Name == "" {
-		log.Info("Using default name for user provided service.", "default_name", defaultName)
-		service.ObjectMeta.Name = defaultName
-	} else {
-		log.Info("Overriding default name for user provided service with name in service.ObjectMeta.Name.",
-			"default_name", defaultName,
-			"provided_name", service.ObjectMeta.Name)
-	}
 }
 
 func setLabelsforUserProvidedService(service *corev1.Service, labels map[string]string) {

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -492,6 +492,10 @@ func ValidateRayServiceSpec(rayService *rayv1.RayService) error {
 		return fmt.Errorf("The RayService spec is invalid: spec.rayClusterConfig.headGroupSpec.headService.metadata.name should not be set")
 	}
 
+	if serveSvc := rayService.Spec.ServeService; serveSvc != nil && serveSvc.Name != "" {
+		return fmt.Errorf("The RayService spec is invalid: spec.serveService.metadata.name should not be set")
+	}
+
 	// only NewClusterWithIncrementalUpgrade, NewCluster, and None are valid upgradeType
 	if rayService.Spec.UpgradeStrategy != nil &&
 		rayService.Spec.UpgradeStrategy.Type != nil &&

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -1866,6 +1866,18 @@ func TestValidateRayServiceSpec(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "spec.serveService.metadata.name should not be set",
+			spec: rayv1.RayServiceSpec{
+				ServeService: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-serve-service",
+					},
+				},
+				RayClusterSpec: *createBasicRayClusterSpec(),
+			},
+			expectError: true,
+		},
+		{
 			name: "The RayService spec is valid.",
 			spec: rayv1.RayServiceSpec{
 				RayClusterSpec: *createBasicRayClusterSpec(),


### PR DESCRIPTION
## Why are these changes needed?

Similar to how we have validation for Head Services to disallow name overrides, we should similarly have validation for Serve services. The embedded Service is for overriding fields in Service.Spec but not the name itself.  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
