### PR TITLE
rayjob: Propagate dashboard deletion failures

### DIFF
--- a/apiserver/test/e2e/job_submission_e2e_test.go
+++ b/apiserver/test/e2e/job_submission_e2e_test.go
@@ -170,7 +170,7 @@ func TestCreateJobSubmission(t *testing.T) {
 			return ""
 		}
 		return jobDetails.Status
-	}, TestTimeoutMedium, TestPollingInterval).Should(gomega.Equal("STOPPED"))
+	}, TestTimeoutMedium, TestPollingInterval).Should(gomega.BeElementOf("STOPPED", "SUCCEEDED", "FAILED"))
 
 	// Delete job
 	deleteJobRequest := api.DeleteRayJobSubmissionRequest{

--- a/apiserver/test/e2e/job_submission_e2e_test.go
+++ b/apiserver/test/e2e/job_submission_e2e_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"testing"
 
+	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
 
 	api "github.com/ray-project/kuberay/proto/go_client"
@@ -162,6 +163,14 @@ func TestCreateJobSubmission(t *testing.T) {
 	jobStopStatus, err = tCtx.GetRayAPIServerClient().StopRayJob(&stopJobRequest)
 	require.NoError(t, err, "No error expected")
 	require.Nil(t, jobStopStatus, "No RPC status expected")
+
+	gomega.NewWithT(t).Eventually(func() string {
+		jobDetails, rpcStatus, err := tCtx.GetRayAPIServerClient().GetRayJobDetails(&jobDetailsRequest)
+		if err != nil || rpcStatus != nil || jobDetails == nil {
+			return ""
+		}
+		return jobDetails.Status
+	}, TestTimeoutMedium, TestPollingInterval).Should(gomega.Equal("STOPPED"))
 
 	// Delete job
 	deleteJobRequest := api.DeleteRayJobSubmissionRequest{

--- a/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient.go
@@ -353,6 +353,19 @@ func (r *RayDashboardClient) DeleteJob(ctx context.Context, jobName string) erro
 	}
 	defer resp.Body.Close()
 
+	// Deleting an already absent job is successful, which keeps deletion idempotent.
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		const maxErrorResponseBodyBytes = 4096
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorResponseBodyBytes))
+		if err != nil {
+			return fmt.Errorf("DeleteJob fail: %s: failed to read response body: %w", resp.Status, err)
+		}
+		return fmt.Errorf("DeleteJob fail: %s %s", resp.Status, string(body))
+	}
+
 	return nil
 }
 

--- a/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboardclient/dashboard_httpclient_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/jarcoal/httpmock"
 	. "github.com/onsi/ginkgo/v2"
@@ -145,6 +146,47 @@ var _ = Describe("RayFrameworkGenerator", func() {
 
 		err := rayDashboardClient.StopJob(context.TODO(), "stop-job-1")
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("returns success when deleting a job succeeds", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		httpmock.RegisterResponder(http.MethodDelete, rayDashboardClient.dashboardURL+JobPath+expectJobId,
+			httpmock.NewStringResponder(http.StatusNoContent, ""))
+
+		err := rayDashboardClient.DeleteJob(context.TODO(), expectJobId)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("returns success when deleting an already absent job", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		httpmock.RegisterResponder(http.MethodDelete, rayDashboardClient.dashboardURL+JobPath+expectJobId,
+			httpmock.NewStringResponder(http.StatusNotFound, "job does not exist"))
+
+		err := rayDashboardClient.DeleteJob(context.TODO(), expectJobId)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("returns bounded response details when deleting a job fails", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		forbiddenBody := "access denied"
+		httpmock.RegisterResponder(http.MethodDelete, rayDashboardClient.dashboardURL+JobPath+"forbidden-job",
+			httpmock.NewStringResponder(http.StatusForbidden, forbiddenBody))
+		largeBody := strings.Repeat("x", 5000)
+		httpmock.RegisterResponder(http.MethodDelete, rayDashboardClient.dashboardURL+JobPath+"failed-job",
+			httpmock.NewStringResponder(http.StatusInternalServerError, largeBody))
+
+		err := rayDashboardClient.DeleteJob(context.TODO(), "forbidden-job")
+		Expect(err).To(MatchError(ContainSubstring("DeleteJob fail: 403 Forbidden")))
+		Expect(err).To(MatchError(ContainSubstring(forbiddenBody)))
+
+		err = rayDashboardClient.DeleteJob(context.TODO(), "failed-job")
+		Expect(err).To(MatchError(ContainSubstring("DeleteJob fail: 500 Internal Server Error")))
+		Expect(err.Error()).To(HaveLen(len("DeleteJob fail: 500 Internal Server Error ") + 4096))
+		Expect(err.Error()).ToNot(ContainSubstring(strings.Repeat("x", 4097)))
 	})
 
 	It("Test stop succeeded job", func() {


### PR DESCRIPTION
## Why are these changes needed?

`RayDashboardClient.DeleteJob` currently reports success for every HTTP response as long as the request itself completes. Dashboard authorization failures and server errors are therefore silently ignored, and the RayJob controller may continue cleanup as if the job were deleted.

This change treats 2xx responses as success, preserves idempotent deletion by treating 404 as success, and returns an error for other non-2xx responses. Error response bodies are limited to 4 KiB.

## Related issue number



## Labels

- [x] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [x] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

Tested with:

```console
go test ./controllers/ray/utils/dashboardclient
```