### PR TITLE
[helm][kuberay-operator] Don't emit empty ServiceMonitor labels; rename selector -> additionalLabels

### DIFF
--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -185,7 +185,7 @@ spec:
 | metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
 | metrics.serviceMonitor.honorLabels | bool | `true` | When true, honorLabels preserves the metric’s labels when they collide with the target’s labels. |
-| metrics.serviceMonitor.selector | object | `{}` | Prometheus ServiceMonitor selector |
+| metrics.serviceMonitor.additionalLabels | object | `{}` | Additional labels to add to the ServiceMonitor's metadata. Prometheus uses these labels (via its `serviceMonitorSelector`) to discover which ServiceMonitors to scrape, e.g. `release: prometheus` for the kube-prometheus-stack chart. |
 | metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | operatorCommand | string | `"/manager"` | Path to the operator binary |
 | leaderElectionEnabled | bool | `true` | If leaderElectionEnabled is set to true, the KubeRay operator will use leader election for high availability. |

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -185,7 +185,7 @@ spec:
 | metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
 | metrics.serviceMonitor.honorLabels | bool | `true` | When true, honorLabels preserves the metric’s labels when they collide with the target’s labels. |
-| metrics.serviceMonitor.additionalLabels | object | `{}` | Additional labels to add to the ServiceMonitor's metadata. Prometheus uses these labels (via its `serviceMonitorSelector`) to discover which ServiceMonitors to scrape, e.g. `release: prometheus` for the kube-prometheus-stack chart. |
+| metrics.serviceMonitor.additionalLabels | object | `{}` | Additional labels to add to the ServiceMonitor's metadata. |
 | metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | operatorCommand | string | `"/manager"` | Path to the operator binary |
 | leaderElectionEnabled | bool | `true` | If leaderElectionEnabled is set to true, the KubeRay operator will use leader election for high availability. |

--- a/helm-chart/kuberay-operator/templates/servicemonitor.yaml
+++ b/helm-chart/kuberay-operator/templates/servicemonitor.yaml
@@ -4,10 +4,10 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "kuberay-operator.fullname" . }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
+  {{- with .Values.metrics.serviceMonitor.additionalLabels }}
   labels:
-    {{- with .Values.metrics.serviceMonitor.selector }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   endpoints:
     - path: /metrics

--- a/helm-chart/kuberay-operator/tests/servicemonitor_test.yaml
+++ b/helm-chart/kuberay-operator/tests/servicemonitor_test.yaml
@@ -1,0 +1,78 @@
+suite: Test ServiceMonitor
+
+templates:
+  - servicemonitor.yaml
+
+release:
+  name: kuberay-operator
+  namespace: kuberay-system
+
+tests:
+  - it: Should not create ServiceMonitor by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not create ServiceMonitor if `metrics.serviceMonitor.enabled` is `false`
+    set:
+      metrics:
+        serviceMonitor:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create ServiceMonitor if `metrics.serviceMonitor.enabled` is `true`
+    set:
+      metrics:
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - containsDocument:
+          apiVersion: monitoring.coreos.com/v1
+          kind: ServiceMonitor
+          name: kuberay-operator
+          namespace: kuberay-system
+
+  - it: Should not render `metadata.labels` when no `additionalLabels` are set
+    set:
+      metrics:
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - notExists:
+          path: metadata.labels
+
+  - it: Should render `metadata.labels` from `metrics.serviceMonitor.additionalLabels`
+    set:
+      metrics:
+        serviceMonitor:
+          enabled: true
+          additionalLabels:
+            release: prometheus
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            release: prometheus
+
+  - it: Should default the namespace to the release namespace
+    set:
+      metrics:
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: kuberay-system
+
+  - it: Should use `metrics.serviceMonitor.namespace` when set
+    set:
+      metrics:
+        serviceMonitor:
+          enabled: true
+          namespace: monitoring
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: monitoring

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -154,7 +154,7 @@ metrics:
     interval: 30s
     # -- When true, honorLabels preserves the metric’s labels when they collide with the target’s labels.
     honorLabels: true
-    # -- Additional labels to add to the ServiceMonitor's metadata. Prometheus uses these labels (via its `serviceMonitorSelector`) to discover which ServiceMonitors to scrape, e.g. `release: prometheus` for the kube-prometheus-stack chart.
+    # -- Additional labels to add to the ServiceMonitor's metadata.
     additionalLabels: {}
       #  release: prometheus
     # -- Prometheus ServiceMonitor namespace

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -154,8 +154,8 @@ metrics:
     interval: 30s
     # -- When true, honorLabels preserves the metric’s labels when they collide with the target’s labels.
     honorLabels: true
-    # -- Prometheus ServiceMonitor selector
-    selector: {}
+    # -- Additional labels to add to the ServiceMonitor's metadata. Prometheus uses these labels (via its `serviceMonitorSelector`) to discover which ServiceMonitors to scrape, e.g. `release: prometheus` for the kube-prometheus-stack chart.
+    additionalLabels: {}
       #  release: prometheus
     # -- Prometheus ServiceMonitor namespace
     namespace: ""  # "monitoring"


### PR DESCRIPTION
## Why are these changes needed?

Two fixes to `helm-chart/kuberay-operator/templates/servicemonitor.yaml`:

### 1. Don't emit an empty `labels:` block

The template unconditionally rendered a `labels:` key:

```yaml
  labels:
    {{- with .Values.metrics.serviceMonitor.selector }}
      {{- toYaml . | nindent 4 }}
    {{- end }}
```

With the default (empty) value, this produced an empty `metadata.labels`, which doesn't match what Kubernetes actually stores on the object. As a result **ArgoCD reports the ServiceMonitor as `OutOfSync`**. The `labels:` key is now wrapped in `{{- with }}` so it's only emitted when labels are actually configured.

### 2. Rename `selector` → `additionalLabels`

`.Values.metrics.serviceMonitor.selector` populates the ServiceMonitor's `metadata.labels` — it is **not** a selector. The name was confusing because:

- It sets labels, not a selector.
- It collided conceptually with the template's real `spec.selector` (which selects the Service to scrape).

The value exists so that Prometheus can discover this ServiceMonitor via its `serviceMonitorSelector` (e.g. `release: prometheus` for kube-prometheus-stack). `additionalLabels` matches the convention used by other charts (e.g. kube-prometheus-stack) and describes what the field actually does.

> [!WARNING]
> **Breaking change:** users setting `metrics.serviceMonitor.selector` must switch to `metrics.serviceMonitor.additionalLabels`. Happy to instead keep `selector` as a deprecated fallback for one release if reviewers prefer a non-breaking path.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

`values.yaml` and the helm-docs-generated `README.md` row were updated to match. Verified with `helm lint` (passes) and `helm template`:

- ServiceMonitor enabled, no `additionalLabels` → no `labels:` key rendered.
- ServiceMonitor enabled, `additionalLabels.release=prometheus` → `metadata.labels.release: prometheus` rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)