### PR TITLE
[RayJob]Refactor the sidecar container failure detection logic and extract common functions

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -1180,21 +1180,53 @@ func getJobFinishedCondition(job *batchv1.Job) *batchv1.JobCondition {
 	return nil
 }
 
-// checkSidecarSubmitterFailed reports whether the submitter sidecar container has failed, without
-// mutating the RayJob status. It uses the same detection logic as
-// checkSidecarSubmitterFailedAndUpdateStatus so the two stay in sync.
-func checkSidecarSubmitterFailed(rayJob *rayv1.RayJob, headPod *corev1.Pod) bool {
-	var failed bool
+// detectSidecarSubmitterFailure detects if the submitter sidecar container has failed and returns
+// the container status if it has. It handles both the non-restart and restart modes based on
+// the SidecarSubmitterRestart feature gate. The third return value indicates whether the failure
+// is due to exceeding the restart count.
+func detectSidecarSubmitterFailure(rayJob *rayv1.RayJob, headPod *corev1.Pod) (bool, *corev1.ContainerStatus, bool) {
 	if !features.Enabled(features.SidecarSubmitterRestart) {
-		failed, _ = checkSidecarContainerStatus(headPod)
-	} else {
-		submitterBackoffLimit := int32(2)
-		if rayJob.Spec.SubmitterConfig != nil && rayJob.Spec.SubmitterConfig.BackoffLimit != nil {
-			submitterBackoffLimit = *rayJob.Spec.SubmitterConfig.BackoffLimit
-		}
-		failed, _ = checkIsRestartCountExceeded(headPod, submitterBackoffLimit)
+		failed, containerStatus := checkSidecarContainerStatus(headPod)
+		return failed, containerStatus, false
 	}
+	submitterBackoffLimit := int32(2)
+	if rayJob.Spec.SubmitterConfig != nil && rayJob.Spec.SubmitterConfig.BackoffLimit != nil {
+		submitterBackoffLimit = *rayJob.Spec.SubmitterConfig.BackoffLimit
+	}
+	failed, containerStatus := checkIsRestartCountExceeded(headPod, submitterBackoffLimit)
+	return failed, containerStatus, failed
+}
+
+// checkSidecarSubmitterFailed reports whether the submitter sidecar container has failed, without
+// mutating the RayJob status.
+func checkSidecarSubmitterFailed(rayJob *rayv1.RayJob, headPod *corev1.Pod) bool {
+	failed, _, _ := detectSidecarSubmitterFailure(rayJob, headPod)
 	return failed
+}
+
+// updateStatusForSidecarSubmitterFailure updates the RayJob status when the submitter sidecar container
+// has failed. It determines the failure reason (AppFailed vs SubmissionFailed) based on the JobStatus.
+// isRestartCountExceeded indicates whether the failure is due to exceeding the restart count.
+func (r *RayJobReconciler) updateStatusForSidecarSubmitterFailure(ctx context.Context, rayJob *rayv1.RayJob, submitterContainerStatus *corev1.ContainerStatus, isRestartCountExceeded bool) {
+	logger := ctrl.LoggerFrom(ctx)
+	rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
+	if rayJob.Status.JobStatus == rayv1.JobStatusFailed {
+		rayJob.Status.Reason = rayv1.AppFailed
+	} else {
+		rayJob.Status.Reason = rayv1.SubmissionFailed
+		if isRestartCountExceeded {
+			rayJob.Status.Message = fmt.Sprintf("Ray head pod submitter container %s terminated after exceeding the maximum restart count",
+				submitterContainerStatus.Name)
+			logger.Info("The submitter sidecar container has exceeded the max restart count. Attempting to transition the status to `Failed`.",
+				"Submitter sidecar container", submitterContainerStatus.Name,
+				"RestartCount", submitterContainerStatus.RestartCount)
+		} else {
+			rayJob.Status.Message = fmt.Sprintf("Ray head pod container %s terminated with exit code %d: %s",
+				submitterContainerStatus.Name, submitterContainerStatus.State.Terminated.ExitCode, submitterContainerStatus.State.Terminated.Reason)
+			logger.Info("The submitter sidecar container has failed. Attempting to transition the status to `Failed`.",
+				"Submitter sidecar container", submitterContainerStatus.Name, "Reason", submitterContainerStatus.State.Terminated.Reason, "Message", submitterContainerStatus.State.Terminated.Message)
+		}
+	}
 }
 
 // pollJobStatusForSidecarFailure does a best-effort poll of the actual Ray job status from the
@@ -1240,42 +1272,9 @@ func (r *RayJobReconciler) pollJobStatusForSidecarFailure(ctx context.Context, r
 }
 
 func (r *RayJobReconciler) checkSidecarSubmitterFailedAndUpdateStatus(ctx context.Context, rayJob *rayv1.RayJob, headPod *corev1.Pod) bool {
-	logger := ctrl.LoggerFrom(ctx)
-	var shouldUpdate bool
-	var submitterContainerStatus *corev1.ContainerStatus
-	if !features.Enabled(features.SidecarSubmitterRestart) {
-		shouldUpdate, submitterContainerStatus = checkSidecarContainerStatus(headPod)
-		if shouldUpdate {
-			logger.Info("The submitter sidecar container has failed. Attempting to transition the status to `Failed`.",
-				"Submitter sidecar container", submitterContainerStatus.Name, "Reason", submitterContainerStatus.State.Terminated.Reason, "Message", submitterContainerStatus.State.Terminated.Message)
-			rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
-			if rayJob.Status.JobStatus == rayv1.JobStatusFailed {
-				rayJob.Status.Reason = rayv1.AppFailed
-			} else {
-				rayJob.Status.Reason = rayv1.SubmissionFailed
-				rayJob.Status.Message = fmt.Sprintf("Ray head pod container %s terminated with exit code %d: %s",
-					submitterContainerStatus.Name, submitterContainerStatus.State.Terminated.ExitCode, submitterContainerStatus.State.Terminated.Reason)
-			}
-		}
-	} else {
-		submitterBackoffLimit := int32(2)
-		if rayJob.Spec.SubmitterConfig != nil && rayJob.Spec.SubmitterConfig.BackoffLimit != nil {
-			submitterBackoffLimit = *rayJob.Spec.SubmitterConfig.BackoffLimit
-		}
-		shouldUpdate, submitterContainerStatus = checkIsRestartCountExceeded(headPod, submitterBackoffLimit)
-		if shouldUpdate {
-			logger.Info("The submitter sidecar container has exceeded the max restart count. Attempting to transition the status to `Failed`.",
-				"Submitter sidecar container", submitterContainerStatus.Name,
-				"RestartCount", submitterContainerStatus.RestartCount)
-			rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
-			if rayJob.Status.JobStatus == rayv1.JobStatusFailed {
-				rayJob.Status.Reason = rayv1.AppFailed
-			} else {
-				rayJob.Status.Reason = rayv1.SubmissionFailed
-				rayJob.Status.Message = fmt.Sprintf("Ray head pod submitter container %s terminated after exceeding the maximum restart count",
-					submitterContainerStatus.Name)
-			}
-		}
+	shouldUpdate, submitterContainerStatus, isRestartCountExceeded := detectSidecarSubmitterFailure(rayJob, headPod)
+	if shouldUpdate {
+		r.updateStatusForSidecarSubmitterFailure(ctx, rayJob, submitterContainerStatus, isRestartCountExceeded)
 	}
 	return shouldUpdate
 }

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -209,9 +209,20 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			if headPod, err = common.GetRayClusterHeadPod(ctx, r.Client, rayClusterInstance); err != nil {
 				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 			}
-			if headPod != nil && r.checkSidecarSubmitterFailedAndUpdateStatus(ctx, rayJobInstance, headPod) {
-				rayJobInstance.Status.RayClusterStatus = rayClusterInstance.Status
-				break
+			if headPod != nil {
+				// If the submitter sidecar container has failed, best-effort poll the actual Ray job
+				// status from the dashboard before deciding the failure reason. During `Initializing`
+				// the controller has not yet polled the job status (that only happens in `Running`),
+				// so without this the reason would always be `SubmissionFailed`. Polling lets a genuine
+				// application failure be reported as `AppFailed`. The poll is a no-op on any error so the
+				// reason falls back to `SubmissionFailed` when the job status can't be determined.
+				if checkSidecarSubmitterFailed(rayJobInstance, headPod) {
+					r.pollJobStatusForSidecarFailure(ctx, rayJobInstance, rayClusterInstance)
+				}
+				if r.checkSidecarSubmitterFailedAndUpdateStatus(ctx, rayJobInstance, headPod) {
+					rayJobInstance.Status.RayClusterStatus = rayClusterInstance.Status
+					break
+				}
 			}
 		}
 
@@ -1147,6 +1158,65 @@ func getJobFinishedCondition(job *batchv1.Job) *batchv1.JobCondition {
 		}
 	}
 	return nil
+}
+
+// checkSidecarSubmitterFailed reports whether the submitter sidecar container has failed, without
+// mutating the RayJob status. It uses the same detection logic as
+// checkSidecarSubmitterFailedAndUpdateStatus so the two stay in sync.
+func checkSidecarSubmitterFailed(rayJob *rayv1.RayJob, headPod *corev1.Pod) bool {
+	var failed bool
+	if !features.Enabled(features.SidecarSubmitterRestart) {
+		failed, _ = checkSidecarContainerStatus(headPod)
+	} else {
+		submitterBackoffLimit := int32(2)
+		if rayJob.Spec.SubmitterConfig != nil && rayJob.Spec.SubmitterConfig.BackoffLimit != nil {
+			submitterBackoffLimit = *rayJob.Spec.SubmitterConfig.BackoffLimit
+		}
+		failed, _ = checkIsRestartCountExceeded(headPod, submitterBackoffLimit)
+	}
+	return failed
+}
+
+// pollJobStatusForSidecarFailure does a best-effort poll of the actual Ray job status from the
+// dashboard and updates rayJob.Status.JobStatus. It is used during `Initializing` when the submitter
+// sidecar has failed, so that checkSidecarSubmitterFailedAndUpdateStatus can map a genuine
+// application failure to `AppFailed` rather than always reporting `SubmissionFailed`.
+//
+// This is best-effort: on ANY error (no dashboardClientFunc, empty JobId, URL build failure,
+// dashboard unreachable, or job not found) it leaves rayJob.Status.JobStatus untouched, so the
+// reason falls back to `SubmissionFailed`.
+func (r *RayJobReconciler) pollJobStatusForSidecarFailure(ctx context.Context, rayJob *rayv1.RayJob, rayClusterInstance *rayv1.RayCluster) {
+	logger := ctrl.LoggerFrom(ctx)
+	// Guard so the pure helper's unit tests (which construct &RayJobReconciler{} without a
+	// dashboardClientFunc) are unaffected, and skip when there is no submission id to query.
+	if r.dashboardClientFunc == nil || rayClusterInstance == nil || rayJob.Status.JobId == "" {
+		return
+	}
+
+	clientURL := rayJob.Status.DashboardURL
+	if clientURL == "" {
+		url, err := utils.FetchHeadServiceURL(ctx, r.Client, rayClusterInstance, utils.DashboardPortName)
+		if err != nil || url == "" {
+			logger.Info("pollJobStatusForSidecarFailure: failed to fetch dashboard URL; falling back to SubmissionFailed", "error", err)
+			return
+		}
+		clientURL = url
+	}
+
+	rayDashboardClient, err := r.dashboardClientFunc(rayClusterInstance, clientURL)
+	if err != nil {
+		logger.Info("pollJobStatusForSidecarFailure: failed to build dashboard client; falling back to SubmissionFailed", "error", err)
+		return
+	}
+
+	jobInfo, err := rayDashboardClient.GetJobInfo(ctx, rayJob.Status.JobId)
+	if err != nil || jobInfo == nil {
+		logger.Info("pollJobStatusForSidecarFailure: failed to get job info; falling back to SubmissionFailed", "JobId", rayJob.Status.JobId, "error", err)
+		return
+	}
+
+	logger.Info("pollJobStatusForSidecarFailure: polled Ray job status after submitter failure", "JobId", rayJob.Status.JobId, "JobStatus", jobInfo.JobStatus)
+	rayJob.Status.JobStatus = jobInfo.JobStatus
 }
 
 func (r *RayJobReconciler) checkSidecarSubmitterFailedAndUpdateStatus(ctx context.Context, rayJob *rayv1.RayJob, headPod *corev1.Pod) bool {

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -204,6 +204,17 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
 		}
 
