### PR TITLE
[Docs] Remove outdated postStart hook section from set_up_collector.md

### DIFF
--- a/historyserver/docs/set_up_collector.md
+++ b/historyserver/docs/set_up_collector.md
@@ -178,33 +178,6 @@ spec:
     emptyDir: {}
 ```
 
-> [!IMPORTANT]
-> The Ray container must also include a `postStart` lifecycle hook to write the raylet node ID
-> to a file. The collector reads this file to identify the node. Without this hook, the
-> collector will fail with errors like `read nodeid file error`. Add the following lifecycle
-> configuration to the Ray container:
-
-```yaml
-lifecycle:
-  postStart:
-    exec:
-      command:
-      - /bin/sh
-      - -c
-      - |
-        while true; do
-          nodeid=$(ps -ef | grep 'raylet.*--node_id' | grep -v grep | sed -n 's/.*--node_id=\([^ ]*\).*/\1/p' | head -1)
-          if [ -n "$nodeid" ]; then
-            echo "$nodeid" > /tmp/ray/raylet_node_id
-            break
-          fi
-          sleep 1
-        done
-```
-
-> Note: The example manifest at `config/raycluster.yaml` uses `grep -oP` (Perl regex) which may
-> not be available in all containers. The `sed` command above is more portable.
-
 Deploy the Ray cluster using the manifest that matches your storage backend:
 
 ```bash


### PR DESCRIPTION
Obsolete since #4983: the collector retrieves the node ID programmatically, so the postStart hook and the `grep -oP` note are no longer needed.