### PR TITLE
[CI] Deflake TestRayServiceSuspendDuringIncrementalUpgrade

### DIFF
--- a/ray-operator/test/e2eincrementalupgrade/rayservice_suspend_test.go
+++ b/ray-operator/test/e2eincrementalupgrade/rayservice_suspend_test.go
@@ -61,11 +61,17 @@ func TestRayServiceSuspendDuringIncrementalUpgrade(t *testing.T) {
 	}, TestTimeoutMedium).Should(Succeed())
 
 	LogWithTimestamp(test.T(), "Setting Spec.Suspend=true while incremental upgrade is in progress")
-	rayService, err = GetRayService(test, namespace.Name, rayServiceName)
-	g.Expect(err).NotTo(HaveOccurred())
-	rayService.Spec.Suspend = true
-	_, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rayService, metav1.UpdateOptions{})
-	g.Expect(err).NotTo(HaveOccurred())
+	// Wrapped in Eventually: the controller concurrently updates the RayService
+	// status (e.g. upgrade progress), so a plain Get-modify-Update can lose the
+	// race and hit a 409 Conflict. Retrying re-reads the latest version.
+	g.Eventually(func(gg Gomega) {
+		rs, err := GetRayService(test, namespace.Name, rayServiceName)
+		gg.Expect(err).NotTo(HaveOccurred())
+		rs.Spec.Suspend = true
+		rs, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rs, metav1.UpdateOptions{})
+		gg.Expect(err).NotTo(HaveOccurred())
+		rayService = rs
+	}, TestTimeoutShort).Should(Succeed())
 
 	LogWithTimestamp(test.T(), "Waiting for the Suspended condition to be True")
 	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).
@@ -93,11 +99,14 @@ func TestRayServiceSuspendDuringIncrementalUpgrade(t *testing.T) {
 	}, TestTimeoutMedium).Should(Succeed())
 
 	LogWithTimestamp(test.T(), "Setting Spec.Suspend=false; the controller must recreate Gateway, HTTPRoute, RayCluster, and Services")
-	rayService, err = GetRayService(test, namespace.Name, rayServiceName)
-	g.Expect(err).NotTo(HaveOccurred())
-	rayService.Spec.Suspend = false
-	_, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rayService, metav1.UpdateOptions{})
-	g.Expect(err).NotTo(HaveOccurred())
+	g.Eventually(func(gg Gomega) {
+		rs, err := GetRayService(test, namespace.Name, rayServiceName)
+		gg.Expect(err).NotTo(HaveOccurred())
+		rs.Spec.Suspend = false
+		rs, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rs, metav1.UpdateOptions{})
+		gg.Expect(err).NotTo(HaveOccurred())
+		rayService = rs
+	}, TestTimeoutShort).Should(Succeed())
 
 	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).
 		Should(WithTransform(IsRayServiceReady, BeTrue()))

--- a/ray-operator/test/e2eincrementalupgrade/rayservice_suspend_test.go
+++ b/ray-operator/test/e2eincrementalupgrade/rayservice_suspend_test.go
@@ -61,16 +61,13 @@ func TestRayServiceSuspendDuringIncrementalUpgrade(t *testing.T) {
 	}, TestTimeoutMedium).Should(Succeed())
 
 	LogWithTimestamp(test.T(), "Setting Spec.Suspend=true while incremental upgrade is in progress")
-	// Wrapped in Eventually: the controller concurrently updates the RayService
-	// status (e.g. upgrade progress), so a plain Get-modify-Update can lose the
-	// race and hit a 409 Conflict. Retrying re-reads the latest version.
-	g.Eventually(func(gg Gomega) {
-		rs, err := GetRayService(test, namespace.Name, rayServiceName)
-		gg.Expect(err).NotTo(HaveOccurred())
-		rs.Spec.Suspend = true
-		_, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rs, metav1.UpdateOptions{})
-		gg.Expect(err).NotTo(HaveOccurred())
-	}, TestTimeoutShort).Should(Succeed())
+	// Server-side apply instead of Get-modify-Update: the controller concurrently
+	// updates the RayService status (e.g. upgrade progress), and a plain
+	// Get-modify-Update can lose that race and hit a 409 Conflict. Apply is a
+	// declarative PATCH that doesn't depend on ResourceVersion, so it isn't
+	// susceptible to the same conflict.
+	g.Expect(triggerIncrementalUpgrade(test, namespace.Name, rayServiceName, stepSize, interval, maxSurge, defaultIncrementalUpgradeServeConfigV2,
+		withWorkerCPURequest("500m"), withUpgradedServeConfig(), withSuspend(true))).To(Succeed())
 
 	LogWithTimestamp(test.T(), "Waiting for the Suspended condition to be True")
 	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).
@@ -98,13 +95,8 @@ func TestRayServiceSuspendDuringIncrementalUpgrade(t *testing.T) {
 	}, TestTimeoutMedium).Should(Succeed())
 
 	LogWithTimestamp(test.T(), "Setting Spec.Suspend=false; the controller must recreate Gateway, HTTPRoute, RayCluster, and Services")
-	g.Eventually(func(gg Gomega) {
-		rs, err := GetRayService(test, namespace.Name, rayServiceName)
-		gg.Expect(err).NotTo(HaveOccurred())
-		rs.Spec.Suspend = false
-		_, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rs, metav1.UpdateOptions{})
-		gg.Expect(err).NotTo(HaveOccurred())
-	}, TestTimeoutShort).Should(Succeed())
+	g.Expect(triggerIncrementalUpgrade(test, namespace.Name, rayServiceName, stepSize, interval, maxSurge, defaultIncrementalUpgradeServeConfigV2,
+		withWorkerCPURequest("500m"), withUpgradedServeConfig(), withSuspend(false))).To(Succeed())
 
 	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).
 		Should(WithTransform(IsRayServiceReady, BeTrue()))

