### PR TITLE
[4/N] [History Server Beta] [Refactor] Clean up context handling and client manager

### DIFF
--- a/historyserver/cmd/historyserver/main.go
+++ b/historyserver/cmd/historyserver/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 
 	"github.com/sirupsen/logrus"
@@ -100,29 +99,15 @@ func main() {
 	defer serverCancel()
 
 	processor := historyserver.NewSessionProcessor(reader, cliMgr.Client())
-	sessionLoader := historyserver.NewSessionLoader(processor, serverCtx, sessionProcessTimeout, sessionCacheSize, sessionCacheTTL)
-
-	// ServerHandler.Run consumes a stop chan; bridge serverCtx into it.
-	var wg sync.WaitGroup
-	stop := make(chan struct{})
-	go func() {
-		<-serverCtx.Done()
-		logrus.Info("Received shutdown signal, initiating graceful shutdown...")
-		close(stop)
-	}()
+	sessionLoader := historyserver.NewSessionLoader(processor, sessionProcessTimeout, sessionCacheSize, sessionCacheTTL)
 
 	handler, err := historyserver.NewServerHandler(&globalConfig, dashboardDir, reader, cliMgr, sessionLoader, useKubernetesProxy)
 	if err != nil {
 		logrus.Fatalf("Failed to create server handler: %v", err)
 	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		handler.Run(stop)
-		logrus.Info("HTTP server shutdown complete")
-	}()
-
-	wg.Wait()
+	if err := handler.Run(serverCtx); err != nil {
+		logrus.Fatalf("HTTP server exited with error: %v", err)
+	}
 	logrus.Info("Graceful shutdown complete")
 }

--- a/historyserver/pkg/historyserver/clientmanager.go
+++ b/historyserver/pkg/historyserver/clientmanager.go
@@ -24,29 +24,26 @@ const (
 )
 
 type ClientManager struct {
-	configs []*rest.Config
-	clients []client.Client
+	config *rest.Config
+	client client.Client
 }
 
