### PR TITLE
[Test] Add NetworkPolicy e2e coverage for RayJob and RayService

### DIFF
--- a/.buildkite/values-kuberay-operator-override.yaml
+++ b/.buildkite/values-kuberay-operator-override.yaml
@@ -24,3 +24,5 @@ featureGates:
     enabled: true
   - name: RayClusterMTLS
     enabled: true
+  - name: RayClusterNetworkPolicy
+    enabled: true

--- a/ray-operator/config/overlays/test-overrides/deployment-override.yaml
+++ b/ray-operator/config/overlays/test-overrides/deployment-override.yaml
@@ -9,4 +9,4 @@ spec:
       containers:
       - name: kuberay-operator
         args:
-        - --feature-gates=RayClusterStatusConditions=true,RayJobDeletionPolicy=true,RayMultiHostIndexing=true,RayCronJob=true,RayServiceIncrementalUpgrade=true,SidecarSubmitterRestart=true,GCSFaultToleranceEmbeddedStorage=true,RayClusterMTLS=true
+        - --feature-gates=RayClusterStatusConditions=true,RayJobDeletionPolicy=true,RayMultiHostIndexing=true,RayCronJob=true,RayServiceIncrementalUpgrade=true,SidecarSubmitterRestart=true,GCSFaultToleranceEmbeddedStorage=true,RayClusterMTLS=true,RayClusterNetworkPolicy=true

