### PR TITLE
Update apiserver and apiserversdk to use v1 events api

### DIFF
--- a/apiserver/deploy/base/insecure/apiserver.yaml
+++ b/apiserver/deploy/base/insecure/apiserver.yaml
@@ -126,7 +126,7 @@ rules:
   verbs:
   - list
 - apiGroups:
-  - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/apiserver/deploy/base/secure/apiserver.yaml
+++ b/apiserver/deploy/base/secure/apiserver.yaml
@@ -157,7 +157,7 @@ rules:
   verbs:
   - list
 - apiGroups:
-  - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/apiserver/pkg/client/kubernetes.go
+++ b/apiserver/pkg/client/kubernetes.go
@@ -3,6 +3,7 @@ package client
 import (
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	eventsv1 "k8s.io/client-go/kubernetes/typed/events/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -15,11 +16,12 @@ type KubernetesClientInterface interface {
 	PodClient(namespace string) v1.PodInterface
 	ConfigMapClient(namespace string) v1.ConfigMapInterface
 	NamespaceClient() v1.NamespaceInterface
-	EventsClient(namespace string) v1.EventInterface
+	EventsClient(namespace string) eventsv1.EventInterface
 }
 
 type KubernetesClient struct {
-	coreV1Client v1.CoreV1Interface
+	coreV1Client   v1.CoreV1Interface
+	eventsV1Client eventsv1.EventsV1Interface
 }
 
 func (c *KubernetesClient) PodClient(namespace string) v1.PodInterface {
@@ -30,8 +32,8 @@ func (c *KubernetesClient) ConfigMapClient(namespace string) v1.ConfigMapInterfa
 	return c.coreV1Client.ConfigMaps(namespace)
 }
 
-func (c *KubernetesClient) EventsClient(namespace string) v1.EventInterface {
-	return c.coreV1Client.Events(namespace)
+func (c *KubernetesClient) EventsClient(namespace string) eventsv1.EventInterface {
+	return c.eventsV1Client.Events(namespace)
 }
 
 func (c *KubernetesClient) NamespaceClient() v1.NamespaceInterface {
@@ -51,5 +53,5 @@ func CreateKubernetesCoreOrFatal(options util.ClientOptions) KubernetesClientInt
 	if err != nil {
 		klog.Fatalf("Failed to create pod client. Error: %v", err)
 	}
-	return &KubernetesClient{clientSet.CoreV1()}
+	return &KubernetesClient{coreV1Client: clientSet.CoreV1(), eventsV1Client: clientSet.EventsV1()}
 }

--- a/apiserver/pkg/client/kubernetes_mock.go
+++ b/apiserver/pkg/client/kubernetes_mock.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	v10 "k8s.io/client-go/kubernetes/typed/events/v1"
 )
 
 // MockKubernetesClientInterface is a mock of KubernetesClientInterface interface.
@@ -49,10 +50,10 @@ func (mr *MockKubernetesClientInterfaceMockRecorder) ConfigMapClient(namespace i
 }
 
 // EventsClient mocks base method.
-func (m *MockKubernetesClientInterface) EventsClient(namespace string) v1.EventInterface {
+func (m *MockKubernetesClientInterface) EventsClient(namespace string) v10.EventInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EventsClient", namespace)
-	ret0, _ := ret[0].(v1.EventInterface)
+	ret0, _ := ret[0].(v10.EventInterface)
 	return ret0
 }
 

--- a/apiserver/pkg/manager/resource_manager.go
+++ b/apiserver/pkg/manager/resource_manager.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	eventsv1client "k8s.io/client-go/kubernetes/typed/events/v1"
 
 	"github.com/ray-project/kuberay/apiserver/pkg/model"
 	"github.com/ray-project/kuberay/apiserver/pkg/util"
@@ -47,7 +49,7 @@ func (r *ResourceManager) getKubernetesConfigMapClient(namespace string) clientv
 	return r.clientManager.KubernetesClient().ConfigMapClient(namespace)
 }
 
