### PR TITLE
[CI] Add Buildkite Go test result parser

### DIFF
--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -1,0 +1,1 @@
+"""Continuous integration helpers for KubeRay."""

--- a/ci/flaky_tracker/__init__.py
+++ b/ci/flaky_tracker/__init__.py
@@ -1,0 +1,19 @@
+"""Utilities for tracking flaky tests in KubeRay CI."""
+
+from ci.flaky_tracker.parser import (
+    FailureKind,
+    GoTestLogParseResult,
+    PackageFailure,
+    TestResult,
+    TestStatus,
+    parse_go_test_log,
+)
+
+__all__ = [
+    "FailureKind",
+    "GoTestLogParseResult",
+    "PackageFailure",
+    "TestResult",
+    "TestStatus",
+    "parse_go_test_log",
+]

--- a/ci/flaky_tracker/__init__.py
+++ b/ci/flaky_tracker/__init__.py
@@ -1,0 +1,31 @@
+"""Utilities for tracking flaky tests in KubeRay CI."""
+
+from ci.flaky_tracker.buildkite import (
+    BuildkiteAPIError,
+    BuildkiteResponseError,
+    BuildkiteTest,
+    BuildkiteTestEngineClient,
+    ExecutionCounts,
+)
+from ci.flaky_tracker.parser import (
+    FailureKind,
+    GoTestLogParseResult,
+    PackageFailure,
+    TestResult,
+    TestStatus,
+    parse_go_test_log,
+)
+
+__all__ = [
+    "BuildkiteAPIError",
+    "BuildkiteResponseError",
+    "BuildkiteTest",
+    "BuildkiteTestEngineClient",
+    "ExecutionCounts",
+    "FailureKind",
+    "GoTestLogParseResult",
+    "PackageFailure",
+    "TestResult",
+    "TestStatus",
+    "parse_go_test_log",
+]

