### PR TITLE
[RayService] Fix broken build: use events.NewFakeRecorder in unit test

### DIFF
--- a/ray-operator/controllers/ray/rayservice_controller_unit_test.go
+++ b/ray-operator/controllers/ray/rayservice_controller_unit_test.go
@@ -2634,7 +2634,7 @@ func TestHandleSuspendResumeResetsReadyToInitializing(t *testing.T) {
 	r := &RayServiceReconciler{
 		Client:   fakeClient,
 		Scheme:   scheme.Scheme,
-		Recorder: record.NewFakeRecorder(10),
+		Recorder: events.NewFakeRecorder(10),
 	}
 
 	_, err := r.handleSuspend(ctx, rs)


### PR DESCRIPTION
## Why

`master` currently does not compile. `golangci-lint` (pre-commit) fails on every open PR with:

```
ray-operator/controllers/ray/rayservice_controller_unit_test.go:2637:13: undefined: record (typecheck)
```

## Root cause

A semantic merge conflict between two independently-green PRs:

- The file was migrated from `k8s.io/client-go/tools/record` to `k8s.io/client-go/tools/events`; every recorder in it now uses `events.NewFakeRecorder(...)` / `events.FakeRecorder{}`, and `tools/record` is no longer imported.
- #4894 (commit a6f00357) added a lone `record.NewFakeRecorder(10)` at line 2637, written against a base that still imported `tools/record`.

Merged together, `record` is undefined, so the test package fails to typecheck. Each PR passed CI on its own base; the combination on `master` does not compile.

## Fix

Switch the single stray call to `events.NewFakeRecorder(10)`, matching every other recorder in the file (e.g. lines 476, 909). One line, no import changes.

## Verification

```
cd ray-operator && go vet ./controllers/ray/   # passes (previously: undefined: record)
```