### PR TITLE
[Feature] Add resource mapping for Huawei Ascend NPUs

### DIFF
--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -41,11 +41,38 @@ const (
 	NeuronCoreRayResourceName          = "neuron_cores"
 	TPUContainerResourceName           = "google.com/tpu"
 	TPURayResourceName                 = "TPU"
+	AscendRayResourceName              = "NPU"
 )
 
 var customAcceleratorToRayResourceMap = map[string]string{
 	NeuronCoreContainerResourceName: NeuronCoreRayResourceName,
 	TPUContainerResourceName:        TPURayResourceName,
+}
+
+func isNPUResourceKey(key string) bool {
+	lowerKey := strings.ToLower(key)
+	if strings.HasPrefix(lowerKey, "huawei.com/ascend") {
+		// Skip metadata resource keys like huawei.com/Ascend910B-memory and huawei.com/Ascend910B-core,
+		// which describe accelerator capacity rather than being actual Ray compute resources.
+		if strings.HasSuffix(lowerKey, "-memory") || strings.HasSuffix(lowerKey, "-core") {
+			return false
+		}
+		return true
+	}
+	if lowerKey == "huawei.com/npu" {
+		return true
+	}
+	return false
+}
+
+func getCustomAcceleratorRayResourceName(resourceKeyString string) string {
+	if rayResourceName, ok := customAcceleratorToRayResourceMap[resourceKeyString]; ok {
+		return rayResourceName
+	}
+	if isNPUResourceKey(resourceKeyString) {
+		return AscendRayResourceName
+	}
+	return ""
 }
 
 // Get the port required to connect to the Ray cluster by worker nodes and drivers
