### PR TITLE
[History server] Add per-session meta.json for session lifecycle tracking

### DIFF
--- a/historyserver/cmd/collector/main.go
+++ b/historyserver/cmd/collector/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/eventcollector"
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/logcollector/runtime"
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
@@ -130,6 +131,23 @@ func main() {
 		panic(fmt.Sprintf("Failed to create writer for runtime class name: %s for role: %s, err: %+v", runtimeClassName, role, err))
 	}
 
+	// Create a storage reader for finalizing previous in_progress sessions.
+	readerRegistry := collector.GetReaderRegistry()
+	readerFactory, readerOk := readerRegistry[runtimeClassName]
+	var reader storage.StorageReader
+	if readerOk {
+		readerConfig := types.RayHistoryServerConfig{
+			RootDir: globalConfig.RootDir,
+		}
+		var readerErr error
+		reader, readerErr = readerFactory(&readerConfig, jsonData)
+		if readerErr != nil {
+			logrus.Warnf("Failed to create storage reader (old session finalization disabled): %v", readerErr)
+		}
+	} else {
+		logrus.Warnf("No reader registered for runtime class %q (old session finalization disabled)", runtimeClassName)
+	}
+
 	var wg sync.WaitGroup
 
 	sigChan := make(chan os.Signal, 1)
@@ -148,7 +166,7 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		logCollector := runtime.NewCollector(&globalConfig, writer)
+		logCollector := runtime.NewCollector(&globalConfig, writer, reader)
 		logCollector.Run(stop)
 		logrus.Info("Log collector shutdown")
 	}()

--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
@@ -2,7 +2,9 @@ package logcollector
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
 	"os"
@@ -75,6 +77,12 @@ func (r *RayLogHandler) Run(stop <-chan struct{}) error {
 	<-stop
 	logrus.Info("Received stop signal, processing all logs...")
 	r.processSessionLatestLogs()
+	// Update meta.json to mark the session as completed.
+	// Only the head collector owns the session-wide meta.json — worker
+	// collectors must not overwrite it on shutdown.
+	if r.IsHead {
+		r.updateMetaJsonOnShutdown()
+	}
 	// Perform one final poll of additional endpoints before shutting down.
 	// This must happen before close(r.ShutdownChan) because pollSingleEndpoint
 	// uses ShutdownChan to cancel in-flight HTTP requests.
@@ -84,6 +92,105 @@ func (r *RayLogHandler) Run(stop <-chan struct{}) error {
 	close(r.ShutdownChan)
 
 	return nil
+}
+
+// updateMetaJsonOnShutdown updates the session's meta.json to mark it as completed.
+func (r *RayLogHandler) updateMetaJsonOnShutdown() {
+	sessionLatestDir := utils.GetRaySessionLatestPath()
+	sessionRealDir, err := filepath.EvalSymlinks(sessionLatestDir)
+	if err != nil {
+		logrus.Errorf("Failed to resolve session_latest symlink for meta.json update: %v", err)
+		return
+	}
+	sessionName := filepath.Base(sessionRealDir)
+	metaPath := clustermetadata.MetaJsonPath(utils.ClusterInfo{
+		Name:      r.RayClusterName,
+		Namespace: r.RayClusterNamespace,
+		OwnerKind: r.OwnerKind,
+		OwnerName: r.OwnerName,
+	}, r.RootDir, sessionName)
+
+	startTime, err := utils.GetDateTimeFromSessionID(sessionName)
+	var startUnix int64
+	if err == nil {
+		startUnix = startTime.Unix()
+	}
+
+	// Best-effort: capture the latest Ray resource status during termination.
+	rayStatus := r.fetchRayStatusOnShutdown()
+	meta := utils.MetaJson{
+		SessionName:      sessionName,
+		ClusterID:        r.RayClusterName,
+		ClusterNamespace: r.RayClusterNamespace,
+		StartTime:        startUnix,
+		EndTime:          time.Now().Unix(),
+		Status:           utils.SessionStatusCompleted,
+		RayStatus:        rayStatus,
+	}
+	if err := r.Writer.WriteMeta(metaPath, meta); err != nil {
+		logrus.Errorf("Failed to update meta.json on shutdown %s: %v", metaPath, err)
+	} else {
+		logrus.Infof("Updated meta.json to completed for session %s", sessionName)
+	}
+}
+
+// fetchRayStatusOnShutdown attempts a best-effort fetch of the Ray resource
+// status from the dashboard during collector termination. Uses a short timeout
+// to avoid blocking shutdown.
+//
+// NOTE: Uses /api/v0/cluster_status (v0 prefix) which is available in Ray >= 2.x.
+func (r *RayLogHandler) fetchRayStatusOnShutdown() string {
+	if r.DashboardAddress == "" || r.HttpClient == nil {
+		return ""
+	}
+	url := r.DashboardAddress + "/api/v0/cluster_status"
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return ""
+	}
+	resp, err := r.HttpClient.Do(req)
+	if err != nil {
+		logrus.Debugf("Ray status fetch skipped (dashboard unreachable): %v", err)
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return ""
+	}
+	return string(body)
+}
+
+// writeMetaJsonInProgress writes a meta.json with in_progress status for a new session.
+// Called only when a new session is first discovered (WatchSessionLatestLoops).
+func (r *RayLogHandler) writeMetaJsonInProgress(sessionID string) {
+	sessionBase := path.Base(sessionID)
+	metaPath := clustermetadata.MetaJsonPath(utils.ClusterInfo{
+		Name:      r.RayClusterName,
+		Namespace: r.RayClusterNamespace,
+		OwnerKind: r.OwnerKind,
+		OwnerName: r.OwnerName,
+	}, r.RootDir, sessionBase)
+	startTime, parseErr := utils.GetDateTimeFromSessionID(sessionBase)
+	var startUnix int64
+	if parseErr == nil {
+		startUnix = startTime.Unix()
+	}
+	meta := utils.MetaJson{
+		SessionName:      sessionBase,
+		ClusterID:        r.RayClusterName,
+		ClusterNamespace: r.RayClusterNamespace,
+		StartTime:        startUnix,
+		Status:           utils.SessionStatusInProgress,
+	}
+	if err := r.Writer.WriteMeta(metaPath, meta); err != nil {
+		logrus.Errorf("Failed to write meta.json %s: %v", metaPath, err)
+	}
 }
 
 // processSessionLatestLogs processes logs in the configured session_latest/logs directory
