### PR TITLE
[RayJob] Deprecate DELETE_RAYJOB_CR_AFTER_JOB_FINISHES env var and remove unused Configuration field

### DIFF
--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -268,6 +268,8 @@ env:
 # Enabling this feature contributes to the robustness of Ray clusters.
 # - name: ENABLE_PROBES_INJECTION
 #   value: "true"
+# DEPRECATED: this environment variable will be removed in a future release.
+# Use the RayJob spec.deletionStrategy API instead (a deletionRules entry with the DeleteSelf policy).
 # If set to true, the RayJob CR itself will be deleted if shutdownAfterJobFinishes is set to true. Note that all resources created by the RayJob CR will be deleted, including the K8s Job. Otherwise, only the RayCluster CR will be deleted. Default is false.
 # - name: DELETE_RAYJOB_CR_AFTER_JOB_FINISHES
 #   value: "false"

--- a/ray-operator/apis/config/v1alpha1/configuration_types.go
+++ b/ray-operator/apis/config/v1alpha1/configuration_types.go
@@ -93,9 +93,6 @@ type Configuration struct {
 	// connectivity to Pods.
 	UseKubernetesProxy bool `json:"useKubernetesProxy,omitempty"`
 
-	// DeleteRayJobAfterJobFinishes deletes the RayJob CR itself if shutdownAfterJobFinishes is set to true.
-	DeleteRayJobAfterJobFinishes bool `json:"deleteRayJobAfterJobFinishes,omitempty"`
-
 	// EnableMetrics indicates whether KubeRay operator should emit control plane metrics.
 	EnableMetrics bool `json:"enableMetrics,omitempty"`
 }

--- a/ray-operator/apis/config/v1alpha1/configuration_types.go
+++ b/ray-operator/apis/config/v1alpha1/configuration_types.go
@@ -83,9 +83,6 @@ type Configuration struct {
 	// connectivity to Pods.
 	UseKubernetesProxy bool `json:"useKubernetesProxy,omitempty"`
 
-	// DeleteRayJobAfterJobFinishes deletes the RayJob CR itself if shutdownAfterJobFinishes is set to true.
-	DeleteRayJobAfterJobFinishes bool `json:"deleteRayJobAfterJobFinishes,omitempty"`
-
 	// EnableMetrics indicates whether KubeRay operator should emit control plane metrics.
 	EnableMetrics bool `json:"enableMetrics,omitempty"`
 }

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -1535,6 +1535,7 @@ func (r *RayJobReconciler) handleShutdownAfterJobFinishes(ctx context.Context, r
 
 	var err error
 	if s := os.Getenv(utils.DELETE_RAYJOB_CR_AFTER_JOB_FINISHES); strings.ToLower(s) == "true" {
+		logger.Info("The DELETE_RAYJOB_CR_AFTER_JOB_FINISHES environment variable is deprecated and will be removed in a future release. Use the RayJob DeletionPolicy API instead.")
 		err = r.Client.Delete(ctx, rayJob)
 		if err == nil {
 			logger.Info("RayJob is deleted", "RayJob", rayJob.Name)

--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -1535,7 +1535,7 @@ func (r *RayJobReconciler) handleShutdownAfterJobFinishes(ctx context.Context, r
 
 	var err error
 	if s := os.Getenv(utils.DELETE_RAYJOB_CR_AFTER_JOB_FINISHES); strings.ToLower(s) == "true" {
-		logger.Info("The DELETE_RAYJOB_CR_AFTER_JOB_FINISHES environment variable is deprecated and will be removed in a future release. Use the RayJob DeletionPolicy API instead.")
+		logger.Info("The DELETE_RAYJOB_CR_AFTER_JOB_FINISHES environment variable is deprecated and will be removed in a future release. Use the RayJob DeletionStrategy API instead.")
 		err = r.Client.Delete(ctx, rayJob)
 		if err == nil {
 			logger.Info("RayJob is deleted", "RayJob", rayJob.Name)

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -132,7 +132,6 @@ func main() {
 		config.EnableBatchScheduler = enableBatchScheduler
 		config.BatchScheduler = batchScheduler
 		config.UseKubernetesProxy = useKubernetesProxy
-		config.DeleteRayJobAfterJobFinishes = os.Getenv(utils.DELETE_RAYJOB_CR_AFTER_JOB_FINISHES) == "true"
 		config.EnableMetrics = enableMetrics
 		config.QPS = &qps
 		config.Burst = &burst

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -136,7 +136,6 @@ func main() {
 		config.EnableBatchScheduler = enableBatchScheduler
 		config.BatchScheduler = batchScheduler
 		config.UseKubernetesProxy = useKubernetesProxy
-		config.DeleteRayJobAfterJobFinishes = os.Getenv(utils.DELETE_RAYJOB_CR_AFTER_JOB_FINISHES) == "true"
 		config.EnableMetrics = enableMetrics
 		config.QPS = &qps
 		config.Burst = &burst


### PR DESCRIPTION
## Why are these changes needed?

`RayJobDeletionPolicy` reached beta in v1.6.0, so the older `DELETE_RAYJOB_CR_AFTER_JOB_FINISHES` env var is now redundant. This PR:

1. **Removes the unused `DeleteRayJobAfterJobFinishes` field** from the `Configuration` struct — it was assigned from the env var in `main.go` but never read (the RayJob controller reads the env var directly), so it was dead code.
2. **Deprecates the `DELETE_RAYJOB_CR_AFTER_JOB_FINISHES` env var** by logging a warning when it's used, pointing users to the `RayJobDeletionPolicy` API. The env var still works — it's only deprecated, not removed.

Notes for reviewers:
- **Warning placement:** I log the deprecation at the point of use in the RayJob controller, so it fires only when the env var is actually set to `true`. Happy to move it to a one-time warning at operator startup if you'd prefer.
- **Tests:** the existing `DELETE_RAYJOB_CR_AFTER_JOB_FINISHES` tests cover behavior that is **retained** (the env var still deletes the RayJob CR), so they're kept. The removed `Configuration` field had no dedicated test.

## Related issue number

Closes #4415

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(