--- a/ci/flaky_tracker/buildkite.py
+++ b/ci/flaky_tracker/buildkite.py
@@ -1,0 +1,430 @@
+"""Read test history from the Buildkite Test Engine API.
+
+The client deliberately covers only read operations.  Test result collection,
+flaky-test policy, and GitHub issue automation are separate concerns that can
+be added after KubeRay has a Buildkite test suite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from http.client import HTTPException
+import json
+import re
+from typing import Any, Callable, Iterable, Mapping, Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode, urljoin, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+
+DEFAULT_API_BASE_URL = "https://api.buildkite.com/v2"
+TESTS_API_VERSION = "2026-08-01"
+_USER_AGENT = "kuberay-flaky-tracker"
+_MAX_ERROR_BODY_BYTES = 64 * 1024
+_LINK_RE = re.compile(r'<([^>]+)>\s*;\s*rel="([^"]+)"')
+
+
+class BuildkiteAPIError(RuntimeError):
+    """A Buildkite HTTP or network request failed."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        retry_after: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.retry_after = retry_after
+
+
+class BuildkiteResponseError(BuildkiteAPIError):
+    """Buildkite returned a response that does not match the API contract."""
+
+
+@dataclass(frozen=True)
+class ExecutionCounts:
+    """Test execution counts grouped by result."""
+
+    passed: int
+    failed: int
+    skipped: int = 0
+    pending: int = 0
+    unknown: int = 0
+
+
+@dataclass(frozen=True)
+class BuildkiteTest:
+    """A test and its aggregated metrics from Buildkite Test Engine."""
+
+    id: str
+    url: str
+    web_url: str
+    scope: str
+    name: str
+    location: Optional[str]
+    file_name: Optional[str]
+    labels: Tuple[str, ...]
+    reliability: Optional[float]
+    duration_avg: Optional[float]
+    duration_sum: Optional[float]
+    duration_min: Optional[float]
+    duration_max: Optional[float]
+    executions_count: int
+    executions_count_by_result: ExecutionCounts
+
+
+def _required_string(payload: Mapping[str, Any], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str):
+        raise BuildkiteResponseError(
+            f"Buildkite test field {field!r} must be a string"
+        )
+    return value
+
+
+def _optional_string(payload: Mapping[str, Any], field: str) -> Optional[str]:
+    value = payload.get(field)
+    if value is not None and not isinstance(value, str):
+        raise BuildkiteResponseError(
+            f"Buildkite test field {field!r} must be a string or null"
+        )
+    return value
+
+
+def _required_int(payload: Mapping[str, Any], field: str) -> int:
+    value = payload.get(field)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise BuildkiteResponseError(
+            f"Buildkite test field {field!r} must be an integer"
+        )
+    return value
+
+
+def _optional_float(payload: Mapping[str, Any], field: str) -> Optional[float]:
+    value = payload.get(field)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise BuildkiteResponseError(
+            f"Buildkite test field {field!r} must be a number or null"
+        )
+    return float(value)
+
+
+def _parse_execution_counts(payload: Mapping[str, Any]) -> ExecutionCounts:
+    raw_counts = payload.get("executions_count_by_result")
+    if not isinstance(raw_counts, Mapping):
+        raise BuildkiteResponseError(
+            "Buildkite test field 'executions_count_by_result' must be an object"
+        )
+
+    return ExecutionCounts(
+        passed=_required_int(raw_counts, "passed"),
+        failed=_required_int(raw_counts, "failed"),
+        skipped=_required_int(raw_counts, "skipped") if "skipped" in raw_counts else 0,
+        pending=_required_int(raw_counts, "pending") if "pending" in raw_counts else 0,
+        unknown=_required_int(raw_counts, "unknown") if "unknown" in raw_counts else 0,
+    )
+
+
+def _parse_test(payload: Any) -> BuildkiteTest:
+    if not isinstance(payload, Mapping):
+        raise BuildkiteResponseError("Buildkite test entries must be objects")
+
+    raw_labels = payload.get("labels")
+    if not isinstance(raw_labels, list) or not all(
+        isinstance(label, str) for label in raw_labels
+    ):
+        raise BuildkiteResponseError(
+            "Buildkite test field 'labels' must be an array of strings"
+        )
+
+    return BuildkiteTest(
+        id=_required_string(payload, "id"),
+        url=_required_string(payload, "url"),
+        web_url=_required_string(payload, "web_url"),
+        scope=_required_string(payload, "scope"),
+        name=_required_string(payload, "name"),
+        location=_optional_string(payload, "location"),
+        file_name=_optional_string(payload, "file_name"),
+        labels=tuple(raw_labels),
+        reliability=_optional_float(payload, "reliability"),
+        duration_avg=_optional_float(payload, "duration_avg"),
+        duration_sum=_optional_float(payload, "duration_sum"),
+        duration_min=_optional_float(payload, "duration_min"),
+        duration_max=_optional_float(payload, "duration_max"),
+        executions_count=_required_int(payload, "executions_count"),
+        executions_count_by_result=_parse_execution_counts(payload),
+    )
+
+
+def _csv_parameter(values: Iterable[str], field: str) -> Optional[str]:
+    if isinstance(values, str):
+        normalized = (values,)
+    else:
+        normalized = tuple(values)
+    if not normalized:
+        return None
+    if any(not isinstance(value, str) or not value for value in normalized):
+        raise ValueError(f"{field} values must be non-empty strings")
+    return ",".join(normalized)
+
+
+def _next_link(link_header: Optional[str]) -> Optional[str]:
+    if not link_header:
+        return None
+    for match in _LINK_RE.finditer(link_header):
+        if "next" in match.group(2).split():
+            return match.group(1)
+    return None
+
+
+def _error_message(error: HTTPError, body: bytes) -> str:
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        payload = None
+
+    if isinstance(payload, Mapping) and isinstance(payload.get("message"), str):
+        return payload["message"]
+    return error.reason or "request failed"
+
+
+class _SameOriginRedirectHandler(HTTPRedirectHandler):
+    """Prevent authenticated requests from redirecting to another origin."""
+
+    def __init__(self, origin: Tuple[str, str]) -> None:
+        super().__init__()
+        self._origin = origin
+
+    def redirect_request(
+        self,
+        request: Request,
+        file_pointer: Any,
+        code: int,
+        message: str,
+        headers: Mapping[str, str],
+        new_url: str,
+    ) -> Optional[Request]:
+        redirect_url = urljoin(request.full_url, new_url)
+        parsed_redirect_url = urlsplit(redirect_url)
+        redirect_origin = (
+            parsed_redirect_url.scheme.lower(),
+            parsed_redirect_url.netloc.lower(),
+        )
+        if redirect_origin != self._origin:
+            raise BuildkiteResponseError(
+                "Buildkite API returned a cross-origin redirect"
+            )
+        return super().redirect_request(
+            request,
+            file_pointer,
+            code,
+            message,
+            headers,
+            redirect_url,
+        )
+
+
+class BuildkiteTestEngineClient:
+    """A dependency-free, read-only client for Buildkite Test Engine tests."""
+
+    def __init__(
+        self,
+        token: str,
+        organization: str,
+        suite: str,
+        *,
+        base_url: str = DEFAULT_API_BASE_URL,
+        timeout: float = 30.0,
+        opener: Optional[Callable[..., Any]] = None,
+    ) -> None:
+        if not isinstance(token, str) or not token:
+            raise ValueError("token must not be empty")
+        if not isinstance(organization, str) or not organization:
+            raise ValueError("organization must not be empty")
+        if not isinstance(suite, str) or not suite:
+            raise ValueError("suite must not be empty")
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or timeout <= 0
+        ):
+            raise ValueError("timeout must be greater than zero")
+        if not isinstance(base_url, str):
+            raise ValueError("base_url must be an absolute HTTPS URL")
+
+        normalized_base_url = base_url.rstrip("/")
+        parsed_base_url = urlsplit(normalized_base_url)
+        if (
+            parsed_base_url.scheme.lower() != "https"
+            or not parsed_base_url.netloc
+        ):
+            raise ValueError("base_url must be an absolute HTTPS URL")
+
+        self._token = token
+        self._organization = organization
+        self._suite = suite
+        self._base_url = normalized_base_url
+        self._origin = (parsed_base_url.scheme.lower(), parsed_base_url.netloc.lower())
+        self._timeout = timeout
+        self._opener = opener or build_opener(
+            _SameOriginRedirectHandler(self._origin)
+        ).open
+
+    def list_tests(
+        self,
+        *,
+        labels: Iterable[str] = (),
+        branch: Optional[str] = None,
+        period: Optional[str] = None,
+        tags: Iterable[str] = (),
+        sort_by: Optional[str] = None,
+        order: Optional[str] = None,
+        per_page: int = 100,
+    ) -> Tuple[BuildkiteTest, ...]:
+        """List tests and their metrics, following all result pages."""
+
+        if (
+            isinstance(per_page, bool)
+            or not isinstance(per_page, int)
+            or not 1 <= per_page <= 100
+        ):
+            raise ValueError("per_page must be between 1 and 100")
+
+        parameters = []
+        labels_value = _csv_parameter(labels, "labels")
+        tags_value = _csv_parameter(tags, "tags")
+        if labels_value is not None:
+            parameters.append(("labels", labels_value))
+        if branch is not None:
+            if not isinstance(branch, str) or not branch:
+                raise ValueError("branch must not be empty")
+            parameters.append(("branch", branch))
+        if period is not None:
+            if not isinstance(period, str) or not period:
+                raise ValueError("period must not be empty")
+            parameters.append(("period", period))
+        if tags_value is not None:
+            parameters.append(("tags", tags_value))
+        if sort_by is not None:
+            if not isinstance(sort_by, str) or not sort_by:
+                raise ValueError("sort_by must not be empty")
+            parameters.append(("sort_by", sort_by))
+        if order is not None:
+            if not isinstance(order, str) or not order:
+                raise ValueError("order must not be empty")
+            parameters.append(("order", order))
+        parameters.append(("per_page", str(per_page)))
+
+        organization = quote(self._organization, safe="")
+        suite = quote(self._suite, safe="")
+        url = (
+            f"{self._base_url}/analytics/organizations/{organization}/"
+            f"suites/{suite}/tests?{urlencode(parameters)}"
+        )
+
+        tests = []
+        seen_urls = set()
+        while url is not None:
+            if url in seen_urls:
+                raise BuildkiteResponseError(
+                    "Buildkite pagination returned a repeated next-page URL"
+                )
+            seen_urls.add(url)
+
+            page, link_header = self._get_page(url)
+            tests.extend(_parse_test(test) for test in page)
+
+            next_url = _next_link(link_header)
+            if next_url is None:
+                url = None
+                continue
+            next_url = urljoin(url, next_url)
+            parsed_next_url = urlsplit(next_url)
+            next_origin = (
+                parsed_next_url.scheme.lower(),
+                parsed_next_url.netloc.lower(),
+            )
+            if next_origin != self._origin:
+                raise BuildkiteResponseError(
+                    "Buildkite pagination returned a cross-origin next-page URL"
+                )
+            url = next_url
+
+        return tuple(tests)
+
+    def list_flaky_tests(
+        self,
+        *,
+        branch: Optional[str] = "master",
+        period: Optional[str] = None,
+    ) -> Tuple[BuildkiteTest, ...]:
+        """List tests that Buildkite has already labeled as flaky.
+
+        This method does not classify tests itself.  The suite must have a
+        Buildkite workflow that applies the ``flaky`` label.
+        """
+
+        return self.list_tests(labels=("flaky",), branch=branch, period=period)
+
+    def _get_page(self, url: str) -> Tuple[Any, Optional[str]]:
+        request = Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self._token}",
+                "Buildkite-Version": TESTS_API_VERSION,
+                "User-Agent": _USER_AGENT,
+            },
+            method="GET",
+        )
+
+        try:
+            with self._opener(request, timeout=self._timeout) as response:
+                body = response.read()
+                link_header = response.headers.get("Link")
+        except HTTPError as error:
+            headers = error.headers or {}
+            retry_after = (
+                headers.get("Retry-After")
+                or headers.get("RateLimit-Reset")
+                or headers.get("RateLimit-User-Reset")
+            )
+            try:
+                try:
+                    body = error.read(_MAX_ERROR_BODY_BYTES)
+                except (OSError, HTTPException) as read_error:
+                    raise BuildkiteAPIError(
+                        "Buildkite API request failed with HTTP "
+                        f"{error.code}: response body could not be read",
+                        status_code=error.code,
+                        retry_after=retry_after,
+                    ) from read_error
+            finally:
+                error.close()
+            message = _error_message(error, body)
+            raise BuildkiteAPIError(
+                f"Buildkite API request failed with HTTP {error.code}: {message}",
+                status_code=error.code,
+                retry_after=retry_after,
+            ) from error
+        except (URLError, TimeoutError, OSError, HTTPException) as error:
+            reason = getattr(error, "reason", str(error))
+            raise BuildkiteAPIError(
+                f"Buildkite API request failed: {reason}"
+            ) from error
+
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise BuildkiteResponseError(
+                "Buildkite API returned invalid JSON"
+            ) from error
+        if not isinstance(payload, list):
+            raise BuildkiteResponseError(
+                "Buildkite tests API response must be an array"
+            )
+        return payload, link_header

