### PR TITLE
[RayService] Associate Gateway and HTTPRoute via ownership labels

### DIFF
--- a/ray-operator/controllers/ray/common/association.go
+++ b/ray-operator/controllers/ray/common/association.go
@@ -217,3 +217,19 @@ func RayServiceHTTPRouteNamespacedName(rayService *rayv1.RayService) types.Names
 		Namespace: rayService.Namespace,
 	}
 }
+
+func RayServiceGatewayLabels(rayService *rayv1.RayService) map[string]string {
+	return map[string]string{
+		utils.RayOriginatedFromCRNameLabelKey: rayService.Name,
+		utils.RayOriginatedFromCRDLabelKey:    utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
+	}
+}
+
+func IsGatewayResourceOwnedByRayService(obj metav1.Object, rayService *rayv1.RayService) bool {
+	if metav1.IsControlledBy(obj, rayService) {
+		return true
+	}
+	labels := obj.GetLabels()
+	return labels[utils.RayOriginatedFromCRNameLabelKey] == rayService.Name &&
+		labels[utils.RayOriginatedFromCRDLabelKey] == utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD)
+}

--- a/ray-operator/controllers/ray/rayservice_controller.go
+++ b/ray-operator/controllers/ray/rayservice_controller.go
@@ -509,16 +509,21 @@ func (r *RayServiceReconciler) deleteRayServiceOwnedResources(ctx context.Contex
 	if utils.IsIncrementalUpgradeEnabled(&rayServiceInstance.Spec) {
 		gateway := &gwv1.Gateway{}
 		if err := r.Get(ctx, common.RayServiceGatewayNamespacedName(rayServiceInstance), gateway); err == nil {
-			allDeleted = false
-			if gateway.DeletionTimestamp.IsZero() {
-				logger.Info("Deleting Gateway for suspend", "name", gateway.Name)
-				if err := r.Delete(ctx, gateway, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !errors.IsNotFound(err) {
-					r.Recorder.Eventf(rayServiceInstance, nil, corev1.EventTypeWarning, string(utils.FailedToDeleteGateway), string(utils.DeleteAction),
-						"Failed to delete the Gateway %s/%s during suspend: %v", gateway.Namespace, gateway.Name, err)
-					return false, err
+			if !common.IsGatewayResourceOwnedByRayService(gateway, rayServiceInstance) {
+				logger.Info("Skipping Gateway deletion during suspend: existing Gateway is not owned by this RayService",
+					"name", gateway.Name, "namespace", gateway.Namespace)
+			} else {
+				allDeleted = false
+				if gateway.DeletionTimestamp.IsZero() {
+					logger.Info("Deleting Gateway for suspend", "name", gateway.Name)
+					if err := r.Delete(ctx, gateway, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !errors.IsNotFound(err) {
+						r.Recorder.Eventf(rayServiceInstance, nil, corev1.EventTypeWarning, string(utils.FailedToDeleteGateway), string(utils.DeleteAction),
+							"Failed to delete the Gateway %s/%s during suspend: %v", gateway.Namespace, gateway.Name, err)
+						return false, err
+					}
+					r.Recorder.Eventf(rayServiceInstance, nil, corev1.EventTypeNormal, string(utils.DeletedGateway), string(utils.DeleteAction),
+						"Deleted the Gateway %s/%s during suspend", gateway.Namespace, gateway.Name)
 				}
-				r.Recorder.Eventf(rayServiceInstance, nil, corev1.EventTypeNormal, string(utils.DeletedGateway), string(utils.DeleteAction),
-					"Deleted the Gateway %s/%s during suspend", gateway.Namespace, gateway.Name)
 			}
 		} else if !errors.IsNotFound(err) {
 			return false, err
@@ -526,16 +531,21 @@ func (r *RayServiceReconciler) deleteRayServiceOwnedResources(ctx context.Contex
 
 		httpRoute := &gwv1.HTTPRoute{}
 		if err := r.Get(ctx, common.RayServiceHTTPRouteNamespacedName(rayServiceInstance), httpRoute); err == nil {
-			allDeleted = false
-			if httpRoute.DeletionTimestamp.IsZero() {
-				logger.Info("Deleting HTTPRoute for suspend", "name", httpRoute.Name)
-				if err := r.Delete(ctx, httpRoute, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !errors.IsNotFound(err) {
-					r.Recorder.Eventf(rayServiceInstance, nil, corev1.EventTypeWarning, string(utils.FailedToDeleteHTTPRoute), string(utils.DeleteAction),
-						"Failed to delete the HTTPRoute %s/%s during suspend: %v", httpRoute.Namespace, httpRoute.Name, err)
-					return false, err
+			if !common.IsGatewayResourceOwnedByRayService(httpRoute, rayServiceInstance) {
+				logger.Info("Skipping HTTPRoute deletion during suspend: existing HTTPRoute is not owned by this RayService",
+					"name", httpRoute.Name, "namespace", httpRoute.Namespace)
+			} else {
+				allDeleted = false
+				if httpRoute.DeletionTimestamp.IsZero() {
+					logger.Info("Deleting HTTPRoute for suspend", "name", httpRoute.Name)
+					if err := r.Delete(ctx, httpRoute, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !errors.IsNotFound(err) {
+						r.Recorder.Eventf(rayServiceInstance, nil, corev1.EventTypeWarning, string(utils.FailedToDeleteHTTPRoute), string(utils.DeleteAction),
+							"Failed to delete the HTTPRoute %s/%s during suspend: %v", httpRoute.Namespace, httpRoute.Name, err)
+						return false, err
+					}
+					r.Recorder.Eventf(rayServiceInstance, nil, corev1.EventTypeNormal, string(utils.DeletedHTTPRoute), string(utils.DeleteAction),
+						"Deleted the HTTPRoute %s/%s during suspend", httpRoute.Namespace, httpRoute.Name)
 				}
-				r.Recorder.Eventf(rayServiceInstance, nil, corev1.EventTypeNormal, string(utils.DeletedHTTPRoute), string(utils.DeleteAction),
-					"Deleted the HTTPRoute %s/%s during suspend", httpRoute.Namespace, httpRoute.Name)
 			}
 		} else if !errors.IsNotFound(err) {
 			return false, err
@@ -899,6 +909,7 @@ func (r *RayServiceReconciler) createGateway(rayServiceInstance *rayv1.RayServic
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gatewayName,
 			Namespace: rayServiceInstance.Namespace,
+			Labels:    common.RayServiceGatewayLabels(rayServiceInstance),
 		},
 		Spec: gwv1.GatewaySpec{
 			GatewayClassName: gwv1.ObjectName(options.GatewayClassName),
@@ -948,6 +959,17 @@ func (r *RayServiceReconciler) reconcileGateway(ctx context.Context, rayServiceI
 			r.Recorder.Eventf(rayServiceInstance, nil, corev1.EventTypeNormal, string(utils.CreatedGateway), string(utils.CreateAction), "Created Gateway for RayService %s/%s", desiredGateway.Namespace, desiredGateway.Name)
 			return nil
 		}
+		return err
+	}
+
+	if !common.IsGatewayResourceOwnedByRayService(existingGateway, rayServiceInstance) {
+		err := fmt.Errorf("found an existing Gateway %s/%s that is not owned by RayService %s; "+
+			"KubeRay associates Gateways via the %q and %q labels and will not modify a resource it does not own. "+
+			"Please remove or rename the conflicting Gateway",
+			existingGateway.Namespace, existingGateway.Name, rayServiceInstance.Name,
+			utils.RayOriginatedFromCRNameLabelKey, utils.RayOriginatedFromCRDLabelKey)
+		r.Recorder.Eventf(rayServiceInstance, nil, corev1.EventTypeWarning, string(utils.FailedToUpdateGateway), string(utils.UpdateAction),
+			"Gateway %s/%s already exists and is not owned by RayService %s", existingGateway.Namespace, existingGateway.Name, rayServiceInstance.Name)
 		return err
 	}
 
@@ -1110,7 +1132,7 @@ func (r *RayServiceReconciler) createHTTPRoute(ctx context.Context, rayServiceIn
 
 	httpRouteName := rayServiceInstance.Name + "-httproute"
 	desiredHTTPRoute := &gwv1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{Name: httpRouteName, Namespace: gatewayInstance.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: httpRouteName, Namespace: gatewayInstance.Namespace, Labels: common.RayServiceGatewayLabels(rayServiceInstance)},
 		Spec: gwv1.HTTPRouteSpec{
 			CommonRouteSpec: gwv1.CommonRouteSpec{
 				ParentRefs: []gwv1.ParentReference{
@@ -1169,6 +1191,17 @@ func (r *RayServiceReconciler) reconcileHTTPRoute(ctx context.Context, rayServic
 			r.Recorder.Eventf(rayServiceInstance, nil, corev1.EventTypeNormal, string(utils.CreatedHTTPRoute), string(utils.CreateAction), "Created HTTPRoute for RayService %s/%s", desiredHTTPRoute.Namespace, desiredHTTPRoute.Name)
 			return desiredHTTPRoute, nil
 		}
+		return nil, err
+	}
+
+	if !common.IsGatewayResourceOwnedByRayService(existingHTTPRoute, rayServiceInstance) {
+		err := fmt.Errorf("found an existing HTTPRoute %s/%s that is not owned by RayService %s; "+
+			"KubeRay associates HTTPRoutes via the %q and %q labels and will not modify a resource it does not own. "+
+			"Please remove or rename the conflicting HTTPRoute",
+			existingHTTPRoute.Namespace, existingHTTPRoute.Name, rayServiceInstance.Name,
+			utils.RayOriginatedFromCRNameLabelKey, utils.RayOriginatedFromCRDLabelKey)
+		r.Recorder.Eventf(rayServiceInstance, nil, corev1.EventTypeWarning, string(utils.FailedToUpdateHTTPRoute), string(utils.UpdateAction),
+			"HTTPRoute %s/%s already exists and is not owned by RayService %s", existingHTTPRoute.Namespace, existingHTTPRoute.Name, rayServiceInstance.Name)
 		return nil, err
 	}
 

--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -1707,7 +1708,10 @@ func TestReconcileHTTPRoute(t *testing.T) {
 	pendingCluster := &rayv1.RayCluster{ObjectMeta: metav1.ObjectMeta{Name: "pending-ray-cluster", Namespace: namespace}}
 	activeServeService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: utils.GenerateServeServiceName(activeCluster.Name), Namespace: namespace}}
 	pendingServeService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: utils.GenerateServeServiceName(pendingCluster.Name), Namespace: namespace}}
-	gateway := &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: namespace}}
+	gateway := &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: namespace, Labels: map[string]string{
+		utils.RayOriginatedFromCRNameLabelKey: "test-rayservice",
+		utils.RayOriginatedFromCRDLabelKey:    utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
+	}}}
 
 	baseRayService := &rayv1.RayService{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-rayservice", Namespace: namespace},
@@ -1780,8 +1784,11 @@ func TestReconcileHTTPRoute(t *testing.T) {
 				rs.Status.PendingServiceStatus.LastTrafficMigratedTime = &metav1.Time{Time: time.Now().Add(-time.Duration(interval+1) * time.Second)}
 			},
 			existingRoute: &gwv1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{Name: routeName, Namespace: namespace},
-				Spec:       gwv1.HTTPRouteSpec{},
+				ObjectMeta: metav1.ObjectMeta{Name: routeName, Namespace: namespace, Labels: map[string]string{
+					utils.RayOriginatedFromCRNameLabelKey: "test-rayservice",
+					utils.RayOriginatedFromCRDLabelKey:    utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
+				}},
+				Spec: gwv1.HTTPRouteSpec{},
 			},
 			expectedActiveWeight:  90,
 			expectedPendingWeight: 10,
@@ -1910,6 +1917,92 @@ func TestReconcileGateway(t *testing.T) {
 	}
 }
 
+func TestReconcileGatewayOwnership(t *testing.T) {
+	newScheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(newScheme)
+	_ = corev1.AddToScheme(newScheme)
+	_ = gwv1.Install(newScheme)
+
+	ctx := context.TODO()
+
+	rayService := makeIncrementalUpgradeRayService(
+		true,
+		"gateway-class",
+		new(int32(20)),
+		new(int32(30)),
+		new(int32(80)),
+		new(metav1.Now()),
+	)
+	gatewayName := fmt.Sprintf("%s-gateway", rayService.Name)
+
+	t.Run("stamps origin labels on a newly created Gateway", func(t *testing.T) {
+		fakeClient := clientFake.NewClientBuilder().
+			WithScheme(newScheme).
+			WithRuntimeObjects(rayService).
+			Build()
+		reconciler := RayServiceReconciler{Client: fakeClient, Scheme: newScheme, Recorder: events.NewFakeRecorder(10)}
+
+		require.NoError(t, reconciler.reconcileGateway(ctx, rayService))
+
+		created := &gwv1.Gateway{}
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: gatewayName, Namespace: rayService.Namespace}, created))
+		assert.Equal(t, rayService.Name, created.Labels[utils.RayOriginatedFromCRNameLabelKey])
+		assert.Equal(t, utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD), created.Labels[utils.RayOriginatedFromCRDLabelKey])
+	})
+
+	t.Run("fails reconciliation when a same-named Gateway is not owned by KubeRay", func(t *testing.T) {
+		userGateway := &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: rayService.Namespace},
+		}
+		fakeClient := clientFake.NewClientBuilder().
+			WithScheme(newScheme).
+			WithRuntimeObjects(rayService, userGateway).
+			Build()
+		reconciler := RayServiceReconciler{Client: fakeClient, Scheme: newScheme, Recorder: events.NewFakeRecorder(10)}
+
+		err := reconciler.reconcileGateway(ctx, rayService)
+		require.Error(t, err, "expected reconciliation to fail on a non-owned Gateway")
+		assert.Contains(t, err.Error(), "not owned by RayService")
+
+		after := &gwv1.Gateway{}
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: gatewayName, Namespace: rayService.Namespace}, after))
+		assert.NotContains(t, after.Labels, utils.RayOriginatedFromCRNameLabelKey)
+	})
+
+	t.Run("fails reconciliation when a same-named Gateway belongs to a different RayService", func(t *testing.T) {
+		otherOwned := &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: rayService.Namespace, Labels: map[string]string{
+				utils.RayOriginatedFromCRNameLabelKey: "some-other-rayservice",
+				utils.RayOriginatedFromCRDLabelKey:    utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
+			}},
+		}
+		fakeClient := clientFake.NewClientBuilder().
+			WithScheme(newScheme).
+			WithRuntimeObjects(rayService, otherOwned).
+			Build()
+		reconciler := RayServiceReconciler{Client: fakeClient, Scheme: newScheme, Recorder: events.NewFakeRecorder(10)}
+
+		err := reconciler.reconcileGateway(ctx, rayService)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not owned by RayService")
+	})
+
+	t.Run("treats a same-named Gateway with only a controller owner reference as owned", func(t *testing.T) {
+		legacyGateway := &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: rayService.Namespace},
+		}
+		require.NoError(t, ctrl.SetControllerReference(rayService, legacyGateway, newScheme))
+
+		fakeClient := clientFake.NewClientBuilder().
+			WithScheme(newScheme).
+			WithRuntimeObjects(rayService, legacyGateway).
+			Build()
+		reconciler := RayServiceReconciler{Client: fakeClient, Scheme: newScheme, Recorder: events.NewFakeRecorder(10)}
+
+		require.NoError(t, reconciler.reconcileGateway(ctx, rayService))
+	})
+}
+
 func TestReconcileServeTargetCapacity(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.RayServiceIncrementalUpgrade, true)
 