--- a/ray-operator/test/e2erayjob/rayjob_network_policy_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_network_policy_test.go
@@ -1,0 +1,163 @@
+package e2erayjob
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
+	. "github.com/ray-project/kuberay/ray-operator/test/support"
+)
+
+// RayJob without clusterSelector, under NetworkPolicy DenyAll. The operator owns
+// the RayCluster so it adds the submitter ingress rule itself; we add DNS egress
+// and operator dashboard ingress (the reconciler polls job status directly).
+// Kindnet enforces NetworkPolicy on k8s >= 1.32 (CI runs on 1.35), so a wrong
+// policy means the pods can't reach each other and the job never finishes.
+func TestRayJobWithNetworkPolicy(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+
+	namespace := test.NewTestNamespace()
+
+	// Job scripts.
+	jobsAC := NewConfigMap(namespace.Name, Files(test, "counter.py"))
+	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), jobsAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
+
+	// DenyAll: intra-cluster and submitter ingress are handled by the operator.
+	// We add DNS egress, plus operator ingress on the dashboard port because the
+	// RayJob reconciler polls job status (GetJobInfo) by dialing the head
+	// dashboard directly, not through the submitter.
+	networkPolicy := rayv1ac.NetworkPolicyConfig().
+		WithMode(rayv1.NetworkPolicyDenyAll).
+		WithHead(rayv1ac.NetworkPolicyRules().
+			WithIngressRules(OperatorIngressRule(utils.DefaultDashboardPort)).
+			WithEgressRules(DNSEgressRule())).
+		WithWorker(rayv1ac.NetworkPolicyRules().WithEgressRules(DNSEgressRule()))
+
+	rayJobAC := rayv1ac.RayJob("counter", namespace.Name).
+		WithSpec(rayv1ac.RayJobSpec().
+			WithRayClusterSpec(NewRayClusterSpec(MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs")).
+				WithNetworkPolicy(networkPolicy)).
+			WithEntrypoint("python /home/ray/jobs/counter.py").
+			WithRuntimeEnvYAML(`
+env_vars:
+  counter_name: test_counter
+`).
+			WithShutdownAfterJobFinishes(false).
+			WithSubmitterPodTemplate(JobSubmitterPodTemplateApplyConfiguration()))
+
+	rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+	// Wait for the operator to spin up the RayCluster.
+	LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to start its RayCluster", rayJob.Namespace, rayJob.Name)
+	g.Eventually(func(gg Gomega) string {
+		rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+		gg.Expect(err).NotTo(HaveOccurred())
+		return rayJob.Status.RayClusterName
+	}, TestTimeoutShort).ShouldNot(BeEmpty())
+
+	rayClusterName := rayJob.Status.RayClusterName
+	// Both policies should exist before the cluster can become ready.
+	g.Eventually(func(gg Gomega) {
+		_, err := test.Client().Core().NetworkingV1().NetworkPolicies(namespace.Name).
+			Get(test.Ctx(), rayClusterName+"-head", metav1.GetOptions{})
+		gg.Expect(err).NotTo(HaveOccurred())
+		_, err = test.Client().Core().NetworkingV1().NetworkPolicies(namespace.Name).
+			Get(test.Ctx(), rayClusterName+"-workers", metav1.GetOptions{})
+		gg.Expect(err).NotTo(HaveOccurred())
+	}, TestTimeoutShort).Should(Succeed())
+	LogWithTimestamp(test.T(), "Head and worker NetworkPolicies created for RayCluster %s/%s", namespace.Name, rayClusterName)
+
+	// If the policies are right the cluster starts and the job completes.
+	LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+	g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutLong).
+		Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+
+	g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)))
+}
+
+// RayJob with clusterSelector pointing at a RayCluster we create ourselves, under
+// NetworkPolicy DenyAll. Since the RayCluster isn't owned by the RayJob, the
+// operator won't add the submitter ingress rule for us, so we add it by hand
+// (matching the submitter pod's labels) plus DNS egress.
+func TestRayJobWithClusterSelectorAndNetworkPolicy(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+
+	namespace := test.NewTestNamespace()
+
+	jobsAC := NewConfigMap(namespace.Name, Files(test, "counter.py"))
+	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), jobsAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
+
+	rayJobName := "counter"
+
+	// Head needs the submitter ingress rule (dashboard) so the submitter can
+	// reach it, operator ingress on the dashboard (the reconciler polls job
+	// status via GetJobInfo directly), and DNS egress. Workers just need DNS.
+	networkPolicy := rayv1ac.NetworkPolicyConfig().
+		WithMode(rayv1.NetworkPolicyDenyAll).
+		WithHead(rayv1ac.NetworkPolicyRules().
+			WithIngressRules(
+				SubmitterIngressRule(rayJobName, utils.DefaultDashboardPort),
+				OperatorIngressRule(utils.DefaultDashboardPort),
+			).
+			WithEgressRules(DNSEgressRule())).
+		WithWorker(rayv1ac.NetworkPolicyRules().WithEgressRules(DNSEgressRule()))
+
+	rayClusterAC := rayv1ac.RayCluster("raycluster", namespace.Name).
+		WithSpec(NewRayClusterSpec(MountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs")).
+			WithNetworkPolicy(networkPolicy))
+
+	rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+	// Sanity check that both policies landed.
+	g.Eventually(func(gg Gomega) {
+		_, err := test.Client().Core().NetworkingV1().NetworkPolicies(namespace.Name).
+			Get(test.Ctx(), rayCluster.Name+"-head", metav1.GetOptions{})
+		gg.Expect(err).NotTo(HaveOccurred())
+		_, err = test.Client().Core().NetworkingV1().NetworkPolicies(namespace.Name).
+			Get(test.Ctx(), rayCluster.Name+"-workers", metav1.GetOptions{})
+		gg.Expect(err).NotTo(HaveOccurred())
+	}, TestTimeoutShort).Should(Succeed())
+
+	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+	g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutLong).
+		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
+
+	// RayJob targeting the existing cluster by label.
+	rayJobAC := rayv1ac.RayJob(rayJobName, namespace.Name).
+		WithSpec(rayv1ac.RayJobSpec().
+			WithClusterSelector(map[string]string{utils.RayClusterLabelKey: rayCluster.Name}).
+			WithEntrypoint("python /home/ray/jobs/counter.py").
+			WithRuntimeEnvYAML(`
+env_vars:
+  counter_name: test_counter
+`).
+			WithSubmitterPodTemplate(JobSubmitterPodTemplateApplyConfiguration()))
+
+	rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+
+	// The submitter has to get through the head policy to reach the dashboard, so
+	// the job succeeding is what proves our ingress rule is correct.
+	LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+	g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutLong).
+		Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
+
+	g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)))
+}

