### PR TITLE
feat: add Valkey as a supported GCS fault tolerance backend option

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -18,6 +18,31 @@
     - KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v ./test/e2e 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-log.tar -T - && exit 1)
     - echo "--- END:RayCluster and GCS E2E (nightly operator) tests finished"
 
+- label: 'Test RayCluster GCS FT with Valkey (nightly operator)'
+  # This step intentionally rebuilds the operator in an isolated kind cluster rather
+  # than sharing the existing GCS E2E step's cluster. The additional ~10 min of CI time
+  # provides clean isolation for validating Valkey wire-compatibility. If CI minutes
+  # become a concern, this is a good candidate for nightly-only gating or folding into
+  # the main GCS E2E step with a matrix variable.
+  instance_size: large
+  image: golang:1.26-bookworm
+  commands:
+    - source .buildkite/setup-env.sh
+    - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
+    - kubectl config set clusters.kind-kind.server https://docker:6443
+    # Build nightly KubeRay operator image
+    - pushd ray-operator
+    - source ../.buildkite/build-start-operator.sh
+    - kubectl wait --timeout=90s --for=condition=Available=true deployment kuberay-operator
+    # Run GCS FT e2e tests with Valkey backend (same tests as Redis, different backing store)
+    - echo "--- START:Running GCS FT with Valkey E2E tests"
+    - if [ -n "$${KUBERAY_TEST_RAY_IMAGE}" ]; then echo "Using Ray Image $${KUBERAY_TEST_RAY_IMAGE}"; fi
+    - set -o pipefail
+    - mkdir -p "$(pwd)/tmp" && export KUBERAY_TEST_OUTPUT_DIR=$(pwd)/tmp
+    - echo "KUBERAY_TEST_OUTPUT_DIR=$$KUBERAY_TEST_OUTPUT_DIR"
+    - KUBERAY_TEST_VALKEY=1 KUBERAY_TEST_TIMEOUT_SHORT=1m KUBERAY_TEST_TIMEOUT_MEDIUM=5m KUBERAY_TEST_TIMEOUT_LONG=10m go test -timeout 30m -v -run "TestRayClusterGCSFaultTolerance|TestGcsFaultToleranceOptions|TestGcsFaultToleranceAnnotations" ./test/e2e 2>&1 | awk -f ../.buildkite/format.awk | tee $$KUBERAY_TEST_OUTPUT_DIR/gotest.log || (kubectl logs --tail -1 -l app.kubernetes.io/name=kuberay | tee $$KUBERAY_TEST_OUTPUT_DIR/kuberay-operator.log && cd $$KUBERAY_TEST_OUTPUT_DIR && find . -name "*.log" | tar -cf /artifact-mount/e2e-valkey-log.tar -T - && exit 1)
+    - echo "--- END:GCS FT with Valkey E2E tests finished"
+
 - label: 'Test RayJob E2E (nightly operator)'
   instance_size: large
   image: golang:1.26-bookworm