@@ -1446,7 +1473,7 @@ func addWellKnownAcceleratorResources(rayStartParams map[string]string, resource
 
 		// Add the first encountered custom accelerator resource from the resource limits to the rayStartParams if not already present
 		if !isCustomAcceleratorResourceAdded {
-			if rayResourceName, ok := customAcceleratorToRayResourceMap[resourceKeyString]; ok && !resourceValue.IsZero() {
+			if rayResourceName := getCustomAcceleratorRayResourceName(resourceKeyString); rayResourceName != "" && !resourceValue.IsZero() {
 				if _, exists := resourcesMap[rayResourceName]; !exists {
 					resourcesMap[rayResourceName] = resourceValue.AsApproximateFloat64()
 
@@ -1473,6 +1500,10 @@ func isCustomAcceleratorPresentInResources(resourcesMap map[string]float64) bool
 			if _, ok := resourcesMap[customAcceleratorRayResource]; ok {
 				return true
 			}
+		}
+
+		if _, ok := resourcesMap[AscendRayResourceName]; ok {
+			return true
 		}
 	}
 
@@ -1657,6 +1688,8 @@ func updateRayStartParamsResources(ctx context.Context, rayStartParams map[strin
 			rayStartParams["memory"] = strconv.FormatInt(q.Value(), 10)
 		} else if utils.IsGPUResourceKey(normalizedName) {
 			rayStartParams["num-gpus"] = strconv.FormatInt(q.Value(), 10)
+		} else if rayResourceName := getCustomAcceleratorRayResourceName(name); rayResourceName != "" {
+			rayResourcesJson[rayResourceName] = q.AsApproximateFloat64()
 		} else {
 			rayResourcesJson[name] = q.AsApproximateFloat64()
 		}

--- a/ray-operator/controllers/ray/common/pod_test.go
+++ b/ray-operator/controllers/ray/common/pod_test.go
@@ -2364,6 +2364,80 @@ func TestGenerateRayStartCommand(t *testing.T) {
 			resource: corev1.ResourceRequirements{},
 			expected: "ray start --head  --include-log-monitor=true ",
 		},
+		{
+			name:           "WorkerNode with Ascend910B NPU",
+			nodeType:       rayv1.WorkerNode,
+			rayStartParams: map[string]string{},
+			resource: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"huawei.com/Ascend910B": resource.MustParse("2"),
+				},
+			},
+			expected: `ray start  --resources='{"NPU":2}' `,
+		},
+		{
+			name:           "WorkerNode with Ascend NPU (huawei.com/npu)",
+			nodeType:       rayv1.WorkerNode,
+			rayStartParams: map[string]string{},
+			resource: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"huawei.com/npu": resource.MustParse("2"),
+				},
+			},
+			expected: `ray start  --resources='{"NPU":2}' `,
+		},
+		{
+			name:           "HeadNode with Ascend910B and GPU",
+			nodeType:       rayv1.HeadNode,
+			rayStartParams: map[string]string{},
+			resource: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"huawei.com/Ascend910B": resource.MustParse("2"),
+					"nvidia.com/gpu":        resource.MustParse("1"),
+				},
+			},
+			expected: `ray start --head  --num-gpus=1  --resources='{"NPU":2}' `,
+		},
+		{
+			name:     "HeadNode with existing resources and Ascend910B",
+			nodeType: rayv1.HeadNode,
+			rayStartParams: map[string]string{
+				"resources": `'{"custom_resource":2}'`,
+			},
+			resource: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"huawei.com/Ascend910B": resource.MustParse("2"),
+				},
+			},
+			expected: `ray start --head  --resources='{"NPU":2,"custom_resource":2}' `,
+		},
+		{
+			name:     "HeadNode with existing NPU resources",
+			nodeType: rayv1.HeadNode,
+			rayStartParams: map[string]string{
+				"resources": `'{"NPU":3,"custom_resource":2}'`,
+			},
+			resource: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"huawei.com/Ascend910B": resource.MustParse("2"),
+				},
+			},
+			expected: `ray start --head  --resources='{"NPU":3,"custom_resource":2}' `,
+		},
+		{
+			name:           "HeadNode with multiple accelerators including Ascend910B",
+			nodeType:       rayv1.HeadNode,
+			rayStartParams: map[string]string{},
+			resource: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"huawei.com/Ascend910B":     resource.MustParse("2"),
+					"google.com/tpu":            resource.MustParse("8"),
+					"aws.amazon.com/neuroncore": resource.MustParse("4"),
+					"nvidia.com/gpu":            resource.MustParse("1"),
+				},
+			},
+			expected: `ray start --head  --num-gpus=1  --resources='{"neuron_cores":4}' `,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2644,6 +2718,35 @@ func TestUpdateRayStartParamsResources(t *testing.T) {
 				"num-cpus":  "4",
 				"memory":    "1000", // preserved
 				"resources": "'{\"Custom-Resource\":5}'",
+			},
+		},
+		"Ascend910B NPU resource set in `Resources`": {
+			initialRayStartParams: map[string]string{},
+			groupResources: map[string]string{
+				"huawei.com/Ascend910B": "2",
+			},
+			expectedRayStartParams: map[string]string{
+				"resources": "'{\"NPU\":2}'",
+			},
+		},
+		"Ascend910c NPU resource set in `Resources`": {
+			initialRayStartParams: map[string]string{},
+			groupResources: map[string]string{
+				"huawei.com/Ascend910c": "4",
+			},
+			expectedRayStartParams: map[string]string{
+				"resources": "'{\"NPU\":4}'",
+			},
+		},
+		"GPU and Ascend910B NPU resource set in `Resources`": {
+			initialRayStartParams: map[string]string{},
+			groupResources: map[string]string{
+				"nvidia.com/gpu":        "1",
+				"huawei.com/Ascend910B": "2",
+			},
+			expectedRayStartParams: map[string]string{
+				"num-gpus":  "1",
+				"resources": "'{\"NPU\":2}'",
 			},
 		},
 	}