--- a/ray-operator/test/e2erayservice/rayservice_network_policy_test.go
+++ b/ray-operator/test/e2erayservice/rayservice_network_policy_test.go
@@ -1,0 +1,103 @@
+package e2erayservice
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
+	. "github.com/ray-project/kuberay/ray-operator/test/support"
+)
+
+// RayService under NetworkPolicy DenyAll. Checks the service comes up and, more
+// importantly, that we can actually hit the Serve app from an external pod. Under
+// DenyAll the operator only allows intra-cluster traffic, so we add DNS egress
+// (FQDN resolution), HTTPS egress (the sample pulls its working_dir from GitHub),
+// Serve-port ingress (so the curl pod can reach 8000), and operator ingress on
+// the dashboard (8265, push Serve config + poll status) and serving (8000, proxy
+// health probe) ports, since the reconciler dials the head directly on both and
+// without them the service never goes Ready. Kindnet enforces NetworkPolicy on
+// k8s >= 1.32 (CI runs on 1.35), so a wrong rule means the service never starts
+// or the curl gets blocked.
+func TestRayServiceWithNetworkPolicy(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+
+	namespace := test.NewTestNamespace()
+	rayServiceName := "rayservice-network-policy"
+
+	networkPolicy := rayv1ac.NetworkPolicyConfig().
+		WithMode(rayv1.NetworkPolicyDenyAll).
+		WithHead(rayv1ac.NetworkPolicyRules().
+			WithIngressRules(
+				ServeIngressRule(utils.DefaultServingPort),
+				// The reconciler hits the head directly on both the dashboard (push
+				// Serve config / poll status) and the serving port (proxy health probe).
+				OperatorIngressRule(utils.DefaultDashboardPort, utils.DefaultServingPort),
+			).
+			WithEgressRules(DNSEgressRule(), AllHostsHTTPSEgressRule())).
+		WithWorker(rayv1ac.NetworkPolicyRules().
+			WithIngressRules(ServeIngressRule(utils.DefaultServingPort)).
+			WithEgressRules(DNSEgressRule(), AllHostsHTTPSEgressRule()))
+
+	rayServiceSpec := RayServiceSampleYamlApplyConfiguration()
+	rayServiceSpec.RayClusterSpec.WithNetworkPolicy(networkPolicy)
+
+	rayServiceAC := rayv1ac.RayService(rayServiceName, namespace.Name).WithSpec(rayServiceSpec)
+
+	rayService, err := test.Client().Ray().RayV1().RayServices(namespace.Name).Apply(test.Ctx(), rayServiceAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(rayService).NotTo(BeNil())
+	LogWithTimestamp(test.T(), "Created RayService %s/%s successfully with NetworkPolicy DenyAll", rayService.Namespace, rayService.Name)
+
+	defer func() {
+		err := test.Client().Ray().RayV1().RayServices(namespace.Name).Delete(test.Ctx(), rayService.Name, metav1.DeleteOptions{})
+		if err != nil {
+			LogWithTimestamp(test.T(), "WARNING: Failed to delete RayService %s: %v", rayService.Name, err)
+		}
+	}()
+
+	LogWithTimestamp(test.T(), "Waiting for RayService %s/%s to be ready", rayService.Namespace, rayService.Name)
+	g.Eventually(RayService(test, rayService.Namespace, rayService.Name), TestTimeoutLong).
+		Should(WithTransform(IsRayServiceReady, BeTrue()))
+
+	rayService, err = GetRayService(test, namespace.Name, rayServiceName)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "RayService %s/%s is ready", rayService.Namespace, rayService.Name)
+
+	rayClusterName := rayService.Status.ActiveServiceStatus.RayClusterName
+	g.Expect(rayClusterName).NotTo(BeEmpty(), "RayCluster name should be populated in status")
+
+	// Sanity check that both policies landed.
+	g.Eventually(func(gg Gomega) {
+		_, err := test.Client().Core().NetworkingV1().NetworkPolicies(namespace.Name).
+			Get(test.Ctx(), rayClusterName+"-head", metav1.GetOptions{})
+		gg.Expect(err).NotTo(HaveOccurred())
+		_, err = test.Client().Core().NetworkingV1().NetworkPolicies(namespace.Name).
+			Get(test.Ctx(), rayClusterName+"-workers", metav1.GetOptions{})
+		gg.Expect(err).NotTo(HaveOccurred())
+	}, TestTimeoutShort).Should(Succeed())
+	LogWithTimestamp(test.T(), "Head and worker NetworkPolicies created for RayCluster %s/%s", namespace.Name, rayClusterName)
+
+	// Spin up a curl pod outside the cluster and confirm it can actually reach
+	// the Serve app through the ingress rule.
+	curlPodName := "curl-pod"
+	curlContainerName := "curl-container"
+	LogWithTimestamp(test.T(), "Creating curl pod %s/%s", namespace.Name, curlPodName)
+	curlPod, err := CreateCurlPod(g, test, curlPodName, curlContainerName, namespace.Name)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	LogWithTimestamp(test.T(), "Sending requests to the RayService Serve application")
+	g.Eventually(func(gg Gomega) {
+		stdout, _ := CurlRayServicePod(test, rayService, curlPod, curlContainerName, "/fruit", `["MANGO", 2]`)
+		gg.Expect(stdout.String()).To(Equal("6"))
+	}, TestTimeoutMedium).Should(Succeed())
+
+	stdout, _ := CurlRayServicePod(test, rayService, curlPod, curlContainerName, "/calc", `["MUL", 3]`)
+	g.Expect(stdout.String()).To(Equal("15 pizzas please!"))
+
+	LogWithTimestamp(test.T(), "RayService %s/%s served requests successfully under NetworkPolicy DenyAll", rayService.Namespace, rayService.Name)
+}

