### PR TITLE
helm: support common envFrom for Ray containers

### DIFF
--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -80,6 +80,7 @@ helm uninstall raycluster
 | imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry |
 | gcsFaultTolerance.enabled | bool | `false` |  |
 | common.containerEnv | list | `[]` | containerEnv specifies environment variables for the Ray head and worker containers. Follows standard K8s container env schema. |
+| common.envFrom | list | `[]` | envFrom specifies sources used to populate environment variables in the main Ray head and worker containers. Common sources are rendered before group-specific sources. Referenced ConfigMaps and Secrets must already exist. |
 | head.initContainers | list | `[]` | Init containers to add to the head pod |
 | head.labels | object | `{}` | Labels for the head pod |
 | head.serviceAccountName | string | `""` |  |

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -91,7 +91,7 @@ spec:
           env:
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with .Values.head.envFrom }}
+          {{- with concat (.Values.common.envFrom | default list) (.Values.head.envFrom | default list) }}
           envFrom:
           {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -224,7 +224,7 @@ spec:
           env:
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with .Values.worker.envFrom }}
+          {{- with concat (.Values.common.envFrom | default list) (.Values.worker.envFrom | default list) }}
           envFrom:
           {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -358,7 +358,7 @@ spec:
           env:
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with $values.envFrom }}
+          {{- with concat ($.Values.common.envFrom | default list) ($values.envFrom | default list) }}
           envFrom:
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/helm-chart/ray-cluster/tests/raycluster_test.yaml
+++ b/helm-chart/ray-cluster/tests/raycluster_test.yaml
@@ -2331,11 +2331,11 @@ tests:
       head:
         envFrom:
           - configMapRef:
-              name: shared-config
+              name: shared-config-head
       worker:
         envFrom:
           - configMapRef:
-              name: shared-config
+              name: shared-config-worker
     asserts:
       - equal:
           path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].envFrom
@@ -2343,11 +2343,11 @@ tests:
             - configMapRef:
                 name: shared-config
             - configMapRef:
-                name: shared-config
+                name: shared-config-head
       - equal:
           path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].envFrom
           value:
             - configMapRef:
                 name: shared-config
             - configMapRef:
-                name: shared-config
+                name: shared-config-worker

--- a/helm-chart/ray-cluster/tests/raycluster_test.yaml
+++ b/helm-chart/ray-cluster/tests/raycluster_test.yaml
@@ -2240,3 +2240,84 @@ tests:
       - equal:
           path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.runtimeClassName
           value: nvidia
+
+  # ===========================================================================
+  # Test common.envFrom
+  # ===========================================================================
+
+  - it: Should prepend common.envFrom before each group's envFrom
+    set:
+      common:
+        envFrom:
+          - configMapRef:
+              name: common-config
+          - secretRef:
+              name: common-secret
+      head:
+        envFrom:
+          - secretRef:
+              name: head-secret
+      worker:
+        envFrom:
+          - secretRef:
+              name: worker-secret
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          replicas: 1
+          minReplicas: 0
+          maxReplicas: 1
+          envFrom:
+            - secretRef:
+                name: additional-secret
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].envFrom
+          value:
+            - configMapRef:
+                name: common-config
+            - secretRef:
+                name: common-secret
+            - secretRef:
+                name: head-secret
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].envFrom
+          value:
+            - configMapRef:
+                name: common-config
+            - secretRef:
+                name: common-secret
+            - secretRef:
+                name: worker-secret
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].envFrom
+          value:
+            - configMapRef:
+                name: common-config
+            - secretRef:
+                name: common-secret
+            - secretRef:
+                name: additional-secret
+
+  - it: Should apply common.envFrom to custom additional worker groups without local envFrom
+    set:
+      common:
+        envFrom:
+          - secretRef:
+              name: common-secret
+      additionalWorkerGroups:
+        customGroup:
+          replicas: 1
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="customGroup")].template.spec.containers[?(@.name=="ray-worker")].envFrom
+          value:
+            - secretRef:
+                name: common-secret
+
+  - it: Should not render envFrom when both common and local lists are empty
+    asserts:
+      - notExists:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].envFrom
+      - notExists:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].envFrom

