### PR TITLE
[kubectl-plugin] Skip out-of-range file modes and close files during log download

### DIFF
--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -392,6 +392,36 @@ func (dre *DefaultRemoteExecutor) CreateExecutor(restConfig *rest.Config, url *u
 	return remotecommand.NewSPDYExecutor(restConfig, "POST", url)
 }
 
+// writeTarFile writes the current tar entry to localFilePath. The file is closed
+// before returning, so descriptors are not retained for the whole extraction as
+// they would be with a deferred close inside the extraction loop.
+func writeTarFile(localFilePath string, mode os.FileMode, tarReader *tar.Reader) (err error) {
+	outFile, openErr := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, mode)
+	if openErr != nil {
+		return fmt.Errorf("Error creating file: %w", openErr)
+	}
+	defer func() {
+		if closeErr := outFile.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("failed while closing file: %w", closeErr)
+		}
+	}()
+
+	// This is to limit the copy size for a decompression bomb, currently set arbitrarily
+	for {
+		n, copyErr := io.CopyN(outFile, tarReader, 1000000)
+		if copyErr != nil {
+			if errors.Is(copyErr, io.EOF) {
+				break
+			}
+			return fmt.Errorf("failed while writing to file: %w", copyErr)
+		}
+		if n == 0 {
+			break
+		}
+	}
+	return nil
+}
+
 // downloadRayLogFiles will use to the executor and retrieve the logs file from the inputted Ray head
 func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec remotecommand.Executor, rayNode corev1.Pod) error {
 	outreader, outStream := io.Pipe()
@@ -433,25 +463,8 @@ func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec 
 			// Check for overflow: G115
 			if header.Mode < 0 || header.Mode > math.MaxUint32 {
 				fmt.Fprintf(options.ioStreams.Out, "file mode out side of acceptable value %d skipping file\n", header.Mode)
-			}
-			// Create file and write contents
-			outFile, err := os.OpenFile(localFilePath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode)) //nolint:gosec // overflow is guarded by bounds check above
-			if err != nil {
-				return fmt.Errorf("Error creating file: %w", err)
-			}
-			defer outFile.Close()
-			// This is to limit the copy size for a decompression bomb, currently set arbitrarily
-			for {
-				n, err := io.CopyN(outFile, tarReader, 1000000)
-				if err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return fmt.Errorf("failed while writing to file: %w", err)
-				}
-				if n == 0 {
-					break
-				}
+			} else if err := writeTarFile(localFilePath, os.FileMode(header.Mode), tarReader); err != nil { //nolint:gosec // overflow is guarded by bounds check above
+				return err
 			}
 		default:
 			fmt.Printf("Ignoring unsupported file type: %b", header.Typeflag)

--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -463,7 +463,7 @@ func (options *ClusterLogOptions) downloadRayLogFiles(ctx context.Context, exec 
 			// Check for overflow: G115
 			if header.Mode < 0 || header.Mode > math.MaxUint32 {
 				fmt.Fprintf(options.ioStreams.Out, "file mode out side of acceptable value %d skipping file\n", header.Mode)
-			} else if err := writeTarFile(localFilePath, os.FileMode(header.Mode), tarReader); err != nil { //nolint:gosec // overflow is guarded by bounds check above
+			} else if err := writeTarFile(localFilePath, os.FileMode(header.Mode), tarReader); err != nil {
 				return err
 			}
 		default:

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -4,7 +4,9 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -482,6 +484,94 @@ func TestDownloadRayLogFiles(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, curr.Body, string(actualContent))
 	}