--- a/ci/flaky_tracker/fixtures/formatted_failure.txt
+++ b/ci/flaky_tracker/fixtures/formatted_failure.txt
@@ -1,0 +1,7 @@
+--- RUN   TestRayClusterAutoscalerV2IdleTimeout
+=== RUN   TestRayClusterAutoscalerV2IdleTimeout/Create_a_RayCluster_with_autoscaler_v2_enabled
+    raycluster_autoscaler_part2_test.go:93: Timed out waiting for one worker.
+### FAIL: TestRayClusterAutoscalerV2IdleTimeout (84.30s)
+    ### FAIL: TestRayClusterAutoscalerV2IdleTimeout/Create_a_RayCluster_with_autoscaler_v2_enabled (84.30s)
+FAIL
+FAIL github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler 84.923s

--- a/ci/flaky_tracker/fixtures/formatted_results.txt
+++ b/ci/flaky_tracker/fixtures/formatted_results.txt
@@ -1,0 +1,8 @@
+--- RUN   TestRayJob
+=== RUN   TestRayJob/succeeds
+=== RUN   TestRayJob/skipped_without_feature_gate
+    ### PASS: TestRayJob/succeeds (1.20s)
+    ### SKIP: TestRayJob/skipped_without_feature_gate (0.00s)
+### PASS: TestRayJob (1.25s)
+PASS
+ok github.com/ray-project/kuberay/ray-operator/test/e2erayjob 1.300s

--- a/ci/flaky_tracker/fixtures/package_failures.txt
+++ b/ci/flaky_tracker/fixtures/package_failures.txt
@@ -1,0 +1,6 @@
+# github.com/ray-project/kuberay/ray-operator/controllers/ray
+controllers/ray/controller.go:10:2: undefined: missingSymbol
+FAIL github.com/ray-project/kuberay/ray-operator/controllers/ray [build failed]
+# github.com/ray-project/kuberay/ray-operator/test/e2e
+test/e2e/suite_test.go:12: malformed import path
+FAIL github.com/ray-project/kuberay/ray-operator/test/e2e [setup failed]

