### PR TITLE
[RayService] Rename TargetClusterChanged condition to DesiredClusterSpecChanged

### DIFF
--- a/ray-operator/apis/ray/v1/rayservice_types.go
+++ b/ray-operator/apis/ray/v1/rayservice_types.go
@@ -230,7 +230,7 @@ const (
 	NoPendingCluster               RayServiceConditionReason = "NoPendingCluster"
 	NoActiveCluster                RayServiceConditionReason = "NoActiveCluster"
 	RayServiceValidationFailed     RayServiceConditionReason = "ValidationFailed"
-	TargetClusterChanged           RayServiceConditionReason = "TargetClusterChanged"
+	DesiredClusterSpecChanged      RayServiceConditionReason = "DesiredClusterSpecChanged"
 	SuspendRequested               RayServiceConditionReason = "SuspendRequested"
 	SuspendInProgress              RayServiceConditionReason = "SuspendInProgress"
 	SuspendComplete                RayServiceConditionReason = "SuspendComplete"

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -2352,7 +2352,7 @@ func (r *RayServiceReconciler) reconcileRollbackState(ctx context.Context, raySe
 	// allowing a new cluster to be spun up.
 	if !isRollbackInProgress {
 		logger.Info("Goal state has changed during upgrade. Initiating safe rollback to the original cluster.", "targetHash", targetHash, "originalHash", originalHash, "pendingHash", pendingHash)
-		setCondition(rayServiceInstance, rayv1.RollbackInProgress, metav1.ConditionTrue, rayv1.TargetClusterChanged, "Goal state changed mid-upgrade, rolling back to original cluster.")
+		setCondition(rayServiceInstance, rayv1.RollbackInProgress, metav1.ConditionTrue, rayv1.DesiredClusterSpecChanged, "Goal state changed mid-upgrade, rolling back to original cluster.")
 	}
 
 	return nil

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2746,7 +2746,7 @@ func TestReconcileRollbackState(t *testing.T) {
 			}
 
 			if tt.isRollbackInProgress {
-				setCondition(rayService, rayv1.RollbackInProgress, metav1.ConditionTrue, rayv1.TargetClusterChanged, "rolling back")
+				setCondition(rayService, rayv1.RollbackInProgress, metav1.ConditionTrue, rayv1.DesiredClusterSpecChanged, "rolling back")
 			}
 
 			reconciler := RayServiceReconciler{
@@ -2961,10 +2961,10 @@ func TestReconcileServe_SkipConfigUpdateDuringRollback(t *testing.T) {
 			}
 
 			if tt.isRollback {
-				setCondition(rayService, rayv1.RollbackInProgress, metav1.ConditionTrue, rayv1.TargetClusterChanged, "rolling back")
-				setCondition(rayService, rayv1.UpgradeInProgress, metav1.ConditionTrue, rayv1.TargetClusterChanged, "upgrade still in progress during rollback")
+				setCondition(rayService, rayv1.RollbackInProgress, metav1.ConditionTrue, rayv1.DesiredClusterSpecChanged, "rolling back")
+				setCondition(rayService, rayv1.UpgradeInProgress, metav1.ConditionTrue, rayv1.DesiredClusterSpecChanged, "upgrade still in progress during rollback")
 			} else {
-				setCondition(rayService, rayv1.UpgradeInProgress, metav1.ConditionTrue, rayv1.TargetClusterChanged, "upgrading")
+				setCondition(rayService, rayv1.UpgradeInProgress, metav1.ConditionTrue, rayv1.DesiredClusterSpecChanged, "upgrading")
 			}
 
 			// Run reconcileServe


### PR DESCRIPTION
## Why are these changes needed?

This PR renames `rayv1.TargetClusterChanged` to `rayv1.DesiredClusterSpecChanged` for clarity based on this discussion: https://github.com/ray-project/kuberay/pull/4989#discussion_r3608636910.

## Related issue number

https://github.com/ray-project/kuberay/issues/4644

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(