### PR TITLE
[Bug] Gracefully handle SIGTERM so worker pods don't terminate with status Error

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -868,7 +868,12 @@ func BuildPod(ctx context.Context, podTemplateSpec corev1.PodTemplateSpec, rayNo
 
 	// TODO (kevin85421): Consider removing the check for the "ray start" string in the future.
 	if !isOverwriteRayContainerCmd && !strings.Contains(cmd, "ray start") {
-		generatedCmd := fmt.Sprintf("%s; %s", ulimitCmd, rayStartCmd)
+		// Wrap the blocking `ray start` command so that a SIGTERM sent by Kubernetes on Pod
+		// deletion (e.g. autoscaler scale-down or `kubectl delete pod`) is forwarded to the
+		// Ray process and the container exits with status 0 instead of 143. Otherwise the
+		// graceful shutdown is misreported as an `Error` container status.
+		// See https://github.com/ray-project/kuberay/issues/3442.
+		generatedCmd := fmt.Sprintf("%s; %s", ulimitCmd, wrapCommandForGracefulTermination(rayStartCmd))
 		log.Info("BuildPod", "rayNodeType", rayNodeType, "generatedCmd", generatedCmd)
 		// replacing the old command
 		pod.Spec.Containers[utils.RayContainerIndex].Command = utils.GetContainerCommand([]string{})
@@ -1271,6 +1276,10 @@ func generateRayStartCommand(ctx context.Context, nodeType rayv1.RayNodeType, ra
 	}
 	log.Info("generateRayStartCommand", "rayStartCmd", rayStartCmd)
 	return rayStartCmd
+}
+
+func wrapCommandForGracefulTermination(blockingCmd string) string {
+	return fmt.Sprintf("%s & ray_start_pid=$!; trap 'kill -TERM $ray_start_pid 2>/dev/null; wait $ray_start_pid; exit 0' TERM; wait $ray_start_pid", blockingCmd)
 }
 
 func addWellKnownAcceleratorResources(rayStartParams map[string]string, resourceLimits corev1.ResourceList) error {

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -796,7 +796,7 @@ func TestBuildPod(t *testing.T) {
 	workerRayStartCommandEnv := getEnvVar(rayContainer, utils.KUBERAY_GEN_RAY_START_CMD)
 	assert.Contains(t, workerRayStartCommandEnv.Value, "ray start")
 
-	expectedCommandArg := splitAndSort("ulimit -n ${RAY_START_ULIMIT_OPEN_FILES:-65536}; ray start --block --dashboard-agent-listen-port=52365 --memory=1073741824 --num-cpus=1 --num-gpus=3 --address=raycluster-sample-head-svc.default.svc.cluster.local:6379 --port=6379 --metrics-export-port=8080")
+	expectedCommandArg := splitAndSort("ulimit -n ${RAY_START_ULIMIT_OPEN_FILES:-65536}; ray start --block --dashboard-agent-listen-port=52365 --memory=1073741824 --num-cpus=1 --num-gpus=3 --address=raycluster-sample-head-svc.default.svc.cluster.local:6379 --port=6379 --metrics-export-port=8080 & ray_start_pid=$!; trap 'kill -TERM $ray_start_pid 2>/dev/null; wait $ray_start_pid; exit 0' TERM; wait $ray_start_pid")
 	actualCommandArg := splitAndSort(pod.Spec.Containers[0].Args[0])
 	assert.Equal(t, expectedCommandArg, actualCommandArg)
 
@@ -806,6 +806,58 @@ func TestBuildPod(t *testing.T) {
 
 	// Test default environment variables injection in ray pods
 	checkContainerEnv(t, rayContainer, "TEST_DEFAULT_ENV_NAME", "TEST_ENV_VALUE")
+}
+
+func TestBuildPod_GracefulTerminationWrapper(t *testing.T) {
+	// Regression test for https://github.com/ray-project/kuberay/issues/3442.
+	// The generated `ray start` command must be wrapped so that a SIGTERM from Kubernetes
+	// on Pod deletion (autoscaler scale-down or `kubectl delete pod`) is forwarded to the
+	// Ray process and the container exits 0 instead of 143 (which shows up as `Error`).
+	ctx := context.Background()
+	cluster := instance.DeepCopy()
+
+	assertWrapped := func(t *testing.T, args string) {
+		t.Helper()
+		// The blocking `ray start` runs in the background and its PID is captured.
+		assert.Contains(t, args, "ray start")
+		assert.Contains(t, args, "& ray_start_pid=$!")
+		// A TERM trap forwards the signal to the Ray process and forces a clean exit.
+		assert.Contains(t, args, "trap 'kill -TERM $ray_start_pid 2>/dev/null; wait $ray_start_pid; exit 0' TERM")
+		// bash blocks on the Ray process; its natural (possibly non-zero) exit is preserved
+		// when the trap does not fire, so genuine failures still surface as `Error`.
+		assert.Contains(t, args, "wait $ray_start_pid")
+	}
+
+	// Head pod.
+	headName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
+	headTemplate := DefaultHeadPodTemplate(ctx, *cluster, cluster.Spec.HeadGroupSpec, headName, "6379")
+	headPod := BuildPod(ctx, headTemplate, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", false, utils.GetCRDType(""), "", nil, "")
+	require.Len(t, headPod.Spec.Containers[utils.RayContainerIndex].Args, 1)
+	assertWrapped(t, headPod.Spec.Containers[utils.RayContainerIndex].Args[0])
+
+	// Worker pod.
+	worker := cluster.Spec.WorkerGroupSpecs[0]
+	workerName := cluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + worker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
+	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, *cluster, cluster.Namespace)
+	workerTemplate := DefaultWorkerPodTemplate(ctx, *cluster, worker, workerName, fqdnRayIP, "6379", "", 0, 0)
+	workerPod := BuildPod(ctx, workerTemplate, rayv1.WorkerNode, worker.RayStartParams, "6379", false, utils.GetCRDType(""), fqdnRayIP, nil, "")
+	require.Len(t, workerPod.Spec.Containers[utils.RayContainerIndex].Args, 1)
+	assertWrapped(t, workerPod.Spec.Containers[utils.RayContainerIndex].Args[0])
+
+	// When the user overrides the container command, KubeRay must not inject the wrapper.
+	overrideCluster := instance.DeepCopy()
+	overrideWorker := overrideCluster.Spec.WorkerGroupSpecs[0]
+	if overrideWorker.Template.ObjectMeta.Annotations == nil {
+		overrideWorker.Template.ObjectMeta.Annotations = map[string]string{}
+	}
+	overrideWorker.Template.ObjectMeta.Annotations[utils.RayOverwriteContainerCmdAnnotationKey] = "true"
+	overrideWorker.Template.Spec.Containers[utils.RayContainerIndex].Command = []string{"echo"}
+	overrideWorker.Template.Spec.Containers[utils.RayContainerIndex].Args = []string{"hello"}
+	overrideName := overrideCluster.Name + utils.DashSymbol + string(rayv1.WorkerNode) + utils.DashSymbol + overrideWorker.GroupName + utils.DashSymbol + utils.FormatInt32(0)
+	overrideTemplate := DefaultWorkerPodTemplate(ctx, *overrideCluster, overrideWorker, overrideName, fqdnRayIP, "6379", "", 0, 0)
+	overridePod := BuildPod(ctx, overrideTemplate, rayv1.WorkerNode, overrideWorker.RayStartParams, "6379", false, utils.GetCRDType(""), fqdnRayIP, nil, "")
+	assert.NotContains(t, strings.Join(overridePod.Spec.Containers[utils.RayContainerIndex].Args, " "), "ray_start_pid",
+		"wrapper must not be injected when the user overrides the container command")
 }
 
 func TestBuildPod_WithUlimitOverride(t *testing.T) {
@@ -823,7 +875,7 @@ func TestBuildPod_WithUlimitOverride(t *testing.T) {
 	pod := BuildPod(ctx, podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", false, utils.GetCRDType(""), "", nil, "")
 
 	// The generated command arg still uses ${RAY_START_ULIMIT_OPEN_FILES:-65536} because the shell resolves it at runtime.
-	expectedCommandArg := splitAndSort("ulimit -n ${RAY_START_ULIMIT_OPEN_FILES:-65536}; ray start --head --block --dashboard-agent-listen-port=52365 --memory=1073741824 --num-cpus=1 --metrics-export-port=8080 --dashboard-host=0.0.0.0")
+	expectedCommandArg := splitAndSort("ulimit -n ${RAY_START_ULIMIT_OPEN_FILES:-65536}; ray start --head --block --dashboard-agent-listen-port=52365 --memory=1073741824 --num-cpus=1 --metrics-export-port=8080 --dashboard-host=0.0.0.0 & ray_start_pid=$!; trap 'kill -TERM $ray_start_pid 2>/dev/null; wait $ray_start_pid; exit 0' TERM; wait $ray_start_pid")
 	actualCommandArg := splitAndSort(pod.Spec.Containers[0].Args[0])
 	assert.Equal(t, expectedCommandArg, actualCommandArg)
 
@@ -1085,7 +1137,7 @@ func TestBuildPod_WithNoCPULimits(t *testing.T) {
 	podName := strings.ToLower(cluster.Name + utils.DashSymbol + string(rayv1.HeadNode) + utils.DashSymbol + utils.FormatInt32(0))
 	podTemplateSpec := DefaultHeadPodTemplate(ctx, *cluster, cluster.Spec.HeadGroupSpec, podName, "6379")
 	pod := BuildPod(ctx, podTemplateSpec, rayv1.HeadNode, cluster.Spec.HeadGroupSpec.RayStartParams, "6379", false, utils.GetCRDType(""), "", nil, "")
-	expectedCommandArg := splitAndSort("ulimit -n ${RAY_START_ULIMIT_OPEN_FILES:-65536}; ray start --head --block --dashboard-agent-listen-port=52365 --memory=1073741824 --num-cpus=2 --metrics-export-port=8080 --dashboard-host=0.0.0.0")
+	expectedCommandArg := splitAndSort("ulimit -n ${RAY_START_ULIMIT_OPEN_FILES:-65536}; ray start --head --block --dashboard-agent-listen-port=52365 --memory=1073741824 --num-cpus=2 --metrics-export-port=8080 --dashboard-host=0.0.0.0 & ray_start_pid=$!; trap 'kill -TERM $ray_start_pid 2>/dev/null; wait $ray_start_pid; exit 0' TERM; wait $ray_start_pid")
 	actualCommandArg := splitAndSort(pod.Spec.Containers[0].Args[0])
 	assert.Equal(t, expectedCommandArg, actualCommandArg)
 
@@ -1095,7 +1147,7 @@ func TestBuildPod_WithNoCPULimits(t *testing.T) {
 	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, *cluster, cluster.Namespace)
 	podTemplateSpec = DefaultWorkerPodTemplate(ctx, *cluster, worker, podName, fqdnRayIP, "6379", "", 0, 0)
 	pod = BuildPod(ctx, podTemplateSpec, rayv1.WorkerNode, worker.RayStartParams, "6379", false, utils.GetCRDType(""), fqdnRayIP, nil, "")
-	expectedCommandArg = splitAndSort("ulimit -n ${RAY_START_ULIMIT_OPEN_FILES:-65536}; ray start --block --dashboard-agent-listen-port=52365 --memory=1073741824 --num-cpus=2 --num-gpus=3 --address=raycluster-sample-head-svc.default.svc.cluster.local:6379 --port=6379 --metrics-export-port=8080")
+	expectedCommandArg = splitAndSort("ulimit -n ${RAY_START_ULIMIT_OPEN_FILES:-65536}; ray start --block --dashboard-agent-listen-port=52365 --memory=1073741824 --num-cpus=2 --num-gpus=3 --address=raycluster-sample-head-svc.default.svc.cluster.local:6379 --port=6379 --metrics-export-port=8080 & ray_start_pid=$!; trap 'kill -TERM $ray_start_pid 2>/dev/null; wait $ray_start_pid; exit 0' TERM; wait $ray_start_pid")
 	actualCommandArg = splitAndSort(pod.Spec.Containers[0].Args[0])
 	assert.Equal(t, expectedCommandArg, actualCommandArg)
 }


### PR DESCRIPTION
## Why are these changes needed?

Fixes #3442.

When the Ray autoscaler scales down a worker (or a pod is deleted via `kubectl delete pod`), Kubernetes sends SIGTERM to PID 1 of the Ray container, which is the `bash` process running the generated `ray start ... --block` command.

Today neither `bash` nor `ray start --block` installs a SIGTERM handler, so the process dies with exit code 143 (128 + SIGTERM). Kubernetes derives a terminated container's `reason` from its exit code and reports any non-zero exit as `Error`. The result is that an intentional, graceful shutdown is misreported as `Error`, which is misleading for monitoring and alerting.

Example scale-down from the issue:

```
raycluster-kuberay-workergroup-worker-lpnx6   1/1     Running       0   21s
raycluster-kuberay-workergroup-worker-lpnx6   1/1     Terminating   0   4m11s
raycluster-kuberay-workergroup-worker-lpnx6   0/1     Error         0   4m12s
```

## What this change does

`BuildPod` now wraps the generated `ray start` command so the container's main process (`bash`) forwards SIGTERM to the Ray process and exits with status 0 on a graceful termination:

```
<ray start ... --block> & ray_start_pid=$!; trap 'kill -TERM $ray_start_pid 2>/dev/null; wait $ray_start_pid; exit 0' TERM; wait $ray_start_pid
```

- On pod deletion, `bash` receives SIGTERM, the trap forwards it to the Ray process, waits for it to stop, and exits 0. The graceful teardown now reads as a clean stop rather than a crash.
- Genuine Ray failures are NOT masked. If the Ray process exits non-zero on its own, the initial `wait $ray_start_pid` returns that exit code (which becomes bash's exit code) before the TERM trap can ever fire, so real failures still surface as `Error`.
- The wrapper is only applied to the KubeRay-generated `ray start` command. It is skipped when the user overrides the container command (via the overwrite-command annotation or by supplying their own `ray start`).

Note: this applies to both head and worker Ray containers, since the head container exhibits the same behavior on cluster teardown. If maintainers prefer to scope this to workers only, it is a one-line gate on `rayNodeType`.

## Related issue number

Fixes #3442

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

Added `TestBuildPod_GracefulTerminationWrapper` which verifies the wrapper is injected on both head and worker pods and is not injected when the user overrides the container command. Updated the existing exact-match argument assertions in `TestBuildPod` and `TestBuildPod_WithNoCPULimits` to account for the wrapped command.

Verified locally:

```
go build ./...
go vet ./controllers/ray/common/...
go test ./controllers/ray/common/
```
