### PR TITLE
[RayService] Assert rollback reason in TestReconcileRollbackState

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2872,6 +2872,12 @@ func TestReconcileRollbackState(t *testing.T) {
 
 			isCurrentlyRollingBack := meta.IsStatusConditionTrue(rayService.Status.Conditions, string(rayv1.RollbackInProgress))
 			assert.Equal(t, tt.expectRollbackStatus, isCurrentlyRollingBack)
+
+			if tt.expectRollbackStatus && !tt.isRollbackInProgress {
+				cond := meta.FindStatusCondition(rayService.Status.Conditions, string(rayv1.RollbackInProgress))
+				require.NotNil(t, cond)
+				assert.Equal(t, string(rayv1.DesiredClusterSpecChanged), cond.Reason)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Why are these changes needed?

`reconcileRollbackState` sets the `RollbackInProgress` condition with reason `DesiredClusterSpecChanged`, but `TestReconcileRollbackState` asserted only the condition's **boolean**, never its **reason**. That let the #5022 rename (`TargetClusterChanged` -> `DesiredClusterSpecChanged`) drift at one of two callsites in `rayservice_controller.go` for ~9 days until the hotfix in #5063.

The new assertion checks the emitted reason, but only on the cases where the controller itself emits the condition (`expectRollbackStatus && !isRollbackInProgress`), excluding the pre-seeded "continues rolling back" path where the controller returns early without re-setting the condition.

## Related issue number

No issue — test-only regression-prevention gap found while reviewing #5063 (the hotfix for the #5022 rename drift).

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested 🙁