-// Client returns the primary controller-runtime client.
+// Client returns the controller-runtime client.
 func (c *ClientManager) Client() client.Client {
-	return c.clients[0]
+	return c.client
 }
 
 func (c *ClientManager) ListRayClusters(ctx context.Context) ([]*rayv1.RayCluster, error) {
-	list := []*rayv1.RayCluster{}
-	for _, c := range c.clients {
-		listOfRayCluster := rayv1.RayClusterList{}
-		err := c.List(ctx, &listOfRayCluster)
-		if err != nil {
-			logrus.Errorf("Failed to list RayClusters: %v", err)
-			continue
-		}
-		for _, rayCluster := range listOfRayCluster.Items {
-			list = append(list, &rayCluster)
-		}
+	var clusterList rayv1.RayClusterList
+	if err := c.client.List(ctx, &clusterList); err != nil {
+		logrus.Errorf("Failed to list RayClusters: %v", err)
+		return nil, err
 	}
-	return list, nil
+	clusters := make([]*rayv1.RayCluster, 0, len(clusterList.Items))
+	for i := range clusterList.Items {
+		clusters = append(clusters, &clusterList.Items[i])
+	}
+	return clusters, nil
 }
 
 type ClientManagerConfig struct {
@@ -59,9 +56,8 @@ type ClientManagerConfig struct {
 func NewClientManager(cfg ClientManagerConfig) (*ClientManager, error) {
 	kubeconfigs := cfg.Kubeconfigs
 
-	var c *rest.Config
+	var restConfig *rest.Config
 	var err error
-	kubeconfigList := []*rest.Config{}
 	if len(kubeconfigs) > 0 {
 		stringList := strings.Split(kubeconfigs, ",")
 		if len(stringList) > 1 {
@@ -74,7 +70,7 @@ func NewClientManager(cfg ClientManagerConfig) (*ClientManager, error) {
 			return nil, fmt.Errorf("kubeconfig is empty")
 		}
 
-		c, err = clientcmd.BuildConfigFromFlags("", stringList[0])
+		restConfig, err = clientcmd.BuildConfigFromFlags("", stringList[0])
 		if err != nil {
 			return nil, fmt.Errorf("failed to build config from kubeconfig: %w", err)
 		}
@@ -85,43 +81,32 @@ func NewClientManager(cfg ClientManagerConfig) (*ClientManager, error) {
 			loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 			configOverrides := &clientcmd.ConfigOverrides{}
 			clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-			c, err = clientConfig.ClientConfig()
+			restConfig, err = clientConfig.ClientConfig()
 			if err != nil {
 				return nil, fmt.Errorf("failed to load default kubeconfig in Kubernetes proxy mode: %w", err)
 			}
 		} else {
-			c, err = rest.InClusterConfig()
+			restConfig, err = rest.InClusterConfig()
 			if err != nil {
 				return nil, fmt.Errorf("failed to build config from in-cluster kubeconfig: %w", err)
 			}
 		}
 	}
-	c.QPS = cfg.QPS
-	c.Burst = cfg.Burst
-	kubeconfigList = append(kubeconfigList, c)
+	restConfig.QPS = cfg.QPS
+	restConfig.Burst = cfg.Burst
 
 	scheme := runtime.NewScheme()
 	utilruntime.Must(rayv1.AddToScheme(scheme))
-	clientList := []client.Client{}
-	for _, config := range kubeconfigList {
-		c, err := client.New(config, client.Options{
-			Scheme: scheme,
-		})
-		if err != nil {
-			logrus.Errorf("Failed to create client: %v", err)
-			continue
-		}
-		clientList = append(clientList, c)
+	cli, err := client.New(restConfig, client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
 
-	if len(clientList) == 0 {
-		return nil, fmt.Errorf("failed to create any client")
-	}
-
-	logrus.Infof("create client manager successfully, clients: %v", len(clientList))
-	clientManager := &ClientManager{
-		configs: kubeconfigList,
-		clients: clientList,
-	}
-	return clientManager, nil
+	logrus.Info("create client manager successfully")
+	return &ClientManager{
+		config: restConfig,
+		client: cli,
+	}, nil
 }

--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -35,7 +35,7 @@ func TestEnterCluster(t *testing.T) {
 			return SessionStatusEventsErr, nil, fmt.Errorf("unknown session")
 		},
 	}
-	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+	handler.sessionLoader = NewSessionLoader(fp, DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
 
 	// Single session cluster
 	keyA := utils.ClusterKey{
@@ -108,7 +108,7 @@ func TestEnterCluster(t *testing.T) {
 	sort.Sort(utils.ClusterInfoList(handler.clustersMap[keyB]))
 
 	// Register actual router
-	routerRayClusterSet(handler)
+	routerRayClusterSet(handler, context.Background())
 
 	container := restful.DefaultContainer
 

--- a/historyserver/pkg/historyserver/router.go
+++ b/historyserver/pkg/historyserver/router.go
@@ -296,7 +296,7 @@ func routerLogical(s *ServerHandler) {
 
 }
 
-func routerRayClusterSet(s *ServerHandler) {
+func routerRayClusterSet(s *ServerHandler, serverCtx context.Context) {
 	ws := new(restful.WebService)
 	defer restful.Add(ws)
 
@@ -322,7 +322,7 @@ func routerRayClusterSet(s *ServerHandler) {
 				return
 			}
 			info := utils.ClusterInfo{Name: name, Namespace: namespace, SessionName: resolvedSession}
-			live, err := s.sessionLoader.LoadSession(r1.Request.Context(), info)
+			live, err := s.sessionLoader.LoadSession(r1.Request.Context(), serverCtx, info)
 			if err != nil {
 				logrus.Errorf("Failed to load session %s/%s/%s: %v", namespace, name, resolvedSession, err)
 				r2.WriteErrorString(http.StatusInternalServerError, err.Error())
@@ -361,8 +361,8 @@ func routerRayClusterSet(s *ServerHandler) {
 		Writes("")) // Placeholder for specific return type
 }
 
-func (s *ServerHandler) RegisterRouter() {
-	routerRayClusterSet(s)
+func (s *ServerHandler) RegisterRouter(serverCtx context.Context) {
+	routerRayClusterSet(s, serverCtx)
 	routerClusters(s)
 	routerTimezone(s)
 	routerNodes(s)
@@ -381,7 +381,7 @@ func (s *ServerHandler) redirectRequest(req *restful.Request, resp *restful.Resp
 	if s.useKubernetesProxy {
 		// Use Kubernetes API server proxy to access the in-cluster RayDashboard services.
 		targetURL = fmt.Sprintf("%s/api/v1/namespaces/%s/services/%s:dashboard/proxy%s",
-			s.clientManager.configs[0].Host,
+			s.clientManager.config.Host,
 			svcInfo.Namespace,
 			svcInfo.ServiceName,
 			req.Request.URL.String())
@@ -1880,7 +1880,7 @@ func (s *ServerHandler) CookieHandle(req *restful.Request, resp *restful.Respons
 		// Always query K8s to get the service name to prevent SSRF attacks.
 		// Do not trust user-provided cookies for service name.
 		// TODO: here might be a bottleneck if there are many requests in the future.
-		svcInfo, err := getClusterSvcInfo(s.clientManager.clients, clusterName.Value, clusterNamespace.Value)
+		svcInfo, err := getClusterSvcInfo(s.clientManager.Client(), clusterName.Value, clusterNamespace.Value)
 		if err != nil {
 			resp.WriteHeaderAndEntity(http.StatusBadRequest, err.Error())
 			return
@@ -1894,11 +1894,10 @@ func (s *ServerHandler) CookieHandle(req *restful.Request, resp *restful.Respons
 	chain.ProcessFilter(req, resp)
 }
 
-func getClusterSvcInfo(clis []client.Client, name, namespace string) (ServiceInfo, error) {
-	if len(clis) == 0 {
+func getClusterSvcInfo(cli client.Client, name, namespace string) (ServiceInfo, error) {
+	if cli == nil {
 		return ServiceInfo{}, errors.New("No available kubernetes config found")
 	}
-	cli := clis[0]
 	rc := rayv1.RayCluster{}
 	err := cli.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &rc)
 	if err != nil {

--- a/historyserver/pkg/historyserver/server.go
+++ b/historyserver/pkg/historyserver/server.go
@@ -43,8 +43,8 @@ func NewServerHandler(c *types.RayHistoryServerConfig, dashboardDir string, read
 		maxClusters: 100,
 	}
 
-	if len(clientManager.configs) > 0 {
-		k8sRestConfig := clientManager.configs[0]
+	if clientManager.config != nil {
+		k8sRestConfig := clientManager.config
 		if useKubernetesProxy {
 			transportConfig, err := k8sRestConfig.TransportConfig()
 			if err != nil {
@@ -73,8 +73,8 @@ func NewServerHandler(c *types.RayHistoryServerConfig, dashboardDir string, read
 	return handler, nil
 }
 
-func (s *ServerHandler) Run(stop <-chan struct{}) error {
-	s.RegisterRouter()
+func (s *ServerHandler) Run(ctx context.Context) error {
+	s.RegisterRouter(ctx)
 	port := ":8080"
 	server := &http.Server{
 		Addr:         port,             // Listen address
@@ -91,14 +91,14 @@ func (s *ServerHandler) Run(stop <-chan struct{}) error {
 		logrus.Infof("Server stopped gracefully")
 	}()
 
-	<-stop
-	logrus.Warnf("Receive stop single, so stop ray history server")
-	// Create a context with 1 second timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	<-ctx.Done()
+	logrus.Info("Received shutdown signal, initiating graceful shutdown...")
+	// Give in-flight requests a brief window to drain before forcing shutdown.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
 	// Shutdown the server
-	if err := server.Shutdown(ctx); err != nil {
+	if err := server.Shutdown(shutdownCtx); err != nil {
 		log.Fatalf("Ray HistoryServer forced to shutdown: %v", err)
 	}
 	return nil

--- a/historyserver/pkg/historyserver/session_loader.go
+++ b/historyserver/pkg/historyserver/session_loader.go
@@ -35,16 +35,14 @@ type SessionLoader struct {
 	processor      processor
 	cache          *expirable.LRU[string, *eventserver.SessionSnapshot]
 	sf             singleflight.Group
-	serverCtx      context.Context
 	processTimeout time.Duration
 }
 
 // NewSessionLoader wires a SessionLoader.
-func NewSessionLoader(p processor, serverCtx context.Context, processTimeout time.Duration, cacheSize int, cacheTTL time.Duration) *SessionLoader {
+func NewSessionLoader(p processor, processTimeout time.Duration, cacheSize int, cacheTTL time.Duration) *SessionLoader {
 	return &SessionLoader{
 		processor:      p,
 		cache:          expirable.NewLRU[string, *eventserver.SessionSnapshot](cacheSize, nil, cacheTTL),
-		serverCtx:      serverCtx,
 		processTimeout: processTimeout,
 	}
 }
@@ -64,7 +62,7 @@ func (s *SessionLoader) GetSnapshot(clusterSessionKey string) (*eventserver.Sess
 
 // LoadSession blocks until a dead session is processed and cached or an
 // unrecoverable error is observed.
-func (s *SessionLoader) LoadSession(ctx context.Context, info utils.ClusterInfo) (live bool, err error) {
+func (s *SessionLoader) LoadSession(ctx context.Context, serverCtx context.Context, info utils.ClusterInfo) (live bool, err error) {
 	// Fast pre-flight: skip singleflight entirely if ctx is already dead.
 	if err := ctx.Err(); err != nil {
 		return false, err
@@ -79,7 +77,7 @@ func (s *SessionLoader) LoadSession(ctx context.Context, info utils.ClusterInfo)
 	// SIGTERM, serverCtx is cancelled immediately, causing any in-flight cold-load
 	// requests to return ctx.Err() and clients to receive HTTP 500.
 	ch := s.sf.DoChan(clusterSessionKey, func() (interface{}, error) {
-		loadCtx, cancel := context.WithTimeout(s.serverCtx, s.processTimeout)
+		loadCtx, cancel := context.WithTimeout(serverCtx, s.processTimeout)
 		defer cancel()
 		return s.doLoadSession(loadCtx, info, clusterSessionKey)
 	})

--- a/historyserver/pkg/historyserver/session_loader_test.go
+++ b/historyserver/pkg/historyserver/session_loader_test.go
@@ -39,7 +39,7 @@ func newTestSessionLoader(t *testing.T, p processor, cacheSize int) *SessionLoad
 	if cacheSize <= 0 {
 		cacheSize = DefaultSessionCacheSize
 	}
-	return NewSessionLoader(p, context.Background(), DefaultSessionProcessTimeout, cacheSize, DefaultSessionCacheTTL)
+	return NewSessionLoader(p, DefaultSessionProcessTimeout, cacheSize, DefaultSessionCacheTTL)
 }
 
 func testEnterClusterInfo() utils.ClusterInfo {
@@ -80,7 +80,7 @@ func TestLoadSession_ProcessorError_PropagatesAndCleans(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			_, errs[idx] = sessionLoader.LoadSession(context.Background(), info)
+			_, errs[idx] = sessionLoader.LoadSession(context.Background(), context.Background(), info)
 		}(i)
 	}
 
@@ -102,7 +102,7 @@ func TestLoadSession_ProcessorError_PropagatesAndCleans(t *testing.T) {
 	fp.setFn(func(_ context.Context, _ utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
 		return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
 	})
-	if _, err := sessionLoader.LoadSession(context.Background(), info); err != nil {
+	if _, err := sessionLoader.LoadSession(context.Background(), context.Background(), info); err != nil {
 		t.Fatalf("post-error retry: expected nil, got %v", err)
 	}
 	if got := fp.callCount(); got != 2 {
@@ -123,7 +123,7 @@ func TestLoadSession_ProcessorError_NoInternalRetry(t *testing.T) {
 	}
 	sessionLoader := newTestSessionLoader(t, fp, 0)
 
-	_, err := sessionLoader.LoadSession(context.Background(), info)
+	_, err := sessionLoader.LoadSession(context.Background(), context.Background(), info)
 	if !errors.Is(err, processorErr) {
 		t.Fatalf("expected LoadSession to return processorErr, got %v", err)
 	}
@@ -134,7 +134,7 @@ func TestLoadSession_ProcessorError_NoInternalRetry(t *testing.T) {
 	fp.setFn(func(_ context.Context, _ utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
 		return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
 	})
-	if _, err := sessionLoader.LoadSession(context.Background(), info); err != nil {
+	if _, err := sessionLoader.LoadSession(context.Background(), context.Background(), info); err != nil {
 		t.Fatalf("client-driven retry: expected nil, got %v", err)
 	}
 	if got := fp.callCount(); got != 2 {
@@ -166,7 +166,7 @@ func TestLoadSession_LiveAndProcessed(t *testing.T) {
 			}
 			sessionLoader := newTestSessionLoader(t, fp, 0)
 
-			live, err := sessionLoader.LoadSession(context.Background(), testEnterClusterInfo())
+			live, err := sessionLoader.LoadSession(context.Background(), context.Background(), testEnterClusterInfo())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -188,7 +188,7 @@ func TestLoadSession_ZeroValueStatus_DoesNotSilentlyMatchLive(t *testing.T) {
 	}
 	sessionLoader := newTestSessionLoader(t, fp, 0)
 
-	live, err := sessionLoader.LoadSession(context.Background(), testEnterClusterInfo())
+	live, err := sessionLoader.LoadSession(context.Background(), context.Background(), testEnterClusterInfo())
 	if err == nil {
 		t.Fatalf("expected error from zero-value status, got nil (live=%v)", live)
 	}
@@ -209,7 +209,7 @@ func TestLoadSession_FastPath_SkipsSingleflight(t *testing.T) {
 	info := testEnterClusterInfo()
 
 	// First call: cold path, processor runs, session marked loaded.
-	if _, err := sessionLoader.LoadSession(context.Background(), info); err != nil {
+	if _, err := sessionLoader.LoadSession(context.Background(), context.Background(), info); err != nil {
 		t.Fatalf("cold-path LoadSession: %v", err)
 	}
 	if got := fp.callCount(); got != 1 {
@@ -218,7 +218,7 @@ func TestLoadSession_FastPath_SkipsSingleflight(t *testing.T) {
 
 	// Subsequent calls: fast path, processor must NOT be invoked again.
 	for i := 0; i < 5; i++ {
-		if _, err := sessionLoader.LoadSession(context.Background(), info); err != nil {
+		if _, err := sessionLoader.LoadSession(context.Background(), context.Background(), info); err != nil {
 			t.Fatalf("fast path LoadSession #%d: %v", i, err)
 		}
 	}
@@ -341,7 +341,7 @@ func TestGetSnapshot_TTLExpiry(t *testing.T) {
 	key := utils.BuildClusterSessionKey(info.Name, info.Namespace, info.SessionName)
 
 	const ttl = 30 * time.Millisecond
-	sl := NewSessionLoader(&fakeProcessor{}, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, ttl)
+	sl := NewSessionLoader(&fakeProcessor{}, DefaultSessionProcessTimeout, DefaultSessionCacheSize, ttl)
 	sl.putSnapshot(key, testSnapshot(key))
 
 	if _, ok := sl.GetSnapshot(key); !ok {
@@ -361,7 +361,7 @@ func TestGetSnapshot_SlidingTTLRenewal(t *testing.T) {
 	key := utils.BuildClusterSessionKey(info.Name, info.Namespace, info.SessionName)
 
 	const ttl = 30 * time.Millisecond
-	sl := NewSessionLoader(&fakeProcessor{}, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, ttl)
+	sl := NewSessionLoader(&fakeProcessor{}, DefaultSessionProcessTimeout, DefaultSessionCacheSize, ttl)
 	sl.putSnapshot(key, testSnapshot(key))
 
 	deadline := time.Now().Add(100 * time.Millisecond)


### PR DESCRIPTION
## Why are these changes needed?

This PR refactors context handling to align with Go's [best practices](https://go.dev/blog/context-and-structs) and makes the client manager easier to maintain.

### Change Summary

- Replace Run's stop channel with a serverCtx
- Collapse ClientManager to a single k8s client/config
- Pass serverCtx via signature instead of storing it in SessionLoader struct

## Related issue number

Follow-up to https://github.com/ray-project/kuberay/pull/4795

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