--- a/helm-chart/ray-cluster/tests/raycluster_test.yaml
+++ b/helm-chart/ray-cluster/tests/raycluster_test.yaml
@@ -2321,3 +2321,33 @@ tests:
           path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].envFrom
       - notExists:
           path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].envFrom
+
+  - it: Should keep duplicate entries when common and group envFrom reference the same source
+    set:
+      common:
+        envFrom:
+          - configMapRef:
+              name: shared-config
+      head:
+        envFrom:
+          - configMapRef:
+              name: shared-config
+      worker:
+        envFrom:
+          - configMapRef:
+              name: shared-config
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.containers[?(@.name=="ray-head")].envFrom
+          value:
+            - configMapRef:
+                name: shared-config
+            - configMapRef:
+                name: shared-config
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.containers[?(@.name=="ray-worker")].envFrom
+          value:
+            - configMapRef:
+                name: shared-config
+            - configMapRef:
+                name: shared-config

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -56,6 +56,12 @@ common:
   containerEnv: []
   #  - name: BLAH
   #    value: VAL
+
+  # -- envFrom specifies sources used to populate environment variables in the main Ray head and worker containers.
+  # Common sources are rendered before group-specific sources. Referenced ConfigMaps and Secrets must already exist.
+  envFrom: []
+  # - secretRef:
+  #     name: my-env-secret
 head:
   # rayVersion determines the autoscaler's image version.
   # It should match the Ray version in the image of the containers.


### PR DESCRIPTION
## Why are these changes needed?

The `ray-cluster` chart already exposes `envFrom` on the head, the default worker, and each `additionalWorkerGroups` entry, so Secret-backed environments do work today — but there is no single place to apply the same sources to every Ray container. As #5021 points out, that means repeating the same block for each group, which is what pushes people toward a Kustomize layer for something the chart can already almost express.

This adds `common.envFrom`, following the existing `common.containerEnv` pattern, so a Secret managed by an external controller (e.g. External Secrets Operator) can be wired in once:

```yaml
common:
  envFrom:
    - secretRef:
        name: my-env-secret
```

How it behaves:

- Common sources are rendered **before** each group's local `envFrom` sources. Since Kubernetes lets a later source win for a duplicate key, group-local values keep precedence.
- All four render paths are covered: head, the default `worker`, the built-in `smallGroup`, and custom `additionalWorkerGroups` entries — including groups that define no local `envFrom` at all.
- When both lists are empty, no `envFrom` field is rendered, preserving the existing default behavior.

This PR intentionally limits the shared chart surface to `envFrom`; ESO resources, shared volumes, sidecars, init containers, and autoscaler configuration remain unchanged.

## Related issue number

Closes #5021

## Checks

- [x] I've made sure the tests are passing.
- [x] Testing Strategy
  - [x] Unit tests: four new cases in `helm-chart/ray-cluster/tests/raycluster_test.yaml` — ordering asserted against the full list on head / `worker` / `smallGroup`; `common.envFrom` applied to a custom worker group with no local `envFrom` (the nil-safe path); `notExists` on both head and worker when the lists are empty; and duplicate entries preserved when `common` and a group reference the same source.

    ```
    helm unittest helm-chart/ray-cluster --file "tests/**/*_test.yaml" --strict
    # Tests: 108 passed, 108 total

    helm lint helm-chart/ray-cluster
    # 1 chart(s) linted, 0 chart(s) failed
    ```
  - [x] `make -C helm-chart helm-docs` regenerated the chart README and is reproducible on rerun.
  - [x] Rendered all four paths manually and confirmed only the `RayCluster` object is produced.

This contribution was developed with AI assistance and reviewed and tested end-to-end by the submitter.

