### PR TITLE
[WIP][History server] Follow up: Refactor collector panics, centralize node ID polling, and clean up test support

### DIFF
--- a/historyserver/cmd/collector/main.go
+++ b/historyserver/cmd/collector/main.go
@@ -90,7 +90,7 @@ func main() {
 	} else if strings.EqualFold(role, "worker") {
 		role = "Worker"
 	} else {
-		panic("Invalid role: " + role + ", must be Head or Worker")
+		logrus.Fatalf("Invalid role: %s, must be Head or Worker", role)
 	}
 
 	if err := validateFlags(&rayClusterName, &rayClusterNamespace, &ownerKind, &ownerName); err != nil {
@@ -111,22 +111,22 @@ func main() {
 	if intervalStr := os.Getenv("RAY_COLLECTOR_POLL_INTERVAL"); intervalStr != "" {
 		parsed, parseErr := time.ParseDuration(intervalStr)
 		if parseErr != nil {
-			panic("Failed to parse RAY_COLLECTOR_POLL_INTERVAL: " + parseErr.Error())
+			logrus.Warnf("Failed to parse RAY_COLLECTOR_POLL_INTERVAL (%q): %v. Falling back to default %v", intervalStr, parseErr, endpointPollInterval)
+		} else if parsed <= 0 {
+			logrus.Warnf("RAY_COLLECTOR_POLL_INTERVAL must be positive, got: %s. Falling back to default %v", intervalStr, endpointPollInterval)
+		} else {
+			endpointPollInterval = parsed
 		}
-		if parsed <= 0 {
-			panic("RAY_COLLECTOR_POLL_INTERVAL must be positive, got: " + intervalStr)
-		}
-		endpointPollInterval = parsed
 	}
 
 	jsonData := make(map[string]interface{})
 	if runtimeClassConfigPath != "" {
 		data, err := os.ReadFile(runtimeClassConfigPath)
 		if err != nil {
-			panic(fmt.Sprintf("Failed to read runtime class config from %s: %v", runtimeClassConfigPath, err))
+			logrus.Fatalf("Failed to read runtime class config from %s: %v", runtimeClassConfigPath, err)
 		}
 		if err := json.Unmarshal(data, &jsonData); err != nil {
-			panic(fmt.Sprintf("Failed to parse runtime class config from %s: %v", runtimeClassConfigPath, err))
+			logrus.Fatalf("Failed to parse runtime class config from %s: %v", runtimeClassConfigPath, err)
 		}
 	}
 
@@ -140,22 +140,22 @@ func main() {
 	registry := collector.GetWriterRegistry()
 	factory, ok := registry[runtimeClassName]
 	if !ok {
-		panic("Not supported runtime class name: " + runtimeClassName + " for role: " + role + ".")
+		logrus.Fatalf("Not supported runtime class name: %s for role: %s.", runtimeClassName, role)
 	}
 
 	rayNodeId, err := utils.GetNodeRayIDWithFQIP()
 	if err != nil {
-		panic("Failed to get ray node id via HTTP endpoint: " + err.Error())
+		logrus.Fatalf("Failed to get ray node id via HTTP endpoint: %v", err)
 	}
 
 	rayNodeId, err = utils.ConvertBase64ToHex(rayNodeId)
 	if err != nil {
-		panic("Failed to normalize ray node id to hex: " + err.Error())
+		logrus.Fatalf("Failed to normalize ray node id to hex: %v", err)
 	}
 
 	activeSessionDir, err := utils.GetSessionDir()
 	if err != nil {
-		panic("Failed to get active session dir after discovering node id: " + err.Error())
+		logrus.Fatalf("Failed to get active session dir after discovering node id: %v", err)
 	}
 
 	if err := utils.MoveLeftoverSessionLogs(activeSessionDir, rayNodeId); err != nil {
@@ -184,7 +184,7 @@ func main() {
 
 	writer, err := factory(&globalConfig, jsonData)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to create writer for runtime class name: %s for role: %s, err: %+v", runtimeClassName, role, err))
+		logrus.Fatalf("Failed to create writer for runtime class name: %s for role: %s, err: %+v", runtimeClassName, role, err)
 	}
 
 	var wg sync.WaitGroup
@@ -193,11 +193,13 @@ func main() {
 	stop := make(chan struct{}, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
+	eventCollector := eventcollector.NewEventCollector(writer, rayRootDir, activeSessionDir, rayNodeId, rayClusterName, rayClusterNamespace, sessionName)
+	logCollector := runtime.NewCollector(&globalConfig, writer)
+
 	wg.Add(1)
 	// Create and initialize EventCollector
 	go func() {
 		defer wg.Done()
-		eventCollector := eventcollector.NewEventCollector(writer, rayRootDir, activeSessionDir, rayNodeId, rayClusterName, rayClusterNamespace, sessionName)
 		eventCollector.Run(stop, eventsPort)
 		logrus.Info("Event collector shutdown")
 	}()
@@ -205,9 +207,45 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		logCollector := runtime.NewCollector(&globalConfig, writer)
 		logCollector.Run(stop)
 		logrus.Info("Log collector shutdown")
+	}()
+
+	// Centralized periodic session & Node ID lifecycle poller
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		currentSessionDir := activeSessionDir
+
+		for {
+			select {
+			case <-ticker.C:
+				// STEP 1: Check if session directory changed (Ray restart)
+				if newSessionDir, err := utils.GetSessionDirOnce(); err == nil && newSessionDir != "" {
+					if currentSessionDir == "" {
+						currentSessionDir = newSessionDir
+					} else if newSessionDir != currentSessionDir {
+						if err := logCollector.HandleSessionChange(newSessionDir); err == nil {
+							currentSessionDir = newSessionDir
+						} else {
+							logrus.Warnf("CentralizedPoller: failed to relocate session logs to %s: %v. Retrying on next tick.", newSessionDir, err)
+						}
+					}
+				}
+
+				// STEP 2: Update Node ID for collectors AFTER session log relocation
+				if newNodeID, err := utils.FetchCurrentNodeID(); err == nil && newNodeID != "" {
+					if hexID, err := utils.ConvertBase64ToHex(newNodeID); err == nil && hexID != "" {
+						eventCollector.UpdateNodeID(hexID)
+						logCollector.UpdateNodeID(hexID)
+					}
+				}
+			case <-stop:
+				return
+			}
+		}
 	}()
 
 	<-sigChan

--- a/historyserver/pkg/collector/eventcollector/eventcollector.go
+++ b/historyserver/pkg/collector/eventcollector/eventcollector.go
@@ -200,19 +200,10 @@ func (ec *EventCollector) PersistEvents(req *restful.Request, resp *restful.Resp
 
 func (ec *EventCollector) periodicFlush() {
 	flushTicker := time.NewTicker(ec.flushInterval)
-	// Periodic node ID update with shorter interval to handle frequent node restarts
-	nodeIDTicker := time.NewTicker(5 * time.Second)
 	defer flushTicker.Stop()
-	defer nodeIDTicker.Stop()
 
 	for {
 		select {
-		case <-nodeIDTicker.C:
-			if freshNodeID, err := utils.FetchCurrentNodeID(); err == nil && freshNodeID != "" {
-				if hexID, err := utils.ConvertBase64ToHex(freshNodeID); err == nil && hexID != "" {
-					ec.UpdateNodeID(hexID)
-				}
-			}
 		case <-flushTicker.C:
 			logrus.Info("Periodic flush triggered")
 			ec.flushEvents()

--- a/historyserver/pkg/collector/logcollector/runtime/interface.go
+++ b/historyserver/pkg/collector/logcollector/runtime/interface.go
@@ -2,4 +2,6 @@ package runtime
 
 type RayLogCollector interface {
 	Run(stop <-chan struct{}) error
+	UpdateNodeID(nodeID string)
+	HandleSessionChange(newSessionDir string) error
 }

--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector.go
@@ -61,6 +61,19 @@ func (r *RayLogHandler) SetRayNodeName(newNodeID string) {
 	}
 }
 
+func (r *RayLogHandler) UpdateNodeID(newNodeID string) {
+	r.SetRayNodeName(newNodeID)
+}
+
+func (r *RayLogHandler) HandleSessionChange(newSessionDir string) error {
+	logrus.Infof("HandleSessionChange: session changed to %s. Relocating old logs.", newSessionDir)
+	if err := utils.MoveLeftoverSessionLogs(newSessionDir, r.GetRayNodeName()); err != nil {
+		logrus.Warnf("HandleSessionChange: failed to relocate leftover session logs to %s: %v", newSessionDir, err)
+		return err
+	}
+	return nil
+}
+
 func (r *RayLogHandler) Run(stop <-chan struct{}) error {
 	// watchPath := r.LogDir
 	r.prevLogsDir = utils.GetRayPrevLogsPath()
@@ -80,7 +93,6 @@ func (r *RayLogHandler) Run(stop <-chan struct{}) error {
 	// After scanning, it watches for new directories and files. This ensures incomplete
 	// uploads from previous runs are resumed.
 	go r.WatchPrevLogsLoops()
-	go r.PollActiveSessionChanges()
 	if r.IsHead {
 		go r.WatchSessionLatestLoops() // Watch session_latest symlink changes
 		go r.FetchAndStoreClusterMetadata()
@@ -786,63 +798,6 @@ func (r *RayLogHandler) WatchSessionLatestLoops() {
 				return
 			}
 			logrus.Errorf("Session latest watcher error: %v", err)
-		}
-	}
-}
-
-// Polls if the active session changes, when it does, it moves the old session logs to a prev-logs/ folder.
-func (r *RayLogHandler) PollActiveSessionChanges() {
-	tmpRayRoot := utils.GetTmpRayRoot()
-	symlinkPath := filepath.Join(tmpRayRoot, "session_latest")
-
-	var lastResolvedDir string
-	currentActiveDir, err := filepath.EvalSymlinks(symlinkPath)
-	if err == nil && currentActiveDir != "" {
-		if r.SessionDir != "" && currentActiveDir != r.SessionDir {
-			logrus.Infof("PollActiveSessionChanges: detected startup session change from %s to %s. Relocating startup session logs.", r.SessionDir, currentActiveDir)
-			if err := utils.MoveLeftoverSessionLogs(currentActiveDir, r.GetRayNodeName()); err != nil {
-				logrus.Warnf("PollActiveSessionChanges: failed to relocate startup session logs: %v. Retrying on next poll tick.", err)
-				lastResolvedDir = r.SessionDir
-			} else {
-				lastResolvedDir = currentActiveDir
-			}
-		} else {
-			lastResolvedDir = currentActiveDir
-		}
-	} else {
-		logrus.Warnf("PollActiveSessionChanges: failed to resolve initial session_latest target: %v. Falling back to startup SessionDir %s", err, r.SessionDir)
-		lastResolvedDir = r.SessionDir
-	}
-
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-
-	logrus.Infof("Started polling active session changes at: %s (initial target: %s)", symlinkPath, lastResolvedDir)
-	for {
-		select {
-		case <-r.ShutdownChan:
-			logrus.Info("PollActiveSessionChanges: stopping active session poller")
-			return
-		case <-ticker.C:
-			newResolvedDir, err := filepath.EvalSymlinks(symlinkPath)
-			if err != nil || newResolvedDir == "" {
-				continue
-			}
-
-			if lastResolvedDir != "" && newResolvedDir != lastResolvedDir {
-				logrus.Infof("PollActiveSessionChanges: session changed from %s to %s. Relocating old logs.", lastResolvedDir, newResolvedDir)
-				if err := utils.MoveLeftoverSessionLogs(newResolvedDir, r.GetRayNodeName()); err != nil {
-					logrus.Warnf("PollActiveSessionChanges: failed to relocate leftover session logs from %s to %s: %v. Retrying on next tick.", lastResolvedDir, newResolvedDir, err)
-					continue
-				}
-			}
-			lastResolvedDir = newResolvedDir
-
-			if freshNodeID, err := utils.FetchCurrentNodeID(); err == nil && freshNodeID != "" {
-				if hexID, err := utils.ConvertBase64ToHex(freshNodeID); err == nil && hexID != "" {
-					r.SetRayNodeName(hexID)
-				}
-			}
 		}
 	}
 }

--- a/historyserver/pkg/collector/logcollector/runtime/logcollector/collector_test.go
+++ b/historyserver/pkg/collector/logcollector/runtime/logcollector/collector_test.go
@@ -1,10 +1,7 @@
 package logcollector
 
 import (
-	"fmt"
 	"io"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sync"
@@ -242,7 +239,7 @@ func TestProcessLogs_SkipSymlinks(t *testing.T) {
 	mockWriter.mu.Unlock()
 }
 
-func TestPollActiveSessionChanges(t *testing.T) {
+func TestHandleSessionChange(t *testing.T) {
 	g := NewWithT(t)
 	baseDir := t.TempDir()
 
@@ -265,38 +262,22 @@ func TestPollActiveSessionChanges(t *testing.T) {
 	logsDirA := filepath.Join(sessionDirA, "logs")
 	createTestLogFile(t, filepath.Join(logsDirA, "raylet.out"), "log content A")
 
-	symlinkPath := filepath.Join(baseDir, "session_latest")
-	if err := os.Symlink(sessionNameA, symlinkPath); err != nil {
-		t.Fatalf("failed to create symlink: %v", err)
-	}
-
-	go handler.PollActiveSessionChanges()
-
-	time.Sleep(500 * time.Millisecond)
-
 	sessionNameB := "session_2026-07-08_16-00-00_123456_1"
 	sessionDirB := filepath.Join(baseDir, sessionNameB)
 	logsDirB := filepath.Join(sessionDirB, "logs")
 	createTestLogFile(t, filepath.Join(logsDirB, "raylet.out"), "log content B")
 
-	os.Remove(symlinkPath)
-	if err := os.Symlink(sessionNameB, symlinkPath); err != nil {
-		t.Fatalf("failed to create symlink: %v", err)
-	}
+	handler.HandleSessionChange(sessionDirB)
 
 	expectedPrevLogsDir := filepath.Join(handler.prevLogsDir, sessionNameA, handler.RayNodeName, "logs")
-	g.Eventually(func() bool {
-		_, err := os.Stat(filepath.Join(expectedPrevLogsDir, "raylet.out"))
-		return err == nil
-	}, 5*time.Second, 100*time.Millisecond).Should(BeTrue(), "Logs from session_A should be moved to prev-logs")
+	_, err := os.Stat(filepath.Join(expectedPrevLogsDir, "raylet.out"))
+	g.Expect(err).To(BeNil(), "Logs from session_A should be moved to prev-logs")
 
-	_, err := os.Stat(filepath.Join(logsDirA, "raylet.out"))
+	_, err = os.Stat(filepath.Join(logsDirA, "raylet.out"))
 	g.Expect(os.IsNotExist(err)).To(BeTrue(), "Original logs in session_A/logs should be deleted (moved)")
-
-	close(handler.ShutdownChan)
 }
 
-func TestPollActiveSessionChanges_MultipleIntermediateSessions(t *testing.T) {
+func TestHandleSessionChange_MultipleIntermediateSessions(t *testing.T) {
 	g := NewWithT(t)
 	baseDir := t.TempDir()
 
@@ -318,15 +299,6 @@ func TestPollActiveSessionChanges_MultipleIntermediateSessions(t *testing.T) {
 	sessionDirA := filepath.Join(baseDir, sessionNameA)
 	createTestLogFile(t, filepath.Join(sessionDirA, "logs", "raylet.out"), "log content A")
 
-	symlinkPath := filepath.Join(baseDir, "session_latest")
-	if err := os.Symlink(sessionNameA, symlinkPath); err != nil {
-		t.Fatalf("failed to create symlink: %v", err)
-	}
-
-	go handler.PollActiveSessionChanges()
-	time.Sleep(200 * time.Millisecond)
-
-	// Simulate rapid restart: session B created (intermediate), then session C created before next ticker poll
 	sessionNameB := "session_2026-07-08_15-30-00_123456_1"
 	sessionDirB := filepath.Join(baseDir, sessionNameB)
 	createTestLogFile(t, filepath.Join(sessionDirB, "logs", "raylet.out"), "log content B")
@@ -335,93 +307,25 @@ func TestPollActiveSessionChanges_MultipleIntermediateSessions(t *testing.T) {
 	sessionDirC := filepath.Join(baseDir, sessionNameC)
 	createTestLogFile(t, filepath.Join(sessionDirC, "logs", "raylet.out"), "log content C")
 
-	os.Remove(symlinkPath)
-	if err := os.Symlink(sessionNameC, symlinkPath); err != nil {
-		t.Fatalf("failed to create symlink: %v", err)
-	}
+	handler.HandleSessionChange(sessionDirC)
 
 	expectedPrevLogsA := filepath.Join(handler.prevLogsDir, sessionNameA, handler.RayNodeName, "logs")
 	expectedPrevLogsB := filepath.Join(handler.prevLogsDir, sessionNameB, handler.RayNodeName, "logs")
 
-	g.Eventually(func() bool {
-		_, errA := os.Stat(filepath.Join(expectedPrevLogsA, "raylet.out"))
-		_, errB := os.Stat(filepath.Join(expectedPrevLogsB, "raylet.out"))
-		return errA == nil && errB == nil
-	}, 6*time.Second, 100*time.Millisecond).Should(BeTrue(), "Logs from both session_A and intermediate session_B should be moved to prev-logs")
-
-	close(handler.ShutdownChan)
+	_, errA := os.Stat(filepath.Join(expectedPrevLogsA, "raylet.out"))
+	_, errB := os.Stat(filepath.Join(expectedPrevLogsB, "raylet.out"))
+	g.Expect(errA == nil && errB == nil).To(BeTrue(), "Logs from both session_A and intermediate session_B should be moved to prev-logs")
 }
 
-func TestNodeIDRefresh(t *testing.T) {
+func TestUpdateNodeID(t *testing.T) {
 	g := NewWithT(t)
-	baseDir := t.TempDir()
-
-	origPodIP := os.Getenv("POD_IP")
-	origFQRayIP := os.Getenv("FQ_RAY_IP")
-	origTmpRoot := os.Getenv("RAY_TMP_ROOT")
-	defer func() {
-		os.Setenv("POD_IP", origPodIP)
-		os.Setenv("FQ_RAY_IP", origFQRayIP)
-		os.Setenv("RAY_TMP_ROOT", origTmpRoot)
-	}()
-
-	os.Setenv("POD_IP", "127.0.0.1")
-	os.Setenv("RAY_TMP_ROOT", baseDir)
-
-	var mu sync.Mutex
-	mockNodeID := "11111111111111111111111111111111"
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v0/nodes" {
-			mu.Lock()
-			nodeID := mockNodeID
-			mu.Unlock()
-			resp := fmt.Sprintf(`{
-				"data": {
-					"result": {
-						"result": [
-							{
-								"node_id": "%s",
-								"node_ip": "127.0.0.1",
-								"state": "ALIVE"
-							}
-						]
-					}
-				}
-			}`, nodeID)
-			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(resp))
-			return
-		}
-		http.NotFound(w, r)
-	}))
-	defer ts.Close()
-
-	os.Setenv("FQ_RAY_IP", ts.URL)
 
 	handler := &RayLogHandler{
-		SessionDir:             baseDir,
-		prevLogsDir:            filepath.Join(baseDir, "prev-logs"),
-		persistCompleteLogsDir: filepath.Join(baseDir, "persist-complete-logs"),
-		ShutdownChan:           make(chan struct{}),
-		RayNodeName:            "11111111111111111111111111111111",
+		RayNodeName: "11111111111111111111111111111111",
 	}
-
-	symlinkPath := filepath.Join(baseDir, "session_latest")
-	if err := os.Symlink(baseDir, symlinkPath); err != nil {
-		t.Fatalf("failed to create symlink: %v", err)
-	}
-	defer os.Remove(symlinkPath)
-
-	go handler.PollActiveSessionChanges()
-	defer close(handler.ShutdownChan)
 
 	g.Expect(handler.GetRayNodeName()).To(Equal("11111111111111111111111111111111"))
 
-	mu.Lock()
-	mockNodeID = "22222222222222222222222222222222"
-	mu.Unlock()
-
-	g.Eventually(func() string {
-		return handler.GetRayNodeName()
-	}, 10*time.Second, 100*time.Millisecond).Should(Equal("22222222222222222222222222222222"), "GetRayNodeName should update dynamically when node ID changes")
+	handler.UpdateNodeID("22222222222222222222222222222222")
+	g.Expect(handler.GetRayNodeName()).To(Equal("22222222222222222222222222222222"), "GetRayNodeName should update when UpdateNodeID is called")
 }

--- a/historyserver/pkg/utils/utils.go
+++ b/historyserver/pkg/utils/utils.go
@@ -89,24 +89,29 @@ func IsSessionDirActive(sessionDir string) bool {
 	return false
 }
 
+// GetSessionDirOnce resolves the session_latest symlink once without retrying.
+func GetSessionDirOnce() (string, error) {
+	symlinkPath := GetRaySessionLatestPath()
+	resolvedPath, resolveErr := filepath.EvalSymlinks(symlinkPath)
+	if resolveErr != nil {
+		var rp string
+		rp, resolveErr = os.Readlink(symlinkPath)
+		if resolveErr != nil {
+			return "", resolveErr
+		}
+		if !filepath.IsAbs(rp) {
+			rp = filepath.Join(filepath.Dir(symlinkPath), rp)
+		}
+		resolvedPath = filepath.Clean(rp)
+	}
+	return resolvedPath, nil
+}
+
+// GetSessionDir resolves the active session directory, retrying at startup until active.
 func GetSessionDir() (string, error) {
 	var lastErr error
 	for i := 0; i < 12; i++ {
-		symlinkPath := GetRaySessionLatestPath()
-		resolvedPath, resolveErr := filepath.EvalSymlinks(symlinkPath)
-		if resolveErr != nil {
-			// Fallback: readlink directly
-			var rp string
-			rp, resolveErr = os.Readlink(symlinkPath)
-			if resolveErr == nil {
-				// If readlink returned a relative target (e.g. session_2026-...), convert to absolute
-				if !filepath.IsAbs(rp) {
-					rp = filepath.Join(filepath.Dir(symlinkPath), rp)
-				}
-				resolvedPath = filepath.Clean(rp)
-			}
-		}
-
+		resolvedPath, resolveErr := GetSessionDirOnce()
 		if resolveErr == nil {
 			if IsSessionDirActive(resolvedPath) {
 				return resolvedPath, nil
@@ -114,7 +119,7 @@ func GetSessionDir() (string, error) {
 			logrus.Infof("Session directory resolved to %s, but it is not active (raylet socket not ready). Retrying...", resolvedPath)
 		} else {
 			if !os.IsNotExist(resolveErr) {
-				return "", fmt.Errorf("failed to resolve session_latest symlink %s: %w", symlinkPath, resolveErr)
+				return "", fmt.Errorf("failed to resolve session_latest symlink: %w", resolveErr)
 			}
 			lastErr = resolveErr
 			logrus.Warnf("Failed to read/resolve session_latest symlink: %v. Retrying...", resolveErr)

--- a/historyserver/test/support/raycluster.go
+++ b/historyserver/test/support/raycluster.go
@@ -68,9 +68,6 @@ func injectCollectorRayClusterNamespaceAndEnvVar(containers []corev1.Container, 
 				containers[i].Command,
 				fmt.Sprintf("--ray-cluster-namespace=%s", rayClusterNamespace),
 			)
-			if containers[i].Env == nil {
-				containers[i].Env = []corev1.EnvVar{}
-			}
 			setOrAppendEnv(&containers[i], "POD_IP", "", &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: "status.podIP",


### PR DESCRIPTION
## Why are these changes needed?
These changes are followup for the following PRs:
1. https://github.com/ray-project/kuberay/pull/4983#discussion_r3643364035 - Centralized Node ID Polling 
2. https://github.com/ray-project/kuberay/pull/4983#discussion_r3635371944 - Replace `panics` so container terminates cleanly
3. https://github.com/ray-project/kuberay/pull/5050#discussion_r3670558801 - Cleanup test

## Related issue number

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

### Manual test instructions

