### PR TITLE
[History Server] Mark non-terminal tasks of finished jobs as FAILED i…

### DIFF
--- a/historyserver/pkg/eventserver/snapshot.go
+++ b/historyserver/pkg/eventserver/snapshot.go
@@ -55,5 +55,11 @@ func reconcileTasksOfFinishedJobs(snapshot *SessionSnapshot) {
 		}
 		task.State = types.FAILED
 		task.EndTime = job.EndTime
+		// Append the FAILED transition so the task's serialized state history
+		// (stateTransitions) ends in the same state as the top-level State.
+		task.StateTransitions = append(task.StateTransitions, types.TaskStateTransition{
+			State:     types.FAILED,
+			Timestamp: job.EndTime,
+		})
 	}
 }

--- a/historyserver/pkg/eventserver/snapshot.go
+++ b/historyserver/pkg/eventserver/snapshot.go
@@ -21,12 +21,39 @@ type SessionSnapshot struct {
 // BuildSnapshot builds a SessionSnapshot from the handler's per-session state.
 func (h *EventHandler) BuildSnapshot(session utils.ClusterInfo) *SessionSnapshot {
 	clusterSessionKey := utils.BuildClusterSessionKey(session.Name, session.Namespace, session.SessionName)
-	return &SessionSnapshot{
+	snapshot := &SessionSnapshot{
 		SessionKey:       clusterSessionKey,
 		Tasks:            h.getTasks(clusterSessionKey),
 		Actors:           h.getActorsMap(clusterSessionKey),
 		Jobs:             h.getJobsMap(clusterSessionKey),
 		Nodes:            h.getNodeMap(clusterSessionKey),
 		LogEventsByJobID: h.getLogEventsByJobID(clusterSessionKey),
+	}
+	reconcileTasksOfFinishedJobs(snapshot)
+	return snapshot
+}
+
+// isTerminalTaskState reports whether a task state can no longer change.
+func isTerminalTaskState(state types.TaskStatus) bool {
+	return state == types.FINISHED || state == types.FAILED
+}
+
+// reconcileTasksOfFinishedJobs marks non-terminal tasks of finished jobs as FAILED.
+// Snapshots are only built for dead sessions, so a task that never reported a
+// terminal state cannot still be running once its job finished; its terminal
+// lifecycle event was lost when the cluster was torn down. Ray core applies the
+// same semantics at job end in GcsTaskManager::OnJobFinished.
+func reconcileTasksOfFinishedJobs(snapshot *SessionSnapshot) {
+	for i := range snapshot.Tasks {
+		task := &snapshot.Tasks[i]
+		if isTerminalTaskState(task.State) {
+			continue
+		}
+		job, ok := snapshot.Jobs[task.JobID]
+		if !ok || job.State != types.JOBFINISHED {
+			continue
+		}
+		task.State = types.FAILED
+		task.EndTime = job.EndTime
 	}
 }

--- a/historyserver/pkg/eventserver/snapshot_test.go
+++ b/historyserver/pkg/eventserver/snapshot_test.go
@@ -161,4 +161,16 @@ func TestBuildSnapshotTasksOfFinishedJob(t *testing.T) {
 	if !task.EndTime.Equal(jobFinished) {
 		t.Errorf("BuildSnapshot() task end time = %v, want job end time %v", task.EndTime, jobFinished)
 	}
+	// The serialized state history must end in the same state as the
+	// top-level State field.
+	if len(task.StateTransitions) == 0 {
+		t.Fatalf("BuildSnapshot() task has no state transitions, want a trailing %s transition", types.FAILED)
+	}
+	lastTransition := task.StateTransitions[len(task.StateTransitions)-1]
+	if lastTransition.State != types.FAILED {
+		t.Errorf("BuildSnapshot() last task state transition = %s, want %s", lastTransition.State, types.FAILED)
+	}
+	if !lastTransition.Timestamp.Equal(jobFinished) {
+		t.Errorf("BuildSnapshot() last task state transition timestamp = %v, want job end time %v", lastTransition.Timestamp, jobFinished)
+	}
 }

--- a/historyserver/pkg/eventserver/snapshot_test.go
+++ b/historyserver/pkg/eventserver/snapshot_test.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/ray-project/kuberay/historyserver/pkg/eventserver/types"
+	"github.com/ray-project/kuberay/historyserver/pkg/utils"
 )
 
 // TestEmptyRoundtrip verifies that an empty SessionSnapshot marshals and
@@ -67,5 +69,96 @@ func TestFullRoundtrip(t *testing.T) {
 
 	if !reflect.DeepEqual(original, decoded) {
 		t.Fatalf("roundtrip mismatch\noriginal=%+v\ndecoded =%+v", original, decoded)
+	}
+}
+
+// TestBuildSnapshotTasksOfFinishedJob covers the scenario reported in
+// https://github.com/ray-project/kuberay/issues/4814: the RayJob finished and the
+// cluster was torn down before the tasks' terminal lifecycle events were exported,
+// so the last recorded task state is RUNNING. Ray core marks non-terminal tasks of
+// a finished job as FAILED at job end (GcsTaskManager::OnJobFinished); the replayed
+// snapshot must do the same instead of showing such tasks as running forever.
+func TestBuildSnapshotTasksOfFinishedJob(t *testing.T) {
+	// IDs follow Ray's ID spec; see TestStoreEvent for rationale.
+	const (
+		jobID    = "aaaabbbb"                                                 // 4B
+		actorID  = "aaaabbbb1234aaaabbbb1234" + jobID                         // 12B unique + JobID
+		taskID   = "ccccdddd5678cccc" + actorID                               // 8B unique + ActorID
+		nodeID   = "eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff1234eeeeffff" // 28B
+		workerID = "eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff0000eeeeffff" // 28B
+	)
+
+	session := utils.ClusterInfo{Name: "raycluster-hs", Namespace: "default", SessionName: "session_2026-05-08_10-00-00"}
+	clusterSessionKey := utils.BuildClusterSessionKey(session.Name, session.Namespace, session.SessionName)
+
+	taskCreated := time.Unix(0, 1000).UTC()
+	taskRunning := time.Unix(0, 2000).UTC()
+	jobCreated := time.Unix(0, 500).UTC()
+	jobFinished := time.Unix(0, 3000).UTC()
+
+	h := NewEventHandler(nil)
+
+	events := []map[string]any{
+		{
+			"eventType": string(types.TASK_DEFINITION_EVENT),
+			"taskDefinitionEvent": map[string]any{
+				"taskId":      taskID,
+				"taskName":    "stuck_task",
+				"nodeId":      nodeID,
+				"taskAttempt": float64(0),
+				"jobId":       jobID,
+			},
+		},
+		{
+			"eventType": string(types.TASK_LIFECYCLE_EVENT),
+			"taskLifecycleEvent": map[string]any{
+				"taskId":      taskID,
+				"taskAttempt": float64(0),
+				"nodeId":      nodeID,
+				"workerId":    workerID,
+				"stateTransitions": []any{
+					map[string]any{"state": "PENDING_ARGS_AVAIL", "timestamp": taskCreated.Format(time.RFC3339Nano)},
+					map[string]any{"state": "RUNNING", "timestamp": taskRunning.Format(time.RFC3339Nano)},
+					// No terminal transition: the cluster was torn down before the
+					// task's FINISHED/FAILED event was exported.
+				},
+			},
+		},
+		{
+			"eventType": string(types.DRIVER_JOB_LIFECYCLE_EVENT),
+			"driverJobLifecycleEvent": map[string]any{
+				"jobId": jobID,
+				"stateTransitions": []any{
+					map[string]any{"state": string(types.CREATED), "timestamp": jobCreated.Format(time.RFC3339Nano)},
+					map[string]any{"state": string(types.JOBFINISHED), "timestamp": jobFinished.Format(time.RFC3339Nano)},
+				},
+			},
+		},
+	}
+	for _, event := range events {
+		if err := h.storeEvent(clusterSessionKey, event); err != nil {
+			t.Fatalf("storeEvent() unexpected error: %v", err)
+		}
+	}
+
+	snap := h.BuildSnapshot(session)
+
+	job, ok := snap.Jobs[jobID]
+	if !ok {
+		t.Fatalf("BuildSnapshot() job %s not found in snapshot", jobID)
+	}
+	if job.State != types.JOBFINISHED {
+		t.Fatalf("BuildSnapshot() job state = %s, want %s", job.State, types.JOBFINISHED)
+	}
+
+	if len(snap.Tasks) != 1 {
+		t.Fatalf("BuildSnapshot() returned %d tasks, want 1", len(snap.Tasks))
+	}
+	task := snap.Tasks[0]
+	if task.State != types.FAILED {
+		t.Errorf("BuildSnapshot() task state = %s, want %s: a non-terminal task of a finished job must not be shown as still running", task.State, types.FAILED)
+	}
+	if !task.EndTime.Equal(jobFinished) {
+		t.Errorf("BuildSnapshot() task end time = %v, want job end time %v", task.EndTime, jobFinished)
 	}
 }


### PR DESCRIPTION
## Why are these changes needed?

When a RayJob finishes and its cluster is torn down, workers are killed before their tasks' terminal FINISHED or FAILED lifecycle events get exported to storage. The History Server derives replayed task state only from each task's own state transitions, so those tasks keep RUNNING as their last recorded state and the replayed dashboard shows them as still running, even though the job is FINISHED and the cluster no longer exists. Ray core handles this exact situation at job end, where `GcsTaskManager::OnJobFinished` marks all non terminal tasks of a finished job as FAILED. The History Server replay path had no equivalent of that sweep.

This adds a reconciliation pass in `BuildSnapshot`, after tasks and jobs are collected: any task whose own state is non terminal and whose job reached FINISHED is presented as FAILED with the job's end time. Doing it at snapshot assembly keeps it independent of event file ordering during ingestion, covers every endpoint served from the snapshot, and leaves the stored event data untouched since `getTasks` returns deep copies. Tasks whose job is absent from the snapshot are left as is.

Added a test that drives the real ingestion path: it feeds a task definition, a task lifecycle that only reaches RUNNING, and a driver job lifecycle that reaches FINISHED through `storeEvent`, then asserts the built snapshot reports the task as FAILED with the job's end time. It fails on master, where the task stays RUNNING with a zero end time, and passes with the change. All historyserver unit packages pass with `go test ./pkg/...`. The e2e suite needs a live kind cluster with MinIO, so it was not run locally.

## Related issue number

Closes #4814

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(