### PR TITLE
[ray-operator] CalculatePodResource should count init containers and pod overhead

### DIFF
--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -520,30 +520,77 @@ func calculatePodResources(podResource *corev1.ResourceList, numPods int64) {
 	}
 }
 
-// CalculatePodResource returns the total resources of a pod.
-// Request values take precedence over limit values.
+// CalculatePodResource returns the total resources of a pod, matching the
+// effective request the scheduler reserves for it. Regular containers and native
+// sidecars (init containers with RestartPolicy Always) are summed, plain init
+// containers contribute through a per-resource max against that running sum, and
+// pod Overhead is added on top. Request values take precedence over limit values.
 func CalculatePodResource(podSpec corev1.PodSpec) corev1.ResourceList {
 	podResource := corev1.ResourceList{}
 	for _, container := range podSpec.Containers {
-		containerResource := container.Resources.Requests.DeepCopy()
-		if containerResource == nil {
-			containerResource = corev1.ResourceList{}
-		}
-		for name, quantity := range container.Resources.Limits {
-			if _, ok := containerResource[name]; !ok {
-				containerResource[name] = quantity
-			}
-		}
-		for name, quantity := range containerResource {
-			if totalQuantity, ok := podResource[name]; ok {
-				totalQuantity.Add(quantity)
-				podResource[name] = totalQuantity
-			} else {
-				podResource[name] = quantity
-			}
+		addResourceList(podResource, effectiveContainerResource(container))
+	}
+
+	// Init containers define the minimum reservation of any resource: a native
+	// sidecar (RestartPolicy Always) runs for the whole pod lifetime and adds to
+	// the sum, while a plain init container only needs to fit alongside the
+	// sidecars that started before it, so it contributes via a max rather than a
+	// sum. See the sidecar KEP resource-calculation rules.
+	restartableInitResource := corev1.ResourceList{}
+	initResource := corev1.ResourceList{}
+	for _, container := range podSpec.InitContainers {
+		containerResource := effectiveContainerResource(container)
+		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			addResourceList(podResource, containerResource)
+			addResourceList(restartableInitResource, containerResource)
+			maxResourceList(initResource, restartableInitResource)
+		} else {
+			addResourceList(containerResource, restartableInitResource)
+			maxResourceList(initResource, containerResource)
 		}
 	}
+	maxResourceList(podResource, initResource)
+
+	if podSpec.Overhead != nil {
+		addResourceList(podResource, podSpec.Overhead)
+	}
 	return podResource
+}
+
+// effectiveContainerResource returns a container's resource requests with each
+// limit filling in a request that is absent, so request values take precedence
+// over limit values. The result is a fresh list that never aliases the container.
+func effectiveContainerResource(container corev1.Container) corev1.ResourceList {
+	containerResource := container.Resources.Requests.DeepCopy()
+	if containerResource == nil {
+		containerResource = corev1.ResourceList{}
+	}
+	for name, quantity := range container.Resources.Limits {
+		if _, ok := containerResource[name]; !ok {
+			containerResource[name] = quantity.DeepCopy()
+		}
+	}
+	return containerResource
+}
+
+func addResourceList(dst, src corev1.ResourceList) {
+	for name, quantity := range src {
+		if total, ok := dst[name]; ok {
+			total.Add(quantity)
+			dst[name] = total
+		} else {
+			dst[name] = quantity.DeepCopy()
+		}
+	}
+}
+
+// maxResourceList raises dst to the greater of dst and src for every resource in src.
+func maxResourceList(dst, src corev1.ResourceList) {
+	for name, quantity := range src {
+		if current, ok := dst[name]; !ok || quantity.Cmp(current) > 0 {
+			dst[name] = quantity.DeepCopy()
+		}
+	}
 }
 
 func ConvertResourceListToMapString(resourceList corev1.ResourceList) map[string]resource.Quantity {

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -1321,6 +1321,136 @@ func TestCalculatePodResourceDoesNotMutateInput(t *testing.T) {
 	assert.Equal(t, wantRequests, podSpec.Containers[0].Resources.Requests)
 }
 
+func TestCalculatePodResourceInitContainersAndOverhead(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	requests := func(cpu, memory string) corev1.ResourceRequirements {
+		list := corev1.ResourceList{}
+		if cpu != "" {
+			list[corev1.ResourceCPU] = resource.MustParse(cpu)
+		}
+		if memory != "" {
+			list[corev1.ResourceMemory] = resource.MustParse(memory)
+		}
+		return corev1.ResourceRequirements{Requests: list}
+	}
+
+	tests := []struct {
+		name     string
+		podSpec  corev1.PodSpec
+		expected corev1.ResourceList
+	}{
+		{
+			name: "regular containers are summed with request falling back to limit",
+			podSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("200Mi"),
+						},
+					}},
+					{Resources: requests("2", "100Mi")},
+				},
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("300Mi"),
+			},
+		},
+		{
+			name: "pod overhead is added to the total",
+			podSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{Resources: requests("1", "100Mi")}},
+				Overhead: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("150Mi"),
+			},
+		},
+		{
+			name: "native sidecar is folded into the sum",
+			podSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{Resources: requests("1", "100Mi")}},
+				InitContainers: []corev1.Container{
+					{RestartPolicy: &always, Resources: requests("1", "50Mi")},
+				},
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("150Mi"),
+			},
+		},
+		{
+			name: "plain init container larger than the running sum wins via max",
+			podSpec: corev1.PodSpec{
+				Containers:     []corev1.Container{{Resources: requests("1", "100Mi")}},
+				InitContainers: []corev1.Container{{Resources: requests("4", "")}},
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+		},
+		{
+			name: "plain init container smaller than the running sum is ignored",
+			podSpec: corev1.PodSpec{
+				Containers:     []corev1.Container{{Resources: requests("2", "200Mi")}},
+				InitContainers: []corev1.Container{{Resources: requests("1", "50Mi")}},
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("200Mi"),
+			},
+		},
+		{
+			name: "init container request falls back to its limit",
+			podSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{Resources: requests("1", "")}},
+				InitContainers: []corev1.Container{{Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5")},
+				}}},
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("5"),
+			},
+		},
+		{
+			name: "sidecar sum, plain init max, and overhead combined",
+			podSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{Resources: requests("1", "100Mi")}},
+				InitContainers: []corev1.Container{
+					{RestartPolicy: &always, Resources: requests("1", "50Mi")},
+					{Resources: requests("5", "20Mi")},
+				},
+				Overhead: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("10Mi"),
+				},
+			},
+			expected: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("7"),
+				corev1.ResourceMemory: resource.MustParse("160Mi"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CalculatePodResource(tc.podSpec)
+			assert.Len(t, got, len(tc.expected))
+			for name, quantity := range tc.expected {
+				actual := got[name]
+				assert.Equal(t, quantity.String(), actual.String(), "resource %s", name)
+			}
+		})
+	}
+}
+
 func TestCalculateResources(t *testing.T) {
 	headStruct := struct {
 		cpu    string


### PR DESCRIPTION
## Why are these changes needed?

`CalculatePodResource` sums only `podSpec.Containers`, so a pod's init containers and its `Overhead` are left out of the total. Two things are undercounted:

- **Native sidecars** (init containers with `RestartPolicy: Always`) run for the whole pod lifetime, so their requests are part of the pod's steady-state reservation.
- **Pod `Overhead`** (injected by a RuntimeClass) is a real per-pod cost.

The result feeds `CalculateDesiredResources` and `CalculateMinResources`, so the `MinResources` KubeRay hands to the gang schedulers (Volcano, YuniKorn, scheduler-plugins) ends up smaller than what the pods actually need. A worker that declares a sidecar or overhead is under-reserved, and gang scheduling can admit a group that does not fit.

Example: a worker with a `1` CPU main container, a `1` CPU native sidecar, and `1` CPU pod overhead was reported as `1` CPU instead of `3`.

The fix follows the scheduler's effective-request formula from the sidecar KEP: sum regular containers and native sidecars, fold plain init containers in through a per-resource max against the running sum, and add `Overhead` on top. The existing request-falls-back-to-limit behavior is preserved, so pods without init containers or overhead are unchanged.

## Related issue number

N/A (self-reported; repro described above)

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
