### PR TITLE
[ray-operator] CalculateMinResources should respect workerGroupSpec.Suspend

### DIFF
--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -498,6 +498,9 @@ func CalculateMinResources(cluster *rayv1.RayCluster) corev1.ResourceList {
 	headPodResource := CalculatePodResource(cluster.Spec.HeadGroupSpec.Template.Spec)
 	minResourcesList = append(minResourcesList, headPodResource)
 	for _, nodeGroup := range cluster.Spec.WorkerGroupSpecs {
+		if nodeGroup.Suspend != nil && *nodeGroup.Suspend {
+			continue
+		}
 		podResource := CalculatePodResource(nodeGroup.Template.Spec)
 		calculateReplicaResource(&podResource, nodeGroup.NumOfHosts)
 		minReplicas := ptr.Deref(nodeGroup.MinReplicas, int32(0))

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -1437,6 +1437,39 @@ func TestCalculateResources(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Head pod with suspended worker group with min replicas",
+			cluster: createRayClusterTemplate(headStruct, []struct {
+				replicas    *int32
+				minReplicas *int32
+				suspend     *bool
+				cpu         string
+				memory      string
+				numOfHosts  int32
+			}{
+				{
+					numOfHosts:  1,
+					replicas:    ptr.To[int32](3),
+					minReplicas: ptr.To[int32](2),
+					cpu:         "4",
+					memory:      "200Mi",
+					suspend:     new(true),
+				},
+			}),
+			expected: struct {
+				desiredResources corev1.ResourceList
+				minResources     corev1.ResourceList
+			}{
+				desiredResources: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+				minResources: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Why are these changes needed?

`CalculateMinResources` sums the minimum resources of every worker group, including suspended ones, while its sibling functions — `CalculateMinReplicas`, `CalculateMaxReplicas`, and `CalculateDesiredResources` — all skip worker groups with `Suspend: true`. The `Suspend` guard was added to those siblings in #2728, but `CalculateMinResources` was missed.

The Volcano scheduler derives a `PodGroup`'s `MinMember` from `CalculateMinReplicas` and its `MinResources` from `CalculateMinResources` (`batchscheduler/volcano/volcano_scheduler.go`). So a suspended worker group with `MinReplicas > 0` makes `MinResources` reserve resources for pods that `MinMember` does not count — an internally inconsistent gang-scheduling reservation that the `MinMember` pods can never satisfy.

This adds the same `Suspend` guard the sibling functions already use, so suspended worker groups are excluded from the minimum-resource total. The existing `TestCalculateResources` "Head pod with suspended worker group" case uses `minReplicas: 0` (so its loop adds nothing and cannot detect the bug); a new case with `minReplicas > 0` fails before this change and passes after.

## Related issue number

Follow-up to #2728, which added the `Suspend` guard to the sibling functions.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