+}
+
+// createTarFileWithModes creates a tar archive containing one regular file per
+// supplied mode, so extraction of out-of-range modes can be exercised.
+func createTarFileWithModes(modes []int64) (*bytes.Buffer, error) {
+	tarbuff := new(bytes.Buffer)
+	tw := tar.NewWriter(tarbuff)
+
+	// Leading directory entry, matching the layout produced by the real archive.
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "/",
+		Mode:     0o755,
+		ModTime:  time.Now(),
+		Typeflag: tar.TypeDir,
+	}); err != nil {
+		return nil, err
+	}
+
+	for ind, mode := range modes {
+		body := "content\n"
+		hdr := &tar.Header{
+			Name:     fmt.Sprintf("file%d.txt", ind),
+			Mode:     mode,
+			ModTime:  time.Now(),
+			Size:     int64(len(body)),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	return tarbuff, nil
+}
+
+// TestDownloadRayLogFilesSkipsOutOfRangeMode verifies that a tar entry whose mode
+// cannot be represented as an os.FileMode is skipped rather than being created
+// with a truncated mode, and that skipping it does not stall extraction of the
+// remaining entries.
+func TestDownloadRayLogFilesSkipsOutOfRangeMode(t *testing.T) {
+	fakeDir, err := os.MkdirTemp("", "fake-directory")
+	require.NoError(t, err)
+	defer os.RemoveAll(fakeDir)
+
+	testStreams, _, _, _ := genericiooptions.NewTestIOStreams()
+	cmdFactory := cmdutil.NewFactory(genericclioptions.NewConfigFlags(true))
+
+	fakeClusterLogOptions := NewClusterLogOptions(cmdFactory, testStreams)
+	fakeClusterLogOptions.ResourceName = "test-cluster"
+	fakeClusterLogOptions.outputDir = fakeDir
+
+	// file0 has a mode outside the range representable by os.FileMode and must be
+	// skipped; file1 is valid and must still be extracted afterwards.
+	fakeTar, err := createTarFileWithModes([]int64{math.MaxUint32 + 1, 0o644})
+	require.NoError(t, err)
+
+	rayHead := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-kuberay-head-1",
+			Namespace: "test",
+		},
+		Status: v1.PodStatus{Phase: v1.PodRunning, PodIP: "10.0.0.1"},
+	}
+
+	executor, _ := fakeNewSPDYExecutor("GET", &url.URL{}, fakeTar)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- fakeClusterLogOptions.downloadRayLogFiles(context.Background(), executor, rayHead)
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("downloadRayLogFiles did not return; extraction is not advancing past the skipped entry")
+	}
+
+	files, err := os.ReadDir(filepath.Join(fakeDir, rayHead.Name))
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "file1.txt", files[0].Name())
 }
 
 // createTempKubeConfigFile creates a temporary kubeconfig file with the given current context.


### PR DESCRIPTION
## Why are these changes needed?

Two bugs in `downloadRayLogFiles` (`kubectl-plugin/pkg/cmd/log/log.go`), reported in #4779.

**1. The mode bounds check does nothing.** The code checks whether `header.Mode` fits in an `os.FileMode` and prints a warning, but has no `continue`/guard — it falls straight through to `os.OpenFile(..., os.FileMode(header.Mode))` and creates the file with a truncated mode. The `//nolint:gosec // overflow is guarded by bounds check above` comment asserted a guard that was not there, so the linter stayed silent.

Worth noting for reviewers: the fix suggested in the issue (adding a bare `continue`) would **hang**. The extraction loop advances the tar reader *after* the `switch`:

```go
for !errors.Is(err, io.EOF) {
    switch header.Typeflag { ... }
    header, err = tarReader.Next()   // <- skipped by `continue`
}
```

so `continue` would re-read the same header forever. This PR guards the write with an `else` branch instead, which skips the file without skipping the advance. A regression test asserts the call returns rather than stalling.

**2. File descriptors accumulate for the whole download.** `defer outFile.Close()` sat inside the extraction loop, so `defer` only ran when `downloadRayLogFiles` returned — every file in the archive stayed open until the entire download finished. Extracting a log archive with many files holds that many descriptors at once.

The per-entry write moves into a `writeTarFile` helper so the file closes at the end of each entry, and close errors are surfaced rather than discarded.

## Related issue number

Closes #4779

## Checks

- `go build ./...`, `go vet`, and `gofmt` are clean.
- Extended `TestDownloadRayLogFiles` coverage with `TestDownloadRayLogFilesSkipsOutOfRangeMode`, which asserts the out-of-range entry is skipped, that the following valid entry still extracts, and that extraction does not stall. Against the previous behaviour it fails with:

```
Error: "[- file0.txt - file1.txt]" should have 1 item(s), but has 2
```

Disclosure: this change was prepared with the assistance of an AI coding agent. The analysis, fix, and tests were verified against the source and the test suite before submitting.