-func (r *ResourceManager) getEventsClient(namespace string) clientv1.EventInterface {
+func (r *ResourceManager) getEventsClient(namespace string) eventsv1client.EventInterface {
 	return r.clientManager.KubernetesClient().EventsClient(namespace)
 }
 
@@ -452,18 +454,18 @@ func getComputeTemplateByName(ctx context.Context, client clientv1.ConfigMapInte
 	return runtime, nil
 }
 
-func (r *ResourceManager) GetClusterEvents(ctx context.Context, clusterName string, namespace string) ([]corev1.Event, error) {
+func (r *ResourceManager) GetClusterEvents(ctx context.Context, clusterName string, namespace string) ([]eventsv1.Event, error) {
 	client := r.getEventsClient(namespace)
 	clusterClient := r.getRayClusterClient(namespace)
 	return getRayClusterEventsByName(ctx, clusterName, client, clusterClient)
 }
 
-func getRayClusterEventsByName(ctx context.Context, name string, client clientv1.EventInterface, clusterClient rayv1.RayClusterInterface) ([]corev1.Event, error) {
+func getRayClusterEventsByName(ctx context.Context, name string, client eventsv1client.EventInterface, clusterClient rayv1.RayClusterInterface) ([]eventsv1.Event, error) {
 	rayCluster, err := getClusterByName(ctx, clusterClient, name)
 	if err != nil {
 		return nil, util.Wrap(err, "get raycluster event failed")
 	}
-	fieldSelectorById := fmt.Sprintf("involvedObject.name=%s", rayCluster.Name)
+	fieldSelectorById := fmt.Sprintf("regarding.name=%s", rayCluster.Name)
 	events, err := client.List(ctx, metav1.ListOptions{
 		FieldSelector: fieldSelectorById,
 		TypeMeta:      metav1.TypeMeta{Kind: "RayCluster"},
@@ -478,7 +480,7 @@ func getRayClusterEventsByName(ctx context.Context, name string, client clientv1
 	return events.Items, nil
 }
 
-func (r *ResourceManager) GetServiceEvents(ctx context.Context, service rayv1api.RayService) ([]corev1.Event, error) {
+func (r *ResourceManager) GetServiceEvents(ctx context.Context, service rayv1api.RayService) ([]eventsv1.Event, error) {
 	eventClient := r.getEventsClient(service.Namespace)
 	events, err := getRayServiceEventsByName(ctx, service.Name, eventClient)
 	if err != nil {
@@ -487,15 +489,15 @@ func (r *ResourceManager) GetServiceEvents(ctx context.Context, service rayv1api
 	if len(service.Status.ActiveServiceStatus.RayClusterName) > 0 {
 		clusterEvents, err := r.GetClusterEvents(ctx, service.Status.ActiveServiceStatus.RayClusterName, service.Namespace)
 		if err != nil {
-			clusterEvents = make([]corev1.Event, 0)
+			clusterEvents = make([]eventsv1.Event, 0)
 		}
 		events = append(events, clusterEvents...)
 	}
 	return events, nil
 }
 
-func getRayServiceEventsByName(ctx context.Context, name string, client clientv1.EventInterface) ([]corev1.Event, error) {
-	fieldSelectorById := fmt.Sprintf("involvedObject.name=%s", name)
+func getRayServiceEventsByName(ctx context.Context, name string, client eventsv1client.EventInterface) ([]eventsv1.Event, error) {
+	fieldSelectorById := fmt.Sprintf("regarding.name=%s", name)
 	events, err := client.List(ctx, metav1.ListOptions{
 		FieldSelector: fieldSelectorById,
 		TypeMeta:      metav1.TypeMeta{Kind: "RayService"},
@@ -504,7 +506,7 @@ func getRayServiceEventsByName(ctx context.Context, name string, client clientv1
 		return nil, util.Wrap(err, "Get Ray Cluster Events failed")
 	}
 	if len(events.Items) == 0 {
-		return make([]corev1.Event, 0), nil
+		return make([]eventsv1.Event, 0), nil
 	}
 
 	return events.Items, nil

--- a/apiserver/pkg/model/converter.go
+++ b/apiserver/pkg/model/converter.go
@@ -9,6 +9,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	klog "k8s.io/klog/v2"
 
 	"github.com/ray-project/kuberay/apiserver/pkg/util"
@@ -84,7 +85,41 @@ func contains(s []string, str string) bool {
 	return slices.Contains(s, str)
 }
 
-func FromCrdToAPIClusters(clusters []*rayv1api.RayCluster, clusterEventsMap map[string][]corev1.Event) []*api.Cluster {
+// An events.k8s.io/v1 Event exposes the same timing/count data through two
+// parallel sets of fields, and which set is populated depends on who wrote it:
+//   - new events API - EventTime, Series{Count, LastObservedTime}
+//   - core v1 API -    DeprecatedFirstTimestamp, DeprecatedLastTimestamp, DeprecatedCount
+// The helpers below ensure that we always return the correct values regardless of which API wrote the event.
+
+// getFirstEventTimestamp returns the event's first-observed time.
+func getFirstEventTimestamp(event eventsv1.Event) *timestamppb.Timestamp {
+	t := event.EventTime.Time // modern: first observed
+	if t.IsZero() {
+		t = event.DeprecatedFirstTimestamp.Time // legacy core v1 events
+	}
+	return &timestamppb.Timestamp{Seconds: t.Unix()}
+}
+
+// getLastEventTimestamp returns the event's last-observed time.
+func getLastEventTimestamp(event eventsv1.Event) *timestamppb.Timestamp {
+	t := event.EventTime.Time // fallback: single, non-aggregated event
+	if event.Series != nil {
+		t = event.Series.LastObservedTime.Time // modern: aggregated last-seen
+	} else if !event.DeprecatedLastTimestamp.Time.IsZero() {
+		t = event.DeprecatedLastTimestamp.Time // legacy core v1 events
+	}
+	return &timestamppb.Timestamp{Seconds: t.Unix()}
+}
+
+// getEventCount returns how many times the event has occurred.
+func getEventCount(event eventsv1.Event) int32 {
+	if event.Series != nil {
+		return event.Series.Count // modern: aggregated occurrence count
+	}
+	return event.DeprecatedCount // legacy core v1 events
+}
+
+func FromCrdToAPIClusters(clusters []*rayv1api.RayCluster, clusterEventsMap map[string][]eventsv1.Event) []*api.Cluster {
 	apiClusters := make([]*api.Cluster, 0, len(clusters))
 	for _, cluster := range clusters {
 		apiClusters = append(apiClusters, FromCrdToAPICluster(cluster, clusterEventsMap[cluster.Name]))
@@ -92,7 +127,7 @@ func FromCrdToAPIClusters(clusters []*rayv1api.RayCluster, clusterEventsMap map[
 	return apiClusters
 }
 
-func FromCrdToAPICluster(cluster *rayv1api.RayCluster, events []corev1.Event) *api.Cluster {
+func FromCrdToAPICluster(cluster *rayv1api.RayCluster, events []eventsv1.Event) *api.Cluster {
 	pbCluster := &api.Cluster{
 		Name:      cluster.Name,
 		Namespace: cluster.Namespace,
@@ -118,12 +153,12 @@ func FromCrdToAPICluster(cluster *rayv1api.RayCluster, events []corev1.Event) *a
 			Id:             event.Name,
 			Name:           fmt.Sprintf("%s-%s", cluster.Labels[util.RayClusterNameLabelKey], event.Name),
 			CreatedAt:      &timestamppb.Timestamp{Seconds: event.ObjectMeta.CreationTimestamp.Unix()},
-			FirstTimestamp: &timestamppb.Timestamp{Seconds: event.FirstTimestamp.Unix()},
-			LastTimestamp:  &timestamppb.Timestamp{Seconds: event.LastTimestamp.Unix()},
+			FirstTimestamp: getFirstEventTimestamp(event),
+			LastTimestamp:  getLastEventTimestamp(event),
 			Reason:         event.Reason,
-			Message:        event.Message,
+			Message:        event.Note,
 			Type:           event.Type,
-			Count:          event.Count,
+			Count:          getEventCount(event),
 		}
 		pbCluster.Events = append(pbCluster.Events, clusterEvent)
 	}
@@ -526,7 +561,7 @@ func FromCrdToAPIJob(job *rayv1api.RayJob) (pbJob *api.RayJob) {
 
 func FromCrdToAPIServices(
 	services []*rayv1api.RayService,
-	serviceEventsMap map[string][]corev1.Event,
+	serviceEventsMap map[string][]eventsv1.Event,
 ) []*api.RayService {
 	apiServices := make([]*api.RayService, 0, len(services))
 	for _, service := range services {
@@ -535,7 +570,7 @@ func FromCrdToAPIServices(
 	return apiServices
 }
 
-func FromCrdToAPIService(service *rayv1api.RayService, events []corev1.Event) *api.RayService {
+func FromCrdToAPIService(service *rayv1api.RayService, events []eventsv1.Event) *api.RayService {
 	defer func() {
 		err := recover()
 		if err != nil {
@@ -577,7 +612,7 @@ func PoplulateUnhealthySecondThreshold(value *int32) int32 {
 func PoplulateRayServiceStatus(
 	serviceName string,
 	serviceStatus rayv1api.RayServiceStatuses,
-	events []corev1.Event,
+	events []eventsv1.Event,
 ) *api.RayServiceStatus {
 	status := &api.RayServiceStatus{
 		RayServiceEvents:       PopulateRayServiceEvent(serviceName, events),
@@ -621,19 +656,19 @@ func PopulateServeDeploymentStatus(
 	return deploymentStatuses
 }
 
-func PopulateRayServiceEvent(serviceName string, events []corev1.Event) []*api.RayServiceEvent {
+func PopulateRayServiceEvent(serviceName string, events []eventsv1.Event) []*api.RayServiceEvent {
 	serviceEvents := make([]*api.RayServiceEvent, 0, len(events))
 	for _, event := range events {
 		serviceEvent := &api.RayServiceEvent{
 			Id:             event.Name,
 			Name:           fmt.Sprintf("%s-%s", serviceName, event.Name),
 			CreatedAt:      &timestamppb.Timestamp{Seconds: event.ObjectMeta.CreationTimestamp.Unix()},
-			FirstTimestamp: &timestamppb.Timestamp{Seconds: event.FirstTimestamp.Unix()},
-			LastTimestamp:  &timestamppb.Timestamp{Seconds: event.LastTimestamp.Unix()},
+			FirstTimestamp: getFirstEventTimestamp(event),
+			LastTimestamp:  getLastEventTimestamp(event),
 			Reason:         event.Reason,
-			Message:        event.Message,
+			Message:        event.Note,
 			Type:           event.Type,
-			Count:          event.Count,
+			Count:          getEventCount(event),
 		}
 		serviceEvents = append(serviceEvents, serviceEvent)
 	}

--- a/apiserver/pkg/model/converter_test.go
+++ b/apiserver/pkg/model/converter_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -597,7 +598,7 @@ func TestNilAutoscalerOptions(t *testing.T) {
 
 func TestFromCrdToAPIClusters(t *testing.T) {
 	clusters := []*rayv1api.RayCluster{&ClusterSpecTest}
-	clusterEventsMap := map[string][]corev1.Event{}
+	clusterEventsMap := map[string][]eventsv1.Event{}
 	apiClusters := FromCrdToAPIClusters(clusters, clusterEventsMap)
 	assert.Len(t, apiClusters, 1)
 
@@ -609,7 +610,7 @@ func TestFromCrdToAPIClusters(t *testing.T) {
 }
 
 func TestPopulateRayClusterSpec(t *testing.T) {
-	cluster := FromCrdToAPICluster(&ClusterSpecTest, []corev1.Event{})
+	cluster := FromCrdToAPICluster(&ClusterSpecTest, []eventsv1.Event{})
 	if len(cluster.Annotations) != 1 {
 		t.Errorf("failed to convert cluster's annotations")
 	}
@@ -617,7 +618,7 @@ func TestPopulateRayClusterSpec(t *testing.T) {
 	if cluster.ClusterSpec.AutoscalerOptions != nil {
 		t.Errorf("unexpected autoscaler annotations")
 	}
-	cluster = FromCrdToAPICluster(&ClusterSpecAutoscalerTest, []corev1.Event{})
+	cluster = FromCrdToAPICluster(&ClusterSpecAutoscalerTest, []eventsv1.Event{})
 	assert.True(t, cluster.ClusterSpec.EnableInTreeAutoscaling)
 	if cluster.ClusterSpec.AutoscalerOptions == nil {
 		t.Errorf("autoscaler annotations not found")
@@ -754,7 +755,7 @@ func TestPopulateJob(t *testing.T) {
 
 func TestFromCrdToAPIServices(t *testing.T) {
 	services := []*rayv1api.RayService{&ServiceV2Test}
-	serviceEventsMap := map[string][]corev1.Event{}
+	serviceEventsMap := map[string][]eventsv1.Event{}
 	apiServices := FromCrdToAPIServices(services, serviceEventsMap)
 	assert.Len(t, apiServices, 1)
 
@@ -765,7 +766,7 @@ func TestFromCrdToAPIServices(t *testing.T) {
 }
 
 func TestPopulateService(t *testing.T) {
-	service := FromCrdToAPIService(&ServiceV2Test, []corev1.Event{})
+	service := FromCrdToAPIService(&ServiceV2Test, []eventsv1.Event{})
 	assert.Equal(t, ServiceV2Test.ObjectMeta.Name, service.Name)
 	assert.Equal(t, ServiceV2Test.ObjectMeta.Namespace, service.Namespace)
 	assert.Equal(t, ServiceV2Test.ObjectMeta.Labels["ray.io/user"], service.User)
@@ -810,16 +811,16 @@ func TestPopulateServeDeploymentStatus(t *testing.T) {
 
 func TestPopulateRayServiceEvent(t *testing.T) {
 	expectedServiceName := "svc0"
-	expectedEvent := corev1.Event{
+	expectedEvent := eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
 		},
-		Reason:  "test",
-		Message: "test",
-		Type:    "Normal",
-		Count:   2,
+		Reason:          "test",
+		Note:            "test",
+		Type:            "Normal",
+		DeprecatedCount: 2,
 	}
-	events := []corev1.Event{expectedEvent}
+	events := []eventsv1.Event{expectedEvent}
 	serviceEvents := PopulateRayServiceEvent(expectedServiceName, events)
 	assert.Len(t, serviceEvents, 1)
 
@@ -827,7 +828,7 @@ func TestPopulateRayServiceEvent(t *testing.T) {
 	assert.Equal(t, expectedEvent.Name, serviceEvent.Id)
 	assert.Equal(t, expectedServiceName+"-"+expectedEvent.ObjectMeta.Name, serviceEvent.Name)
 	assert.Equal(t, expectedEvent.Reason, serviceEvent.Reason)
-	assert.Equal(t, expectedEvent.Message, serviceEvent.Message)
+	assert.Equal(t, expectedEvent.Note, serviceEvent.Message)
 	assert.Equal(t, expectedEvent.Type, serviceEvent.Type)
-	assert.Equal(t, expectedEvent.Count, serviceEvent.Count)
+	assert.Equal(t, expectedEvent.DeprecatedCount, serviceEvent.Count)
 }

--- a/apiserver/pkg/server/cluster_server.go
+++ b/apiserver/pkg/server/cluster_server.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"google.golang.org/protobuf/types/known/emptypb"
-	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	klog "k8s.io/klog/v2"
 
 	"github.com/ray-project/kuberay/apiserver/pkg/manager"
@@ -78,7 +78,7 @@ func (s *ClusterServer) ListCluster(ctx context.Context, request *api.ListCluste
 	if err != nil {
 		return nil, util.Wrap(err, "List clusters failed.")
 	}
-	clusterEventMap := make(map[string][]corev1.Event)
+	clusterEventMap := make(map[string][]eventsv1.Event)
 	for _, cluster := range clusters {
 		clusterEvents, err := s.resourceManager.GetClusterEvents(ctx, cluster.Name, cluster.Namespace)
 		if err != nil {
@@ -101,7 +101,7 @@ func (s *ClusterServer) ListAllClusters(ctx context.Context, request *api.ListAl
 	if err != nil {
 		return nil, util.Wrap(err, "List clusters from all namespaces failed.")
 	}
-	clusterEventMap := make(map[string][]corev1.Event)
+	clusterEventMap := make(map[string][]eventsv1.Event)
 	for _, cluster := range clusters {
 		clusterEvents, err := s.resourceManager.GetClusterEvents(ctx, cluster.Name, cluster.Namespace)
 		if err != nil {

--- a/apiserver/pkg/server/ray_job_submission_service_server_test.go
+++ b/apiserver/pkg/server/ray_job_submission_service_server_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 
@@ -56,7 +57,7 @@ func TestGetRayClusterURL(t *testing.T) {
 
 	tests := []struct {
 		rayCluster          *rayv1.RayCluster
-		rayEvent            *corev1.Event
+		rayEvent            *eventsv1.Event
 		name                string
 		expectedURL         string
 		expectedErrorString string
@@ -106,7 +107,7 @@ func TestGetRayClusterURL(t *testing.T) {
 				Namespace: tc.rayCluster.Namespace,
 			}
 
-			expectedEvent := &corev1.Event{
+			expectedEvent := &eventsv1.Event{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ray-event-1",
 					Namespace: tc.rayCluster.Namespace,
@@ -130,7 +131,7 @@ func TestGetRayClusterURL(t *testing.T) {
 			mockKubeClient := client.NewMockKubernetesClientInterface(ctrl)
 			// create fake events
 			fakeClientset := kubernetesfake.NewClientset(expectedEvent)
-			fakeEvents := fakeClientset.CoreV1().Events(tc.rayCluster.Namespace)
+			fakeEvents := fakeClientset.EventsV1().Events(tc.rayCluster.Namespace)
 			mockKubeClient.EXPECT().EventsClient(tc.rayCluster.Namespace).Return(fakeEvents).MaxTimes(1)
 			mockClientManager.EXPECT().KubernetesClient().Return(mockKubeClient).MaxTimes(1)
 

--- a/apiserver/pkg/server/serve_server.go
+++ b/apiserver/pkg/server/serve_server.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"google.golang.org/protobuf/types/known/emptypb"
-	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	klog "k8s.io/klog/v2"
 
 	"github.com/ray-project/kuberay/apiserver/pkg/manager"
@@ -93,7 +93,7 @@ func (s *RayServiceServer) ListRayServices(ctx context.Context, request *api.Lis
 		return nil, util.Wrap(err, "failed to list rayservice.")
 	}
 
-	serviceEventMap := make(map[string][]corev1.Event)
+	serviceEventMap := make(map[string][]eventsv1.Event)
 	for _, service := range services {
 		serviceEvents, err := s.resourceManager.GetServiceEvents(ctx, *service)
 		if err != nil {
@@ -113,7 +113,7 @@ func (s *RayServiceServer) ListAllRayServices(ctx context.Context, request *api.
 	if err != nil {
 		return nil, util.Wrap(err, "list all services failed.")
 	}
-	serviceEventMap := make(map[string][]corev1.Event)
+	serviceEventMap := make(map[string][]eventsv1.Event)
 	for _, service := range services {
 		serviceEvents, err := s.resourceManager.GetServiceEvents(ctx, *service)
 		if err != nil {

--- a/apiserversdk/proxy.go
+++ b/apiserversdk/proxy.go
@@ -43,8 +43,8 @@ func NewMux(config MuxConfig, clientManager manager.ClientManagerInterface) (*ht
 
 	mux := http.NewServeMux()
 	// TODO: add template features to specify routes.
-	mux.Handle("/apis/ray.io/v1/", handler)                                                                                    // forward KubeRay CR requests.
-	mux.Handle("GET /api/v1/namespaces/{namespace}/events", withFieldSelector(handler, "involvedObject.apiVersion=ray.io/v1")) // allow querying KubeRay CR events.
+	mux.Handle("/apis/ray.io/v1/", handler)                                                                                              // forward KubeRay CR requests.
+	mux.Handle("GET /apis/events.k8s.io/v1/namespaces/{namespace}/events", withFieldSelector(handler, "regarding.apiVersion=ray.io/v1")) // allow querying KubeRay CR events.
 
 	k8sClient := kubernetes.NewForConfigOrDie(config.KubernetesConfig)
 

--- a/apiserversdk/proxy_test.go
+++ b/apiserversdk/proxy_test.go
@@ -17,10 +17,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	eventsv1client "k8s.io/client-go/kubernetes/typed/events/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -37,6 +39,7 @@ var (
 	rayClient             *rayclient.RayV1Client
 	k8sClient             *k8sclient.CoreV1Client
 	k8sClientWithoutProxy *k8sclient.CoreV1Client
+	eventsClient          *eventsv1client.EventsV1Client
 	testEnv               *envtest.Environment
 	lastReq               atomic.Pointer[http.Request]
 )
@@ -87,6 +90,7 @@ var _ = BeforeSuite(func(_ SpecContext) {
 	rayClient = rayclient.NewForConfigOrDie(proxyCfg)
 	k8sClient = k8sclient.NewForConfigOrDie(proxyCfg)
 	k8sClientWithoutProxy = k8sclient.NewForConfigOrDie(cfg)
+	eventsClient = eventsv1client.NewForConfigOrDie(proxyCfg)
 })
 
 var _ = AfterSuite(func() {
@@ -256,15 +260,15 @@ var _ = Describe("RayService", Ordered, func() {
 
 var _ = Describe("events", Ordered, func() {
 	It("List events", func() {
-		events, err := k8sClient.Events("default").List(context.Background(), metav1.ListOptions{})
+		events, err := eventsClient.Events("default").List(context.Background(), metav1.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(events.Items).To(BeEmpty())
 		Expect(lastReq.Load().Method).To(Equal(http.MethodGet))
-		Expect(lastReq.Load().RequestURI).To(Equal("/api/v1/namespaces/default/events"))
+		Expect(lastReq.Load().RequestURI).To(Equal("/apis/events.k8s.io/v1/namespaces/default/events"))
 	})
 	It("Only GET method is allowed for events endpoint", func() {
-		event := &corev1.Event{}
-		_, err := k8sClient.Events("default").Create(context.Background(), event, metav1.CreateOptions{})
+		event := &eventsv1.Event{}
+		_, err := eventsClient.Events("default").Create(context.Background(), event, metav1.CreateOptions{})
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(MatchError(ContainSubstring("the server does not allow this method on the requested resource")))
 	})
@@ -289,18 +293,20 @@ var _ = Describe("events", Ordered, func() {
 		}
 		testEvent2 := testEvent.DeepCopy()
 		testEvent2.InvolvedObject.APIVersion = ""
+		// Events created through the core API are readable through events.k8s.io/v1
+		// since both APIs are backed by the same storage.
 		_, err := k8sClientWithoutProxy.Events("default").Create(context.Background(), testEvent, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		_, err = k8sClientWithoutProxy.Events("default").Create(context.Background(), testEvent2, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		events, err := k8sClient.Events("default").List(context.Background(), metav1.ListOptions{})
+		events, err := eventsClient.Events("default").List(context.Background(), metav1.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(events.Items).To(HaveLen(1))
 		Expect(events.Items[0].ObjectMeta.GenerateName).To(Equal(testEvent.ObjectMeta.GenerateName))
-		Expect(events.Items[0].InvolvedObject.APIVersion).To(Equal("ray.io/v1"))
-		// Test the user selector won't override "involvedObject.apiVersion=ray.io/v1"
-		fieldSelectorString := "involvedObject.apiVersion="
-		events, err = k8sClient.Events("default").List(context.Background(), metav1.ListOptions{FieldSelector: fieldSelectorString})
+		Expect(events.Items[0].Regarding.APIVersion).To(Equal("ray.io/v1"))
+		// Test the user selector won't override "regarding.apiVersion=ray.io/v1"
+		fieldSelectorString := "regarding.apiVersion="
+		events, err = eventsClient.Events("default").List(context.Background(), metav1.ListOptions{FieldSelector: fieldSelectorString})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(events.Items).To(BeEmpty())
 	})

--- a/helm-chart/kuberay-apiserver/templates/rbac/cluster_role.yaml
+++ b/helm-chart/kuberay-apiserver/templates/rbac/cluster_role.yaml
@@ -14,7 +14,7 @@ rules:
   verbs:
   - list
 - apiGroups:
-  - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/helm-chart/kuberay-apiserver/templates/rbac/role.yaml
+++ b/helm-chart/kuberay-apiserver/templates/rbac/role.yaml
@@ -15,7 +15,7 @@ rules:
   verbs:
   - list
 - apiGroups:
-  - ""
+  - events.k8s.io
   resources:
   - events
   verbs:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

corev1 events were recently deprecated in favor of v1 events.
This PR updates the apiserver and apiserversdk packages to use the new APIs (will support for reading legacy / corev1 API events handled in converter.go)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

x-ref #4855

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