--- a/ray-operator/test/support/networkpolicy.go
+++ b/ray-operator/test/support/networkpolicy.go
@@ -1,0 +1,132 @@
+package support
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// NetworkPolicy rule builders for the e2e tests. Under DenyAll the operator only
+// allows intra-cluster traffic, so anything else (DNS, internet, external
+// ingress) has to be added by hand here. See the network-policy-deny-all sample.
+
+// DNSEgressRule allows DNS to kube-dns on 53 (UDP+TCP). Ray pods resolve the head
+// by FQDN, so without this the cluster won't come up under DenyAll/DenyAllEgress.
+func DNSEgressRule() networkingv1.NetworkPolicyEgressRule {
+	udp := corev1.ProtocolUDP
+	tcp := corev1.ProtocolTCP
+	dnsPort := intstr.FromInt32(53)
+	return networkingv1.NetworkPolicyEgressRule{
+		To: []networkingv1.NetworkPolicyPeer{
+			{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"kubernetes.io/metadata.name": "kube-system",
+					},
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"k8s-app": "kube-dns",
+					},
+				},
+			},
+		},
+		Ports: []networkingv1.NetworkPolicyPort{
+			{Protocol: &udp, Port: &dnsPort},
+			{Protocol: &tcp, Port: &dnsPort},
+		},
+	}
+}
+
+// AllHostsHTTPSEgressRule allows egress to anywhere on 443, needed when a job
+// pulls its runtimeEnv working_dir or pip packages from the internet.
+func AllHostsHTTPSEgressRule() networkingv1.NetworkPolicyEgressRule {
+	tcp := corev1.ProtocolTCP
+	httpsPort := intstr.FromInt32(443)
+	return networkingv1.NetworkPolicyEgressRule{
+		To: []networkingv1.NetworkPolicyPeer{
+			{
+				IPBlock: &networkingv1.IPBlock{
+					CIDR: "0.0.0.0/0",
+				},
+			},
+		},
+		Ports: []networkingv1.NetworkPolicyPort{
+			{Protocol: &tcp, Port: &httpsPort},
+		},
+	}
+}
+
+// ServeIngressRule opens the Serve port to every pod in the namespace so an
+// external curl pod can hit the app. Empty PodSelector = all pods in the namespace.
+func ServeIngressRule(servePort int32) networkingv1.NetworkPolicyIngressRule {
+	tcp := corev1.ProtocolTCP
+	port := intstr.FromInt32(servePort)
+	return networkingv1.NetworkPolicyIngressRule{
+		From: []networkingv1.NetworkPolicyPeer{
+			{
+				PodSelector: &metav1.LabelSelector{},
+			},
+		},
+		Ports: []networkingv1.NetworkPolicyPort{
+			{Protocol: &tcp, Port: &port},
+		},
+	}
+}
+
+// OperatorIngressRule lets the kuberay operator reach the given head ports. The
+// RayService reconciler talks to the head directly: it pushes the Serve config
+// and polls app status over the dashboard port (8265), and it probes Serve proxy
+// health over the serving port (8000) by dialing the head pod IP. Both are needed
+// under DenyAll or the head serve label never flips to true and serve endpoints
+// stay empty. The operator runs in a different namespace than the test, so we
+// match it by pod label across all namespaces (empty NamespaceSelector). We match
+// on app.kubernetes.io/component=kuberay-operator because it's the same in both
+// deploy paths; app.kubernetes.io/name differs (kuberay via kustomize vs
+// kuberay-operator via the Helm chart).
+func OperatorIngressRule(ports ...int32) networkingv1.NetworkPolicyIngressRule {
+	tcp := corev1.ProtocolTCP
+	npPorts := make([]networkingv1.NetworkPolicyPort, 0, len(ports))
+	for _, p := range ports {
+		port := intstr.FromInt32(p)
+		npPorts = append(npPorts, networkingv1.NetworkPolicyPort{Protocol: &tcp, Port: &port})
+	}
+	return networkingv1.NetworkPolicyIngressRule{
+		From: []networkingv1.NetworkPolicyPeer{
+			{
+				NamespaceSelector: &metav1.LabelSelector{},
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/component": "kuberay-operator",
+					},
+				},
+			},
+		},
+		Ports: npPorts,
+	}
+}
+
+// SubmitterIngressRule lets the K8sJobMode submitter pod reach the head dashboard.
+// The operator adds this for RayJob-owned clusters, but with clusterSelector the
+// RayCluster isn't owned by the RayJob, so we add it ourselves matching the
+// submitter's originated-from-cr labels.
+func SubmitterIngressRule(rayJobName string, dashboardPort int32) networkingv1.NetworkPolicyIngressRule {
+	tcp := corev1.ProtocolTCP
+	port := intstr.FromInt32(dashboardPort)
+	return networkingv1.NetworkPolicyIngressRule{
+		From: []networkingv1.NetworkPolicyPeer{
+			{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"ray.io/originated-from-cr-name": rayJobName,
+						"ray.io/originated-from-crd":     "RayJob",
+					},
+				},
+			},
+		},
+		Ports: []networkingv1.NetworkPolicyPort{
+			{Protocol: &tcp, Port: &port},
+		},
+	}
+}