--- a/ci/flaky_tracker/fixtures/timeout.txt
+++ b/ci/flaky_tracker/fixtures/timeout.txt
@@ -1,0 +1,8 @@
+--- RUN   TestRayServiceUpgrade
+panic: test timed out after 30m0s
+	running tests:
+		TestRayServiceUpgrade (30m0s)
+
+goroutine 123 [running]:
+testing.(*M).startAlarm.func1()
+FAIL github.com/ray-project/kuberay/ray-operator/test/e2erayservice 1800.042s

--- a/ci/flaky_tracker/parser.py
+++ b/ci/flaky_tracker/parser.py
@@ -1,0 +1,264 @@
+"""Parse test outcomes from Go test logs produced by KubeRay's Buildkite jobs.
+
+KubeRay pipes its verbose Go test output through ``.buildkite/format.awk``.
+That formatter changes top-level ``=== RUN`` lines to ``--- RUN`` and Go's
+``--- FAIL`` markers to ``### FAIL``.  This parser intentionally accepts both
+the original Go output and the formatted output so it can also process logs
+from jobs that do not use the formatter.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+import re
+from typing import Iterable, Optional, Tuple
+
+
+class FailureKind(str, Enum):
+    """The failure category that can be inferred from a Go test log."""
+
+    TEST = "test"
+    TIMEOUT = "timeout"
+    BUILD = "build"
+    SETUP = "setup"
+    UNKNOWN = "unknown"
+
+
+class TestStatus(str, Enum):
+    """The terminal status reported by Go for a test or subtest."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    SKIP = "skip"
+
+
+@dataclass(frozen=True)
+class TestResult:
+    """A completed Go test or subtest."""
+
+    test_name: str
+    package: Optional[str]
+    duration: Optional[str]
+    status: TestStatus
+    kind: Optional[FailureKind]
+    line_number: int
+
+    @property
+    def is_subtest(self) -> bool:
+        """Return whether this record represents a Go subtest."""
+
+        return "/" in self.test_name
+
+    @property
+    def is_failure(self) -> bool:
+        """Return whether this result represents a failed test."""
+
+        return self.status == TestStatus.FAIL
+
+
+@dataclass(frozen=True)
+class PackageFailure:
+    """A package-level failure not attributed to an individual test."""
+
+    package: str
+    kind: FailureKind
+    line_number: int
+
+
+@dataclass(frozen=True)
+class GoTestLogParseResult:
+    """Structured test results and package failures from one Go test log."""
+
+    test_results: Tuple[TestResult, ...]
+    package_failures: Tuple[PackageFailure, ...]
+
+    @property
+    def test_failures(self) -> Tuple[TestResult, ...]:
+        """Return all failed tests and subtests."""
+
+        return tuple(result for result in self.test_results if result.is_failure)
+
+    @property
+    def test_passes(self) -> Tuple[TestResult, ...]:
+        """Return all passing tests and subtests."""
+
+        return tuple(
+            result for result in self.test_results if result.status == TestStatus.PASS
+        )
+
+    @property
+    def test_skips(self) -> Tuple[TestResult, ...]:
+        """Return all skipped tests and subtests."""
+
+        return tuple(
+            result for result in self.test_results if result.status == TestStatus.SKIP
+        )
+
+    @property
+    def has_failures(self) -> bool:
+        """Return whether the log contains any recognized failure."""
+
+        return bool(self.test_failures or self.package_failures)
+
+
+# Terminal escape sequences appear in logs downloaded from Buildkite.  The
+# first expression covers OSC and Buildkite's private ``ESC _ ... BEL``
+# sequences.  The second covers colors and other CSI sequences.
+_STRING_ESCAPE_RE = re.compile(r"\x1b(?:\]|_).*?(?:\x07|\x1b\\)")
+_CSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+_TEST_RESULT_RE = re.compile(
+    r"^\s*(?:---|###)\s+(?P<status>PASS|FAIL|SKIP):\s+"
+    r"(?P<test>\S+)"
+    r"(?:\s+\((?P<duration>[^)]+)\))?\s*$"
+)
+_PACKAGE_RESULT_RE = re.compile(
+    r"^\s*(?P<status>ok|FAIL)\s+(?P<package>\S+)"
+    r"(?:\s+(?P<detail>[0-9.]+s|\(cached\)|"
+    r"\[(?P<reason>build|setup) failed\]))?\s*$"
+)
+_TIMEOUT_RE = re.compile(r"^\s*panic:\s+test timed out after\s+(?P<duration>\S+)")
+_RUNNING_TEST_RE = re.compile(r"^\s*(?P<test>Test\S+)\s+\((?P<duration>[^)]+)\)\s*$")
+
+
+def _clean_lines(log: str) -> Iterable[Tuple[int, str]]:
+    for line_number, line in enumerate(log.splitlines(), start=1):
+        line = _STRING_ESCAPE_RE.sub("", line)
+        line = _CSI_ESCAPE_RE.sub("", line)
+        yield line_number, line.rstrip("\r")
+
+
+def _package_failure_kind(reason: Optional[str]) -> FailureKind:
+    if reason == "build":
+        return FailureKind.BUILD
+    if reason == "setup":
+        return FailureKind.SETUP
+    return FailureKind.UNKNOWN
+
+
+def _status_from_marker(marker: str) -> TestStatus:
+    return {
+        "PASS": TestStatus.PASS,
+        "FAIL": TestStatus.FAIL,
+        "SKIP": TestStatus.SKIP,
+    }[marker]
+
+
+def _merge_timeout_duplicates(
+    results: Iterable[TestResult],
+) -> Tuple[TestResult, ...]:
+    """Merge duplicate timeout and failure markers while preserving retries.
+
+    A timeout can be reported both in Go's ``running tests`` section and in a
+    later failure marker.  Two ordinary results for the same test are retained
+    because they may represent separate executions made with ``-count``.
+    """
+
+    merged = []
+    unmatched_timeout_positions = {}
+    for result in results:
+        key = (result.package, result.test_name)
+        if result.kind == FailureKind.TIMEOUT:
+            unmatched_timeout_positions[key] = len(merged)
+            merged.append(result)
+            continue
+
+        timeout_position = unmatched_timeout_positions.pop(key, None)
+        if result.is_failure and timeout_position is not None:
+            timeout = merged[timeout_position]
+            merged[timeout_position] = replace(
+                timeout,
+                duration=timeout.duration or result.duration,
+            )
+            continue
+
+        merged.append(result)
+
+    return tuple(merged)
+
+
+def parse_go_test_log(log: str) -> GoTestLogParseResult:
+    """Parse test outcomes and package failures from ``go test`` output.
+
+    The parser associates test markers with the next Go package summary.  A
+    marker remains package-less when the supplied log is truncated before that
+    summary, which is preferable to inventing a package name.
+    """
+
+    test_results = []
+    package_failures = []
+    unassigned_start = 0
+    waiting_for_running_tests = False
+    reading_running_tests = False
+
+    for line_number, line in _clean_lines(log):
+        test_match = _TEST_RESULT_RE.match(line)
+        if test_match:
+            status = _status_from_marker(test_match.group("status"))
+            test_results.append(
+                TestResult(
+                    test_name=test_match.group("test"),
+                    package=None,
+                    duration=test_match.group("duration"),
+                    status=status,
+                    kind=FailureKind.TEST if status == TestStatus.FAIL else None,
+                    line_number=line_number,
+                )
+            )
+            continue
+
+        timeout_match = _TIMEOUT_RE.match(line)
+        if timeout_match:
+            waiting_for_running_tests = True
+            reading_running_tests = False
+            continue
+
+        if waiting_for_running_tests and line.strip() == "running tests:":
+            waiting_for_running_tests = False
+            reading_running_tests = True
+            continue
+
+        if reading_running_tests:
+            running_test_match = _RUNNING_TEST_RE.match(line)
+            if running_test_match:
+                test_results.append(
+                    TestResult(
+                        test_name=running_test_match.group("test"),
+                        package=None,
+                        duration=running_test_match.group("duration"),
+                        status=TestStatus.FAIL,
+                        kind=FailureKind.TIMEOUT,
+                        line_number=line_number,
+                    )
+                )
+                continue
+            reading_running_tests = False
+
+        package_match = _PACKAGE_RESULT_RE.match(line)
+        if not package_match:
+            continue
+
+        package = package_match.group("package")
+        newly_assigned = test_results[unassigned_start:]
+        for index in range(unassigned_start, len(test_results)):
+            test_results[index] = replace(test_results[index], package=package)
+
+        reason = package_match.group("reason")
+        has_test_failure = any(result.is_failure for result in newly_assigned)
+        if package_match.group("status") == "FAIL" and (
+            reason or not has_test_failure
+        ):
+            package_failures.append(
+                PackageFailure(
+                    package=package,
+                    kind=_package_failure_kind(reason),
+                    line_number=line_number,
+                )
+            )
+        unassigned_start = len(test_results)
+
+    return GoTestLogParseResult(
+        test_results=_merge_timeout_duplicates(test_results),
+        package_failures=tuple(package_failures),
+    )

