### PR TITLE
[History Server] Update history server to retrieve nodeid and move leftover session logs programmatically 

### DIFF
--- a/historyserver/cmd/collector/main.go
+++ b/historyserver/cmd/collector/main.go
@@ -22,8 +22,6 @@ import (
 	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
-const runtimeClassConfigPath = "/var/collector-config/data"
-
 func main() {
 	role := ""
 	runtimeClassName := ""
@@ -33,9 +31,9 @@ func main() {
 	logBatching := 1000
 	eventsPort := 8080
 	pushInterval := time.Minute
-	runtimeClassConfigPath := "/var/collector-config/data"
 	ownerKind := ""
 	ownerName := ""
+	runtimeClassConfigPath := "/var/collector-config/data"
 
 	flag.StringVar(&role, "role", "Worker", "")
 	flag.StringVar(&runtimeClassName, "runtime-class-name", "", "")
@@ -50,6 +48,31 @@ func main() {
 	flag.StringVar(&ownerName, "owner-name", "", "")
 
 	flag.Parse()
+
+	if val := os.Getenv("RAY_CLUSTER_NAME"); val != "" {
+		rayClusterName = val
+	}
+	if val := os.Getenv("RAY_CLUSTER_NAMESPACE"); val != "" {
+		rayClusterNamespace = val
+	}
+	if val := os.Getenv("RAY_ROLE"); val != "" {
+		role = val
+	}
+	if val := os.Getenv("OWNER_KIND"); val != "" {
+		ownerKind = val
+	}
+	if val := os.Getenv("OWNER_NAME"); val != "" {
+		ownerName = val
+	}
+	role = strings.TrimSpace(role)
+	// Check incase users manually set role env var
+	if strings.EqualFold(role, "head") {
+		role = "Head"
+	} else if strings.EqualFold(role, "worker") {
+		role = "Worker"
+	} else {
+		panic("Invalid role: " + role + ", must be Head or Worker")
+	}
 
 	if err := validateFlags(&rayClusterName, &rayClusterNamespace, &ownerKind, &ownerName); err != nil {
 		logrus.Fatalf("Failed to validate flags: %v", err)
@@ -77,29 +100,23 @@ func main() {
 		endpointPollInterval = parsed
 	}
 
-	sessionDir, err := utils.GetSessionDir()
-	if err != nil {
-		panic("Failed to get session dir: " + err.Error())
-	}
-
-	rayNodeId, err := utils.GetRayNodeID()
-	if err != nil {
-		panic("Failed to get ray node id: " + err.Error())
-	}
-
-	sessionName := path.Base(sessionDir)
-
 	jsonData := make(map[string]interface{})
 	if runtimeClassConfigPath != "" {
 		data, err := os.ReadFile(runtimeClassConfigPath)
 		if err != nil {
-			panic("Failed to read runtime class config " + err.Error())
+			panic(fmt.Sprintf("Failed to read runtime class config from %s: %v", runtimeClassConfigPath, err))
 		}
-		err = json.Unmarshal(data, &jsonData)
-		if err != nil {
-			panic("Failed to parse runtime class config: " + err.Error())
+		if err := json.Unmarshal(data, &jsonData); err != nil {
+			panic(fmt.Sprintf("Failed to parse runtime class config from %s: %v", runtimeClassConfigPath, err))
 		}
 	}
+
+	if val := os.Getenv("STORAGE_BACKEND"); val != "" {
+		runtimeClassName = val
+	} else if val := os.Getenv("RUNTIME_CLASS_NAME"); val != "" {
+		runtimeClassName = val
+	}
+	runtimeClassName = strings.ToLower(runtimeClassName)
 
 	registry := collector.GetWriterRegistry()
 	factory, ok := registry[runtimeClassName]
@@ -107,9 +124,30 @@ func main() {
 		panic("Not supported runtime class name: " + runtimeClassName + " for role: " + role + ".")
 	}
 
+	rayNodeId, err := utils.GetNodeRayIDWithFQIP()
+	if err != nil {
+		panic("Failed to get ray node id via HTTP endpoint: " + err.Error())
+	}
+
+	rayNodeId, err = utils.ConvertBase64ToHex(rayNodeId)
+	if err != nil {
+		panic("Failed to normalize ray node id to hex: " + err.Error())
+	}
+
+	activeSessionDir, err := utils.GetSessionDir()
+	if err != nil {
+		panic("Failed to get active session dir after discovering node id: " + err.Error())
+	}
+
+	if err := utils.MoveLeftoverSessionLogs(activeSessionDir, rayNodeId); err != nil {
+		logrus.Warnf("Failed to relocate leftover session logs at startup: %v", err)
+	}
+
+	sessionName := path.Base(activeSessionDir)
+
 	globalConfig := types.RayCollectorConfig{
 		RootDir:             rayRootDir,
-		SessionDir:          sessionDir,
+		SessionDir:          activeSessionDir,
 		RayNodeName:         rayNodeId,
 		Role:                role,
 		RayClusterName:      rayClusterName,
@@ -140,7 +178,7 @@ func main() {
 	// Create and initialize EventCollector
 	go func() {
 		defer wg.Done()
-		eventCollector := eventcollector.NewEventCollector(writer, rayRootDir, sessionDir, rayNodeId, rayClusterName, rayClusterNamespace, sessionName)
+		eventCollector := eventcollector.NewEventCollector(writer, rayRootDir, activeSessionDir, rayNodeId, rayClusterName, rayClusterNamespace, sessionName)
 		eventCollector.Run(stop, eventsPort)
 		logrus.Info("Event collector shutdown")
 	}()

--- a/historyserver/cmd/historyserver/main.go
+++ b/historyserver/cmd/historyserver/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -41,9 +42,16 @@ func main() {
 	flag.DurationVar(&sessionCacheTTL, "session-cache-ttl", historyserver.DefaultSessionCacheTTL, "How long a dead-session snapshot stays cached after last access. 0 disables TTL.")
 	flag.Parse()
 
-	if runtimeClassName == "" {
-		logrus.Fatal("--runtime-class-name is required")
+	if val := os.Getenv("STORAGE_BACKEND"); val != "" {
+		runtimeClassName = val
+	} else if val := os.Getenv("RUNTIME_CLASS_NAME"); val != "" {
+		runtimeClassName = val
 	}
+	if runtimeClassName == "" {
+		logrus.Fatal("--runtime-class-name, STORAGE_BACKEND, or RUNTIME_CLASS_NAME environment variable is required")
+	}
+	runtimeClassName = strings.ToLower(runtimeClassName)
+
 	if qps <= 0 {
 		logrus.Fatalf("--kube-api-qps must be > 0, got %v", qps)
 	}

--- a/historyserver/pkg/collector/eventcollector/eventcollector.go
+++ b/historyserver/pkg/collector/eventcollector/eventcollector.go
@@ -5,14 +5,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"path"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/emicklei/go-restful/v3"
-	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/compression"
@@ -76,10 +74,28 @@ func NewEventCollector(writer storage.StorageWriter, rootDir, sessionDir, nodeID
 		currentNodeID:      nodeID,      // Initialize with configured nodeID
 	}
 
-	// Start goroutine to watch nodeID file changes
-	go collector.watchNodeIDFile()
-
 	return collector
+}
+
+func (ec *EventCollector) UpdateNodeID(newNodeID string) {
+	ec.mutex.Lock()
+	if ec.currentNodeID != newNodeID {
+		logrus.Infof("EventCollector: node ID changed from %s to %s. Flushing %d buffered events", ec.currentNodeID, newNodeID, len(ec.events))
+		var eventsToFlush []Event
+		if len(ec.events) > 0 {
+			eventsToFlush = make([]Event, len(ec.events))
+			copy(eventsToFlush, ec.events)
+			ec.events = ec.events[:0]
+		}
+		ec.currentNodeID = newNodeID
+		ec.mutex.Unlock()
+
+		if len(eventsToFlush) > 0 {
+			ec.flushEventsInternal(eventsToFlush)
+		}
+		return
+	}
+	ec.mutex.Unlock()
 }
 
 func (ec *EventCollector) Run(stop <-chan struct{}, port int) {
@@ -104,99 +120,6 @@ func (ec *EventCollector) Run(stop <-chan struct{}, port int) {
 	logrus.Info("Received stop signal, flushing events to storage")
 	ec.flushEvents()
 	close(ec.stopped)
-}
-
-// watchNodeIDFile watches the configured raylet_node_id file for content changes.
-func (ec *EventCollector) watchNodeIDFile() {
-	nodeIDFilePath := utils.GetRayNodeIDPath()
-
-	// Create new watcher
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		logrus.Errorf("Failed to create file watcher: %v", err)
-		return
-	}
-	defer watcher.Close()
-
-	// Add file to watch list
-	err = watcher.Add(nodeIDFilePath)
-	if err != nil {
-		logrus.Infof("Failed to add %s to watcher, will watch for file creation: %v", nodeIDFilePath, err)
-		// If file doesn't exist, watch parent directory
-		tmpRayRoot := utils.GetTmpRayRoot()
-		err = watcher.Add(tmpRayRoot)
-		if err != nil {
-			logrus.Errorf("Failed to watch directory %s: %v", tmpRayRoot, err)
-			return
-		}
-	}
-
-	for {
-		select {
-		case event, ok := <-watcher.Events:
-			if !ok {
-				return
-			}
-
-			// Check if this is the target file
-			if event.Name == nodeIDFilePath && (event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create) {
-				// Read file content
-				content, err := os.ReadFile(nodeIDFilePath)
-				if err != nil {
-					logrus.Errorf("Failed to read node ID file %s: %v", nodeIDFilePath, err)
-					continue
-				}
-
-				// Trim whitespace
-				newNodeID := strings.TrimSpace(string(content))
-				if newNodeID == "" {
-					continue
-				}
-
-				// Check if nodeID changed
-				ec.mutex.Lock()
-				if ec.currentNodeID != newNodeID {
-					oldNodeID := ec.currentNodeID
-					logrus.Infof("Node ID changed from %s to %s, flushing events", oldNodeID, newNodeID)
-
-					// Update current nodeID
-					ec.currentNodeID = newNodeID
-
-					// Collect events with same nodeID
-					var eventsToFlush []Event
-					var remainingEvents []Event
-					for _, event := range ec.events {
-						if event.NodeID == oldNodeID {
-							eventsToFlush = append(eventsToFlush, event)
-						} else if event.NodeID == newNodeID {
-							remainingEvents = append(remainingEvents, event)
-						} else {
-							logrus.Errorf("Drop event with nodeId %v, event: %v", event.NodeID, event.Data)
-						}
-					}
-
-					// Update event list, keep only events with different nodeID
-					ec.events = remainingEvents
-					ec.mutex.Unlock()
-
-					// Flush events with same nodeID
-					if len(eventsToFlush) > 0 {
-						go ec.flushEventsInternal(eventsToFlush)
-					}
-					continue
-				}
-				ec.mutex.Unlock()
-			}
-		case err, ok := <-watcher.Errors:
-			if !ok {
-				return
-			}
-			logrus.Errorf("File watcher error: %v", err)
-		case <-ec.stopped:
-			logrus.Info("Event collector stopped, exiting node ID watcher")
-			return
-		}
-	}
 }
 
 func (ec *EventCollector) PersistEvents(req *restful.Request, resp *restful.Response) {
@@ -243,7 +166,7 @@ func (ec *EventCollector) PersistEvents(req *restful.Request, resp *restful.Resp
 			Data:        eventData,
 			Timestamp:   timestamp,
 			SessionName: sessionNameStr,
-			NodeID:      ec.currentNodeID, // Store currentNodeID when event arrived
+			NodeID:      ec.currentNodeID, // Store currentNodeID when event arrived (under lock)
 		}
 		ec.events = append(ec.events, event)
 
@@ -276,12 +199,21 @@ func (ec *EventCollector) PersistEvents(req *restful.Request, resp *restful.Resp
 }
 
 func (ec *EventCollector) periodicFlush() {
-	ticker := time.NewTicker(ec.flushInterval)
-	defer ticker.Stop()
+	flushTicker := time.NewTicker(ec.flushInterval)
+	// Periodic node ID update with shorter interval to handle frequent node restarts
+	nodeIDTicker := time.NewTicker(5 * time.Second)
+	defer flushTicker.Stop()
+	defer nodeIDTicker.Stop()
 
 	for {
 		select {
-		case <-ticker.C:
+		case <-nodeIDTicker.C:
+			if freshNodeID, err := utils.FetchCurrentNodeID(); err == nil && freshNodeID != "" {
+				if hexID, err := utils.ConvertBase64ToHex(freshNodeID); err == nil && hexID != "" {
+					ec.UpdateNodeID(hexID)
+				}
+			}
+		case <-flushTicker.C:
 			logrus.Info("Periodic flush triggered")
 			ec.flushEvents()
 		case <-ec.stopped:

--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
@@ -39,11 +39,26 @@ type RayLogHandler struct {
 	persistCompleteLogsDir string
 	PushInterval           time.Duration
 	LogBatching            int
-	filePathMu             sync.Mutex
 	IsHead                 bool
 	DashboardAddress       string
 	AdditionalEndpoints    []string
 	EndpointPollInterval   time.Duration
+	mu                     sync.RWMutex
+}
+
+func (r *RayLogHandler) GetRayNodeName() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.RayNodeName
+}
+
+func (r *RayLogHandler) SetRayNodeName(newNodeID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.RayNodeName != newNodeID {
+		logrus.Infof("RayLogHandler: updated node ID: %s -> %s", r.RayNodeName, newNodeID)
+		r.RayNodeName = newNodeID
+	}
 }
 
 func (r *RayLogHandler) Run(stop <-chan struct{}) error {
@@ -65,6 +80,7 @@ func (r *RayLogHandler) Run(stop <-chan struct{}) error {
 	// After scanning, it watches for new directories and files. This ensures incomplete
 	// uploads from previous runs are resumed.
 	go r.WatchPrevLogsLoops()
+	go r.PollActiveSessionChanges()
 	if r.IsHead {
 		go r.WatchSessionLatestLoops() // Watch session_latest symlink changes
 		go r.FetchAndStoreClusterMetadata()
@@ -121,13 +137,8 @@ func (r *RayLogHandler) processSessionLatestLogs() {
 		}
 	}
 
-	// Read node ID from the configured raylet_node_id file.
-	nodeIDBytes, err := os.ReadFile(utils.GetRayNodeIDPath())
-	if err != nil {
-		logrus.Errorf("Failed to read raylet_node_id: %v", err)
-		return
-	}
-	nodeID := strings.TrimSpace(string(nodeIDBytes))
+	// Use already discovered node ID (RayNodeName) instead of retrying network requests during shutdown
+	nodeID := strings.TrimSpace(r.GetRayNodeName())
 
 	// Process logs in session_latest/logs
 	logsDir := filepath.Join(sessionLatestDir, utils.RAY_SESSIONDIR_LOGDIR_NAME)
@@ -702,6 +713,7 @@ func (r *RayLogHandler) processPrevLogFile(absoluteLogPathName, localLogDir, ses
 // Any session change triggers sessiondir updates on all head and worker nodes,
 // so we only need to update from one node.
 // for example:
+//
 //	my-cluster_abc123/
 //		session_2024-12-15_10-30-45_123456    ← Empty file! The path itself is the information
 //		session_2024-12-15_14-20-10_789012
@@ -774,6 +786,63 @@ func (r *RayLogHandler) WatchSessionLatestLoops() {
 				return
 			}
 			logrus.Errorf("Session latest watcher error: %v", err)
+		}
+	}
+}
+
+// Polls if the active session changes, when it does, it moves the old session logs to a prev-logs/ folder.
+func (r *RayLogHandler) PollActiveSessionChanges() {
+	tmpRayRoot := utils.GetTmpRayRoot()
+	symlinkPath := filepath.Join(tmpRayRoot, "session_latest")
+
+	var lastResolvedDir string
+	currentActiveDir, err := filepath.EvalSymlinks(symlinkPath)
+	if err == nil && currentActiveDir != "" {
+		if r.SessionDir != "" && currentActiveDir != r.SessionDir {
+			logrus.Infof("PollActiveSessionChanges: detected startup session change from %s to %s. Relocating startup session logs.", r.SessionDir, currentActiveDir)
+			if err := utils.MoveLeftoverSessionLogs(currentActiveDir, r.GetRayNodeName()); err != nil {
+				logrus.Warnf("PollActiveSessionChanges: failed to relocate startup session logs: %v. Retrying on next poll tick.", err)
+				lastResolvedDir = r.SessionDir
+			} else {
+				lastResolvedDir = currentActiveDir
+			}
+		} else {
+			lastResolvedDir = currentActiveDir
+		}
+	} else {
+		logrus.Warnf("PollActiveSessionChanges: failed to resolve initial session_latest target: %v. Falling back to startup SessionDir %s", err, r.SessionDir)
+		lastResolvedDir = r.SessionDir
+	}
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	logrus.Infof("Started polling active session changes at: %s (initial target: %s)", symlinkPath, lastResolvedDir)
+	for {
+		select {
+		case <-r.ShutdownChan:
+			logrus.Info("PollActiveSessionChanges: stopping active session poller")
+			return
+		case <-ticker.C:
+			newResolvedDir, err := filepath.EvalSymlinks(symlinkPath)
+			if err != nil || newResolvedDir == "" {
+				continue
+			}
+
+			if lastResolvedDir != "" && newResolvedDir != lastResolvedDir {
+				logrus.Infof("PollActiveSessionChanges: session changed from %s to %s. Relocating old logs.", lastResolvedDir, newResolvedDir)
+				if err := utils.MoveLeftoverSessionLogs(newResolvedDir, r.GetRayNodeName()); err != nil {
+					logrus.Warnf("PollActiveSessionChanges: failed to relocate leftover session logs from %s to %s: %v. Retrying on next tick.", lastResolvedDir, newResolvedDir, err)
+					continue
+				}
+			}
+			lastResolvedDir = newResolvedDir
+
+			if freshNodeID, err := utils.FetchCurrentNodeID(); err == nil && freshNodeID != "" {
+				if hexID, err := utils.ConvertBase64ToHex(freshNodeID); err == nil && hexID != "" {
+					r.SetRayNodeName(hexID)
+				}
+			}
 		}
 	}
 }

--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector_test.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector_test.go
@@ -1,7 +1,10 @@
 package logcollector
 
 import (
+	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sync"
@@ -196,7 +199,6 @@ func TestScanAndProcess(t *testing.T) {
 	// Signal the background goroutine to exit gracefully
 	close(handler.ShutdownChan)
 }
-
 // TestProcessLogs_SkipSymlinks verifies that symlinks are skipped during directory scanning in prev-logs (processPrevLogsDir).
 func TestProcessLogs_SkipSymlinks(t *testing.T) {
 	baseDir, cleanup := setupRayTestEnvironment(t)
@@ -238,4 +240,188 @@ func TestProcessLogs_SkipSymlinks(t *testing.T) {
 		}
 	}
 	mockWriter.mu.Unlock()
+}
+
+func TestPollActiveSessionChanges(t *testing.T) {
+	g := NewWithT(t)
+	baseDir := t.TempDir()
+
+	originalTmpRoot := os.Getenv("RAY_TMP_ROOT")
+	defer os.Setenv("RAY_TMP_ROOT", originalTmpRoot)
+	os.Setenv("RAY_TMP_ROOT", baseDir)
+
+	handler := &RayLogHandler{
+		SessionDir:             filepath.Join(baseDir, "session_2026-07-08_15-00-00_123456_1"),
+		prevLogsDir:            filepath.Join(baseDir, "prev-logs"),
+		persistCompleteLogsDir: filepath.Join(baseDir, "persist-complete-logs"),
+		ShutdownChan:           make(chan struct{}),
+		RayClusterName:         "test-cluster",
+		RayClusterNamespace:    "cluster-123",
+		RayNodeName:            "node-1",
+	}
+
+	sessionNameA := "session_2026-07-08_15-00-00_123456_1"
+	sessionDirA := filepath.Join(baseDir, sessionNameA)
+	logsDirA := filepath.Join(sessionDirA, "logs")
+	createTestLogFile(t, filepath.Join(logsDirA, "raylet.out"), "log content A")
+
+	symlinkPath := filepath.Join(baseDir, "session_latest")
+	if err := os.Symlink(sessionNameA, symlinkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	go handler.PollActiveSessionChanges()
+
+	time.Sleep(500 * time.Millisecond)
+
+	sessionNameB := "session_2026-07-08_16-00-00_123456_1"
+	sessionDirB := filepath.Join(baseDir, sessionNameB)
+	logsDirB := filepath.Join(sessionDirB, "logs")
+	createTestLogFile(t, filepath.Join(logsDirB, "raylet.out"), "log content B")
+
+	os.Remove(symlinkPath)
+	if err := os.Symlink(sessionNameB, symlinkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	expectedPrevLogsDir := filepath.Join(handler.prevLogsDir, sessionNameA, handler.RayNodeName, "logs")
+	g.Eventually(func() bool {
+		_, err := os.Stat(filepath.Join(expectedPrevLogsDir, "raylet.out"))
+		return err == nil
+	}, 5*time.Second, 100*time.Millisecond).Should(BeTrue(), "Logs from session_A should be moved to prev-logs")
+
+	_, err := os.Stat(filepath.Join(logsDirA, "raylet.out"))
+	g.Expect(os.IsNotExist(err)).To(BeTrue(), "Original logs in session_A/logs should be deleted (moved)")
+
+	close(handler.ShutdownChan)
+}
+
+func TestPollActiveSessionChanges_MultipleIntermediateSessions(t *testing.T) {
+	g := NewWithT(t)
+	baseDir := t.TempDir()
+
+	originalTmpRoot := os.Getenv("RAY_TMP_ROOT")
+	defer os.Setenv("RAY_TMP_ROOT", originalTmpRoot)
+	os.Setenv("RAY_TMP_ROOT", baseDir)
+
+	handler := &RayLogHandler{
+		SessionDir:             filepath.Join(baseDir, "session_2026-07-08_15-00-00_123456_1"),
+		prevLogsDir:            filepath.Join(baseDir, "prev-logs"),
+		persistCompleteLogsDir: filepath.Join(baseDir, "persist-complete-logs"),
+		ShutdownChan:           make(chan struct{}),
+		RayClusterName:         "test-cluster",
+		RayClusterNamespace:    "cluster-123",
+		RayNodeName:            "node-1",
+	}
+
+	sessionNameA := "session_2026-07-08_15-00-00_123456_1"
+	sessionDirA := filepath.Join(baseDir, sessionNameA)
+	createTestLogFile(t, filepath.Join(sessionDirA, "logs", "raylet.out"), "log content A")
+
+	symlinkPath := filepath.Join(baseDir, "session_latest")
+	if err := os.Symlink(sessionNameA, symlinkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	go handler.PollActiveSessionChanges()
+	time.Sleep(200 * time.Millisecond)
+
+	// Simulate rapid restart: session B created (intermediate), then session C created before next ticker poll
+	sessionNameB := "session_2026-07-08_15-30-00_123456_1"
+	sessionDirB := filepath.Join(baseDir, sessionNameB)
+	createTestLogFile(t, filepath.Join(sessionDirB, "logs", "raylet.out"), "log content B")
+
+	sessionNameC := "session_2026-07-08_16-00-00_123456_1"
+	sessionDirC := filepath.Join(baseDir, sessionNameC)
+	createTestLogFile(t, filepath.Join(sessionDirC, "logs", "raylet.out"), "log content C")
+
+	os.Remove(symlinkPath)
+	if err := os.Symlink(sessionNameC, symlinkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	expectedPrevLogsA := filepath.Join(handler.prevLogsDir, sessionNameA, handler.RayNodeName, "logs")
+	expectedPrevLogsB := filepath.Join(handler.prevLogsDir, sessionNameB, handler.RayNodeName, "logs")
+
+	g.Eventually(func() bool {
+		_, errA := os.Stat(filepath.Join(expectedPrevLogsA, "raylet.out"))
+		_, errB := os.Stat(filepath.Join(expectedPrevLogsB, "raylet.out"))
+		return errA == nil && errB == nil
+	}, 6*time.Second, 100*time.Millisecond).Should(BeTrue(), "Logs from both session_A and intermediate session_B should be moved to prev-logs")
+
+	close(handler.ShutdownChan)
+}
+
+func TestNodeIDRefresh(t *testing.T) {
+	g := NewWithT(t)
+	baseDir := t.TempDir()
+
+	origPodIP := os.Getenv("POD_IP")
+	origFQRayIP := os.Getenv("FQ_RAY_IP")
+	origTmpRoot := os.Getenv("RAY_TMP_ROOT")
+	defer func() {
+		os.Setenv("POD_IP", origPodIP)
+		os.Setenv("FQ_RAY_IP", origFQRayIP)
+		os.Setenv("RAY_TMP_ROOT", origTmpRoot)
+	}()
+
+	os.Setenv("POD_IP", "127.0.0.1")
+	os.Setenv("RAY_TMP_ROOT", baseDir)
+
+	var mu sync.Mutex
+	mockNodeID := "11111111111111111111111111111111"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v0/nodes" {
+			mu.Lock()
+			nodeID := mockNodeID
+			mu.Unlock()
+			resp := fmt.Sprintf(`{
+				"data": {
+					"result": {
+						"result": [
+							{
+								"node_id": "%s",
+								"node_ip": "127.0.0.1",
+								"state": "ALIVE"
+							}
+						]
+					}
+				}
+			}`, nodeID)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(resp))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	os.Setenv("FQ_RAY_IP", ts.URL)
+
+	handler := &RayLogHandler{
+		SessionDir:             baseDir,
+		prevLogsDir:            filepath.Join(baseDir, "prev-logs"),
+		persistCompleteLogsDir: filepath.Join(baseDir, "persist-complete-logs"),
+		ShutdownChan:           make(chan struct{}),
+		RayNodeName:            "11111111111111111111111111111111",
+	}
+
+	symlinkPath := filepath.Join(baseDir, "session_latest")
+	if err := os.Symlink(baseDir, symlinkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+	defer os.Remove(symlinkPath)
+
+	go handler.PollActiveSessionChanges()
+	defer close(handler.ShutdownChan)
+
+	g.Expect(handler.GetRayNodeName()).To(Equal("11111111111111111111111111111111"))
+
+	mu.Lock()
+	mockNodeID = "22222222222222222222222222222222"
+	mu.Unlock()
+
+	g.Eventually(func() string {
+		return handler.GetRayNodeName()
+	}, 10*time.Second, 100*time.Millisecond).Should(Equal("22222222222222222222222222222222"), "GetRayNodeName should update dynamically when node ID changes")
 }

--- a/historyserver/pkg/utils/constant.go
+++ b/historyserver/pkg/utils/constant.go
@@ -33,7 +33,3 @@ func GetRayPersistCompletePath() string {
 func GetRaySessionLatestPath() string {
 	return filepath.Join(GetTmpRayRoot(), "session_latest")
 }
-
-func GetRayNodeIDPath() string {
-	return filepath.Join(GetTmpRayRoot(), "raylet_node_id")
-}

--- a/historyserver/pkg/utils/utils.go
+++ b/historyserver/pkg/utils/utils.go
@@ -3,9 +3,14 @@ package utils
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -73,30 +78,203 @@ func AppendRayClusterNameNamespace(rayClusterName, rayClusterNamespace string) s
 	return fmt.Sprintf("%s%s%s", rayClusterName, Connector, rayClusterNamespace)
 }
 
-func GetSessionDir() (string, error) {
-	for i := 0; i < 12; i++ {
-		rp, err := os.Readlink(GetRaySessionLatestPath())
-		if err != nil {
-			logrus.Errorf("read session_latest file error %v", err)
-			time.Sleep(time.Second * 5)
-			continue
-		}
-		return rp, nil
+// IsSessionDirActive checks if the raylet socket is running. Connection means raylet is active.
+func IsSessionDirActive(sessionDir string) bool {
+	socketPath := filepath.Join(sessionDir, "sockets", "raylet")
+	conn, err := net.DialTimeout("unix", socketPath, 1*time.Second)
+	if err == nil {
+		conn.Close()
+		return true
 	}
-	return "", fmt.Errorf("timeout log_monitor --session-dir not found")
+	return false
 }
 
-func GetRayNodeID() (string, error) {
+func GetSessionDir() (string, error) {
+	var lastErr error
 	for i := 0; i < 12; i++ {
-		nodeidBytes, err := os.ReadFile(GetRayNodeIDPath())
-		if err != nil {
-			logrus.Errorf("read nodeid file error %v", err)
-			time.Sleep(time.Second * 5)
+		symlinkPath := GetRaySessionLatestPath()
+		resolvedPath, resolveErr := filepath.EvalSymlinks(symlinkPath)
+		if resolveErr != nil {
+			// Fallback: readlink directly
+			var rp string
+			rp, resolveErr = os.Readlink(symlinkPath)
+			if resolveErr == nil {
+				// If readlink returned a relative target (e.g. session_2026-...), convert to absolute
+				if !filepath.IsAbs(rp) {
+					rp = filepath.Join(filepath.Dir(symlinkPath), rp)
+				}
+				resolvedPath = filepath.Clean(rp)
+			}
+		}
+
+		if resolveErr == nil {
+			if IsSessionDirActive(resolvedPath) {
+				return resolvedPath, nil
+			}
+			logrus.Infof("Session directory resolved to %s, but it is not active (raylet socket not ready). Retrying...", resolvedPath)
+		} else {
+			if !os.IsNotExist(resolveErr) {
+				return "", fmt.Errorf("failed to resolve session_latest symlink %s: %w", symlinkPath, resolveErr)
+			}
+			lastErr = resolveErr
+			logrus.Warnf("Failed to read/resolve session_latest symlink: %v. Retrying...", resolveErr)
+		}
+
+		time.Sleep(time.Second * 5)
+	}
+	return "", fmt.Errorf("timeout waiting for active Ray session: %w", lastErr)
+}
+
+// MoveSessionLogsToPrevLogs moves the logs/ folder of the specified sessionDir to prev-logs
+func MoveSessionLogsToPrevLogs(sessionDir, nodeID string) error {
+	if nodeID == "" {
+		return fmt.Errorf("nodeID cannot be empty")
+	}
+	sessionName := filepath.Base(sessionDir)
+
+	oldLogsDir := filepath.Join(sessionDir, "logs")
+	if _, err := os.Stat(oldLogsDir); err != nil {
+		// No logs directory, nothing to move
+		return nil
+	}
+
+	dest := filepath.Join(GetTmpRayRoot(), "prev-logs", sessionName, nodeID)
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return fmt.Errorf("failed to create destination path %s: %w", dest, err)
+	}
+
+	destLogsDir := filepath.Join(dest, "logs")
+	if err := os.Rename(oldLogsDir, destLogsDir); err != nil {
+		return fmt.Errorf("failed to move logs from %s to %s: %w", oldLogsDir, destLogsDir, err)
+	}
+	logrus.Infof("Moved session logs from %s to %s", oldLogsDir, destLogsDir)
+	return nil
+}
+
+// MoveLeftoverSessionLogs scans /tmp/ray/ for any old session_* directories (dirPath != activeSessionDir)
+// and moves their logs/ folder to prev-logs/<sessionName>/<nodeID>/logs for final upload and cleanup.
+//
+// Parity with Boilerplate Command:
+// This function replaces the exact shell check and move previously required in Ray container `command:` override:
+//
+//	[ -d "$RAY_TMP_ROOT/session_latest" ] && mv "$RAY_TMP_ROOT/session_latest/logs" "$dest/logs"
+//
+// Both the old command and this Go code move the previous session's logs out of the way before overwrite,
+// allowing logcollector to upload them to storage (GCS/S3) and clean up the temporary directory.
+//
+// Uses MoveSessionLogsToPrevLogs()
+func MoveLeftoverSessionLogs(activeSessionDir, nodeID string) error {
+	if activeSessionDir == "" || nodeID == "" {
+		return fmt.Errorf("activeSessionDir and nodeID cannot be empty")
+	}
+	activeSessionName := filepath.Base(activeSessionDir)
+	entries, err := os.ReadDir(GetTmpRayRoot())
+	if err != nil {
+		return fmt.Errorf("failed to read Ray temporary root directory %s: %w", GetTmpRayRoot(), err)
+	}
+	var moveErrs []string
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 {
 			continue
 		}
-		return strings.Trim(string(nodeidBytes), "\n"), nil
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "session_") {
+			continue
+		}
+		if entry.Name() == activeSessionName || entry.Name() == "session_latest" {
+			continue
+		}
+		dirPath := filepath.Join(GetTmpRayRoot(), entry.Name())
+		if err := MoveSessionLogsToPrevLogs(dirPath, nodeID); err != nil {
+			logrus.Warnf("Failed to relocate leftover session logs for %s: %v", dirPath, err)
+			moveErrs = append(moveErrs, fmt.Sprintf("%s: %v", dirPath, err))
+		}
 	}
-	return "", fmt.Errorf("timeout --node_id= not found")
+	if len(moveErrs) > 0 {
+		return fmt.Errorf("failed to relocate some session logs: %s", strings.Join(moveErrs, "; "))
+	}
+	return nil
+}
+
+
+type nodeSummaryResp struct {
+	Data struct {
+		Result struct {
+			Result []struct {
+				NodeID string `json:"node_id"`
+				NodeIP string `json:"node_ip"`
+				State  string `json:"state"`
+			} `json:"result"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+var (
+	ErrPodIPNotSet   = errors.New("POD_IP environment variable is not set")
+	ErrFQRayIPNotSet = errors.New("FQ_RAY_IP environment variable is not set")
+)
+
+// FetchCurrentNodeID performs a single non-blocking query to discover the active Ray NodeID for the current Pod IP.
+func FetchCurrentNodeID() (string, error) {
+	podIP := os.Getenv("POD_IP")
+	if podIP == "" {
+		return "", ErrPodIPNotSet
+	}
+	rayheadAddr := os.Getenv("FQ_RAY_IP")
+	if rayheadAddr == "" {
+		return "", ErrFQRayIPNotSet
+	}
+	addr := rayheadAddr
+	scheme := "http://"
+	if strings.HasPrefix(addr, "https://") {
+		scheme, addr = "https://", strings.TrimPrefix(addr, "https://")
+	}
+	addr = strings.TrimPrefix(addr, "http://")
+	if !strings.Contains(addr, ":") {
+		port := os.Getenv("RAY_DASHBOARD_PORT")
+		if port == "" {
+			port = "8265"
+		}
+		addr += ":" + port
+	}
+	endpoint := fmt.Sprintf("%s%s/api/v0/nodes?limit=10000", scheme, strings.TrimRight(addr, "/"))
+	client := &http.Client{Timeout: 1 * time.Second}
+
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP status %d from endpoint %s", resp.StatusCode, endpoint)
+	}
+
+	var payload nodeSummaryResp
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	for _, node := range payload.Data.Result.Result {
+		if node.NodeIP == podIP && node.NodeID != "" && node.State == "ALIVE" {
+			return node.NodeID, nil
+		}
+	}
+	return "", fmt.Errorf("no ALIVE Ray node found for Pod IP %s", podIP)
+}
+
+func GetNodeRayIDWithFQIP() (string, error) {
+	var lastErr error
+	// Retry loop waiting for Ray Head to become ready. 12 times so the total timeout is 60 seconds
+	for i := 0; i < 12; i++ {
+		nodeID, err := FetchCurrentNodeID()
+		if err == nil {
+			return nodeID, nil
+		}
+		if errors.Is(err, ErrPodIPNotSet) || errors.Is(err, ErrFQRayIPNotSet) {
+			return "", err
+		}
+		lastErr = err
+		time.Sleep(5 * time.Second)
+	}
+	return "", fmt.Errorf("timeout: failed to discover Ray NodeID via HTTP endpoint for Pod IP %s: %w", os.Getenv("POD_IP"), lastErr)
 }
 
 // ConvertBase64ToHex converts an ID to hex format.

--- a/historyserver/pkg/utils/utils_test.go
+++ b/historyserver/pkg/utils/utils_test.go
@@ -1,6 +1,11 @@
 package utils
 
 import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -115,5 +120,243 @@ func TestGetDateTimeFromSessionID(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGetNodeRayIDWithFQIP_EnvVars(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v0/nodes" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"data":{"result":{"result":[{"node_id":"node-id-abc","node_ip":"10.0.0.1","state":"ALIVE"}]}}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	os.Setenv("POD_IP", "10.0.0.1")
+	defer os.Unsetenv("POD_IP")
+
+	hostPort := strings.TrimPrefix(ts.URL, "http://")
+	parts := strings.Split(hostPort, ":")
+	host, port := parts[0], parts[1]
+
+	tests := []struct {
+		name        string
+		fqRayIP     string
+		dashPortEnv string
+	}{
+		{"Full URL with scheme and port", ts.URL, ""},
+		{"Host and port without scheme", hostPort, ""},
+		{"Bare host with RAY_DASHBOARD_PORT set", host, port},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("FQ_RAY_IP", tt.fqRayIP)
+			if tt.dashPortEnv != "" {
+				os.Setenv("RAY_DASHBOARD_PORT", tt.dashPortEnv)
+			} else {
+				os.Unsetenv("RAY_DASHBOARD_PORT")
+			}
+
+			nodeID, err := GetNodeRayIDWithFQIP()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if nodeID != "node-id-abc" {
+				t.Errorf("expected node-id-abc, got %s", nodeID)
+			}
+		})
+	}
+}
+
+func TestGetSessionDir_Symlinks(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "s-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	t.Setenv("RAY_TMP_ROOT", tmpDir)
+
+	sessionDirName := "session_1"
+	absSessionDir := filepath.Join(tmpDir, sessionDirName)
+	if err := os.MkdirAll(absSessionDir, 0755); err != nil {
+		t.Fatalf("failed to create session dir: %v", err)
+	}
+
+	// Create and start a Unix domain socket listener to mock the active raylet process.
+	socketDir := filepath.Join(absSessionDir, "sockets")
+	if err := os.MkdirAll(socketDir, 0755); err != nil {
+		t.Fatalf("failed to create sockets dir: %v", err)
+	}
+	socketPath := filepath.Join(socketDir, "raylet")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to listen on unix socket: %v", err)
+	}
+	defer listener.Close()
+
+	symlinkPath := filepath.Join(tmpDir, "session_latest")
+
+	// Test 1: Symlink pointing to relative session name
+	if err := os.Symlink(sessionDirName, symlinkPath); err != nil {
+		t.Fatalf("failed to create relative symlink: %v", err)
+	}
+
+	got, err := GetSessionDir()
+	if err != nil {
+		t.Fatalf("GetSessionDir with relative symlink failed: %v", err)
+	}
+	evalAbs, _ := filepath.EvalSymlinks(absSessionDir)
+	if got != evalAbs {
+		t.Errorf("expected %s, got %s", evalAbs, got)
+	}
+
+	// Test 2: Symlink pointing to absolute session dir
+	os.Remove(symlinkPath)
+	if err := os.Symlink(absSessionDir, symlinkPath); err != nil {
+		t.Fatalf("failed to create absolute symlink: %v", err)
+	}
+
+	gotAbs, err := GetSessionDir()
+	if err != nil {
+		t.Fatalf("GetSessionDir with absolute symlink failed: %v", err)
+	}
+	if gotAbs != evalAbs {
+		t.Errorf("expected %s, got %s", evalAbs, gotAbs)
+	}
+}
+
+func TestGetSessionDir_FatalError_FailsFast(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "s-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	// Create a file (not a directory)
+	filePath := filepath.Join(tmpDir, "file")
+	if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	// Set RAY_TMP_ROOT to a sub-path of a file (ENOTDIR error, non-IsNotExist)
+	t.Setenv("RAY_TMP_ROOT", filepath.Join(filePath, "sub"))
+
+	start := time.Now()
+	_, err = GetSessionDir()
+	duration := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if duration > 1*time.Second {
+		t.Errorf("expected fail fast within 1s, took %v", duration)
+	}
+}
+
+func TestGetSessionDir_WaitsForActive(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "s-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	t.Setenv("RAY_TMP_ROOT", tmpDir)
+
+	sessionDirName := "session_1"
+	absSessionDir := filepath.Join(tmpDir, sessionDirName)
+	if err := os.MkdirAll(absSessionDir, 0755); err != nil {
+		t.Fatalf("failed to create session dir: %v", err)
+	}
+
+	symlinkPath := filepath.Join(tmpDir, "session_latest")
+	if err := os.Symlink(sessionDirName, symlinkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	socketDir := filepath.Join(absSessionDir, "sockets")
+	if err := os.MkdirAll(socketDir, 0755); err != nil {
+		t.Fatalf("failed to create sockets dir: %v", err)
+	}
+	socketPath := filepath.Join(socketDir, "raylet")
+
+	// Start a goroutine that will create the active raylet socket after a short delay (e.g., 2 seconds).
+	go func() {
+		time.Sleep(2 * time.Second)
+		listener, err := net.Listen("unix", socketPath)
+		if err == nil {
+			t.Cleanup(func() {
+				listener.Close()
+			})
+		}
+	}()
+
+	start := time.Now()
+	got, err := GetSessionDir()
+	duration := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("GetSessionDir failed: %v", err)
+	}
+	evalAbs, _ := filepath.EvalSymlinks(absSessionDir)
+	if got != evalAbs {
+		t.Errorf("expected %s, got %s", evalAbs, got)
+	}
+	if duration < 4*time.Second {
+		t.Errorf("expected test to take at least 5s, took %v", duration)
+	}
+}
+
+func TestMoveLeftoverSessionLogs(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalTmpRoot := os.Getenv("RAY_TMP_ROOT")
+	defer os.Setenv("RAY_TMP_ROOT", originalTmpRoot)
+	os.Setenv("RAY_TMP_ROOT", tmpDir)
+
+	// 1. Create a prior session directory
+	priorSessionName := "session_2026-07-08_14-00-00_123456_1"
+	priorSessionDir := filepath.Join(tmpDir, priorSessionName)
+	priorLogsDir := filepath.Join(priorSessionDir, "logs")
+	if err := os.MkdirAll(priorLogsDir, 0755); err != nil {
+		t.Fatalf("failed to create prior logs dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(priorLogsDir, "raylet.out"), []byte("prior logs"), 0644); err != nil {
+		t.Fatalf("failed to write prior log file: %v", err)
+	}
+
+	// 2. Create the active session directory
+	activeSessionName := "session_2026-07-08_15-00-00_123456_1"
+	activeSessionDir := filepath.Join(tmpDir, activeSessionName)
+	activeLogsDir := filepath.Join(activeSessionDir, "logs")
+	if err := os.MkdirAll(activeLogsDir, 0755); err != nil {
+		t.Fatalf("failed to create active logs dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(activeLogsDir, "raylet.out"), []byte("active logs"), 0644); err != nil {
+		t.Fatalf("failed to write active log file: %v", err)
+	}
+
+	// Create session_latest symlink pointing to active session
+	symlinkPath := filepath.Join(tmpDir, "session_latest")
+	if err := os.Symlink(activeSessionName, symlinkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	nodeID := "node-abc"
+
+	// 3. Run MoveLeftoverSessionLogs
+	if err := MoveLeftoverSessionLogs(activeSessionDir, nodeID); err != nil {
+		t.Fatalf("MoveLeftoverSessionLogs failed: %v", err)
+	}
+
+	// 4. Verify that the prior session's logs were moved to prev-logs
+	expectedDest := filepath.Join(tmpDir, "prev-logs", priorSessionName, nodeID, "logs")
+	if _, err := os.Stat(filepath.Join(expectedDest, "raylet.out")); err != nil {
+		t.Errorf("Expected leftover logs to be moved to %s, but got error: %v", expectedDest, err)
+	}
+
+	// Verify that the active session's logs were NOT moved
+	if _, err := os.Stat(filepath.Join(activeLogsDir, "raylet.out")); err != nil {
+		t.Errorf("Expected active logs to remain in %s, but got error: %v", activeLogsDir, err)
 	}
 }

--- a/historyserver/test/e2e/historyserver_test.go
+++ b/historyserver/test/e2e/historyserver_test.go
@@ -495,7 +495,7 @@ func testLogFileEndpointDeadCluster(test Test, g *WithT, namespace *corev1.Names
 	headPod, err := GetHeadPod(test, rayCluster)
 	g.Expect(err).NotTo(HaveOccurred())
 	savedNodeIP := headPod.Status.PodIP
-	savedNodeID := GetNodeIDFromHeadPod(test, g, rayCluster)
+	savedNodeID := GetNodeIDFromPod(test, g, HeadPod(test, rayCluster), "ray-head")
 	LogWithTimestamp(test.T(), "Captured node IP %s and node ID %s before cluster deletion", savedNodeIP, savedNodeID)
 
 	// Delete RayCluster to trigger log upload

--- a/historyserver/test/support/raycluster.go
+++ b/historyserver/test/support/raycluster.go
@@ -95,39 +95,14 @@ fi`
 	return sessionID
 }
 
-// GetNodeIDFromHeadPod retrieves the nodeID from the Ray head pod by reading /tmp/ray/raylet_node_id.
-func GetNodeIDFromHeadPod(test Test, g *WithT, rayCluster *rayv1.RayCluster) string {
-	headPod, err := GetHeadPod(test, rayCluster)
-	g.Expect(err).NotTo(HaveOccurred())
-
-	getNodeIDCmd := `ray_tmp_root="${RAY_TMP_ROOT:-/tmp/ray}"
-if [ -f "${ray_tmp_root}/raylet_node_id" ]; then
-  cat "${ray_tmp_root}/raylet_node_id"
-else
-  echo "raylet_node_id not found"
-  exit 1
-fi`
-	output, _ := ExecPodCmd(test, headPod, "ray-head", []string{"sh", "-c", getNodeIDCmd})
-
-	nodeID := strings.TrimSpace(output.String())
-	LogWithTimestamp(test.T(), "Retrieved nodeID: %s", nodeID)
-	g.Expect(nodeID).NotTo(BeEmpty(), "nodeID should not be empty")
-
-	return nodeID
-}
-
-// GetNodeIDFromPod retrieves the nodeID from the Ray head or worker pod by reading /tmp/ray/raylet_node_id.
+// GetNodeIDFromPod retrieves the nodeID from the Ray head or worker pod by extracting
+// the --node_id argument from the active raylet process command line.
 func GetNodeIDFromPod(test Test, g *WithT, getPod func() (*corev1.Pod, error), containerName string) string {
 	pod, err := getPod()
 	g.Expect(err).NotTo(HaveOccurred())
 
-	getNodeIDCmd := `ray_tmp_root="${RAY_TMP_ROOT:-/tmp/ray}"
-if [ -f "${ray_tmp_root}/raylet_node_id" ]; then
-  cat "${ray_tmp_root}/raylet_node_id"
-else
-  echo "raylet_node_id not found"
-  exit 1
-fi`
+	// Extract node_id from raylet process arguments as history server retrieves node_id programmatically via HTTP API.
+	getNodeIDCmd := `ps -ef | grep raylet | grep -v grep | sed -n 's/.*--node_id=\([^ ]*\).*/\1/p'`
 	output, _ := ExecPodCmd(test, pod, containerName, []string{"sh", "-c", getNodeIDCmd})
 
 	// Parse output to extract the nodeID.


### PR DESCRIPTION
## Why are these changes needed?
This PR will allow history server to 1. retrieve the nodeID without the need to read the external file and 2. move the leftover logs before they are overwritten by current session. By having these changes, users will no longer need to add the lifecycle hook and the extra start command to the config. 

This PR is also part of enabling the history server kubeRay API

## Related issue number
Part of #4706 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
