### PR TITLE
[CI] Fix master build: use events.NewFakeRecorder in RayService unit test

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2634,7 +2634,7 @@ func TestHandleSuspendResumeResetsReadyToInitializing(t *testing.T) {
 	r := &RayServiceReconciler{
 		Client:   fakeClient,
 		Scheme:   scheme.Scheme,
-		Recorder: record.NewFakeRecorder(10),
+		Recorder: events.NewFakeRecorder(10),
 	}
 
 	_, err := r.handleSuspend(ctx, rs)


### PR DESCRIPTION
Master `Go-build-and-test` is failing to compile: #4894 added a test using the old `record.NewFakeRecorder`, but `RayServiceReconciler.Recorder` had migrated to `events.EventRecorder`, and the two merged without a rebase (`undefined: record`). Align the test with the other tests in the file.

Verified: `go test -run TestHandleSuspendResumeResetsReadyToInitializing ./controllers/ray/` passes.