--- a/ci/flaky_tracker/test_buildkite.py
+++ b/ci/flaky_tracker/test_buildkite.py
@@ -1,0 +1,398 @@
+import io
+import json
+import unittest
+from http.client import IncompleteRead
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qs, urlsplit
+from urllib.request import Request
+
+from ci.flaky_tracker.buildkite import (
+    BuildkiteAPIError,
+    BuildkiteResponseError,
+    BuildkiteTestEngineClient,
+    ExecutionCounts,
+    _SameOriginRedirectHandler,
+    TESTS_API_VERSION,
+)
+
+
+def _test_payload(test_id="test-1", name="TestRayServiceUpgrade"):
+    return {
+        "id": test_id,
+        "url": f"https://api.buildkite.test/tests/{test_id}",
+        "web_url": f"https://buildkite.test/tests/{test_id}",
+        "scope": "github.com/ray-project/kuberay/ray-operator/test/e2e",
+        "name": name,
+        "location": "rayservice_upgrade_test.go:42",
+        "file_name": "rayservice_upgrade_test.go",
+        "labels": ["flaky"],
+        "reliability": 0.8,
+        "duration_avg": 1.5,
+        "duration_sum": 15.0,
+        "duration_min": 1.0,
+        "duration_max": 2.0,
+        "executions_count": 10,
+        "executions_count_by_result": {
+            "passed": 8,
+            "failed": 2,
+            "skipped": 1,
+        },
+    }
+
+
+class _FakeResponse:
+    def __init__(self, payload, *, headers=None, raw=False):
+        self._body = payload if raw else json.dumps(payload).encode("utf-8")
+        self.headers = headers or {}
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+class _ReadErrorResponse(_FakeResponse):
+    def read(self):
+        raise IncompleteRead(b"partial response")
+
+
+class _ReadErrorFile:
+    def read(self, amount=None):
+        raise IncompleteRead(b"partial error response")
+
+    def close(self):
+        pass
+
+
+class _FakeOpener:
+    def __init__(self, *responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def __call__(self, request, *, timeout):
+        self.calls.append((request, timeout))
+        response = self._responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _headers(request):
+    return {name.lower(): value for name, value in request.header_items()}
+
+
+class BuildkiteTestEngineClientTest(unittest.TestCase):
+    def test_lists_tests_with_filters_headers_and_metrics(self):
+        opener = _FakeOpener(_FakeResponse([_test_payload()]))
+        client = BuildkiteTestEngineClient(
+            "secret-token",
+            "ray project",
+            "KubeRay/E2E",
+            base_url="https://api.buildkite.test/v2",
+            timeout=12.5,
+            opener=opener,
+        )
+
+        tests = client.list_tests(
+            labels=("flaky", "slow"),
+            branch="master/next",
+            period="28days",
+            tags=("result:~failed",),
+            sort_by="reliability",
+            order="asc",
+        )
+
+        self.assertEqual(1, len(tests))
+        test = tests[0]
+        self.assertEqual("TestRayServiceUpgrade", test.name)
+        self.assertEqual(0.8, test.reliability)
+        self.assertEqual(
+            ExecutionCounts(passed=8, failed=2, skipped=1),
+            test.executions_count_by_result,
+        )
+
+        request, timeout = opener.calls[0]
+        self.assertEqual(12.5, timeout)
+        parsed_url = urlsplit(request.full_url)
+        self.assertEqual(
+            "/v2/analytics/organizations/ray%20project/"
+            "suites/KubeRay%2FE2E/tests",
+            parsed_url.path,
+        )
+        self.assertEqual(
+            {
+                "labels": ["flaky,slow"],
+                "branch": ["master/next"],
+                "period": ["28days"],
+                "tags": ["result:~failed"],
+                "sort_by": ["reliability"],
+                "order": ["asc"],
+                "per_page": ["100"],
+            },
+            parse_qs(parsed_url.query),
+        )
+        headers = _headers(request)
+        self.assertEqual("Bearer secret-token", headers["authorization"])
+        self.assertEqual(TESTS_API_VERSION, headers["buildkite-version"])
+        self.assertEqual("application/json", headers["accept"])
+        self.assertEqual("kuberay-flaky-tracker", headers["user-agent"])
+
+    def test_lists_tests_from_every_page(self):
+        next_url = (
+            "https://api.buildkite.test/v2/analytics/organizations/ray-project/"
+            "suites/kuberay/tests?page=2&per_page=100"
+        )
+        opener = _FakeOpener(
+            _FakeResponse(
+                [_test_payload("test-1", "TestOne")],
+                headers={
+                    "Link": (
+                        f'<{next_url}>; rel="next", '
+                        f'<{next_url}>; rel="last"'
+                    )
+                },
+            ),
+            _FakeResponse([_test_payload("test-2", "TestTwo")]),
+        )
+        client = BuildkiteTestEngineClient(
+            "token",
+            "ray-project",
+            "kuberay",
+            base_url="https://api.buildkite.test/v2",
+            opener=opener,
+        )
+
+        tests = client.list_tests(branch="master")
+
+        self.assertEqual(["TestOne", "TestTwo"], [test.name for test in tests])
+        self.assertEqual(2, len(opener.calls))
+        self.assertEqual(next_url, opener.calls[1][0].full_url)
+        self.assertEqual(
+            "Bearer token", _headers(opener.calls[1][0])["authorization"]
+        )
+
+    def test_lists_only_tests_already_labeled_flaky(self):
+        opener = _FakeOpener(_FakeResponse([]))
+        client = BuildkiteTestEngineClient(
+            "token",
+            "ray-project",
+            "kuberay",
+            base_url="https://api.buildkite.test/v2",
+            opener=opener,
+        )
+
+        self.assertEqual((), client.list_flaky_tests(period="7days"))
+
+        query = parse_qs(urlsplit(opener.calls[0][0].full_url).query)
+        self.assertEqual(["flaky"], query["labels"])
+        self.assertEqual(["master"], query["branch"])
+        self.assertEqual(["7days"], query["period"])
+
+    def test_defaults_optional_result_counts_to_zero(self):
+        payload = _test_payload()
+        payload["reliability"] = None
+        payload["location"] = None
+        payload["file_name"] = None
+        payload["executions_count_by_result"] = {"passed": 0, "failed": 3}
+        opener = _FakeOpener(_FakeResponse([payload]))
+        client = BuildkiteTestEngineClient(
+            "token",
+            "ray-project",
+            "kuberay",
+            base_url="https://api.buildkite.test/v2",
+            opener=opener,
+        )
+
+        test = client.list_tests()[0]
+
+        self.assertIsNone(test.reliability)
+        self.assertIsNone(test.location)
+        self.assertEqual(
+            ExecutionCounts(passed=0, failed=3),
+            test.executions_count_by_result,
+        )
+
+    def test_reports_http_error_message_and_retry_hint(self):
+        error = HTTPError(
+            "https://api.buildkite.test/tests",
+            429,
+            "Too Many Requests",
+            {"Retry-After": "60"},
+            io.BytesIO(b'{"message":"rate limit exceeded"}'),
+        )
+        opener = _FakeOpener(error)
+        client = BuildkiteTestEngineClient(
+            "token",
+            "ray-project",
+            "kuberay",
+            base_url="https://api.buildkite.test/v2",
+            opener=opener,
+        )
+
+        with self.assertRaises(BuildkiteAPIError) as context:
+            client.list_tests()
+
+        self.assertEqual(429, context.exception.status_code)
+        self.assertEqual("60", context.exception.retry_after)
+        self.assertIn("rate limit exceeded", str(context.exception))
+        self.assertNotIn("token", str(context.exception))
+
+    def test_reports_truncated_http_error_body_as_api_error(self):
+        error = HTTPError(
+            "https://api.buildkite.test/tests",
+            502,
+            "Bad Gateway",
+            {"Retry-After": "10"},
+            _ReadErrorFile(),
+        )
+        client = BuildkiteTestEngineClient(
+            "token",
+            "ray-project",
+            "kuberay",
+            base_url="https://api.buildkite.test/v2",
+            opener=_FakeOpener(error),
+        )
+
+        with self.assertRaises(BuildkiteAPIError) as context:
+            client.list_tests()
+
+        self.assertEqual(502, context.exception.status_code)
+        self.assertEqual("10", context.exception.retry_after)
+        self.assertIsInstance(context.exception.__cause__, IncompleteRead)
+
+    def test_reports_network_error(self):
+        opener = _FakeOpener(URLError("connection refused"))
+        client = BuildkiteTestEngineClient(
+            "token",
+            "ray-project",
+            "kuberay",
+            base_url="https://api.buildkite.test/v2",
+            opener=opener,
+        )
+
+        with self.assertRaisesRegex(BuildkiteAPIError, "connection refused"):
+            client.list_tests()
+
+    def test_reports_truncated_response_as_api_error(self):
+        opener = _FakeOpener(_ReadErrorResponse([]))
+        client = BuildkiteTestEngineClient(
+            "token",
+            "ray-project",
+            "kuberay",
+            base_url="https://api.buildkite.test/v2",
+            opener=opener,
+        )
+
+        with self.assertRaises(BuildkiteAPIError) as context:
+            client.list_tests()
+
+        self.assertIsInstance(context.exception.__cause__, IncompleteRead)
+
+    def test_rejects_cross_origin_redirect(self):
+        handler = _SameOriginRedirectHandler(("https", "api.buildkite.test"))
+        request = Request(
+            "https://api.buildkite.test/v2/tests",
+            headers={"Authorization": "Bearer secret-token"},
+        )
+
+        with self.assertRaisesRegex(BuildkiteResponseError, "redirect"):
+            handler.redirect_request(
+                request,
+                None,
+                302,
+                "Found",
+                {},
+                "https://example.com/steal-token",
+            )
+
+    def test_rejects_invalid_json_and_response_shapes(self):
+        invalid_responses = (
+            _FakeResponse(b"not-json", raw=True),
+            _FakeResponse({"tests": []}),
+            _FakeResponse([{"id": "missing-fields"}]),
+        )
+
+        for response in invalid_responses:
+            with self.subTest(response=response):
+                client = BuildkiteTestEngineClient(
+                    "token",
+                    "ray-project",
+                    "kuberay",
+                    base_url="https://api.buildkite.test/v2",
+                    opener=_FakeOpener(response),
+                )
+                with self.assertRaises(BuildkiteResponseError):
+                    client.list_tests()
+
+    def test_rejects_cross_origin_and_repeated_pagination_links(self):
+        cross_origin = _FakeResponse(
+            [],
+            headers={
+                "Link": '<https://example.com/tests?page=2>; rel="next"'
+            },
+        )
+        client = BuildkiteTestEngineClient(
+            "token",
+            "ray-project",
+            "kuberay",
+            base_url="https://api.buildkite.test/v2",
+            opener=_FakeOpener(cross_origin),
+        )
+        with self.assertRaisesRegex(BuildkiteResponseError, "cross-origin"):
+            client.list_tests()
+
+        first_url = (
+            "https://api.buildkite.test/v2/analytics/organizations/ray-project/"
+            "suites/kuberay/tests?per_page=100"
+        )
+        repeated = _FakeResponse(
+            [], headers={"Link": f'<{first_url}>; rel="next"'}
+        )
+        client = BuildkiteTestEngineClient(
+            "token",
+            "ray-project",
+            "kuberay",
+            base_url="https://api.buildkite.test/v2",
+            opener=_FakeOpener(repeated),
+        )
+        with self.assertRaisesRegex(BuildkiteResponseError, "repeated"):
+            client.list_tests()
+
+    def test_validates_configuration_and_filters(self):
+        invalid_configurations = (
+            {"token": "", "organization": "org", "suite": "suite"},
+            {"token": "token", "organization": "", "suite": "suite"},
+            {"token": "token", "organization": "org", "suite": ""},
+            {
+                "token": "token",
+                "organization": "org",
+                "suite": "suite",
+                "base_url": "http://api.buildkite.test/v2",
+            },
+        )
+        for configuration in invalid_configurations:
+            with self.subTest(configuration=configuration):
+                with self.assertRaises(ValueError):
+                    BuildkiteTestEngineClient(**configuration)
+
+        client = BuildkiteTestEngineClient(
+            "token", "org", "suite", opener=_FakeOpener(_FakeResponse([]))
+        )
+        for kwargs in (
+            {"per_page": 0},
+            {"per_page": 101},
+            {"labels": ("",)},
+            {"branch": ""},
+            {"period": ""},
+        ):
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(ValueError):
+                    client.list_tests(**kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/flaky_tracker/test_parser.py
+++ b/ci/flaky_tracker/test_parser.py
@@ -1,0 +1,174 @@
+from pathlib import Path
+import unittest
+
+from ci.flaky_tracker.parser import FailureKind, TestStatus, parse_go_test_log
+
+
+FIXTURES = Path(__file__).with_name("fixtures")
+
+
+class GoTestLogParserTest(unittest.TestCase):
+    def test_parses_kuberay_formatted_parent_and_subtest_failures(self):
+        result = parse_go_test_log(
+            (FIXTURES / "formatted_failure.txt").read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(2, len(result.test_failures))
+        parent, subtest = result.test_failures
+        self.assertEqual("TestRayClusterAutoscalerV2IdleTimeout", parent.test_name)
+        self.assertFalse(parent.is_subtest)
+        self.assertEqual("84.30s", parent.duration)
+        self.assertEqual(FailureKind.TEST, parent.kind)
+        self.assertEqual(
+            "github.com/ray-project/kuberay/ray-operator/test/e2eautoscaler",
+            parent.package,
+        )
+        self.assertEqual(
+            "TestRayClusterAutoscalerV2IdleTimeout/"
+            "Create_a_RayCluster_with_autoscaler_v2_enabled",
+            subtest.test_name,
+        )
+        self.assertTrue(subtest.is_subtest)
+        self.assertFalse(result.package_failures)
+
+    def test_parses_unformatted_go_failure_marker(self):
+        result = parse_go_test_log(
+            "\n".join(
+                [
+                    "=== RUN   TestCreateRayJob",
+                    "--- FAIL: TestCreateRayJob (1.25s)",
+                    "FAIL\texample.com/kuberay/test/e2erayjob\t1.300s",
+                ]
+            )
+        )
+
+        self.assertEqual(1, len(result.test_failures))
+        failure = result.test_failures[0]
+        self.assertEqual("TestCreateRayJob", failure.test_name)
+        self.assertEqual("example.com/kuberay/test/e2erayjob", failure.package)
+        self.assertEqual("1.25s", failure.duration)
+
+    def test_parses_formatted_pass_and_skip_results(self):
+        result = parse_go_test_log(
+            (FIXTURES / "formatted_results.txt").read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(3, len(result.test_results))
+        self.assertEqual(2, len(result.test_passes))
+        self.assertEqual(1, len(result.test_skips))
+        self.assertFalse(result.test_failures)
+        self.assertEqual(
+            [TestStatus.PASS, TestStatus.SKIP, TestStatus.PASS],
+            [test_result.status for test_result in result.test_results],
+        )
+        self.assertEqual(
+            "github.com/ray-project/kuberay/ray-operator/test/e2erayjob",
+            result.test_results[0].package,
+        )
+
+    def test_parses_build_and_setup_failures(self):
+        result = parse_go_test_log(
+            (FIXTURES / "package_failures.txt").read_text(encoding="utf-8")
+        )
+
+        self.assertFalse(result.test_failures)
+        self.assertEqual(
+            [FailureKind.BUILD, FailureKind.SETUP],
+            [failure.kind for failure in result.package_failures],
+        )
+        self.assertEqual(
+            "github.com/ray-project/kuberay/ray-operator/controllers/ray",
+            result.package_failures[0].package,
+        )
+
+    def test_parses_test_timeout(self):
+        result = parse_go_test_log(
+            (FIXTURES / "timeout.txt").read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(1, len(result.test_failures))
+        failure = result.test_failures[0]
+        self.assertEqual("TestRayServiceUpgrade", failure.test_name)
+        self.assertEqual(FailureKind.TIMEOUT, failure.kind)
+        self.assertEqual("30m0s", failure.duration)
+        self.assertEqual(
+            "github.com/ray-project/kuberay/ray-operator/test/e2erayservice",
+            failure.package,
+        )
+        self.assertFalse(result.package_failures)
+
+    def test_preserves_failure_when_package_summary_is_missing(self):
+        result = parse_go_test_log("### FAIL: TestTruncatedLog (2.00s)\n")
+
+        self.assertEqual(1, len(result.test_failures))
+        self.assertIsNone(result.test_failures[0].package)
+
+    def test_strips_ansi_and_buildkite_control_sequences(self):
+        log = (
+            "\x1b[31m### FAIL: TestColored (0.10s)\x1b[0m\n"
+            "\x1b_bk;t=1710000000\x07"
+            "FAIL example.com/colored 0.20s\n"
+        )
+
+        result = parse_go_test_log(log)
+
+        self.assertEqual(1, len(result.test_failures))
+        self.assertEqual("example.com/colored", result.test_failures[0].package)
+
+    def test_deduplicates_timeout_and_failure_marker(self):
+        log = "\n".join(
+            [
+                "panic: test timed out after 10m0s",
+                "running tests:",
+                "    TestSlow (10m0s)",
+                "--- FAIL: TestSlow (600.00s)",
+                "FAIL example.com/slow 600.01s",
+            ]
+        )
+
+        result = parse_go_test_log(log)
+
+        self.assertEqual(1, len(result.test_failures))
+        self.assertEqual(FailureKind.TIMEOUT, result.test_failures[0].kind)
+
+    def test_preserves_repeated_test_executions(self):
+        log = "\n".join(
+            [
+                "--- PASS: TestRepeated (0.01s)",
+                "--- FAIL: TestRepeated (0.02s)",
+                "FAIL example.com/repeated 0.04s",
+            ]
+        )
+
+        result = parse_go_test_log(log)
+
+        self.assertEqual(2, len(result.test_results))
+        self.assertEqual(
+            [TestStatus.PASS, TestStatus.FAIL],
+            [test_result.status for test_result in result.test_results],
+        )
+
+    def test_records_unattributed_package_failure(self):
+        result = parse_go_test_log("FAIL example.com/unknown 0.01s\n")
+
+        self.assertTrue(result.has_failures)
+        self.assertEqual(FailureKind.UNKNOWN, result.package_failures[0].kind)
+
+    def test_ignores_passing_output_and_failure_text_inside_messages(self):
+        result = parse_go_test_log(
+            "\n".join(
+                [
+                    "=== RUN   TestHealthy",
+                    "logger: --- FAIL: this is application text",
+                    "--- PASS: TestHealthy (0.01s)",
+                    "PASS",
+                    "ok example.com/healthy 0.02s",
+                ]
+            )
+        )
+
+        self.assertFalse(result.has_failures)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why are these changes needed?

Issue #5064 proposes automatically tracking flaky tests observed in KubeRay's Buildkite CI. Before the tracker can evaluate test history, it needs a reliable way to extract individual test outcomes from existing Buildkite logs.

This PR adds a dependency-free Go test log parser that:

- accepts both standard Go test markers such as `--- FAIL` and the `### FAIL` markers produced by KubeRay's `.buildkite/format.awk`;
- captures pass, fail, skip, timeout, build, setup, and unknown package failures;
- associates test and subtest results with their Go package when the package summary is available;
- strips ANSI and Buildkite control sequences while preserving source line numbers; and
- retains repeated test executions while merging duplicate timeout/failure markers.

Representative fixtures and unit tests cover nested tests, repeated executions, truncated logs, terminal control sequences, timeouts, and package-level failures.

This PR intentionally contains only the parser foundation. The Buildkite API client, flaky-state evaluation, issue creation/update logic, and scheduled GitHub Actions workflow will be implemented in follow-up changes.

## Related issue number

Refs #5064

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

Validation performed:

```bash
uv run python -m unittest discover -s ci/flaky_tracker -t . -p 'test_*.py' -v
make -C ray-operator test
```
