### PR TITLE
test: replace fixed wait in RayCluster scale-down test

### DIFF
--- a/ray-operator/test/e2e/raycluster_test.go
+++ b/ray-operator/test/e2e/raycluster_test.go
@@ -184,21 +184,18 @@ func TestRayClusterScalingDown(t *testing.T) {
 	rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
 	g.Expect(err).NotTo(HaveOccurred(), "Failed to scale down RayCluster")
 
-	time.Sleep(5 * time.Second)
+	// Wait until the scale-down marks exactly one worker pod for deletion.
+	g.Eventually(WorkerPods(test, rayCluster), TestTimeoutShort).Should(
+		ConsistOf(
+			HaveField("DeletionTimestamp", BeNil()),
+			HaveField("DeletionTimestamp", Not(BeNil())),
+		),
+		"Should have only one worker pod having deletionTimestamp",
+	)
 
 	headPod, err = GetHeadPod(test, rayCluster)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(headPod.DeletionTimestamp).To(BeNil(), "Head pod should not have deletionTimestamp")
-
-	workerPods, err = GetWorkerPods(test, rayCluster)
-	g.Expect(err).NotTo(HaveOccurred())
-	deletingCount := 0
-	for _, pod := range workerPods {
-		if pod.DeletionTimestamp != nil {
-			deletingCount++
-		}
-	}
-	g.Expect(deletingCount).To(Equal(1), "Should have only one worker pod having deletionTimestamp")
 
 	LogWithTimestamp(test.T(), "Removing finalizers from pods")
 	for _, pod := range allPods {


### PR DESCRIPTION
## Why are these changes needed?

`TestRayClusterScalingDown` currently waits for a fixed five seconds before checking that exactly one worker Pod has been marked for deletion.

This change replaces the fixed sleep with the existing Gomega `Eventually` polling mechanism and waits directly for the same worker deletion condition. The redundant second worker Pod query and manual count assertion are removed.

This only changes E2E test synchronization. Production behavior is unchanged.

## Related issue number

N/A — small test synchronization cleanup.

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

### Manual test instructions

Ran the targeted E2E test locally on kind:

```bash
KUBECONFIG=~/kubeconfig-kind \
KUBERAY_TEST_TIMEOUT_SHORT=1m \
go test -v -count=1 -timeout 30m \
-run '^TestRayClusterScalingDown$' ./test/e2e/
```

Results:

- 20/20 development validation runs passed
- 3/3 final smoke-test runs passed