### PR TITLE
[CI] Deflaky rayjob_test.go e2e tests

### DIFF
--- a/ray-operator/test/e2erayjob/rayjob_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_test.go
@@ -283,6 +283,9 @@ env_vars:
 			WithSpec(rayv1ac.RayJobSpec().
 				WithRayClusterSpec(NewRayClusterSpec()).
 				WithEntrypoint("python -c \"import time; time.sleep(60)\"").
+				// BackoffLimit=0 prevents the submitter Job from retrying after the head Pod is deleted.
+				// Otherwise it may resubmit to the recreated (non GCS FT) GCS and non-deterministically succeed.
+				WithSubmitterConfig(rayv1ac.SubmitterConfig().WithBackoffLimit(0)).
 				WithShutdownAfterJobFinishes(true))
 
 		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)

--- a/ray-operator/test/e2erayjob/rayjob_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_test.go
@@ -284,7 +284,7 @@ env_vars:
 				WithRayClusterSpec(NewRayClusterSpec()).
 				WithEntrypoint("python -c \"import time; time.sleep(60)\"").
 				// BackoffLimit=0 prevents the submitter Job from retrying after the head Pod is deleted.
-				// Otherwise it may resubmit to the recreated (non GCS FT) GCS and non-deterministically succeed.
+				// Otherwise it may resubmit to the recreated (non GCS FT) head pod and non-deterministically succeed.
 				WithSubmitterConfig(rayv1ac.SubmitterConfig().WithBackoffLimit(0)).
 				WithShutdownAfterJobFinishes(true))
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We recently observed a flaky CI test for the scenario where the `RayJob controller recreates the head Pod if it is deleted while the job is running`. The test expects the RayJob to transition to `JobDeploymentStatus=Failed` in `K8sJobMode`, but it intermittently completes successfully instead.

https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/15895/canvas?jid=019f7186-a9f3-45ab-a928-9832a46f8ba4&tab=artifacts

https://buildkite.com/ray-project/ray-ecosystem-ci-kuberay-ci/builds/15895/canvas?jid=019f7186-a9f3-45ab-a928-9832a46f8ba4&tab=artifacts

```
=== RUN   TestRayJob/RayJob_controller_recreates_the_head_Pod_if_it_is_deleted_while_the_job_is_running
=== NAME  TestRayJob
    rayjob_test.go:290: [2026-07-17T20:06:14Z] Created RayJob test-ns-2kqt5/delete-head-after-submit successfully
    rayjob_test.go:293: [2026-07-17T20:06:14Z] Waiting for RayJob test-ns-2kqt5/delete-head-after-submit to be 'Running'
    rayjob_test.go:306: [2026-07-17T20:06:55Z] Deleting head Pod test-ns-2kqt5/delete-head-after-submit-sxrtv-head-drxt7 for RayCluster delete-head-after-submit-sxrtv
    rayjob_test.go:315: 
        Timed out after 300.000s.
        Expected
            <v1.JobDeploymentStatus>: Complete
        to equal
            <v1.JobDeploymentStatus>: Failed
```

This PR sets BackoffLimit=0 so the submitter Job runs exactly once, making the test deterministic and preventing it from succeeding due to a retry after the head Pod is deleted.

### Details

- Ray's dashboard has no graceful shutdown on SIGTERM: `os._exit()` fires immediately, no draining of in-flight requests ([dashboard.py#L302-L313](https://github.com/ray-project/ray/blob/89751b697a3bba1bf63559d75c91f09d08189c26/python/ray/dashboard/dashboard.py#L302-L313)):
    ```python
    def sigterm_handler():
        logger.warning("Exiting with SIGTERM immediately...")
        os._exit(signal.SIGTERM)
- If the submitter's request finishes (full response written) before `os._exit()` fires, the CLI gets a normal reply: `Status for job ...: RUNNING`.
- If the request has been sent and accepted, but the response isn't written yet when `os._exit()` fires (The head Pod is deleted too early), exit non-zero → `RemoteDisconnected: Remote end closed connection without response`.
- The submitter Job's BackoffLimit defaults to 2, so k8s job retries the failed submitter Pod.

https://github.com/ray-project/kuberay/blob/942ed40aaa5562ce54339a9b4c1519e43798e6ab/ray-operator/controllers/ray/rayjob_controller.go#L715-L718

- Without GCS fault tolerance, the recreated head Pod starts a brand-new GCS. So the retried submitter's `ray job status <jobId>` finds nothing, treats the job as never submitted, and runs ray job submit again. And then a second, independent run that completes normally and drives `JobDeploymentStatus` to Complete instead of the Failed the test expects.

```
❯ k get pod -n test-ns-4lljf
NAME                                                      READY   STATUS    RESTARTS      AGE
delete-head-after-submit-8nzv8-head-glv8l                 1/1     Running   0             51s
delete-head-after-submit-8nzv8-small-group-worker-xpr44   0/1     Running   1 (11s ago)   2m16s
delete-head-after-submit-chqwf                            0/1     Error     0             71s
delete-head-after-submit-mfmdf                            1/1     Running   0             48s

