### PR TITLE
[History Server] Treat suspended RayCluster as dead in isDead

### DIFF
--- a/historyserver/pkg/historyserver/enter_cluster_test.go
+++ b/historyserver/pkg/historyserver/enter_cluster_test.go
@@ -366,6 +366,90 @@ func TestEnterClusterLatestPrioritizesLive(t *testing.T) {
 	}
 }
 
+func TestEnterClusterSuspendedFallsBackToStorage(t *testing.T) {
+	restful.DefaultContainer = restful.NewContainer()
+
+	// RayCluster CR is present but fully suspended (all Pods deleted): it must
+	// not be treated as live, even though the CR itself still exists.
+	scheme := runtime.NewScheme()
+	_ = rayv1.AddToScheme(scheme)
+	suspendedCluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-suspended"},
+		Status: rayv1.RayClusterStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(rayv1.RayClusterSuspended),
+					Status: metav1.ConditionTrue,
+					Reason: string(rayv1.RayClusterSuspended),
+				},
+			},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(suspendedCluster).WithStatusSubresource(suspendedCluster).Build()
+	clientManager := &ClientManager{
+		clients: []client.Client{k8sClient},
+	}
+
+	mockReader := &mockStorageReader{
+		clusters: []utils.ClusterInfo{
+			{
+				Namespace:       "default",
+				Name:            "cluster-suspended",
+				SessionName:     "session_2026-04-22_10-00-00_000000_1",
+				CreateTimeStamp: 1000,
+			},
+		},
+	}
+
+	handler := &ServerHandler{
+		maxClusters:   100,
+		clientManager: clientManager,
+		reader:        mockReader,
+	}
+
+	fp := &fakeProcessor{
+		fn: func(ctx context.Context, info utils.ClusterInfo) (SessionStatus, *eventserver.SessionSnapshot, error) {
+			return SessionStatusProcessed, &eventserver.SessionSnapshot{}, nil
+		},
+	}
+	handler.sessionLoader = NewSessionLoader(fp, context.Background(), DefaultSessionProcessTimeout, DefaultSessionCacheSize, DefaultSessionCacheTTL)
+
+	routerRayClusterSet(handler)
+	container := restful.DefaultContainer
+
+	// listClusters must not surface the suspended cluster as a live entry.
+	t.Run("listClusters excludes suspended cluster from live entries", func(t *testing.T) {
+		clusters := handler.listClusters(100)
+		for _, c := range clusters {
+			if c.Name == "cluster-suspended" && c.SessionName == "live" {
+				t.Fatalf("Expected suspended cluster to be excluded from live entries, but found: %+v", c)
+			}
+		}
+	})
+
+	// Entering the cluster with "latest" must fall back to the stored dead session
+	// instead of resolving to "live" (which would proxy to a head Pod that no longer exists).
+	t.Run("enter_cluster with latest resolves to stored session, not live", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/enter_cluster/default/raycluster/cluster-suspended/latest", nil)
+		resp := httptest.NewRecorder()
+		container.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+		}
+
+		cookies := resp.Result().Cookies()
+		cookieMap := make(map[string]*http.Cookie)
+		for _, cookie := range cookies {
+			cookieMap[cookie.Name] = cookie
+		}
+
+		if c, ok := cookieMap[COOKIE_SESSION_NAME_KEY]; !ok || c.Value != "session_2026-04-22_10-00-00_000000_1" {
+			t.Errorf("Expected cookie %s to fall back to the stored session, got %v", COOKIE_SESSION_NAME_KEY, c)
+		}
+	})
+}
+
 func TestEnterClusterReturnsNotFoundWhenRemovedFromStorage(t *testing.T) {
 	restful.DefaultContainer = restful.NewContainer()
 

--- a/historyserver/pkg/historyserver/reader.go
+++ b/historyserver/pkg/historyserver/reader.go
@@ -96,6 +96,10 @@ func (s *ServerHandler) listClusters(limit int) []utils.ClusterInfo {
 		logrus.Errorf("Failed to list live RayClusters: %v", err)
 	}
 	for _, liveCluster := range liveClusters {
+		if isRayClusterSuspended(liveCluster) {
+			// No live head Pod to show; it will surface via stored sessions below.
+			continue
+		}
 		liveClusterInfo := buildLiveClusterInfo(liveCluster)
 		liveClusterInfos = append(liveClusterInfos, liveClusterInfo)
 		liveClusterNames = append(liveClusterNames, liveCluster.Name)
@@ -123,9 +127,9 @@ func (s *ServerHandler) resolveSession(ctx context.Context, namespace, resourceT
 	if isLatestOrEmpty || session == "live" {
 		if resTypeLower == utils.RayClusterKind {
 			liveCluster, err := s.clientManager.GetRayCluster(ctx, namespace, resourceName)
-			if err == nil {
+			if err == nil && !isRayClusterSuspended(liveCluster) {
 				return buildLiveClusterInfo(liveCluster), true, nil
-			} else if !apierrors.IsNotFound(err) {
+			} else if err != nil && !apierrors.IsNotFound(err) {
 				return utils.ClusterInfo{}, false, fmt.Errorf("failed to check live RayCluster %s/%s: %w", namespace, resourceName, err)
 			}
 		} else {
@@ -142,8 +146,11 @@ func (s *ServerHandler) resolveSession(ctx context.Context, namespace, resourceT
 				return utils.ClusterInfo{}, false, fmt.Errorf("failed to list live RayClusters: %w", err)
 			}
 			// TODO: A RayService owns both an active and a pending cluster during an upgrade. Needs to decide which one to take.
-			if len(liveClusters) > 0 {
-				info := buildLiveClusterInfo(liveClusters[0])
+			for _, liveCluster := range liveClusters {
+				if isRayClusterSuspended(liveCluster) {
+					continue
+				}
+				info := buildLiveClusterInfo(liveCluster)
 				if info.OwnerKind == "" {
 					info.OwnerKind = resTypeLower
 					info.OwnerName = resourceName

--- a/historyserver/pkg/historyserver/session_processor.go
+++ b/historyserver/pkg/historyserver/session_processor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -93,7 +94,7 @@ func (p *SessionProcessor) isDead(ctx context.Context, session utils.ClusterInfo
 	if err != nil {
 		return false, err
 	}
-	if rc.Spec.Suspend != nil && *rc.Spec.Suspend {
+	if meta.IsStatusConditionTrue(rc.Status.Conditions, string(rayv1.RayClusterSuspended)) {
 		return true, nil
 	}
 	return false, nil

--- a/historyserver/pkg/historyserver/session_processor.go
+++ b/historyserver/pkg/historyserver/session_processor.go
@@ -94,10 +94,16 @@ func (p *SessionProcessor) isDead(ctx context.Context, session utils.ClusterInfo
 	if err != nil {
 		return false, err
 	}
-	if meta.IsStatusConditionTrue(rc.Status.Conditions, string(rayv1.RayClusterSuspended)) {
+	if isRayClusterSuspended(rc) {
 		return true, nil
 	}
 	return false, nil
+}
+
+// isRayClusterSuspended reports whether the controller has confirmed all Pods
+// belonging to the RayCluster are deleted (spec.suspend=true fully applied).
+func isRayClusterSuspended(rc *rayv1.RayCluster) bool {
+	return meta.IsStatusConditionTrue(rc.Status.Conditions, string(rayv1.RayClusterSuspended))
 }
 
 // isCtxCanceled checks if the error is caused by context cancellation

--- a/historyserver/pkg/historyserver/session_processor.go
+++ b/historyserver/pkg/historyserver/session_processor.go
@@ -23,8 +23,8 @@ type SessionStatus int
 const (
 	// SessionStatusUnknown is the zero value, reserved as a defensive guard.
 	SessionStatusUnknown SessionStatus = iota
-	// SessionStatusLive means the RayCluster CR is still present and the
-	// session is intentionally skipped.
+	// SessionStatusLive means the RayCluster CR is still present and not
+	// suspended, so the session is intentionally skipped.
 	SessionStatusLive
 	// SessionStatusProcessed means events were ingested into EventHandler's
 	// in-memory state.
@@ -78,7 +78,7 @@ func (p *SessionProcessor) ProcessSession(ctx context.Context, session utils.Clu
 	return SessionStatusProcessed, h.BuildSnapshot(session), nil
 }
 
-// isDead determines if the RayCluster CR is absent.
+// isDead determines if the RayCluster CR is absent or suspended.
 //
 // Known limit: An old session of a still-running RayCluster will be misclassified as live.
 func (p *SessionProcessor) isDead(ctx context.Context, session utils.ClusterInfo) (bool, error) {
@@ -92,6 +92,9 @@ func (p *SessionProcessor) isDead(ctx context.Context, session utils.ClusterInfo
 	}
 	if err != nil {
 		return false, err
+	}
+	if rc.Spec.Suspend != nil && *rc.Spec.Suspend {
+		return true, nil
 	}
 	return false, nil
 }

--- a/historyserver/pkg/historyserver/session_processor_test.go
+++ b/historyserver/pkg/historyserver/session_processor_test.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -32,6 +33,12 @@ func rayCluster(namespace, name string) *rayv1.RayCluster {
 	}
 }
 
+func suspendedRayCluster(namespace, name string) *rayv1.RayCluster {
+	rc := rayCluster(namespace, name)
+	rc.Spec.Suspend = ptr.To(true)
+	return rc
+}
+
 func TestIsDead(t *testing.T) {
 	const (
 		ns             = "default"
@@ -53,6 +60,11 @@ func TestIsDead(t *testing.T) {
 			name:     "RayCluster CR present -> alive",
 			cr:       rayCluster(ns, name),
 			wantDead: false,
+		},
+		{
+			name:     "RayCluster CR present but suspended -> dead",
+			cr:       suspendedRayCluster(ns, name),
+			wantDead: true,
 		},
 	}
 

--- a/historyserver/pkg/historyserver/session_processor_test.go
+++ b/historyserver/pkg/historyserver/session_processor_test.go
@@ -7,7 +7,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -33,9 +32,16 @@ func rayCluster(namespace, name string) *rayv1.RayCluster {
 	}
 }
 
-func suspendedRayCluster(namespace, name string) *rayv1.RayCluster {
+func rayClusterWithCondition(namespace, name string, condType rayv1.RayClusterConditionType) *rayv1.RayCluster {
 	rc := rayCluster(namespace, name)
-	rc.Spec.Suspend = ptr.To(true)
+	rc.Status.Conditions = []metav1.Condition{
+		{
+			Type:               string(condType),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(condType),
+			LastTransitionTime: metav1.Now(),
+		},
+	}
 	return rc
 }
 
@@ -62,9 +68,14 @@ func TestIsDead(t *testing.T) {
 			wantDead: false,
 		},
 		{
-			name:     "RayCluster CR present but suspended -> dead",
-			cr:       suspendedRayCluster(ns, name),
+			name:     "RayCluster CR present and fully suspended -> dead",
+			cr:       rayClusterWithCondition(ns, name, rayv1.RayClusterSuspended),
 			wantDead: true,
+		},
+		{
+			name:     "RayCluster CR present but still suspending -> alive",
+			cr:       rayClusterWithCondition(ns, name, rayv1.RayClusterSuspending),
+			wantDead: false,
 		},
 	}
 


### PR DESCRIPTION
## Why are these changes needed?

When a RayCluster is suspended (`spec.suspend = true`), KubeRay deletes all Pods (including the head Pod) but keeps the RayCluster CR. The history server had multiple places that treated "the RayCluster CR exists" as "the cluster is live," none of which accounted for suspension, so it kept trying to proxy dashboard requests to a head Pod that no longer exists — failing with a DNS lookup error — and neither the live nor the dead session for that cluster could be viewed.

### `SessionProcessor.isDead`

Only checked whether the CR existed. Now also treats a suspended RayCluster as dead so its sessions fall back to reading stored historical data.

We check the `RayClusterSuspended` status condition rather than `spec.Suspend` directly: `spec.Suspend` flips `true` the instant a user requests suspension, well before Pods are actually deleted. Marking the session dead (and caching its snapshot — dead-session snapshots are cached indefinitely) at that point would race the collector's SIGTERM-triggered flush of the final logs/events, permanently caching an incomplete snapshot. `RayClusterSuspended` is only set by the controller once it observes zero running Pods ([raycluster_controller.go#L2064-L2083](https://github.com/ray-project/kuberay/blob/master/ray-operator/controllers/ray/raycluster_controller.go#L2064-L2083)), which is after the flush window has passed. During the brief `RayClusterSuspending` transition, the session is still treated as live and a proxy attempt can transiently fail, but `SessionStatusLive` is never cached, so the next request re-checks and resolves automatically — no permanent breakage.

### `listClusters` and `resolveSession`

`isDead` alone wasn't sufficient: `listClusters` (used to build the cluster list) and `resolveSession` (used to resolve `/enter_cluster/...` requests, including the default `"latest"` resolution — the primary path a user hits when opening a cluster) each independently call into the K8s client and treat any existing RayCluster CR as live, bypassing `isDead` entirely. A suspended cluster was still shown as a live entry in the list, and entering it still resolved to `"live"` and proxied to a Pod that no longer exists.

Extracted `isRayClusterSuspended` as a shared helper (used by `isDead` too) and applied it in both places so a suspended cluster is excluded from the live list and falls back to stored session data when resolved.

## Related issue number

Closes #5062

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(