### PR TITLE
[Refactor] Extract mTLS issuer reconciliation helper

### DIFF
--- a/ray-operator/controllers/ray/raycluster_mtls_controller.go
+++ b/ray-operator/controllers/ray/raycluster_mtls_controller.go
@@ -156,34 +156,52 @@ func (r *RayClusterMTLSController) ensureSecretOwnedByCertificate(ctx context.Co
 	return r.Update(ctx, secret)
 }
 
+// reconcileIssuer creates an issuer with the given configuration if it does not exist.
+// Issuer specs are static once created, so no update is needed.
+func (r *RayClusterMTLSController) reconcileIssuer(
+	ctx context.Context,
+	instance *rayv1.RayCluster,
+	issuerName string,
+	component string,
+	issuerConfig certmanagerv1.IssuerConfig,
+) error {
+	existing := &certmanagerv1.Issuer{}
+	err := r.Get(ctx, client.ObjectKey{Name: issuerName, Namespace: instance.Namespace}, existing)
+	if err == nil {
+		return nil
+	}
+	if !errors.IsNotFound(err) {
+		return err
+	}
+
+	issuer := &certmanagerv1.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      issuerName,
+			Namespace: instance.Namespace,
+			Labels:    tlsResourceLabels(instance.Name, component),
+		},
+		Spec: certmanagerv1.IssuerSpec{
+			IssuerConfig: issuerConfig,
+		},
+	}
+	if err := controllerutil.SetControllerReference(instance, issuer, r.Scheme); err != nil {
+		return err
+	}
+	return r.Create(ctx, issuer)
+}
+
 // reconcileSelfSignedIssuer creates the self-signed issuer used to bootstrap the CA if it does not exist.
 // The issuer spec is static once created so no update is needed.
 func (r *RayClusterMTLSController) reconcileSelfSignedIssuer(ctx context.Context, instance *rayv1.RayCluster) error {
-	issuerName := utils.GetSelfSignedIssuerName(instance.Name)
-	existing := &certmanagerv1.Issuer{}
-	err := r.Get(ctx, client.ObjectKey{Name: issuerName, Namespace: instance.Namespace}, existing)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-		issuer := &certmanagerv1.Issuer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      issuerName,
-				Namespace: instance.Namespace,
-				Labels:    tlsResourceLabels(instance.Name, "selfsigned-issuer"),
-			},
-			Spec: certmanagerv1.IssuerSpec{
-				IssuerConfig: certmanagerv1.IssuerConfig{
-					SelfSigned: &certmanagerv1.SelfSignedIssuer{},
-				},
-			},
-		}
-		if err := controllerutil.SetControllerReference(instance, issuer, r.Scheme); err != nil {
-			return err
-		}
-		return r.Create(ctx, issuer)
-	}
-	return nil
+	return r.reconcileIssuer(
+		ctx,
+		instance,
+		utils.GetSelfSignedIssuerName(instance.Name),
+		"selfsigned-issuer",
+		certmanagerv1.IssuerConfig{
+			SelfSigned: &certmanagerv1.SelfSignedIssuer{},
+		},
+	)
 }
 
 // reconcileCACertificate creates the root CA certificate signed by the self-signed issuer if it does not exist.
@@ -241,33 +259,17 @@ func (r *RayClusterMTLSController) reconcileCACertificate(ctx context.Context, i
 // reconcileCAIssuer creates the issuer backed by the generated CA certificate's secret if it does not exist.
 // The issuer spec is static once created (keyed on RayCluster UID) so no update is needed.
 func (r *RayClusterMTLSController) reconcileCAIssuer(ctx context.Context, instance *rayv1.RayCluster) error {
-	issuerName := utils.GetCAIssuerName(instance.Name)
-	existing := &certmanagerv1.Issuer{}
-	err := r.Get(ctx, client.ObjectKey{Name: issuerName, Namespace: instance.Namespace}, existing)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-		issuer := &certmanagerv1.Issuer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      issuerName,
-				Namespace: instance.Namespace,
-				Labels:    tlsResourceLabels(instance.Name, "ca-issuer"),
+	return r.reconcileIssuer(
+		ctx,
+		instance,
+		utils.GetCAIssuerName(instance.Name),
+		"ca-issuer",
+		certmanagerv1.IssuerConfig{
+			CA: &certmanagerv1.CAIssuer{
+				SecretName: utils.GetCASecretName(instance.Name, instance.UID),
 			},
-			Spec: certmanagerv1.IssuerSpec{
-				IssuerConfig: certmanagerv1.IssuerConfig{
-					CA: &certmanagerv1.CAIssuer{
-						SecretName: utils.GetCASecretName(instance.Name, instance.UID),
-					},
-				},
-			},
-		}
-		if err := controllerutil.SetControllerReference(instance, issuer, r.Scheme); err != nil {
-			return err
-		}
-		return r.Create(ctx, issuer)
-	}
-	return nil
+		},
+	)
 }
 
 // reconcileHeadCertificate creates or updates the head node leaf certificate.

