### PR TITLE
[Feature] Merge user-provided submitterPodTemplate with computed defa…

### DIFF
--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -231,8 +231,11 @@ func GetSubmitterTemplate(rayJobSpec *rayv1.RayJobSpec, rayClusterSpec *rayv1.Ra
 			defaultSubmitterPodTemplate.ObjectMeta.Annotations = userSubmitterPodTemplate.ObjectMeta.Annotations
 		}
 		if len(userSubmitterPodTemplate.Spec.Containers) > 0 {
-			if len(userSubmitterPodTemplate.Spec.Containers[0].Resources.Requests) > 0 || len(userSubmitterPodTemplate.Spec.Containers[0].Resources.Limits) > 0 {
-				defaultSubmitterPodTemplate.Spec.Containers[0].Resources = userSubmitterPodTemplate.Spec.Containers[0].Resources
+			if len(userSubmitterPodTemplate.Spec.Containers[0].Resources.Requests) > 0 {
+				defaultSubmitterPodTemplate.Spec.Containers[0].Resources.Requests = userSubmitterPodTemplate.Spec.Containers[0].Resources.Requests
+			}
+			if len(userSubmitterPodTemplate.Spec.Containers[0].Resources.Limits) > 0 {
+				defaultSubmitterPodTemplate.Spec.Containers[0].Resources.Limits = userSubmitterPodTemplate.Spec.Containers[0].Resources.Limits
 			}
 			if userSubmitterPodTemplate.Spec.Containers[0].Image != "" {
 				defaultSubmitterPodTemplate.Spec.Containers[0].Image = userSubmitterPodTemplate.Spec.Containers[0].Image

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -213,17 +213,41 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 
 // GetSubmitterTemplate creates a default submitter template for the Ray job.
 func GetSubmitterTemplate(rayJobSpec *rayv1.RayJobSpec, rayClusterSpec *rayv1.RayClusterSpec) corev1.PodTemplateSpec {
-	if rayJobSpec.SubmitterPodTemplate != nil {
-		return *rayJobSpec.SubmitterPodTemplate.DeepCopy()
-	}
-	return corev1.PodTemplateSpec{
+	defaultSubmitterPodTemplate := corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				GetDefaultSubmitterContainer(rayClusterSpec),
-			},
+			Containers:    []corev1.Container{GetDefaultSubmitterContainer(rayClusterSpec)},
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}
+
+	var userSubmitterPodTemplate corev1.PodTemplateSpec
+	if rayJobSpec.SubmitterPodTemplate != nil {
+		userSubmitterPodTemplate = *rayJobSpec.SubmitterPodTemplate.DeepCopy()
+
+		if len(userSubmitterPodTemplate.ObjectMeta.Labels) > 0 {
+			defaultSubmitterPodTemplate.ObjectMeta.Labels = userSubmitterPodTemplate.ObjectMeta.Labels
+		}
+		if len(userSubmitterPodTemplate.ObjectMeta.Annotations) > 0 {
+			defaultSubmitterPodTemplate.ObjectMeta.Annotations = userSubmitterPodTemplate.ObjectMeta.Annotations
+		}
+		if len(userSubmitterPodTemplate.Spec.Containers) > 0 {
+			if len(userSubmitterPodTemplate.Spec.Containers[0].Resources.Requests) > 0 || len(userSubmitterPodTemplate.Spec.Containers[0].Resources.Limits) > 0 {
+				defaultSubmitterPodTemplate.Spec.Containers[0].Resources = userSubmitterPodTemplate.Spec.Containers[0].Resources
+			}
+			if userSubmitterPodTemplate.Spec.Containers[0].Image != "" {
+				defaultSubmitterPodTemplate.Spec.Containers[0].Image = userSubmitterPodTemplate.Spec.Containers[0].Image
+			}
+		}
+
+		if userSubmitterPodTemplate.Spec.Tolerations != nil {
+			defaultSubmitterPodTemplate.Spec.Tolerations = userSubmitterPodTemplate.Spec.Tolerations
+		}
+		if userSubmitterPodTemplate.Spec.NodeSelector != nil {
+			defaultSubmitterPodTemplate.Spec.NodeSelector = userSubmitterPodTemplate.Spec.NodeSelector
+		}
+	}
+
+	return defaultSubmitterPodTemplate
 }
 
 // GetDefaultSubmitterContainer creates a default submitter container for the Ray job.

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -219,8 +219,10 @@ func GetSubmitterTemplate(rayJobSpec *rayv1.RayJobSpec, rayClusterSpec *rayv1.Ra
 	if rayJobSpec.SubmitterPodTemplate == nil {
 		return corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
-				Containers:    []corev1.Container{defaultContainer},
-				RestartPolicy: corev1.RestartPolicyNever,
+				Containers:         []corev1.Container{defaultContainer},
+				RestartPolicy:      corev1.RestartPolicyNever,
+				ServiceAccountName: rayClusterSpec.HeadGroupSpec.Template.Spec.ServiceAccountName,
+				ImagePullSecrets:   rayClusterSpec.HeadGroupSpec.Template.Spec.ImagePullSecrets,
 			},
 		}
 	}
@@ -231,6 +233,16 @@ func GetSubmitterTemplate(rayJobSpec *rayv1.RayJobSpec, rayClusterSpec *rayv1.Ra
 
 	// Always enforce RestartPolicy: Never
 	finalTemplate.Spec.RestartPolicy = corev1.RestartPolicyNever
+
+	// Fallback to default ServiceAccountName if user omitted it
+	if finalTemplate.Spec.ServiceAccountName == "" {
+		finalTemplate.Spec.ServiceAccountName = rayClusterSpec.HeadGroupSpec.Template.Spec.ServiceAccountName
+	}
+
+	// Fallback to default ImagePullSecrets if user omitted it
+	if len(finalTemplate.Spec.ImagePullSecrets) == 0 {
+		finalTemplate.Spec.ImagePullSecrets = rayClusterSpec.HeadGroupSpec.Template.Spec.ImagePullSecrets
+	}
 
 	// Ensure there is at least one container
 	if len(finalTemplate.Spec.Containers) == 0 {
@@ -244,6 +256,11 @@ func GetSubmitterTemplate(rayJobSpec *rayv1.RayJobSpec, rayClusterSpec *rayv1.Ra
 		//  Fallback to default image if user omitted it
 		if userContainer.Image == "" {
 			userContainer.Image = defaultContainer.Image
+		}
+
+		// Fallback to default ImagePullPolicy if user omitted it
+		if userContainer.ImagePullPolicy == "" {
+			userContainer.ImagePullPolicy = defaultContainer.ImagePullPolicy
 		}
 
 		// Fallback to default Requests if user omitted them
@@ -265,7 +282,8 @@ func GetDefaultSubmitterContainer(rayClusterSpec *rayv1.RayClusterSpec) corev1.C
 	return corev1.Container{
 		Name: utils.SubmitterContainerName,
 		// Use the image of the Ray head to be defensive against version mismatch issues
-		Image: rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Image,
+		Image:           rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Image,
+		ImagePullPolicy: rayClusterSpec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].ImagePullPolicy,
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -213,44 +213,51 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 
 // GetSubmitterTemplate creates a default submitter template for the Ray job.
 func GetSubmitterTemplate(rayJobSpec *rayv1.RayJobSpec, rayClusterSpec *rayv1.RayClusterSpec) corev1.PodTemplateSpec {
-	defaultSubmitterPodTemplate := corev1.PodTemplateSpec{
-		Spec: corev1.PodSpec{
-			Containers:    []corev1.Container{GetDefaultSubmitterContainer(rayClusterSpec)},
-			RestartPolicy: corev1.RestartPolicyNever,
-		},
-	}
+	defaultContainer := GetDefaultSubmitterContainer(rayClusterSpec)
 
-	var userSubmitterPodTemplate corev1.PodTemplateSpec
-	if rayJobSpec.SubmitterPodTemplate != nil {
-		userSubmitterPodTemplate = *rayJobSpec.SubmitterPodTemplate.DeepCopy()
-
-		if len(userSubmitterPodTemplate.ObjectMeta.Labels) > 0 {
-			defaultSubmitterPodTemplate.ObjectMeta.Labels = userSubmitterPodTemplate.ObjectMeta.Labels
-		}
-		if len(userSubmitterPodTemplate.ObjectMeta.Annotations) > 0 {
-			defaultSubmitterPodTemplate.ObjectMeta.Annotations = userSubmitterPodTemplate.ObjectMeta.Annotations
-		}
-		if len(userSubmitterPodTemplate.Spec.Containers) > 0 {
-			if len(userSubmitterPodTemplate.Spec.Containers[0].Resources.Requests) > 0 {
-				defaultSubmitterPodTemplate.Spec.Containers[0].Resources.Requests = userSubmitterPodTemplate.Spec.Containers[0].Resources.Requests
-			}
-			if len(userSubmitterPodTemplate.Spec.Containers[0].Resources.Limits) > 0 {
-				defaultSubmitterPodTemplate.Spec.Containers[0].Resources.Limits = userSubmitterPodTemplate.Spec.Containers[0].Resources.Limits
-			}
-			if userSubmitterPodTemplate.Spec.Containers[0].Image != "" {
-				defaultSubmitterPodTemplate.Spec.Containers[0].Image = userSubmitterPodTemplate.Spec.Containers[0].Image
-			}
-		}
-
-		if userSubmitterPodTemplate.Spec.Tolerations != nil {
-			defaultSubmitterPodTemplate.Spec.Tolerations = userSubmitterPodTemplate.Spec.Tolerations
-		}
-		if userSubmitterPodTemplate.Spec.NodeSelector != nil {
-			defaultSubmitterPodTemplate.Spec.NodeSelector = userSubmitterPodTemplate.Spec.NodeSelector
+	// If no user template is provided, return the defaults
+	if rayJobSpec.SubmitterPodTemplate == nil {
+		return corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers:    []corev1.Container{defaultContainer},
+				RestartPolicy: corev1.RestartPolicyNever,
+			},
 		}
 	}
 
-	return defaultSubmitterPodTemplate
+	// Start with a deep copy of the user's template to preserve all their custom fields
+	// (like Volumes, Env, Command, Tolerations, Labels, Annotations, etc.)
+	finalTemplate := *rayJobSpec.SubmitterPodTemplate.DeepCopy()
+
+	// Always enforce RestartPolicy: Never
+	finalTemplate.Spec.RestartPolicy = corev1.RestartPolicyNever
+
+	// Ensure there is at least one container
+	if len(finalTemplate.Spec.Containers) == 0 {
+		finalTemplate.Spec.Containers = []corev1.Container{defaultContainer}
+	} else {
+		userContainer := &finalTemplate.Spec.Containers[0]
+
+		// Always enforce the KubeRay default container name
+		userContainer.Name = defaultContainer.Name
+
+		//  Fallback to default image if user omitted it
+		if userContainer.Image == "" {
+			userContainer.Image = defaultContainer.Image
+		}
+
+		// Fallback to default Requests if user omitted them
+		if len(userContainer.Resources.Requests) == 0 {
+			userContainer.Resources.Requests = defaultContainer.Resources.Requests
+		}
+
+		// Fallback to default Limits if user omitted them
+		if len(userContainer.Resources.Limits) == 0 {
+			userContainer.Resources.Limits = defaultContainer.Resources.Limits
+		}
+	}
+
+	return finalTemplate
 }
 
 // GetDefaultSubmitterContainer creates a default submitter container for the Ray job.

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -219,10 +219,9 @@ func GetSubmitterTemplate(rayJobSpec *rayv1.RayJobSpec, rayClusterSpec *rayv1.Ra
 	if rayJobSpec.SubmitterPodTemplate == nil {
 		return corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
-				Containers:         []corev1.Container{defaultContainer},
-				RestartPolicy:      corev1.RestartPolicyNever,
-				ServiceAccountName: rayClusterSpec.HeadGroupSpec.Template.Spec.ServiceAccountName,
-				ImagePullSecrets:   rayClusterSpec.HeadGroupSpec.Template.Spec.ImagePullSecrets,
+				Containers:       []corev1.Container{defaultContainer},
+				RestartPolicy:    corev1.RestartPolicyNever,
+				ImagePullSecrets: rayClusterSpec.HeadGroupSpec.Template.Spec.ImagePullSecrets,
 			},
 		}
 	}
@@ -233,11 +232,6 @@ func GetSubmitterTemplate(rayJobSpec *rayv1.RayJobSpec, rayClusterSpec *rayv1.Ra
 
 	// Always enforce RestartPolicy: Never
 	finalTemplate.Spec.RestartPolicy = corev1.RestartPolicyNever
-
-	// Fallback to default ServiceAccountName if user omitted it
-	if finalTemplate.Spec.ServiceAccountName == "" {
-		finalTemplate.Spec.ServiceAccountName = rayClusterSpec.HeadGroupSpec.Template.Spec.ServiceAccountName
-	}
 
 	// Fallback to default ImagePullSecrets if user omitted it
 	if len(finalTemplate.Spec.ImagePullSecrets) == 0 {

--- a/ray-operator/controllers/ray/common/job.go
+++ b/ray-operator/controllers/ray/common/job.go
@@ -213,62 +213,18 @@ func BuildJobSubmitCommand(rayJobInstance *rayv1.RayJob, submissionMode rayv1.Jo
 
 // GetSubmitterTemplate creates a default submitter template for the Ray job.
 func GetSubmitterTemplate(rayJobSpec *rayv1.RayJobSpec, rayClusterSpec *rayv1.RayClusterSpec) corev1.PodTemplateSpec {
-	defaultContainer := GetDefaultSubmitterContainer(rayClusterSpec)
-
-	// If no user template is provided, return the defaults
-	if rayJobSpec.SubmitterPodTemplate == nil {
-		return corev1.PodTemplateSpec{
-			Spec: corev1.PodSpec{
-				Containers:       []corev1.Container{defaultContainer},
-				RestartPolicy:    corev1.RestartPolicyNever,
-				ImagePullSecrets: rayClusterSpec.HeadGroupSpec.Template.Spec.ImagePullSecrets,
+	if rayJobSpec.SubmitterPodTemplate != nil {
+		return *rayJobSpec.SubmitterPodTemplate.DeepCopy()
+	}
+	return corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				GetDefaultSubmitterContainer(rayClusterSpec),
 			},
-		}
+			RestartPolicy:    corev1.RestartPolicyNever,
+			ImagePullSecrets: rayClusterSpec.HeadGroupSpec.Template.Spec.ImagePullSecrets,
+		},
 	}
-
-	// Start with a deep copy of the user's template to preserve all their custom fields
-	// (like Volumes, Env, Command, Tolerations, Labels, Annotations, etc.)
-	finalTemplate := *rayJobSpec.SubmitterPodTemplate.DeepCopy()
-
-	// Always enforce RestartPolicy: Never
-	finalTemplate.Spec.RestartPolicy = corev1.RestartPolicyNever
-
-	// Fallback to default ImagePullSecrets if user omitted it
-	if len(finalTemplate.Spec.ImagePullSecrets) == 0 {
-		finalTemplate.Spec.ImagePullSecrets = rayClusterSpec.HeadGroupSpec.Template.Spec.ImagePullSecrets
-	}
-
-	// Ensure there is at least one container
-	if len(finalTemplate.Spec.Containers) == 0 {
-		finalTemplate.Spec.Containers = []corev1.Container{defaultContainer}
-	} else {
-		userContainer := &finalTemplate.Spec.Containers[0]
-
-		// Always enforce the KubeRay default container name
-		userContainer.Name = defaultContainer.Name
-
-		//  Fallback to default image if user omitted it
-		if userContainer.Image == "" {
-			userContainer.Image = defaultContainer.Image
-		}
-
-		// Fallback to default ImagePullPolicy if user omitted it
-		if userContainer.ImagePullPolicy == "" {
-			userContainer.ImagePullPolicy = defaultContainer.ImagePullPolicy
-		}
-
-		// Fallback to default Requests if user omitted them
-		if len(userContainer.Resources.Requests) == 0 {
-			userContainer.Resources.Requests = defaultContainer.Resources.Requests
-		}
-
-		// Fallback to default Limits if user omitted them
-		if len(userContainer.Resources.Limits) == 0 {
-			userContainer.Resources.Limits = defaultContainer.Resources.Limits
-		}
-	}
-
-	return finalTemplate
 }
 
 // GetDefaultSubmitterContainer creates a default submitter container for the Ray job.

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/ray-project/kuberay/ray-operator/pkg/features"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func rayJobTemplate() *rayv1.RayJob {
@@ -476,4 +478,47 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	}
 	template := GetSubmitterTemplate(&rayJob.Spec, &rayCluster.Spec)
 	assert.Equal(t, template.Spec.Containers[0].Image, rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Image)
+
+}
+
+func TestGetSubmitterPodTemplate(t *testing.T) {
+	rayJob := &rayv1.RayJob{
+		Spec: rayv1.RayJobSpec{},
+	}
+	rayCluster := &rayv1.RayCluster{
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Image: "my-custom-image:latest",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	rayJob.Spec.SubmitterPodTemplate = &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{"my-label": "true"},
+			Annotations: map[string]string{"my-annotation": "true"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Image: "rayproject/ray:test-submitter-template",
+				},
+			},
+		},
+	}
+	template := GetSubmitterTemplate(&rayJob.Spec, &rayCluster.Spec)
+	assert.Equal(t, "rayproject/ray:test-submitter-template", template.Spec.Containers[0].Image)
+	assert.Equal(t, corev1.RestartPolicyNever, template.Spec.RestartPolicy)
+	assert.Equal(t, "true", template.ObjectMeta.Labels["my-label"])
+	assert.Equal(t, "true", template.ObjectMeta.Annotations["my-annotation"])
+
+	assert.Equal(t, resource.MustParse("500m"), template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("200Mi"), template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory])
 }

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -509,6 +509,11 @@ func TestGetSubmitterPodTemplate(t *testing.T) {
 			Containers: []corev1.Container{
 				{
 					Image: "rayproject/ray:test-submitter-template",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("250m"),
+						},
+					},
 				},
 			},
 		},
