### PR TITLE
[Bug][RayJob] Mark HTTPMode RayJob as Failed instead of resubmitting …

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -1302,7 +1302,11 @@ func clearJobStatusCheckFailureTimer(rayJob *rayv1.RayJob) bool {
 	return true
 }
 
-// reconcileHTTPModeJobNotFound handles GetJobInfo 404 in HTTP mode by resubmitting the job.
+// reconcileHTTPModeJobNotFound handles GetJobInfo 404 in HTTP mode. If the job has not been
+// observed on the cluster yet, this performs the initial submission. If the job was already
+// observed, the 404 means the cluster lost the job state (e.g. the head Pod was recreated),
+// so the RayJob transitions to Failed and retries are governed by spec.backoffLimit, consistent
+// with the other submission modes.
 // Returns whether status should be persisted.
 func reconcileHTTPModeJobNotFound(
 	ctx context.Context,
@@ -1310,6 +1314,16 @@ func reconcileHTTPModeJobNotFound(
 	rayDashboardClient dashboardclient.RayDashboardClientInterface,
 ) bool {
 	logger := ctrl.LoggerFrom(ctx)
+
+	if rayJob.Status.JobStatus != rayv1.JobStatusNew {
+		logger.Info("The Ray job was previously submitted but no longer exists in the RayCluster. Marking the RayJob as Failed.",
+			"JobId", rayJob.Status.JobId, "JobStatus", rayJob.Status.JobStatus)
+		rayJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusFailed
+		rayJob.Status.Reason = rayv1.AppFailed
+		rayJob.Status.Message = "The Ray job was previously submitted but no longer exists in the RayCluster, possibly because the head Pod was recreated."
+		return true
+	}
+
 	logger.Info("The Ray job was not found. Submit a Ray job via an HTTP request.", "JobId", rayJob.Status.JobId)
 
 	if _, submitErr := rayDashboardClient.SubmitJob(ctx, rayJob); submitErr != nil {

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -1302,7 +1302,7 @@ func clearJobStatusCheckFailureTimer(rayJob *rayv1.RayJob) bool {
 	return true
 }
 
-// reconcileHTTPModeJobNotFound handles GetJobInfo 404 in HTTP mode. If the job has not been
+// reconcileHTTPModeJobNotFound handles GetJobInfo 404 in HTTPMode. If the job has not been
 // observed on the cluster yet, this performs the initial submission. If the job was already
 // observed, the 404 means the cluster lost the job state (e.g. the head Pod was recreated),
 // so the RayJob transitions to Failed and retries are governed by spec.backoffLimit, consistent

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -3970,7 +3970,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				transitionRayJobToRunning(ctx, rayJob, rayCluster, namespace)
 			})
 
-			It("Clears JobStatusCheckFailureStartTime after successful HTTP resubmit", func() {
+			It("Clears JobStatusCheckFailureStartTime after successful HTTP submit when the job has not been observed yet", func() {
 				getJobInfo := func(_ context.Context, _ string) (*utiltypes.RayJobInfo, error) {
 					return nil, apierrors.NewBadRequest("job not found")
 				}
@@ -3980,7 +3980,7 @@ var _ = Context("RayJob with different submission modes", func() {
 				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob)).Should(Succeed())
 				recentTime := metav1.NewTime(time.Now().Add(-30 * time.Second))
 				rayJob.Status.JobStatusCheckFailureStartTime = &recentTime
-				rayJob.Status.JobStatus = rayv1.JobStatusRunning
+				rayJob.Status.JobStatus = rayv1.JobStatusNew
 				Expect(k8sClient.Status().Update(ctx, rayJob)).Should(Succeed())
 
 				Eventually(func() (*metav1.Time, error) {
@@ -3993,6 +3993,23 @@ var _ = Context("RayJob with different submission modes", func() {
 				Consistently(
 					getRayJobDeploymentStatus(ctx, rayJob),
 					time.Second*3, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusRunning))
+			})
+
+			It("Marks the RayJob as Failed when a previously observed job no longer exists", func() {
+				getJobInfo := func(_ context.Context, _ string) (*utiltypes.RayJobInfo, error) {
+					return nil, apierrors.NewBadRequest("job not found")
+				}
+				fakeRayDashboardClient.GetJobInfoMock.Store(&getJobInfo)
+				defer fakeRayDashboardClient.GetJobInfoMock.Store(nil)
+
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: rayJob.Name, Namespace: namespace}, rayJob)).Should(Succeed())
+				rayJob.Status.JobStatus = rayv1.JobStatusRunning
+				Expect(k8sClient.Status().Update(ctx, rayJob)).Should(Succeed())
+
+				Eventually(
+					getRayJobDeploymentStatus(ctx, rayJob),
+					time.Second*10, time.Millisecond*500).Should(Equal(rayv1.JobDeploymentStatusFailed))
+				Expect(rayJob.Status.Reason).To(Equal(rayv1.AppFailed))
 			})
 		})
 	})

