### PR TITLE
[Feature] Expose spec.upgradeStrategy in the ray-cluster Helm chart

### DIFF
--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -78,6 +78,7 @@ helm uninstall raycluster
 | nameOverride | string | `"kuberay"` | String to partially override release name. |
 | fullnameOverride | string | `""` | String to fully override release name. |
 | imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry |
+| upgradeStrategy | object | `{}` | Upgrade strategy for the RayCluster (requires KubeRay v1.6.0+). Set `type: Recreate` to automatically recreate all Ray cluster Pods when the spec changes; unset (or `type: None`) leaves running Pods untouched on spec changes. |
 | gcsFaultTolerance.enabled | bool | `false` |  |
 | common.containerEnv | list | `[]` | containerEnv specifies environment variables for the Ray head and worker containers. Follows standard K8s container env schema. |
 | head.initContainers | list | `[]` | Init containers to add to the head pod |

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -13,6 +13,10 @@ spec:
   {{- with .Values.head.rayVersion }}
   rayVersion: {{ . }}
   {{- end }}
+  {{- with .Values.upgradeStrategy }}
+  upgradeStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.head.enableInTreeAutoscaling }}
   enableInTreeAutoscaling: {{ . }}
   {{- end }}

--- a/helm-chart/ray-cluster/tests/raycluster_test.yaml
+++ b/helm-chart/ray-cluster/tests/raycluster_test.yaml
@@ -25,6 +25,15 @@ tests:
           path: spec.rayVersion
           value: 2.52.0
 
+  - it: Should set upgradeStrategy when `upgradeStrategy.type` is set
+    set:
+      upgradeStrategy:
+        type: Recreate
+    asserts:
+      - equal:
+          path: spec.upgradeStrategy.type
+          value: Recreate
+
   - it: Should enable in-tree auto scaling when `head.enableInTreeAutoscaling` is `true`
     set:
       head:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -23,6 +23,16 @@ fullnameOverride: ""
 imagePullSecrets: []
   # - name: an-existing-secret
 
+# upgradeStrategy defines how the KubeRay operator rolls out changes to the
+# RayCluster spec (requires KubeRay v1.6.0+). With `type: Recreate`, the
+# operator automatically deletes and recreates all Ray cluster Pods when the
+# spec changes (e.g. a new image tag) — no manual Pod deletion needed. With
+# `type: None` (the default behavior when unset), running Pods are left
+# untouched on spec changes. Not recommended if Ray cluster state needs to be
+# persisted in-cluster.
+upgradeStrategy: {}
+  # type: Recreate
+
 # gcsFaultTolerance specifies configuration for GCS fault tolerance.
 # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/kuberay-gcs-ft.html#kuberay-gcs-ft
 # for more details.


### PR DESCRIPTION
## Why are these changes needed?

The RayCluster CRD gained `spec.upgradeStrategy` in KubeRay v1.6.0 (`type: Recreate | None`), which lets the operator automatically recreate all Ray cluster Pods when the cluster spec changes. The `ray-cluster` Helm chart has no way to set it, so GitOps-managed clusters (Helm / Argo CD / Flux) still require a manual `kubectl delete pod` after every image or pod-template change — the exact gap `upgradeStrategy` was added to close (#234, #527).

This adds a minimal values passthrough:

```yaml
upgradeStrategy:
  type: Recreate
```

- Default stays `{}` — rendered output is unchanged unless the value is set (verified: `helm template` output is byte-identical without the value).
- Documented in `values.yaml` (including the state-persistence caveat from the v1.6.0 release notes) and the README values table (added by hand in the table's existing order — the pre-commit helm-docs hook only regenerates the kuberay-operator chart).
- Covered by a helm-unittest case; full suite passes (105/105).

## Related issue number

Related: #234, #527 (the operator-side feature shipped in v1.6.0; this exposes it in the chart).

## Checks

- [x] I've made sure the tests are passing (`helm-unittest`: 105 passed).
- [x] Testing Strategy: unit tests added; `helm template` verified with and without the value.