@@ -767,6 +874,9 @@ func (r *RayLogHandler) WatchSessionLatestLoops() {
 					logrus.Errorf("Failed to write session file %s error %v", metafile, err)
 					return
 				}
+
+				// Write meta.json for session lifecycle tracking
+				r.writeMetaJsonInProgress(sessionID)
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok {

--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
@@ -24,7 +24,9 @@ import (
 
 type RayLogHandler struct {
 	Writer                 storage.StorageWriter
+	Reader                 storage.StorageReader // optional: for finalizing previous in_progress sessions
 	LogFiles               chan string
+	finalizedPrev          bool
 	HttpClient             *http.Client
 	ShutdownChan           chan struct{}
 	logFilePaths           map[string]bool
@@ -193,6 +195,54 @@ func (r *RayLogHandler) writeMetaJsonInProgress(sessionID string) {
 	}
 	if err := r.Writer.WriteMeta(metaPath, meta); err != nil {
 		logrus.Errorf("Failed to write meta.json %s: %v", metaPath, err)
+	}
+
+	// Finalize any previous sessions for the same cluster that are still
+	// stuck in_progress (e.g. from a killed previous collector).
+	r.finalizePreviousSessions(sessionBase)
+}
+
+// finalizePreviousSessions scans all stored clusters and finalizes any
+// in_progress sessions for the same cluster (namespace + name) that are
+// NOT the current session.
+func (r *RayLogHandler) finalizePreviousSessions(currentSession string) {
+	if r.Reader == nil || r.finalizedPrev {
+		return
+	}
+	r.finalizedPrev = true
+
+	clusters := r.Reader.List()
+	for _, c := range clusters {
+		if c.Namespace != r.RayClusterNamespace || c.Name != r.RayClusterName {
+			continue
+		}
+		if c.SessionName == currentSession {
+			continue
+		}
+		if c.Status != utils.SessionStatusInProgress {
+			continue
+		}
+
+		metaPath := clustermetadata.MetaJsonPath(utils.ClusterInfo{
+			Name:      c.Name,
+			Namespace: c.Namespace,
+			OwnerKind: c.OwnerKind,
+			OwnerName: c.OwnerName,
+		}, r.RootDir, c.SessionName)
+
+		meta := utils.MetaJson{
+			SessionName:      c.SessionName,
+			ClusterID:        c.Name,
+			ClusterNamespace: c.Namespace,
+			StartTime:        c.CreateTimeStamp,
+			EndTime:          time.Now().Unix(),
+			Status:           utils.SessionStatusCompleted,
+		}
+		if err := r.Writer.WriteMeta(metaPath, meta); err != nil {
+			logrus.Errorf("Failed to finalize previous session %s: %v", c.SessionName, err)
+		} else {
+			logrus.Infof("Finalized previous session %s (was in_progress, now completed)", c.SessionName)
+		}
 	}
 }
 

--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
@@ -77,12 +77,6 @@ func (r *RayLogHandler) Run(stop <-chan struct{}) error {
 	<-stop
 	logrus.Info("Received stop signal, processing all logs...")
 	r.processSessionLatestLogs()
-	// Update meta.json to mark the session as completed.
-	// Only the head collector owns the session-wide meta.json — worker
-	// collectors must not overwrite it on shutdown.
-	if r.IsHead {
-		r.updateMetaJsonOnShutdown()
-	}
 	// Perform one final poll of additional endpoints before shutting down.
 	// This must happen before close(r.ShutdownChan) because pollSingleEndpoint
 	// uses ShutdownChan to cancel in-flight HTTP requests.
@@ -90,6 +84,15 @@ func (r *RayLogHandler) Run(stop <-chan struct{}) error {
 		r.processAdditionalEndpoints()
 	}
 	close(r.ShutdownChan)
+	// Update meta.json to mark the session as completed.
+	// Must happen after ShutdownChan is closed so that WatchSessionLatestLoops
+	// has exited — a late fsnotify event could otherwise overwrite the
+	// completed status back to in_progress.
+	// Only the head collector owns the session-wide meta.json — worker
+	// collectors must not overwrite it on shutdown.
+	if r.IsHead {
+		r.updateMetaJsonOnShutdown()
+	}
 
 	return nil
 }

--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector_test.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector_test.go
@@ -44,6 +44,10 @@ func (m *MockStorageWriter) WriteFile(file string, reader io.ReadSeeker) error {
 	return nil
 }
 
+func (m *MockStorageWriter) WriteMeta(path string, meta utils.MetaJson) error {
+	return nil
+}
+
 // setupRayTestEnvironment creates test directories under /tmp/ray for realistic testing
 // This matches the actual paths used by the logcollector
 func setupRayTestEnvironment(t *testing.T) (string, func()) {

--- a/historyserver/pkg/collector/logcollector/runtime/runtime.go
+++ b/historyserver/pkg/collector/logcollector/runtime/runtime.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
-func NewCollector(config *types.RayCollectorConfig, writer storage.StorageWriter) RayLogCollector {
+func NewCollector(config *types.RayCollectorConfig, writer storage.StorageWriter, reader storage.StorageReader) RayLogCollector {
 	handler := logcollector.RayLogHandler{
 		IsHead:   config.Role == "Head",
 		LogFiles: make(chan string),
@@ -42,6 +42,7 @@ func NewCollector(config *types.RayCollectorConfig, writer storage.StorageWriter
 			},
 		},
 		Writer:       writer,
+		Reader:       reader,
 		ShutdownChan: make(chan struct{}),
 	}
 

--- a/historyserver/pkg/eventserver/log_event_reader_test.go
+++ b/historyserver/pkg/eventserver/log_event_reader_test.go
@@ -2,6 +2,7 @@ package eventserver
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -58,6 +59,10 @@ func (m *logEventMockReader) ListFiles(clusterID string, dir string) []string {
 		}
 	}
 	return []string{}
+}
+
+func (m *logEventMockReader) ReadMeta(path string) (*utils.MetaJson, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 // --- Tests ---

--- a/historyserver/pkg/historyserver/clientmanager.go
+++ b/historyserver/pkg/historyserver/clientmanager.go
@@ -48,10 +48,10 @@ func (c *ClientManager) ListRayClusters(ctx context.Context) ([]*rayv1.RayCluste
 			list = append(list, &rayCluster)
 		}
 	}
-	// If every client failed, return an error so callers can distinguish
-	// "no clusters exist" from "API unreachable".
-	if len(errs) > 0 && len(list) == 0 && len(errs) == len(c.clients) {
-		return list, fmt.Errorf("all %d client(s) failed to list RayClusters", len(errs))
+	// If any client failed, return an error so callers skip crash detection
+	// rather than reasoning over an incomplete live set.
+	if len(errs) > 0 {
+		return list, fmt.Errorf("%d of %d client(s) failed to list RayClusters", len(errs), len(c.clients))
 	}
 	return list, nil
 }

--- a/historyserver/pkg/historyserver/clientmanager.go
+++ b/historyserver/pkg/historyserver/clientmanager.go
@@ -35,16 +35,23 @@ func (c *ClientManager) Client() client.Client {
 
 func (c *ClientManager) ListRayClusters(ctx context.Context) ([]*rayv1.RayCluster, error) {
 	list := []*rayv1.RayCluster{}
-	for _, c := range c.clients {
+	var errs []error
+	for _, cl := range c.clients {
 		listOfRayCluster := rayv1.RayClusterList{}
-		err := c.List(ctx, &listOfRayCluster)
+		err := cl.List(ctx, &listOfRayCluster)
 		if err != nil {
 			logrus.Errorf("Failed to list RayClusters: %v", err)
+			errs = append(errs, err)
 			continue
 		}
 		for _, rayCluster := range listOfRayCluster.Items {
 			list = append(list, &rayCluster)
 		}
+	}
+	// If every client failed, return an error so callers can distinguish
+	// "no clusters exist" from "API unreachable".
+	if len(errs) > 0 && len(list) == 0 && len(errs) == len(c.clients) {
+		return list, fmt.Errorf("all %d client(s) failed to list RayClusters", len(errs))
 	}
 	return list, nil
 }

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -47,10 +47,17 @@ func (s *ServerHandler) listClusters(limit int) []utils.ClusterInfo {
 	// Initial continuation marker
 	logrus.Debugf("Prepare to get list clusters info ...")
 	ctx := context.Background()
-	liveClusters, _ := s.clientManager.ListRayClusters(ctx)
+	liveClusters, listErr := s.clientManager.ListRayClusters(ctx)
+
+	// Build a set of live cluster keys for crash detection.
+	// Key format: "namespace/name" (K8s-style, distinct from the storage key
+	// format "name_namespace" produced by utils.AppendRayClusterNameNamespace).
+	liveKeySet := make(map[string]bool, len(liveClusters))
 	liveClusterNames := []string{}
 	liveClusterInfos := []utils.ClusterInfo{}
 	for _, liveCluster := range liveClusters {
+		key := liveCluster.Namespace + "/" + liveCluster.Name
+		liveKeySet[key] = true
 		liveClusterInfo := utils.ClusterInfo{
 			Name:            liveCluster.Name,
 			Namespace:       liveCluster.Namespace,
@@ -63,6 +70,22 @@ func (s *ServerHandler) listClusters(limit int) []utils.ClusterInfo {
 	}
 	logrus.Infof("live clusters: %v", liveClusterNames)
 	clusters := s.reader.List()
+
+	// Crash detection: a session recorded as in_progress whose RayCluster CR
+	// no longer exists is inferred as terminated. This is a read-time inference
+	// only (no write-back to storage) and uses data already fetched above.
+	// Skip inference when ListRayClusters returned an error (e.g. K8s API
+	// unreachable) to avoid false positives during transient failures.
+	if listErr == nil {
+		for i := range clusters {
+			if clusters[i].Status == utils.SessionStatusInProgress {
+				key := clusters[i].Namespace + "/" + clusters[i].Name
+				if !liveKeySet[key] {
+					clusters[i].Status = utils.SessionStatusTerminated
+				}
+			}
+		}
+	}
 	sort.Sort(utils.ClusterInfoList(clusters))
 	if limit > 0 && limit < len(clusters) {
 		clusters = clusters[:limit]

--- a/historyserver/pkg/historyserver/reader_test.go
+++ b/historyserver/pkg/historyserver/reader_test.go
@@ -1,0 +1,55 @@
+package historyserver
+
+import (
+	"testing"
+
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/localtest"
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestListClustersCrashDetection(t *testing.T) {
+	mockReader := localtest.NewMockReader()
+	if mockReader == nil {
+		t.Fatal("NewMockReader returned nil")
+	}
+
+	// ClientManager with no clients simulates an environment with no live
+	// RayClusters — every in_progress session should be inferred as terminated.
+	cm := &ClientManager{
+		configs: []*rest.Config{},
+		clients: []client.Client{},
+	}
+
+	handler := &ServerHandler{
+		maxClusters:   100,
+		reader:        mockReader,
+		clientManager: cm,
+		clustersMap:   make(map[utils.ClusterKey][]utils.ClusterInfo),
+	}
+
+	clusters := handler.listClusters(0)
+
+	// Localtest mock defines:
+	//   cluster-1 → completed → must stay completed
+	//   cluster-2 → in_progress, no live cluster → must become terminated
+	found := 0
+	for _, c := range clusters {
+		if c.Name == "cluster-1" {
+			found++
+			if c.Status != utils.SessionStatusCompleted {
+				t.Errorf("cluster-1: expected completed, got %q", c.Status)
+			}
+		}
+		if c.Name == "cluster-2" {
+			found++
+			if c.Status != utils.SessionStatusTerminated {
+				t.Errorf("cluster-2: expected terminated (crash detected), got %q", c.Status)
+			}
+		}
+	}
+	if found < 2 {
+		t.Errorf("expected both cluster-1 and cluster-2 in result, found %d matches", found)
+	}
+}

--- a/historyserver/pkg/storage/aliyunoss/ray/ray.go
+++ b/historyserver/pkg/storage/aliyunoss/ray/ray.go
@@ -204,7 +204,7 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 			logrus.Infof("[List]Returned objects in %v. length of Contents: %v, length of CommonPrefixes: %v", prefix, len(page.Contents),
 				len(page.CommonPrefixes))
 			for _, objects := range page.Contents {
-				// Skip meta.json files — they are not session markers
+				// Skip meta.json files - they are not session markers
 				if strings.HasSuffix(*objects.Key, ".meta.json") {
 					continue
 				}

--- a/historyserver/pkg/storage/aliyunoss/ray/ray.go
+++ b/historyserver/pkg/storage/aliyunoss/ray/ray.go
@@ -3,6 +3,7 @@ package ray
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -83,6 +84,42 @@ func (r *RayLogsHandler) WriteFile(file string, reader io.ReadSeeker) error {
 		Body:   reader,
 	})
 	return err
+}
+
+func (r *RayLogsHandler) WriteMeta(path string, meta utils.MetaJson) error {
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal meta json: %w", err)
+	}
+	_, err = r.OssClient.PutObject(context.TODO(), &oss.PutObjectRequest{
+		Bucket:      oss.Ptr(r.OssBucket),
+		Key:         oss.Ptr(path),
+		Body:        bytes.NewReader(data),
+		ContentType: oss.Ptr("application/json"),
+	})
+	return err
+}
+
+func (r *RayLogsHandler) ReadMeta(path string) (*utils.MetaJson, error) {
+	result, err := r.OssClient.GetObject(context.TODO(), &oss.GetObjectRequest{
+		Bucket: oss.Ptr(r.OssBucket),
+		Key:    oss.Ptr(path),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer result.Body.Close()
+
+	data, err := io.ReadAll(result.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read meta json: %w", err)
+	}
+
+	var meta utils.MetaJson
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal meta json: %w", err)
+	}
+	return &meta, nil
 }
 
 func (r *RayLogsHandler) _listFiles(prefix string, delimiter string, onlyBase bool) []string {
@@ -167,11 +204,23 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 			logrus.Infof("[List]Returned objects in %v. length of Contents: %v, length of CommonPrefixes: %v", prefix, len(page.Contents),
 				len(page.CommonPrefixes))
 			for _, objects := range page.Contents {
+				// Skip meta.json files — they are not session markers
+				if strings.HasSuffix(*objects.Key, ".meta.json") {
+					continue
+				}
 				c, err := clustermetadata.DecodePath(*objects.Key, r.OssRootDir)
 				if err != nil {
 					logrus.Errorf("Failed to parse meta file path: %s, error: %v", *objects.Key, err)
 					continue
 				}
+
+				// Enrich with meta.json data if available
+				metaPath := clustermetadata.MetaJsonPath(c, r.OssRootDir, c.SessionName)
+				if meta, metaErr := r.ReadMeta(metaPath); metaErr == nil {
+					c.Status = meta.Status
+					c.EndTime = meta.EndTime
+				}
+
 				clusters = append(clusters, c)
 			}
 		}

--- a/historyserver/pkg/storage/azureblob/azureblob.go
+++ b/historyserver/pkg/storage/azureblob/azureblob.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -72,10 +73,6 @@ func (r *RayLogsHandler) WriteFile(file string, reader io.ReadSeeker) error {
 	return nil
 }
 
-func ptrString(s string) *string {
-	return &s
-}
-
 func (r *RayLogsHandler) WriteMeta(path string, meta utils.MetaJson) error {
 	data, err := json.Marshal(meta)
 	if err != nil {
@@ -87,7 +84,7 @@ func (r *RayLogsHandler) WriteMeta(path string, meta utils.MetaJson) error {
 	blobClient := r.ContainerClient.NewBlockBlobClient(path)
 	_, err = blobClient.UploadStream(ctx, bytes.NewReader(data), &azblob.UploadStreamOptions{
 		HTTPHeaders: &blob.HTTPHeaders{
-			BlobContentType: ptrString("application/json"),
+			BlobContentType: to.Ptr("application/json"),
 		},
 	})
 	return err
@@ -230,7 +227,7 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 			prefix, len(resp.Segment.BlobItems))
 
 		for _, blob := range resp.Segment.BlobItems {
-			// Skip meta.json files — they are not session markers
+			// Skip meta.json files - they are not session markers
 			if strings.HasSuffix(*blob.Name, ".meta.json") {
 				continue
 			}

--- a/historyserver/pkg/storage/azureblob/azureblob.go
+++ b/historyserver/pkg/storage/azureblob/azureblob.go
@@ -3,6 +3,7 @@ package azureblob
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/sirupsen/logrus"
 
@@ -68,6 +70,51 @@ func (r *RayLogsHandler) WriteFile(file string, reader io.ReadSeeker) error {
 	}
 
 	return nil
+}
+
+func ptrString(s string) *string {
+	return &s
+}
+
+func (r *RayLogsHandler) WriteMeta(path string, meta utils.MetaJson) error {
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal meta json: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), uploadTimeout)
+	defer cancel()
+
+	blobClient := r.ContainerClient.NewBlockBlobClient(path)
+	_, err = blobClient.UploadStream(ctx, bytes.NewReader(data), &azblob.UploadStreamOptions{
+		HTTPHeaders: &blob.HTTPHeaders{
+			BlobContentType: ptrString("application/json"),
+		},
+	})
+	return err
+}
+
+func (r *RayLogsHandler) ReadMeta(path string) (*utils.MetaJson, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
+	defer cancel()
+
+	blobClient := r.ContainerClient.NewBlockBlobClient(path)
+	resp, err := blobClient.DownloadStream(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	body := resp.Body
+	defer body.Close()
+
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read meta json: %w", err)
+	}
+
+	var meta utils.MetaJson
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal meta json: %w", err)
+	}
+	return &meta, nil
 }
 
 func (r *RayLogsHandler) listBlobs(prefix string, delimiter string, onlyBase bool) []string {
@@ -183,11 +230,23 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 			prefix, len(resp.Segment.BlobItems))
 
 		for _, blob := range resp.Segment.BlobItems {
+			// Skip meta.json files — they are not session markers
+			if strings.HasSuffix(*blob.Name, ".meta.json") {
+				continue
+			}
 			c, err := clustermetadata.DecodePath(*blob.Name, r.RootDir)
 			if err != nil {
 				logrus.Errorf("Failed to parse meta file path: %s, error: %v", *blob.Name, err)
 				continue
 			}
+
+			// Enrich with meta.json data if available
+			metaPath := clustermetadata.MetaJsonPath(c, r.RootDir, c.SessionName)
+			if meta, metaErr := r.ReadMeta(metaPath); metaErr == nil {
+				c.Status = meta.Status
+				c.EndTime = meta.EndTime
+			}
+
 			clusters = append(clusters, c)
 		}
 	}

--- a/historyserver/pkg/storage/clustermetadata/clustermetadata.go
+++ b/historyserver/pkg/storage/clustermetadata/clustermetadata.go
@@ -91,6 +91,12 @@ func DecodePath(filePath string, rootDir string) (utils.ClusterInfo, error) {
 	return c, nil
 }
 
+// MetaJsonPath returns the storage path for a session's meta.json file,
+// alongside the session marker.
+func MetaJsonPath(info utils.ClusterInfo, rootDir, sessionID string) string {
+	return EncodePath(info, rootDir, sessionID) + ".meta.json"
+}
+
 // Prefix returns the root directory prefix.
 func Prefix(rootDir string) string {
 	if rootDir == "" {

--- a/historyserver/pkg/storage/clustermetadata/clustermetadata_test.go
+++ b/historyserver/pkg/storage/clustermetadata/clustermetadata_test.go
@@ -9,16 +9,16 @@ import (
 
 func TestDecodePath(t *testing.T) {
 	tests := []struct {
-		name        string
-		filePath    string
-		rootDir     string
-		expectErr   bool
-		expected    utils.ClusterInfo
+		name      string
+		filePath  string
+		rootDir   string
+		expectErr bool
+		expected  utils.ClusterInfo
 	}{
 		{
-			name:        "valid hierarchical path job",
-			filePath:    "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
-			expectErr:   false,
+			name:      "valid hierarchical path job",
+			filePath:  "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
+			expectErr: false,
 			expected: utils.ClusterInfo{
 				Namespace:       "defaultns",
 				OwnerKind:       "rayjob",
@@ -30,9 +30,9 @@ func TestDecodePath(t *testing.T) {
 			},
 		},
 		{
-			name:        "valid hierarchical path standalone",
-			filePath:    "cluster-metadata/raycluster/defaultns_mycluster1/session_2024-05-15_10-30-55_123456",
-			expectErr:   false,
+			name:      "valid hierarchical path standalone",
+			filePath:  "cluster-metadata/raycluster/defaultns_mycluster1/session_2024-05-15_10-30-55_123456",
+			expectErr: false,
 			expected: utils.ClusterInfo{
 				Namespace:       "defaultns",
 				Name:            "mycluster1",
@@ -42,40 +42,40 @@ func TestDecodePath(t *testing.T) {
 			},
 		},
 		{
-			name:        "invalid path prefix",
-			filePath:    "wrong-prefix/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
-			expectErr:   true,
+			name:      "invalid path prefix",
+			filePath:  "wrong-prefix/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
+			expectErr: true,
 		},
 		{
-			name:        "invalid path prefix with custom rootDir",
-			filePath:    "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
-			rootDir:     "custom-root",
-			expectErr:   true,
+			name:      "invalid path prefix with custom rootDir",
+			filePath:  "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session_2024-05-15_10-30-55_123456",
+			rootDir:   "custom-root",
+			expectErr: true,
 		},
 		{
-			name:        "invalid path structure - missing session",
-			filePath:    "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3",
-			expectErr:   true,
+			name:      "invalid path structure - missing session",
+			filePath:  "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3",
+			expectErr: true,
 		},
 		{
-			name:        "invalid path structure - too many parts",
-			filePath:    "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session/extra",
-			expectErr:   true,
+			name:      "invalid path structure - too many parts",
+			filePath:  "cluster-metadata/rayjob/defaultns_myrayjob_mycluster3/session/extra",
+			expectErr: true,
 		},
 		{
-			name:        "invalid metadir segment - only one part",
-			filePath:    "cluster-metadata/raycluster/defaultns/session_2024-05-15_10-30-55_123456",
-			expectErr:   true,
+			name:      "invalid metadir segment - only one part",
+			filePath:  "cluster-metadata/raycluster/defaultns/session_2024-05-15_10-30-55_123456",
+			expectErr: true,
 		},
 		{
-			name:        "invalid metadir segment with owner - too few parts",
-			filePath:    "cluster-metadata/rayjob/defaultns/session_2024-05-15_10-30-55_123456",
-			expectErr:   true,
+			name:      "invalid metadir segment with owner - too few parts",
+			filePath:  "cluster-metadata/rayjob/defaultns/session_2024-05-15_10-30-55_123456",
+			expectErr: true,
 		},
 		{
-			name:        "session id with bad timestamp pattern",
-			filePath:    "cluster-metadata/raycluster/defaultns_mycluster/session_not-a-real-timestamp",
-			expectErr:   true,
+			name:      "session id with bad timestamp pattern",
+			filePath:  "cluster-metadata/raycluster/defaultns_mycluster/session_not-a-real-timestamp",
+			expectErr: true,
 		},
 		{
 			name:      "invalid decode - raycluster with 3 meta parts",
@@ -83,9 +83,9 @@ func TestDecodePath(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:        "valid owner kind - mixed case",
-			filePath:    "cluster-metadata/RaYSerVice/defaultns_myservice_mycluster3/session_2024-05-15_10-30-55_123456",
-			expectErr:   false,
+			name:      "valid owner kind - mixed case",
+			filePath:  "cluster-metadata/RaYSerVice/defaultns_myservice_mycluster3/session_2024-05-15_10-30-55_123456",
+			expectErr: false,
 			expected: utils.ClusterInfo{
 				Namespace:       "defaultns",
 				OwnerKind:       "rayservice",
@@ -175,6 +175,46 @@ func TestMetadirPathRoundTrip(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestMetaJsonPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		info      utils.ClusterInfo
+		rootDir   string
+		sessionID string
+		want      string
+	}{
+		{
+			name:      "standalone cluster",
+			info:      utils.ClusterInfo{Namespace: "ns", Name: "cluster"},
+			rootDir:   "",
+			sessionID: "session-123",
+			want:      "cluster-metadata/raycluster/ns_cluster/session-123.meta.json",
+		},
+		{
+			name:      "with rootDir",
+			info:      utils.ClusterInfo{Namespace: "ns", Name: "cluster"},
+			rootDir:   "myroot",
+			sessionID: "session-123",
+			want:      "myroot/cluster-metadata/raycluster/ns_cluster/session-123.meta.json",
+		},
+		{
+			name:      "job with owner",
+			info:      utils.ClusterInfo{OwnerKind: "rayjob", OwnerName: "job1", Namespace: "ns", Name: "cluster"},
+			rootDir:   "",
+			sessionID: "session-456",
+			want:      "cluster-metadata/rayjob/ns_job1_cluster/session-456.meta.json",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MetaJsonPath(tc.info, tc.rootDir, tc.sessionID)
+			if got != tc.want {
+				t.Errorf("MetaJsonPath() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/historyserver/pkg/storage/gcs/gcs_handler.go
+++ b/historyserver/pkg/storage/gcs/gcs_handler.go
@@ -199,7 +199,7 @@ func (h *RayLogsHandler) List() []utils.ClusterInfo {
 			return nil
 		}
 
-		// Skip meta.json files — they are not session markers
+		// Skip meta.json files - they are not session markers
 		if strings.HasSuffix(objectAttr.Name, ".meta.json") {
 			continue
 		}

--- a/historyserver/pkg/storage/gcs/gcs_handler.go
+++ b/historyserver/pkg/storage/gcs/gcs_handler.go
@@ -3,6 +3,7 @@ package gcs
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -86,6 +87,45 @@ func (h *RayLogsHandler) WriteFile(file string, reader io.ReadSeeker) error {
 	return nil
 }
 
+func (h *RayLogsHandler) WriteMeta(path string, meta utils.MetaJson) error {
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal meta json: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	writer := h.StorageClient.Bucket(h.GCSBucket).Object(path).NewWriter(ctx)
+	writer.ContentType = "application/json"
+	if _, err := io.Copy(writer, bytes.NewReader(data)); err != nil {
+		writer.Close() // best-effort close to release resources
+		return fmt.Errorf("GCS Client failed to write meta json: %w", err)
+	}
+	return writer.Close()
+}
+
+func (h *RayLogsHandler) ReadMeta(path string) (*utils.MetaJson, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	reader, err := h.StorageClient.Bucket(h.GCSBucket).Object(path).NewReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read meta json: %w", err)
+	}
+
+	var meta utils.MetaJson
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal meta json: %w", err)
+	}
+	return &meta, nil
+}
+
 // ListFiles will return all files within the directory.
 func (h *RayLogsHandler) ListFiles(clusterId string, directory string) []string {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -159,13 +199,25 @@ func (h *RayLogsHandler) List() []utils.ClusterInfo {
 			return nil
 		}
 
+		// Skip meta.json files — they are not session markers
+		if strings.HasSuffix(objectAttr.Name, ".meta.json") {
+			continue
+		}
+
 		c, err := clustermetadata.DecodePath(objectAttr.Name, h.RootDir)
 		if err != nil {
 			logrus.Errorf("Failed to parse meta file path: %s, error: %v", objectAttr.Name, err)
 			continue
 		}
 
-		logrus.Infof("Parsed cluster %s for session %s to list", c.Name, c.SessionName)
+		// Enrich with meta.json data if available
+		metaPath := clustermetadata.MetaJsonPath(c, h.RootDir, c.SessionName)
+		metaPath = strings.TrimPrefix(metaPath, "/")
+		if meta, metaErr := h.ReadMeta(metaPath); metaErr == nil {
+			c.Status = meta.Status
+			c.EndTime = meta.EndTime
+		}
+
 		clusterList = append(clusterList, c)
 	}
 

--- a/historyserver/pkg/storage/interface.go
+++ b/historyserver/pkg/storage/interface.go
@@ -10,6 +10,7 @@ import (
 type StorageWriter interface {
 	CreateDirectory(path string) error
 	WriteFile(file string, reader io.ReadSeeker) error
+	WriteMeta(path string, meta utils.MetaJson) error
 }
 
 // HistoryServer create readers for each storage runtime
@@ -23,4 +24,6 @@ type StorageReader interface {
 	GetContent(clusterId string, fileName string) io.Reader
 
 	ListFiles(clusterId string, dir string) []string
+
+	ReadMeta(path string) (*utils.MetaJson, error)
 }

--- a/historyserver/pkg/storage/localtest/reader.go
+++ b/historyserver/pkg/storage/localtest/reader.go
@@ -1,11 +1,13 @@
 package localtest
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/storage/clustermetadata"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
@@ -13,6 +15,7 @@ import (
 type MockReader struct {
 	data     map[string]map[string]string
 	clusters []utils.ClusterInfo
+	metas    map[string]*utils.MetaJson
 }
 
 // NewMockReader creates a new mock reader
@@ -20,12 +23,14 @@ func NewMockReader() *MockReader {
 	clusters := []utils.ClusterInfo{
 		{
 			Name:            "cluster-1",
+			Namespace:       "default",
 			SessionName:     "session_2023-01-01_00-00-00_000000",
 			CreateTime:      "2023-01-01T00:00:00Z",
 			CreateTimeStamp: 1672531200000,
 		},
 		{
 			Name:            "cluster-2",
+			Namespace:       "default",
 			SessionName:     "session_2023-01-02_00-00-00_000000",
 			CreateTime:      "2023-01-02T00:00:00Z",
 			CreateTimeStamp: 1672617600000,
@@ -43,15 +48,41 @@ func NewMockReader() *MockReader {
 		},
 	}
 
+	metas := map[string]*utils.MetaJson{
+		"cluster-metadata/raycluster/default_cluster-1/session_2023-01-01_00-00-00_000000.meta.json": {
+			SessionName:      "session_2023-01-01_00-00-00_000000",
+			ClusterID:        "cluster-1",
+			ClusterNamespace: "default",
+			Status:           utils.SessionStatusCompleted,
+			EndTime:          1672534800,
+		},
+		"cluster-metadata/raycluster/default_cluster-2/session_2023-01-02_00-00-00_000000.meta.json": {
+			SessionName:      "session_2023-01-02_00-00-00_000000",
+			ClusterID:        "cluster-2",
+			ClusterNamespace: "default",
+			Status:           utils.SessionStatusInProgress,
+		},
+	}
+
 	return &MockReader{
 		clusters: clusters,
 		data:     data,
+		metas:    metas,
 	}
 }
 
-// List returns all available files from backend
+// List returns all available files from backend, enriched with meta.json data
 func (r *MockReader) List() []utils.ClusterInfo {
-	return r.clusters
+	result := make([]utils.ClusterInfo, len(r.clusters))
+	copy(result, r.clusters)
+	for i := range result {
+		metaPath := clustermetadata.MetaJsonPath(result[i], "", result[i].SessionName)
+		if meta, err := r.ReadMeta(metaPath); err == nil {
+			result[i].Status = meta.Status
+			result[i].EndTime = meta.EndTime
+		}
+	}
+	return result
 }
 
 // GetContent returns content for a specific file
@@ -73,6 +104,13 @@ func (r *MockReader) ListFiles(clusterId string, dir string) []string {
 		return files
 	}
 	return []string{}
+}
+
+func (r *MockReader) ReadMeta(path string) (*utils.MetaJson, error) {
+	if meta, ok := r.metas[path]; ok {
+		return meta, nil
+	}
+	return nil, fmt.Errorf("meta not found: %s", path)
 }
 
 // NewReader creates a new StorageReader

--- a/historyserver/pkg/storage/localtest/reader_test.go
+++ b/historyserver/pkg/storage/localtest/reader_test.go
@@ -1,0 +1,72 @@
+package localtest
+
+import (
+	"testing"
+
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+)
+
+func TestMockReaderListEnrichment(t *testing.T) {
+	r := NewMockReader()
+	clusters := r.List()
+
+	if len(clusters) != 2 {
+		t.Fatalf("expected 2 clusters, got %d", len(clusters))
+	}
+
+	if clusters[0].Name != "cluster-1" {
+		t.Fatalf("expected cluster-1 first (sorted by CreateTimeStamp descending), got %s", clusters[0].Name)
+	}
+
+	// cluster-1 has completed status and EndTime set in mock meta
+	if clusters[0].Status != utils.SessionStatusCompleted {
+		t.Errorf("cluster-1 Status = %q, want %q", clusters[0].Status, utils.SessionStatusCompleted)
+	}
+	if clusters[0].EndTime != 1672534800 {
+		t.Errorf("cluster-1 EndTime = %d, want 1672534800", clusters[0].EndTime)
+	}
+
+	// cluster-2 has in_progress status and no EndTime in mock meta
+	if clusters[1].Status != utils.SessionStatusInProgress {
+		t.Errorf("cluster-2 Status = %q, want %q", clusters[1].Status, utils.SessionStatusInProgress)
+	}
+	if clusters[1].EndTime != 0 {
+		t.Errorf("cluster-2 EndTime = %d, want 0", clusters[1].EndTime)
+	}
+}
+
+func TestMockReaderReadMetaNotFound(t *testing.T) {
+	r := NewMockReader()
+
+	// ReadMeta for a path that does not exist should return an error.
+	// This simulates backward compatibility: sessions without meta.json
+	// must not cause failures.
+	_, err := r.ReadMeta("nonexistent/path.meta.json")
+	if err == nil {
+		t.Error("ReadMeta for non-existent path should return an error")
+	}
+}
+
+func TestMockWriterWriteMeta(t *testing.T) {
+	w := NewMockWriter()
+	meta := utils.MetaJson{
+		SessionName:      "session-test",
+		ClusterID:        "cluster-test",
+		ClusterNamespace: "default",
+		Status:           utils.SessionStatusInProgress,
+		StartTime:        1234567890,
+	}
+	err := w.WriteMeta("cluster-metadata/raycluster/default_cluster-test/session-test.meta.json", meta)
+	if err != nil {
+		t.Fatalf("WriteMeta failed: %v", err)
+	}
+
+	// Verify the written data is stored and valid JSON
+	raw, ok := w.metaJsons["cluster-metadata/raycluster/default_cluster-test/session-test.meta.json"]
+	if !ok {
+		t.Fatal("meta.json not found in mock writer map")
+	}
+	if raw == "" {
+		t.Error("meta.json content should not be empty")
+	}
+}

--- a/historyserver/pkg/storage/localtest/writer.go
+++ b/historyserver/pkg/storage/localtest/writer.go
@@ -1,16 +1,19 @@
 package localtest
 
 import (
+	"encoding/json"
 	"io"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/collector/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/storage"
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
 // MockWriter is a mock implementation of the StorageWriter interface
 type MockWriter struct {
 	directories map[string]bool
 	files       map[string]string // filePath -> content
+	metaJsons   map[string]string // metaPath -> JSON string
 }
 
 // NewMockWriter creates a new mock writer
@@ -18,6 +21,7 @@ func NewMockWriter() *MockWriter {
 	return &MockWriter{
 		directories: make(map[string]bool),
 		files:       make(map[string]string),
+		metaJsons:   make(map[string]string),
 	}
 }
 
@@ -35,6 +39,16 @@ func (w *MockWriter) WriteFile(file string, reader io.ReadSeeker) error {
 	}
 
 	w.files[file] = string(content)
+	return nil
+}
+
+// WriteMeta writes a meta.json file (mock implementation)
+func (w *MockWriter) WriteMeta(path string, meta utils.MetaJson) error {
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	w.metaJsons[path] = string(data)
 	return nil
 }
 

--- a/historyserver/pkg/storage/s3/s3.go
+++ b/historyserver/pkg/storage/s3/s3.go
@@ -18,6 +18,7 @@ package s3
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -86,6 +87,42 @@ func (r *RayLogsHandler) WriteFile(file string, reader io.ReadSeeker) error {
 		Body:   reader,
 	})
 	return err
+}
+
+func (r *RayLogsHandler) WriteMeta(path string, meta utils.MetaJson) error {
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal meta json: %w", err)
+	}
+	_, err = r.S3Client.PutObject(&s3.PutObjectInput{
+		Bucket:      aws.String(r.S3Bucket),
+		Key:         aws.String(path),
+		Body:        bytes.NewReader(data),
+		ContentType: aws.String("application/json"),
+	})
+	return err
+}
+
+func (r *RayLogsHandler) ReadMeta(path string) (*utils.MetaJson, error) {
+	result, err := r.S3Client.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(r.S3Bucket),
+		Key:    aws.String(path),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer result.Body.Close()
+
+	data, err := io.ReadAll(result.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read meta json: %w", err)
+	}
+
+	var meta utils.MetaJson
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal meta json: %w", err)
+	}
+	return &meta, nil
 }
 
 func (r *RayLogsHandler) _listFiles(prefix string, delimiter string, onlyBase bool) []string {
@@ -169,12 +206,23 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 					prefix, len(page.Contents), len(page.CommonPrefixes))
 
 				for _, object := range page.Contents {
+					// Skip meta.json files — they are not session markers
+					if strings.HasSuffix(*object.Key, ".meta.json") {
+						continue
+					}
 					c, err := clustermetadata.DecodePath(*object.Key, r.S3RootDir)
 					if err != nil {
 						logrus.Errorf("Failed to parse meta file path: %s, error: %v", *object.Key, err)
 						continue
 					}
-					logrus.Infof("Parsed cluster %s for session %s to list", c.Name, c.SessionName)
+
+					// Enrich with meta.json data if available
+					metaPath := clustermetadata.MetaJsonPath(c, r.S3RootDir, c.SessionName)
+					if meta, metaErr := r.ReadMeta(metaPath); metaErr == nil {
+						c.Status = meta.Status
+						c.EndTime = meta.EndTime
+					}
+
 					clusters = append(clusters, c)
 				}
 				return true

--- a/historyserver/pkg/storage/s3/s3.go
+++ b/historyserver/pkg/storage/s3/s3.go
@@ -206,7 +206,7 @@ func (r *RayLogsHandler) List() (res []utils.ClusterInfo) {
 					prefix, len(page.Contents), len(page.CommonPrefixes))
 
 				for _, object := range page.Contents {
-					// Skip meta.json files — they are not session markers
+					// Skip meta.json files - they are not session markers
 					if strings.HasSuffix(*object.Key, ".meta.json") {
 						continue
 					}

--- a/historyserver/pkg/utils/types.go
+++ b/historyserver/pkg/utils/types.go
@@ -1,13 +1,35 @@
 package utils
 
+type SessionStatus string
+
+const (
+	SessionStatusInProgress SessionStatus = "in_progress"
+	SessionStatusCompleted  SessionStatus = "completed"
+	SessionStatusTerminated SessionStatus = "terminated"
+)
+
+type MetaJson struct {
+	SessionName      string        `json:"session_name"`
+	ClusterID        string        `json:"cluster_id"`
+	ClusterNamespace string        `json:"cluster_namespace"`
+	StartTime        int64         `json:"start_time"`
+	EndTime          int64         `json:"end_time"`
+	Status           SessionStatus `json:"status"`
+	// RayStatus captures the latest Ray resource status/condition at termination time.
+	// Populated on a best-effort basis from the Ray dashboard during collector shutdown.
+	RayStatus string `json:"ray_status,omitempty"`
+}
+
 type ClusterInfo struct {
-	Name            string `json:"name"`
-	Namespace       string `json:"namespace"`
-	SessionName     string `json:"sessionName"`
-	CreateTime      string `json:"createTime"`
-	CreateTimeStamp int64  `json:"createTimeStamp"`
-	OwnerKind       string `json:"ownerKind,omitempty"`
-	OwnerName       string `json:"ownerName,omitempty"`
+	Name            string        `json:"name"`
+	Namespace       string        `json:"namespace"`
+	SessionName     string        `json:"sessionName"`
+	CreateTime      string        `json:"createTime"`
+	CreateTimeStamp int64         `json:"createTimeStamp"`
+	Status          SessionStatus `json:"status,omitempty"`
+	EndTime         int64         `json:"endTime,omitempty"`
+	OwnerKind       string        `json:"ownerKind,omitempty"`
+	OwnerName       string        `json:"ownerName,omitempty"`
 }
 
 type ClusterKey struct {


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Add per-session `meta.json` files to the cluster-metadata directory so the History Server can track session lifecycle status (in_progress, completed, terminated).

Currently, the History Server lists sessions from cluster-metadata markers but has no way to tell whether a session is active, finished gracefully, or crashed. This matters for operators debugging failed Ray clusters — they need to quickly identify which sessions exited abnormally.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #4885

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
      - E2E (kind + MinIO): deployed RayCluster → ran RayJob → deleted, verified 
        `/clusters` shows `completed` with `endTime`.
  - [ ] This PR is not tested :(

## Summary

**Collector** (head only, write):
- Writes `in_progress` meta.json when a new session directory is detected
- On graceful shutdown (SIGTERM/SIGINT), writes `completed` + best-effort Ray dashboard cluster_status (3s timeout)
- SIGKILL leaves meta.json as `in_progress` — crash detection handles it

**History Server** (read-only inference):
- During `/clusters` listing, cross-references stored sessions against live RayCluster CRs
- An `in_progress` session whose K8s CR no longer exists → `terminated`
- Inference is read-time only (no write-back to storage), self-correcting on next List
- Skips inference when K8s API is unreachable (`ListRayClusters` returns error)

**Storage** (4 backends: S3, GCS, Azure Blob, Aliyun OSS):
- `WriteMeta` / `ReadMeta` on `StorageWriter` / `StorageReader`
- `List()` filters `.meta.json` to avoid duplicate session entries, enriches `ClusterInfo` with `Status` + `EndTime`