--- a/ray-operator/test/e2eincrementalupgrade/rayservice_suspend_test.go
+++ b/ray-operator/test/e2eincrementalupgrade/rayservice_suspend_test.go
@@ -68,9 +68,8 @@ func TestRayServiceSuspendDuringIncrementalUpgrade(t *testing.T) {
 		rs, err := GetRayService(test, namespace.Name, rayServiceName)
 		gg.Expect(err).NotTo(HaveOccurred())
 		rs.Spec.Suspend = true
-		rs, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rs, metav1.UpdateOptions{})
+		_, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rs, metav1.UpdateOptions{})
 		gg.Expect(err).NotTo(HaveOccurred())
-		rayService = rs
 	}, TestTimeoutShort).Should(Succeed())
 
 	LogWithTimestamp(test.T(), "Waiting for the Suspended condition to be True")

--- a/ray-operator/test/e2eincrementalupgrade/rayservice_suspend_test.go
+++ b/ray-operator/test/e2eincrementalupgrade/rayservice_suspend_test.go
@@ -103,9 +103,8 @@ func TestRayServiceSuspendDuringIncrementalUpgrade(t *testing.T) {
 		rs, err := GetRayService(test, namespace.Name, rayServiceName)
 		gg.Expect(err).NotTo(HaveOccurred())
 		rs.Spec.Suspend = false
-		rs, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rs, metav1.UpdateOptions{})
+		_, err = test.Client().Ray().RayV1().RayServices(namespace.Name).Update(test.Ctx(), rs, metav1.UpdateOptions{})
 		gg.Expect(err).NotTo(HaveOccurred())
-		rayService = rs
 	}, TestTimeoutShort).Should(Succeed())
 
 	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutMedium).

--- a/ray-operator/test/e2eincrementalupgrade/rayservice_suspend_test.go
+++ b/ray-operator/test/e2eincrementalupgrade/rayservice_suspend_test.go
@@ -61,11 +61,6 @@ func TestRayServiceSuspendDuringIncrementalUpgrade(t *testing.T) {
 	}, TestTimeoutMedium).Should(Succeed())
 
 	LogWithTimestamp(test.T(), "Setting Spec.Suspend=true while incremental upgrade is in progress")
-	// Server-side apply instead of Get-modify-Update: the controller concurrently
-	// updates the RayService status (e.g. upgrade progress), and a plain
-	// Get-modify-Update can lose that race and hit a 409 Conflict. Apply is a
-	// declarative PATCH that doesn't depend on ResourceVersion, so it isn't
-	// susceptible to the same conflict.
 	g.Expect(triggerIncrementalUpgrade(test, namespace.Name, rayServiceName, stepSize, interval, maxSurge, defaultIncrementalUpgradeServeConfigV2,
 		withWorkerCPURequest("500m"), withUpgradedServeConfig(), withSuspend(true))).To(Succeed())
 

--- a/ray-operator/test/e2eincrementalupgrade/support.go
+++ b/ray-operator/test/e2eincrementalupgrade/support.go
@@ -226,6 +226,12 @@ func withUpgradedServeConfig() SupportOption[rayv1ac.RayServiceSpecApplyConfigur
 	}
 }
 
+func withSuspend(suspend bool) SupportOption[rayv1ac.RayServiceSpecApplyConfiguration] {
+	return func(spec *rayv1ac.RayServiceSpecApplyConfiguration) *rayv1ac.RayServiceSpecApplyConfiguration {
+		return spec.WithSuspend(suspend)
+	}
+}
+
 // triggerIncrementalUpgrade updates the RayService to trigger an incremental upgrade:
 //   - RayCluster spec: Set worker CPU request to custom value
 //   - Serve config: Update (price 3->4, factor 5->3)


### PR DESCRIPTION
## Why are these changes needed?

`TestRayServiceSuspendDuringIncrementalUpgrade` intermittently fails with a 409 Conflict when flipping `Spec.Suspend` on the RayService:

```
Operation cannot be fulfilled on rayservices.ray.io "suspend-incremental-rayservice": the object has been modified; please apply your changes to the latest version and try again
```

This happens because the test does a plain Get → mutate → Update, and the controller can concurrently write to `Status` between the Get and the Update, invalidating the `ResourceVersion`.

Per the fix suggested in https://github.com/ray-project/kuberay/pull/4915#pullrequestreview-4606495545, both `Spec.Suspend` read-modify-write blocks in this test are now wrapped in `Eventually`. If the Update hits a conflict, the block is retried (fresh Get + Update) until it succeeds or times out, instead of failing the test outright.

Scope is intentionally limited to `TestRayServiceSuspendDuringIncrementalUpgrade` in `rayservice_suspend_test.go`; the similarly-flaky spots noted in the issue thread (`e2erayservice/rayservice_suspend_test.go`, `TestRayServiceIncrementalUpgradeRollback`) are left for follow-up PRs.

## Related issue number

Closes #5020

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

`go build`, `go vet`, and `gofmt` all pass. This is an e2e test requiring a live cluster (kind + Gateway API/Istio + the operator deployed), which isn't available in my dev environment, so the actual race-condition fix hasn't been exercised locally — CI running this job (ideally a few times, since the original failure was intermittent) is needed to confirm the 409 no longer occurs.