@@ -519,6 +524,7 @@ func TestGetSubmitterPodTemplate(t *testing.T) {
 	assert.Equal(t, "true", template.ObjectMeta.Labels["my-label"])
 	assert.Equal(t, "true", template.ObjectMeta.Annotations["my-annotation"])
 
-	assert.Equal(t, resource.MustParse("500m"), template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU])
-	assert.Equal(t, resource.MustParse("200Mi"), template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory])
+	assert.Equal(t, resource.MustParse("250m"), template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("1"), template.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("1Gi"), template.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory])
 }

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/ray-project/kuberay/ray-operator/pkg/features"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func rayJobTemplate() *rayv1.RayJob {

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -584,7 +584,7 @@ func TestGetSubmitterPodTemplateNoOverride(t *testing.T) {
 		},
 	}
 	template := GetSubmitterTemplate(&rayJob.Spec, &rayCluster.Spec)
-	
+
 	// Verify that user-provided fields are NOT overridden by the Head Pod
 	assert.Equal(t, corev1.PullIfNotPresent, template.Spec.Containers[0].ImagePullPolicy)
 	assert.Equal(t, "user-sa", template.Spec.ServiceAccountName)

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -466,9 +466,14 @@ func TestGetSubmitterTemplate(t *testing.T) {
 			HeadGroupSpec: rayv1.HeadGroupSpec{
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
+						ServiceAccountName: "head-sa",
+						ImagePullSecrets: []corev1.LocalObjectReference{
+							{Name: "head-secret"},
+						},
 						Containers: []corev1.Container{
 							{
-								Image: "rayproject/ray:test-submitter-template",
+								Image:           "rayproject/ray:test-submitter-template",
+								ImagePullPolicy: corev1.PullAlways,
 							},
 						},
 					},
@@ -478,7 +483,9 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	}
 	template := GetSubmitterTemplate(&rayJob.Spec, &rayCluster.Spec)
 	assert.Equal(t, template.Spec.Containers[0].Image, rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Image)
