### PR TITLE
[ray-operator] Update RayCluster status on validation failure

### DIFF
--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -431,11 +431,14 @@ const (
 	HeadPodNotFound                = "HeadPodNotFound"
 	HeadPodRunningAndReady         = "HeadPodRunningAndReady"
 	RayClusterValidationFailed     = "ValidationFailed"
+	RayClusterSpecValid            = "Valid"
 	// UnknownReason says that the reason for the condition is unknown.
 	UnknownReason = "Unknown"
 )
 
 const (
+	// RayClusterValid indicates whether the RayCluster metadata and spec pass controller validation.
+	RayClusterValid RayClusterConditionType = "Valid"
 	// RayClusterProvisioned indicates whether all Ray Pods are ready for the first time.
 	// After RayClusterProvisioned is set to true for the first time, it will not change anymore.
 	RayClusterProvisioned RayClusterConditionType = "RayClusterProvisioned"

--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -430,6 +430,7 @@ const (
 	RayClusterPodsProvisioning     = "RayClusterPodsProvisioning"
 	HeadPodNotFound                = "HeadPodNotFound"
 	HeadPodRunningAndReady         = "HeadPodRunningAndReady"
+	RayClusterValidationFailed     = "ValidationFailed"
 	// UnknownReason says that the reason for the condition is unknown.
 	UnknownReason = "Unknown"
 )

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1557,24 +1557,27 @@ func (r *RayClusterReconciler) handleRayClusterValidationError(ctx context.Conte
 	// Record the event
 	r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(eventType), eventMessageFmt, instance.Namespace, instance.Name, validationErr.Error())
 
+	// When status conditions are disabled, validation failure is reported via Events only.
+	if !features.Enabled(features.RayClusterStatusConditions) {
+		return ctrl.Result{}, nil
+	}
+
 	original := instance.DeepCopy()
 	newInstance := instance.DeepCopy()
 
-	// Record that the controller processed this spec generation
+	// Record that the controller processed this spec generation.
 	newInstance.Status.ObservedGeneration = newInstance.ObjectMeta.Generation
 
 	timeNow := metav1.Now()
 	newInstance.Status.LastUpdateTime = &timeNow
 
-	if features.Enabled(features.RayClusterStatusConditions) {
-		meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
-			Type:               string(rayv1.RayClusterProvisioned),
-			Status:             metav1.ConditionFalse,
-			Reason:             rayv1.RayClusterValidationFailed,
-			Message:            validationErr.Error(),
-			ObservedGeneration: newInstance.Generation,
-		})
-	}
+	meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
+		Type:               string(rayv1.RayClusterValid),
+		Status:             metav1.ConditionFalse,
+		Reason:             rayv1.RayClusterValidationFailed,
+		Message:            validationErr.Error(),
+		ObservedGeneration: newInstance.Generation,
+	})
 
 	_, updateErr := r.updateRayClusterStatus(ctx, original, newInstance)
 	if updateErr != nil {
@@ -1596,6 +1599,13 @@ func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *ra
 
 	statusConditionGateEnabled := features.Enabled(features.RayClusterStatusConditions)
 	if statusConditionGateEnabled {
+		meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
+			Type:               string(rayv1.RayClusterValid),
+			Status:             metav1.ConditionTrue,
+			Reason:             rayv1.RayClusterSpecValid,
+			Message:            "RayCluster metadata and spec are valid",
+			ObservedGeneration: newInstance.Generation,
+		})
 		if reconcileErr != nil {
 			if reason := utils.RayClusterReplicaFailureReason(reconcileErr); reason != "" {
 				meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -157,24 +157,15 @@ func (r *RayClusterReconciler) rayClusterReconcile(ctx context.Context, instance
 	setDefaults(instance)
 
 	if err := utils.ValidateRayClusterMetadata(instance.ObjectMeta); err != nil {
-		logger.Error(err, "The RayCluster metadata is invalid")
-		r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.InvalidRayClusterMetadata),
-			"The RayCluster metadata is invalid %s/%s: %v", instance.Namespace, instance.Name, err)
-		return ctrl.Result{}, nil
+		return r.handleRayClusterValidationError(ctx, instance, err, utils.InvalidRayClusterMetadata, "The RayCluster metadata is invalid %s/%s: %v")
 	}
 
 	if err := utils.ValidateRayClusterSpec(&instance.Spec, instance.Annotations); err != nil {
-		logger.Error(err, "The RayCluster spec is invalid")
-		r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.InvalidRayClusterSpec),
-			"The RayCluster spec is invalid %s/%s: %v", instance.Namespace, instance.Name, err)
-		return ctrl.Result{}, nil
+		return r.handleRayClusterValidationError(ctx, instance, err, utils.InvalidRayClusterSpec, "The RayCluster spec is invalid %s/%s: %v")
 	}
 
 	if err := utils.ValidateRayClusterUpgradeOptions(instance); err != nil {
-		logger.Error(err, "The RayCluster UpgradeStrategy is invalid")
-		r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.InvalidRayClusterSpec),
-			"The RayCluster UpgradeStrategy is invalid %s/%s: %v", instance.Namespace, instance.Name, err)
-		return ctrl.Result{}, nil
+		return r.handleRayClusterValidationError(ctx, instance, err, utils.InvalidRayClusterSpec, "The RayCluster UpgradeStrategy is invalid %s/%s: %v")
 	}
 
 	if err := utils.ValidateRayClusterStatus(instance); err != nil {
@@ -1557,6 +1548,40 @@ func (r *RayClusterReconciler) SetupWithManager(mgr ctrl.Manager, reconcileConcu
 			},
 		}).
 		Complete(r)
