### PR TITLE
[CI] Add additional_dependencies to eslint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,8 @@ repos:
         require_serial: true
         pass_filenames: true
         files: .*\.(js|jsx|ts|tsx|cjs|mjs)$
+        additional_dependencies:
+          - eslint@8
 
 
   - repo: https://github.com/igorshubovych/markdownlint-cli


### PR DESCRIPTION
## What does this PR do?

Fixes the `Lint (pre-commit)` CI job that is currently failing across open PRs with:

```
AssertionError: `language: node` must have package.json or additional_dependencies
```

`pre-commit` >= 4.6 now requires `language: node` hooks to declare `additional_dependencies` or have a local `package.json`. The `eslint` hook was missing this, so every PR whose `Lint (pre-commit)` job runs against the current runner image fails before any hook executes.

## Changes

Added `eslint@8` to `additional_dependencies` on the `eslint` hook in `.pre-commit-config.yaml`. The actual linting still runs via `yarn lint` inside the dashboard directory through `scripts/dashboard-lint.sh` — this dependency just satisfies pre-commit's environment bootstrap requirement.

## Affected PRs

Confirmed failing with this exact `AssertionError` on their latest `Lint (pre-commit)` run:

- #5024 — [CI] Deflake TestRayServiceSuspendDuringIncrementalUpgrade
- #5022 — [RayService] Rename TargetClusterChanged condition to DesiredClusterSpecChanged
- #4983 — [History Server] Update history server to retrieve nodeid and move leftover session logs
- #4982 — [Feature][History server] Add history server api to kuberay for injecting collector sidecar
- #4901 — [Feature] Final Built-In Ingress Support with Host, Path, PathType, and TLS Fields

Any PR that re-runs the `Lint (pre-commit)` job against the current runner will hit the same failure until this is merged.

## Verification

- All pre-commit hooks pass locally after this change