--- a/ray-operator/controllers/ray/rayjob_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_unit_test.go
@@ -1132,6 +1132,69 @@ func TestCheckJobStatusCheckTimeoutAndUpdateStatusIfNeeded(t *testing.T) {
 	assert.Contains(t, rayJob.Status.Message, "exceeded timeout of 1s")
 }
 
+// TestReconcileHTTPModeJobNotFound covers the two meanings of a GetJobInfo 404 in HTTPMode
+// (https://github.com/ray-project/kuberay/issues/4824). If the job was never observed on the
+// cluster, the 404 simply means the job has not been submitted yet, so the initial submission
+// must proceed. If the job was already observed, the 404 means the cluster lost the job state
+// (e.g. the head Pod was recreated), so the RayJob must transition to Failed and let
+// spec.backoffLimit govern retries (consistent with K8sJobMode) instead of being silently
+// resubmitted to the new head.
+func TestReconcileHTTPModeJobNotFound(t *testing.T) {
+	tests := []struct {
+		name                        string
+		jobStatus                   rayv1.JobStatus
+		expectedJobDeploymentStatus rayv1.JobDeploymentStatus
+		expectedReason              rayv1.JobFailedReason
+		expectedSubmitCalls         int
+	}{
+		{
+			name:                        "job not observed yet, initial submission proceeds",
+			jobStatus:                   rayv1.JobStatusNew,
+			expectedJobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
+			expectedSubmitCalls:         1,
+		},
+		{
+			name:                        "previously observed job disappeared, mark Failed instead of resubmitting",
+			jobStatus:                   rayv1.JobStatusRunning,
+			expectedJobDeploymentStatus: rayv1.JobDeploymentStatusFailed,
+			expectedReason:              rayv1.AppFailed,
+			expectedSubmitCalls:         0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			rayJob := &rayv1.RayJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-rayjob", Namespace: "default"},
+				Spec: rayv1.RayJobSpec{
+					SubmissionMode: rayv1.HTTPMode,
+					BackoffLimit:   ptr.To[int32](0),
+				},
+				Status: rayv1.RayJobStatus{
+					JobId:               "test-rayjob-abcde",
+					JobStatus:           tc.jobStatus,
+					JobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
+				},
+			}
+
+			fakeDashboardClient := &utils.FakeRayDashboardClient{}
+			submitCalls := 0
+			submitJobMock := func(_ context.Context, _ *rayv1.RayJob) (string, error) { //nolint:unparam // This is a mock function so the signature cannot change
+				submitCalls++
+				return rayJob.Status.JobId, nil
+			}
+			fakeDashboardClient.SubmitJobMock.Store(&submitJobMock)
+
+			reconcileHTTPModeJobNotFound(ctx, rayJob, fakeDashboardClient)
+
+			assert.Equal(t, tc.expectedSubmitCalls, submitCalls)
+			assert.Equal(t, tc.expectedJobDeploymentStatus, rayJob.Status.JobDeploymentStatus)
+			assert.Equal(t, tc.expectedReason, rayJob.Status.Reason)
+		})
+	}
+}
+
 // TestBatchSchedulerCleanupCalledWhenRayJobSuspending verifies that batch scheduler resources are
 // cleaned up when a RayJob is suspended/retrying. Unlike the terminal (Complete/Failed) path, the
 // suspend path must requeue on cleanup failure rather than swallow the error, otherwise the PodGroup

--- a/ray-operator/controllers/ray/utils/fake_serve_httpclient.go
+++ b/ray-operator/controllers/ray/utils/fake_serve_httpclient.go
@@ -14,6 +14,7 @@ import (
 type FakeRayDashboardClient struct {
 	multiAppStatuses  map[string]*utiltypes.ServeApplicationStatus
 	GetJobInfoMock    atomic.Pointer[func(context.Context, string) (*utiltypes.RayJobInfo, error)]
+	SubmitJobMock     atomic.Pointer[func(context.Context, *rayv1.RayJob) (string, error)]
 	serveDetails      utiltypes.ServeDetails
 	LastUpdatedConfig []byte
 }
@@ -59,7 +60,10 @@ func (r *FakeRayDashboardClient) ListJobs(ctx context.Context) (*[]utiltypes.Ray
 	return nil, nil
 }
 
-func (r *FakeRayDashboardClient) SubmitJob(_ context.Context, _ *rayv1.RayJob) (jobId string, err error) {
+func (r *FakeRayDashboardClient) SubmitJob(ctx context.Context, rayJob *rayv1.RayJob) (jobId string, err error) {
+	if mock := r.SubmitJobMock.Load(); mock != nil {
+		return (*mock)(ctx, rayJob)
+	}
 	return "", nil
 }
 

--- a/ray-operator/test/e2erayjob/rayjob_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_test.go
@@ -325,6 +325,61 @@ env_vars:
 		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 	})
 