--- a/ray-operator/config/samples/ray-cluster.external-valkey.yaml
+++ b/ray-operator/config/samples/ray-cluster.external-valkey.yaml
@@ -1,0 +1,214 @@
+# This sample demonstrates GCS fault tolerance using Valkey (BSD-3 licensed,
+# Linux Foundation) as the external metadata store. Valkey is wire-compatible
+# with Redis and serves as a drop-in replacement for the GCS FT backend.
+#
+# Usage:
+#   kubectl apply -f ray-cluster.external-valkey.yaml
+#
+# This deploys:
+#   - A Valkey pod + Service (valkey/valkey:8.1.8-alpine)
+#   - A RayCluster with GCS fault tolerance enabled pointing at Valkey
+#   - Example scripts for testing detached actor recovery
+#
+# The RayCluster spec is identical to the Redis-based sample
+# (ray-cluster.external-redis.yaml). Only the backing store image differs.
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: raycluster-external-valkey
+spec:
+  rayVersion: "2.52.0"
+  gcsFaultToleranceOptions:
+    # In most cases, you don't need to set `externalStorageNamespace` because KubeRay will
+    # automatically set it to the UID of RayCluster. Only modify this annotation if you fully understand
+    # the behaviors of the Ray GCS FT and RayService to avoid misconfiguration.
+    # [Example]:
+    # externalStorageNamespace: "my-raycluster-storage"
+    redisAddress: "valkey:6379"
+    redisPassword:
+      valueFrom:
+        secretKeyRef:
+          name: valkey-password-secret
+          key: password
+  headGroupSpec:
+    # The `rayStartParams` are used to configure the `ray start` command.
+    # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+    # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+    rayStartParams:
+      # Setting "num-cpus: 0" to avoid any Ray actors or tasks being scheduled on the Ray head Pod.
+      num-cpus: "0"
+    # Pod template
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.52.0
+          resources:
+            limits:
+              cpu: "1"
+              memory: "5Gi"
+            requests:
+              cpu: "1"
+              memory: "2Gi"
+          ports:
+          - containerPort: 6379
+            name: valkey
+          - containerPort: 8265
+            name: dashboard
+          - containerPort: 10001
+            name: client
+          volumeMounts:
+          - mountPath: /tmp/ray
+            name: ray-logs
+          - mountPath: /home/ray/samples
+            name: ray-example-configmap
+        volumes:
+        - name: ray-logs
+          emptyDir: {}
+        - name: ray-example-configmap
+          configMap:
+            name: ray-example
+            defaultMode: 0777
+            items:
+            - key: detached_actor.py
+              path: detached_actor.py
+            - key: increment_counter.py
+              path: increment_counter.py
+  workerGroupSpecs:
+  # the pod replicas in this group typed worker
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 10
+    groupName: small-group
+    # The `rayStartParams` are used to configure the `ray start` command.
+    # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+    # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+    rayStartParams: {}
+    # Pod template
+    template:
+      spec:
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:2.52.0
+          volumeMounts:
+          - mountPath: /tmp/ray
+            name: ray-logs
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+            requests:
+              cpu: "1"
+              memory: "1Gi"
+        volumes:
+        - name: ray-logs
+          emptyDir: {}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: valkey-config
+  labels:
+    app: valkey
+data:
+  valkey.conf: |-
+    dir /data
+    port 6379
+    bind 0.0.0.0
+    appendonly yes
+    # WARNING: protected-mode is explicitly disabled here; authentication is still
+    # required by --requirepass. In production, remove this line, use a strong password,
+    # and add network isolation/TLS; requirepass alone only authenticates clients.
+    protected-mode no
+    pidfile /data/valkey-6379.pid
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey
+  labels:
+    app: valkey
+spec:
+  type: ClusterIP
+  ports:
+  - name: valkey
+    port: 6379
+  selector:
+    app: valkey
+---
+# Valkey password — CHANGE THIS before deploying to production.
+# Generate a strong password: openssl rand -base64 32
+apiVersion: v1
+kind: Secret
+metadata:
+  name: valkey-password-secret
+type: Opaque
+data:
+  # echo -n "5241590000000000" | base64
+  password: NTI0MTU5MDAwMDAwMDAwMA==
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey
+  labels:
+    app: valkey
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: valkey
+  template:
+    metadata:
+      labels:
+        app: valkey
+    spec:
+      containers:
+      - name: valkey
+        image: valkey/valkey:8.1.8-alpine
+        command:
+        - "sh"
+        - "-c"
+        - "valkey-server /usr/local/etc/valkey/valkey.conf --requirepass \"$VALKEY_PASSWORD\""
+        env:
+        - name: VALKEY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: valkey-password-secret
+              key: password
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: config
+          mountPath: /usr/local/etc/valkey/valkey.conf
+          subPath: valkey.conf
+      volumes:
+      - name: config
+        configMap:
+          name: valkey-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ray-example
+data:
+  detached_actor.py: |
+    import ray
+
+    @ray.remote(num_cpus=1)
+    class Counter:
+      def __init__(self):
+          self.value = 0
+
+      def increment(self):
+          self.value += 1
+          return self.value
+
+    ray.init(namespace="default_namespace")
+    Counter.options(name="counter_actor", lifetime="detached").remote()
+  increment_counter.py: |
+    import ray
+
+    ray.init(namespace="default_namespace")
+    counter = ray.get_actor("counter_actor")
+    print(ray.get(counter.increment.remote()))