@@ -2014,6 +2107,10 @@ func makeGateway(name, namespace string, isReady bool) *gwv1.Gateway {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				utils.RayOriginatedFromCRNameLabelKey: strings.TrimSuffix(name, "-gateway"),
+				utils.RayOriginatedFromCRDLabelKey:    utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
+			},
 		},
 		Status: gwv1.GatewayStatus{
 			Conditions: []metav1.Condition{
@@ -2040,6 +2137,10 @@ func makeHTTPRoute(name, namespace string, isReady bool) *gwv1.HTTPRoute {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				utils.RayOriginatedFromCRNameLabelKey: strings.TrimSuffix(name, "-httproute"),
+				utils.RayOriginatedFromCRDLabelKey:    utils.RayOriginatedFromCRDLabelValue(utils.RayServiceCRD),
+			},
 		},
 		Status: gwv1.HTTPRouteStatus{
 			RouteStatus: gwv1.RouteStatus{


### PR DESCRIPTION
## Why are these changes needed?

The RayService controller currently associates a RayService with its Gateway
and HTTPRoute purely by a deterministic name (`<name>-gateway` /
`<name>-httproute`). Because the association is name-only, a user who happens to
create a Gateway or HTTPRoute with that same name has their resource silently
adopted by the controller: it can be updated to match the RayService's desired
spec, and — after #4881 — **deleted when `spec.suspend` is set to `true`**, even
though the resource is not owned by KubeRay.

This PR makes the association ownership-aware. When KubeRay creates a Gateway or
HTTPRoute for a RayService, it now stamps the existing origin labels used
elsewhere in the codebase (`ray.io/originated-from-cr-name` and
`ray.io/originated-from-crd`). The controller then checks those labels before
touching an existing same-named resource:

- **Reconcile:** if a Gateway/HTTPRoute with the deterministic name already
  exists but is not owned by this RayService, reconciliation fails with a clear
  error and a warning event, instead of adopting or overwriting the resource.
- **Suspend:** an existing Gateway/HTTPRoute that is not owned by this RayService
  is skipped (logged) rather than deleted, so a user's same-named resource is
  never destroyed.

The default behavior for KubeRay-managed resources is unchanged — they carry the
labels and continue to be created, updated, and deleted as before.

## Related issue number

Closes #4887

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests

### Manual test instructions

The new behavior is covered by unit tests in
`ray-operator/controllers/ray/rayservice_controller_unit_test.go`
(`TestReconcileGatewayOwnership`), which verify:

1. A newly created Gateway is stamped with the `ray.io/originated-from-cr-name`
   and `ray.io/originated-from-crd` labels.
2. Reconciliation fails (and the existing resource is left untouched) when a
   same-named Gateway is not owned by KubeRay.
3. Reconciliation fails when a same-named Gateway is owned by a *different*
   RayService.

Existing Gateway/HTTPRoute reconcile and suspend tests were updated so their
fixtures carry the ownership labels, reflecting that they represent
KubeRay-managed resources.

Run the affected tests with:

```bash
cd ray-operator
go test ./controllers/ray/ -run 'TestReconcileGateway|TestReconcileGatewayOwnership|TestReconcileHTTPRoute|TestCheckIfNeedTargetCapacityUpdate'
go test ./controllers/ray/common/


## Notes on their standards
- **Checked the boxes honestly** — `tests are passing` + `Unit tests` are checked because they genuinely are; I left the two label checkboxes unchecked since this is neither a breaking change nor a docs-requiring change (behavior for KubeRay-managed resources is unchanged, and it only hardens against a misconfiguration).
- **`Closes #4887`** — KubeRay uses `Closes #`, which auto-links and auto-closes the issue on merge.
- KubeRay does **not** enforce DCO sign-off or Conventional Commit PR titles (I verified — no such workflow in `.github/`), so the `[RayService]` component-prefix style, which matches their existing merged PR titles, is the right convention.
- One reminder from the template's top comment: *"add a reviewer to the assignee section."* Once it's reassigned to you, request `kevin85421` and/or `Future-Outlier` as reviewers.

Want me to also draft the short reassignment comment to post on the issue first (surfacing gokuljs's inactivity), so you can claim it before opening the PR?