### PR TITLE
Add stale issue/PR bot workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -62,7 +62,7 @@ jobs:
 
             Thanks again for the report!
 
-          # --- Pull request settings (Ray's current stale-PR policy) ---
+          # --- Pull request settings ---
           # Number of days of inactivity before a pull request becomes stale.
           days-before-pr-stale: 120
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,6 +10,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
+      actions: write # Required to manage the actions cache used to persist state across runs.
       issues: write # Required to add labels, comment, close issues.
       pull-requests: write # Required to add labels, comment, close PRs.
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,112 @@
+name: Mark and close stale issues and pull requests
+
+on:
+  schedule:
+    # Runs twice a day at 15 minutes past midnight and noon UTC (same cadence as Ray's stale workflow).
+    - cron: '15 */12 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # Required to add labels, comment, close issues.
+      pull-requests: write # Required to add labels, comment, close PRs.
+
+    steps:
+      - name: Mark and close stale issues and pull requests
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # --- Issue settings (Ray's historical stale-issue policy) ---
+          # Number of days of inactivity before an issue becomes stale.
+          days-before-issue-stale: 120
+
+          # Number of days of inactivity after being marked stale before an issue is closed.
+          days-before-issue-close: 14
+
+          # Label to use when marking an issue as stale.
+          stale-issue-label: 'stale'
+
+          # Issues with these labels will never be considered stale.
+          exempt-issue-labels: >
+            P0,
+            P0.5,
+            P1,
+            P2,
+            P3,
+            triage,
+            good-first-issue,
+            release-blocker
+
+          # Comment to post when marking an issue as stale.
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had
+            any activity for 120 days. It will be closed in 14 days if no further activity occurs.
+
+            If you'd like to keep this issue open, just leave any comment, and the stale label will be removed.
+            If you'd like to get more attention on this issue, please tag one of the KubeRay maintainers.
+
+            You can always ask for help on [Ray's public Slack channel](https://github.com/ray-project/kuberay#getting-involved).
+
+          # Comment to post when closing a stale issue.
+          close-issue-message: |
+            This issue has been automatically closed because there has been no more activity in the
+            14 days since being marked stale.
+
+            Please feel free to reopen or open a new issue if you'd still like this to be addressed.
+
+            Again, you can always ask for help on [Ray's public Slack channel](https://github.com/ray-project/kuberay#getting-involved).
+
+            Thanks again for the report!
+
+          # --- Pull request settings (Ray's current stale-PR policy) ---
+          # Number of days of inactivity before a pull request becomes stale.
+          days-before-pr-stale: 14
+
+          # Number of days of inactivity after being marked stale before a pull request is closed.
+          days-before-pr-close: 14
+
+          # Label to use when marking a PR as stale.
+          stale-pr-label: 'stale'
+
+          # Pull requests with these labels will never be considered stale.
+          exempt-pr-labels: >
+            release-blocker,
+            branch-cut-blocker
+
+          # Comment to post when marking a PR as stale.
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had
+            any activity for 14 days. It will be closed in another 14 days if no further activity occurs.
+            Thank you for your contributions.
+
+            You can always ask for help on [Ray's public Slack channel](https://github.com/ray-project/kuberay#getting-involved).
+
+            If you'd like to keep this open, just leave any comment, and the stale label will be removed.
+
+          # Comment to post when closing a stale PR.
+          close-pr-message: |
+            This pull request has been automatically closed because there has been no more activity in the 14 days
+            since being marked stale.
+
+            Please feel free to reopen or open a new pull request if you'd still like this to be addressed.
+
+            Again, you can always ask for help on [Ray's public Slack channel](https://github.com/ray-project/kuberay#getting-involved).
+
+            Thanks again for your contribution!
+
+          # --- Shared settings & other options ---
+          # Limit the number of actions per run.
+          operations-per-run: 500
+
+          # Remove the stale label from issues/PRs when they receive new activity.
+          remove-issue-stale-when-updated: true
+          remove-pr-stale-when-updated: true
+
+          # Set to true to ignore issues/PRs in a milestone.
+          exempt-all-issue-milestones: true
+          exempt-all-pr-milestones: true
+
+          ascending: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-          # --- Issue settings (Ray's historical stale-issue policy) ---
+          # --- Issue settings ---
           # Number of days of inactivity before an issue becomes stale.
           days-before-issue-stale: 120
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -2,7 +2,7 @@ name: Mark and close stale issues and pull requests
 
 on:
   schedule:
-    # Runs twice a day at 15 minutes past midnight and noon UTC (same cadence as Ray's stale workflow).
+    # Runs twice a day at 15 minutes past midnight and noon UTC.
     - cron: '15 */12 * * *'
   workflow_dispatch: {}
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -37,7 +37,6 @@ jobs:
             P1,
             P2,
             P3,
-            triage,
             good-first-issue,
             release-blocker
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -64,7 +64,7 @@ jobs:
 
           # --- Pull request settings (Ray's current stale-PR policy) ---
           # Number of days of inactivity before a pull request becomes stale.
-          days-before-pr-stale: 14
+          days-before-pr-stale: 120
 
           # Number of days of inactivity after being marked stale before a pull request is closed.
           days-before-pr-close: 14

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -80,7 +80,7 @@ jobs:
           # Comment to post when marking a PR as stale.
           stale-pr-message: |
             This pull request has been automatically marked as stale because it has not had
-            any activity for 14 days. It will be closed in another 14 days if no further activity occurs.
+            any activity for 120 days. It will be closed in another 14 days if no further activity occurs.
             Thank you for your contributions.
 
             You can always ask for help on [Ray's public Slack channel](https://github.com/ray-project/kuberay#getting-involved).


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We have old issues and PRs that would benefit from being automatically marked stale and closed after prolonged inactivity.

Adds `.github/workflows/stale.yaml` using [`actions/stale@v9`](https://github.com/actions/stale), the same action Ray currently uses for its own [stale PR workflow](https://github.com/ray-project/ray/blob/master/.github/workflows/stale_pull_request.yaml).

Ray's *current* workflow only handles PRs (issues are explicitly disabled). Ray previously handled issues too, via a now-retired [`probot-stale` config](https://github.com/ray-project/ray/blob/9f40d3eeac887f982bc9528fd3c4d536415a1a77/.github/stale.yml). This PR carries that historical issue policy forward on top of Ray's current PR policy:

- **Issues**: 120 days inactivity → marked `stale`; 14 more days → closed. Exempt labels: `P0`, `P0.5`, `P1`, `P2`, `P3`, `good-first-issue`, `release-blocker`.
- **Pull requests**: 120 days inactivity → marked `stale`; 14 more days → closed. Exempt labels: `release-blocker`, `branch-cut-blocker`.

The day thresholds and exempt labels are easy to tune in a single place if maintainers prefer different values — flagging this explicitly since [a comment on #681](https://github.com/ray-project/kuberay/issues/681#issuecomment-5078063424) noted the timeframe should be a maintainer decision.

## Related issue number

Closes #681

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

### Manual test instructions

Verified end-to-end on a fork with a temporary copy of this workflow (thresholds set to 0 days, `debug-only` dry run first, then a live run):

| Test case | Label | Result | Link |
|---|---|---|---|
| Issue, no exempt label | — | marked `stale`, commented, closed ✅ | https://github.com/yjaw/kuberay/issues/1 |
| Issue, `P1` | P1 | untouched ✅ | https://github.com/yjaw/kuberay/issues/2 |
| PR, no exempt label | — | marked `stale`, commented, closed ✅ | https://github.com/yjaw/kuberay/pull/3 |
| PR, `release-blocker` | release-blocker | untouched ✅ | https://github.com/yjaw/kuberay/pull/4 |