### PR TITLE
docs: make API reference cross-links version-aware

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -10,14 +10,14 @@
 Package v1 contains API Schema definitions for the ray v1 API group
 
 ### Resource Types
-- [RayCluster](#raycluster)
-- [RayCronJob](#raycronjob)
-- [RayJob](#rayjob)
-- [RayService](#rayservice)
+- [RayCluster](#raycluster-v1)
+- [RayCronJob](#raycronjob-v1)
+- [RayJob](#rayjob-v1)
+- [RayService](#rayservice-v1)
 
 
 
-#### AuthMode
+#### <a id="authmode-v1" name="authmode-v1"></a>AuthMode
 
 _Underlying type:_ _string_
 
@@ -26,7 +26,7 @@ AuthMode describes the authentication mode for the Ray cluster.
 
 
 _Appears in:_
-- [AuthOptions](#authoptions)
+- [AuthOptions](#authoptions-v1)
 
 | Field | Description |
 | --- | --- |
@@ -34,7 +34,7 @@ _Appears in:_
 | `token` | AuthModeToken enables token-based authentication.<br /> |
 
 
-#### AuthOptions
+#### <a id="authoptions-v1" name="authoptions-v1"></a>AuthOptions
 
 
 
@@ -43,16 +43,16 @@ AuthOptions defines the authentication options for a RayCluster.
 
 
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `enableK8sTokenAuth` _boolean_ | EnableK8sTokenAuth enables Kubernetes-delegated token authentication.<br />When true, the RAY_ENABLE_K8S_TOKEN_AUTH environment variable is set to "true"<br />across all Ray Pods, and Ray will delegate authentication to the K8s API server.<br />NOTE: The Kubernetes ServiceAccount token mounted to Raylets must be granted<br />the `ray:write` custom verb via RBAC for this to function correctly.<br />WARNING: This feature is intended for standalone RayCluster objects and is<br />currently unsupported for RayJob or RayService resources. |  |  |
 | `secretName` _string_ | SecretName is the name of the Secret that contains the authentication token.<br />If set, KubeRay will skip generating a Secret object per RayCluster containing a token.<br />The Secret must have a data key `auth_token` that contains the value of the token. |  |  |
-| `mode` _[AuthMode](#authmode)_ | Mode specifies the authentication mode.<br />Supported values are "disabled" and "token".<br />Defaults to "token". |  | Enum: [disabled token] <br /> |
+| `mode` _[AuthMode](#authmode-v1)_ | Mode specifies the authentication mode.<br />Supported values are "disabled" and "token".<br />Defaults to "token". |  | Enum: [disabled token] <br /> |
 
 
-#### AutoscalerOptions
+#### <a id="autoscaleroptions-v1" name="autoscaleroptions-v1"></a>AutoscalerOptions
 
 
 
@@ -61,7 +61,7 @@ AutoscalerOptions specifies optional configuration for the Ray autoscaler.
 
 
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -70,8 +70,8 @@ _Appears in:_
 | `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | ImagePullPolicy optionally overrides the autoscaler container's image pull policy. This override is provided for autoscaler testing and development. |  |  |
 | `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the container should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  |  |
 | `idleTimeoutSeconds` _integer_ | IdleTimeoutSeconds is the number of seconds to wait before scaling down a worker pod which is not using Ray resources.<br />Defaults to 60 (one minute). It is not read by the KubeRay operator but by the Ray autoscaler. |  |  |
-| `upscalingMode` _[UpscalingMode](#upscalingmode)_ | UpscalingMode is "Conservative", "Default", or "Aggressive."<br />Conservative: Upscaling is rate-limited; the number of pending worker pods is at most the size of the Ray cluster.<br />Default: Upscaling is not rate-limited.<br />Aggressive: An alias for Default; upscaling is not rate-limited.<br />It is not read by the KubeRay operator but by the Ray autoscaler. |  | Enum: [Default Aggressive Conservative] <br /> |
-| `version` _[AutoscalerVersion](#autoscalerversion)_ | Version is the version of the Ray autoscaler.<br />Setting this to v1 will explicitly use autoscaler v1.<br />Setting this to v2 will explicitly use autoscaler v2.<br />If this isn't set, the Ray version determines the autoscaler version.<br />In Ray 2.47.0 and later, the default autoscaler version is v2. It's v1 before that. |  | Enum: [v1 v2] <br /> |
+| `upscalingMode` _[UpscalingMode](#upscalingmode-v1)_ | UpscalingMode is "Conservative", "Default", or "Aggressive."<br />Conservative: Upscaling is rate-limited; the number of pending worker pods is at most the size of the Ray cluster.<br />Default: Upscaling is not rate-limited.<br />Aggressive: An alias for Default; upscaling is not rate-limited.<br />It is not read by the KubeRay operator but by the Ray autoscaler. |  | Enum: [Default Aggressive Conservative] <br /> |
+| `version` _[AutoscalerVersion](#autoscalerversion-v1)_ | Version is the version of the Ray autoscaler.<br />Setting this to v1 will explicitly use autoscaler v1.<br />Setting this to v2 will explicitly use autoscaler v2.<br />If this isn't set, the Ray version determines the autoscaler version.<br />In Ray 2.47.0 and later, the default autoscaler version is v2. It's v1 before that. |  | Enum: [v1 v2] <br /> |
 | `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | Optional list of environment variables to set in the autoscaler container. |  |  |
 | `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | Optional list of sources to populate environment variables in the autoscaler container. |  |  |
 | `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Optional list of volumeMounts.  This is needed for enabling TLS for the autoscaler container. |  |  |
@@ -79,7 +79,7 @@ _Appears in:_
 | `args` _string array_ | Optional to overwrite the default args of the autoscaler container. |  |  |
 
 
-#### AutoscalerVersion
+#### <a id="autoscalerversion-v1" name="autoscalerversion-v1"></a>AutoscalerVersion
 
 _Underlying type:_ _string_
 
@@ -89,7 +89,7 @@ _Validation:_
 - Enum: [v1 v2]
 
 _Appears in:_
-- [AutoscalerOptions](#autoscaleroptions)
+- [AutoscalerOptions](#autoscaleroptions-v1)
 
 | Field | Description |
 | --- | --- |
@@ -97,7 +97,7 @@ _Appears in:_
 | `v2` |  |
 
 
-#### ClusterUpgradeOptions
+#### <a id="clusterupgradeoptions-v1" name="clusterupgradeoptions-v1"></a>ClusterUpgradeOptions
 
 
 
@@ -106,7 +106,7 @@ These options are currently only supported for the IncrementalUpgrade type.
 
 
 _Appears in:_
-- [RayServiceUpgradeStrategy](#rayserviceupgradestrategy)
+- [RayServiceUpgradeStrategy](#rayserviceupgradestrategy-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -116,7 +116,7 @@ _Appears in:_
 | `gatewayClassName` _string_ | The name of the Gateway Class installed by the Kubernetes Cluster admin. |  |  |
 
 
-#### CollectorOptions
+#### <a id="collectoroptions-v1" name="collectoroptions-v1"></a>CollectorOptions
 
 
 
@@ -125,7 +125,7 @@ CollectorOptions defines settings for the history server collector sidecar.
 
 
 _Appears in:_
-- [HistoryServerOptions](#historyserveroptions)
+- [HistoryServerOptions](#historyserveroptions-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -135,7 +135,7 @@ _Appears in:_
 | `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | Env allows injecting custom environment variables into the collector container. |  |  |
 
 
-#### DeletionCondition
+#### <a id="deletioncondition-v1" name="deletioncondition-v1"></a>DeletionCondition
 
 
 
@@ -147,14 +147,14 @@ Exactly one of JobStatus or JobDeploymentStatus must be specified:
 
 
 _Appears in:_
-- [DeletionRule](#deletionrule)
+- [DeletionRule](#deletionrule-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `ttlSeconds` _integer_ | TTLSeconds is the time in seconds from when the JobStatus or JobDeploymentStatus<br />reaches the specified terminal state to when this deletion action should be triggered.<br />The value must be a non-negative integer. | 0 | Minimum: 0 <br /> |
 
 
-#### DeletionPolicy
+#### <a id="deletionpolicy-v1" name="deletionpolicy-v1"></a>DeletionPolicy
 
 
 
@@ -164,14 +164,14 @@ Deprecated: This struct is part of the legacy API. Use DeletionRule for new conf
 
 
 _Appears in:_
-- [DeletionStrategy](#deletionstrategy)
+- [DeletionStrategy](#deletionstrategy-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `policy` _[DeletionPolicyType](#deletionpolicytype)_ | Policy is the action to take when the condition is met.<br />This field is logically required when using the legacy OnSuccess/OnFailure policies.<br />It is marked as '+optional' at the API level to allow the 'deletionRules' field to be used instead. |  | Enum: [DeleteCluster DeleteWorkers DeleteSelf DeleteNone] <br /> |
+| `policy` _[DeletionPolicyType](#deletionpolicytype-v1)_ | Policy is the action to take when the condition is met.<br />This field is logically required when using the legacy OnSuccess/OnFailure policies.<br />It is marked as '+optional' at the API level to allow the 'deletionRules' field to be used instead. |  | Enum: [DeleteCluster DeleteWorkers DeleteSelf DeleteNone] <br /> |
 
 
-#### DeletionPolicyType
+#### <a id="deletionpolicytype-v1" name="deletionpolicytype-v1"></a>DeletionPolicyType
 
 _Underlying type:_ _string_
 
@@ -180,8 +180,8 @@ _Underlying type:_ _string_
 
 
 _Appears in:_
-- [DeletionPolicy](#deletionpolicy)
-- [DeletionRule](#deletionrule)
+- [DeletionPolicy](#deletionpolicy-v1)
+- [DeletionRule](#deletionrule-v1)
 
 | Field | Description |
 | --- | --- |
@@ -191,7 +191,7 @@ _Appears in:_
 | `DeleteNone` |  |
 
 
-#### DeletionRule
+#### <a id="deletionrule-v1" name="deletionrule-v1"></a>DeletionRule
 
 
 
@@ -201,15 +201,15 @@ This is the new, recommended way to define deletion behavior.
 
 
 _Appears in:_
-- [DeletionStrategy](#deletionstrategy)
+- [DeletionStrategy](#deletionstrategy-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `policy` _[DeletionPolicyType](#deletionpolicytype)_ | Policy is the action to take when the condition is met. This field is required. |  | Enum: [DeleteCluster DeleteWorkers DeleteSelf DeleteNone] <br /> |
-| `condition` _[DeletionCondition](#deletioncondition)_ | The condition under which this deletion rule is triggered. This field is required. |  |  |
+| `policy` _[DeletionPolicyType](#deletionpolicytype-v1)_ | Policy is the action to take when the condition is met. This field is required. |  | Enum: [DeleteCluster DeleteWorkers DeleteSelf DeleteNone] <br /> |
+| `condition` _[DeletionCondition](#deletioncondition-v1)_ | The condition under which this deletion rule is triggered. This field is required. |  |  |
 
 
-#### DeletionStrategy
+#### <a id="deletionstrategy-v1" name="deletionstrategy-v1"></a>DeletionStrategy
 
 
 
@@ -233,18 +233,18 @@ Validation:
 
 
 _Appears in:_
-- [RayJobSpec](#rayjobspec)
+- [RayJobSpec](#rayjobspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `onSuccess` _[DeletionPolicy](#deletionpolicy)_ | OnSuccess is the deletion policy for a successful RayJob.<br />Deprecated: Use `deletionRules` instead for more flexible, multi-stage deletion strategies.<br />This field will be removed in release 1.6.0. |  |  |
-| `onFailure` _[DeletionPolicy](#deletionpolicy)_ | OnFailure is the deletion policy for a failed RayJob.<br />Deprecated: Use `deletionRules` instead for more flexible, multi-stage deletion strategies.<br />This field will be removed in release 1.6.0. |  |  |
-| `deletionRules` _[DeletionRule](#deletionrule) array_ | DeletionRules is a list of deletion rules, processed based on their trigger conditions.<br />While the rules can be used to define a sequence, if multiple rules are overdue (e.g., due to controller downtime),<br />the most impactful rule (e.g., DeleteSelf) will be executed first to prioritize resource cleanup. |  | MinItems: 1 <br /> |
+| `onSuccess` _[DeletionPolicy](#deletionpolicy-v1)_ | OnSuccess is the deletion policy for a successful RayJob.<br />Deprecated: Use `deletionRules` instead for more flexible, multi-stage deletion strategies.<br />This field will be removed in release 1.6.0. |  |  |
+| `onFailure` _[DeletionPolicy](#deletionpolicy-v1)_ | OnFailure is the deletion policy for a failed RayJob.<br />Deprecated: Use `deletionRules` instead for more flexible, multi-stage deletion strategies.<br />This field will be removed in release 1.6.0. |  |  |
+| `deletionRules` _[DeletionRule](#deletionrule-v1) array_ | DeletionRules is a list of deletion rules, processed based on their trigger conditions.<br />While the rules can be used to define a sequence, if multiple rules are overdue (e.g., due to controller downtime),<br />the most impactful rule (e.g., DeleteSelf) will be executed first to prioritize resource cleanup. |  | MinItems: 1 <br /> |
 
 
 
 
-#### GCSStorageDeletionPolicy
+#### <a id="gcsstoragedeletionpolicy-v1" name="gcsstoragedeletionpolicy-v1"></a>GCSStorageDeletionPolicy
 
 _Underlying type:_ _string_
 
@@ -255,7 +255,7 @@ _Validation:_
 - Enum: [DeleteWithCluster Retain]
 
 _Appears in:_
-- [GcsEmbeddedStorage](#gcsembeddedstorage)
+- [GcsEmbeddedStorage](#gcsembeddedstorage-v1)
 
 | Field | Description |
 | --- | --- |
@@ -263,7 +263,7 @@ _Appears in:_
 | `Retain` | RetainGCSStorageDeletionPolicy keeps the operator-managed PVC (and its data)<br />after the owning RayCluster is deleted: the operator omits the ownerReference<br />so the PVC outlives the cluster. Recover the GCS state by pointing a new<br />cluster's ClaimName at the retained PVC.<br /> |
 
 
-#### GcsEmbeddedStorage
+#### <a id="gcsembeddedstorage-v1" name="gcsembeddedstorage-v1"></a>GcsEmbeddedStorage
 
 
 
@@ -277,7 +277,7 @@ caller is responsible for ensuring only one Ray head writes to it at a time.
 
 
 _Appears in:_
-- [GcsFaultToleranceOptions](#gcsfaulttoleranceoptions)
+- [GcsFaultToleranceOptions](#gcsfaulttoleranceoptions-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -286,10 +286,10 @@ _Appears in:_
 | `storageClassName` _string_ | StorageClassName for the operator-managed PVC. Uses the cluster default<br />StorageClass when omitted. Ignored when ClaimName is set. |  |  |
 | `accessModes` _[PersistentVolumeAccessMode](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeaccessmode-v1-core) array_ | AccessModes for the operator-managed PVC. Defaults to [ReadWriteOnce].<br />Ignored when ClaimName is set.<br />ReadWriteOnce is the sane default for a standalone RayCluster (one head Pod<br />attaches at a time). ReadWriteMany is a valid choice when you need the volume<br />attached to multiple Pods concurrently (e.g. to overlap the old and new head<br />during a RayService upgrade); RocksDB still requires that only one of them<br />writes at a time, which you must coordinate externally. |  |  |
 | `subPath` _string_ | SubPath mounts a subdirectory of the volume instead of its root. |  |  |
-| `deletionPolicy` _[GCSStorageDeletionPolicy](#gcsstoragedeletionpolicy)_ | DeletionPolicy controls the lifecycle of the operator-managed PVC relative to<br />the owning RayCluster. Defaults to DeleteWithCluster. Ignored when ClaimName<br />is set (the operator never owns a bring-your-own PVC, so it is never deleted<br />or retained by the operator).<br />Recovery after Retain: a PVC left behind by a Retain delete can be recovered<br />either by pointing a new cluster's ClaimName at it, or by recreating a<br />RayCluster with the same name on the operator-managed path -- the operator<br />adopts the existing \{cluster\}-gcs-pvc and reuses its RocksDB state. To start<br />from a fresh store instead, delete the leftover PVC first. |  | Enum: [DeleteWithCluster Retain] <br /> |
+| `deletionPolicy` _[GCSStorageDeletionPolicy](#gcsstoragedeletionpolicy-v1)_ | DeletionPolicy controls the lifecycle of the operator-managed PVC relative to<br />the owning RayCluster. Defaults to DeleteWithCluster. Ignored when ClaimName<br />is set (the operator never owns a bring-your-own PVC, so it is never deleted<br />or retained by the operator).<br />Recovery after Retain: a PVC left behind by a Retain delete can be recovered<br />either by pointing a new cluster's ClaimName at it, or by recreating a<br />RayCluster with the same name on the operator-managed path -- the operator<br />adopts the existing \{cluster\}-gcs-pvc and reuses its RocksDB state. To start<br />from a fresh store instead, delete the leftover PVC first. |  | Enum: [DeleteWithCluster Retain] <br /> |
 
 
-#### GcsFaultToleranceBackend
+#### <a id="gcsfaulttolerancebackend-v1" name="gcsfaulttolerancebackend-v1"></a>GcsFaultToleranceBackend
 
 _Underlying type:_ _string_
 
@@ -299,7 +299,7 @@ _Validation:_
 - Enum: [redis rocksdb]
 
 _Appears in:_
-- [GcsFaultToleranceOptions](#gcsfaulttoleranceoptions)
+- [GcsFaultToleranceOptions](#gcsfaulttoleranceoptions-v1)
 
 | Field | Description |
 | --- | --- |
@@ -307,7 +307,7 @@ _Appears in:_
 | `rocksdb` | GcsFTBackendRocksDB persists GCS metadata in an embedded RocksDB store on a<br />persistent volume mounted on the head Pod.<br /> |
 
 
-#### GcsFaultToleranceOptions
+#### <a id="gcsfaulttoleranceoptions-v1" name="gcsfaulttoleranceoptions-v1"></a>GcsFaultToleranceOptions
 
 
 
@@ -316,19 +316,19 @@ GcsFaultToleranceOptions contains configs for GCS FT
 
 
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `backend` _[GcsFaultToleranceBackend](#gcsfaulttolerancebackend)_ | Backend selects the GCS FT persistence backend. Defaults to "redis" for<br />backward compatibility. Immutable: the backend cannot be switched on an<br />existing RayCluster (doing so would swap the entire GCS store and head-Pod<br />wiring, losing fault-tolerance state). |  | Enum: [redis rocksdb] <br /> |
-| `redisUsername` _[RedisCredential](#rediscredential)_ |  |  |  |
-| `redisPassword` _[RedisCredential](#rediscredential)_ |  |  |  |
+| `backend` _[GcsFaultToleranceBackend](#gcsfaulttolerancebackend-v1)_ | Backend selects the GCS FT persistence backend. Defaults to "redis" for<br />backward compatibility. Immutable: the backend cannot be switched on an<br />existing RayCluster (doing so would swap the entire GCS store and head-Pod<br />wiring, losing fault-tolerance state). |  | Enum: [redis rocksdb] <br /> |
+| `redisUsername` _[RedisCredential](#rediscredential-v1)_ |  |  |  |
+| `redisPassword` _[RedisCredential](#rediscredential-v1)_ |  |  |  |
 | `externalStorageNamespace` _string_ |  |  |  |
 | `redisAddress` _string_ | RedisAddress is the address of the external Redis service used when Backend<br />is "redis". It may alternatively be supplied via env vars/annotations. |  |  |
-| `storage` _[GcsEmbeddedStorage](#gcsembeddedstorage)_ | Storage configures the persistent volume backing the embedded RocksDB<br />store. Only used when Backend is "rocksdb". |  |  |
+| `storage` _[GcsEmbeddedStorage](#gcsembeddedstorage-v1)_ | Storage configures the persistent volume backing the embedded RocksDB<br />store. Only used when Backend is "rocksdb". |  |  |
 
 
-#### HeadGroupSpec
+#### <a id="headgroupspec-v1" name="headgroupspec-v1"></a>HeadGroupSpec
 
 
 
@@ -337,21 +337,21 @@ HeadGroupSpec are the spec for the head pod
 
 
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `template` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | Template is the exact pod template used in K8s deployments, statefulsets, etc. |  |  |
 | `headService` _[Service](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#service-v1-core)_ | HeadService is the Kubernetes service of the head pod. |  |  |
 | `enableIngress` _boolean_ | EnableIngress indicates whether operator should create ingress object for head service or not. |  |  |
-| `ingressOptions` _[IngressOptions](#ingressoptions)_ | IngressOptions specifies optional ingress configuration for the head service. |  |  |
+| `ingressOptions` _[IngressOptions](#ingressoptions-v1)_ | IngressOptions specifies optional ingress configuration for the head service. |  |  |
 | `resources` _object (keys:string, values:string)_ | Resources specifies the resource quantities for the head group.<br />These values override the resources passed to `rayStartParams` for the group, but<br />have no effect on the resources set at the K8s Pod container level. |  |  |
 | `labels` _object (keys:string, values:string)_ | Labels specifies the Ray node labels for the head group.<br />These labels will also be added to the Pods of this head group and override the `--labels`<br />argument passed to `rayStartParams`. |  |  |
 | `rayStartParams` _object (keys:string, values:string)_ | RayStartParams are the params of the start command: node-manager-port, object-store-memory, ... |  |  |
 | `serviceType` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#servicetype-v1-core)_ | ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod |  |  |
 
 
-#### HistoryServerOptions
+#### <a id="historyserveroptions-v1" name="historyserveroptions-v1"></a>HistoryServerOptions
 
 
 
@@ -360,14 +360,14 @@ HistoryServerOptions used for history server related configuration
 
 
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `collectorOptions` _[CollectorOptions](#collectoroptions)_ | CollectorOptions used for collector sidecar configuration |  |  |
+| `collectorOptions` _[CollectorOptions](#collectoroptions-v1)_ | CollectorOptions used for collector sidecar configuration |  |  |
 
 
-#### IngressOptions
+#### <a id="ingressoptions-v1" name="ingressoptions-v1"></a>IngressOptions
 
 
 
@@ -376,17 +376,17 @@ IngressOptions defines the host, path, and TLS configuration for the ingress gen
 
 
 _Appears in:_
-- [HeadGroupSpec](#headgroupspec)
+- [HeadGroupSpec](#headgroupspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `host` _string_ | Host is the fully-qualified domain name used to route external traffic to the<br />Ray head dashboard. When unset, the generated ingress rule matches any host. |  |  |
 | `path` _string_ | Path is the HTTP path that routes to the Ray head dashboard.<br />When unset, the operator defaults it to "/", which routes all traffic on the<br />host to the dashboard. |  |  |
-| `pathType` _[IngressPathType](#ingresspathtype)_ | PathType is the path matching mode applied to Path.<br />When unset, the operator defaults it to "Prefix", which works out of the box<br />without a rewrite-target annotation or controller-specific regex support. |  | Enum: [Exact Prefix ImplementationSpecific] <br /> |
+| `pathType` _[IngressPathType](#ingresspathtype-v1)_ | PathType is the path matching mode applied to Path.<br />When unset, the operator defaults it to "Prefix", which works out of the box<br />without a rewrite-target annotation or controller-specific regex support. |  | Enum: [Exact Prefix ImplementationSpecific] <br /> |
 | `tls` _[IngressTLS](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#ingresstls-v1-networking) array_ | TLS configures TLS termination for the generated ingress. |  |  |
 
 
-#### IngressPathType
+#### <a id="ingresspathtype-v1" name="ingresspathtype-v1"></a>IngressPathType
 
 _Underlying type:_ _string_
 
@@ -396,7 +396,7 @@ _Validation:_
 - Enum: [Exact Prefix ImplementationSpecific]
 
 _Appears in:_
-- [IngressOptions](#ingressoptions)
+- [IngressOptions](#ingressoptions-v1)
 
 | Field | Description |
 | --- | --- |
@@ -407,7 +407,7 @@ _Appears in:_
 
 
 
-#### JobSubmissionMode
+#### <a id="jobsubmissionmode-v1" name="jobsubmissionmode-v1"></a>JobSubmissionMode
 
 _Underlying type:_ _string_
 
@@ -416,7 +416,7 @@ _Underlying type:_ _string_
 
 
 _Appears in:_
-- [RayJobSpec](#rayjobspec)
+- [RayJobSpec](#rayjobspec-v1)
 
 | Field | Description |
 | --- | --- |
@@ -426,7 +426,7 @@ _Appears in:_
 | `SidecarMode` |  |
 
 
-#### NetworkPolicyConfig
+#### <a id="networkpolicyconfig-v1" name="networkpolicyconfig-v1"></a>NetworkPolicyConfig
 
 
 
@@ -438,17 +438,17 @@ for why it must be added under DenyAll/DenyAllEgress.
 
 
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `mode` _[NetworkPolicyMode](#networkpolicymode)_ | Mode controls the security level. All modes permit intra-cluster pod-to-pod<br />traffic (DNS egress excluded, see EgressRules).<br />- "DenyAll": Denies all Ingress and Egress.<br />- "DenyAllIngress": Denies all Ingress.<br />- "DenyAllEgress": Denies all Egress. | DenyAll | Enum: [DenyAll DenyAllIngress DenyAllEgress] <br /> |
-| `head` _[NetworkPolicyRules](#networkpolicyrules)_ | Head specifies custom NetworkPolicy rules applied only to the head pod's policy.<br />The base head policy always allows intra-cluster traffic and (for K8sJobMode<br />RayJob-owned clusters) the submitter pod. Rules here are appended to those<br />base rules. Platforms that need operator dashboard access should add it here<br />(e.g. via a mutating webhook). |  |  |
-| `worker` _[NetworkPolicyRules](#networkpolicyrules)_ | Worker specifies custom NetworkPolicy rules applied only to worker pods' policy.<br />The base worker policy always allows intra-cluster traffic.<br />Rules here are appended to that base rule.<br />Acts as the default for all worker groups; see WorkerGroups for per-group overrides. |  |  |
-| `workerGroups` _[WorkerGroupNetworkPolicyRules](#workergroupnetworkpolicyrules) array_ | WorkerGroups specifies per-worker-group NetworkPolicy rules, keyed by group name.<br />If an entry exists for a worker group, it replaces (not merges with) Worker for<br />that group. Worker groups without an entry fall back to Worker. |  |  |
+| `mode` _[NetworkPolicyMode](#networkpolicymode-v1)_ | Mode controls the security level. All modes permit intra-cluster pod-to-pod<br />traffic (DNS egress excluded, see EgressRules).<br />- "DenyAll": Denies all Ingress and Egress.<br />- "DenyAllIngress": Denies all Ingress.<br />- "DenyAllEgress": Denies all Egress. | DenyAll | Enum: [DenyAll DenyAllIngress DenyAllEgress] <br /> |
+| `head` _[NetworkPolicyRules](#networkpolicyrules-v1)_ | Head specifies custom NetworkPolicy rules applied only to the head pod's policy.<br />The base head policy always allows intra-cluster traffic and (for K8sJobMode<br />RayJob-owned clusters) the submitter pod. Rules here are appended to those<br />base rules. Platforms that need operator dashboard access should add it here<br />(e.g. via a mutating webhook). |  |  |
+| `worker` _[NetworkPolicyRules](#networkpolicyrules-v1)_ | Worker specifies custom NetworkPolicy rules applied only to worker pods' policy.<br />The base worker policy always allows intra-cluster traffic.<br />Rules here are appended to that base rule.<br />Acts as the default for all worker groups; see WorkerGroups for per-group overrides. |  |  |
+| `workerGroups` _[WorkerGroupNetworkPolicyRules](#workergroupnetworkpolicyrules-v1) array_ | WorkerGroups specifies per-worker-group NetworkPolicy rules, keyed by group name.<br />If an entry exists for a worker group, it replaces (not merges with) Worker for<br />that group. Worker groups without an entry fall back to Worker. |  |  |
 
 
-#### NetworkPolicyMode
+#### <a id="networkpolicymode-v1" name="networkpolicymode-v1"></a>NetworkPolicyMode
 
 _Underlying type:_ _string_
 
@@ -458,7 +458,7 @@ _Validation:_
 - Enum: [DenyAll DenyAllIngress DenyAllEgress]
 
 _Appears in:_
-- [NetworkPolicyConfig](#networkpolicyconfig)
+- [NetworkPolicyConfig](#networkpolicyconfig-v1)
 
 | Field | Description |
 | --- | --- |
@@ -467,7 +467,7 @@ _Appears in:_
 | `DenyAllEgress` | NetworkPolicyDenyAllEgress denies all egress traffic.<br /> |
 
 
-#### NetworkPolicyRules
+#### <a id="networkpolicyrules-v1" name="networkpolicyrules-v1"></a>NetworkPolicyRules
 
 
 
@@ -476,8 +476,8 @@ NetworkPolicyRules defines custom ingress and egress rules for a NetworkPolicy.
 
 
 _Appears in:_
-- [NetworkPolicyConfig](#networkpolicyconfig)
-- [WorkerGroupNetworkPolicyRules](#workergroupnetworkpolicyrules)
+- [NetworkPolicyConfig](#networkpolicyconfig-v1)
+- [WorkerGroupNetworkPolicyRules](#workergroupnetworkpolicyrules-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -485,7 +485,7 @@ _Appears in:_
 | `egressRules` _[NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#networkpolicyegressrule-v1-networking) array_ | EgressRules specifies custom egress rules appended to the base policy.<br />Only meaningful when the mode includes egress denial (DenyAll or DenyAllEgress).<br />DNS egress is NOT added automatically: under DenyAll/DenyAllEgress you MUST<br />add a DNS rule here (e.g. to kube-system pods labeled k8s-app=kube-dns on<br />port 53), because Ray workers reach the head via its service FQDN and cannot<br />resolve it without DNS. See the network-policy-deny-all sample. |  |  |
 
 
-#### RayCluster
+#### <a id="raycluster-v1" name="raycluster-v1"></a>RayCluster
 
 
 
@@ -500,12 +500,12 @@ RayCluster is the Schema for the RayClusters API
 | `apiVersion` _string_ | `ray.io/v1` | | |
 | `kind` _string_ | `RayCluster` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[RayClusterSpec](#rayclusterspec)_ | Specification of the desired behavior of the RayCluster. |  |  |
+| `spec` _[RayClusterSpec](#rayclusterspec-v1)_ | Specification of the desired behavior of the RayCluster. |  |  |
 
 
 
 
-#### RayClusterSpec
+#### <a id="rayclusterspec-v1" name="rayclusterspec-v1"></a>RayClusterSpec
 
 
 
@@ -514,29 +514,29 @@ RayClusterSpec defines the desired state of RayCluster
 
 
 _Appears in:_
-- [RayCluster](#raycluster)
-- [RayJobSpec](#rayjobspec)
-- [RayServiceSpec](#rayservicespec)
+- [RayCluster](#raycluster-v1)
+- [RayJobSpec](#rayjobspec-v1)
+- [RayServiceSpec](#rayservicespec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `upgradeStrategy` _[RayClusterUpgradeStrategy](#rayclusterupgradestrategy)_ | UpgradeStrategy defines the scaling policy used when upgrading the RayCluster |  |  |
-| `authOptions` _[AuthOptions](#authoptions)_ | AuthOptions specifies the authentication options for the RayCluster. |  |  |
+| `upgradeStrategy` _[RayClusterUpgradeStrategy](#rayclusterupgradestrategy-v1)_ | UpgradeStrategy defines the scaling policy used when upgrading the RayCluster |  |  |
+| `authOptions` _[AuthOptions](#authoptions-v1)_ | AuthOptions specifies the authentication options for the RayCluster. |  |  |
 | `suspend` _boolean_ | Suspend indicates whether a RayCluster should be suspended.<br />A suspended RayCluster will have head pods and worker pods deleted. |  |  |
 | `managedBy` _string_ | ManagedBy is an optional configuration for the controller or entity that manages a RayCluster.<br />The value must be either 'ray.io/kuberay-operator' or 'kueue.x-k8s.io/multikueue'.<br />The kuberay-operator reconciles a RayCluster which doesn't have this field at all or<br />the field value is the reserved string 'ray.io/kuberay-operator',<br />but delegates reconciling the RayCluster with 'kueue.x-k8s.io/multikueue' to the Kueue.<br />The field is immutable. |  |  |
-| `autoscalerOptions` _[AutoscalerOptions](#autoscaleroptions)_ | AutoscalerOptions specifies optional configuration for the Ray autoscaler. |  |  |
+| `autoscalerOptions` _[AutoscalerOptions](#autoscaleroptions-v1)_ | AutoscalerOptions specifies optional configuration for the Ray autoscaler. |  |  |
 | `headServiceAnnotations` _object (keys:string, values:string)_ |  |  |  |
 | `enableInTreeAutoscaling` _boolean_ | EnableInTreeAutoscaling indicates whether operator should create in tree autoscaling configs |  |  |
-| `gcsFaultToleranceOptions` _[GcsFaultToleranceOptions](#gcsfaulttoleranceoptions)_ | GcsFaultToleranceOptions for enabling GCS FT |  |  |
-| `historyServerOptions` _[HistoryServerOptions](#historyserveroptions)_ | HistoryServerOptions used for history server related configuration |  |  |
-| `networkPolicy` _[NetworkPolicyConfig](#networkpolicyconfig)_ | NetworkPolicy specifies optional configuration for network isolation.<br />When set, separate NetworkPolicies are created for head and worker pods.<br />The reconciler always permits intra-cluster pod-to-pod traffic.<br />Note: under DenyAll/DenyAllEgress, DNS egress is not added<br />automatically; since Ray pods reach the head via its service FQDN, you must<br />allow DNS egress via Head/Worker EgressRules or the cluster will fail to start. |  |  |
-| `tlsOptions` _[TLSOptions](#tlsoptions)_ | TLSOptions specifies optional TLS encryption settings for the RayCluster.<br />If omitted or Enabled is false, TLS is disabled. When Enabled is true,<br />the operator enables mTLS using cert-manager to provision and manage certificates.<br />Requires the RayClusterMTLS feature gate on the operator. |  |  |
-| `headGroupSpec` _[HeadGroupSpec](#headgroupspec)_ | HeadGroupSpec is the spec for the head pod |  |  |
+| `gcsFaultToleranceOptions` _[GcsFaultToleranceOptions](#gcsfaulttoleranceoptions-v1)_ | GcsFaultToleranceOptions for enabling GCS FT |  |  |
+| `historyServerOptions` _[HistoryServerOptions](#historyserveroptions-v1)_ | HistoryServerOptions used for history server related configuration |  |  |
+| `networkPolicy` _[NetworkPolicyConfig](#networkpolicyconfig-v1)_ | NetworkPolicy specifies optional configuration for network isolation.<br />When set, separate NetworkPolicies are created for head and worker pods.<br />The reconciler always permits intra-cluster pod-to-pod traffic.<br />Note: under DenyAll/DenyAllEgress, DNS egress is not added<br />automatically; since Ray pods reach the head via its service FQDN, you must<br />allow DNS egress via Head/Worker EgressRules or the cluster will fail to start. |  |  |
+| `tlsOptions` _[TLSOptions](#tlsoptions-v1)_ | TLSOptions specifies optional TLS encryption settings for the RayCluster.<br />If omitted or Enabled is false, TLS is disabled. When Enabled is true,<br />the operator enables mTLS using cert-manager to provision and manage certificates.<br />Requires the RayClusterMTLS feature gate on the operator. |  |  |
+| `headGroupSpec` _[HeadGroupSpec](#headgroupspec-v1)_ | HeadGroupSpec is the spec for the head pod |  |  |
 | `rayVersion` _string_ | RayVersion is used to determine the command for the Kubernetes Job managed by RayJob |  |  |
-| `workerGroupSpecs` _[WorkerGroupSpec](#workergroupspec) array_ | WorkerGroupSpecs are the specs for the worker pods |  |  |
+| `workerGroupSpecs` _[WorkerGroupSpec](#workergroupspec-v1) array_ | WorkerGroupSpecs are the specs for the worker pods |  |  |
 
 
-#### RayClusterUpgradeStrategy
+#### <a id="rayclusterupgradestrategy-v1" name="rayclusterupgradestrategy-v1"></a>RayClusterUpgradeStrategy
 
 
 
@@ -545,14 +545,14 @@ _Appears in:_
 
 
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _[RayClusterUpgradeType](#rayclusterupgradetype)_ | Type represents the strategy used when upgrading the RayCluster Pods. Currently supports `Recreate` and `None`. |  | Enum: [Recreate None] <br /> |
+| `type` _[RayClusterUpgradeType](#rayclusterupgradetype-v1)_ | Type represents the strategy used when upgrading the RayCluster Pods. Currently supports `Recreate` and `None`. |  | Enum: [Recreate None] <br /> |
 
 
-#### RayClusterUpgradeType
+#### <a id="rayclusterupgradetype-v1" name="rayclusterupgradetype-v1"></a>RayClusterUpgradeType
 
 _Underlying type:_ _string_
 
@@ -562,7 +562,7 @@ _Validation:_
 - Enum: [Recreate None]
 
 _Appears in:_
-- [RayClusterUpgradeStrategy](#rayclusterupgradestrategy)
+- [RayClusterUpgradeStrategy](#rayclusterupgradestrategy-v1)
 
 | Field | Description |
 | --- | --- |
@@ -570,7 +570,7 @@ _Appears in:_
 | `None` | No new pod will be created while the strategy is set to None<br /> |
 
 
-#### RayCronJob
+#### <a id="raycronjob-v1" name="raycronjob-v1"></a>RayCronJob
 
 
 
@@ -585,10 +585,10 @@ RayCronJob is the Schema for the raycronjobs API
 | `apiVersion` _string_ | `ray.io/v1` | | |
 | `kind` _string_ | `RayCronJob` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[RayCronJobSpec](#raycronjobspec)_ |  |  |  |
+| `spec` _[RayCronJobSpec](#raycronjobspec-v1)_ |  |  |  |
 
 
-#### RayCronJobSpec
+#### <a id="raycronjobspec-v1" name="raycronjobspec-v1"></a>RayCronJobSpec
 
 
 
@@ -597,17 +597,17 @@ RayCronJob is the Schema for the raycronjobs API
 
 
 _Appears in:_
-- [RayCronJob](#raycronjob)
+- [RayCronJob](#raycronjob-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `jobTemplate` _[RayJobSpec](#rayjobspec)_ | JobTemplate defines the job spec that will be created by cron scheduling |  |  |
+| `jobTemplate` _[RayJobSpec](#rayjobspec-v1)_ | JobTemplate defines the job spec that will be created by cron scheduling |  |  |
 | `schedule` _string_ | Schedule is the cron schedule string |  |  |
 | `timeZone` _string_ | TimeZone is the time zone name for the given schedule. If not specified, default to the local time zone of the<br />Kuberay Operator. Empty string is not allowed.<br />The bundled version of the time zone database is used. |  | MinLength: 1 <br /> |
 | `suspend` _boolean_ | Suspend tells the controller to suspend the scheduling, it does not apply to<br />scheduled RayJob. |  |  |
 
 
-#### RayJob
+#### <a id="rayjob-v1" name="rayjob-v1"></a>RayJob
 
 
 
@@ -622,10 +622,10 @@ RayJob is the Schema for the rayjobs API
 | `apiVersion` _string_ | `ray.io/v1` | | |
 | `kind` _string_ | `RayJob` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[RayJobSpec](#rayjobspec)_ |  |  |  |
+| `spec` _[RayJobSpec](#rayjobspec-v1)_ |  |  |  |
 
 
-#### RayJobSpec
+#### <a id="rayjobspec-v1" name="rayjobspec-v1"></a>RayJobSpec
 
 
 
@@ -634,24 +634,24 @@ RayJobSpec defines the desired state of RayJob
 
 
 _Appears in:_
-- [RayCronJobSpec](#raycronjobspec)
-- [RayJob](#rayjob)
+- [RayCronJobSpec](#raycronjobspec-v1)
+- [RayJob](#rayjob-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `activeDeadlineSeconds` _integer_ | ActiveDeadlineSeconds is the duration in seconds that the RayJob may be active before<br />KubeRay actively tries to terminate the RayJob; value must be positive integer. |  |  |
 | `backoffLimit` _integer_ | Specifies the number of retries before marking this job failed.<br />Each retry creates a new RayCluster. | 0 |  |
-| `rayClusterSpec` _[RayClusterSpec](#rayclusterspec)_ | RayClusterSpec is the cluster template to run the job |  |  |
+| `rayClusterSpec` _[RayClusterSpec](#rayclusterspec-v1)_ | RayClusterSpec is the cluster template to run the job |  |  |
 | `submitterPodTemplate` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | SubmitterPodTemplate is the template for the pod that will run `ray job submit`. |  |  |
 | `metadata` _object (keys:string, values:string)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
 | `clusterSelector` _object (keys:string, values:string)_ | clusterSelector is used to select running rayclusters by labels |  |  |
-| `submitterConfig` _[SubmitterConfig](#submitterconfig)_ | Configurations of submitter k8s job. |  |  |
+| `submitterConfig` _[SubmitterConfig](#submitterconfig-v1)_ | Configurations of submitter k8s job. |  |  |
 | `managedBy` _string_ | ManagedBy is an optional configuration for the controller or entity that manages a RayJob.<br />The value must be either 'ray.io/kuberay-operator' or 'kueue.x-k8s.io/multikueue'.<br />The kuberay-operator reconciles a RayJob which doesn't have this field at all or<br />the field value is the reserved string 'ray.io/kuberay-operator',<br />but delegates reconciling the RayJob with 'kueue.x-k8s.io/multikueue' to the Kueue.<br />The field is immutable. |  |  |
-| `deletionStrategy` _[DeletionStrategy](#deletionstrategy)_ | DeletionStrategy automates post-completion cleanup.<br />Choose one style or omit:<br />  - Legacy: both onSuccess & onFailure (deprecated; may combine with shutdownAfterJobFinishes and TTLSecondsAfterFinished).<br />  - Rules: deletionRules (non-empty) — incompatible with shutdownAfterJobFinishes, legacy fields, and global TTLSecondsAfterFinished (use per-rule condition.ttlSeconds).<br />Global TTLSecondsAfterFinished > 0 requires shutdownAfterJobFinishes=true.<br />Feature gate RayJobDeletionPolicy must be enabled when this field is set. |  |  |
+| `deletionStrategy` _[DeletionStrategy](#deletionstrategy-v1)_ | DeletionStrategy automates post-completion cleanup.<br />Choose one style or omit:<br />  - Legacy: both onSuccess & onFailure (deprecated; may combine with shutdownAfterJobFinishes and TTLSecondsAfterFinished).<br />  - Rules: deletionRules (non-empty) — incompatible with shutdownAfterJobFinishes, legacy fields, and global TTLSecondsAfterFinished (use per-rule condition.ttlSeconds).<br />Global TTLSecondsAfterFinished > 0 requires shutdownAfterJobFinishes=true.<br />Feature gate RayJobDeletionPolicy must be enabled when this field is set. |  |  |
 | `entrypoint` _string_ | Entrypoint represents the command to start execution. |  |  |
 | `runtimeEnvYAML` _string_ | RuntimeEnvYAML represents the runtime environment configuration<br />provided as a multi-line YAML string. |  |  |
 | `jobId` _string_ | If jobId is not set, a new jobId will be auto-generated. |  |  |
-| `submissionMode` _[JobSubmissionMode](#jobsubmissionmode)_ | SubmissionMode specifies how RayJob submits the Ray job to the RayCluster.<br />In "K8sJobMode", the KubeRay operator creates a submitter Kubernetes Job to submit the Ray job.<br />In "HTTPMode", the KubeRay operator sends a request to the RayCluster to create a Ray job.<br />In "InteractiveMode", the KubeRay operator waits for a user to submit a job to the Ray cluster.<br />In "SidecarMode", the KubeRay operator injects a container into the Ray head Pod that acts as the job submitter to submit the Ray job. | K8sJobMode |  |
+| `submissionMode` _[JobSubmissionMode](#jobsubmissionmode-v1)_ | SubmissionMode specifies how RayJob submits the Ray job to the RayCluster.<br />In "K8sJobMode", the KubeRay operator creates a submitter Kubernetes Job to submit the Ray job.<br />In "HTTPMode", the KubeRay operator sends a request to the RayCluster to create a Ray job.<br />In "InteractiveMode", the KubeRay operator waits for a user to submit a job to the Ray cluster.<br />In "SidecarMode", the KubeRay operator injects a container into the Ray head Pod that acts as the job submitter to submit the Ray job. | K8sJobMode |  |
 | `entrypointResources` _string_ | EntrypointResources specifies the custom resources and quantities to reserve for the<br />entrypoint command. |  |  |
 | `entrypointNumCpus` _float_ | EntrypointNumCpus specifies the number of cpus to reserve for the entrypoint command. |  |  |
 | `entrypointNumGpus` _float_ | EntrypointNumGpus specifies the number of gpus to reserve for the entrypoint command. |  |  |
@@ -665,7 +665,7 @@ _Appears in:_
 
 
 
-#### RayService
+#### <a id="rayservice-v1" name="rayservice-v1"></a>RayService
 
 
 
@@ -680,14 +680,14 @@ RayService is the Schema for the rayservices API
 | `apiVersion` _string_ | `ray.io/v1` | | |
 | `kind` _string_ | `RayService` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[RayServiceSpec](#rayservicespec)_ |  |  |  |
+| `spec` _[RayServiceSpec](#rayservicespec-v1)_ |  |  |  |
 
 
 
 
 
 
-#### RayServiceSpec
+#### <a id="rayservicespec-v1" name="rayservicespec-v1"></a>RayServiceSpec
 
 
 
@@ -696,7 +696,7 @@ RayServiceSpec defines the desired state of RayService
 
 
 _Appears in:_
-- [RayService](#rayservice)
+- [RayService](#rayservice-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -704,17 +704,17 @@ _Appears in:_
 | `serviceUnhealthySecondThreshold` _integer_ | Deprecated: This field is not used anymore. ref: https://github.com/ray-project/kuberay/issues/1685 |  |  |
 | `deploymentUnhealthySecondThreshold` _integer_ | Deprecated: This field is not used anymore. ref: https://github.com/ray-project/kuberay/issues/1685 |  |  |
 | `serveService` _[Service](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#service-v1-core)_ | ServeService is the Kubernetes service for head node and worker nodes who have healthy http proxy to serve traffics. |  |  |
-| `upgradeStrategy` _[RayServiceUpgradeStrategy](#rayserviceupgradestrategy)_ | UpgradeStrategy defines the scaling policy used when upgrading the RayService. |  |  |
+| `upgradeStrategy` _[RayServiceUpgradeStrategy](#rayserviceupgradestrategy-v1)_ | UpgradeStrategy defines the scaling policy used when upgrading the RayService. |  |  |
 | `managedBy` _string_ | ManagedBy is an optional configuration for the controller or entity that manages a RayService.<br />The value must be either 'ray.io/kuberay-operator' or 'kueue.x-k8s.io/multikueue'.<br />The kuberay-operator reconciles a RayService which doesn't have this field at all or<br />the field value is the reserved string 'ray.io/kuberay-operator',<br />but delegates reconciling the RayService with 'kueue.x-k8s.io/multikueue' to the Kueue.<br />The field is immutable. |  |  |
 | `serveConfigV2` _string_ | Important: Run "make" to regenerate code after modifying this file<br />Defines the applications and deployments to deploy, should be a YAML multi-line scalar string. |  |  |
-| `rayClusterConfig` _[RayClusterSpec](#rayclusterspec)_ |  |  |  |
+| `rayClusterConfig` _[RayClusterSpec](#rayclusterspec-v1)_ |  |  |  |
 | `excludeHeadPodFromServeSvc` _boolean_ | If the field is set to true, the value of the label `ray.io/serve` on the head Pod should always be false.<br />Therefore, the head Pod's endpoint will not be added to the Kubernetes Serve service. |  |  |
 | `suspend` _boolean_ | Suspend indicates whether the RayService should suspend its execution. When set to true,<br />all Kubernetes resources owned by the RayService controller will be deleted. Setting it<br />back to false will allow the RayService controller to recreate the resources. |  |  |
 
 
 
 
-#### RayServiceUpgradeStrategy
+#### <a id="rayserviceupgradestrategy-v1" name="rayserviceupgradestrategy-v1"></a>RayServiceUpgradeStrategy
 
 
 
@@ -723,15 +723,15 @@ _Appears in:_
 
 
 _Appears in:_
-- [RayServiceSpec](#rayservicespec)
+- [RayServiceSpec](#rayservicespec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _[RayServiceUpgradeType](#rayserviceupgradetype)_ | Type represents the strategy used when upgrading the RayService. Currently supports `NewCluster`, `NewClusterWithIncrementalUpgrade` and `None`. |  |  |
-| `clusterUpgradeOptions` _[ClusterUpgradeOptions](#clusterupgradeoptions)_ | ClusterUpgradeOptions defines the behavior of a NewClusterWithIncrementalUpgrade type.<br />RayServiceIncrementalUpgrade feature gate must be enabled to set ClusterUpgradeOptions. |  |  |
+| `type` _[RayServiceUpgradeType](#rayserviceupgradetype-v1)_ | Type represents the strategy used when upgrading the RayService. Currently supports `NewCluster`, `NewClusterWithIncrementalUpgrade` and `None`. |  |  |
+| `clusterUpgradeOptions` _[ClusterUpgradeOptions](#clusterupgradeoptions-v1)_ | ClusterUpgradeOptions defines the behavior of a NewClusterWithIncrementalUpgrade type.<br />RayServiceIncrementalUpgrade feature gate must be enabled to set ClusterUpgradeOptions. |  |  |
 
 
-#### RayServiceUpgradeType
+#### <a id="rayserviceupgradetype-v1" name="rayserviceupgradetype-v1"></a>RayServiceUpgradeType
 
 _Underlying type:_ _string_
 
@@ -740,7 +740,7 @@ _Underlying type:_ _string_
 
 
 _Appears in:_
-- [RayServiceUpgradeStrategy](#rayserviceupgradestrategy)
+- [RayServiceUpgradeStrategy](#rayserviceupgradestrategy-v1)
 
 | Field | Description |
 | --- | --- |
@@ -749,7 +749,7 @@ _Appears in:_
 | `None` | No new cluster will be created while the strategy is set to None<br /> |
 
 
-#### RedisCredential
+#### <a id="rediscredential-v1" name="rediscredential-v1"></a>RedisCredential
 
 
 
@@ -758,7 +758,7 @@ RedisCredential is the redis username/password or a reference to the source cont
 
 
 _Appears in:_
-- [GcsFaultToleranceOptions](#gcsfaulttoleranceoptions)
+- [GcsFaultToleranceOptions](#gcsfaulttoleranceoptions-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -766,7 +766,7 @@ _Appears in:_
 | `value` _string_ |  |  |  |
 
 
-#### ScaleStrategy
+#### <a id="scalestrategy-v1" name="scalestrategy-v1"></a>ScaleStrategy
 
 
 
@@ -775,14 +775,14 @@ ScaleStrategy to remove workers
 
 
 _Appears in:_
-- [WorkerGroupSpec](#workergroupspec)
+- [WorkerGroupSpec](#workergroupspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `workersToDelete` _string array_ | WorkersToDelete workers to be deleted |  |  |
 
 
-#### SubmitterConfig
+#### <a id="submitterconfig-v1" name="submitterconfig-v1"></a>SubmitterConfig
 
 
 
@@ -791,14 +791,14 @@ _Appears in:_
 
 
 _Appears in:_
-- [RayJobSpec](#rayjobspec)
+- [RayJobSpec](#rayjobspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `backoffLimit` _integer_ | BackoffLimit of the submitter. In K8sJobMode, this is the K8s Job backoffLimit.<br />In SidecarMode with SidecarSubmitterRestart enabled, this is the maximum container restart count. |  |  |
 
 
-#### TLSOptions
+#### <a id="tlsoptions-v1" name="tlsoptions-v1"></a>TLSOptions
 
 
 
@@ -811,14 +811,14 @@ and keeps certificates up to date as pod IPs change during autoscaling.
 
 
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Enabled controls whether mTLS is active for this RayCluster.<br />Defaults to false when omitted. Set to true to enable mTLS. |  |  |
 
 
-#### UpscalingMode
+#### <a id="upscalingmode-v1" name="upscalingmode-v1"></a>UpscalingMode
 
 _Underlying type:_ _string_
 
@@ -828,11 +828,11 @@ _Validation:_
 - Enum: [Default Aggressive Conservative]
 
 _Appears in:_
-- [AutoscalerOptions](#autoscaleroptions)
+- [AutoscalerOptions](#autoscaleroptions-v1)
 
 
 
-#### WorkerGroupNetworkPolicyRules
+#### <a id="workergroupnetworkpolicyrules-v1" name="workergroupnetworkpolicyrules-v1"></a>WorkerGroupNetworkPolicyRules
 
 
 
@@ -841,7 +841,7 @@ WorkerGroupNetworkPolicyRules is NetworkPolicyRules bound to one worker group.
 
 
 _Appears in:_
-- [NetworkPolicyConfig](#networkpolicyconfig)
+- [NetworkPolicyConfig](#networkpolicyconfig-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -850,7 +850,7 @@ _Appears in:_
 | `egressRules` _[NetworkPolicyEgressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#networkpolicyegressrule-v1-networking) array_ | EgressRules specifies custom egress rules appended to the base policy.<br />Only meaningful when the mode includes egress denial (DenyAll or DenyAllEgress).<br />DNS egress is NOT added automatically: under DenyAll/DenyAllEgress you MUST<br />add a DNS rule here (e.g. to kube-system pods labeled k8s-app=kube-dns on<br />port 53), because Ray workers reach the head via its service FQDN and cannot<br />resolve it without DNS. See the network-policy-deny-all sample. |  |  |
 
 
-#### WorkerGroupSpec
+#### <a id="workergroupspec-v1" name="workergroupspec-v1"></a>WorkerGroupSpec
 
 
 
@@ -859,7 +859,7 @@ WorkerGroupSpec are the specs for the worker pods
 
 
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -874,7 +874,7 @@ _Appears in:_
 | `labels` _object (keys:string, values:string)_ | Labels specifies the Ray node labels for this worker group.<br />These labels will also be added to the Pods of this worker group and override the `--labels`<br />argument passed to `rayStartParams`. |  |  |
 | `rayStartParams` _object (keys:string, values:string)_ | RayStartParams are the params of the start command: address, object-store-memory, ... |  |  |
 | `template` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | Template is a pod template for the worker |  |  |
-| `scaleStrategy` _[ScaleStrategy](#scalestrategy)_ | ScaleStrategy defines which pods to remove |  |  |
+| `scaleStrategy` _[ScaleStrategy](#scalestrategy-v1)_ | ScaleStrategy defines which pods to remove |  |  |
 | `numOfHosts` _integer_ | NumOfHosts denotes the number of hosts to create per replica. The default value is 1. | 1 |  |
 
 
@@ -885,13 +885,13 @@ _Appears in:_
 Package v1alpha1 contains API Schema definitions for the ray v1alpha1 API group
 
 ### Resource Types
-- [RayCluster](#raycluster)
-- [RayJob](#rayjob)
-- [RayService](#rayservice)
+- [RayCluster](#raycluster-v1alpha1)
+- [RayJob](#rayjob-v1alpha1)
+- [RayService](#rayservice-v1alpha1)
 
 
 
-#### AutoscalerOptions
+#### <a id="autoscaleroptions-v1alpha1" name="autoscaleroptions-v1alpha1"></a>AutoscalerOptions
 
 
 
@@ -900,7 +900,7 @@ AutoscalerOptions specifies optional configuration for the Ray autoscaler.
 
 
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1alpha1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -909,7 +909,7 @@ _Appears in:_
 | `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ | ImagePullPolicy optionally overrides the autoscaler container's image pull policy. This override is provided for autoscaler testing and development. |  |  |
 | `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | SecurityContext defines the security options the container should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |  |  |
 | `idleTimeoutSeconds` _integer_ | IdleTimeoutSeconds is the number of seconds to wait before scaling down a worker pod which is not using Ray resources.<br />Defaults to 60 (one minute). It is not read by the KubeRay operator but by the Ray autoscaler. |  |  |
-| `upscalingMode` _[UpscalingMode](#upscalingmode)_ | UpscalingMode is "Conservative", "Default", or "Aggressive."<br />Conservative: Upscaling is rate-limited; the number of pending worker pods is at most the size of the Ray cluster.<br />Default: Upscaling is not rate-limited.<br />Aggressive: An alias for Default; upscaling is not rate-limited.<br />It is not read by the KubeRay operator but by the Ray autoscaler. |  | Enum: [Default Aggressive Conservative] <br /> |
+| `upscalingMode` _[UpscalingMode](#upscalingmode-v1alpha1)_ | UpscalingMode is "Conservative", "Default", or "Aggressive."<br />Conservative: Upscaling is rate-limited; the number of pending worker pods is at most the size of the Ray cluster.<br />Default: Upscaling is not rate-limited.<br />Aggressive: An alias for Default; upscaling is not rate-limited.<br />It is not read by the KubeRay operator but by the Ray autoscaler. |  | Enum: [Default Aggressive Conservative] <br /> |
 | `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | Optional list of environment variables to set in the autoscaler container. |  |  |
 | `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envfromsource-v1-core) array_ | Optional list of sources to populate environment variables in the autoscaler container. |  |  |
 | `volumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumemount-v1-core) array_ | Optional list of volumeMounts.  This is needed for enabling TLS for the autoscaler container. |  |  |
@@ -917,7 +917,7 @@ _Appears in:_
 
 
 
-#### HeadGroupSpec
+#### <a id="headgroupspec-v1alpha1" name="headgroupspec-v1alpha1"></a>HeadGroupSpec
 
 
 
@@ -926,7 +926,7 @@ HeadGroupSpec are the spec for the head pod
 
 
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1alpha1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -937,7 +937,7 @@ _Appears in:_
 | `serviceType` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#servicetype-v1-core)_ | ServiceType is Kubernetes service type of the head service. it will be used by the workers to connect to the head pod |  |  |
 
 
-#### RayCluster
+#### <a id="raycluster-v1alpha1" name="raycluster-v1alpha1"></a>RayCluster
 
 
 
@@ -952,10 +952,10 @@ RayCluster is the Schema for the RayClusters API
 | `apiVersion` _string_ | `ray.io/v1alpha1` | | |
 | `kind` _string_ | `RayCluster` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[RayClusterSpec](#rayclusterspec)_ | Specification of the desired behavior of the RayCluster. |  |  |
+| `spec` _[RayClusterSpec](#rayclusterspec-v1alpha1)_ | Specification of the desired behavior of the RayCluster. |  |  |
 
 
-#### RayClusterSpec
+#### <a id="rayclusterspec-v1alpha1" name="rayclusterspec-v1alpha1"></a>RayClusterSpec
 
 
 
@@ -964,22 +964,22 @@ RayClusterSpec defines the desired state of RayCluster
 
 
 _Appears in:_
-- [RayCluster](#raycluster)
-- [RayJobSpec](#rayjobspec)
-- [RayServiceSpec](#rayservicespec)
+- [RayCluster](#raycluster-v1alpha1)
+- [RayJobSpec](#rayjobspec-v1alpha1)
+- [RayServiceSpec](#rayservicespec-v1alpha1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `enableInTreeAutoscaling` _boolean_ | EnableInTreeAutoscaling indicates whether operator should create in tree autoscaling configs |  |  |
-| `autoscalerOptions` _[AutoscalerOptions](#autoscaleroptions)_ | AutoscalerOptions specifies optional configuration for the Ray autoscaler. |  |  |
+| `autoscalerOptions` _[AutoscalerOptions](#autoscaleroptions-v1alpha1)_ | AutoscalerOptions specifies optional configuration for the Ray autoscaler. |  |  |
 | `suspend` _boolean_ | Suspend indicates whether a RayCluster should be suspended.<br />A suspended RayCluster will have head pods and worker pods deleted. |  |  |
 | `headServiceAnnotations` _object (keys:string, values:string)_ |  |  |  |
-| `headGroupSpec` _[HeadGroupSpec](#headgroupspec)_ | HeadGroupSpec is the spec for the head pod |  |  |
+| `headGroupSpec` _[HeadGroupSpec](#headgroupspec-v1alpha1)_ | HeadGroupSpec is the spec for the head pod |  |  |
 | `rayVersion` _string_ | RayVersion is used to determine the command for the Kubernetes Job managed by RayJob |  |  |
-| `workerGroupSpecs` _[WorkerGroupSpec](#workergroupspec) array_ | WorkerGroupSpecs are the specs for the worker pods |  |  |
+| `workerGroupSpecs` _[WorkerGroupSpec](#workergroupspec-v1alpha1) array_ | WorkerGroupSpecs are the specs for the worker pods |  |  |
 
 
-#### RayJob
+#### <a id="rayjob-v1alpha1" name="rayjob-v1alpha1"></a>RayJob
 
 
 
@@ -994,10 +994,10 @@ RayJob is the Schema for the rayjobs API
 | `apiVersion` _string_ | `ray.io/v1alpha1` | | |
 | `kind` _string_ | `RayJob` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[RayJobSpec](#rayjobspec)_ |  |  |  |
+| `spec` _[RayJobSpec](#rayjobspec-v1alpha1)_ |  |  |  |
 
 
-#### RayJobSpec
+#### <a id="rayjobspec-v1alpha1" name="rayjobspec-v1alpha1"></a>RayJobSpec
 
 
 
@@ -1006,13 +1006,13 @@ RayJobSpec defines the desired state of RayJob
 
 
 _Appears in:_
-- [RayJob](#rayjob)
+- [RayJob](#rayjob-v1alpha1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `submitterPodTemplate` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | SubmitterPodTemplate is the template for the pod that will run `ray job submit`. |  |  |
 | `metadata` _object (keys:string, values:string)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `rayClusterSpec` _[RayClusterSpec](#rayclusterspec)_ | RayClusterSpec is the cluster template to run the job |  |  |
+| `rayClusterSpec` _[RayClusterSpec](#rayclusterspec-v1alpha1)_ | RayClusterSpec is the cluster template to run the job |  |  |
 | `clusterSelector` _object (keys:string, values:string)_ | ClusterSelector is used to select running rayclusters by labels |  |  |
 | `entrypoint` _string_ | Entrypoint represents the command to start execution. |  |  |
 | `runtimeEnvYAML` _string_ | RuntimeEnvYAML represents the runtime environment configuration<br />provided as a multi-line YAML string. |  |  |
@@ -1027,7 +1027,7 @@ _Appears in:_
 
 
 
-#### RayService
+#### <a id="rayservice-v1alpha1" name="rayservice-v1alpha1"></a>RayService
 
 
 
@@ -1042,10 +1042,10 @@ RayService is the Schema for the rayservices API
 | `apiVersion` _string_ | `ray.io/v1alpha1` | | |
 | `kind` _string_ | `RayService` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[RayServiceSpec](#rayservicespec)_ |  |  |  |
+| `spec` _[RayServiceSpec](#rayservicespec-v1alpha1)_ |  |  |  |
 
 
-#### RayServiceSpec
+#### <a id="rayservicespec-v1alpha1" name="rayservicespec-v1alpha1"></a>RayServiceSpec
 
 
 
@@ -1054,7 +1054,7 @@ RayServiceSpec defines the desired state of RayService
 
 
 _Appears in:_
-- [RayService](#rayservice)
+- [RayService](#rayservice-v1alpha1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -1062,12 +1062,12 @@ _Appears in:_
 | `serviceUnhealthySecondThreshold` _integer_ | Deprecated: This field is not used anymore. ref: https://github.com/ray-project/kuberay/issues/1685 |  |  |
 | `deploymentUnhealthySecondThreshold` _integer_ | Deprecated: This field is not used anymore. ref: https://github.com/ray-project/kuberay/issues/1685 |  |  |
 | `serveConfigV2` _string_ | Important: Run "make" to regenerate code after modifying this file<br />Defines the applications and deployments to deploy, should be a YAML multi-line scalar string. |  |  |
-| `rayClusterConfig` _[RayClusterSpec](#rayclusterspec)_ |  |  |  |
+| `rayClusterConfig` _[RayClusterSpec](#rayclusterspec-v1alpha1)_ |  |  |  |
 
 
 
 
-#### ScaleStrategy
+#### <a id="scalestrategy-v1alpha1" name="scalestrategy-v1alpha1"></a>ScaleStrategy
 
 
 
@@ -1076,14 +1076,14 @@ ScaleStrategy to remove workers
 
 
 _Appears in:_
-- [WorkerGroupSpec](#workergroupspec)
+- [WorkerGroupSpec](#workergroupspec-v1alpha1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `workersToDelete` _string array_ | WorkersToDelete workers to be deleted |  |  |
 
 
-#### UpscalingMode
+#### <a id="upscalingmode-v1alpha1" name="upscalingmode-v1alpha1"></a>UpscalingMode
 
 _Underlying type:_ _string_
 
@@ -1093,11 +1093,11 @@ _Validation:_
 - Enum: [Default Aggressive Conservative]
 
 _Appears in:_
-- [AutoscalerOptions](#autoscaleroptions)
+- [AutoscalerOptions](#autoscaleroptions-v1alpha1)
 
 
 
-#### WorkerGroupSpec
+#### <a id="workergroupspec-v1alpha1" name="workergroupspec-v1alpha1"></a>WorkerGroupSpec
 
 
 
@@ -1106,7 +1106,7 @@ WorkerGroupSpec are the specs for the worker pods
 
 
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1alpha1)
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -1116,6 +1116,6 @@ _Appears in:_
 | `maxReplicas` _integer_ | MaxReplicas denotes the maximum number of desired Pods for this worker group, and the default value is maxInt32. | 2147483647 |  |
 | `rayStartParams` _object (keys:string, values:string)_ | RayStartParams are the params of the start command: address, object-store-memory, ... |  |  |
 | `template` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core)_ | Template is a pod template for the worker |  |  |
-| `scaleStrategy` _[ScaleStrategy](#scalestrategy)_ | ScaleStrategy defines which pods to remove |  |  |
+| `scaleStrategy` _[ScaleStrategy](#scalestrategy-v1alpha1)_ | ScaleStrategy defines which pods to remove |  |  |
 
 

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -260,6 +260,8 @@ Run tests on your local environment
 
 We use [elastic/crd-ref-docs](https://github.com/elastic/crd-ref-docs) to generate API reference for CRDs of KubeRay. The configuration file of `crd-ref-docs` is located at `hack/config.yaml`. Please refer to the documentation for more details.
 
+The Markdown templates in `hack/api-docs-templates` are a copy of the built-in `crd-ref-docs` Markdown templates, with one change: each type gets an explicit anchor that is qualified with its API version (for example `#rayclusterspec-v1alpha1`), and all cross-references point at those anchors. Without this, types that exist in more than one API version share a single anchor and every link in the `ray.io/v1alpha1` section resolves to the `ray.io/v1` type. When bumping the `crd-ref-docs` version, re-sync these templates with the upstream ones.
+
 Generate API refernece:
 
 ```bash

--- a/ray-operator/Makefile
+++ b/ray-operator/Makefile
@@ -177,6 +177,7 @@ api-docs: crd-ref-docs ## Generate CRD documentation.
     --config=./hack/config.yaml \
     --source-path=./apis/ray \
     --renderer=markdown \
+    --templates-dir=./hack/api-docs-templates \
     --output-path=../docs/reference/api.md
 
 certmanager:

--- a/ray-operator/hack/api-docs-templates/gv_details.tpl
+++ b/ray-operator/hack/api-docs-templates/gv_details.tpl
@@ -1,0 +1,19 @@
+{{- define "gvDetails" -}}
+{{- $gv := . -}}
+
+## {{ $gv.GroupVersionString }}
+
+{{ $gv.Doc }}
+
+{{- if $gv.Kinds  }}
+### Resource Types
+{{- range $gv.SortedKinds }}
+- {{ template "typeLink" ($gv.TypeForKind .) }}
+{{- end }}
+{{ end }}
+
+{{ range $gv.SortedTypes }}
+{{ template "type" . }}
+{{ end }}
+
+{{- end -}}

--- a/ray-operator/hack/api-docs-templates/gv_list.tpl
+++ b/ray-operator/hack/api-docs-templates/gv_list.tpl
@@ -1,0 +1,15 @@
+{{- define "gvList" -}}
+{{- $groupVersions := . -}}
+
+# API Reference
+
+## Packages
+{{- range $groupVersions }}
+- {{ markdownRenderGVLink . }}
+{{- end }}
+
+{{ range $groupVersions }}
+{{ template "gvDetails" . }}
+{{ end }}
+
+{{- end -}}

--- a/ray-operator/hack/api-docs-templates/helpers.tpl
+++ b/ray-operator/hack/api-docs-templates/helpers.tpl
@@ -1,0 +1,48 @@
+{{/*
+  Helpers that make cross-references in the generated API reference unambiguous.
+
+  crd-ref-docs' built-in Markdown renderer derives an anchor from the type name
+  alone, so a type that exists in more than one API version (RayClusterSpec is
+  defined in both ray.io/v1 and ray.io/v1alpha1, among others) produces the same
+  anchor twice. Markdown renderers de-duplicate the heading ids but not the
+  links, so every link in the ray.io/v1alpha1 section silently resolves to the
+  ray.io/v1 definition of that type.
+
+  We therefore emit an explicit, version-qualified anchor next to each type
+  heading (`#rayclusterspec-v1alpha1`) and point every link at it. The
+  auto-generated heading ids are left untouched, so existing deep links such as
+  `#rayclusterspec` keep working.
+*/}}
+
+{{/* Version-qualified anchor for a locally defined type, e.g. "rayclusterspec-v1alpha1". */}}
+{{- define "typeAnchor" -}}
+{{- markdownSafeID (printf "%s-%s" .Name (last (splitList "/" .Package))) -}}
+{{- end -}}
+
+{{/*
+  Same as markdownRenderTypeLink, except that links to locally defined types use
+  the version-qualified anchor. External links (Kubernetes API docs and known
+  types) and plain text are passed through unchanged.
+*/}}
+{{- define "typeLink" -}}
+{{- $type := . -}}
+{{- $rendered := markdownRenderTypeLink $type -}}
+{{- if hasPrefix (printf "[%s](#" $type.Name) $rendered -}}
+[{{ $type.Name }}](#{{ template "typeAnchor" $type }})
+{{- else -}}
+{{- $rendered -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Same as markdownRenderType, but routes every link through "typeLink". */}}
+{{- define "typeRef" -}}
+{{- $type := . -}}
+{{- $kind := trimAll "\"" (toJson $type.Kind) -}}
+{{- if eq $kind "MAP" -}}
+object (keys:{{ template "typeLink" $type.KeyType }}, values:{{ template "typeLink" $type.ValueType }})
+{{- else if eq $kind "SLICE" -}}
+{{ template "typeLink" $type.UnderlyingType }} array
+{{- else -}}
+{{- template "typeLink" $type -}}
+{{- end -}}
+{{- end -}}

--- a/ray-operator/hack/api-docs-templates/type.tpl
+++ b/ray-operator/hack/api-docs-templates/type.tpl
@@ -1,0 +1,49 @@
+{{- define "type" -}}
+{{- $type := . -}}
+{{- if markdownShouldRenderType $type -}}
+
+#### <a id="{{ template "typeAnchor" $type }}" name="{{ template "typeAnchor" $type }}"></a>{{ $type.Name }}
+
+{{ if $type.IsAlias }}_Underlying type:_ _{{ template "typeLink" $type.UnderlyingType }}_{{ end }}
+
+{{ $type.Doc }}
+
+{{ if $type.Validation -}}
+_Validation:_
+{{- range $type.Validation }}
+- {{ . }}
+{{- end }}
+{{- end }}
+
+{{ if $type.References -}}
+_Appears in:_
+{{- range $type.SortedReferences }}
+- {{ template "typeLink" . }}
+{{- end }}
+{{- end }}
+
+{{ if $type.Members -}}
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+{{ if $type.GVK -}}
+| `apiVersion` _string_ | `{{ $type.GVK.Group }}/{{ $type.GVK.Version }}` | | |
+| `kind` _string_ | `{{ $type.GVK.Kind }}` | | |
+{{ end -}}
+
+{{ range $type.Members -}}
+| `{{ .Name  }}` _{{ template "typeRef" .Type }}_ | {{ template "type_members" . }} | {{ markdownRenderDefault .Default }} | {{ range .Validation -}} {{ markdownRenderFieldDoc . }} <br />{{ end }} |
+{{ end -}}
+
+{{ end -}}
+
+{{ if $type.EnumValues -}}
+| Field | Description |
+| --- | --- |
+{{ range $type.EnumValues -}}
+| `{{ .Name }}` | {{ markdownRenderFieldDoc .Doc }} |
+{{ end -}}
+{{ end -}}
+
+
+{{- end -}}
+{{- end -}}

--- a/ray-operator/hack/api-docs-templates/type_members.tpl
+++ b/ray-operator/hack/api-docs-templates/type_members.tpl
@@ -1,0 +1,8 @@
+{{- define "type_members" -}}
+{{- $field := . -}}
+{{- if eq $field.Name "metadata" -}}
+Refer to Kubernetes API documentation for fields of `metadata`.
+{{- else -}}
+{{ markdownRenderFieldDoc $field.Doc }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
## Why are these changes needed?

`crd-ref-docs` derives Markdown anchors from the type name alone, so the eleven types that exist in both `ray.io/v1` and `ray.io/v1alpha1` (`RayClusterSpec`, `WorkerGroupSpec`, `RayJob`, ...) emit the same anchor twice. Markdown renderers de-duplicate the *heading ids* (`rayclusterspec`, `rayclusterspec_1`) but not the *links*, so all 23 cross-links in the `ray.io/v1alpha1` section of `docs/reference/api.md` resolved to the `ray.io/v1` definition. The failure is silent — no broken link, no warning at generation time — and the definitions differ substantially (`RayClusterSpec` has 14 fields in v1 and 7 in v1alpha1), so a reader following a v1alpha1 link lands on a table advertising fields that do not exist in v1alpha1.

This is issue direction (1): version-qualified slugs, fixed in the generation step rather than by post-processing the output.

`make api-docs` now renders through a local copy of the upstream `crd-ref-docs` Markdown templates (`ray-operator/hack/api-docs-templates/`). The only change from upstream is that each type heading carries an explicit, version-qualified anchor and every cross-reference resolves against it:

```
{{- define "typeAnchor" -}}
{{- markdownSafeID (printf "%s-%s" .Name (last (splitList "/" .Package))) -}}
{{- end -}}
```

Heading *text* is byte-for-byte unchanged, so the auto-generated ids the published site already exposes (`#rayclusterspec`, `#rayclusterspec_1`) still exist and existing external deep links keep working.

### Before / after

Heading (`RayClusterSpec`, `ray.io/v1alpha1` section):

```diff
-#### RayClusterSpec
+#### <a id="rayclusterspec-v1alpha1" name="rayclusterspec-v1alpha1"></a>RayClusterSpec
```

Cross-link from `AutoscalerOptions` in the `ray.io/v1alpha1` section:

```diff
 _Appears in:_
-- [RayClusterSpec](#rayclusterspec)
+- [RayClusterSpec](#rayclusterspec-v1alpha1)
```

Field reference in the v1alpha1 `RayClusterSpec` table:

```diff
-| `workerGroupSpecs` _[WorkerGroupSpec](#workergroupspec) array_ | ...
+| `workerGroupSpecs` _[WorkerGroupSpec](#workergroupspec-v1alpha1) array_ | ...
```

All 23 previously-wrong links in the v1alpha1 section, after regeneration:

```
2 [AutoscalerOptions](#autoscaleroptions-v1alpha1)
1 [HeadGroupSpec](#headgroupspec-v1alpha1)
6 [RayClusterSpec](#rayclusterspec-v1alpha1)
2 [RayCluster](#raycluster-v1alpha1)
2 [RayJobSpec](#rayjobspec-v1alpha1)
2 [RayJob](#rayjob-v1alpha1)
2 [RayServiceSpec](#rayservicespec-v1alpha1)
2 [RayService](#rayservice-v1alpha1)
1 [ScaleStrategy](#scalestrategy-v1alpha1)
1 [UpscalingMode](#upscalingmode-v1alpha1)
2 [WorkerGroupSpec](#workergroupspec-v1alpha1)
```

## Related issue number

Closes #5091

## Labels

- [ ] If this PR has user-facing changes that require documentation updates at release time, I have added the `doc-updates-required` label.
- [ ] If this PR contains breaking changes, I have added the `breaking-change` label.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Manual tests

### Manual test instructions

```bash
cd ray-operator && make api-docs

# every local link target now has a matching explicit anchor;
# the only unanchored targets are the two group-version headings,
# whose auto ids (rayiov1 / rayiov1alpha1) are already unique.
cd ..
grep -oE '\]\(#[a-z0-9_-]*\)' docs/reference/api.md | sed 's/](#//;s/)//' | sort -u > /tmp/targets
grep -oE '<a id="[a-z0-9_-]*"' docs/reference/api.md | sed 's/<a id="//;s/"//' | sort -u > /tmp/anchors
comm -23 /tmp/targets /tmp/anchors   # -> rayiov1, rayiov1alpha1
comm -13 /tmp/targets /tmp/anchors   # -> empty (no orphan anchors)
grep -oE '<a id="[a-z0-9_-]*"' docs/reference/api.md | sort | uniq -d   # -> empty (no duplicates)

# heading text is unchanged, so pre-existing heading ids are preserved
diff <(git show upstream/master:docs/reference/api.md | grep -E '^#### ') \
     <(grep -E '^#### ' docs/reference/api.md | sed -E 's/<a id="[^"]*" name="[^"]*"><\/a>//')
```

Also verified:

- `./hack/verify-api-docs.sh` -> `./hack/../../docs/reference up to date.` (regeneration is idempotent, so the consistency check passes)
- `go build ./...` in `ray-operator/` -> clean
- `markdownlint-cli@0.44.0 --disable=MD033` on `docs/reference/api.md`: no new violations; `MD024/no-duplicate-heading` drops from 12 to 1

`MD033` (inline HTML) is already disabled in `.pre-commit-config.yaml`, so the `<a>` anchors don't trip the linter. The `name` attribute is emitted alongside `id` so the anchors also resolve when the file is viewed on GitHub.

`ray-operator/DEVELOPMENT.md` notes that the templates are a fork of the upstream ones and should be re-synced when the `crd-ref-docs` version is bumped.