--- a/ray-operator/test/e2e/raycluster_gcs_ft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcs_ft_test.go
@@ -28,7 +28,7 @@ func TestRayClusterGCSFaultTolerance(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	test.T().Run("Test Detached Actor", func(_ *testing.T) {
-		checkRedisDBSize := DeployRedis(test, namespace.Name, RedisPassword)
+		checkRedisDBSize := DeployStore(test, namespace.Name, RedisPassword)
 		defer g.Eventually(checkRedisDBSize, time.Second*30, time.Second).Should(BeEquivalentTo("0"))
 
 		rayClusterSpecAC := rayv1ac.RayClusterSpec().
@@ -208,7 +208,7 @@ func TestGcsFaultToleranceOptions(t *testing.T) {
 			g := NewWithT(t)
 			namespace := test.NewTestNamespace()
 
-			checkRedisDBSize := DeployRedis(test, namespace.Name, tc.redisPassword)
+			checkRedisDBSize := DeployStore(test, namespace.Name, tc.redisPassword)
 			defer g.Eventually(checkRedisDBSize, time.Second*30, time.Second).Should(BeEquivalentTo("0"))
 
 			if tc.createSecret {
@@ -300,7 +300,7 @@ func TestGcsFaultToleranceAnnotations(t *testing.T) {
 				redisPassword = tc.redisPasswordInRayStartParams
 			}
 
-			checkRedisDBSize := DeployRedis(test, namespace.Name, redisPassword)
+			checkRedisDBSize := DeployStore(test, namespace.Name, redisPassword)
 			defer g.Eventually(checkRedisDBSize, time.Second*30, time.Second).Should(BeEquivalentTo("0"))
 
 			// Prepare RayCluster ApplyConfiguration

--- a/ray-operator/test/sampleyaml/raycluster_test.go
+++ b/ray-operator/test/sampleyaml/raycluster_test.go
@@ -43,6 +43,9 @@ func TestRayCluster(t *testing.T) {
 			name: "ray-cluster.external-redis.yaml",
 		},
 		{
+			name: "ray-cluster.external-valkey.yaml",
+		},
+		{
 			name: "ray-cluster.head-command.yaml",
 		},
 		{

--- a/ray-operator/test/support/redis.go
+++ b/ray-operator/test/support/redis.go
@@ -1,26 +1,76 @@
 package support
 
 import (
+	"os"
 	"strings"
 
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
+// StoreConfig defines the container image and CLI commands for a
+// Redis-protocol-compatible store (Redis, Valkey, etc.).
+type StoreConfig struct {
+	Image     string // container image, e.g. "redis:7.4" or "valkey/valkey:8.1.8-alpine"
+	ServerCmd string // server binary, e.g. "redis-server" or "valkey-server"
+	CLICmd    string // CLI binary, e.g. "redis-cli" or "valkey-cli"
+}
+
+var (
+	// RedisConfig is the StoreConfig for Redis.
+	RedisConfig = StoreConfig{
+		Image:     "redis:7.4",
+		ServerCmd: "redis-server",
+		CLICmd:    "redis-cli",
+	}
+	// ValkeyConfig is the StoreConfig for Valkey.
+	ValkeyConfig = StoreConfig{
+		Image:     "valkey/valkey:8.1.8-alpine",
+		ServerCmd: "valkey-server",
+		CLICmd:    "valkey-cli",
+	}
+)
+
+// DeployRedis deploys a Redis pod and service in the given namespace.
 func DeployRedis(t Test, namespace string, password string) func() string {
-	redisContainer := v1.Container().WithName("redis").WithImage("redis:7.4").
+	return deployStore(t, namespace, password, RedisConfig)
+}
+
+// DeployValkey deploys a Valkey pod and service in the given namespace.
+// Valkey (valkey.io) is a BSD-3 licensed, wire-compatible fork of Redis
+// maintained by the Linux Foundation.
+func DeployValkey(t Test, namespace string, password string) func() string {
+	return deployStore(t, namespace, password, ValkeyConfig)
+}
+
+// DeployStore deploys the appropriate Redis-compatible store based on the
+// KUBERAY_TEST_VALKEY environment variable. When KUBERAY_TEST_VALKEY=1, it
+// deploys Valkey; otherwise it deploys Redis. This allows the same GCS FT
+// e2e tests to validate both backends without duplicating test functions,
+// following the same env-var toggle pattern used by Ray's RocksDB GCS tests
+// (TEST_GCS_ROCKSDB=1 in python/ray/tests/conftest.py).
+func DeployStore(t Test, namespace string, password string) func() string {
+	if os.Getenv("KUBERAY_TEST_VALKEY") == "1" {
+		return DeployValkey(t, namespace, password)
+	}
+	return DeployRedis(t, namespace, password)
+}
+
+func deployStore(t Test, namespace string, password string, cfg StoreConfig) func() string {
+	t.T().Logf("deployStore: deploying %s (server=%s, cli=%s)", cfg.Image, cfg.ServerCmd, cfg.CLICmd)
+	container := v1.Container().WithName("redis").WithImage(cfg.Image).
 		WithPorts(v1.ContainerPort().WithContainerPort(6379))
-	dbSizeCmd := []string{"redis-cli", "--no-auth-warning", "DBSIZE"}
+	dbSizeCmd := []string{cfg.CLICmd, "--no-auth-warning", "DBSIZE"}
 	if password != "" {
-		redisContainer.WithCommand("redis-server", "--requirepass", password)
-		dbSizeCmd = []string{"redis-cli", "--no-auth-warning", "-a", password, "DBSIZE"}
+		container.WithCommand(cfg.ServerCmd, "--requirepass", password)
+		dbSizeCmd = []string{cfg.CLICmd, "--no-auth-warning", "-a", password, "DBSIZE"}
 	}
 
 	pod, err := t.Client().Core().CoreV1().Pods(namespace).Apply(
 		t.Ctx(),
 		v1.Pod("redis", namespace).
 			WithLabels(map[string]string{"app": "redis"}).
-			WithSpec(v1.PodSpec().WithContainers(redisContainer)),
+			WithSpec(v1.PodSpec().WithContainers(container)),
 		TestApplyOptions,
 	)
 	require.NoError(t.T(), err)


### PR DESCRIPTION
## Summary

Adds [Valkey](https://valkey.io) (BSD-3 licensed, Linux Foundation) as an additional supported backend option for GCS fault tolerance. Redis remains the default and is unchanged — this PR provides Valkey as an alternative for users who prefer its licensing or governance model.

## Changes

### Test infrastructure (`ray-operator/test/support/redis.go`)
- Add `StoreConfig` struct with named fields (`Image`, `ServerCmd`, `CLICmd`)
- Add `DeployValkey()` and `DeployStore()` helpers
- `DeployStore` dispatches via `KUBERAY_TEST_VALKEY=1` env var (same pattern as Ray's `TEST_GCS_ROCKSDB=1` in `python/ray/tests/conftest.py`)
- Add diagnostic `t.T().Logf` for CI triage visibility
- Default behavior unchanged — without the env var, Redis is deployed

### E2E tests (`ray-operator/test/e2e/raycluster_gcs_ft_test.go`)
- Replace `DeployRedis` → `DeployStore` in all 3 GCS FT test functions
- No behavioral change when `KUBERAY_TEST_VALKEY` is unset

### CI (`.buildkite/test-e2e.yml`)
- Add isolated Buildkite step running all 3 GCS FT tests with Valkey backend
- Includes comment documenting intentional CI cost trade-off

### Sample YAML test (`ray-operator/test/sampleyaml/raycluster_test.go`)
- Register `ray-cluster.external-valkey.yaml` in `TestRayCluster` suite

### Sample manifest (`ray-operator/config/samples/ray-cluster.external-valkey.yaml`)
- Self-contained sample: Valkey Deployment, Service, Secret, ConfigMap, RayCluster
- Password injected from Secret via env var (not hardcoded in ConfigMap)
- Quoted shell expansion prevents word-splitting
- WARNING comment on `protected-mode` explains production guidance
- Secret ordered before Deployment for reliable startup

## Design Decisions

- **Additive, not a replacement:** Redis is untouched. Valkey is a new option alongside it.
- **Env-var toggle pattern:** Follows Ray's own precedent (`TEST_GCS_ROCKSDB=1`)
- **Resource naming in tests:** Pod/Service remain `"redis"` to match the `RedisAddress = "redis:6379"` constant (each test runs in an isolated namespace)
- **File naming:** Kept as `redis.go` — consistent with how Ray's `conftest.py` retains `maybe_setup_external_redis` despite handling RocksDB

## Testing

- `go build ./...` passes
- Manual wire-compatibility smoke test via Finch confirms:
  - `valkey-server --requirepass` works identically to `redis-server`
  - `PING`, `SET/GET`, `DBSIZE`, `FLUSHALL` all produce expected results
  - `INFO server` reports `redis_version:7.2.4` (wire compat) + `valkey_version:8.1.8`
- YAML decoder verification: `DeserializeRayClusterYAML` correctly reads multi-doc YAML
- Kubernetes YAML parser (`sigs.k8s.io/yaml`) confirmed to handle `\"` quoting correctly