-
+	assert.Equal(t, corev1.PullAlways, template.Spec.Containers[0].ImagePullPolicy)
+	assert.Equal(t, "head-sa", template.Spec.ServiceAccountName)
+	assert.Equal(t, "head-secret", template.Spec.ImagePullSecrets[0].Name)
 }
 
 func TestGetSubmitterPodTemplate(t *testing.T) {
@@ -490,9 +497,14 @@ func TestGetSubmitterPodTemplate(t *testing.T) {
 			HeadGroupSpec: rayv1.HeadGroupSpec{
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
+						ServiceAccountName: "head-sa",
+						ImagePullSecrets: []corev1.LocalObjectReference{
+							{Name: "head-secret"},
+						},
 						Containers: []corev1.Container{
 							{
-								Image: "my-custom-image:latest",
+								Image:           "my-custom-image:latest",
+								ImagePullPolicy: corev1.PullAlways,
 							},
 						},
 					},
@@ -527,4 +539,54 @@ func TestGetSubmitterPodTemplate(t *testing.T) {
 	assert.Equal(t, resource.MustParse("250m"), template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU])
 	assert.Equal(t, resource.MustParse("1"), template.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU])
 	assert.Equal(t, resource.MustParse("1Gi"), template.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory])
+
+	// Verify that omitted fields are copied from the Head Pod
+	assert.Equal(t, corev1.PullAlways, template.Spec.Containers[0].ImagePullPolicy)
+	assert.Equal(t, "head-sa", template.Spec.ServiceAccountName)
+	assert.Equal(t, "head-secret", template.Spec.ImagePullSecrets[0].Name)
+}
+
+func TestGetSubmitterPodTemplateNoOverride(t *testing.T) {
+	rayJob := &rayv1.RayJob{
+		Spec: rayv1.RayJobSpec{},
+	}
+	rayCluster := &rayv1.RayCluster{
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						ServiceAccountName: "head-sa",
+						ImagePullSecrets: []corev1.LocalObjectReference{
+							{Name: "head-secret"},
+						},
+						Containers: []corev1.Container{
+							{
+								Image:           "my-custom-image:latest",
+								ImagePullPolicy: corev1.PullAlways,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	rayJob.Spec.SubmitterPodTemplate = &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "user-sa",
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: "user-secret"},
+			},
+			Containers: []corev1.Container{
+				{
+					ImagePullPolicy: corev1.PullIfNotPresent,
+				},
+			},
+		},
+	}
+	template := GetSubmitterTemplate(&rayJob.Spec, &rayCluster.Spec)
+	
+	// Verify that user-provided fields are NOT overridden by the Head Pod
+	assert.Equal(t, corev1.PullIfNotPresent, template.Spec.Containers[0].ImagePullPolicy)
+	assert.Equal(t, "user-sa", template.Spec.ServiceAccountName)
+	assert.Equal(t, "user-secret", template.Spec.ImagePullSecrets[0].Name)
 }

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -484,7 +484,6 @@ func TestGetSubmitterTemplate(t *testing.T) {
 	template := GetSubmitterTemplate(&rayJob.Spec, &rayCluster.Spec)
 	assert.Equal(t, template.Spec.Containers[0].Image, rayCluster.Spec.HeadGroupSpec.Template.Spec.Containers[utils.RayContainerIndex].Image)
 	assert.Equal(t, corev1.PullAlways, template.Spec.Containers[0].ImagePullPolicy)
-	assert.Equal(t, "head-sa", template.Spec.ServiceAccountName)
 	assert.Equal(t, "head-secret", template.Spec.ImagePullSecrets[0].Name)
 }
 