### PR DESCRIPTION
## Why are these changes needed?

Follow-up to #4638 / #5030: add NetworkPolicy e2e coverage on a Kind v1.35 cluster (Kindnet enforces NetworkPolicy since v1.32, and the KubeRay Buildkite e2e jobs already run on a v1.35 Kind node via `ci/kind-config-buildkite.yml`).

The NetworkPolicy controller only bakes in intra-cluster pod-to-pod traffic; DNS egress, internet egress for runtimeEnv/pip, and any external ingress must be added by the user via head/worker rules. These tests exercise that contract end-to-end under `mode: DenyAll` on an enforcing CNI, so a wrong policy fails the test (cluster never starts, or the request never reaches the app) instead of silently passing on a non-enforcing CNI.

## What this adds

Covers the three scenarios from the epic:

- `TestRayJobWithNetworkPolicy` (`test/e2erayjob/rayjob_network_policy_test.go`): RayJob without clusterSelector, using runtimeEnv. The operator owns the RayCluster and adds the submitter dashboard ingress rule automatically; the test only adds DNS egress. Asserts head/worker NetworkPolicies are created and the job succeeds.
- `TestRayJobWithClusterSelectorAndNetworkPolicy` (same file): RayJob with clusterSelector against a pre-created RayCluster. Because the RayCluster is not owned by the RayJob, the operator cannot add the submitter rule, so the test supplies it explicitly on the head policy (matching the K8sJobMode submitter pod's stable `originated-from-cr` labels) plus DNS egress. Job succeeding proves the ingress rule works.
- `TestRayServiceWithNetworkPolicy` (`test/e2erayservice/rayservice_network_policy_test.go`): RayService under DenyAll with DNS + HTTPS egress and a Serve-port ingress rule. Verifies the service becomes ready and that an external curl pod actually receives a response from the Serve application (`/fruit` returns `6`, `/calc` returns `15 pizzas please!`).

Shared rule builders live in `test/support/networkpolicy.go` (`DNSEgressRule`, `AllHostsHTTPSEgressRule`, `ServeIngressRule`, `SubmitterIngressRule`).

No CI wiring change is needed: the new tests run inside the existing `Test RayJob E2E` and `Test E2E rayservice` Buildkite steps, which already use the v1.35 Kind node and run the full package with no `-run` filter.

## Related issue number

Part of #5030 (follow-up to #4638).

## Checks

- `go vet ./test/support/... ./test/e2erayjob/... ./test/e2erayservice/...` passes
- `go test -run xxx` (compile check) passes on all three packages
- `gofmt` clean
