### PR TITLE
[3/N] [History Server Beta] [Feat] Byte-based cache

### DIFF
--- a/historyserver/cmd/historyserver/main.go
+++ b/historyserver/cmd/historyserver/main.go
@@ -27,6 +27,7 @@ func main() {
 	burst := historyserver.DefaultKubeAPIBurst
 	sessionProcessTimeout := historyserver.DefaultSessionProcessTimeout
 	sessionCacheSize := historyserver.DefaultSessionCacheSize
+	sessionCacheMaxBytes := historyserver.DefaultSessionCacheMaxBytes
 	sessionCacheTTL := historyserver.DefaultSessionCacheTTL
 	flag.StringVar(&runtimeClassName, "runtime-class-name", "", "Storage backend: s3 / gcs / azureblob / aliyunoss / localtest")
 	flag.StringVar(&rayRootDir, "ray-root-dir", "", "Root dir inside the bucket")
@@ -38,6 +39,7 @@ func main() {
 	flag.IntVar(&burst, "kube-api-burst", historyserver.DefaultKubeAPIBurst, "The maximum burst for throttling requests from this client to the Kubernetes API server.")
 	flag.DurationVar(&sessionProcessTimeout, "session-process-timeout", historyserver.DefaultSessionProcessTimeout, "Timeout duration for processing and loading a single Ray cluster session.")
 	flag.IntVar(&sessionCacheSize, "session-cache-size", historyserver.DefaultSessionCacheSize, "Max number of dead-session snapshots held in the LRU cache.")
+	flag.IntVar(&sessionCacheMaxBytes, "session-cache-max-bytes", historyserver.DefaultSessionCacheMaxBytes, "Max total bytes of cached dead-session snapshots. 0 disables the byte bound.")
 	flag.DurationVar(&sessionCacheTTL, "session-cache-ttl", historyserver.DefaultSessionCacheTTL, "How long a dead-session snapshot stays cached after last access. 0 disables TTL.")
 	flag.Parse()
 
@@ -52,6 +54,9 @@ func main() {
 	}
 	if sessionCacheSize <= 0 {
 		logrus.Fatalf("--session-cache-size must be > 0, got %d", sessionCacheSize)
+	}
+	if sessionCacheMaxBytes < 0 {
+		logrus.Fatalf("--session-cache-max-bytes must be >= 0, got %d", sessionCacheMaxBytes)
 	}
 	if sessionCacheTTL < 0 {
 		logrus.Fatalf("--session-cache-ttl must be >= 0, got %s", sessionCacheTTL)
@@ -100,7 +105,7 @@ func main() {
 	defer serverCancel()
 
 	processor := historyserver.NewSessionProcessor(reader, cliMgr.Client())
-	sessionLoader := historyserver.NewSessionLoader(processor, serverCtx, sessionProcessTimeout, sessionCacheSize, sessionCacheTTL)
+	sessionLoader := historyserver.NewSessionLoader(processor, serverCtx, sessionProcessTimeout, sessionCacheSize, sessionCacheMaxBytes, sessionCacheTTL)
 
 	// ServerHandler.Run consumes a stop chan; bridge serverCtx into it.
 	var wg sync.WaitGroup

--- a/historyserver/cmd/historyserver/main.go
+++ b/historyserver/cmd/historyserver/main.go
@@ -39,7 +39,7 @@ func main() {
 	flag.IntVar(&burst, "kube-api-burst", historyserver.DefaultKubeAPIBurst, "The maximum burst for throttling requests from this client to the Kubernetes API server.")
 	flag.DurationVar(&sessionProcessTimeout, "session-process-timeout", historyserver.DefaultSessionProcessTimeout, "Timeout duration for processing and loading a single Ray cluster session.")
 	flag.IntVar(&sessionCacheSize, "session-cache-size", historyserver.DefaultSessionCacheSize, "Max number of dead-session snapshots held in the LRU cache.")
-	flag.IntVar(&sessionCacheMaxBytes, "session-cache-max-bytes", historyserver.DefaultSessionCacheMaxBytes, "Max total bytes of cached dead-session snapshots. 0 disables the byte bound.")
+	flag.IntVar(&sessionCacheMaxBytes, "session-cache-max-bytes", historyserver.DefaultSessionCacheMaxBytes, "Soft cap on cached snapshot bytes; tune under pod memory. 0 disables the byte bound.")
 	flag.DurationVar(&sessionCacheTTL, "session-cache-ttl", historyserver.DefaultSessionCacheTTL, "How long a dead-session snapshot stays cached after last access. 0 disables TTL.")
 	flag.Parse()
 

--- a/historyserver/pkg/eventserver/snapshot.go
+++ b/historyserver/pkg/eventserver/snapshot.go
@@ -6,8 +6,7 @@ import (
 )
 
 // SessionSnapshot is the in-memory representation of a dead session's processed
-// event state. The same *SessionSnapshot is shared by all concurrent handlers.
-// To avoid races, handlers MUST treat all fields as read-only.
+// event state.
 type SessionSnapshot struct {
 	SessionKey string `json:"sessionKey"`
 

--- a/historyserver/pkg/historyserver/byte_cache_integration_test.go
+++ b/historyserver/pkg/historyserver/byte_cache_integration_test.go
@@ -1,0 +1,91 @@
+package historyserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/emicklei/go-restful/v3"
+
+	"github.com/ray-project/kuberay/historyserver/pkg/eventserver"
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
+)
+
+// TestByteCache_ReadEndpointsRoundTripIsLossless is an in-process HTTP test:
+//
+// 1. Wire ServerHandler with a fake processor.
+// 2. Register routers for /enter_cluster and the dead-session read endpoints.
+// 3. GET /enter_cluster to trigger cold load and encode snapshot into the byte cache.
+// 4. GET each read endpoint to decode from cache and serve.
+// 5. Assert each response still contains the richSnapshot sentinel values (including nested CustomFields).
+func TestByteCache_ReadEndpointsRoundTripIsLossless(t *testing.T) {
+	restful.DefaultContainer = restful.NewContainer()
+
+	const (
+		ns      = "default"
+		name    = "cluster-bc"
+		session = "session_2026-04-22_10-00-00_000000_1"
+	)
+
+	handler := &ServerHandler{
+		maxClusters: 100,
+		clustersMap: make(map[utils.ClusterKey][]utils.ClusterInfo),
+	}
+	fp := &fakeProcessor{
+		fn: func(_ context.Context, info utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
+			key := utils.BuildClusterSessionKey(info.Name, info.Namespace, info.SessionName)
+			return SessionStatusProcessed, richSnapshot(key), nil
+		},
+	}
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
+	handler.clustersMap[utils.ClusterKey{Namespace: ns, Name: name}] = []utils.ClusterInfo{
+		{Namespace: ns, Name: name, SessionName: session, OwnerKind: "RayJob", OwnerName: "job-bc"},
+	}
+
+	routerRayClusterSet(handler)
+	routerNodes(handler)
+	routerEvents(handler)
+	routerAPI(handler)
+	routerLogical(handler)
+	container := restful.DefaultContainer
+
+	enterURL := "/enter_cluster/" + ns + "/" + name + "/" + session
+	enterReq := httptest.NewRequest(http.MethodGet, enterURL, nil)
+	enterResp := httptest.NewRecorder()
+	container.ServeHTTP(enterResp, enterReq)
+	if enterResp.Code != http.StatusOK {
+		t.Fatalf("enter_cluster: got %d, body=%s", enterResp.Code, enterResp.Body.String())
+	}
+	cookies := enterResp.Result().Cookies()
+
+	cases := []struct {
+		name       string
+		url        string
+		wantSubstr string
+	}{
+		{"nodes", "/nodes", "node-e2e-dead"},
+		{"actors", "/logical/actors", "actor-e2e-cafe"},
+		{"jobs", "/api/jobs/", "sub-e2e-bbbb"},
+		{"tasks", "/api/v0/tasks", "task-e2e-1111"},
+		{"events_customFields", "/events/", "e2e-custom-value"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			for _, c := range cookies {
+				req.AddCookie(c)
+			}
+			resp := httptest.NewRecorder()
+			container.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusOK {
+				t.Fatalf("%s: got %d, body=%s", tc.url, resp.Code, resp.Body.String())
+			}
+			if !strings.Contains(resp.Body.String(), tc.wantSubstr) {
+				t.Fatalf("%s: response missing sentinel %q; body=%s", tc.url, tc.wantSubstr, resp.Body.String())
+			}
+		})
+	}
+}

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -35,7 +35,7 @@ func TestEnterCluster(t *testing.T) {
 			return SessionStatusEventsErr, nil, fmt.Errorf("unknown session")
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheMaxBytes, DefaultSessionCacheTTL)
 
 	// Single session cluster
 	keyA := utils.ClusterKey{

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -147,7 +147,9 @@ func (s *SessionLoader) doLoadSession(ctx context.Context, info utils.ClusterInf
 		if snap == nil {
 			return false, fmt.Errorf("unexpected nil snapshot for session status %v", status)
 		}
-		s.putSnapshot(clusterSessionKey, snap)
+		if err := s.putSnapshot(clusterSessionKey, snap); err != nil {
+			return false, err
+		}
 		return false, nil
 
 	case SessionStatusLive:
@@ -161,17 +163,18 @@ func (s *SessionLoader) doLoadSession(ctx context.Context, info utils.ClusterInf
 }
 
 // putSnapshot stores encoded session snapshot bytes in the LRU cache.
-func (s *SessionLoader) putSnapshot(clusterSessionKey string, snap *eventserver.SessionSnapshot) {
+func (s *SessionLoader) putSnapshot(clusterSessionKey string, snap *eventserver.SessionSnapshot) error {
 	encoded, err := encodeSnapshot(snap)
 	if err != nil {
-		logrus.Errorf("Failed to encode snapshot for session %q; skipping cache: %v", clusterSessionKey, err)
-		return
+		logrus.Errorf("Failed to encode snapshot for session %q: %v", clusterSessionKey, err)
+		return fmt.Errorf("encode snapshot for session %q: %w", clusterSessionKey, err)
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.cache.Add(clusterSessionKey, encoded)
 	s.evictToByteBudget()
+	return nil
 }
 
 // evictToByteBudget evicts LRU entries until the total cached bytes < maxBytes.

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -23,8 +23,14 @@ const (
 	// DefaultSessionCacheTTL is how long a dead-session snapshot stays cached after last access.
 	// 0 disables expiry.
 	DefaultSessionCacheTTL time.Duration = 0
-	// DefaultSessionCacheMaxBytes is the max total bytes of cached dead-session snapshots.
-	// 0 disables the byte bound; defaulted to 256 MiB.
+	// DefaultSessionCacheMaxBytes bounds the total bytes of cached dead-session snapshots.
+	// 0 disables the byte bound.
+	//
+	// This is a soft bound on the idle resident cache, not a hard cap on process memory.
+	// Real usage can exceed it in three ways:
+	//   - add-then-evict: cache momentarily holds oldTotal + newEntry
+	//   - one large session: a single snapshot bigger than the whole budget is kept
+	//   - per-request decode: every GET unmarshals cached bytes into a full *SessionSnapshot
 	DefaultSessionCacheMaxBytes = 256 << 20
 )
 
@@ -225,11 +231,4 @@ func decodeSnapshot(encoded []byte) (*eventserver.SessionSnapshot, error) {
 		return nil, err
 	}
 	return &snap, nil
-}
-
-// CacheStats reports the number of sessions and the total bytes held by the cache.
-func (s *SessionLoader) CacheStats() (int, int) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.cache.Len(), s.totalBytes()
 }

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -64,7 +64,7 @@ func (s *SessionLoader) GetSnapshot(clusterSessionKey string) (*eventserver.Sess
 	if !ok {
 		return nil, false
 	}
-	s.renewTTL(clusterSessionKey, encoded)
+	s.renewTTL(clusterSessionKey)
 
 	snap, err := decodeSnapshot(encoded)
 	if err != nil {
@@ -82,13 +82,12 @@ func (s *SessionLoader) GetSnapshot(clusterSessionKey string) (*eventserver.Sess
 // renewTTL extends ExpiresAt for a cache hit.
 //
 // Must not re-insert after a concurrent byte eviction.
-func (s *SessionLoader) renewTTL(clusterSessionKey string, encoded []byte) {
+func (s *SessionLoader) renewTTL(clusterSessionKey string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, stillCached := s.cache.Peek(clusterSessionKey); !stillCached {
-		return
+	if v, ok := s.cache.Peek(clusterSessionKey); ok {
+		s.cache.Add(clusterSessionKey, v)
 	}
-	s.cache.Add(clusterSessionKey, encoded)
 }
 
 // LoadSession blocks until a dead session is processed and cached or an

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -64,18 +64,31 @@ func (s *SessionLoader) GetSnapshot(clusterSessionKey string) (*eventserver.Sess
 	if !ok {
 		return nil, false
 	}
-	// Renew the TTL so active debug sessions are not evicted.
-	s.cache.Add(clusterSessionKey, encoded)
+	s.renewTTL(clusterSessionKey, encoded)
 
 	snap, err := decodeSnapshot(encoded)
 	if err != nil {
 		// A corrupt entry should be impossible since we encoded it ourselves.
 		// If it ever happens, report a miss so it can be re-processed.
 		logrus.Errorf("Dropping corrupt cache entry for session %q: %v", clusterSessionKey, err)
+		s.mu.Lock()
 		s.cache.Remove(clusterSessionKey)
+		s.mu.Unlock()
 		return nil, false
 	}
 	return snap, true
+}
+
+// renewTTL extends ExpiresAt for a cache hit.
+//
+// Must not re-insert after a concurrent byte eviction.
+func (s *SessionLoader) renewTTL(clusterSessionKey string, encoded []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, stillCached := s.cache.Peek(clusterSessionKey); !stillCached {
+		return
+	}
+	s.cache.Add(clusterSessionKey, encoded)
 }
 
 // LoadSession blocks until a dead session is processed and cached or an

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -196,6 +196,9 @@ func (s *SessionLoader) totalBytes() int {
 }
 
 // encodeSnapshot serializes a snapshot to its cached byte form.
+//
+// Use JSON, not gob since snapshots have map[string]any CustomFields and gob requires
+// registering concrete types and fails to round-trip the arbitrary nested values reliably.
 func encodeSnapshot(snap *eventserver.SessionSnapshot) ([]byte, error) {
 	return json.Marshal(snap)
 }

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -43,9 +43,11 @@ type processor interface {
 // TTL expiry and triggers session processing on cache miss. Concurrent callers
 // for the same session are coalesced via singleflight.
 type SessionLoader struct {
-	processor      processor
-	cache          *expirable.LRU[string, []byte]
-	maxBytes       int
+	processor processor
+	cache     *expirable.LRU[string, []byte]
+	maxBytes  int
+	// mu guards only the byte-budget read-modify-write; expirable.LRU is
+	// independently thread-safe. A lone Get/Add/Peek does not need mu.
 	mu             sync.Mutex
 	sf             singleflight.Group
 	serverCtx      context.Context

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -2,14 +2,16 @@ package historyserver
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver"
-	eventtypes "github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
@@ -19,8 +21,11 @@ const (
 	// DefaultSessionCacheSize is the LRU capacity for dead-session snapshots.
 	DefaultSessionCacheSize = 100
 	// DefaultSessionCacheTTL is how long a dead-session snapshot stays cached after last access.
-	// 0 disables expiry, leaving LRU capacity (cacheSize) as the only bound.
+	// 0 disables expiry.
 	DefaultSessionCacheTTL time.Duration = 0
+	// DefaultSessionCacheMaxBytes is the max total bytes of cached dead-session snapshots.
+	// 0 disables the byte bound; defaulted to 256 MiB.
+	DefaultSessionCacheMaxBytes = 256 << 20
 )
 
 // processor is an interface to enable mocking SessionProcessor in tests.
@@ -33,33 +38,44 @@ type processor interface {
 // for the same session are coalesced via singleflight.
 type SessionLoader struct {
 	processor      processor
-	cache          *expirable.LRU[string, *eventserver.SessionSnapshot]
+	cache          *expirable.LRU[string, []byte]
+	maxBytes       int
+	mu             sync.Mutex
 	sf             singleflight.Group
 	serverCtx      context.Context
 	processTimeout time.Duration
 }
 
 // NewSessionLoader wires a SessionLoader.
-func NewSessionLoader(p processor, serverCtx context.Context, processTimeout time.Duration, cacheSize int, cacheTTL time.Duration) *SessionLoader {
+func NewSessionLoader(p processor, serverCtx context.Context, processTimeout time.Duration, cacheSize, cacheMaxBytes int, cacheTTL time.Duration) *SessionLoader {
 	return &SessionLoader{
 		processor:      p,
-		cache:          expirable.NewLRU[string, *eventserver.SessionSnapshot](cacheSize, nil, cacheTTL),
+		cache:          expirable.NewLRU[string, []byte](cacheSize, nil, cacheTTL),
+		maxBytes:       cacheMaxBytes,
 		serverCtx:      serverCtx,
 		processTimeout: processTimeout,
 	}
 }
 
-// GetSnapshot returns a per-request view of the cached snapshot.
+// GetSnapshot returns a per-request view of the cached snapshot, which is
+// a freshly decoded copy, safe for concurrent use.
 func (s *SessionLoader) GetSnapshot(clusterSessionKey string) (*eventserver.SessionSnapshot, bool) {
-	cached, ok := s.cache.Get(clusterSessionKey)
+	encoded, ok := s.cache.Get(clusterSessionKey)
 	if !ok {
 		return nil, false
 	}
 	// Renew the TTL so active debug sessions are not evicted.
-	s.cache.Add(clusterSessionKey, cached)
-	out := *cached
-	out.Tasks = append([]eventtypes.Task(nil), cached.Tasks...)
-	return &out, true
+	s.cache.Add(clusterSessionKey, encoded)
+
+	snap, err := decodeSnapshot(encoded)
+	if err != nil {
+		// A corrupt entry should be impossible since we encoded it ourselves.
+		// If it ever happens, report a miss so it can be re-processed.
+		logrus.Errorf("Dropping corrupt cache entry for session %q: %v", clusterSessionKey, err)
+		s.cache.Remove(clusterSessionKey)
+		return nil, false
+	}
+	return snap, true
 }
 
 // LoadSession blocks until a dead session is processed and cached or an
@@ -131,7 +147,71 @@ func (s *SessionLoader) doLoadSession(ctx context.Context, info utils.ClusterInf
 	}
 }
 
-// putSnapshot stores a dead-session snapshot in the LRU cache.
+// putSnapshot stores encoded session snapshot bytes in the LRU cache.
 func (s *SessionLoader) putSnapshot(clusterSessionKey string, snap *eventserver.SessionSnapshot) {
-	s.cache.Add(clusterSessionKey, snap)
+	encoded, err := encodeSnapshot(snap)
+	if err != nil {
+		logrus.Errorf("Failed to encode snapshot for session %q; skipping cache: %v", clusterSessionKey, err)
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cache.Add(clusterSessionKey, encoded)
+	s.evictToByteBudget()
+}
+
+// evictToByteBudget evicts LRU entries until the total cached bytes < maxBytes.
+func (s *SessionLoader) evictToByteBudget() {
+	if s.maxBytes <= 0 {
+		return
+	}
+	total := s.totalBytes()
+	for total > s.maxBytes && s.cache.Len() > 1 {
+		_, evicted, ok := s.cache.RemoveOldest()
+		if !ok {
+			logrus.Errorf("byte-budget eviction stalled: RemoveOldest failed with %d entries, %d bytes (budget %d)",
+				s.cache.Len(), total, s.maxBytes)
+			break
+		}
+		total -= len(evicted)
+	}
+	if total > s.maxBytes {
+		if s.cache.Len() == 1 {
+			logrus.Warnf("single cached snapshot exceeds byte budget (%d > %d bytes); keeping it", total, s.maxBytes)
+		} else {
+			logrus.Errorf("cache still over byte budget after eviction (%d > %d bytes, %d entries)",
+				total, s.maxBytes, s.cache.Len())
+		}
+	}
+}
+
+// totalBytes sums the length of every cached entry.
+func (s *SessionLoader) totalBytes() int {
+	total := 0
+	for _, encoded := range s.cache.Values() {
+		total += len(encoded)
+	}
+	return total
+}
+
+// encodeSnapshot serializes a snapshot to its cached byte form.
+func encodeSnapshot(snap *eventserver.SessionSnapshot) ([]byte, error) {
+	return json.Marshal(snap)
+}
+
+// decodeSnapshot reconstructs a snapshot from its cached byte form.
+func decodeSnapshot(encoded []byte) (*eventserver.SessionSnapshot, error) {
+	var snap eventserver.SessionSnapshot
+	if err := json.Unmarshal(encoded, &snap); err != nil {
+		return nil, err
+	}
+	return &snap, nil
+}
+
+// CacheStats reports the number of sessions and the total bytes held by the cache.
+func (s *SessionLoader) CacheStats() (int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cache.Len(), s.totalBytes()
 }

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -189,17 +189,15 @@ func (s *SessionLoader) evictToByteBudget() {
 	if s.maxBytes <= 0 {
 		return
 	}
-	total := s.totalBytes()
-	for total > s.maxBytes && s.cache.Len() > 1 {
-		_, evicted, ok := s.cache.RemoveOldest()
-		if !ok {
+	// Recompute after each removal: RemoveOldest may drop TTL-expired entries that totalBytes skips.
+	for s.totalBytes() > s.maxBytes && s.cache.Len() > 1 {
+		if _, _, ok := s.cache.RemoveOldest(); !ok {
 			logrus.Errorf("byte-budget eviction stalled: RemoveOldest failed with %d entries, %d bytes (budget %d)",
-				s.cache.Len(), total, s.maxBytes)
+				s.cache.Len(), s.totalBytes(), s.maxBytes)
 			break
 		}
-		total -= len(evicted)
 	}
-	if total > s.maxBytes {
+	if total := s.totalBytes(); total > s.maxBytes {
 		if s.cache.Len() == 1 {
 			logrus.Warnf("single cached snapshot exceeds byte budget (%d > %d bytes); keeping it", total, s.maxBytes)
 		} else {

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -31,7 +31,7 @@ const (
 	//   - add-then-evict: cache momentarily holds oldTotal + newEntry
 	//   - one large session: a single snapshot bigger than the whole budget is kept
 	//   - per-request decode: every GET unmarshals cached bytes into a full *SessionSnapshot
-	DefaultSessionCacheMaxBytes = 256 << 20
+	DefaultSessionCacheMaxBytes = 2 << 30
 )
 
 // processor is an interface to enable mocking SessionProcessor in tests.

--- a/historyserver/pkg/historyserver/session_loader_test.go
+++ b/historyserver/pkg/historyserver/session_loader_test.go
@@ -292,29 +292,58 @@ func TestGetSnapshot_PutOverwrites(t *testing.T) {
 	}
 }
 
-// TestGetSnapshot_MapsArePerRequest verifies every section is an independent copy
-// per request, so one reader's mutation cannot leak to another.
-func TestGetSnapshot_MapsArePerRequest(t *testing.T) {
+// TestGetSnapshot_ConcurrentReadsAreThreadSafe verifies the thread-safety
+// of the byte cache under data race detection (-race).
+func TestGetSnapshot_ConcurrentReadsAreThreadSafe(t *testing.T) {
 	key := testClusterSessionKey()
 
 	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{})
 	sl.putSnapshot(key, richSnapshot(key))
-	first, _ := sl.GetSnapshot(key)
-	second, _ := sl.GetSnapshot(key)
 
-	first.Actors["actor-e2e-cafe"] = eventtypes.Actor{ActorID: "MUTATED"}
-	delete(first.Nodes, "node-e2e-dead")
-	first.Jobs["injected"] = eventtypes.Job{}
+	const goroutines = 50
+	var wg sync.WaitGroup
 
-	if second.Actors["actor-e2e-cafe"].ActorID != "actor-e2e-cafe" {
-		t.Fatal("Actors map leaked across requests")
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := sl.putSnapshot(key, richSnapshot(key)); err != nil {
+				t.Errorf("putSnapshot: %v", err)
+			}
+		}()
 	}
-	if _, ok := second.Nodes["node-e2e-dead"]; !ok {
-		t.Fatal("Nodes map leaked across requests")
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mine, ok := sl.GetSnapshot(key)
+			if !ok {
+				t.Errorf("GetSnapshot: unexpected miss")
+				return
+			}
+			mine.Actors["actor-e2e-cafe"] = eventtypes.Actor{ActorID: "MUTATED"}
+			delete(mine.Nodes, "node-e2e-dead")
+			mine.Jobs["injected"] = eventtypes.Job{}
+
+			fresh, ok := sl.GetSnapshot(key)
+			if !ok {
+				t.Errorf("GetSnapshot: unexpected miss on re-read")
+				return
+			}
+			if fresh.Actors["actor-e2e-cafe"].ActorID != "actor-e2e-cafe" {
+				t.Errorf("Actors map leaked across requests")
+			}
+			if _, ok := fresh.Nodes["node-e2e-dead"]; !ok {
+				t.Errorf("Nodes map leaked across requests")
+			}
+			if _, ok := fresh.Jobs["injected"]; ok {
+				t.Errorf("Jobs map leaked across requests")
+			}
+		}()
 	}
-	if _, ok := second.Jobs["injected"]; ok {
-		t.Fatal("Jobs map leaked across requests")
-	}
+
+	wg.Wait()
 }
 
 // TestGetSnapshot_CorruptEntry_TreatedAsMiss verifies that a non-decodable cache

--- a/historyserver/pkg/historyserver/session_loader_test.go
+++ b/historyserver/pkg/historyserver/session_loader_test.go
@@ -444,6 +444,9 @@ func TestCache_ByteBudgetKeepsOversizedSoleEntry(t *testing.T) {
 	sl.putSnapshot(key, richSnapshot(key))
 
 	requireSnapshotCached(t, sl, key, true)
+	if entries, total := sl.cache.Len(), sl.totalBytes(); entries != 1 || total <= sl.maxBytes {
+		t.Fatalf("oversized sole entry: got (entries=%d, bytes=%d), want (1, >%d)", entries, total, sl.maxBytes)
+	}
 }
 
 // TestSnapshotCache_RoundTripPreservesData verifies the encode/decode round-trip

--- a/historyserver/pkg/historyserver/session_loader_test.go
+++ b/historyserver/pkg/historyserver/session_loader_test.go
@@ -473,6 +473,18 @@ func TestSnapshotCache_RoundTripPreservesData(t *testing.T) {
 	if !reflect.DeepEqual(wantCF, gotCF) {
 		t.Fatalf("CustomFields round-trip mismatch:\n want=%#v\n  got=%#v", wantCF, gotCF)
 	}
+
+	wantTask, gotTask := snap.Tasks[0], got.Tasks[0]
+	if gotTask.State != wantTask.State ||
+		!gotTask.CreationTime.Equal(wantTask.CreationTime) ||
+		!gotTask.StartTime.Equal(wantTask.StartTime) ||
+		!gotTask.EndTime.Equal(wantTask.EndTime) {
+		t.Fatalf("Task derived fields lost in round-trip:\n want=%+v\n  got=%+v", wantTask, gotTask)
+	}
+	if got.Actors["actor-e2e-cafe"].State != snap.Actors["actor-e2e-cafe"].State {
+		t.Fatalf("Actor.State lost in round-trip: want=%q got=%q",
+			snap.Actors["actor-e2e-cafe"].State, got.Actors["actor-e2e-cafe"].State)
+	}
 }
 
 // richSnapshot builds a snapshot exercising all five session states.
@@ -483,11 +495,19 @@ func richSnapshot(clusterSessionKey string) *eventserver.SessionSnapshot {
 	return &eventserver.SessionSnapshot{
 		SessionKey: clusterSessionKey,
 		Tasks: []eventtypes.Task{
-			{TaskID: "task-e2e-1111", TaskAttempt: 0, JobID: "job-e2e-aaaa", TaskName: "café-task-名前", RequiredResources: map[string]float64{"CPU": 2}},
+			{
+				TaskID: "task-e2e-1111", TaskAttempt: 0, JobID: "job-e2e-aaaa",
+				TaskName: "task-e2e-name", RequiredResources: map[string]float64{"CPU": 2},
+				// Set derived lifecycle fields so the round-trip test proves they survive encoding/decoding.
+				State:        eventtypes.RUNNING,
+				CreationTime: time.Unix(1770635700, 0).UTC(),
+				StartTime:    time.Unix(1770635705, 0).UTC(),
+				EndTime:      time.Unix(1770635710, 0).UTC(),
+			},
 			{TaskID: "task-e2e-2222", TaskAttempt: 1, JobID: "job-e2e-aaaa"},
 		},
 		Actors: map[string]eventtypes.Actor{
-			"actor-e2e-cafe": {ActorID: "actor-e2e-cafe", JobID: "job-e2e-aaaa", ActorClass: "MyActor", Name: "actorname-e2e", NumRestarts: 3},
+			"actor-e2e-cafe": {ActorID: "actor-e2e-cafe", JobID: "job-e2e-aaaa", ActorClass: "MyActor", Name: "actorname-e2e", NumRestarts: 3, State: eventtypes.ALIVE},
 		},
 		Jobs: map[string]eventtypes.Job{
 			"job-e2e-aaaa": {JobID: "job-e2e-aaaa", SubmissionID: "sub-e2e-bbbb", JobType: "SUBMISSION", EntryPoint: "python main.py", RuntimeEnv: map[string]string{"pip": "ray"}},

--- a/historyserver/pkg/historyserver/session_loader_test.go
+++ b/historyserver/pkg/historyserver/session_loader_test.go
@@ -1,9 +1,10 @@
 package historyserver
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"sort"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -34,20 +35,37 @@ func (f *fakeProcessor) setFn(fn func(ctx context.Context, info utils.ClusterInf
 	f.fn = fn
 }
 
-func newTestSessionLoader(t *testing.T, p processor, cacheSize int) *SessionLoader {
+type loaderTestConfig struct {
+	cacheSize int
+	maxBytes  int
+	cacheTTL  time.Duration
+}
+
+func newTestLoader(t *testing.T, p processor, cfg loaderTestConfig) *SessionLoader {
 	t.Helper()
+	cacheSize := cfg.cacheSize
 	if cacheSize <= 0 {
 		cacheSize = DefaultSessionCacheSize
 	}
-	return NewSessionLoader(p, context.Background(), DefaultSessionProcessTimeout, cacheSize, DefaultSessionCacheTTL)
+	return NewSessionLoader(p, context.Background(), DefaultSessionProcessTimeout, cacheSize, cfg.maxBytes, cfg.cacheTTL)
 }
 
-func testEnterClusterInfo() utils.ClusterInfo {
+func testClusterInfo() utils.ClusterInfo {
 	return utils.ClusterInfo{
 		Name:        "raycluster-test",
 		Namespace:   "default",
 		SessionName: "session_2026-04-22_10-00-00_000000_1",
 	}
+}
+
+func testClusterSessionKey() string {
+	info := testClusterInfo()
+	return utils.BuildClusterSessionKey(info.Name, info.Namespace, info.SessionName)
+}
+
+func testClusterSessionKeyFor(sessionName string) string {
+	info := testClusterInfo()
+	return utils.BuildClusterSessionKey(info.Name, info.Namespace, sessionName)
 }
 
 // testSnapshot builds a minimal snapshot.
@@ -57,52 +75,21 @@ func testSnapshot(clusterSessionKey string) *eventserver.SessionSnapshot {
 	}
 }
 
-// TestLoadSession_ProcessorError_PropagatesAndCleans verifies that on the error
-// path, all coalesced callers see the same error and the dedup group is cleared.
-func TestLoadSession_ProcessorError_PropagatesAndCleans(t *testing.T) {
-	info := testEnterClusterInfo()
-	processorErr := errors.New("simulated parse failure")
-
-	// Phase 1: error path
-	release := make(chan struct{})
-	fp := &fakeProcessor{
-		fn: func(_ context.Context, _ utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
-			<-release
-			return SessionStatusEventsErr, nil, processorErr
-		},
+func requireSnapshotCached(t *testing.T, sl *SessionLoader, key string, wantOK bool) {
+	t.Helper()
+	_, ok := sl.GetSnapshot(key)
+	if ok != wantOK {
+		t.Fatalf("GetSnapshot(%q): ok=%v, want %v", key, ok, wantOK)
 	}
-	sessionLoader := newTestSessionLoader(t, fp, 0)
+}
 
-	const n = 5
-	var wg sync.WaitGroup
-	errs := make([]error, n)
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			_, errs[idx] = sessionLoader.LoadSession(context.Background(), info)
-		}(i)
-	}
-
-	// 50ms >> scheduling latency, well under a second.
-	time.Sleep(50 * time.Millisecond)
-	close(release)
-	wg.Wait()
-
-	if got := fp.callCount(); got != 1 {
-		t.Fatalf("expected exactly 1 processor call (dedup applies on error path), got %d", got)
-	}
-	for i, err := range errs {
-		if !errors.Is(err, processorErr) {
-			t.Errorf("caller %d: expected error wrapping processorErr, got %v", i, err)
-		}
-	}
-
-	// Phase 2: dedup group cleared
+// A failed cold load must not block the next LoadSession from re-running the processor.
+func assertProcessorRetryAfterError(t *testing.T, sl *SessionLoader, fp *fakeProcessor, info utils.ClusterInfo) {
+	t.Helper()
 	fp.setFn(func(_ context.Context, _ utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
 		return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
 	})
-	if _, err := sessionLoader.LoadSession(context.Background(), info); err != nil {
+	if _, err := sl.LoadSession(context.Background(), info); err != nil {
 		t.Fatalf("post-error retry: expected nil, got %v", err)
 	}
 	if got := fp.callCount(); got != 2 {
@@ -110,36 +97,68 @@ func TestLoadSession_ProcessorError_PropagatesAndCleans(t *testing.T) {
 	}
 }
 
-// TestLoadSession_ProcessorError_NoInternalRetry verifies a processor error
-// is returned to the caller exactly once; SessionLoader does not re-invoke
-// processor within the same LoadSession call.
-func TestLoadSession_ProcessorError_NoInternalRetry(t *testing.T) {
-	info := testEnterClusterInfo()
+// TestLoadSession_ProcessorError verifies processor errors propagate without
+// internal retry and that singleflight dedup applies on the error path.
+func TestLoadSession_ProcessorError(t *testing.T) {
+	info := testClusterInfo()
 	processorErr := errors.New("simulated parse failure")
-	fp := &fakeProcessor{
-		fn: func(_ context.Context, _ utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
-			return SessionStatusEventsErr, nil, processorErr
-		},
-	}
-	sessionLoader := newTestSessionLoader(t, fp, 0)
 
-	_, err := sessionLoader.LoadSession(context.Background(), info)
-	if !errors.Is(err, processorErr) {
-		t.Fatalf("expected LoadSession to return processorErr, got %v", err)
-	}
-	if got := fp.callCount(); got != 1 {
-		t.Fatalf("expected processor called exactly 1x (no internal retry), got %d", got)
-	}
+	t.Run("no_internal_retry", func(t *testing.T) {
+		fp := &fakeProcessor{
+			fn: func(_ context.Context, _ utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
+				return SessionStatusEventsErr, nil, processorErr
+			},
+		}
+		sl := newTestLoader(t, fp, loaderTestConfig{})
 
-	fp.setFn(func(_ context.Context, _ utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
-		return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
+		_, err := sl.LoadSession(context.Background(), info)
+		if !errors.Is(err, processorErr) {
+			t.Fatalf("expected LoadSession to return processorErr, got %v", err)
+		}
+		if got := fp.callCount(); got != 1 {
+			t.Fatalf("expected processor called exactly 1x (no internal retry), got %d", got)
+		}
+
+		assertProcessorRetryAfterError(t, sl, fp, info)
 	})
-	if _, err := sessionLoader.LoadSession(context.Background(), info); err != nil {
-		t.Fatalf("client-driven retry: expected nil, got %v", err)
-	}
-	if got := fp.callCount(); got != 2 {
-		t.Fatalf("expected processor called 2x total (1 error + 1 client retry), got %d", got)
-	}
+
+	t.Run("concurrent_dedup", func(t *testing.T) {
+		release := make(chan struct{})
+		fp := &fakeProcessor{
+			fn: func(_ context.Context, _ utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
+				<-release
+				return SessionStatusEventsErr, nil, processorErr
+			},
+		}
+		sl := newTestLoader(t, fp, loaderTestConfig{})
+
+		const n = 5
+		var wg sync.WaitGroup
+		errs := make([]error, n)
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				_, errs[idx] = sl.LoadSession(context.Background(), info)
+			}(i)
+		}
+
+		// 50ms >> scheduling latency, well under a second.
+		time.Sleep(50 * time.Millisecond)
+		close(release)
+		wg.Wait()
+
+		if got := fp.callCount(); got != 1 {
+			t.Fatalf("expected exactly 1 processor call (dedup applies on error path), got %d", got)
+		}
+		for i, err := range errs {
+			if !errors.Is(err, processorErr) {
+				t.Errorf("caller %d: expected error wrapping processorErr, got %v", i, err)
+			}
+		}
+
+		assertProcessorRetryAfterError(t, sl, fp, info)
+	})
 }
 
 // TestLoadSession_LiveAndProcessed verifies LoadSession surfaces the live/processed distinction.
@@ -164,9 +183,9 @@ func TestLoadSession_LiveAndProcessed(t *testing.T) {
 					return tc.status, built, nil
 				},
 			}
-			sessionLoader := newTestSessionLoader(t, fp, 0)
+			sl := newTestLoader(t, fp, loaderTestConfig{})
 
-			live, err := sessionLoader.LoadSession(context.Background(), testEnterClusterInfo())
+			live, err := sl.LoadSession(context.Background(), testClusterInfo())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -186,9 +205,9 @@ func TestLoadSession_ZeroValueStatus_DoesNotSilentlyMatchLive(t *testing.T) {
 			return zero, nil, nil
 		},
 	}
-	sessionLoader := newTestSessionLoader(t, fp, 0)
+	sl := newTestLoader(t, fp, loaderTestConfig{})
 
-	live, err := sessionLoader.LoadSession(context.Background(), testEnterClusterInfo())
+	live, err := sl.LoadSession(context.Background(), testClusterInfo())
 	if err == nil {
 		t.Fatalf("expected error from zero-value status, got nil (live=%v)", live)
 	}
@@ -205,11 +224,11 @@ func TestLoadSession_FastPath_SkipsSingleflight(t *testing.T) {
 			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
 		},
 	}
-	sessionLoader := newTestSessionLoader(t, fp, 0)
-	info := testEnterClusterInfo()
+	sl := newTestLoader(t, fp, loaderTestConfig{})
+	info := testClusterInfo()
 
 	// First call: cold path, processor runs, session marked loaded.
-	if _, err := sessionLoader.LoadSession(context.Background(), info); err != nil {
+	if _, err := sl.LoadSession(context.Background(), info); err != nil {
 		t.Fatalf("cold-path LoadSession: %v", err)
 	}
 	if got := fp.callCount(); got != 1 {
@@ -218,7 +237,7 @@ func TestLoadSession_FastPath_SkipsSingleflight(t *testing.T) {
 
 	// Subsequent calls: fast path, processor must NOT be invoked again.
 	for i := 0; i < 5; i++ {
-		if _, err := sessionLoader.LoadSession(context.Background(), info); err != nil {
+		if _, err := sl.LoadSession(context.Background(), info); err != nil {
 			t.Fatalf("fast path LoadSession #%d: %v", i, err)
 		}
 	}
@@ -230,14 +249,13 @@ func TestLoadSession_FastPath_SkipsSingleflight(t *testing.T) {
 // TestGetSnapshot_PutThenGet verifies the canonical hot path:
 // putSnapshot, then GetSnapshot returns a snapshot with matching content.
 func TestGetSnapshot_PutThenGet(t *testing.T) {
-	info := testEnterClusterInfo()
-	clusterSessionKey := utils.BuildClusterSessionKey(info.Name, info.Namespace, info.SessionName)
+	key := testClusterSessionKey()
 
-	sl := newTestSessionLoader(t, &fakeProcessor{}, 0)
-	stored := testSnapshot(clusterSessionKey)
-	sl.putSnapshot(clusterSessionKey, stored)
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{})
+	stored := testSnapshot(key)
+	sl.putSnapshot(key, stored)
 
-	got, ok := sl.GetSnapshot(clusterSessionKey)
+	got, ok := sl.GetSnapshot(key)
 	if !ok {
 		t.Fatal("GetSnapshot: ok=false")
 	}
@@ -248,31 +266,24 @@ func TestGetSnapshot_PutThenGet(t *testing.T) {
 
 // TestGetSnapshot_ColdMiss verifies that a miss returns (nil, false).
 func TestGetSnapshot_ColdMiss(t *testing.T) {
-	info := testEnterClusterInfo()
-	clusterSessionKey := utils.BuildClusterSessionKey(info.Name, info.Namespace, info.SessionName)
-
-	sl := newTestSessionLoader(t, &fakeProcessor{}, 0)
-	snap, ok := sl.GetSnapshot(clusterSessionKey)
-	if ok || snap != nil {
-		t.Fatalf("expected (nil, false) on cold miss, got (%v, %v)", snap, ok)
-	}
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{})
+	requireSnapshotCached(t, sl, testClusterSessionKey(), false)
 }
 
 // TestGetSnapshot_PutOverwrites verifies that putSnapshot replaces any prior entry.
 func TestGetSnapshot_PutOverwrites(t *testing.T) {
-	info := testEnterClusterInfo()
-	clusterSessionKey := utils.BuildClusterSessionKey(info.Name, info.Namespace, info.SessionName)
+	key := testClusterSessionKey()
 
-	stale := testSnapshot(clusterSessionKey)
+	stale := testSnapshot(key)
 	stale.Tasks = []eventtypes.Task{{TaskID: "stale-task"}}
-	fresh := testSnapshot(clusterSessionKey)
+	fresh := testSnapshot(key)
 	fresh.Tasks = []eventtypes.Task{{TaskID: "fresh-task"}}
 
-	sl := newTestSessionLoader(t, &fakeProcessor{}, 0)
-	sl.putSnapshot(clusterSessionKey, stale)
-	sl.putSnapshot(clusterSessionKey, fresh)
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{})
+	sl.putSnapshot(key, stale)
+	sl.putSnapshot(key, fresh)
 
-	got, ok := sl.GetSnapshot(clusterSessionKey)
+	got, ok := sl.GetSnapshot(key)
 	if !ok {
 		t.Fatal("Get: ok=false")
 	}
@@ -281,99 +292,234 @@ func TestGetSnapshot_PutOverwrites(t *testing.T) {
 	}
 }
 
-// TestGetSnapshot_TasksIsPerRequest verifies that mutating the slice returned
-// by one GetSnapshot call must not affect another concurrent reader of the same
-// cached entry.
-func TestGetSnapshot_TasksIsPerRequest(t *testing.T) {
-	info := testEnterClusterInfo()
-	key := utils.BuildClusterSessionKey(info.Name, info.Namespace, info.SessionName)
+// TestGetSnapshot_MapsArePerRequest verifies every section is an independent copy
+// per request, so one reader's mutation cannot leak to another.
+func TestGetSnapshot_MapsArePerRequest(t *testing.T) {
+	key := testClusterSessionKey()
 
-	sl := newTestSessionLoader(t, &fakeProcessor{}, 0)
-	sl.putSnapshot(key, &eventserver.SessionSnapshot{
-		SessionKey: key,
-		Tasks:      []eventtypes.Task{{TaskID: "c"}, {TaskID: "a"}, {TaskID: "b"}},
-	})
-
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{})
+	sl.putSnapshot(key, richSnapshot(key))
 	first, _ := sl.GetSnapshot(key)
 	second, _ := sl.GetSnapshot(key)
 
-	sort.Slice(first.Tasks, func(i, j int) bool {
-		return first.Tasks[i].TaskID < first.Tasks[j].TaskID
-	})
+	first.Actors["actor-e2e-cafe"] = eventtypes.Actor{ActorID: "MUTATED"}
+	delete(first.Nodes, "node-e2e-dead")
+	first.Jobs["injected"] = eventtypes.Job{}
 
-	wantOriginal := []string{"c", "a", "b"}
-	for i, task := range second.Tasks {
-		if task.TaskID != wantOriginal[i] {
-			t.Fatalf("second.Tasks[%d].TaskID = %q, want %q (mutation leaked)", i, task.TaskID, wantOriginal[i])
-		}
+	if second.Actors["actor-e2e-cafe"].ActorID != "actor-e2e-cafe" {
+		t.Fatal("Actors map leaked across requests")
+	}
+	if _, ok := second.Nodes["node-e2e-dead"]; !ok {
+		t.Fatal("Nodes map leaked across requests")
+	}
+	if _, ok := second.Jobs["injected"]; ok {
+		t.Fatal("Jobs map leaked across requests")
+	}
+}
+
+// TestGetSnapshot_CorruptEntry_TreatedAsMiss verifies that a non-decodable cache
+// entry is dropped and reported as a miss instead of panicking.
+func TestGetSnapshot_CorruptEntry_TreatedAsMiss(t *testing.T) {
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{})
+	sl.cache.Add("corrupt", []byte("{not valid json"))
+
+	snap, ok := sl.GetSnapshot("corrupt")
+	if ok || snap != nil {
+		t.Fatalf("corrupt entry: got (%v, %v), want (nil, false)", snap, ok)
+	}
+	if _, stillCached := sl.cache.Get("corrupt"); stillCached {
+		t.Fatal("corrupt entry should have been dropped")
 	}
 }
 
 // TestGetSnapshot_LRUEviction verifies that once capacity is exceeded, the
 // oldest cached entry is evicted and GetSnapshot for that key returns ok=false.
 func TestGetSnapshot_LRUEviction(t *testing.T) {
-	info := testEnterClusterInfo()
-	k1 := utils.BuildClusterSessionKey(info.Name, info.Namespace, "session_2026-04-22_10-00-00_000000_1")
-	k2 := utils.BuildClusterSessionKey(info.Name, info.Namespace, "session_2026-04-22_11-00-00_000000_1")
-	k3 := utils.BuildClusterSessionKey(info.Name, info.Namespace, "session_2026-04-22_12-00-00_000000_1")
+	k1 := testClusterSessionKey()
+	k2 := testClusterSessionKeyFor("session_2026-04-22_11-00-00_000000_1")
+	k3 := testClusterSessionKeyFor("session_2026-04-22_12-00-00_000000_1")
 
-	sl := newTestSessionLoader(t, &fakeProcessor{}, 2)
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{cacheSize: 2})
 	sl.putSnapshot(k1, testSnapshot(k1))
 	sl.putSnapshot(k2, testSnapshot(k2))
 	// Third session evicts the first (LRU).
 	sl.putSnapshot(k3, testSnapshot(k3))
 
-	if _, ok := sl.GetSnapshot(k1); ok {
-		t.Fatal("expected first session to be evicted")
-	}
-	if _, ok := sl.GetSnapshot(k2); !ok {
-		t.Fatal("expected second session to still be cached")
-	}
-	if _, ok := sl.GetSnapshot(k3); !ok {
-		t.Fatal("expected third session to still be cached")
-	}
+	requireSnapshotCached(t, sl, k1, false)
+	requireSnapshotCached(t, sl, k2, true)
+	requireSnapshotCached(t, sl, k3, true)
 }
 
 // TestGetSnapshot_TTLExpiry verifies that when a TTL is set, a cached snapshot
 // expires after the TTL elapses and GetSnapshot returns ok=false.
 func TestGetSnapshot_TTLExpiry(t *testing.T) {
-	info := testEnterClusterInfo()
-	key := utils.BuildClusterSessionKey(info.Name, info.Namespace, info.SessionName)
+	key := testClusterSessionKey()
 
 	const ttl = 30 * time.Millisecond
-	sl := NewSessionLoader(&fakeProcessor{}, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, ttl)
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{cacheTTL: ttl})
 	sl.putSnapshot(key, testSnapshot(key))
 
-	if _, ok := sl.GetSnapshot(key); !ok {
-		t.Fatal("expected snapshot to be cached right after put")
-	}
+	requireSnapshotCached(t, sl, key, true)
 
 	time.Sleep(80 * time.Millisecond)
-	if _, ok := sl.GetSnapshot(key); ok {
-		t.Fatal("expected snapshot to be evicted after TTL expiry")
-	}
+	requireSnapshotCached(t, sl, key, false)
 }
 
 // TestGetSnapshot_SlidingTTLRenewal verifies that repeated GetSnapshot calls
 // keep a cached entry alive until idle TTL expiry.
 func TestGetSnapshot_SlidingTTLRenewal(t *testing.T) {
-	info := testEnterClusterInfo()
-	key := utils.BuildClusterSessionKey(info.Name, info.Namespace, info.SessionName)
+	key := testClusterSessionKey()
 
 	const ttl = 30 * time.Millisecond
-	sl := NewSessionLoader(&fakeProcessor{}, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, ttl)
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{cacheTTL: ttl})
 	sl.putSnapshot(key, testSnapshot(key))
 
 	deadline := time.Now().Add(100 * time.Millisecond)
 	for time.Now().Before(deadline) {
-		if _, ok := sl.GetSnapshot(key); !ok {
-			t.Fatal("expected snapshot to stay cached while being accessed")
-		}
+		requireSnapshotCached(t, sl, key, true)
 		time.Sleep(10 * time.Millisecond)
 	}
 
 	time.Sleep(80 * time.Millisecond)
-	if _, ok := sl.GetSnapshot(key); ok {
-		t.Fatal("expected snapshot to expire after idle period")
+	requireSnapshotCached(t, sl, key, false)
+}
+
+// TestCacheStats_TracksEntriesAndBytes verifies CacheStats reports the entry
+// count and the exact sum of encoded snapshot lengths.
+func TestCacheStats_TracksEntriesAndBytes(t *testing.T) {
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{})
+
+	if entries, total := sl.CacheStats(); entries != 0 || total != 0 {
+		t.Fatalf("empty cache: got (entries=%d, bytes=%d), want (0, 0)", entries, total)
+	}
+
+	key1 := testClusterSessionKey()
+	s1 := richSnapshot(key1)
+	sl.putSnapshot(key1, s1)
+	enc1, _ := encodeSnapshot(s1)
+	if entries, total := sl.CacheStats(); entries != 1 || total != len(enc1) {
+		t.Fatalf("after 1 put: got (entries=%d, bytes=%d), want (1, %d)", entries, total, len(enc1))
+	}
+
+	key2 := testClusterSessionKeyFor("session_2026-04-22_11-00-00_000000_1")
+	s2 := richSnapshot(key2)
+	sl.putSnapshot(key2, s2)
+	enc2, _ := encodeSnapshot(s2)
+	if entries, total := sl.CacheStats(); entries != 2 || total != len(enc1)+len(enc2) {
+		t.Fatalf("after 2 puts: got (entries=%d, bytes=%d), want (2, %d)", entries, total, len(enc1)+len(enc2))
+	}
+}
+
+// TestCache_ByteBudgetEviction verifies that exceeding maxBytes evicts the
+// LRU entries until the cache is back under budget.
+func TestCache_ByteBudgetEviction(t *testing.T) {
+	olderKey := testClusterSessionKey()
+	newerKey := testClusterSessionKeyFor("session_2026-04-22_11-00-00_000000_1")
+
+	s1 := richSnapshot(olderKey)
+
+	// Budget large enough for one richSnapshot but not two.
+	enc1, _ := encodeSnapshot(s1)
+	maxBytes := len(enc1) + 1
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{cacheSize: 1000, maxBytes: maxBytes})
+
+	sl.putSnapshot(olderKey, s1)
+	sl.putSnapshot(newerKey, richSnapshot(newerKey))
+
+	requireSnapshotCached(t, sl, olderKey, false)
+	requireSnapshotCached(t, sl, newerKey, true)
+	if entries, total := sl.CacheStats(); entries != 1 || total > maxBytes {
+		t.Fatalf("after byte-budget eviction: got (entries=%d, bytes=%d), want (1, <=%d)", entries, total, maxBytes)
+	}
+}
+
+// TestCache_ByteBudgetKeepsOversizedSoleEntry verifies a single snapshot larger
+// than the whole budget is kept.
+func TestCache_ByteBudgetKeepsOversizedSoleEntry(t *testing.T) {
+	key := testClusterSessionKey()
+	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{cacheSize: 1000, maxBytes: 1})
+	sl.putSnapshot(key, richSnapshot(key))
+
+	requireSnapshotCached(t, sl, key, true)
+}
+
+// TestSnapshotCache_RoundTripPreservesData verifies the encode/decode round-trip
+// is lossless.
+func TestSnapshotCache_RoundTripPreservesData(t *testing.T) {
+	snap := richSnapshot(testClusterSessionKey())
+
+	b1, err := encodeSnapshot(snap)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := decodeSnapshot(b1)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	b2, err := encodeSnapshot(got)
+	if err != nil {
+		t.Fatalf("re-encode: %v", err)
+	}
+	if !bytes.Equal(b1, b2) {
+		t.Fatalf("round-trip changed the snapshot:\n before=%s\n  after=%s", b1, b2)
+	}
+
+	// byte equality can hide int to float64 drift inside map[string]any after JSON unmarshal.
+	wantCF := snap.LogEventsByJobID["job-e2e-aaaa"][0].CustomFields
+	gotCF := got.LogEventsByJobID["job-e2e-aaaa"][0].CustomFields
+	if !reflect.DeepEqual(wantCF, gotCF) {
+		t.Fatalf("CustomFields round-trip mismatch:\n want=%#v\n  got=%#v", wantCF, gotCF)
+	}
+}
+
+// richSnapshot builds a snapshot exercising all five session states.
+//
+// Sentinel strings (…-e2e-…) are asserted by the HTTP e2e test.
+// TODO(jiangjiawei1103): Move to test data.
+func richSnapshot(clusterSessionKey string) *eventserver.SessionSnapshot {
+	return &eventserver.SessionSnapshot{
+		SessionKey: clusterSessionKey,
+		Tasks: []eventtypes.Task{
+			{TaskID: "task-e2e-1111", TaskAttempt: 0, JobID: "job-e2e-aaaa", TaskName: "café-task-名前", RequiredResources: map[string]float64{"CPU": 2}},
+			{TaskID: "task-e2e-2222", TaskAttempt: 1, JobID: "job-e2e-aaaa"},
+		},
+		Actors: map[string]eventtypes.Actor{
+			"actor-e2e-cafe": {ActorID: "actor-e2e-cafe", JobID: "job-e2e-aaaa", ActorClass: "MyActor", Name: "actorname-e2e", NumRestarts: 3},
+		},
+		Jobs: map[string]eventtypes.Job{
+			"job-e2e-aaaa": {JobID: "job-e2e-aaaa", SubmissionID: "sub-e2e-bbbb", JobType: "SUBMISSION", EntryPoint: "python main.py", RuntimeEnv: map[string]string{"pip": "ray"}},
+		},
+		Nodes: map[string]eventtypes.Node{
+			"node-e2e-dead": {
+				NodeID:        "node-e2e-dead",
+				NodeIPAddress: "10.0.0.7",
+				Hostname:      "host-e2e",
+				Labels:        map[string]string{},
+				StateTransitions: []eventtypes.NodeStateTransition{
+					{State: eventtypes.NODE_ALIVE, Timestamp: time.Unix(1770635705, 0).UTC(), Resources: map[string]float64{"CPU": 8}},
+				},
+			},
+		},
+		LogEventsByJobID: map[string][]eventtypes.LogEvent{
+			"job-e2e-aaaa": {
+				{
+					EventID:    "evt-e2e-1",
+					SourceType: "GCS",
+					Severity:   "INFO",
+					Message:    "e2e-log-message-sentinel",
+					Timestamp:  "1770635705",
+					// JSON-safe values only (numbers as float64) so the decoded
+					// map[string]any compares equal to the original.
+					CustomFields: map[string]any{
+						"job_id":     "job-e2e-aaaa",
+						"custom_str": "e2e-custom-value",
+						"nested":     map[string]any{"inner": "e2e-nested-value"},
+						"list":       []any{"e2e-list-a", "e2e-list-b"},
+						"num":        float64(42),
+						"flag":       true,
+					},
+				},
+			},
+		},
 	}
 }

--- a/historyserver/pkg/historyserver/session_loader_test.go
+++ b/historyserver/pkg/historyserver/session_loader_test.go
@@ -384,32 +384,6 @@ func TestGetSnapshot_SlidingTTLRenewal(t *testing.T) {
 	requireSnapshotCached(t, sl, key, false)
 }
 
-// TestCacheStats_TracksEntriesAndBytes verifies CacheStats reports the entry
-// count and the exact sum of encoded snapshot lengths.
-func TestCacheStats_TracksEntriesAndBytes(t *testing.T) {
-	sl := newTestLoader(t, &fakeProcessor{}, loaderTestConfig{})
-
-	if entries, total := sl.CacheStats(); entries != 0 || total != 0 {
-		t.Fatalf("empty cache: got (entries=%d, bytes=%d), want (0, 0)", entries, total)
-	}
-
-	key1 := testClusterSessionKey()
-	s1 := richSnapshot(key1)
-	sl.putSnapshot(key1, s1)
-	enc1, _ := encodeSnapshot(s1)
-	if entries, total := sl.CacheStats(); entries != 1 || total != len(enc1) {
-		t.Fatalf("after 1 put: got (entries=%d, bytes=%d), want (1, %d)", entries, total, len(enc1))
-	}
-
-	key2 := testClusterSessionKeyFor("session_2026-04-22_11-00-00_000000_1")
-	s2 := richSnapshot(key2)
-	sl.putSnapshot(key2, s2)
-	enc2, _ := encodeSnapshot(s2)
-	if entries, total := sl.CacheStats(); entries != 2 || total != len(enc1)+len(enc2) {
-		t.Fatalf("after 2 puts: got (entries=%d, bytes=%d), want (2, %d)", entries, total, len(enc1)+len(enc2))
-	}
-}
-
 // TestCache_ByteBudgetEviction verifies that exceeding maxBytes evicts the
 // LRU entries until the cache is back under budget.
 func TestCache_ByteBudgetEviction(t *testing.T) {
@@ -428,7 +402,7 @@ func TestCache_ByteBudgetEviction(t *testing.T) {
 
 	requireSnapshotCached(t, sl, olderKey, false)
 	requireSnapshotCached(t, sl, newerKey, true)
-	if entries, total := sl.CacheStats(); entries != 1 || total > maxBytes {
+	if entries, total := sl.cache.Len(), sl.totalBytes(); entries != 1 || total > maxBytes {
 		t.Fatalf("after byte-budget eviction: got (entries=%d, bytes=%d), want (1, <=%d)", entries, total, maxBytes)
 	}
 }


### PR DESCRIPTION
## Why are these changes needed?

Count-based LRU caps entries, not memory: a few large dead-session snapshots can cause OOM while the count is still within limits. This PR caches JSON-encoded `[]byte` per session so we can enforce a **byte budget** on top of the existing count and TTL bounds.

## Change Summary

- Cache encoded snapshot bytes in the LRU and decode a **fresh copy per request** to prevent race
- Evict LRU sessions when over budget (add-then-trim)
- Add integration test that gates the `encode → cache → decode → serve` path

## Related issue number

Follow-up to #4796

## Performance Tests

Go's GC traces every pointer in every live object on each cycle, so an object cache incurs GC scanning cost proportional to session data size. A byte slice, however, is a pointer-free leaf and its contents are opaque to the GC. This PR reduces the per-entry mark cost to O(1), decoupling GC overhead from session data size.

<img width="800" height="500" alt="image" src="https://github.com/user-attachments/assets/203917a0-43f0-42d1-9222-22c006de80ed" />

- Each point forces `runtime.GC()` and reports per-cycle wall time = how long GC spends walking the cache.
- The benchmark fixes 50 sessions, scaling per-session size from 10^2 to 10^6.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