❯ k get rayjob -n test-ns-4lljf
NAME                       JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME  START TIME             END TIME   AGE
delete-head-after-submit   RUNNING      Running             delete-head-after-submit-8nzv8  2026-07-28T11:32:49Z              2m32s



❯ k get pod -n test-ns-4lljf
NAME                             READY   STATUS      RESTARTS   AGE
delete-head-after-submit-chqwf   0/1     Error       0      2m26s
delete-head-after-submit-mfmdf   0/1     Completed   0      2m3s
❯ k get rayjob -n test-ns-4lljf
NAME                       JOB STATUS   DEPLOYMENT STATUS  RAY CLUSTER NAME                 START TIMEEND TIME               AGE
delete-head-after-submit   SUCCEEDED    Complete  delete-head-after-submit-8nzv8   2026-07-28T11:32:49Z2026-07-28T11:36:06Z   3m38s
```

https://github.com/ray-project/kuberay/blob/942ed40aaa5562ce54339a9b4c1519e43798e6ab/ray-operator/controllers/ray/common/job.go#L119-L130


submitter pod logs:

- Successful: 
```
❯ k logs delete-head-after-submit-rzkn9 -n  test-ns-6q6hm
2026-07-28 04:40:33,672 INFO cli.py:41 -- Job submission server address: http://delete-head-after-submit-c4l45-head-svc.test-ns-6q6hm.svc.cluster.local:8265
2026-07-28 04:40:35,358 SUCC cli.py:65 -- -----------------------------------------------------------
2026-07-28 04:40:35,358 SUCC cli.py:66 -- Job 'delete-head-after-submit-hm7cw' submitted successfully
2026-07-28 04:40:35,358 SUCC cli.py:67 -- -----------------------------------------------------------
2026-07-28 04:40:35,358 INFO cli.py:326 -- Next steps
2026-07-28 04:40:35,358 INFO cli.py:327 -- Query the logs of the job:
2026-07-28 04:40:35,358 INFO cli.py:329 -- ray job logs delete-head-after-submit-hm7cw
2026-07-28 04:40:35,358 INFO cli.py:331 -- Query the status of the job:
2026-07-28 04:40:35,358 INFO cli.py:333 -- ray job status delete-head-after-submit-hm7cw
2026-07-28 04:40:35,358 INFO cli.py:335 -- Request the job to be stopped:
2026-07-28 04:40:35,358 INFO cli.py:337 -- ray job stop delete-head-after-submit-hm7cw
2026-07-28 04:40:37,673 INFO cli.py:41 -- Job submission server address: http://delete-head-after-submit-c4l45-head-svc.test-ns-6q6hm.svc.cluster.local:8265
2026-07-28 04:40:40,763 INFO cli.py:91 -- Status for job 'delete-head-after-submit-hm7cw': RUNNING
2026-07-28 04:40:40,763 INFO cli.py:93 -- Status message: Job is currently running.
```

- Failed:
```
❯ k logs delete-head-after-submit-drr7k -n test-ns-gws7j
2026-07-28 03:30:24,677 INFO cli.py:41 -- Job submission server address: http://delete-head-after-submit-bdsd8-head-svc.test-ns-gws7j.svc.cluster.local:8265
2026-07-28 03:30:26,190 SUCC cli.py:65 -- -----------------------------------------------------------
2026-07-28 03:30:26,190 SUCC cli.py:66 -- Job 'delete-head-after-submit-94z24' submitted successfully
2026-07-28 03:30:26,190 SUCC cli.py:67 -- -----------------------------------------------------------
2026-07-28 03:30:26,190 INFO cli.py:326 -- Next steps
2026-07-28 03:30:26,190 INFO cli.py:327 -- Query the logs of the job:
2026-07-28 03:30:26,190 INFO cli.py:329 -- ray job logs delete-head-after-submit-94z24
2026-07-28 03:30:26,190 INFO cli.py:331 -- Query the status of the job:
2026-07-28 03:30:26,190 INFO cli.py:333 -- ray job status delete-head-after-submit-94z24
2026-07-28 03:30:26,190 INFO cli.py:335 -- Request the job to be stopped:
2026-07-28 03:30:26,190 INFO cli.py:337 -- ray job stop delete-head-after-submit-94z24
2026-07-28 03:30:28,463 INFO cli.py:41 -- Job submission server address: http://delete-head-after-submit-bdsd8-head-svc.test-ns-gws7j.svc.cluster.local:8265
Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.10/site-packages/urllib3/connectionpool.py", line 715, in urlopen
    httplib_response = self._make_request(
  File "/home/ray/anaconda3/lib/python3.10/site-packages/urllib3/connectionpool.py", line 467, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/home/ray/anaconda3/lib/python3.10/site-packages/urllib3/connectionpool.py", line 462, in _make_request
    httplib_response = conn.getresponse()
  File "/home/ray/anaconda3/lib/python3.10/http/client.py", line 1395, in getresponse
    response.begin()
  File "/home/ray/anaconda3/lib/python3.10/http/client.py", line 323, in begin
    version, status, reason = self._read_status()
  File "/home/ray/anaconda3/lib/python3.10/http/client.py", line 292, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
http.client.RemoteDisconnected: Remote end closed connection without response

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.10/site-packages/requests/adapters.py", line 644, in send
    resp = conn.urlopen(
  File "/home/ray/anaconda3/lib/python3.10/site-packages/urllib3/connectionpool.py", line 801, in urlopen
    retries = retries.increment(
  File "/home/ray/anaconda3/lib/python3.10/site-packages/urllib3/util/retry.py", line 552, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/urllib3/packages/six.py", line 769, in reraise
    raise value.with_traceback(tb)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/urllib3/connectionpool.py", line 715, in urlopen
    httplib_response = self._make_request(
  File "/home/ray/anaconda3/lib/python3.10/site-packages/urllib3/connectionpool.py", line 467, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/home/ray/anaconda3/lib/python3.10/site-packages/urllib3/connectionpool.py", line 462, in _make_request
    httplib_response = conn.getresponse()
  File "/home/ray/anaconda3/lib/python3.10/http/client.py", line 1395, in getresponse
    response.begin()
  File "/home/ray/anaconda3/lib/python3.10/http/client.py", line 323, in begin
    version, status, reason = self._read_status()
  File "/home/ray/anaconda3/lib/python3.10/http/client.py", line 292, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
urllib3.exceptions.ProtocolError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ray/anaconda3/bin/ray", line 8, in <module>
    sys.exit(main())
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/scripts/scripts.py", line 2892, in main
    return cli()
  File "/home/ray/anaconda3/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ray/anaconda3/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ray/anaconda3/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/job/cli_utils.py", line 54, in wrapper
    return func(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/autoscaler/_private/cli_logger.py", line 823, in wrapper
    return f(*args, **kwargs)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/job/cli.py", line 525, in logs
    get_or_create_event_loop().run_until_complete(_tail_logs(client, job_id))
  File "/home/ray/anaconda3/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/job/cli.py", line 101, in _tail_logs
    return _log_job_status(client, job_id)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/job/cli.py", line 80, in _log_job_status
    info = client.get_job_info(job_id)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/job/sdk.py", line 369, in get_job_info
    r = self._do_request("GET", f"/api/jobs/{job_id}")
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/dashboard_sdk.py", line 319, in _do_request
    response = requests.request(
  File "/home/ray/anaconda3/lib/python3.10/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/home/ray/anaconda3/lib/python3.10/site-packages/requests/adapters.py", line 659, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->

### Manual test instructions

<!--
  Provide step-by-step instructions so reviewers can verify your changes.
  Include any relevant screenshots or logs demonstrating the behavior.
-->