--- a/ray-operator/controllers/ray/raycluster_mtls_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_mtls_controller_test.go
@@ -241,6 +241,66 @@ func TestMTLSController_AutoGenerate_Idempotent(t *testing.T) {
 	assert.Len(t, certList.Items, 3, "should have 3 certificates: CA + head + worker")
 }
 
+func TestMTLSController_ReconcileIssuer(t *testing.T) {
+	cluster := newMTLSTestCluster("issuer-test")
+	tests := []struct {
+		name             string
+		reconcile        func(*RayClusterMTLSController, context.Context, *rayv1.RayCluster) error
+		issuerName       string
+		component        string
+		wantIssuerConfig certmanagerv1.IssuerConfig
+	}{
+		{
+			name:       "self-signed issuer",
+			reconcile:  (*RayClusterMTLSController).reconcileSelfSignedIssuer,
+			issuerName: utils.GetSelfSignedIssuerName(cluster.Name),
+			component:  "selfsigned-issuer",
+			wantIssuerConfig: certmanagerv1.IssuerConfig{
+				SelfSigned: &certmanagerv1.SelfSignedIssuer{},
+			},
+		},
+		{
+			name:       "CA issuer",
+			reconcile:  (*RayClusterMTLSController).reconcileCAIssuer,
+			issuerName: utils.GetCAIssuerName(cluster.Name),
+			component:  "ca-issuer",
+			wantIssuerConfig: certmanagerv1.IssuerConfig{
+				CA: &certmanagerv1.CAIssuer{
+					SecretName: utils.GetCASecretName(cluster.Name, cluster.UID),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newMTLSController(t)
+			ctx := context.Background()
+
+			require.NoError(t, tt.reconcile(r, ctx, cluster))
+			require.NoError(t, tt.reconcile(r, ctx, cluster))
+
+			issuer := &certmanagerv1.Issuer{}
+			require.NoError(t, r.Get(ctx, types.NamespacedName{
+				Name:      tt.issuerName,
+				Namespace: cluster.Namespace,
+			}, issuer))
+			assert.Equal(t, tt.wantIssuerConfig, issuer.Spec.IssuerConfig)
+			assert.Equal(t, tt.component, issuer.Labels["app.kubernetes.io/component"])
+			assert.Equal(t, cluster.Name, issuer.Labels[utils.RayClusterLabelKey])
+
+			controllerRef := metav1.GetControllerOf(issuer)
+			require.NotNil(t, controllerRef)
+			assert.Equal(t, cluster.Name, controllerRef.Name)
+			assert.Equal(t, cluster.UID, controllerRef.UID)
+
+			issuerList := &certmanagerv1.IssuerList{}
+			require.NoError(t, r.List(ctx, issuerList, client.InNamespace(cluster.Namespace)))
+			assert.Len(t, issuerList.Items, 1)
+		})
+	}
+}
+
 func TestMTLSController_AutoGenerate_UpdatesIPAddresses(t *testing.T) {
 	cluster := newMTLSTestCluster("test-cluster")
 	cluster.Spec.TLSOptions = &rayv1.TLSOptions{Enabled: new(true)}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The self-signed and CA issuer reconciliation paths contained duplicated cert-manager `Issuer` get-or-create logic.

This PR extracts that logic into a shared helper while keeping the issuer-specific names and configurations in their respective reconciliation methods. It also adds table-driven unit tests covering both issuer types, including their configuration, labels, controller ownership, and idempotency.

This is a behavior-preserving refactor.

## Related issue number

Part of #5048

Follow-up to https://github.com/ray-project/kuberay/pull/4566#discussion_r3537218847

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

### Tests run

```console
go test ./controllers/ray
go vet ./controllers/ray