+		if rayJobInstance.Spec.SubmissionMode == rayv1.SidecarMode {
+			var headPod *corev1.Pod
+			if headPod, err = common.GetRayClusterHeadPod(ctx, r.Client, rayClusterInstance); err != nil {
+				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
+			}
+			if headPod != nil && r.checkSidecarSubmitterFailedAndUpdateStatus(ctx, rayJobInstance, headPod) {
+				rayJobInstance.Status.RayClusterStatus = rayClusterInstance.Status
+				break
+			}
+		}
+
 		// Check the current status of RayCluster before submitting.
 		if clientURL := rayJobInstance.Status.DashboardURL; clientURL == "" {
 			if rayClusterInstance.Status.State != rayv1.Ready {
@@ -1043,7 +1054,6 @@ func (r *RayJobReconciler) checkSubmitterAndUpdateStatusIfNeeded(ctx context.Con
 	logger := ctrl.LoggerFrom(ctx)
 	shouldUpdate = false
 	finishedAt = nil
-	var submitterContainerStatus *corev1.ContainerStatus
 	var condition *batchv1.JobCondition
 
 	switch rayJob.Spec.SubmissionMode {
@@ -1072,46 +1082,7 @@ func (r *RayJobReconciler) checkSubmitterAndUpdateStatusIfNeeded(ctx context.Con
 			return
 		}
 
-		// Only check exit code when the feature gate is disabled.
-		// When SidecarSubmitterRestart is enabled, the container restarts on non-zero exit,
-		// so a terminated container is transient — not a permanent failure.
-		if !features.Enabled(features.SidecarSubmitterRestart) {
-			shouldUpdate, submitterContainerStatus = checkSidecarContainerStatus(headPod)
-			if shouldUpdate {
-				logger.Info("The submitter sidecar container has failed. Attempting to transition the status to `Failed`.",
-					"Submitter sidecar container", submitterContainerStatus.Name, "Reason", submitterContainerStatus.State.Terminated.Reason, "Message", submitterContainerStatus.State.Terminated.Message)
-				rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
-				// The submitter sidecar container needs to wait for the user code to finish and retrieve its logs.
-				// Therefore, a failed Submitter sidecar container indicates that the submission itself has failed or the user code has thrown an error.
-				// If the failure is due to user code, the JobStatus and Job message will be updated accordingly from the previous reconciliation.
-				if rayJob.Status.JobStatus == rayv1.JobStatusFailed {
-					rayJob.Status.Reason = rayv1.AppFailed
-				} else {
-					rayJob.Status.Reason = rayv1.SubmissionFailed
-					rayJob.Status.Message = fmt.Sprintf("Ray head pod container %s terminated with exit code %d: %s",
-						submitterContainerStatus.Name, submitterContainerStatus.State.Terminated.ExitCode, submitterContainerStatus.State.Terminated.Reason)
-				}
-			}
-		} else {
-			submitterBackoffLimit := int32(2)
-			if rayJob.Spec.SubmitterConfig != nil && rayJob.Spec.SubmitterConfig.BackoffLimit != nil {
-				submitterBackoffLimit = *rayJob.Spec.SubmitterConfig.BackoffLimit
-			}
-			shouldUpdate, submitterContainerStatus = checkIsRestartCountExceeded(headPod, submitterBackoffLimit)
-			if shouldUpdate {
-				logger.Info("The submitter sidecar container has exceeded the max restart count. Attempting to transition the status to `Failed`.",
-					"Submitter sidecar container", submitterContainerStatus.Name,
-					"RestartCount", submitterContainerStatus.RestartCount)
-				rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
-				if rayJob.Status.JobStatus == rayv1.JobStatusFailed {
-					rayJob.Status.Reason = rayv1.AppFailed
-				} else {
-					rayJob.Status.Reason = rayv1.SubmissionFailed
-					rayJob.Status.Message = fmt.Sprintf("Ray head pod submitter container %s terminated after exceeding the maximum restart count",
-						submitterContainerStatus.Name)
-				}
-			}
-		}
+		shouldUpdate = r.checkSidecarSubmitterFailedAndUpdateStatus(ctx, rayJob, headPod)
 
 		finishedAt = getSubmitterContainerFinishedTime(headPod)
 		return
@@ -1176,6 +1147,47 @@ func getJobFinishedCondition(job *batchv1.Job) *batchv1.JobCondition {
 		}
 	}
 	return nil
+}
+
+func (r *RayJobReconciler) checkSidecarSubmitterFailedAndUpdateStatus(ctx context.Context, rayJob *rayv1.RayJob, headPod *corev1.Pod) bool {
+	logger := ctrl.LoggerFrom(ctx)
+	var shouldUpdate bool
+	var submitterContainerStatus *corev1.ContainerStatus
+	if !features.Enabled(features.SidecarSubmitterRestart) {
+		shouldUpdate, submitterContainerStatus = checkSidecarContainerStatus(headPod)
+		if shouldUpdate {
+			logger.Info("The submitter sidecar container has failed. Attempting to transition the status to `Failed`.",
+				"Submitter sidecar container", submitterContainerStatus.Name, "Reason", submitterContainerStatus.State.Terminated.Reason, "Message", submitterContainerStatus.State.Terminated.Message)
+			rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
+			if rayJob.Status.JobStatus == rayv1.JobStatusFailed {
+				rayJob.Status.Reason = rayv1.AppFailed
+			} else {
+				rayJob.Status.Reason = rayv1.SubmissionFailed
+				rayJob.Status.Message = fmt.Sprintf("Ray head pod container %s terminated with exit code %d: %s",
+					submitterContainerStatus.Name, submitterContainerStatus.State.Terminated.ExitCode, submitterContainerStatus.State.Terminated.Reason)
+			}
+		}
+	} else {
+		submitterBackoffLimit := int32(2)
+		if rayJob.Spec.SubmitterConfig != nil && rayJob.Spec.SubmitterConfig.BackoffLimit != nil {
+			submitterBackoffLimit = *rayJob.Spec.SubmitterConfig.BackoffLimit
+		}
+		shouldUpdate, submitterContainerStatus = checkIsRestartCountExceeded(headPod, submitterBackoffLimit)
+		if shouldUpdate {
+			logger.Info("The submitter sidecar container has exceeded the max restart count. Attempting to transition the status to `Failed`.",
+				"Submitter sidecar container", submitterContainerStatus.Name,
+				"RestartCount", submitterContainerStatus.RestartCount)
+			rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
+			if rayJob.Status.JobStatus == rayv1.JobStatusFailed {
+				rayJob.Status.Reason = rayv1.AppFailed
+			} else {
+				rayJob.Status.Reason = rayv1.SubmissionFailed
+				rayJob.Status.Message = fmt.Sprintf("Ray head pod submitter container %s terminated after exceeding the maximum restart count",
+					submitterContainerStatus.Name)
+			}
+		}
+	}
+	return shouldUpdate
 }
 
 func checkSidecarContainerStatus(headPod *corev1.Pod) (bool, *corev1.ContainerStatus) {

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -30,6 +30,8 @@ import (
 	schedulerinterface "github.com/ray-project/kuberay/ray-operator/controllers/ray/batchscheduler/interface"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/metrics/mocks"
 	utils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils/dashboardclient"
+	utiltypes "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils/types"
 	"github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/scheme"
 	"github.com/ray-project/kuberay/ray-operator/pkg/features"
 )
@@ -429,6 +431,76 @@ func TestCheckSidecarSubmitterFailedAndUpdateStatus(t *testing.T) {
 
 		assert.True(t, shouldUpdate)
 		assert.Equal(t, rayv1.JobDeploymentStatusFailed, rayJob.Status.JobDeploymentStatus)
+	})
+}
+
+func TestPollJobStatusForSidecarFailure(t *testing.T) {
+	ctx := context.Background()
+
+	// Use a pre-set DashboardURL so the poll does not need to resolve the head service.
+	newRayJob := func() *rayv1.RayJob {
+		return &rayv1.RayJob{
+			Spec: rayv1.RayJobSpec{SubmissionMode: rayv1.SidecarMode},
+			Status: rayv1.RayJobStatus{
+				JobDeploymentStatus: rayv1.JobDeploymentStatusInitializing,
+				JobId:               "test-job-id",
+				DashboardURL:        "http://fake-dashboard:8265",
+			},
+		}
+	}
+	rayCluster := &rayv1.RayCluster{}
+
+	reconcilerWithJobStatus := func(status rayv1.JobStatus, getErr error) *RayJobReconciler {
+		fakeClient := &utils.FakeRayDashboardClient{}
+		getJobInfo := func(_ context.Context, _ string) (*utiltypes.RayJobInfo, error) {
+			if getErr != nil {
+				return nil, getErr
+			}
+			return &utiltypes.RayJobInfo{JobStatus: status}, nil
+		}
+		fakeClient.GetJobInfoMock.Store(&getJobInfo)
+		return &RayJobReconciler{
+			dashboardClientFunc: func(_ *rayv1.RayCluster, _ string) (dashboardclient.RayDashboardClientInterface, error) {
+				return fakeClient, nil
+			},
+		}
+	}
+
+	t.Run("job ran and failed -> JobStatus updated to FAILED (reason becomes AppFailed)", func(t *testing.T) {
+		reconciler := reconcilerWithJobStatus(rayv1.JobStatusFailed, nil)
+		rayJob := newRayJob()
+
+		reconciler.pollJobStatusForSidecarFailure(ctx, rayJob, rayCluster)
+
+		assert.Equal(t, rayv1.JobStatusFailed, rayJob.Status.JobStatus)
+	})
+
+	t.Run("dashboard GetJobInfo error -> JobStatus unchanged (falls back to SubmissionFailed)", func(t *testing.T) {
+		reconciler := reconcilerWithJobStatus("", errors.New("dashboard unreachable"))
+		rayJob := newRayJob()
+
+		reconciler.pollJobStatusForSidecarFailure(ctx, rayJob, rayCluster)
+
+		assert.Equal(t, rayv1.JobStatus(""), rayJob.Status.JobStatus)
+	})
+
+	t.Run("nil dashboardClientFunc -> no-op", func(t *testing.T) {
+		reconciler := &RayJobReconciler{}
+		rayJob := newRayJob()
+
+		reconciler.pollJobStatusForSidecarFailure(ctx, rayJob, rayCluster)
+
+		assert.Equal(t, rayv1.JobStatus(""), rayJob.Status.JobStatus)
+	})
+
+	t.Run("empty JobId -> no-op", func(t *testing.T) {
+		reconciler := reconcilerWithJobStatus(rayv1.JobStatusFailed, nil)
+		rayJob := newRayJob()
+		rayJob.Status.JobId = ""
+
+		reconciler.pollJobStatusForSidecarFailure(ctx, rayJob, rayCluster)
+
+		assert.Equal(t, rayv1.JobStatus(""), rayJob.Status.JobStatus)
 	})
 }
 

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -338,6 +338,100 @@ func TestCheckIsRestartCountExceeded(t *testing.T) {
 	}
 }
 
