### PR TITLE
[history server] Fix job event naming, graceful collector exit, and add default helm value

### DIFF
--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -187,6 +187,8 @@ spec:
 | featureGates[5].enabled | bool | `false` |  |
 | featureGates[6].name | string | `"RayClusterNetworkPolicy"` |  |
 | featureGates[6].enabled | bool | `false` |  |
+| featureGates[7].name | string | `"RayClusterHistoryServer"` |  |
+| featureGates[7].enabled | bool | `false` |  |
 | metrics.enabled | bool | `true` | Whether KubeRay operator should emit control plane metrics. |
 | metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -161,6 +161,8 @@ featureGates:
   enabled: false
 - name: RayClusterNetworkPolicy
   enabled: false
+- name: RayClusterHistoryServer
+  enabled: false
 
 # Configurations for KubeRay operator metrics.
 metrics:

--- a/historyserver/cmd/collector/main.go
+++ b/historyserver/cmd/collector/main.go
@@ -90,7 +90,7 @@ func main() {
 	} else if strings.EqualFold(role, "worker") {
 		role = "Worker"
 	} else {
-		panic("Invalid role: " + role + ", must be Head or Worker")
+		logrus.Fatalf("Invalid role: %s, must be Head or Worker", role)
 	}
 
 	if err := validateFlags(&rayClusterName, &rayClusterNamespace, &ownerKind, &ownerName); err != nil {
@@ -111,10 +111,10 @@ func main() {
 	if intervalStr := os.Getenv("RAY_COLLECTOR_POLL_INTERVAL"); intervalStr != "" {
 		parsed, parseErr := time.ParseDuration(intervalStr)
 		if parseErr != nil {
-			panic("Failed to parse RAY_COLLECTOR_POLL_INTERVAL: " + parseErr.Error())
+			logrus.Fatalf("Failed to parse RAY_COLLECTOR_POLL_INTERVAL: %v", parseErr)
 		}
 		if parsed <= 0 {
-			panic("RAY_COLLECTOR_POLL_INTERVAL must be positive, got: " + intervalStr)
+			logrus.Fatalf("RAY_COLLECTOR_POLL_INTERVAL must be positive, got: %s", intervalStr)
 		}
 		endpointPollInterval = parsed
 	}
@@ -123,10 +123,10 @@ func main() {
 	if runtimeClassConfigPath != "" {
 		data, err := os.ReadFile(runtimeClassConfigPath)
 		if err != nil {
-			panic(fmt.Sprintf("Failed to read runtime class config from %s: %v", runtimeClassConfigPath, err))
+			logrus.Fatalf("Failed to read runtime class config from %s: %v", runtimeClassConfigPath, err)
 		}
 		if err := json.Unmarshal(data, &jsonData); err != nil {
-			panic(fmt.Sprintf("Failed to parse runtime class config from %s: %v", runtimeClassConfigPath, err))
+			logrus.Fatalf("Failed to parse runtime class config from %s: %v", runtimeClassConfigPath, err)
 		}
 	}
 
@@ -140,22 +140,22 @@ func main() {
 	registry := collector.GetWriterRegistry()
 	factory, ok := registry[runtimeClassName]
 	if !ok {
-		panic("Not supported runtime class name: " + runtimeClassName + " for role: " + role + ".")
+		logrus.Fatalf("Not supported runtime class name: %s for role: %s.", runtimeClassName, role)
 	}
 
 	rayNodeId, err := utils.GetNodeRayIDWithFQIP()
 	if err != nil {
-		panic("Failed to get ray node id via HTTP endpoint: " + err.Error())
+		logrus.Fatalf("Failed to get ray node id via HTTP endpoint: %v", err)
 	}
 
 	rayNodeId, err = utils.ConvertBase64ToHex(rayNodeId)
 	if err != nil {
-		panic("Failed to normalize ray node id to hex: " + err.Error())
+		logrus.Fatalf("Failed to normalize ray node id to hex: %v", err)
 	}
 
 	activeSessionDir, err := utils.GetSessionDir()
 	if err != nil {
-		panic("Failed to get active session dir after discovering node id: " + err.Error())
+		logrus.Fatalf("Failed to get active session dir after discovering node id: %v", err)
 	}
 
 	if err := utils.MoveLeftoverSessionLogs(activeSessionDir, rayNodeId); err != nil {
@@ -184,7 +184,7 @@ func main() {
 
 	writer, err := factory(&globalConfig, jsonData)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to create writer for runtime class name: %s for role: %s, err: %+v", runtimeClassName, role, err))
+		logrus.Fatalf("Failed to create writer for runtime class name: %s for role: %s, err: %v", runtimeClassName, role, err)
 	}
 
 	var wg sync.WaitGroup

--- a/historyserver/pkg/collector/eventcollector/eventcollector.go
+++ b/historyserver/pkg/collector/eventcollector/eventcollector.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"path"
-	"strings"
 	"sync"
 	"time"
 
@@ -250,9 +249,14 @@ func (ec *EventCollector) flushEvents() {
 
 // flushEventsInternal performs the actual event flush
 func (ec *EventCollector) flushEventsInternal(eventsToFlush []Event) {
+	type jobHourKey struct {
+		jobID   string
+		hourKey string
+	}
+
 	// Group events by hour and type
-	nodeEventsByHour := make(map[string][]Event) // Node-related events
-	jobEventsByHour := make(map[string][]Event)  // Job-related events
+	nodeEventsByHour := make(map[string][]Event)    // Node-related events
+	jobEventsByHour := make(map[jobHourKey][]Event) // Job-related events
 
 	// Categorize events
 	for _, event := range eventsToFlush {
@@ -263,9 +267,8 @@ func (ec *EventCollector) flushEventsInternal(eventsToFlush []Event) {
 			// Node-related events
 			nodeEventsByHour[hourKey] = append(nodeEventsByHour[hourKey], event)
 		} else if jobID := getJobID(event.Data); jobID != "" {
-			// Job-related events, use jobID-hour as key
-			jobKey := fmt.Sprintf("%s-%s", jobID, hourKey)
-			jobEventsByHour[jobKey] = append(jobEventsByHour[jobKey], event)
+			key := jobHourKey{jobID: jobID, hourKey: hourKey}
+			jobEventsByHour[key] = append(jobEventsByHour[key], event)
 		} else {
 			// Default to node events
 			nodeEventsByHour[hourKey] = append(nodeEventsByHour[hourKey], event)
@@ -288,24 +291,14 @@ func (ec *EventCollector) flushEventsInternal(eventsToFlush []Event) {
 	}
 
 	// Upload job-related events
-	for jobHour, events := range jobEventsByHour {
+	for jk, events := range jobEventsByHour {
 		wg.Add(1)
-		go func(jobHourKey string, hourEvents []Event) {
+		go func(groupKey jobHourKey, hourEvents []Event) {
 			defer wg.Done()
-			// Split jobID and hourKey
-			parts := strings.SplitN(jobHourKey, "-", 4) // Date format has 3 dashes, so use 4 parts
-			if len(parts) < 4 {
-				errChan <- fmt.Errorf("invalid job hour key: %s", jobHourKey)
-				return
-			}
-
-			jobID := parts[0]
-			hourKey := strings.Join(parts[1:], "-") // Rejoin time parts as hourKey
-
-			if err := ec.flushJobEventsForHour(jobID, hourKey, hourEvents); err != nil {
+			if err := ec.flushJobEventsForHour(groupKey.jobID, groupKey.hourKey, hourEvents); err != nil {
 				errChan <- err
 			}
-		}(jobHour, events)
+		}(jk, events)
 	}
 
 	wg.Wait()
@@ -317,10 +310,14 @@ func (ec *EventCollector) flushEventsInternal(eventsToFlush []Event) {
 	}
 
 	totalEvents := len(eventsToFlush)
+	jobEventsCount := 0
+	for _, events := range jobEventsByHour {
+		jobEventsCount += len(events)
+	}
 	logrus.Infof("Successfully flushed %d events to storage (%d node events, %d job events)",
 		totalEvents,
 		countEventsInMap(nodeEventsByHour),
-		countEventsInMap(jobEventsByHour))
+		jobEventsCount)
 }
 
 // countEventsInMap counts total events in map


### PR DESCRIPTION
## Why are these changes needed?
This PR contains some fixes/missing values for history server.

- Fix job event grouping: Group job events using a typed Go struct key (jobHourKey) instead of hyphen-joined strings to prevent job IDs containing hyphens (e.g., rayjob-sample-123) from being corrupted by strings.SplitN. 
- Graceful collector exit: Replaced unhandled panic calls in cmd/collector/main.go with structured logrus.Fatalf logging.
- Helm values: Added the RayClusterHistoryServer feature gate field to helm-chart/kuberay-operator/values.yaml.

## Related issue number

N/A

## Labels
- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

### Manual test instructions

1. Deploy a RayJob with a hyphenated jobId:

```yaml
apiVersion: ray.io/v1
kind: RayJob
metadata:
  name: rayjob-hyphen-test
spec:
  jobId: "custom-hyphen-job-id-99"   # Hyphenated job ID
  entrypoint: python sample_code.py
  rayClusterSpec:
    historyServerOptions:
      collectorOptions:
        image: us-west1-docker.pkg.dev/aaronliang-gke-dev/ray-ar/ray-collector:old-broken-test
``` 

2. Inspect GCS bucket directory paths:
gcloud storage ls --recursive gs://<BUCKET>/<ROOT>/cluster-history/rayjob/default/rayjob-hyphen-test/**

3. Observed Result:
Broken version: Under .../job_events/, no custom-hyphen-job-id-99/ folder is created (events are misfiled under custom/ or fail to upload due to corrupted timestamp format).