+}
+
+func (r *RayClusterReconciler) handleRayClusterValidationError(ctx context.Context, instance *rayv1.RayCluster, validationErr error, eventType utils.K8sEventType, eventMessageFmt string) (ctrl.Result, error) {
+	logger := ctrl.LoggerFrom(ctx)
+	logger.Error(validationErr, "RayCluster validation failed")
+
+	// Record the event
+	r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(eventType), eventMessageFmt, instance.Namespace, instance.Name, validationErr.Error())
+
+	original := instance.DeepCopy()
+	newInstance := instance.DeepCopy()
+
+	// Record that the controller processed this spec generation
+	newInstance.Status.ObservedGeneration = newInstance.ObjectMeta.Generation
+
+	timeNow := metav1.Now()
+	newInstance.Status.LastUpdateTime = &timeNow
+
+	if features.Enabled(features.RayClusterStatusConditions) {
+		meta.SetStatusCondition(&newInstance.Status.Conditions, metav1.Condition{
+			Type:               string(rayv1.RayClusterProvisioned),
+			Status:             metav1.ConditionFalse,
+			Reason:             rayv1.RayClusterValidationFailed,
+			Message:            validationErr.Error(),
+			ObservedGeneration: newInstance.Generation,
+		})
+	}
+
+	_, updateErr := r.updateRayClusterStatus(ctx, original, newInstance)
+	if updateErr != nil {
+		logger.Error(updateErr, "Failed to update RayCluster status after validation error")
+		return ctrl.Result{RequeueAfter: DefaultRequeueDuration}, updateErr
+	}
+	return ctrl.Result{}, nil
 }
 
 func (r *RayClusterReconciler) calculateStatus(ctx context.Context, instance *rayv1.RayCluster, reconcileErr error) (*rayv1.RayCluster, error) {

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1316,6 +1316,163 @@ func TestReconcile_UpdateClusterReason(t *testing.T) {
 	assert.Equal(t, cluster.Status.Reason, reason, "Cluster reason should be updated")
 }
 
+func TestHandleRayClusterValidationError(t *testing.T) {
+	setupTest(t)
+	features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+	newScheme := runtime.NewScheme()
+	require.NoError(t, rayv1.AddToScheme(newScheme))
+
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "invalid-raycluster",
+			Namespace:  namespaceStr,
+			Generation: 3,
+		},
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "ray-head", Image: support.GetRayImage()},
+						},
+					},
+				},
+			},
+			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+				{
+					GroupName:   groupNameStr,
+					Replicas:    ptr.To[int32](1),
+					MinReplicas: ptr.To[int32](10),
+					MaxReplicas: ptr.To[int32](1),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "ray-worker", Image: support.GetRayImage()},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(newScheme).
+		WithObjects(cluster).
+		WithStatusSubresource(cluster).
+		Build()
+
+	r := &RayClusterReconciler{
+		Client:                     fakeClient,
+		Recorder:                   &record.FakeRecorder{},
+		Scheme:                     newScheme,
+		rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
+	}
+
+	validationErr := errors.New("worker group " + groupNameStr + " has minReplicas 10 greater than maxReplicas 1")
+	ctx := context.Background()
+
+	result, err := r.handleRayClusterValidationError(
+		ctx,
+		cluster,
+		validationErr,
+		utils.InvalidRayClusterSpec,
+		"The RayCluster spec is invalid %s/%s: %v",
+	)
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+
+	namespacedName := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
+	var updated rayv1.RayCluster
+	require.NoError(t, fakeClient.Get(ctx, namespacedName, &updated))
+
+	assert.Equal(t, cluster.Generation, updated.Status.ObservedGeneration)
+	assert.NotNil(t, updated.Status.LastUpdateTime)
+	assert.True(t, meta.IsStatusConditionPresentAndEqual(
+		updated.Status.Conditions,
+		string(rayv1.RayClusterProvisioned),
+		metav1.ConditionFalse,
+	))
+
+	cond := meta.FindStatusCondition(updated.Status.Conditions, string(rayv1.RayClusterProvisioned))
+	require.NotNil(t, cond)
+	assert.Equal(t, rayv1.RayClusterValidationFailed, cond.Reason)
+	assert.Equal(t, validationErr.Error(), cond.Message)
+	assert.Equal(t, cluster.Generation, cond.ObservedGeneration)
+}
+
+func TestRayClusterReconcile_InvalidSpecUpdatesValidationStatus(t *testing.T) {
+	setupTest(t)
+	features.SetFeatureGateDuringTest(t, features.RayClusterStatusConditions, true)
+
+	newScheme := runtime.NewScheme()
+	require.NoError(t, rayv1.AddToScheme(newScheme))
+
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "invalid-raycluster-reconcile",
+			Namespace:  namespaceStr,
+			Generation: 2,
+		},
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "ray-head", Image: support.GetRayImage()},
+						},
+					},
+				},
+			},
+			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+				{
+					GroupName:   groupNameStr,
+					Replicas:    ptr.To[int32](1),
+					MinReplicas: ptr.To[int32](10),
+					MaxReplicas: ptr.To[int32](1),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "ray-worker", Image: support.GetRayImage()},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(newScheme).
+		WithObjects(cluster).
+		WithStatusSubresource(cluster).
+		Build()
+
+	r := &RayClusterReconciler{
+		Client:                     fakeClient,
+		Recorder:                   &record.FakeRecorder{},
+		Scheme:                     newScheme,
+		rayClusterScaleExpectation: expectations.NewRayClusterScaleExpectation(fakeClient),
+	}
+
+	ctx := context.Background()
+	result, err := r.rayClusterReconcile(ctx, cluster)
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+
+	namespacedName := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
+	var updated rayv1.RayCluster
+	require.NoError(t, fakeClient.Get(ctx, namespacedName, &updated))
+
+	assert.Equal(t, cluster.Generation, updated.Status.ObservedGeneration)
+	cond := meta.FindStatusCondition(updated.Status.Conditions, string(rayv1.RayClusterProvisioned))
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, rayv1.RayClusterValidationFailed, cond.Reason)
+	assert.Contains(t, cond.Message, "minReplicas 10 greater than maxReplicas 1")
+}
+
 func TestUpdateEndpoints(t *testing.T) {
 	setupTest(t)
 

--- a/ray-operator/controllers/ray/raycluster_controller_unit_test.go
+++ b/ray-operator/controllers/ray/raycluster_controller_unit_test.go
@@ -1391,11 +1391,11 @@ func TestHandleRayClusterValidationError(t *testing.T) {
 	assert.NotNil(t, updated.Status.LastUpdateTime)
 	assert.True(t, meta.IsStatusConditionPresentAndEqual(
 		updated.Status.Conditions,
-		string(rayv1.RayClusterProvisioned),
+		string(rayv1.RayClusterValid),
 		metav1.ConditionFalse,
 	))
 
-	cond := meta.FindStatusCondition(updated.Status.Conditions, string(rayv1.RayClusterProvisioned))
+	cond := meta.FindStatusCondition(updated.Status.Conditions, string(rayv1.RayClusterValid))
 	require.NotNil(t, cond)
 	assert.Equal(t, rayv1.RayClusterValidationFailed, cond.Reason)
 	assert.Equal(t, validationErr.Error(), cond.Message)
@@ -1466,7 +1466,7 @@ func TestRayClusterReconcile_InvalidSpecUpdatesValidationStatus(t *testing.T) {
 	require.NoError(t, fakeClient.Get(ctx, namespacedName, &updated))
 
 	assert.Equal(t, cluster.Generation, updated.Status.ObservedGeneration)
-	cond := meta.FindStatusCondition(updated.Status.Conditions, string(rayv1.RayClusterProvisioned))
+	cond := meta.FindStatusCondition(updated.Status.Conditions, string(rayv1.RayClusterValid))
 	require.NotNil(t, cond)
 	assert.Equal(t, metav1.ConditionFalse, cond.Status)
 	assert.Equal(t, rayv1.RayClusterValidationFailed, cond.Reason)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When RayCluster metadata, spec, or upgrade strategy validation fails, the operator only logs an error and emits a Kubernetes Event, then returns early without updating .status. 

As a result, status.observedGeneration can stay stale, and there is no condition indicating validation failed unlike RayJob and RayService 

This change updates RayCluster status immediately on user input validation failure: 
-> Sets `observedGeneration`, `LastUpdateTime`, and `RayClusterProvisioned=False` with `reason=ValidationFailed`, following the RayService pattern.



## Related issue number

<!-- For example: "Closes #1234" -->

Closes #4974 

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

<img width="627" height="142" alt="Screenshot 2026-07-04 at 5 58 27 PM" src="https://github.com/user-attachments/assets/c31f2fab-323b-48a9-a631-60f07c07045b" />
