### PR TITLE
ray-operator: add limit reader for serve actor health checks

### DIFF
--- a/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
+++ b/ray-operator/controllers/ray/utils/httpproxy_httpclient.go
@@ -36,7 +36,7 @@ func (r *RayHttpProxyClient) CheckProxyActorHealth(ctx context.Context) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if err != nil {
 			return fmt.Errorf("CheckProxyActorHealth fails. status code: %d, status: %s, error reading body: %w", resp.StatusCode, resp.Status, err)
 		}


### PR DESCRIPTION
## Why are these changes needed?

Add limit reader for Ray Serve proxy actor health checks. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
