### PR TITLE
[ray-operator] CalculatePodResource should not mutate the input PodSpec

### DIFF
--- a/kubectl-plugin/pkg/cmd/get/get_workergroup.go
+++ b/kubectl-plugin/pkg/cmd/get/get_workergroup.go
@@ -349,7 +349,7 @@ func calculateDesiredResourcesForWorkerGroup(workerGroupSpec rayv1.WorkerGroupSp
 func calculatePodResource(podSpec corev1.PodSpec) corev1.ResourceList {
 	podResource := corev1.ResourceList{}
 	for _, container := range podSpec.Containers {
-		containerResource := container.Resources.Requests
+		containerResource := container.Resources.Requests.DeepCopy()
 		if containerResource == nil {
 			containerResource = corev1.ResourceList{}
 		}

--- a/kubectl-plugin/pkg/cmd/get/get_workergroup_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_workergroup_test.go
@@ -812,3 +812,28 @@ namespace-2   pod-2   1     5            3/3        1      1      1      1Gi    
 		})
 	}
 }
+
+func TestCalculatePodResourceDoesNotMutateInput(t *testing.T) {
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("200Mi"),
+					},
+				},
+			},
+		},
+	}
+	wantRequests := podSpec.Containers[0].Resources.Requests.DeepCopy()
+
+	got := calculatePodResource(podSpec)
+
+	assert.Equal(t, "1", got.Cpu().String())
+	assert.Equal(t, "200Mi", got.Memory().String())
+	assert.Equal(t, wantRequests, podSpec.Containers[0].Resources.Requests)
+}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -528,7 +528,7 @@ func calculateReplicaResource(podResource *corev1.ResourceList, numOfHosts int32
 func CalculatePodResource(podSpec corev1.PodSpec) corev1.ResourceList {
 	podResource := corev1.ResourceList{}
 	for _, container := range podSpec.Containers {
-		containerResource := container.Resources.Requests
+		containerResource := container.Resources.Requests.DeepCopy()
 		if containerResource == nil {
 			containerResource = corev1.ResourceList{}
 		}

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -1296,6 +1296,31 @@ func createRayClusterTemplate(
 	return cluster
 }
 
+func TestCalculatePodResourceDoesNotMutateInput(t *testing.T) {
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("200Mi"),
+					},
+				},
+			},
+		},
+	}
+	wantRequests := podSpec.Containers[0].Resources.Requests.DeepCopy()
+
+	got := CalculatePodResource(podSpec)
+
+	assert.Equal(t, "1", got.Cpu().String())
+	assert.Equal(t, "200Mi", got.Memory().String())
+	assert.Equal(t, wantRequests, podSpec.Containers[0].Resources.Requests)
+}
+
 func TestCalculateResources(t *testing.T) {
 	headStruct := struct {
 		cpu    string


### PR DESCRIPTION
## Why are these changes needed?

`CalculatePodResource` aliases `container.Resources.Requests` and then writes the container's limit-only entries into that map (limits that have no matching request). Because the map is shared with the caller, this mutates the input `PodSpec` in place.

It is called on the head and worker-group pod templates via `CalculateDesiredResources` and `CalculateMinResources`, so computing a cluster's resources permanently adds limit-only resources to the templates' `requests`. `TestCalculateResources` already asserts these functions do not mutate the cluster (`assert.Equal(deepCopyCluster, tt.cluster)`), but no existing case has a container whose limits are absent from its requests, so the mutation went undetected.

This `DeepCopy`s the requests before merging limits, leaving the input unchanged. A new test (`TestCalculatePodResourceDoesNotMutateInput`) fails before this change and passes after.

## Related issue number

N/A

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