+func TestCheckSidecarSubmitterFailedAndUpdateStatus(t *testing.T) {
+	reconciler := &RayJobReconciler{}
+	ctx := context.Background()
+
+	headPodWithSubmitterState := func(state corev1.ContainerState) *corev1.Pod {
+		return &corev1.Pod{
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{Name: utils.SubmitterContainerName, State: state},
+				},
+			},
+		}
+	}
+	initializingRayJob := func() *rayv1.RayJob {
+		return &rayv1.RayJob{
+			Spec:   rayv1.RayJobSpec{SubmissionMode: rayv1.SidecarMode},
+			Status: rayv1.RayJobStatus{JobDeploymentStatus: rayv1.JobDeploymentStatusInitializing},
+		}
+	}
+
+	t.Run("submitter terminated non-zero is detected during Initializing -> Failed/SubmissionFailed", func(t *testing.T) {
+		rayJob := initializingRayJob()
+		headPod := headPodWithSubmitterState(corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"},
+		})
+
+		shouldUpdate := reconciler.checkSidecarSubmitterFailedAndUpdateStatus(ctx, rayJob, headPod)
+
+		assert.True(t, shouldUpdate)
+		assert.Equal(t, rayv1.JobDeploymentStatusFailed, rayJob.Status.JobDeploymentStatus)
+		assert.Equal(t, rayv1.SubmissionFailed, rayJob.Status.Reason)
+	})
+
+	t.Run("submitter terminated non-zero with JobStatus already Failed -> AppFailed", func(t *testing.T) {
+		rayJob := initializingRayJob()
+		rayJob.Status.JobStatus = rayv1.JobStatusFailed
+		headPod := headPodWithSubmitterState(corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"},
+		})
+
+		shouldUpdate := reconciler.checkSidecarSubmitterFailedAndUpdateStatus(ctx, rayJob, headPod)
+
+		assert.True(t, shouldUpdate)
+		assert.Equal(t, rayv1.JobDeploymentStatusFailed, rayJob.Status.JobDeploymentStatus)
+		assert.Equal(t, rayv1.AppFailed, rayJob.Status.Reason)
+	})
+
+	t.Run("submitter terminated with zero exit -> no update", func(t *testing.T) {
+		rayJob := initializingRayJob()
+		headPod := headPodWithSubmitterState(corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+		})
+
+		shouldUpdate := reconciler.checkSidecarSubmitterFailedAndUpdateStatus(ctx, rayJob, headPod)
+
+		assert.False(t, shouldUpdate)
+		assert.Equal(t, rayv1.JobDeploymentStatusInitializing, rayJob.Status.JobDeploymentStatus)
+	})
+
+	t.Run("submitter still running -> no update", func(t *testing.T) {
+		rayJob := initializingRayJob()
+		headPod := headPodWithSubmitterState(corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{},
+		})
+
+		shouldUpdate := reconciler.checkSidecarSubmitterFailedAndUpdateStatus(ctx, rayJob, headPod)
+
+		assert.False(t, shouldUpdate)
+		assert.Equal(t, rayv1.JobDeploymentStatusInitializing, rayJob.Status.JobDeploymentStatus)
+	})
+
+	t.Run("feature gate enabled routes to restart-count check", func(t *testing.T) {
+		features.SetFeatureGateDuringTest(t, features.SidecarSubmitterRestart, true)
+		rayJob := initializingRayJob()
+		headPod := &corev1.Pod{
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:                 utils.SubmitterContainerName,
+						RestartCount:         2,
+						State:                corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1}},
+						LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1}},
+					},
+				},
+			},
+		}
+
+		shouldUpdate := reconciler.checkSidecarSubmitterFailedAndUpdateStatus(ctx, rayJob, headPod)
+
+		assert.True(t, shouldUpdate)
+		assert.Equal(t, rayv1.JobDeploymentStatusFailed, rayJob.Status.JobDeploymentStatus)
+	})
+}
+
 func TestUpdateStatusToSuspendingIfNeeded(t *testing.T) {
 	newScheme := runtime.NewScheme()
 	_ = rayv1.AddToScheme(newScheme)


### PR DESCRIPTION
## Why are these changes needed?

In `SidecarMode`, the `ray-job-submitter` runs as a container inside the head Pod with the head Pod's `RestartPolicy` set to `Never`. If the submitter exits non-zero **before the RayCluster reaches `Ready`** (e.g. the job fails while workers are still being scheduled), the terminated submitter container keeps the head Pod `Ready=False`, so `RayCluster.Status.State` never becomes `Ready`.

The RayJob `Initializing -> Running` transition is gated on `RayCluster.Status.State == Ready`, and the only submitter-failure detector (`checkSubmitterAndUpdateStatusIfNeeded`) runs only in the `Running` state. As a result the RayJob is wedged in `Initializing` forever: it never transitions to `Failed`, `shutdownAfterJobFinishes` never runs, and the autoscaler keeps retrying workers — even though the submitter failure is already observable.

This PR detects a terminal submitter failure during `Initializing` (SidecarMode) and fails fast. The feature-gate-aware detection (`SidecarSubmitterRestart`) is extracted into `checkSidecarSubmitterFailedAndUpdateStatus` and shared by the `Initializing` and `Running` states; the `Initializing` call skips when the head Pod does not exist yet.

## Related issue number

Closes #4945

## Checks

- [x] I've made sure the tests are passing.

Testing:
- `go build ./controllers/ray/...`, `go vet ./controllers/ray/`, `gofumpt -l` — clean
- New unit test `TestCheckSidecarSubmitterFailedAndUpdateStatus`: submitter `Terminated` exit != 0 → `Failed`/`SubmissionFailed`; same with `JobStatus` already `Failed` → `AppFailed`; exit 0 → no-op; still `Running` → no-op; `SidecarSubmitterRestart` enabled → routes to the restart-count check
- `go test ./controllers/ray/ -run 'TestCheckSidecarSubmitterFailedAndUpdateStatus|TestCheckIsRestartCountExceeded'` — pass