@@ -2983,4 +3086,121 @@ func TestBuildCollectorContainerAndPodInjection(t *testing.T) {
 	workerEventTypesV2Env, ok := utils.EnvVarByName(utils.RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISHER_HTTP_ENDPOINT_EXPOSABLE_EVENT_TYPES, workerPod.Spec.Containers[utils.RayContainerIndex].Env)
 	assert.True(t, ok)
 	assert.Equal(t, utils.DEFAULT_RAY_EXPOSABLE_EVENT_TYPES, workerEventTypesV2Env.Value)
+}
+
+func TestIsNPUResourceKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		resourceKey string
+		expected    bool
+	}{
+		{
+			name:        "huawei.com/Ascend910B",
+			resourceKey: "huawei.com/Ascend910B",
+			expected:    true,
+		},
+		{
+			name:        "huawei.com/Ascend910B-power",
+			resourceKey: "huawei.com/Ascend910B-power",
+			expected:    true,
+		},
+		{
+			name:        "huawei.com/npu",
+			resourceKey: "huawei.com/npu",
+			expected:    true,
+		},
+		{
+			name:        "huawei.com/NPU",
+			resourceKey: "huawei.com/NPU",
+			expected:    true,
+		},
+		{
+			name:        "huawei.com/ascend-memory excluded",
+			resourceKey: "huawei.com/ascend-memory",
+			expected:    false,
+		},
+		{
+			name:        "huawei.com/ascend-core excluded",
+			resourceKey: "huawei.com/ascend-core",
+			expected:    false,
+		},
+		{
+			name:        "huawei.com/Ascend910B-memory excluded",
+			resourceKey: "huawei.com/Ascend910B-memory",
+			expected:    false,
+		},
+		{
+			name:        "huawei.com/Ascend910B-core excluded",
+			resourceKey: "huawei.com/Ascend910B-core",
+			expected:    false,
+		},
+		{
+			name:        "nvidia gpu not NPU",
+			resourceKey: "nvidia.com/gpu",
+			expected:    false,
+		},
+		{
+			name:        "cpu not NPU",
+			resourceKey: "cpu",
+			expected:    false,
+		},
+		{
+			name:        "memory not NPU",
+			resourceKey: "memory",
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isNPUResourceKey(tt.resourceKey)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetCustomAcceleratorRayResourceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		expected string
+	}{
+		{
+			name:     "nvidia neuron core direct match",
+			key:      "aws.amazon.com/neuroncore",
+			expected: "neuron_cores",
+		},
+		{
+			name:     "google TPU direct match",
+			key:      "google.com/tpu",
+			expected: "TPU",
+		},
+		{
+			name:     "huawei Ascend910B NPU",
+			key:      "huawei.com/Ascend910B",
+			expected: "NPU",
+		},
+		{
+			name:     "huawei.com/npu NPU",
+			key:      "huawei.com/npu",
+			expected: "NPU",
+		},
+		{
+			name:     "huawei ascend-memory returns empty",
+			key:      "huawei.com/ascend-memory",
+			expected: "",
+		},
+		{
+			name:     "unknown resource returns empty",
+			key:      "unknown.com/accelerator",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getCustomAcceleratorRayResourceName(tt.key)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/ray-operator/controllers/ray/utils/resources_test.go
+++ b/ray-operator/controllers/ray/utils/resources_test.go
@@ -42,6 +42,16 @@ func TestIsGPUResourceKey(t *testing.T) {
 			resourceKey: "memory",
 			expected:    false,
 		},
+		{
+			name:        "huawei Ascend910B",
+			resourceKey: "huawei.com/Ascend910B",
+			expected:    false,
+		},
+		{
+			name:        "huawei npu",
+			resourceKey: "huawei.com/npu",
+			expected:    false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This adds prefix-based resource mapping for Huawei Ascend NPUs to properly inject Ray NPU limits. Resolves #5039.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds native support for Huawei Ascend NPUs in KubeRay by mapping Kubernetes Ascend device resources to Ray's logical `NPU` resource. 

Because Huawei device plugins and virtualization schedulers (like HAMi) expose several variations of resource names depending on the chip model and slicing (e.g., `huawei.com/Ascend910B`, `huawei.com/ascend-1980`, `huawei.com/npu`), this change introduces a case-insensitive prefix check (`huawei.com/ascend`) instead of hardcoding exact exact model names in the `customAcceleratorToRayResourceMap`. 

This ensures that the operator correctly parses the limits and automatically injects `--resources='{"NPU": X}'` into the Ray worker startup parameters for all current and future Ascend hardware generations.

The refactor also unifies the accelerator resource mapping logic across both code paths that populate `rayStartParams` (top-level `Resources` field and container `resources.limits`). Previously, custom accelerators like `google.com/tpu` and `aws.amazon.com/neuroncore` could end up under different keys in `--resources` depending on which field was used. Both paths now go through `getCustomAcceleratorRayResourceName`, producing consistent Ray resource names (`TPU`, `neuron_cores`) regardless of the input field.

## Related issue number

Closes #5039

## Labels

<!-- Please add the appropriate labels to this PR. -->

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- If you selected "Manual tests" above, please fill in the section below. Otherwise you can remove it. -->