+	test.T().Run("RayJob in HTTPMode fails when the head Pod is deleted while the job is running", func(_ *testing.T) {
+		rayJobAC := rayv1ac.RayJob("delete-head-after-submit-http-mode", namespace.Name).
+			WithSpec(rayv1ac.RayJobSpec().
+				WithSubmissionMode(rayv1.HTTPMode).
+				WithRayClusterSpec(NewRayClusterSpec()).
+				WithEntrypoint("python -c \"import time; time.sleep(60)\"").
+				// BackoffLimit=0 is the default, but it is set explicitly because this test
+				// asserts that the RayJob stays Failed instead of being retried.
+				WithBackoffLimit(0).
+				WithShutdownAfterJobFinishes(true))
+
+		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+		// Wait until the RayJob's job status transitions to Running
+		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to be 'Running'", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobStatus, Equal(rayv1.JobStatusRunning)))
+
+		// Fetch RayCluster and delete the head Pod
+		rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+		g.Expect(err).NotTo(HaveOccurred())
+		rayCluster, err := GetRayCluster(test, rayJob.Namespace, rayJob.Status.RayClusterName)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(rayCluster.Labels[utils.RayJobSubmissionModeLabelKey]).To(Equal(string(rayv1.HTTPMode)))
+		headPod, err := GetHeadPod(test, rayCluster)
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(test.T(), "Deleting head Pod %s/%s for RayCluster %s", headPod.Namespace, headPod.Name, rayCluster.Name)
+		err = test.Client().Core().CoreV1().Pods(headPod.Namespace).Delete(test.Ctx(), headPod.Name, metav1.DeleteOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Head pod should be recreated for non-sidecar modes. The recreated head has an empty
+		// job registry, so the job the RayJob already observed no longer exists on the cluster.
+		g.Eventually(func() (*corev1.Pod, error) {
+			return GetHeadPod(test, rayCluster)
+		}, TestTimeoutMedium, 2*time.Second).ShouldNot(BeNil())
+
+		// The RayJob must be marked as Failed instead of being resubmitted to the recreated head,
+		// so that spec.backoffLimit governs retries as it does in the other submission modes.
+		// Unlike the K8sJobMode case above, the reason is asserted exactly: HTTPMode has no
+		// submitter Job, so SubmissionFailed and the submitter grace period cannot apply, and the
+		// job status check timeout is only reached after RAYJOB_STATUS_CHECK_TIMEOUT_SECONDS,
+		// which is longer than this assertion window.
+		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
+		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+			Should(WithTransform(RayJobReason, Equal(rayv1.AppFailed)))
+
+		// Cleanup
+		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+	})
+
 	test.T().Run("RayJob should be created, but not updated when managed externally", func(_ *testing.T) {
 		// RayJob
 		rayJobAC := rayv1ac.RayJob("managed-externally", namespace.Name).


### PR DESCRIPTION
## Why are these changes needed?

When a RayJob runs in HTTPMode and the head Pod gets recreated, for example after an eviction, the new head comes up with an empty job registry and `GetJobInfo` returns 404. The operator treats every 404 as "not submitted yet" because the same code path also performs the initial submission, so it resubmits the job to the new head. The job silently reruns no matter what `backoffLimit` says, even `backoffLimit: 0`. K8sJobMode marks the RayJob as Failed in this exact scenario, while the docs present the submission modes as interchangeable, so HTTPMode accepting a silent rerun was inconsistent.

This adds a guard in `reconcileHTTPModeJobNotFound` that distinguishes the two meanings of a 404 using `Status.JobStatus`, which stays `JobStatusNew` until the operator first observes the job on the cluster. If the job has not been observed yet, the initial submission proceeds as before. If it has, the RayJob transitions to Failed with reason `AppFailed`, and the existing `backoffLimit` machinery decides what happens next, matching the other submission modes. Anyone who wants automatic recovery can set `backoffLimit` above zero and recover through the `Retrying` path, which resets `JobStatus` to `JobStatusNew` and flows back into the initial submission branch. Builds on the refactor from #4916. Note this changes the default HTTPMode recovery behavior: a lost job now surfaces as Failed instead of silently rerunning.

Added a table-driven unit test covering both cases: a job that was never observed still gets submitted, and a previously observed job that disappears is marked Failed without a resubmit call. The "HTTPMode recovery" envtest from #4916 now exercises the timer clearing through the initial submission branch, with a new spec asserting the Failed transition for an observed job. The test fake gained a `SubmitJobMock` hook mirroring the existing `GetJobInfoMock`. The full ray-operator suite (`make test`) passes and `golangci-lint` reports no issues.

## Related issue number

Closes #4824

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(