@@ -542,7 +541,6 @@ func TestGetSubmitterPodTemplate(t *testing.T) {
 
 	// Verify that omitted fields are copied from the Head Pod
 	assert.Equal(t, corev1.PullAlways, template.Spec.Containers[0].ImagePullPolicy)
-	assert.Equal(t, "head-sa", template.Spec.ServiceAccountName)
 	assert.Equal(t, "head-secret", template.Spec.ImagePullSecrets[0].Name)
 }
 

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -531,60 +531,11 @@ func TestGetSubmitterPodTemplate(t *testing.T) {
 	}
 	template := GetSubmitterTemplate(&rayJob.Spec, &rayCluster.Spec)
 	assert.Equal(t, "rayproject/ray:test-submitter-template", template.Spec.Containers[0].Image)
-	assert.Equal(t, corev1.RestartPolicyNever, template.Spec.RestartPolicy)
 	assert.Equal(t, "true", template.ObjectMeta.Labels["my-label"])
 	assert.Equal(t, "true", template.ObjectMeta.Annotations["my-annotation"])
-
 	assert.Equal(t, resource.MustParse("250m"), template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU])
-	assert.Equal(t, resource.MustParse("1"), template.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU])
-	assert.Equal(t, resource.MustParse("1Gi"), template.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory])
 
