### PR TITLE
[Bug][RayService] Skip Serve proxy readiness check and serve label for proxy-less workers

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -72,6 +72,13 @@ func initTemplateAnnotations(instance rayv1.RayCluster, podTemplate *corev1.PodT
 	if isOverwriteRayContainerCmd(instance) {
 		podTemplate.Annotations[utils.RayOverwriteContainerCmdAnnotationKey] = "true"
 	}
+
+	// Propagate the Serve proxy location (extracted from the RayService's Serve config by the
+	// rayservice controller) so that BuildPod can tell whether this cluster's worker Pods run
+	// a Serve proxy. See issue #4994.
+	if proxyLocation, ok := instance.Annotations[utils.RayServeProxyLocationAnnotationKey]; ok {
+		podTemplate.Annotations[utils.RayServeProxyLocationAnnotationKey] = proxyLocation
+	}
 }
 
 func configureGCSFaultTolerance(podTemplate *corev1.PodTemplateSpec, instance rayv1.RayCluster, rayNodeType rayv1.RayNodeType) {
@@ -717,7 +724,7 @@ func supportsUnifiedHealthCheck(rayVersion string) bool {
 	return v.AtLeast(minVersion)
 }
 
-func initLivenessAndReadinessProbe(rayContainer *corev1.Container, rayNodeType rayv1.RayNodeType, creatorCRDType utils.CRDType, rayStartParams map[string]string, rayVersion string) {
+func initLivenessAndReadinessProbe(rayContainer *corev1.Container, rayNodeType rayv1.RayNodeType, creatorCRDType utils.CRDType, rayStartParams map[string]string, rayVersion string, serveProxyDisabledOnWorkers bool) {
 	getPort := func(key string, defaultVal int32) int32 {
 		if portStr, ok := rayStartParams[key]; ok {
 			// ParseInt with bitSize=32 ensures the value fits in int32
@@ -801,7 +808,10 @@ func initLivenessAndReadinessProbe(rayContainer *corev1.Container, rayNodeType r
 		// For worker Pods serving traffic, we need to add an additional HTTP proxy health check for the readiness probe.
 		// Note: head Pod checks the HTTP proxy's health at every rayservice controller reconcile instaed of using readiness probe.
 		// See https://github.com/ray-project/kuberay/pull/1808 for reasons.
-		if creatorCRDType == utils.RayServiceCRD && rayNodeType == rayv1.WorkerNode {
+		// Skip the proxy health check when the Serve config's proxy_location is HeadOnly or
+		// Disabled: no proxy runs on workers, so checking it would keep every worker
+		// permanently unready. See issue #4994.
+		if creatorCRDType == utils.RayServiceCRD && rayNodeType == rayv1.WorkerNode && !serveProxyDisabledOnWorkers {
 			rayContainer.ReadinessProbe.FailureThreshold = utils.ServeReadinessProbeFailureThreshold
 			rayServeProxyHealthCommand := fmt.Sprintf(
 				utils.BaseWgetHealthCommand,
@@ -820,13 +830,19 @@ func initLivenessAndReadinessProbe(rayContainer *corev1.Container, rayNodeType r
 func BuildPod(ctx context.Context, podTemplateSpec corev1.PodTemplateSpec, rayNodeType rayv1.RayNodeType, rayStartParams map[string]string, headPort string, enableRayAutoscaler bool, creatorCRDType utils.CRDType, fqdnRayIP string, defaultContainerEnvs []corev1.EnvVar, rayVersion string) (aPod corev1.Pod) {
 	log := ctrl.LoggerFrom(ctx)
 
+	// Whether the Serve config places no proxy on worker Pods (proxy_location: HeadOnly/Disabled).
+	// The rayservice controller propagates this via an annotation; see issue #4994.
+	serveProxyDisabledOnWorkers := utils.IsServeProxyDisabledOnWorkers(podTemplateSpec.Annotations)
+
 	// For Worker Pod: Traffic readiness is determined by the readiness probe.
-	// Therefore, the RayClusterServingServiceLabelKey label is not utilized and should always be set to true.
+	// Therefore, the RayClusterServingServiceLabelKey label is not utilized and should always be set to true,
+	// unless no Serve proxy runs on workers — then the serve service must not select worker Pods at all,
+	// so the label is set to false.
 	// For Head Pod: Traffic readiness is determined by the value of the RayClusterServingServiceLabelKey label.
 	// Initially, set the label to false and let the rayservice controller to manage its value.
 	if creatorCRDType == utils.RayServiceCRD {
 		podTemplateSpec.Labels[utils.RayClusterServingServiceLabelKey] = utils.EnableRayClusterServingServiceTrue
-		if rayNodeType == rayv1.HeadNode {
+		if rayNodeType == rayv1.HeadNode || serveProxyDisabledOnWorkers {
 			podTemplateSpec.Labels[utils.RayClusterServingServiceLabelKey] = utils.EnableRayClusterServingServiceFalse
 		}
 	}
@@ -913,7 +929,7 @@ func BuildPod(ctx context.Context, podTemplateSpec corev1.PodTemplateSpec, rayNo
 		// Configure the readiness and liveness probes for the Ray container. These probes
 		// play a crucial role in KubeRay health checks. Without them, certain failures,
 		// such as the Raylet process crashing, may go undetected.
-		initLivenessAndReadinessProbe(&pod.Spec.Containers[utils.RayContainerIndex], rayNodeType, creatorCRDType, rayStartParams, rayVersion)
+		initLivenessAndReadinessProbe(&pod.Spec.Containers[utils.RayContainerIndex], rayNodeType, creatorCRDType, rayStartParams, rayVersion, serveProxyDisabledOnWorkers)
 	}
 
 	return pod

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -1188,6 +1188,32 @@ func TestBuildPod_WithCreatedByRayService(t *testing.T) {
 	utils.EnvVarExists(utils.RAY_TIMEOUT_MS_TASK_WAIT_FOR_DEATH_INFO, pod.Spec.Containers[utils.RayContainerIndex].Env)
 }
 
+func TestBuildPod_WithCreatedByRayServiceProxyDisabledOnWorkers(t *testing.T) {
+	// When the Serve config's proxy_location is HeadOnly (or Disabled), worker Pods run no
+	// Serve proxy: they must not get the Serve proxy readiness check, and they must not carry
+	// the ray.io/serve=true label that would add them to the serve service. See issue #4994.
+	ctx := context.Background()
+
+	cluster := instance.DeepCopy()
+	cluster.Annotations = map[string]string{
+		utils.RayServeProxyLocationAnnotationKey: utils.ServeProxyLocationHeadOnly,
+	}
+	worker := cluster.Spec.WorkerGroupSpecs[0]
+	podName := cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
+	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, *cluster, cluster.Namespace)
+	podTemplateSpec := DefaultWorkerPodTemplate(ctx, *cluster, worker, podName, fqdnRayIP, "6379", "", 0, 0)
+	pod := BuildPod(ctx, podTemplateSpec, rayv1.WorkerNode, worker.RayStartParams, "6379", false, utils.RayServiceCRD, fqdnRayIP, nil, "")
+
+	val, ok := pod.Labels[utils.RayClusterServingServiceLabelKey]
+	assert.True(t, ok, "Expected serve label is not present")
+	assert.Equal(t, utils.EnableRayClusterServingServiceFalse, val, "proxy-less worker must not be selected by the serve service")
+
+	rayContainer := pod.Spec.Containers[utils.RayContainerIndex]
+	assert.NotNil(t, rayContainer.ReadinessProbe.Exec)
+	assert.NotContains(t, strings.Join(rayContainer.ReadinessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath,
+		"proxy-less worker readiness probe must not check the Serve proxy")
+}
+
 func TestBuildPod_WithLoginBash(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -2068,7 +2094,7 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 
 	rayContainer.LivenessProbe = &httpGetProbe
 	rayContainer.ReadinessProbe = &httpGetProbe
-	initLivenessAndReadinessProbe(rayContainer, rayv1.HeadNode, "", rayStartParams, "")
+	initLivenessAndReadinessProbe(rayContainer, rayv1.HeadNode, "", rayStartParams, "", false)
 	assert.NotNil(t, rayContainer.LivenessProbe.HTTPGet)
 	assert.NotNil(t, rayContainer.ReadinessProbe.HTTPGet)
 	assert.Nil(t, rayContainer.LivenessProbe.Exec)
@@ -2079,7 +2105,7 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 	// implying that an additional serve health check will be added to the readiness probe.
 	rayContainer.LivenessProbe = nil
 	rayContainer.ReadinessProbe = nil
-	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayServiceCRD, rayStartParams, "")
+	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayServiceCRD, rayStartParams, "", false)
 	assert.NotNil(t, rayContainer.LivenessProbe.Exec)
 	assert.NotNil(t, rayContainer.ReadinessProbe.Exec)
 	assert.NotContains(t, strings.Join(rayContainer.LivenessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath)
@@ -2092,7 +2118,7 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 	// implying that an additional serve health check will be added to the readiness probe.
 	rayContainer.LivenessProbe = nil
 	rayContainer.ReadinessProbe = nil
-	initLivenessAndReadinessProbe(rayContainer, rayv1.HeadNode, utils.RayServiceCRD, rayStartParams, "")
+	initLivenessAndReadinessProbe(rayContainer, rayv1.HeadNode, utils.RayServiceCRD, rayStartParams, "", false)
 	assert.NotNil(t, rayContainer.LivenessProbe.Exec)
 	assert.NotNil(t, rayContainer.ReadinessProbe.Exec)
 	// head pod should not have Ray Serve proxy health probes
@@ -2108,7 +2134,7 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 		"dashboard-agent-listen-port": "8266",
 		"dashboard-port":              "8365",
 	}
-	initLivenessAndReadinessProbe(rayContainer, rayv1.HeadNode, utils.RayClusterCRD, customRayStartParams, "")
+	initLivenessAndReadinessProbe(rayContainer, rayv1.HeadNode, utils.RayClusterCRD, customRayStartParams, "", false)
 	assert.NotNil(t, rayContainer.LivenessProbe.Exec)
 	assert.NotNil(t, rayContainer.ReadinessProbe.Exec)
 
@@ -2126,7 +2152,7 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 	workerRayStartParams := map[string]string{
 		"dashboard-agent-listen-port": "9000",
 	}
-	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayClusterCRD, workerRayStartParams, "")
+	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayClusterCRD, workerRayStartParams, "", false)
 	assert.NotNil(t, rayContainer.LivenessProbe.Exec)
 	assert.NotNil(t, rayContainer.ReadinessProbe.Exec)
 
@@ -2150,11 +2176,23 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 	rayServiceWorkerParams := map[string]string{
 		"dashboard-agent-listen-port": "8500",
 	}
-	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayServiceCRD, rayServiceWorkerParams, "")
+	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayServiceCRD, rayServiceWorkerParams, "", false)
 	rayServiceReadinessCommand := strings.Join(rayContainer.ReadinessProbe.Exec.Command, " ")
 	assert.Contains(t, rayServiceReadinessCommand, ":8500", "RayService worker should use custom dashboard-agent-listen-port")
 	assert.Contains(t, rayServiceReadinessCommand, utils.RayServeProxyHealthPath, "RayService worker should include serve proxy health check")
 	assert.Equal(t, int32(utils.ServeReadinessProbeFailureThreshold), rayContainer.ReadinessProbe.FailureThreshold, "RayService worker should have correct failure threshold")
+
+	// Test 7: RayService worker whose cluster runs no Serve proxy on workers
+	// (proxy_location: HeadOnly or Disabled). The readiness probe must only check
+	// raylet health, like a plain RayCluster worker. See issue #4994.
+	rayContainer.LivenessProbe = nil
+	rayContainer.ReadinessProbe = nil
+	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayServiceCRD, rayStartParams, "", true)
+	assert.NotNil(t, rayContainer.ReadinessProbe.Exec)
+	assert.NotContains(t, strings.Join(rayContainer.ReadinessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath,
+		"proxy-less RayService worker must not check the Serve proxy in its readiness probe")
+	assert.Equal(t, int32(utils.DefaultReadinessProbeFailureThreshold), rayContainer.ReadinessProbe.FailureThreshold,
+		"proxy-less RayService worker should keep the default failure threshold")
 
 	// Test 8: Test invalid port values (should fall back to defaults)
 	rayContainer.LivenessProbe = nil
@@ -2163,7 +2201,7 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 		"dashboard-agent-listen-port": "invalid-port",
 		"dashboard-port":              "not-a-number",
 	}
-	initLivenessAndReadinessProbe(rayContainer, rayv1.HeadNode, utils.RayClusterCRD, invalidPortParams, "")
+	initLivenessAndReadinessProbe(rayContainer, rayv1.HeadNode, utils.RayClusterCRD, invalidPortParams, "", false)
 
 	invalidPortLivenessCommand := strings.Join(rayContainer.LivenessProbe.Exec.Command, " ")
 
@@ -2175,7 +2213,7 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 	rayContainer.LivenessProbe = nil
 	rayContainer.ReadinessProbe = nil
 	// Verify head node has http probes and no exec probes.
-	initLivenessAndReadinessProbe(rayContainer, rayv1.HeadNode, utils.RayClusterCRD, rayStartParams, "2.53.0")
+	initLivenessAndReadinessProbe(rayContainer, rayv1.HeadNode, utils.RayClusterCRD, rayStartParams, "2.53.0", false)
 	assert.NotNil(t, rayContainer.LivenessProbe.HTTPGet)
 	assert.NotNil(t, rayContainer.ReadinessProbe.HTTPGet)
 	assert.Nil(t, rayContainer.LivenessProbe.Exec)
@@ -2186,7 +2224,7 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 	// Worker nodes also should have only http probes.
 	rayContainer.LivenessProbe = nil
 	rayContainer.ReadinessProbe = nil
-	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayClusterCRD, rayStartParams, "2.53.0")
+	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayClusterCRD, rayStartParams, "2.53.0", false)
 	assert.Nil(t, rayContainer.LivenessProbe.Exec)
 	assert.Nil(t, rayContainer.ReadinessProbe.Exec)
 	assert.NotNil(t, rayContainer.LivenessProbe.HTTPGet)
@@ -2195,17 +2233,24 @@ func TestInitLivenessAndReadinessProbe(t *testing.T) {
 	// Ray Serve workers still use exec probes for readiness to check the proxy actor.
 	rayContainer.LivenessProbe = nil
 	rayContainer.ReadinessProbe = nil
-	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayServiceCRD, rayStartParams, "2.53.0")
+	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayServiceCRD, rayStartParams, "2.53.0", false)
 	assert.NotNil(t, rayContainer.LivenessProbe.HTTPGet)
 	assert.Nil(t, rayContainer.LivenessProbe.Exec)
 	assert.Nil(t, rayContainer.ReadinessProbe.HTTPGet)
 	assert.NotNil(t, rayContainer.ReadinessProbe.Exec)
 	assert.Contains(t, strings.Join(rayContainer.ReadinessProbe.Exec.Command, " "), utils.RayServeProxyHealthPath)
 
+	// Ray Serve workers keep the unified HTTP health check when no proxy runs on workers.
+	rayContainer.LivenessProbe = nil
+	rayContainer.ReadinessProbe = nil
+	initLivenessAndReadinessProbe(rayContainer, rayv1.WorkerNode, utils.RayServiceCRD, rayStartParams, "2.53.0", true)
+	assert.NotNil(t, rayContainer.ReadinessProbe.HTTPGet)
+	assert.Nil(t, rayContainer.ReadinessProbe.Exec)
+
 	// Versions parsed below 2.53 must use exec probes.
 	rayContainer.LivenessProbe = nil
 	rayContainer.ReadinessProbe = nil
-	initLivenessAndReadinessProbe(rayContainer, rayv1.HeadNode, utils.RayClusterCRD, rayStartParams, "2.52.0")
+	initLivenessAndReadinessProbe(rayContainer, rayv1.HeadNode, utils.RayClusterCRD, rayStartParams, "2.52.0", false)
 	assert.NotNil(t, rayContainer.LivenessProbe.Exec)
 	assert.NotNil(t, rayContainer.ReadinessProbe.Exec)
 }

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -1510,6 +1510,14 @@ func constructRayClusterForRayService(rayService *rayv1.RayService, rayClusterNa
 	// set the KubeRay version used to create the RayCluster
 	rayClusterAnnotations[utils.KubeRayVersion] = utils.KUBERAY_VERSION
 
+	// Propagate the Serve config's `proxy_location` to the RayCluster so that Pod construction,
+	// which only sees the RayCluster, knows whether worker Pods run a Serve proxy. Without this,
+	// workers get a Serve proxy readiness check even when `proxy_location: HeadOnly` leaves no
+	// proxy on workers, making every worker permanently unready. See issue #4994.
+	if proxyLocation := getServeProxyLocation(rayService.Spec.ServeConfigV2); proxyLocation != "" {
+		rayClusterAnnotations[utils.RayServeProxyLocationAnnotationKey] = proxyLocation
+	}
+
 	clusterSpec := rayService.Spec.RayClusterSpec.DeepCopy()
 	isPendingClusterForUpgrade := utils.IsIncrementalUpgradeEnabled(&rayService.Spec) &&
 		rayService.Status.ActiveServiceStatus.RayClusterName != ""
@@ -1537,6 +1545,20 @@ func constructRayClusterForRayService(rayService *rayv1.RayService, rayClusterNa
 	}
 
 	return rayCluster, nil
+}
+
+// getServeProxyLocation extracts the top-level `proxy_location` field from the
+// multi-application Serve config (serveConfigV2). It returns "" if the field is unset
+// or the config cannot be parsed; malformed configs are surfaced to the user later,
+// when the config is submitted to the Ray dashboard.
+func getServeProxyLocation(serveConfigV2 string) string {
+	serveConfig := struct {
+		ProxyLocation string `json:"proxy_location"`
+	}{}
+	if err := yaml.Unmarshal([]byte(serveConfigV2), &serveConfig); err != nil {
+		return ""
+	}
+	return serveConfig.ProxyLocation
 }
 
 func checkIfNeedSubmitServeApplications(cachedServeConfigV2 string, serveConfigV2 string, serveApplications map[string]rayv1.AppStatus) (bool, string) {

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -928,6 +928,65 @@ func TestCalculateConditions(t *testing.T) {
 	}
 }
 
+func TestConstructRayClusterForRayServiceProxyLocationAnnotation(t *testing.T) {
+	// The Serve config's top-level proxy_location must be propagated to the RayCluster as an
+	// annotation so that Pod construction can skip the Serve proxy readiness check and serve
+	// label on worker Pods when workers run no proxy. See issue #4994.
+	tests := []struct {
+		name               string
+		serveConfigV2      string
+		expectedAnnotation string
+	}{
+		{
+			name: "proxy_location HeadOnly",
+			serveConfigV2: `
+proxy_location: HeadOnly
+applications:
+  - name: app1
+    import_path: app:graph
+`,
+			expectedAnnotation: "HeadOnly",
+		},
+		{
+			name: "proxy_location unset",
+			serveConfigV2: `
+applications:
+  - name: app1
+    import_path: app:graph
+`,
+			expectedAnnotation: "",
+		},
+		{
+			name:               "malformed Serve config",
+			serveConfigV2:      "{{ not yaml",
+			expectedAnnotation: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rayService := rayv1.RayService{
+				Spec: rayv1.RayServiceSpec{
+					ServeConfigV2: tt.serveConfigV2,
+					RayClusterSpec: rayv1.RayClusterSpec{
+						WorkerGroupSpecs: []rayv1.WorkerGroupSpec{{GroupName: "worker-group-1"}},
+					},
+				},
+			}
+			rayService.Name = "test-service"
+			rayService.Namespace = "test-namespace"
+			rayCluster, err := constructRayClusterForRayService(&rayService, "test-cluster", scheme.Scheme)
+			require.NoError(t, err)
+
+			if tt.expectedAnnotation == "" {
+				assert.NotContains(t, rayCluster.Annotations, utils.RayServeProxyLocationAnnotationKey)
+			} else {
+				assert.Equal(t, tt.expectedAnnotation, rayCluster.Annotations[utils.RayServeProxyLocationAnnotationKey])
+			}
+		})
+	}
+}
+
 func TestConstructRayClusterForRayService(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -68,6 +68,17 @@ const (
 	// `KUBERAY_GEN_RAY_START_CMD`.
 	RayOverwriteContainerCmdAnnotationKey = "ray.io/overwrite-container-cmd"
 
+	// RayServeProxyLocationAnnotationKey carries the top-level `proxy_location` field of the
+	// RayService's Serve config (serveConfigV2) from the RayService to the RayCluster it creates,
+	// and from there to the Pods. Pod construction uses it to decide whether worker Pods run a
+	// Serve proxy: when the proxy location is "HeadOnly" or "Disabled", workers must not get the
+	// Serve proxy readiness check or the ray.io/serve label. See issue #4994.
+	RayServeProxyLocationAnnotationKey = "ray.io/serve-proxy-location"
+
+	// Values of the Serve config's `proxy_location` field for which worker Pods run no Serve proxy.
+	ServeProxyLocationHeadOnly = "HeadOnly"
+	ServeProxyLocationDisabled = "Disabled"
+
 	// RayServiceInitializingTimeoutAnnotation specifies the timeout for RayService initialization.
 	// Accepts Go duration format (e.g., "30m", "1h") or integer seconds.
 	//

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -792,6 +792,15 @@ func GetGCSStoragePVCName(instance *rayv1.RayCluster) string {
 	return instance.Name + GCSStoragePVCSuffix
 }
 
+// IsServeProxyDisabledOnWorkers returns true if the Serve config's `proxy_location`
+// (propagated via the RayServeProxyLocationAnnotationKey annotation) means worker Pods
+// run no Serve proxy: "HeadOnly" (proxy only on the head) or "Disabled" (no proxy at all).
+func IsServeProxyDisabledOnWorkers(annotations map[string]string) bool {
+	proxyLocation := annotations[RayServeProxyLocationAnnotationKey]
+	return strings.EqualFold(proxyLocation, ServeProxyLocationHeadOnly) ||
+		strings.EqualFold(proxyLocation, ServeProxyLocationDisabled)
+}
+
 // IsAuthEnabled returns whether Ray auth is enabled.
 func IsAuthEnabled(spec *rayv1.RayClusterSpec) bool {
 	return spec.AuthOptions != nil && spec.AuthOptions.Mode == rayv1.AuthModeToken

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -1175,6 +1175,26 @@ func TestIsAutoscalingV1Enabled(t *testing.T) {
 	}
 }
 
+func TestIsServeProxyDisabledOnWorkers(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{name: "HeadOnly", annotations: map[string]string{RayServeProxyLocationAnnotationKey: "HeadOnly"}, expected: true},
+		{name: "Disabled", annotations: map[string]string{RayServeProxyLocationAnnotationKey: "Disabled"}, expected: true},
+		{name: "case-insensitive", annotations: map[string]string{RayServeProxyLocationAnnotationKey: "headonly"}, expected: true},
+		{name: "EveryNode", annotations: map[string]string{RayServeProxyLocationAnnotationKey: "EveryNode"}, expected: false},
+		{name: "annotation absent", annotations: map[string]string{}, expected: false},
+		{name: "nil annotations", annotations: nil, expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsServeProxyDisabledOnWorkers(tt.annotations))
+		})
+	}
+}
+
 func TestIsGCSFaultToleranceEnabled(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Why are these changes needed?

For RayService-managed clusters, `initLivenessAndReadinessProbe` unconditionally appends a local Serve proxy health check (`wget … localhost:8000/-/healthz`) to worker readiness probes, and `BuildPod` always labels workers `ray.io/serve=true`. When the Serve config sets `proxy_location: HeadOnly` (or `Disabled`), workers run no proxy, so every worker pod is permanently `Ready=False` (with a misleading `Readiness probe failed: success` kubelet event every 5s), and the serve service's selector matches pods with nothing listening on the serve port — the broken probe is the only thing keeping them out of the endpoints.

The pod-building code never sees `serveConfigV2` (it lives on the RayService; pods are built by the RayCluster controller), so this PR plumbs the needed bit through an annotation:

1. The rayservice controller extracts the top-level `proxy_location` from `serveConfigV2` and stamps it on the RayCluster it creates as `ray.io/serve-proxy-location` (`constructRayClusterForRayService`).
2. `initTemplateAnnotations` — the existing RayCluster→pod-template propagation point — copies it to pod templates.
3. `BuildPod`: when the proxy location is `HeadOnly`/`Disabled`, worker pods get a raylet-only readiness probe (matching the liveness probe, in both the legacy exec and the Ray ≥ 2.53 unified-HTTP forms) and `ray.io/serve=false`, so the serve service does not select them. `EveryNode`/unset keeps today's behavior; user-defined probes are still honored.

Note: probes reflect `proxy_location` at pod-creation time; an in-place Serve config change does not rebuild running pods (same as other pod-spec-affecting settings).

## Related issue number

Closes #4994

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