-	// Verify that omitted fields are copied from the Head Pod
-	assert.Equal(t, corev1.PullAlways, template.Spec.Containers[0].ImagePullPolicy)
-	assert.Equal(t, "head-secret", template.Spec.ImagePullSecrets[0].Name)
-}
-
-func TestGetSubmitterPodTemplateNoOverride(t *testing.T) {
-	rayJob := &rayv1.RayJob{
-		Spec: rayv1.RayJobSpec{},
-	}
-	rayCluster := &rayv1.RayCluster{
-		Spec: rayv1.RayClusterSpec{
-			HeadGroupSpec: rayv1.HeadGroupSpec{
-				Template: corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						ServiceAccountName: "head-sa",
-						ImagePullSecrets: []corev1.LocalObjectReference{
-							{Name: "head-secret"},
-						},
-						Containers: []corev1.Container{
-							{
-								Image:           "my-custom-image:latest",
-								ImagePullPolicy: corev1.PullAlways,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	rayJob.Spec.SubmitterPodTemplate = &corev1.PodTemplateSpec{
-		Spec: corev1.PodSpec{
-			ServiceAccountName: "user-sa",
-			ImagePullSecrets: []corev1.LocalObjectReference{
-				{Name: "user-secret"},
-			},
-			Containers: []corev1.Container{
-				{
-					ImagePullPolicy: corev1.PullIfNotPresent,
-				},
-			},
-		},
-	}
-	template := GetSubmitterTemplate(&rayJob.Spec, &rayCluster.Spec)
-
-	// Verify that user-provided fields are NOT overridden by the Head Pod
-	assert.Equal(t, corev1.PullIfNotPresent, template.Spec.Containers[0].ImagePullPolicy)
-	assert.Equal(t, "user-sa", template.Spec.ServiceAccountName)
-	assert.Equal(t, "user-secret", template.Spec.ImagePullSecrets[0].Name)
+	// Verify that custom SubmitterPodTemplate is returned as-is without merging/overriding from Head Pod
+	assert.Equal(t, corev1.PullPolicy(""), template.Spec.Containers[0].ImagePullPolicy)
+	assert.Equal(t, 0, len(template.Spec.ImagePullSecrets))
 }

--- a/ray-operator/controllers/ray/common/job_test.go
+++ b/ray-operator/controllers/ray/common/job_test.go
@@ -537,5 +537,5 @@ func TestGetSubmitterPodTemplate(t *testing.T) {
 
 	// Verify that custom SubmitterPodTemplate is returned as-is without merging/overriding from Head Pod
 	assert.Equal(t, corev1.PullPolicy(""), template.Spec.Containers[0].ImagePullPolicy)
-	assert.Equal(t, 0, len(template.Spec.ImagePullSecrets))
+	assert.Empty(t, template.Spec.ImagePullSecrets)
 }

--- a/ray-operator/controllers/ray/rayjob_controller_test.go
+++ b/ray-operator/controllers/ray/rayjob_controller_test.go
@@ -397,7 +397,9 @@ var _ = Context("RayJob with different submission modes", func() {
 			rayJob := rayJobTemplate("rayjob-invalid-test", namespace)
 			rayCluster := &rayv1.RayCluster{Spec: *rayJob.Spec.RayClusterSpec}
 			template := common.GetSubmitterTemplate(&rayJob.Spec, &rayCluster.Spec)
-			template.Spec.RestartPolicy = "" // Make it invalid to create a submitter. Ref: https://github.com/ray-project/kuberay/pull/2389#issuecomment-2359564334
+			// Make it invalid to create a submitter. We use an invalid label key to guarantee
+			// the Kubernetes API server rejects the Job creation.
+			template.ObjectMeta.Labels = map[string]string{"invalid key": "invalid value"}
 			rayJob.Spec.SubmitterPodTemplate = &template
 
 			It("Verify RayJob spec", func() {


### PR DESCRIPTION
## Why are these changes needed?

Currently, when a user provides a `SubmitterPodTemplate` (e.g., to add simple annotations or labels to their job submitter pod), KubeRay uses that template completely overriding the default one. This unexpectedly wipes out critical defaults that the operator relies on, such as the Head Node's Image, default resource requests, and `RestartPolicy: Never`.

This PR fixes that by using KubeRay's computed default template as the baseline, and selectively merging the user's `SubmitterPodTemplate` overrides on top of it. This matches the KubeRay convention for K8s pod templates. 

Fields currently supported for merging:
- `Labels`
- `Annotations`
- `Resources` (Requests and Limits)
- `Image`
- `Tolerations`
- `NodeSelector`

## Related issue number

Closes #4812

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
